### PR TITLE
fix(disk): bound the BuildKit registry cache (cache/*) and make PVC size defaults honest

### DIFF
--- a/deploy/helm/djinn/README.md
+++ b/deploy/helm/djinn/README.md
@@ -70,9 +70,10 @@ validates every setting locally; no live cluster is required.
 
 Two independent safety properties hold before anything is deleted:
 
-1. **Scope.** The rendered policy targets `repositories: ["djinn-image-*"]` only.
-   BuildKit cache repos (`djinn-buildkitd-*`) and infra repos are out of scope.
-   Do not widen this glob.
+1. **Scope.** The rendered catalog policy targets `repositories:
+   ["djinn-image-*"]` only. BuildKit cache repos (`cache/*`) and infra repos are
+   out of scope of *this* policy — cache repos get their own, differently
+   shaped one (see below). Do not widen this glob.
 2. **Digest pins, not tags.** Every task-run and warm Job references its project
    image *by digest*. The authoritative keep-set is therefore the database
    (`ImageRepository::list_selected_catalog_images`), not the tag list. The
@@ -105,6 +106,92 @@ Rollout order:
 policy cannot render at all unless `imagePipeline.enabled` and
 `imagePipeline.zot.enabled` are both true — `zot-configmap.yaml` fails the
 render otherwise, rather than producing a policy with no matching preflight.
+
+## BuildKit registry cache retention (`cache/*`)
+
+The catalog policy is scoped to `djinn-image-*`, which is correct — and it left
+a second repo family with **no retention, no TTL and no eviction of any kind**,
+inside the same PVC. `build_job.rs` exports build cache with:
+
+```
+--export-cache type=registry,ref=<registry>/cache/<subject>,mode=max,image-manifest=true,oci-mediatypes=true
+--import-cache type=registry,ref=<registry>/cache/<subject>
+```
+
+so every project's BuildKit cache is a `cache/<subject>` repo in the same Zot.
+
+**The growth vector is not tag count.** `mode=max` rewrites the *same* `:latest`
+ref on every build, so a cache repo has exactly one tag forever and newest-N tag
+retention is a no-op against it. What accumulates is the **superseded manifest**:
+each export leaves the previous cache manifest in the repo's index, untagged but
+still indexed, still referencing its blobs. Because those blobs are still
+*reachable*, live blob GC has nothing to collect — which is precisely why
+`gc: true` / `gcDelay: 1h` / `gcInterval: 24h` measured **0.0 GiB** reclaimed on
+the production VPS while the store kept growing. `gc` is the collector; it was
+missing an operator to produce garbage in the first place.
+
+`imagePipeline.zot.retention.cache.enabled` (default `true`) renders that
+operator as a second policy:
+
+```json
+{
+  "repositories": ["cache/*"],
+  "deleteUntagged": true,
+  "keepTags": [{ "patterns": [".*"] }]
+}
+```
+
+`keepTags: [{patterns: [".*"]}]` is load-bearing, not decorative. It retains
+every tag unconditionally, so the live `:latest` ref that in-flight builds
+`--import-cache` is structurally ineligible for deletion; only already-superseded
+manifests are candidates. It also makes the policy well-defined regardless of how
+Zot treats a policy with an empty `keepTags` list.
+
+### Safety: worst case is a cache miss, never a failed build
+
+* The live ref is never a candidate — see above.
+* A superseded manifest becomes a candidate only after the retention `delay`
+  (`1h`), and its now-unreachable blobs are only reclaimed after `gcDelay` (`1h`)
+  on the next `gcInterval` (`24h`) sweep. A build resolves and fetches its cache
+  in seconds. The window is not close.
+* Even a total miss is a state this code path already handles in production: the
+  **first** build of every project imports a `cache/<subject>` ref that does not
+  exist yet, and those builds succeed. `buildctl` treats an unresolvable
+  `--import-cache` as "no cache available", not as an error. A pruned ref is
+  indistinguishable from a never-created one.
+
+### Dedupe: why no byte figure is promised
+
+`storage.dedupe: true` stores one copy of each blob digest and shares it across
+repos. A `mode=max` cache export and a `djinn-image-*` layer frequently *are* the
+same blob. So:
+
+* Deleting a cache manifest frees **zero** bytes for every blob a live catalog
+  manifest still references, and vice versa.
+* The reclaimable set is bounded above by the size of the *cache-only* blobs, not
+  by the nominal size of the deleted manifests.
+* The two policies are therefore complementary, not additive. Pruning only one
+  side leaves shared blobs alive through the other side's references, and the
+  catalog policy's own estimate is an upper bound for the same reason.
+
+Report the real number from the dry-run, do not predict it.
+
+### Rollout
+
+The cache policy is governed by the **shared** `retention.dryRun` flag — Zot's
+`dryRun` is a single retention-block-level switch and cannot be set per policy.
+So it ships report-only alongside the catalog policy and goes destructive at the
+same moment, on the same one operator action. To roll the catalog policy
+destructive while leaving cache repos untouched, set
+`imagePipeline.zot.retention.cache.enabled=false`.
+
+The server's startup preflight (`retention_preflight.rs`) covers `djinn-image-*`
+**only**, and needs nothing for `cache/*`: no database row and no kubelet pull
+ever references a cache repo. Its only reader is `buildctl --import-cache`, whose
+failure mode is the cache miss above. The cache policy's dry-run report comes
+from Zot's own logs, not from the server preflight.
+
+`tests/zot-cache-retention-render.sh` pins all of this.
 
 ## Build admission mode
 

--- a/deploy/helm/djinn/templates/zot-configmap.yaml
+++ b/deploy/helm/djinn/templates/zot-configmap.yaml
@@ -7,6 +7,29 @@
 # storage bounded without a restart; dedupe dedupes identical blobs across
 # repos which matters heavily for per-project devcontainer builds that share
 # the djinn-agent-worker Feature base layers.
+#
+# Two retention policies, addressing two different growth vectors:
+#
+#   djinn-image-*  catalog repos. One NEW TAG per content hash, forever. The
+#                  growth vector is tag count, so the policy is newest-N.
+#   cache/*        BuildKit registry cache repos, written by
+#                  `--export-cache type=registry,ref=<reg>/cache/<subject>`
+#                  (build_job.rs). `mode=max` overwrites the SAME `:latest`
+#                  ref every build, so tag count is pinned at one and
+#                  newest-N is a no-op here. The growth vector is the
+#                  SUPERSEDED MANIFEST: every export leaves the previous
+#                  cache manifest in the repo's index, untagged, still
+#                  referencing its blobs. Those blobs are therefore still
+#                  reachable, which is exactly why `gc: true` measured 0.0
+#                  GiB of unreachable garbage on the production VPS while
+#                  the store kept growing. `deleteUntagged` is the operator
+#                  that turns them into garbage; `gc` then reclaims them.
+#
+# `keepTags: [{patterns: [".*"]}]` on the cache policy is load-bearing, not
+# decorative: it retains EVERY tag unconditionally, so the live `:latest`
+# cache ref that in-flight builds `--import-cache` can never be a deletion
+# candidate. Only superseded, already-untagged manifests are in scope, and
+# the retention `delay` below exempts anything untagged within the last hour.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,7 +60,16 @@ data:
                   "newest": {{ .Values.imagePipeline.zot.retention.newestTags }}
                 }
               ]
-            }
+            }{{- if .Values.imagePipeline.zot.retention.cache.enabled }},
+            {
+              "repositories": ["cache/*"],
+              "deleteUntagged": true,
+              "keepTags": [
+                {
+                  "patterns": [".*"]
+                }
+              ]
+            }{{- end }}
           ]
         }{{- end }}
       },

--- a/deploy/helm/djinn/tests/zot-cache-retention-render.sh
+++ b/deploy/helm/djinn/tests/zot-cache-retention-render.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+# Helm rendering test for the BuildKit registry cache (`cache/*`) retention
+# policy, and for the honesty of the declared PVC sizes.
+#
+# Companion to zot-retention-render.sh, which owns the `djinn-image-*` CATALOG
+# policy. The two repo families grow differently and therefore need different
+# policy shapes:
+#
+#   djinn-image-*  one new TAG per content hash → newest-N tag retention.
+#   cache/*        `--export-cache ...,mode=max` rewrites the SAME `:latest`
+#                  ref every build, so tag count is pinned at one and newest-N
+#                  is a no-op. What accumulates is the superseded, untagged
+#                  manifest, which keeps its blobs reachable — which is exactly
+#                  why `gc: true` reclaimed 0.0 GiB in production. The operator
+#                  that produces the garbage is `deleteUntagged`.
+#
+# Usage: bash deploy/helm/djinn/tests/zot-cache-retention-render.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+require_tool() {
+    if ! command -v "$1" &>/dev/null; then
+        echo "FAIL: required test tool '$1' is not installed" >&2
+        exit 1
+    fi
+}
+
+require_tool helm
+require_tool python3
+
+TMPDIR_RENDER=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_RENDER"' EXIT
+
+# Render the Zot ConfigMap for an in-cluster-Zot topology.
+render_zot_config() {
+    local output=$1
+    shift
+
+    helm template test-release "$CHART_DIR" \
+        --is-upgrade \
+        --show-only templates/zot-configmap.yaml \
+        --set imagePipeline.enabled=true \
+        --set imagePipeline.zot.enabled=true \
+        "$@" \
+        > "$output"
+}
+
+# Shared helper: pull `data.config.json` out of a rendered ConfigMap without
+# requiring a third-party YAML parser. Written to a real module on PYTHONPATH so
+# every checker below can use a QUOTED heredoc — an unquoted one would let the
+# shell perform command substitution on backticks inside the Python comments.
+cat > "$TMPDIR_RENDER/zotcfg.py" <<'PY'
+import json
+
+
+def load_zot_config(path):
+    rendered = open(path, encoding="utf-8").read().splitlines()
+    try:
+        start = rendered.index("  config.json: |") + 1
+    except ValueError:
+        raise AssertionError("zot ConfigMap data.config.json was not rendered")
+    lines = []
+    for line in rendered[start:]:
+        if line and not line.startswith("    "):
+            break
+        lines.append(line[4:] if line else "")
+    return json.loads("\n".join(lines))
+PY
+export PYTHONPATH="$TMPDIR_RENDER"
+
+echo "=== Test 1: shipped defaults render a cache/* policy alongside the catalog one ==="
+# No retention.* override at all: this is what an operator who installs the
+# chart and reads nothing actually gets.
+render_zot_config "$TMPDIR_RENDER/shipped-defaults.yaml"
+
+python3 - "$TMPDIR_RENDER/shipped-defaults.yaml" <<'PY'
+from zotcfg import load_zot_config
+
+import sys
+
+config = load_zot_config(sys.argv[1])
+retention = config["storage"]["retention"]
+policies = retention["policies"]
+
+# The catalog policy must survive untouched — this test must not silently
+# unpick the policy the catalog rollout depends on.
+catalog = [p for p in policies if p["repositories"] == ["djinn-image-*"]]
+assert len(catalog) == 1, f"catalog policy missing or duplicated: {policies}"
+assert policies[0] is catalog[0], "catalog policy must stay first"
+
+cache = [p for p in policies if p["repositories"] == ["cache/*"]]
+assert len(cache) == 1, (
+    "shipped defaults must render exactly one ['cache/*'] policy; without it the "
+    f"BuildKit cache repos have no retention, no TTL and no eviction. Got {policies}"
+)
+cache = cache[0]
+
+# deleteUntagged is the whole point: it is the only operator that turns a
+# superseded cache manifest into garbage that gc can then reclaim.
+assert cache["deleteUntagged"] is True, (
+    "cache policy must set deleteUntagged: it is the only setting that targets "
+    "the actual growth vector (superseded, still-indexed manifests). Without it "
+    "the policy renders but bounds nothing — gc already measured 0.0 GiB."
+)
+
+# Non-destructive by default, inherited from the shared retention-level flag.
+assert retention["dryRun"] is True, (
+    "shipped default must stay report-only; Zot's dryRun is retention-level and "
+    "governs the cache policy too"
+)
+print("PASS: shipped defaults render a report-only cache/* policy with deleteUntagged")
+PY
+
+echo ""
+echo "=== Test 2: the catch-all keepTags rule protects the live :latest ref ==="
+# This is the assertion that would stay green if the body did nothing, unless
+# it is written against the property that matters. The property: an in-flight
+# build about to `--import-cache <reg>/cache/<subject>` must never race a policy
+# that could select that live ref. A catch-all keepTags rule makes the live ref
+# STRUCTURALLY ineligible. Any narrowing qualifier (pushedWithin / pulledWithin /
+# newest) reintroduces an expiry and breaks that guarantee.
+python3 - "$TMPDIR_RENDER/shipped-defaults.yaml" <<'PY'
+from zotcfg import load_zot_config
+
+import re
+import sys
+
+config = load_zot_config(sys.argv[1])
+cache = next(p for p in config["storage"]["retention"]["policies"]
+             if p["repositories"] == ["cache/*"])
+
+keep = cache.get("keepTags")
+assert isinstance(keep, list) and keep, (
+    "cache policy must carry an explicit keepTags list. An empty/absent list "
+    "leaves tag disposition up to Zot's default, which is not a property this "
+    "chart may assume for a live cache ref."
+)
+
+catch_all = [r for r in keep
+             if any(re.fullmatch(p, "any-live-cache-tag") for p in r.get("patterns", []))]
+assert catch_all, (
+    f"no keepTags rule matches an arbitrary live tag; keepTags={keep}. The live "
+    "`:latest` ref would become a deletion candidate and a mid-flight "
+    "--import-cache could lose its cache."
+)
+for rule in catch_all:
+    for narrowing in ("pushedWithin", "pulledWithin", "newest"):
+        assert narrowing not in rule, (
+            f"the catch-all keepTags rule carries {narrowing!r}, which re-adds an "
+            "expiry to the live cache ref. The retention guarantee here is "
+            "'retain every tag, collect superseded manifests' — nothing weaker."
+        )
+print("PASS: cache policy retains every tag unconditionally; only superseded manifests are candidates")
+PY
+
+echo ""
+echo "=== Test 3: the two globs are disjoint over the repo names this system produces ==="
+# Zot compiles repository patterns with '/' as the glob separator, so `*` does
+# not cross a path segment. Prove the globs against the ACTUAL repo names the
+# image controller emits, rather than trusting that they look different:
+#   catalog: `<registry>/djinn-image-<sanitized-id>`   (controller.rs)
+#   project: `<registry>/djinn-project-<sanitized-id>` (controller.rs)
+#   cache:   `<registry>/cache/<sanitized-id>`         (build_job.rs)
+# `sanitize_id` maps '/' to '-', so a cache repo is always exactly two segments.
+python3 - "$TMPDIR_RENDER/shipped-defaults.yaml" <<'PY'
+from zotcfg import load_zot_config
+
+import re
+import sys
+
+config = load_zot_config(sys.argv[1])
+policies = config["storage"]["retention"]["policies"]
+
+
+def glob_to_re(pattern):
+    """gobwas/glob semantics with '/' as separator: ** crosses, * does not."""
+    out, i = "", 0
+    while i < len(pattern):
+        if pattern.startswith("**", i):
+            out += ".*"
+            i += 2
+        elif pattern[i] == "*":
+            out += "[^/]*"
+            i += 1
+        elif pattern[i] == "?":
+            out += "[^/]"
+            i += 1
+        else:
+            out += re.escape(pattern[i])
+            i += 1
+    return re.compile(out + r"\Z")
+
+
+def matches(policy, repo):
+    return any(glob_to_re(g).match(repo) for g in policy["repositories"])
+
+
+catalog = next(p for p in policies if p["repositories"] == ["djinn-image-*"])
+cache = next(p for p in policies if p["repositories"] == ["cache/*"])
+
+cases = [
+    # repo name,                     catalog?, cache?
+    ("djinn-image-019e9907-img",     True,     False),
+    ("cache/019e9907-img",           False,    True),
+    ("cache/proj-abc",               False,    True),
+    # djinn-project-* is a THIRD repo family (format_image_tag) and is
+    # deliberately matched by NEITHER policy — see the PR body. Assert the
+    # current state explicitly so it cannot drift in unnoticed.
+    ("djinn-project-019e51db-proj",  False,    False),
+    # '*' must not cross '/': a hypothetical nested repo is out of scope, and
+    # so is the bare `cache` repo name.
+    ("cache/a/b",                    False,    False),
+    ("cache",                        False,    False),
+]
+for repo, want_catalog, want_cache in cases:
+    assert matches(catalog, repo) is want_catalog, (
+        f"catalog glob match for {repo!r} should be {want_catalog}"
+    )
+    assert matches(cache, repo) is want_cache, (
+        f"cache glob match for {repo!r} should be {want_cache}"
+    )
+
+# Belt and braces: no repo name may be claimed by both policies. Zot applies
+# the first matching policy, so an overlap would silently apply newest-N tag
+# pruning to a cache repo.
+for repo, _, _ in cases:
+    assert not (matches(catalog, repo) and matches(cache, repo)), (
+        f"{repo!r} matches BOTH policies; the first-match rule would apply the "
+        "wrong policy shape to it"
+    )
+print("PASS: catalog and cache globs are disjoint over the real repo names")
+PY
+
+echo ""
+echo "=== Test 4: cache.enabled=false removes the cache policy and nothing else ==="
+render_zot_config "$TMPDIR_RENDER/cache-off.yaml" \
+    --set imagePipeline.zot.retention.cache.enabled=false
+python3 - "$TMPDIR_RENDER/cache-off.yaml" <<'PY'
+from zotcfg import load_zot_config
+
+import sys
+
+config = load_zot_config(sys.argv[1])
+policies = config["storage"]["retention"]["policies"]
+assert len(policies) == 1, f"expected only the catalog policy, got {policies}"
+assert policies[0]["repositories"] == ["djinn-image-*"], (
+    f"disabling the cache policy must leave the catalog policy intact, got {policies}"
+)
+print("PASS: cache.enabled=false renders the catalog policy alone")
+PY
+if grep -Fq '"cache/' "$TMPDIR_RENDER/cache-off.yaml"; then
+    echo "FAIL: cache glob still present with cache.enabled=false" >&2
+    exit 1
+fi
+
+echo ""
+echo "=== Test 5: the master switch still governs the cache policy ==="
+# retention.enabled=false must remove the WHOLE retention block. A cache policy
+# that leaked out from under the master switch would be a policy an operator
+# who disabled retention did not consent to.
+render_zot_config "$TMPDIR_RENDER/retention-off.yaml" \
+    --set imagePipeline.zot.retention.enabled=false
+python3 - "$TMPDIR_RENDER/retention-off.yaml" <<'PY'
+from zotcfg import load_zot_config
+
+import sys
+
+config = load_zot_config(sys.argv[1])
+assert "retention" not in config["storage"], (
+    "retention.enabled=false must render no retention block at all, got "
+    f"{config['storage'].get('retention')}"
+)
+print("PASS: retention.enabled=false removes both policies")
+PY
+
+echo ""
+echo "=== Test 6: destructive mode renders both policies ==="
+render_zot_config "$TMPDIR_RENDER/destructive.yaml" \
+    --set imagePipeline.zot.retention.dryRun=false
+python3 - "$TMPDIR_RENDER/destructive.yaml" <<'PY'
+from zotcfg import load_zot_config
+
+import sys
+
+config = load_zot_config(sys.argv[1])
+retention = config["storage"]["retention"]
+assert retention["dryRun"] is False, "dryRun=false must reach the rendered policy"
+globs = [g for p in retention["policies"] for g in p["repositories"]]
+assert globs == ["djinn-image-*", "cache/*"], (
+    f"destructive mode must carry both policies, in catalog-first order; got {globs}"
+)
+# Zot's dryRun is retention-level, not per-policy: the operator opt-in is a
+# single action covering both. Assert no per-policy dryRun key was invented,
+# because Zot would silently ignore it and the safety story would be a fiction.
+for policy in retention["policies"]:
+    assert "dryRun" not in policy, (
+        "per-policy dryRun is not a Zot setting; it would be silently ignored"
+    )
+print("PASS: destructive mode renders catalog + cache policies under one shared dryRun")
+PY
+
+echo ""
+echo "=== Test 7: external-registry topology stays inert (regression guard) ==="
+# The server's startup preflight is fail-closed and its caller exit(1)s on a Zot
+# fetch error. With the chart default `zot.enabled: false` there is no Zot
+# ConfigMap and no auth Secret, so the effective retention flag must stay false.
+# Adding a second policy must not have disturbed that.
+if helm template test-release "$CHART_DIR" \
+    --is-upgrade \
+    --show-only templates/zot-configmap.yaml \
+    > "$TMPDIR_RENDER/no-zot-cm.yaml" 2>&1; then
+    echo "FAIL: a Zot ConfigMap rendered with the default zot.enabled=false" >&2
+    exit 1
+fi
+
+helm template test-release "$CHART_DIR" \
+    --is-upgrade \
+    --show-only templates/deployment-server.yaml \
+    > "$TMPDIR_RENDER/no-zot-server.yaml"
+python3 - "$TMPDIR_RENDER/no-zot-server.yaml" <<'PY'
+import re
+import sys
+
+rendered = open(sys.argv[1], encoding="utf-8").read().splitlines()
+start = next(i for i, line in enumerate(rendered)
+             if line == "            - name: DJINN_ZOT_RETENTION_ENABLED")
+end = next((i for i in range(start + 1, len(rendered))
+            if rendered[i].startswith("            - name: ")), len(rendered))
+match = re.search(r"^              value: (.+)$", "\n".join(rendered[start:end]), re.MULTILINE)
+assert match and match.group(1).strip('"') == "false", (
+    "effective retention must stay false without an in-cluster Zot, or the "
+    "fail-closed startup preflight exit(1)s the server on boot"
+)
+print("PASS: external-registry default still renders effective retention=false")
+PY
+
+echo ""
+echo "=== Test 8: declared PVC sizes are the documented ones ==="
+# Problem 2. Under the k3s/kind `local-path` provisioner these numbers enforce
+# NOTHING — production runs 40Gi-declared PVCs holding 83G each. They are kept
+# here (rather than raised to match observed usage) because raising a request on
+# a non-expandable StorageClass makes `helm upgrade` fail outright, and because
+# the real bound is on the producers, not the volume. This assertion exists so
+# the numbers cannot drift away from what values.yaml and docs/deploy/vps.md say
+# about them.
+helm template test-release "$CHART_DIR" \
+    --is-upgrade \
+    --show-only templates/zot-pvc.yaml \
+    --show-only templates/pvc-cache.yaml \
+    --show-only templates/pvc-mirror.yaml \
+    --set imagePipeline.enabled=true \
+    --set imagePipeline.zot.enabled=true \
+    > "$TMPDIR_RENDER/pvcs.yaml"
+python3 - "$TMPDIR_RENDER/pvcs.yaml" <<'PY'
+import re
+import sys
+
+rendered = open(sys.argv[1], encoding="utf-8").read()
+sizes = {}
+for doc in rendered.split("\n---\n"):
+    name = re.search(r"^  name: (\S+)$", doc, re.MULTILINE)
+    storage = re.search(r"^      storage: (\S+)$", doc, re.MULTILINE)
+    if name and storage:
+        sizes[name.group(1)] = storage.group(1)
+
+expected = {
+    "test-release-djinn-zot": "100Gi",
+    "test-release-djinn-cache": "20Gi",
+    "test-release-djinn-mirrors": "50Gi",
+}
+for pvc, want in expected.items():
+    assert sizes.get(pvc) == want, (
+        f"{pvc} should request {want}, got {sizes.get(pvc)!r}. If this changed "
+        "deliberately, update values.yaml's storage preamble and "
+        "docs/deploy/vps.md together — and check the StorageClass allows volume "
+        "expansion, because local-path does not and helm upgrade will be rejected."
+    )
+print(f"PASS: declared PVC requests match the documented defaults: {sizes}")
+PY
+
+echo ""
+echo "=== All BuildKit cache retention rendering tests passed ==="

--- a/deploy/helm/djinn/tests/zot-retention-render.sh
+++ b/deploy/helm/djinn/tests/zot-retention-render.sh
@@ -195,10 +195,16 @@ echo "=== Test 6: shipped chart defaults are report-only, not unbounded growth =
 render_manifests "$TMPDIR_RENDER/shipped-defaults.yaml"
 assert_manifests "$TMPDIR_RENDER/shipped-defaults.yaml" true true 5 test-release-djinn-zot-auth
 
-# assert_manifests reads the policy out of the rendered JSON, but the safety
-# glob deserves its own explicit, independent check: widening `repositories`
-# beyond `djinn-image-*` would put the buildkitd cache repos (djinn-buildkitd-*)
-# in scope of tag pruning. Assert the rendered glob is exactly the catalog one.
+# assert_manifests reads the CATALOG policy out of the rendered JSON, but the
+# safety glob deserves its own explicit, independent check: widening
+# `repositories` beyond `djinn-image-*` would put the BuildKit registry cache
+# repos (`cache/*` — see build_job.rs `--export-cache
+# type=registry,ref=<reg>/cache/<subject>`) in scope of NEWEST-N TAG pruning,
+# which is the wrong policy shape for them entirely. Assert the catalog glob is
+# exactly the catalog one and that it is still the FIRST policy.
+#
+# `cache/*` has its own, differently shaped policy; it is asserted in
+# tests/zot-cache-retention-render.sh. This test only guards the catalog one.
 python3 - "$TMPDIR_RENDER/shipped-defaults.yaml" <<'PY'
 import json, sys
 
@@ -212,16 +218,25 @@ for line in rendered[start:]:
 config = json.loads("\n".join(lines))
 
 policies = config["storage"]["retention"]["policies"]
-assert len(policies) == 1, f"expected exactly one policy, got {len(policies)}"
-assert policies[0]["repositories"] == ["djinn-image-*"], (
-    "retention repositories glob must stay exactly ['djinn-image-*']; widening it "
-    f"would put buildkitd cache repos in scope, got {policies[0]['repositories']}"
+catalog = [p for p in policies if p["repositories"] == ["djinn-image-*"]]
+assert len(catalog) == 1, (
+    f"expected exactly one ['djinn-image-*'] policy, got {len(catalog)} of {policies}"
 )
-assert policies[0]["deleteUntagged"] is True, "shipped default must delete untagged manifests"
+assert policies[0] is catalog[0], (
+    "the catalog policy must stay first; Zot applies the first matching policy "
+    f"per repo, got {policies[0]['repositories']} first"
+)
+assert catalog[0]["deleteUntagged"] is True, "shipped default must delete untagged manifests"
+# No OTHER policy may claim a glob that could also match a catalog repo.
+for other in policies[1:]:
+    for glob in other["repositories"]:
+        assert not glob.startswith("djinn-image"), (
+            f"a non-catalog policy widened into catalog scope: {glob}"
+        )
 assert config["storage"]["retention"]["dryRun"] is True, (
     "shipped default must be dry-run: destructive deletion is an explicit operator opt-in"
 )
-print("PASS: shipped defaults render a report-only policy scoped to djinn-image-* only")
+print("PASS: shipped defaults render a report-only catalog policy scoped to djinn-image-* only")
 PY
 
 echo ""

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -340,6 +340,36 @@ monitoring:
 # RWX is required for the mirrors PVC on multi-node clusters — the controller
 # writes mirror clones and task-run Job Pods read from them. The cache PVC is
 # similarly RWX so cargo/pnpm/pip caches survive across task runs.
+#
+# -----------------------------------------------------------------------------
+# `size:` IS A REQUEST, NOT A QUOTA. READ THIS BEFORE RAISING ONE.
+# -----------------------------------------------------------------------------
+# Every `size:` below lands in `spec.resources.requests.storage` on a PVC. What
+# that means depends entirely on the provisioner:
+#
+#   local-path (k3s / kind — the default on the VPS): the provisioner mkdirs a
+#     directory on the node filesystem and hands it over. It applies no quota of
+#     any kind. The number is ADVISORY. Measured on the production VPS:
+#     `djinn-zot` and `djinn-cache` are declared 40Gi and each holds 83G. No
+#     layer complains, because no layer is checking.
+#   CSI block volumes (EBS, PD, Ceph RBD, Longhorn, TopoLVM …): the number IS
+#     enforced — the filesystem is exactly that big and writes past it get
+#     ENOSPC. Undersizing here is a hard outage, not a warning.
+#
+# So a number in this file is either meaningless or dangerous, never a
+# backstop. Two consequences the chart deliberately accepts:
+#
+#  1. These defaults are NOT raised to match observed production usage. On a
+#     non-expandable StorageClass (local-path is non-expandable) `helm upgrade`
+#     with a larger request is REJECTED by the API server, wedging the release.
+#     Growing a number that enforces nothing is not worth breaking upgrades for.
+#  2. The real bound is on the PRODUCERS, not the volumes: Zot tag/cache
+#     retention (`imagePipeline.zot.retention`), `cacheCleanup.mode`,
+#     `graphRetention`, and node-level kubelet image GC + eviction thresholds.
+#     Those are the things that actually stop growth. See
+#     `docs/deploy/vps.md` for the operator-side quota and alerting options,
+#     including why the chart does not ship a PVC-fullness alert it cannot
+#     actually make fire.
 storage:
   # ---------------------------------------------------------------------------
   # Volume ownership contract (task pwrr / goxi)
@@ -759,10 +789,25 @@ imagePipeline:
     # pipeline — avoids wiring pull-secrets onto every Job Pod Spec.
     # Leave false in environments where image confidentiality matters.
     anonymousPull: false
-    # Catalog image tag retention policy. When enabled, Zot prunes old tags
-    # from djinn-image-* catalog repositories on a schedule, keeping only the
-    # newest N tags per repo. BuildKit cache repos (djinn-buildkitd-*) and any
-    # other non-catalog repos are never touched.
+    # Zot retention policies. Two repo families grow without bound and each
+    # needs a DIFFERENT policy shape, because they grow differently:
+    #
+    #   djinn-image-*  Shared catalog image repos. Every content hash pushes a
+    #                  NEW TAG and nothing removes the old ones. Growth vector
+    #                  = tag count → newest-N tag retention (`newestTags`).
+    #   cache/*        BuildKit registry cache repos. `build_job.rs` exports
+    #                  `--export-cache type=registry,ref=<reg>/cache/<subject>,
+    #                  mode=max`, which rewrites the SAME `:latest` ref on every
+    #                  build. Tag count is pinned at one, so newest-N does
+    #                  nothing here. Growth vector = the SUPERSEDED MANIFEST
+    #                  each export leaves behind, untagged but still indexed and
+    #                  therefore still pinning its blobs → `deleteUntagged`
+    #                  (see `retention.cache` below).
+    #
+    # Neither family is bounded by `gc: true` alone. Live blob GC only reclaims
+    # blobs no manifest references, and untagged-but-indexed manifests still
+    # reference theirs — measured on the production VPS as 0.0 GiB reclaimed
+    # while the store kept growing.
     #
     # Safety model:
     # - `retention.enabled` controls whether the policy is rendered into
@@ -786,11 +831,56 @@ imagePipeline:
     # by retained tag or digest pin BEFORE destructive deletion can proceed.
     # If the preflight finds an unsafe image, it blocks and reports —
     # destructive retention never silently removes a selected image.
+    #
+    # NOTE: that preflight covers `djinn-image-*` ONLY. It reads the DB's
+    # selected-catalog-image set; it knows nothing about `cache/*`, and it
+    # needs nothing, because no database row and no kubelet pull ever
+    # references a cache repo — the only reader is buildctl's `--import-cache`.
     retention:
       enabled: true
       dryRun: true
       deleteUntagged: true
       newestTags: 5
+      # BuildKit registry cache retention (`cache/*`). Default ON, and — like
+      # the catalog policy — governed by the SHARED `dryRun` flag above, so it
+      # ships report-only and deletes nothing until an operator opts in once
+      # for both. Zot's `dryRun` is a single retention-block-level switch; it
+      # cannot be set per policy. Set `cache.enabled: false` to roll the
+      # catalog policy destructive while leaving cache repos untouched.
+      #
+      # The rendered policy is `deleteUntagged: true` plus a catch-all
+      # `keepTags` rule, i.e. "retain every tag, collect superseded
+      # manifests". It targets the actual growth vector and it cannot touch
+      # the live `:latest` cache ref.
+      #
+      # Worst case is a cache MISS, never a failed build:
+      #  * The live ref is never a candidate (catch-all keepTags), so the
+      #    common path is untouched.
+      #  * A superseded manifest becomes a candidate only after the
+      #    retention `delay` (1h) and its blobs only vanish after `gcDelay`
+      #    (1h) on the next `gcInterval` (24h) sweep. A build resolves and
+      #    fetches its cache in seconds.
+      #  * Even a total miss is a proven-safe state: the FIRST build of every
+      #    project already imports a cache ref that does not exist yet, and
+      #    those builds succeed. buildctl treats an unresolvable
+      #    `--import-cache` as "no cache", not as an error.
+      #
+      # Byte reclamation is deliberately not promised. `storage.dedupe: true`
+      # means a `mode=max` cache blob and an identical `djinn-image-*` layer
+      # blob are the same stored object; deleting a cache manifest frees
+      # nothing for blobs a live catalog manifest still references, and vice
+      # versa. The two policies are complementary — pruning only one side
+      # leaves shared blobs alive through the other side's references.
+      cache:
+        enabled: true
+    # ---------------------------------------------------------------------
+    # Declared PVC size is a REQUEST, not a quota. See the top-level
+    # `storage:` block's preamble for the full explanation.
+    # ---------------------------------------------------------------------
+    # On the k3s/kind `local-path` provisioner this number is advisory only —
+    # nothing enforces it, and a Zot PVC declared 40Gi will happily hold 83G.
+    # The bound that actually holds is the retention policy above, not this
+    # field. Do not treat a larger number here as a fix.
     storage:
       size: 100Gi
       storageClassName: ""   # "" → cluster default

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -116,6 +116,66 @@ k3s crictl images | wc -l
 If `/etc/rancher/k3s/config.yaml` already exists, merge the `kubelet-arg` key
 into it rather than overwriting the file.
 
+### PVC sizes are requests, not quotas
+
+Read this before you "fix" a full volume by raising a number.
+
+Measured on this production VPS: the `djinn-zot` and `djinn-cache` PVCs are each
+declared **40Gi** and each holds **83G**. Nothing errored, nothing alerted,
+nothing was evicted. That is not a bug in the chart's numbers — it is what
+`spec.resources.requests.storage` *means* under the k3s `local-path`
+provisioner, which mkdirs a directory on the node filesystem and applies no
+quota of any kind. The declared capacity is advisory. There is no backstop at
+any layer below it.
+
+(Both 40Gi values are install-time overrides. The chart's own defaults are
+100Gi for `imagePipeline.zot.storage.size` and 20Gi for `storage.cache.size`.
+Raising them would not have changed anything here — see below.)
+
+**Why the chart does not simply ship bigger numbers.** On `local-path` a bigger
+number enforces nothing, so it buys nothing. On a StorageClass that *does*
+enforce (EBS, PD, Ceph RBD, Longhorn, TopoLVM) a bigger number is also a
+one-way door: `local-path` sets `allowVolumeExpansion: false`, and raising a
+PVC request against a non-expandable StorageClass is **rejected by the API
+server**, which wedges `helm upgrade` for every existing install. Growing a
+number that means nothing is not worth breaking upgrades for.
+
+There are exactly three things that actually bound this node, in order of how
+much they matter:
+
+1. **Bound the producers.** This is the real fix and it is where the chart's
+   defaults do the work: `imagePipeline.zot.retention` (catalog *and* BuildKit
+   cache repos), `cacheCleanup.mode`, `graphRetention`, and the kubelet image
+   GC configured in the previous section. A volume with no producer bound will
+   fill any number you give it; a volume with bounded producers does not need
+   one.
+2. **Use a StorageClass that can enforce, if you need enforcement.** `local-path`
+   cannot. XFS project quotas on the backing filesystem, or a real CSI driver
+   (TopoLVM, Longhorn), can. This is a node/infrastructure decision, not a chart
+   value — the chart honours `storageClassName` and takes no position beyond
+   that. Expect to size deliberately at that point, because on those drivers
+   `size:` becomes a hard ENOSPC boundary rather than a suggestion.
+3. **Watch the node filesystem, not the PVCs.** Under `local-path` every PVC on
+   this box shares one filesystem, so per-PVC accounting is a fiction anyway and
+   node-level free space is the only real signal:
+
+   ```bash
+   df -h /var/lib/rancher/k3s/storage
+   du -sh /var/lib/rancher/k3s/storage/* | sort -h | tail
+   ```
+
+**On alerting.** The chart bundles Prometheus + Alertmanager
+(`monitoring.enabled`, default off), and it deliberately does **not** ship a
+"PVC is N% full" rule. The metrics that would carry that signal
+(`kubelet_volume_stats_*`) come from the kubelet, and the bundled Prometheus
+scrapes only `djinn-server` and `djinn-log-rotator` — it runs with
+`automountServiceAccountToken: false` and has no RBAC for `nodes/metrics`. A
+rule written against those metrics today would be permanently inert: an alert
+that never fires, which is worse than no alert because it reads like coverage.
+If you want that alert, add the kubelet scrape job, ServiceAccount and
+ClusterRole first, then the rule — and verify the target is `up` before
+believing it.
+
 Install Helm if the box doesn't have it:
 
 ```bash

--- a/server/crates/djinn-image-controller/src/retention.rs
+++ b/server/crates/djinn-image-controller/src/retention.rs
@@ -8,9 +8,14 @@
 //!
 //! ## Retention model
 //!
-//! * Only `djinn-image-*` catalog repositories are eligible for retention.
-//!   BuildKit cache repos (`djinn-buildkitd-*`) and any other repo are never
-//!   touched.
+//! * Only `djinn-image-*` catalog repositories are eligible for this planner.
+//!   Every other repo is invisible to it — notably the BuildKit registry cache
+//!   repos, which live under `cache/*` (`--export-cache
+//!   type=registry,ref=<registry>/cache/<subject>` in [`crate::build_job`]).
+//!   Those are bounded separately by the Zot-side `cache/*` retention policy
+//!   the Helm chart renders, and need no planner coverage here: nothing in the
+//!   database and no kubelet pull ever references a cache repo, so there is no
+//!   selected-image safety property to prove for them.
 //! * Within each eligible repo, the **newest-N** tags by push timestamp are
 //!   retained; the rest are deletion candidates.
 //! * Every selected catalog image must remain pullable after retention. A
@@ -494,10 +499,11 @@ mod tests {
     #[test]
     fn non_catalog_repos_are_ignored() {
         let repos = vec![
-            repo(
-                "djinn-buildkitd-foo",
-                vec![tag("a", "sha256:1", 100, "2024-01-01")],
-            ),
+            // The real BuildKit registry cache repo shape. The old fixture
+            // said `djinn-buildkitd-foo`, a repo name this system has never
+            // produced, so it proved nothing about the repo that actually
+            // has to stay out of scope.
+            repo("cache/foo", vec![tag("a", "sha256:1", 100, "2024-01-01")]),
             repo("random-repo", vec![tag("b", "sha256:2", 200, "2024-01-01")]),
         ];
         let plan = plan_retention(&repos, &[], &RetentionPolicy { newest_tags: 1 });


### PR DESCRIPTION
**Stacked on #2683** (`fix/disk-retention-zot-default-kubelet-image-gc`). Base is that branch, not `main` — we touch the same three files. Merge #2683 first; this diff is only the delta on top.

Nothing from #2683 is unpicked. `DJINN_ZOT_RETENTION_ENABLED` still renders from the *effective* value (intent ANDed with `imagePipeline.enabled` and `imagePipeline.zot.enabled`), and Test 7 of the new suite is a dedicated regression guard for exactly that: it asserts the external-registry topology still renders `false`, because `run_zot_retention_preflight` is fail-closed and its caller `process::exit(1)`s on a Zot fetch error. The existing `{{ fail }}` guard does not catch that case and is not asked to.

---

## Problem 1 — `cache/*` had no bound of any kind

`build_job.rs:288` exports build cache with `--export-cache type=registry,ref={registry}/cache/{subject},mode=max`, so every project's BuildKit cache is a `cache/<subject>` repo inside the same Zot and the same PVC. #2683's policy is scoped `["djinn-image-*"]`, which is the correct scope — and it meant `cache/*` had no retention, no TTL, and no eviction.

### The growth vector is not tag count

`mode=max` rewrites the **same `:latest` ref** on every build. A cache repo therefore has exactly one tag, forever, and newest-N tag retention is a no-op against it. What accumulates is the **superseded manifest**: each export leaves the previous cache manifest in the repo's index, untagged but still indexed, still referencing its blobs.

Because those blobs are still *reachable*, live blob GC has nothing to collect. That is precisely why `gc: true` / `gcDelay: 1h` / `gcInterval: 24h` measured **0.0 GiB** of unreachable garbage while the store kept growing. `gc` is the collector and it works; nothing was producing garbage for it. `deleteUntagged` is that missing operator.

### What ships

A second policy, default on, under `imagePipeline.zot.retention.cache.enabled`:

```json
{
  "repositories": ["cache/*"],
  "deleteUntagged": true,
  "keepTags": [{ "patterns": [".*"] }]
}
```

`keepTags: [{patterns: [".*"]}]` is load-bearing, not decorative. It retains every tag unconditionally, which makes the live `:latest` ref **structurally** ineligible for deletion — only already-superseded manifests are ever candidates. It also makes the policy well-defined regardless of how Zot treats a policy with an empty `keepTags` list, which I did not want to depend on.

Following #2683's dry-run-first pattern, it ships non-destructive. Zot's `dryRun` is a single retention-block-level switch and cannot be set per policy, so the cache policy inherits the same report-only default and goes destructive on the same single operator action. `cache.enabled: false` is the escape hatch for rolling the catalog policy destructive while leaving cache repos alone.

### Mid-flight safety: worst case is a cache miss, never a failed build

Confirmed, three independent ways:

1. **The live ref is never a candidate.** The catch-all `keepTags` rule removes it from the candidate set entirely. The common path is untouched by construction, not by timing.
2. **The timing window is not close.** A superseded manifest becomes a candidate only after the retention `delay` (`1h`); its blobs are only reclaimed after `gcDelay` (`1h`) on the next `gcInterval` (`24h`) sweep. A build resolves and fetches its cache in seconds.
3. **A total miss is an already-proven-safe state.** The **first** build of every project imports a `cache/<subject>` ref that does not exist yet, and those builds succeed in production today. `buildctl` treats an unresolvable `--import-cache` as "no cache available", not as an error. A pruned ref is indistinguishable from a never-created one on that code path.

### Dedupe interaction — no byte figure is promised

`storage.dedupe: true` stores one copy per blob digest and shares it across repos, and `mode=max` cache blobs and `djinn-image-*` layer blobs frequently *are* the same object. So:

- Deleting a cache manifest frees **zero** bytes for every blob a live catalog manifest still references — and symmetrically, catalog pruning frees zero bytes for blobs a cache manifest still holds.
- The reclaimable set is bounded above by the size of the **cache-only** blobs, not by the nominal size of the deleted manifests.
- The two policies are **complementary, not additive**. Pruning one side leaves shared blobs alive through the other side's references. This also means #2683's "~78.5 GiB" is an upper bound for the same reason — the two policies landing together is what makes either estimate reachable.

I have deliberately not put a number on this PR. Read it off the dry-run.

### Preflight coverage

`retention_preflight.rs` covers `djinn-image-*` only, and needs nothing for `cache/*`: no database row and no kubelet pull ever references a cache repo. Its only reader is `buildctl --import-cache`, whose failure mode is the cache miss above. The cache policy's dry-run report comes from Zot's own logs, not the server preflight — called out explicitly in `values.yaml` and the chart README so nobody goes looking for it there.

---

## Problem 2 — PVC declared sizes are fiction

**The framing in the task was slightly off and I verified it before writing anything.** The chart's cache default is `storage.cache.size: 20Gi` (values.yaml:386), not 50Gi — 50Gi at line 380 is `storage.mirrors.size`. The Zot default of 100Gi is correct. So production's 40Gi is an install-time override that is *larger* than the chart default for cache and *smaller* for Zot, and there is no `40Gi` anywhere in this repo. It is a deploy-time value, as suspected, just not for the reason given.

### The honest conclusion: the chart cannot enforce this, and a bigger number is not a fix

I did not invent enforcement. Evaluating the options:

| Option | Verdict |
|---|---|
| Raise the declared sizes | **Rejected.** On `local-path` a bigger number enforces nothing. Worse, `local-path` sets `allowVolumeExpansion: false`, and raising a PVC request against a non-expandable StorageClass is *rejected by the API server* — it would wedge `helm upgrade` for every existing install at the default. Breaking upgrades to change a number that means nothing is a bad trade. |
| Quota-capable StorageClass (XFS project quotas, TopoLVM, Longhorn) | **Real enforcement, but not a chart value.** It is a node/infrastructure decision. The chart already honours `storageClassName` and takes no further position. Documented as the option that actually works, with the warning that `size:` becomes a hard ENOSPC boundary once you go there. |
| A Prometheus PVC-fullness alert | **Rejected, and this is the important one.** The chart bundles Prometheus + Alertmanager, but it scrapes only `djinn-server` and `djinn-log-rotator`, runs with `automountServiceAccountToken: false`, and has no RBAC for `nodes/metrics`. A rule written against `kubelet_volume_stats_*` today would be **permanently inert** — an alert that never fires, which is worse than no alert because it reads like coverage. Shipping it would have been exactly the failure mode the task warned about, one layer up. |
| Bound the producers | **This is the actual fix**, and it is what this PR and #2683 do. |

So: documentation plus honest defaults, stated plainly. `values.yaml` gets a `size: IS A REQUEST, NOT A QUOTA` preamble on the `storage:` block explaining what the number means per provisioner, why it is not being raised, and where the real bound lives. `docs/deploy/vps.md` gets an operator-facing section with the measured reality (40Gi declared / 83G held, nothing errored or alerted), the three things that actually bound the node, the `df`/`du` commands for the only signal that is real under `local-path` (all PVCs share one filesystem, so per-PVC accounting is a fiction anyway), and an explicit note on what it would take to make a PVC alert real — add the kubelet scrape job, ServiceAccount and ClusterRole *first*, then the rule, then verify the target is `up` before believing it.

Test 8 in the new suite pins the declared sizes as a golden so the numbers and the prose cannot drift apart silently.

---

## Also fixed: stale `djinn-buildkitd-*` naming

The doc comment at `retention.rs:12`, the chart README, and the `zot-retention-render.sh` comment all called the cache repos `djinn-buildkitd-*`. That repo name has never existed — the real path is `cache/*`. The unit-test fixture at `retention.rs:498` used it too, so `non_catalog_repos_are_ignored` was asserting against a repo shape this system does not produce. It now uses `cache/foo`, which is the repo that actually has to stay out of the catalog planner's scope.

---

## Finding: a **third** unbounded repo family, deliberately not fixed here

`controller.rs:609` / `format_image_tag` pushes per-project devcontainer images to **`djinn-project-<id>`**, one new tag per content hash, exactly like the catalog repos. Neither #2683's policy nor this one matches that glob, and the build path is live (`watcher.rs:556`).

I did **not** add a policy for it, on purpose. `retention_preflight.rs` proves its safety property from `list_selected_catalog_images` — the *catalog* keep-set. It has no equivalent for project images, whose pinned digest lives in `images.registry_digest`. Pruning `djinn-project-*` tags with no preflight coverage would risk deleting the manifest a project's pinned digest resolves to, and unlike the cache case the failure mode there is a **failed kubelet pull**, not a slow build. That needs preflight coverage first, and preflight coverage is Rust — out of scope for this PR.

Test 3 of the new suite asserts the current state explicitly (`djinn-project-*` matches *neither* glob) so it cannot drift in unnoticed while it waits for a proper fix.

---

## Testing

New: `deploy/helm/djinn/tests/zot-cache-retention-render.sh`, 8 tests — cache policy present in shipped defaults with `deleteUntagged`; catch-all `keepTags` present *and* free of any narrowing qualifier (`pushedWithin`/`pulledWithin`/`newest`) that would re-add an expiry to the live ref; glob disjointness proved against the real repo names the controller emits, using `gobwas/glob` separator semantics (`*` does not cross `/`); `cache.enabled=false`; master-switch containment; destructive mode; the #2683 external-registry regression guard; and the PVC-size golden.

**Verified by neutralization**, not just by green:
- flipping the rendered `deleteUntagged` to `false` → Test 1 fails with the reason;
- adding `pushedWithin: 168h` to the catch-all `keepTags` → Test 2 fails with the reason.

Suite status (`for f in deploy/helm/djinn/tests/*.sh; do bash "$f"; done`):

| Test | Result |
|---|---|
| build-admission-topology | PASS |
| cache-cleanup-render | PASS |
| cgroup-writable-render | PASS |
| deadman-fixture | FAIL — pre-existing |
| graph-retention-render | PASS |
| incident-observability-contract | FAIL — pre-existing (no `vector` binary locally) |
| log-collector-contract | FAIL — pre-existing (no `vector` binary locally) |
| log-collector-delivery | FAIL — pre-existing (no `vector` binary locally) |
| malloc-conf-render | PASS |
| migration-lifecycle-render | FAIL — known-red, owned elsewhere |
| projects-pvc-configmap-render | FAIL — known-red, owned elsewhere |
| server-memory-limit-render | PASS |
| volume-ownership-render | PASS |
| wrapper-manifest-render | PASS |
| **zot-cache-retention-render** | **PASS (new)** |
| zot-retention-render | PASS |

Six red, not the two expected — all pre-existing on this branch and none caused by this diff. Three are environmental (`vector` is not installed locally). `deadman-fixture` fails on the fresh-install `migration.designatedOperatorSecret` guard, which is on `origin/main` already (`deployment-server.yaml:6`) and is the same root cause as `migration-lifecycle-render`. Per instructions I did not touch `migration-lifecycle-render.sh` or `projects-pvc-configmap-render.sh`; nothing here makes them worse.

`helm lint deploy/helm/djinn` and `helm lint deploy/helm/djinn --values deploy/helm/djinn/values.local.yaml`: both clean.
`cargo test -p djinn-image-controller --lib retention::`: 15/15 pass, including the renamed fixture.

`zot-retention-render.sh` needed one update: its `len(policies) == 1` assertion is now `exactly one ['djinn-image-*'] policy, and it must be first`, plus a new check that no other policy widens into catalog scope. Zot applies the first matching policy per repo, so ordering is a real property and is now asserted rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
