### PR TITLE
fix(graph): bound the SCIP indexer cache with a default TTL and size cap

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -427,6 +427,20 @@ spec:
               value: {{ .Values.resources.warm.limits.memory | quote }}
             - name: DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS
               value: {{ .Values.resources.warm.jobTimeoutSeconds | quote }}
+            # SCIP indexer cache retention. Tuning only — djinn-graph carries
+            # the same defaults, so a deployment that omits these still gets a
+            # bounded cache. The server forwards both onto every warm and
+            # task-run Pod it dispatches (djinn_k8s::job::common_cache_env_vars),
+            # because those Pods, not this one, are what write the cache.
+            #
+            # `int64` is load-bearing: Helm decodes YAML numbers as float64, so
+            # a bare `| quote` renders the 4 GiB default as "4.294967296e+09",
+            # which the consumer cannot parse and silently discards in favour
+            # of its own default.
+            - name: DJINN_SCIP_CACHE_MAX_BYTES
+              value: {{ .Values.scipCache.maxBytes | int64 | quote }}
+            - name: DJINN_SCIP_CACHE_MAX_IDLE_HOURS
+              value: {{ .Values.scipCache.maxIdleHours | quote }}
             # Per-invocation CPU lease. `required` renders the cgroup-launcher
             # sidecar onto every task-run Pod; `disabled` is an explicit local
             # development compatibility profile that renders no launcher surface.

--- a/deploy/helm/djinn/tests/scip-cache-retention-render.sh
+++ b/deploy/helm/djinn/tests/scip-cache-retention-render.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Exact Helm render contract for the SCIP indexer cache retention bound.
+# Usage: bash deploy/helm/djinn/tests/scip-cache-retention-render.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "FAIL: required test tool '$1' is not installed" >&2
+        exit 1
+    }
+}
+
+require_tool helm
+require_tool python3
+TMPDIR_RENDER=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_RENDER"' EXIT
+
+render() {
+    local output=$1
+    shift
+    helm template scip-cache-retention-test "$CHART_DIR" \
+        --is-upgrade \
+        --show-only templates/deployment-server.yaml "$@" > "$output"
+}
+
+assert_env() {
+    local manifest=$1 expected_bytes=$2 expected_idle_hours=$3
+    python3 - "$manifest" "$expected_bytes" "$expected_idle_hours" <<'PY'
+import re
+import sys
+
+manifest, expected_bytes, expected_idle_hours = sys.argv[1:]
+lines = open(manifest, encoding="utf-8").read().splitlines()
+
+
+def env_value(name):
+    """Value of the `- name: <name>` / `value: <v>` pair, as rendered."""
+    for index, line in enumerate(lines):
+        if re.match(rf"^\s*- name: {re.escape(name)}$", line):
+            match = re.match(r"^\s*value: (.+)$", lines[index + 1])
+            assert match, f"{name} has no rendered value"
+            value = match.group(1)
+            assert value.startswith('"') and value.endswith('"'), (
+                f"{name} must render as a quoted literal, got {value!r}"
+            )
+            return value.strip('"')
+    raise AssertionError(f"{name} is not rendered onto the server Deployment")
+
+
+for name, expected in (
+    ("DJINN_SCIP_CACHE_MAX_BYTES", expected_bytes),
+    ("DJINN_SCIP_CACHE_MAX_IDLE_HOURS", expected_idle_hours),
+):
+    actual = env_value(name)
+    assert actual == expected, f"{name}: expected {expected!r}, got {actual!r}"
+    # Helm decodes YAML numbers as float64. A bare `| quote` renders the 4 GiB
+    # default as "4.294967296e+09", which djinn-graph cannot parse and silently
+    # drops in favour of its own default — a knob that reads as wired but is
+    # not. Pin the decimal-integer form, not merely the numeric equality.
+    assert re.fullmatch(r"[0-9]+", actual), (
+        f"{name} must render as a decimal integer, got {actual!r}"
+    )
+PY
+}
+
+expect_rejected() {
+    local name=$1
+    shift
+    echo "=== invalid $name ==="
+    if render "$TMPDIR_RENDER/$name.yaml" "$@" 2>&1; then
+        echo "FAIL: invalid scipCache scenario '$name' rendered successfully" >&2
+        exit 1
+    fi
+}
+
+echo "=== shipped defaults are a finite bound ==="
+render "$TMPDIR_RENDER/defaults.yaml"
+assert_env "$TMPDIR_RENDER/defaults.yaml" 4294967296 168
+
+echo "=== operator tuning ==="
+render "$TMPDIR_RENDER/tuned.yaml" \
+    --set scipCache.maxBytes=1073741824 \
+    --set scipCache.maxIdleHours=48
+assert_env "$TMPDIR_RENDER/tuned.yaml" 1073741824 48
+
+echo "=== explicit opt-out of a single leg ==="
+render "$TMPDIR_RENDER/uncapped.yaml" --set scipCache.maxBytes=0
+assert_env "$TMPDIR_RENDER/uncapped.yaml" 0 168
+
+expect_rejected negative-bytes --set scipCache.maxBytes=-1
+expect_rejected negative-idle --set scipCache.maxIdleHours=-1
+expect_rejected noninteger-bytes --set-string scipCache.maxBytes=lots
+expect_rejected unknown-key --set scipCache.maxGigabytes=4
+
+echo "=== All SCIP cache retention Helm render tests passed ==="

--- a/deploy/helm/djinn/values.schema.json
+++ b/deploy/helm/djinn/values.schema.json
@@ -20,6 +20,15 @@
         "historyN": { "type": "integer", "minimum": 1, "maximum": 64 }
       }
     },
+    "scipCache": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["maxBytes", "maxIdleHours"],
+      "properties": {
+        "maxBytes": { "type": "integer", "minimum": 0 },
+        "maxIdleHours": { "type": "integer", "minimum": 0 }
+      }
+    },
     "buildAdmission": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -37,6 +37,36 @@ graphRetention:
   historyN: 3
 
 # -----------------------------------------------------------------------------
+# SCIP indexer cache retention
+# -----------------------------------------------------------------------------
+# Bounds the content-addressed SCIP index cache on the shared `/cache` PVC
+# (`$XDG_CACHE_HOME/djinn/scip-indexer`). Every warm mints a new entry for each
+# workspace whose sources changed, and nothing used to remove one: the tree on
+# the production cluster reached 4.5 GiB across 40 entries, of which 33 had
+# never been read back.
+#
+# These are TUNING ONLY. The binary carries the same two defaults, so a
+# deployment that never sets them — an older chart, a raw manifest, a local
+# `cargo run` — still gets a bounded cache. Removing this block does not
+# unbound anything.
+#
+# Eviction is least-recently-USED (newest of atime/mtime), so entries that keep
+# producing cache hits keep surviving; entries written once and never read back
+# are exactly what gets reclaimed. An entry another pod is publishing into or
+# has touched in the last 30 minutes is never a candidate.
+#
+# Set either value to 0 to disable that bound. Nothing else does.
+scipCache:
+  # Total-size ceiling for the cache tree, in bytes. Default 4 GiB ≈ 25 warm
+  # generations of the largest project measured on the cluster (~165 MiB per
+  # generation across all its workspaces), comfortably above the longest reuse
+  # distance observed there (26 h) and ~5% of the shared cache claim.
+  maxBytes: 4294967296
+  # Evict entries unused for longer than this. The size cap binds first on a
+  # busy project; this leg bounds a project warmed too rarely to ever hit it.
+  maxIdleHours: 168
+
+# -----------------------------------------------------------------------------
 # Build admission
 # -----------------------------------------------------------------------------
 # Admission controls the combined task-run and warm-build concurrency cap. The

--- a/server/crates/djinn-graph/src/scip_indexer/cache.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/cache.rs
@@ -12,9 +12,13 @@ use djinn_core::clock::{Clock, SystemClock};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use super::cache_gc;
 use super::{PlannedIndexerCommand, SupportedIndexer};
 
 const SCHEMA_VERSION: &str = "v1";
+/// Manifest file name. Single-sourced with [`cache_gc`], which identifies an
+/// entry directory by the presence of this file.
+const MANIFEST_FILE: &str = cache_gc::ENTRY_MANIFEST;
 const CACHE_DIR_ENV: &str = "DJINN_SCIP_CACHE_DIR";
 const DEFAULT_CACHE_SUFFIX: &str = "djinn/scip-indexer";
 
@@ -260,7 +264,7 @@ impl ScipCacheStore {
 
     pub(crate) fn load_bytes(&self, key: &ScipCacheKey) -> Result<Option<Vec<u8>>> {
         let entry = self.entry_dir(key);
-        let manifest_path = entry.join("manifest.json");
+        let manifest_path = entry.join(MANIFEST_FILE);
         let artifact_path = entry.join("artifact.scip");
         let manifest_bytes = match fs::read(&manifest_path) {
             Ok(bytes) => bytes,
@@ -297,7 +301,36 @@ impl ScipCacheStore {
             .with_context(|| format!("create SCIP cache entry dir {}", entry.display()))?;
 
         self.publish_artifact(key, &entry, bytes)?;
+        self.enforce_retention();
         Ok(())
+    }
+
+    /// Apply the retention bound to this store's root.
+    ///
+    /// Hung off the write path deliberately: a write is the only event that
+    /// grows the tree, it is the only moment every producer (warm Job,
+    /// task-run Pod, server process) is guaranteed to reach, and it needs no
+    /// scheduler of its own. The sweep is throttled and cross-process locked
+    /// inside [`cache_gc`], so a burst of stores costs one walk, and it is
+    /// best-effort: retention never fails a store or a warm.
+    fn enforce_retention(&self) {
+        let policy = cache_gc::RetentionPolicy::from_environment();
+        let Some(report) = cache_gc::maybe_enforce_retention(&self.root, &policy) else {
+            return;
+        };
+        if report.evicted() > 0 || report.reclaimed_staged > 0 {
+            tracing::info!(
+                root = %self.root.display(),
+                scanned = report.scanned,
+                evicted_idle = report.evicted_idle,
+                evicted_over_cap = report.evicted_over_cap,
+                reclaimed_bytes = report.reclaimed_bytes,
+                retained_bytes = report.retained_bytes,
+                skipped_in_flight = report.skipped_in_flight,
+                reclaimed_staged = report.reclaimed_staged,
+                "SCIP cache retention sweep evicted entries"
+            );
+        }
     }
 
     fn publish_artifact(&self, key: &ScipCacheKey, entry: &Path, bytes: &[u8]) -> Result<()> {
@@ -323,7 +356,7 @@ impl ScipCacheStore {
                         serde_json::to_vec_pretty(&manifest).context("serialize cache manifest")?;
 
                     atomic_write(entry, "artifact.scip", bytes)?;
-                    atomic_write(entry, "manifest.json", &manifest_bytes)?;
+                    atomic_write(entry, MANIFEST_FILE, &manifest_bytes)?;
                     return Ok(());
                 }
                 None => std::thread::sleep(Duration::from_millis(5)),
@@ -341,7 +374,7 @@ impl ScipCacheStore {
     }
 
     fn entry_is_valid(&self, key: &ScipCacheKey, entry: &Path) -> Result<bool> {
-        let manifest_path = entry.join("manifest.json");
+        let manifest_path = entry.join(MANIFEST_FILE);
         let artifact_path = entry.join("artifact.scip");
         let manifest_bytes = match fs::read(&manifest_path) {
             Ok(bytes) => bytes,
@@ -370,7 +403,7 @@ impl ScipCacheStore {
 
     fn try_lookup(&self, key: &ScipCacheKey, output_path: &Path) -> Result<bool> {
         let entry = self.entry_dir(key);
-        let manifest_path = entry.join("manifest.json");
+        let manifest_path = entry.join(MANIFEST_FILE);
         let artifact_path = entry.join("artifact.scip");
         let manifest_bytes = match fs::read(&manifest_path) {
             Ok(bytes) => bytes,
@@ -537,7 +570,7 @@ struct PublishLock {
 
 impl PublishLock {
     fn try_acquire(entry: &Path) -> Result<Option<Self>> {
-        let path = entry.join(".publish.lock");
+        let path = entry.join(cache_gc::PUBLISH_LOCK_DIR);
         match fs::create_dir(&path) {
             Ok(()) => Ok(Some(Self { path })),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(None),
@@ -930,7 +963,7 @@ mod tests {
             .expect("store artifact");
         let entry = store.entry_dir(&key);
 
-        fs::write(entry.join("manifest.json"), b"not json").expect("corrupt manifest");
+        fs::write(entry.join(MANIFEST_FILE), b"not json").expect("corrupt manifest");
         assert_eq!(store.lookup(&key, &output), CacheLookup::Miss);
 
         store
@@ -943,7 +976,7 @@ mod tests {
             artifact_len: 4,
         };
         fs::write(
-            entry.join("manifest.json"),
+            entry.join(MANIFEST_FILE),
             serde_json::to_vec(&manifest).expect("manifest json"),
         )
         .expect("write mismatch manifest");
@@ -969,7 +1002,7 @@ mod tests {
             artifact_len: 4,
         };
         fs::write(
-            entry.join("manifest.json"),
+            entry.join(MANIFEST_FILE),
             serde_json::to_vec(&manifest).expect("manifest json"),
         )
         .expect("write v2 manifest");

--- a/server/crates/djinn-graph/src/scip_indexer/cache_gc.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/cache_gc.rs
@@ -1,0 +1,852 @@
+//! Retention bound for the on-disk SCIP indexer cache.
+//!
+//! # Why this exists
+//!
+//! [`crate::scip_indexer::cache::ScipCacheStore`] is content-addressed and
+//! append-only: every distinct key mints a new entry directory and nothing
+//! ever removed one. On the production cluster that tree had grown to 4.5 GiB
+//! across 40 entries on the shared `/cache` PVC — the same claim that already
+//! causes recurring node DiskPressure — with no prune, no TTL, and no cap.
+//! Growth is proportional to warm frequency, so the tree is unbounded in time.
+//!
+//! # What "in use" means here
+//!
+//! Multiple warm Jobs and task-run Pods mount the same PVC concurrently, so a
+//! sweep runs against a tree other processes are actively reading and writing.
+//! Three independent layers keep an eviction from ever destroying live work:
+//!
+//! 1. **Publication lock.** A writer inside
+//!    [`crate::scip_indexer::cache::ScipCacheStore::store_bytes`] holds the
+//!    entry's [`PUBLISH_LOCK_DIR`] for the whole tmp-write-and-rename. An entry
+//!    carrying that directory is never a candidate.
+//! 2. **In-flight grace.** An entry whose newest access or modification time is
+//!    within `RetentionPolicy::in_flight_grace` is never a candidate, which
+//!    covers a reader that has opened the manifest but not yet the artifact,
+//!    and any writer whose lock this sweep raced past.
+//! 3. **Stage-then-delete.** An eviction `rename(2)`s the entry directory to a
+//!    sibling `.<name>.evicting.<nanos>.<pid>.tmp` before `remove_dir_all`.
+//!    The rename is atomic, so a concurrent lookup on that key sees either the
+//!    complete entry or `ENOENT` — never a directory whose manifest survived
+//!    its artifact. Both `ENOENT` shapes are already a plain cache miss on the
+//!    read path, and a POSIX unlink cannot pull bytes out from under a reader
+//!    that already has the file open. The `.tmp` suffix and pid qualifier match
+//!    the [`crate::warm_sentinel`] convention for partial state.
+//!
+//! Sweeps are serialised across processes by a directory-based lock, and
+//! throttled by a stamp file so a burst of stores does not rescan the tree
+//! once per store.
+//!
+//! # Ordering
+//!
+//! Eviction is least-recently-*used*, not least-recently-written: an entry's
+//! age is the newest of its files' `atime`/`mtime`, so an entry that keeps
+//! getting cache hits keeps getting younger and survives. On a `noatime` mount
+//! `atime` never advances and this degrades to least-recently-written, which
+//! is still a bound — just a less selective one.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use djinn_core::clock::{Clock, SystemClock};
+
+/// Marker file that identifies a directory as a cache entry. Single-sourced
+/// with the writer in [`crate::scip_indexer::cache`].
+pub(super) const ENTRY_MANIFEST: &str = "manifest.json";
+
+/// Directory a publishing writer creates inside an entry for the duration of
+/// its tmp-write-and-rename.
+pub(super) const PUBLISH_LOCK_DIR: &str = ".publish.lock";
+
+/// Cross-process mutex (a directory, so `mkdir` gives us the atomic test-and-set)
+/// serialising sweeps over one cache root.
+const SWEEP_LOCK_DIR: &str = ".retention.lock";
+
+/// Stamp file whose mtime throttles how often a sweep may run.
+const SWEEP_STAMP_FILE: &str = ".retention.stamp";
+
+/// A sweep lock older than this is assumed to belong to a crashed process and
+/// is reclaimed. Generous relative to a sweep, which is a directory walk.
+const SWEEP_LOCK_STALE_AFTER: Duration = Duration::from_secs(3600);
+
+/// Env override for the total-size ceiling, in bytes. `0` disables the size
+/// leg (an explicit operator opt-out); absent or unparseable keeps the default.
+pub(super) const MAX_BYTES_ENV: &str = "DJINN_SCIP_CACHE_MAX_BYTES";
+
+/// Env override for the idle window, in hours. `0` disables the idle leg.
+pub(super) const MAX_IDLE_HOURS_ENV: &str = "DJINN_SCIP_CACHE_MAX_IDLE_HOURS";
+
+/// Default ceiling on the total size of the cache tree: 4 GiB.
+///
+/// Sized from the production measurement rather than a round guess. One warm
+/// generation of the largest project on the cluster costs ~165 MiB across all
+/// its workspaces (a ~154 MiB Rust index plus a ~11 MiB TypeScript one), and
+/// warms land roughly hourly, so 4 GiB retains ~25 generations ≈ 25 h. Every
+/// reuse actually observed on that tree re-read an entry written 0.8–26 h
+/// earlier, so the cap sits above the real reuse distance and evicts only
+/// entries that were already dead. It is also ~5% of the 76 GiB the shared
+/// cache claim currently occupies, against the 4.5 GiB and climbing that an
+/// unbounded tree had reached.
+pub(super) const DEFAULT_MAX_TOTAL_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Default idle window: 7 days.
+///
+/// The size cap is the binding constraint for a busy project. This leg exists
+/// for the opposite case — a project warmed rarely, whose few entries would
+/// otherwise sit on the PVC forever. Measured against *last use*, so an entry
+/// that keeps hitting is never idle.
+pub(super) const DEFAULT_MAX_IDLE: Duration = Duration::from_secs(7 * 24 * 3600);
+
+/// Entries touched within this window are never evicted. Covers the widest
+/// plausible in-flight read or publish; a 154 MiB artifact reads in seconds.
+const DEFAULT_IN_FLIGHT_GRACE: Duration = Duration::from_secs(30 * 60);
+
+/// Minimum wall-clock gap between sweeps over one root.
+const DEFAULT_MIN_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Retention bounds applied to one cache root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RetentionPolicy {
+    /// Total-size ceiling in bytes. `None` disables the size leg.
+    pub max_total_bytes: Option<u64>,
+    /// Maximum time since last use. `None` disables the idle leg.
+    pub max_idle: Option<Duration>,
+    /// Entries touched more recently than this are never candidates.
+    pub in_flight_grace: Duration,
+    /// Minimum gap between sweeps over one root.
+    pub min_sweep_interval: Duration,
+}
+
+impl Default for RetentionPolicy {
+    fn default() -> Self {
+        Self {
+            max_total_bytes: Some(DEFAULT_MAX_TOTAL_BYTES),
+            max_idle: Some(DEFAULT_MAX_IDLE),
+            in_flight_grace: DEFAULT_IN_FLIGHT_GRACE,
+            min_sweep_interval: DEFAULT_MIN_SWEEP_INTERVAL,
+        }
+    }
+}
+
+impl RetentionPolicy {
+    /// Resolve the policy from the process environment.
+    ///
+    /// Both bounds are **on by default**: an absent, empty, or unparseable
+    /// override leaves the shipped default in place. Only an explicit `0`
+    /// disables a leg, and only the leg it names.
+    pub(super) fn from_environment() -> Self {
+        Self::from_env(|name| std::env::var(name).ok())
+    }
+
+    fn from_env(mut get_env: impl FnMut(&str) -> Option<String>) -> Self {
+        let default = Self::default();
+        let max_total_bytes = match parse_u64(get_env(MAX_BYTES_ENV)) {
+            Some(0) => None,
+            Some(bytes) => Some(bytes),
+            None => default.max_total_bytes,
+        };
+        let max_idle = match parse_u64(get_env(MAX_IDLE_HOURS_ENV)) {
+            Some(0) => None,
+            Some(hours) => Some(Duration::from_secs(hours.saturating_mul(3600))),
+            None => default.max_idle,
+        };
+        Self {
+            max_total_bytes,
+            max_idle,
+            ..default
+        }
+    }
+}
+
+fn parse_u64(value: Option<String>) -> Option<u64> {
+    value?.trim().parse::<u64>().ok()
+}
+
+/// What a sweep did. Every field is a counted side effect, not a label.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct SweepReport {
+    /// Entries considered.
+    pub scanned: usize,
+    /// Entries removed because they exceeded the idle window.
+    pub evicted_idle: usize,
+    /// Entries removed to bring the tree under the size ceiling.
+    pub evicted_over_cap: usize,
+    /// Total bytes reclaimed.
+    pub reclaimed_bytes: u64,
+    /// Bytes still on disk after the sweep.
+    pub retained_bytes: u64,
+    /// Candidates skipped because they were in flight (publish lock or grace).
+    pub skipped_in_flight: usize,
+    /// Staging directories left behind by a previously interrupted sweep.
+    pub reclaimed_staged: usize,
+}
+
+impl SweepReport {
+    pub(super) fn evicted(&self) -> usize {
+        self.evicted_idle + self.evicted_over_cap
+    }
+}
+
+/// Run a sweep if one is due and no other process is already sweeping.
+///
+/// Returns `None` when the sweep was throttled or the lock was held — both are
+/// ordinary outcomes, not errors. Never returns an error: retention is
+/// best-effort maintenance and must not fail a warm.
+pub(super) fn maybe_enforce_retention(
+    root: &Path,
+    policy: &RetentionPolicy,
+) -> Option<SweepReport> {
+    let now = SystemClock::new().now();
+    if !root.is_dir() {
+        return None;
+    }
+    if !sweep_is_due(root, policy, now) {
+        return None;
+    }
+    let _lock = SweepLock::try_acquire(root, now)?;
+    // Stamp before sweeping so a crash mid-sweep still throttles the retry.
+    write_stamp(root);
+    Some(enforce_retention(root, policy, now))
+}
+
+/// Apply the retention policy to `root` as of `now`.
+///
+/// Exposed separately from [`maybe_enforce_retention`] so tests drive the
+/// policy against an explicit clock instead of backdating files.
+pub(super) fn enforce_retention(
+    root: &Path,
+    policy: &RetentionPolicy,
+    now: SystemTime,
+) -> SweepReport {
+    let mut report = SweepReport::default();
+    let mut entries = Vec::new();
+    collect(root, &mut entries, &mut report);
+    report.scanned = entries.len();
+
+    // A candidate is an entry no one is publishing into and whose newest
+    // access is outside the in-flight grace window.
+    let (mut candidates, protected): (Vec<_>, Vec<_>) = entries
+        .into_iter()
+        .partition(|entry| entry.is_evictable(now, policy.in_flight_grace));
+    report.skipped_in_flight = protected.len();
+
+    let mut live_bytes: u64 = protected.iter().map(|entry| entry.bytes).sum();
+
+    // Least-recently-used first, so the survivors of a size trim are the
+    // entries a subsequent run is most likely to hit.
+    candidates.sort_by(|left, right| {
+        left.last_used
+            .cmp(&right.last_used)
+            .then_with(|| left.dir.cmp(&right.dir))
+    });
+
+    let mut retained: Vec<CacheEntry> = Vec::with_capacity(candidates.len());
+    for entry in candidates {
+        let idle_expired = policy.max_idle.is_some_and(|max_idle| {
+            now.duration_since(entry.last_used)
+                .is_ok_and(|idle| idle > max_idle)
+        });
+        if idle_expired && evict(&entry) {
+            report.evicted_idle += 1;
+            report.reclaimed_bytes += entry.bytes;
+            continue;
+        }
+        live_bytes += entry.bytes;
+        retained.push(entry);
+    }
+
+    if let Some(cap) = policy.max_total_bytes {
+        // `retained` is still in LRU order, so draining from the front trims
+        // the coldest entries first.
+        for entry in &retained {
+            if live_bytes <= cap {
+                break;
+            }
+            if evict(entry) {
+                report.evicted_over_cap += 1;
+                report.reclaimed_bytes += entry.bytes;
+                live_bytes = live_bytes.saturating_sub(entry.bytes);
+            }
+        }
+    }
+
+    report.retained_bytes = live_bytes;
+    report
+}
+
+/// One cache entry: a directory holding a manifest and its artifact.
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    dir: PathBuf,
+    bytes: u64,
+    /// Newest `atime`/`mtime` across the entry's files.
+    last_used: SystemTime,
+    /// A writer holds this entry's publication lock right now.
+    publishing: bool,
+}
+
+impl CacheEntry {
+    fn is_evictable(&self, now: SystemTime, grace: Duration) -> bool {
+        if self.publishing {
+            return false;
+        }
+        match now.duration_since(self.last_used) {
+            // Clock skew across pods can put an entry "in the future"; treat
+            // that as freshly touched rather than infinitely old.
+            Err(_) => false,
+            Ok(idle) => idle >= grace,
+        }
+    }
+}
+
+/// Walk `root`, appending every entry directory found and reclaiming staging
+/// directories abandoned by an interrupted sweep.
+///
+/// Directories whose name begins with `.` are never entries: that covers the
+/// publication lock, the sweep lock, and staged evictions.
+fn collect(dir: &Path, out: &mut Vec<CacheEntry>, report: &mut SweepReport) {
+    let Ok(read_dir) = fs::read_dir(dir) else {
+        return;
+    };
+    for child in read_dir.flatten() {
+        if !child.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let path = child.path();
+        let name = child.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') {
+            // Staged evictions only ever exist while the sweep lock is held,
+            // so any we can see here belong to a sweep that died.
+            if name.ends_with(".tmp") && fs::remove_dir_all(&path).is_ok() {
+                report.reclaimed_staged += 1;
+            }
+            continue;
+        }
+        if path.join(ENTRY_MANIFEST).is_file() {
+            if let Some(entry) = measure(&path) {
+                out.push(entry);
+            }
+        } else {
+            collect(&path, out, report);
+        }
+    }
+}
+
+fn measure(dir: &Path) -> Option<CacheEntry> {
+    let read_dir = fs::read_dir(dir).ok()?;
+    let mut bytes = 0u64;
+    let mut last_used = SystemTime::UNIX_EPOCH;
+    let mut publishing = false;
+    for child in read_dir.flatten() {
+        let Ok(kind) = child.file_type() else {
+            continue;
+        };
+        if kind.is_dir() {
+            if child.file_name() == PUBLISH_LOCK_DIR {
+                publishing = true;
+            }
+            continue;
+        }
+        let Ok(metadata) = child.metadata() else {
+            continue;
+        };
+        bytes = bytes.saturating_add(metadata.len());
+        for stamp in [metadata.modified().ok(), metadata.accessed().ok()]
+            .into_iter()
+            .flatten()
+        {
+            if stamp > last_used {
+                last_used = stamp;
+            }
+        }
+    }
+    Some(CacheEntry {
+        dir: dir.to_path_buf(),
+        bytes,
+        last_used,
+        publishing,
+    })
+}
+
+/// Remove one entry: rename it out of the keyspace, then delete the staged
+/// copy. Returns whether the entry is gone from its key path.
+fn evict(entry: &CacheEntry) -> bool {
+    let Some(parent) = entry.dir.parent() else {
+        return false;
+    };
+    let Some(name) = entry.dir.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let staged = parent.join(format!(
+        ".{name}.evicting.{}.{}.tmp",
+        unix_nanos(),
+        std::process::id()
+    ));
+    match fs::rename(&entry.dir, &staged) {
+        Ok(()) => {}
+        // Another sweep or a manual clean-up got there first: the key path is
+        // still gone, which is what the caller is asking about.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return true,
+        Err(error) => {
+            tracing::debug!(
+                error = %error,
+                entry = %entry.dir.display(),
+                "scip cache retention: could not stage entry for eviction"
+            );
+            return false;
+        }
+    }
+    if let Err(error) = fs::remove_dir_all(&staged) {
+        // The entry is already unreachable by key; the staged directory will
+        // be reclaimed by the next sweep's `collect`.
+        tracing::debug!(
+            error = %error,
+            staged = %staged.display(),
+            "scip cache retention: staged entry removal failed; will retry next sweep"
+        );
+    }
+    true
+}
+
+fn sweep_is_due(root: &Path, policy: &RetentionPolicy, now: SystemTime) -> bool {
+    let Ok(metadata) = fs::metadata(root.join(SWEEP_STAMP_FILE)) else {
+        return true;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return true;
+    };
+    now.duration_since(modified)
+        .is_ok_and(|since| since >= policy.min_sweep_interval)
+}
+
+fn write_stamp(root: &Path) {
+    let path = root.join(SWEEP_STAMP_FILE);
+    let temp = root.join(format!(
+        ".{SWEEP_STAMP_FILE}.{}.{}.tmp",
+        unix_nanos(),
+        std::process::id()
+    ));
+    if fs::write(&temp, b"").is_ok() && fs::rename(&temp, &path).is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+}
+
+/// Cross-process sweep mutex. `mkdir` is the atomic test-and-set; `Drop`
+/// releases it.
+struct SweepLock {
+    path: PathBuf,
+}
+
+impl SweepLock {
+    fn try_acquire(root: &Path, now: SystemTime) -> Option<Self> {
+        let path = root.join(SWEEP_LOCK_DIR);
+        match fs::create_dir(&path) {
+            Ok(()) => return Some(Self { path }),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(_) => return None,
+        }
+        // Reclaim a lock left behind by a process that died mid-sweep,
+        // otherwise retention would stop forever after one crash.
+        let stale = fs::metadata(&path)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_some_and(|held| held > SWEEP_LOCK_STALE_AFTER);
+        if !stale {
+            return None;
+        }
+        if fs::remove_dir(&path).is_err() {
+            return None;
+        }
+        fs::create_dir(&path).ok().map(|()| Self { path })
+    }
+}
+
+impl Drop for SweepLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
+    }
+}
+
+fn unix_nanos() -> u128 {
+    SystemClock::new()
+        .now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|since| since.as_nanos())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("djinn-scip-retention-")
+            .tempdir_in(".")
+            .expect("create tempdir")
+    }
+
+    /// Materialise an entry at the real store layout: `v1/<shard>/<key>/`.
+    fn write_entry(root: &Path, key: &str, artifact_bytes: usize) -> PathBuf {
+        let dir = root.join("v1").join(&key[..2]).join(key);
+        fs::create_dir_all(&dir).expect("create entry dir");
+        fs::write(dir.join(ENTRY_MANIFEST), format!("{{\"key\":\"{key}\"}}"))
+            .expect("write manifest");
+        fs::write(dir.join("artifact.scip"), vec![b'x'; artifact_bytes]).expect("write artifact");
+        dir
+    }
+
+    /// Set both atime and mtime on every file in an entry. Lets a test place
+    /// entries at exact points on the LRU axis without sleeping.
+    #[cfg(unix)]
+    fn set_entry_times(dir: &Path, seconds_since_epoch: i64) {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        for child in fs::read_dir(dir).expect("read entry").flatten() {
+            if !child.file_type().expect("file type").is_file() {
+                continue;
+            }
+            let path = CString::new(child.path().as_os_str().as_bytes()).expect("path bytes");
+            let times = [
+                libc::timespec {
+                    tv_sec: seconds_since_epoch,
+                    tv_nsec: 0,
+                },
+                libc::timespec {
+                    tv_sec: seconds_since_epoch,
+                    tv_nsec: 0,
+                },
+            ];
+            // SAFETY: `path` is a valid NUL-terminated path and `times` is a
+            // two-element timespec array, exactly what `utimensat` expects.
+            let rc = unsafe { libc::utimensat(libc::AT_FDCWD, path.as_ptr(), times.as_ptr(), 0) };
+            assert_eq!(rc, 0, "utimensat failed for {}", child.path().display());
+        }
+    }
+
+    fn at(seconds_since_epoch: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(seconds_since_epoch)
+    }
+
+    fn exists(dir: &Path) -> bool {
+        dir.join(ENTRY_MANIFEST).is_file()
+    }
+
+    // ------------------------------------------------------------------
+    // The load-bearing test: entries that must go are GONE from disk and
+    // entries that must stay are STILL THERE, with their bytes intact.
+    //
+    // Neutralisation check (documented in the PR): replacing the body of
+    // `evict` with `true` — i.e. reporting the eviction without performing
+    // it — turns the four `exists(...)` assertions below red, because they
+    // stat the key path rather than reading the returned counters.
+    // ------------------------------------------------------------------
+    #[cfg(unix)]
+    #[test]
+    fn sweep_deletes_expired_and_over_cap_entries_and_keeps_the_live_ones() {
+        let tmp = tempdir();
+        let root = tmp.path();
+
+        // Four entries, 1 KiB each, placed at distinct points on the LRU axis.
+        let ancient = write_entry(root, "aa11111111111111", 1024);
+        let cold = write_entry(root, "bb22222222222222", 1024);
+        let warm = write_entry(root, "cc33333333333333", 1024);
+        let hot = write_entry(root, "dd44444444444444", 1024);
+
+        const DAY: u64 = 24 * 3600;
+        set_entry_times(&ancient, (30 * DAY) as i64);
+        set_entry_times(&cold, (100 * DAY) as i64);
+        set_entry_times(&warm, (101 * DAY) as i64);
+        set_entry_times(&hot, (102 * DAY) as i64);
+
+        let entry_bytes = 1024
+            + fs::read(hot.join(ENTRY_MANIFEST))
+                .expect("read manifest")
+                .len() as u64;
+        let now = at(102 * DAY + 3600);
+        let policy = RetentionPolicy {
+            // `ancient` is 72 days idle; the rest are at most 2 days.
+            max_idle: Some(Duration::from_secs(7 * DAY)),
+            // Room for exactly two of the three entries that survive the idle
+            // leg, so the size leg must trim exactly one more.
+            max_total_bytes: Some(2 * entry_bytes),
+            in_flight_grace: Duration::from_secs(600),
+            min_sweep_interval: Duration::ZERO,
+        };
+
+        let report = enforce_retention(root, &policy, now);
+
+        // Side effects on disk, not the report's own arithmetic.
+        assert!(
+            !exists(&ancient),
+            "an entry {} days past the idle window must be gone from {}",
+            72,
+            ancient.display()
+        );
+        assert!(
+            !exists(&cold),
+            "the coldest survivor must be trimmed to satisfy the size cap: {}",
+            cold.display()
+        );
+        assert!(
+            exists(&warm),
+            "an entry inside both bounds must survive: {}",
+            warm.display()
+        );
+        assert!(
+            exists(&hot),
+            "the most recently used entry must survive: {}",
+            hot.display()
+        );
+        // Survivors keep their bytes — eviction must not truncate neighbours.
+        assert_eq!(
+            fs::read(warm.join("artifact.scip"))
+                .expect("read surviving artifact")
+                .len(),
+            1024
+        );
+        assert_eq!(
+            fs::read(hot.join("artifact.scip"))
+                .expect("read surviving artifact")
+                .len(),
+            1024
+        );
+
+        // And nothing is left staged in the keyspace.
+        let shard = root.join("v1").join("bb");
+        let leftovers = fs::read_dir(&shard)
+            .expect("read shard")
+            .flatten()
+            .filter(|child| child.file_name().to_string_lossy().ends_with(".tmp"))
+            .count();
+        assert_eq!(leftovers, 0, "no staged eviction may remain visible");
+
+        assert_eq!(report.scanned, 4);
+        assert_eq!(report.evicted_idle, 1);
+        assert_eq!(report.evicted_over_cap, 1);
+        assert_eq!(report.reclaimed_bytes, 2 * entry_bytes);
+        assert_eq!(report.retained_bytes, 2 * entry_bytes);
+    }
+
+    /// The size trim must be able to reach every unprotected entry, including
+    /// the newest one, when the cap is smaller than a single entry. Without
+    /// this the cap would be advisory for a cache whose entries are large.
+    #[cfg(unix)]
+    #[test]
+    fn size_cap_smaller_than_one_entry_empties_the_unprotected_tree() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        let first = write_entry(root, "aa11111111111111", 4096);
+        let second = write_entry(root, "bb22222222222222", 4096);
+        set_entry_times(&first, 1_000_000);
+        set_entry_times(&second, 1_000_100);
+
+        let report = enforce_retention(
+            root,
+            &RetentionPolicy {
+                max_idle: None,
+                max_total_bytes: Some(1),
+                in_flight_grace: Duration::from_secs(60),
+                min_sweep_interval: Duration::ZERO,
+            },
+            at(1_000_200),
+        );
+
+        assert!(!exists(&first), "{} must be gone", first.display());
+        assert!(!exists(&second), "{} must be gone", second.display());
+        assert_eq!(report.evicted_over_cap, 2);
+        assert_eq!(report.retained_bytes, 0);
+    }
+
+    /// Constraint: eviction must never remove an entry another process is
+    /// publishing into. The publication lock is the writer's own signal.
+    #[cfg(unix)]
+    #[test]
+    fn an_entry_being_published_survives_a_sweep_that_would_otherwise_evict_it() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        let entry = write_entry(root, "aa11111111111111", 4096);
+        set_entry_times(&entry, 1_000);
+        fs::create_dir(entry.join(PUBLISH_LOCK_DIR)).expect("hold publish lock");
+
+        let report = enforce_retention(
+            root,
+            &RetentionPolicy {
+                // Both legs would condemn this entry if the lock were ignored.
+                max_idle: Some(Duration::from_secs(1)),
+                max_total_bytes: Some(0),
+                in_flight_grace: Duration::from_secs(60),
+                min_sweep_interval: Duration::ZERO,
+            },
+            at(10_000_000),
+        );
+
+        assert!(
+            exists(&entry),
+            "a locked entry must survive: {}",
+            entry.display()
+        );
+        assert_eq!(report.evicted(), 0);
+        assert_eq!(report.skipped_in_flight, 1);
+    }
+
+    /// Constraint: an entry touched inside the grace window is assumed to be
+    /// mid-read by another pod and is never a candidate.
+    #[cfg(unix)]
+    #[test]
+    fn an_entry_touched_inside_the_grace_window_survives() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        let entry = write_entry(root, "aa11111111111111", 4096);
+        set_entry_times(&entry, 1_000_000);
+
+        let report = enforce_retention(
+            root,
+            &RetentionPolicy {
+                max_idle: Some(Duration::from_secs(1)),
+                max_total_bytes: Some(0),
+                in_flight_grace: Duration::from_secs(3600),
+                min_sweep_interval: Duration::ZERO,
+            },
+            // 10 minutes after its last use — inside the 1 h grace window.
+            at(1_000_600),
+        );
+
+        assert!(
+            exists(&entry),
+            "an entry touched 10 min ago must survive: {}",
+            entry.display()
+        );
+        assert_eq!(report.skipped_in_flight, 1);
+    }
+
+    /// A staging directory from a sweep that died between rename and delete
+    /// must be reclaimed, and must never be mistaken for a live entry.
+    #[test]
+    fn a_staged_eviction_left_by_a_crashed_sweep_is_reclaimed() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        let live = write_entry(root, "aa11111111111111", 16);
+        let staged = root.join("v1").join("bb").join(".bb2222.evicting.7.9.tmp");
+        fs::create_dir_all(&staged).expect("create staged dir");
+        fs::write(staged.join(ENTRY_MANIFEST), b"{}").expect("write staged manifest");
+
+        let report = enforce_retention(
+            root,
+            &RetentionPolicy {
+                max_idle: None,
+                max_total_bytes: None,
+                ..RetentionPolicy::default()
+            },
+            SystemClock::new().now(),
+        );
+
+        assert!(!staged.exists(), "{} must be reclaimed", staged.display());
+        assert_eq!(report.reclaimed_staged, 1);
+        assert_eq!(
+            report.scanned, 1,
+            "a staged directory must not be counted as a cache entry"
+        );
+        assert!(exists(&live));
+    }
+
+    /// Both bounds ship on. A deployment that sets nothing at all must still
+    /// get a finite cache.
+    #[test]
+    fn defaults_are_on_without_any_environment_configuration() {
+        let policy = RetentionPolicy::from_env(|_| None);
+        assert_eq!(policy.max_total_bytes, Some(DEFAULT_MAX_TOTAL_BYTES));
+        assert_eq!(policy.max_idle, Some(DEFAULT_MAX_IDLE));
+        assert!(policy.max_total_bytes.expect("cap") > 0);
+    }
+
+    #[test]
+    fn environment_overrides_each_leg_independently_and_zero_disables_it() {
+        let sized = RetentionPolicy::from_env(|name| match name {
+            MAX_BYTES_ENV => Some("123456".to_string()),
+            _ => None,
+        });
+        assert_eq!(sized.max_total_bytes, Some(123_456));
+        assert_eq!(sized.max_idle, Some(DEFAULT_MAX_IDLE));
+
+        let aged = RetentionPolicy::from_env(|name| match name {
+            MAX_IDLE_HOURS_ENV => Some("48".to_string()),
+            _ => None,
+        });
+        assert_eq!(aged.max_idle, Some(Duration::from_secs(48 * 3600)));
+        assert_eq!(aged.max_total_bytes, Some(DEFAULT_MAX_TOTAL_BYTES));
+
+        let uncapped = RetentionPolicy::from_env(|name| match name {
+            MAX_BYTES_ENV => Some("0".to_string()),
+            _ => None,
+        });
+        assert_eq!(uncapped.max_total_bytes, None);
+        assert_eq!(uncapped.max_idle, Some(DEFAULT_MAX_IDLE));
+
+        // Garbage must not silently disable a bound.
+        let garbage = RetentionPolicy::from_env(|name| match name {
+            MAX_BYTES_ENV => Some("not-a-number".to_string()),
+            MAX_IDLE_HOURS_ENV => Some(String::new()),
+            _ => None,
+        });
+        assert_eq!(garbage.max_total_bytes, Some(DEFAULT_MAX_TOTAL_BYTES));
+        assert_eq!(garbage.max_idle, Some(DEFAULT_MAX_IDLE));
+    }
+
+    /// The throttle must actually suppress the second sweep, and the lock must
+    /// actually exclude a second sweeper.
+    #[test]
+    fn sweeps_are_throttled_by_the_stamp_and_serialised_by_the_lock() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        write_entry(root, "aa11111111111111", 16);
+        let policy = RetentionPolicy {
+            min_sweep_interval: Duration::from_secs(3600),
+            ..RetentionPolicy::default()
+        };
+
+        assert!(maybe_enforce_retention(root, &policy).is_some());
+        assert!(
+            root.join(SWEEP_STAMP_FILE).is_file(),
+            "the first sweep must leave a stamp"
+        );
+        assert!(
+            maybe_enforce_retention(root, &policy).is_none(),
+            "a sweep inside the throttle window must not run"
+        );
+
+        // Held lock, throttle satisfied: still no second sweeper.
+        fs::remove_file(root.join(SWEEP_STAMP_FILE)).expect("clear stamp");
+        let held = SweepLock::try_acquire(root, SystemTime::UNIX_EPOCH).expect("acquire lock");
+        assert!(
+            maybe_enforce_retention(root, &policy).is_none(),
+            "a sweep must not run while another holds the lock"
+        );
+        drop(held);
+        assert!(maybe_enforce_retention(root, &policy).is_some());
+    }
+
+    /// A lock orphaned by a crashed process must not disable retention forever.
+    #[test]
+    fn a_stale_sweep_lock_is_reclaimed() {
+        let tmp = tempdir();
+        let root = tmp.path();
+        // Simulate a process that died holding the lock: the directory exists
+        // with no owner alive to drop it.
+        fs::create_dir(root.join(SWEEP_LOCK_DIR)).expect("orphan the lock");
+
+        assert!(
+            SweepLock::try_acquire(root, SystemClock::new().now()).is_none(),
+            "a fresh lock must not be stolen"
+        );
+        let far_future = SystemClock::new().now() + SWEEP_LOCK_STALE_AFTER * 2;
+        assert!(
+            SweepLock::try_acquire(root, far_future).is_some(),
+            "a lock held past the stale window must be reclaimed"
+        );
+    }
+}

--- a/server/crates/djinn-graph/src/scip_indexer/mod.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/mod.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 
 mod budget;
 pub(crate) mod cache;
+mod cache_gc;
 mod indexing;
 #[cfg(test)]
 mod warm_cost_regression;

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -895,7 +895,7 @@ fn common_cache_env_vars(project_id: &str, cpu_limit: &str) -> Vec<EnvVar> {
     // job count from the pod's declared CPU limit keeps the aggregate runnable
     // process count bounded by the node's real capacity.
     let jobs = cpu_limit_to_jobs(cpu_limit).to_string();
-    vec![
+    let mut env = vec![
         // Generic XDG cache root, rendered for the same reason CARGO_HOME,
         // SCCACHE_DIR, GOMODCACHE and PNPM_HOME are: `$HOME`-relative stores are
         // both unwritable and ephemeral in these pods (task 9jrg).
@@ -1007,7 +1007,42 @@ fn common_cache_env_vars(project_id: &str, cpu_limit: &str) -> Vec<EnvVar> {
         // per-pod value so test execution parallelism matches build
         // parallelism.
         env_var("NEXTEST_TEST_THREADS", &jobs),
-    ]
+    ];
+    // SCIP indexer cache retention (djinn-graph scip_indexer::cache_gc). The
+    // cache lives on the same /cache PVC these env vars route everything else
+    // onto, and the pods rendered here — not the server — are what write it, so
+    // the chart's tuning has to reach them. Forwarded rather than templated
+    // because it is optional: djinn-graph ships the same defaults, so a chart
+    // that sets nothing still yields a bounded cache and this simply renders
+    // nothing.
+    env.extend(forwarded_env_vars(SCIP_CACHE_FORWARDED_ENV, |name| {
+        std::env::var(name).ok()
+    }));
+    env
+}
+
+/// Env var names forwarded verbatim from the server process onto build pods.
+const SCIP_CACHE_FORWARDED_ENV: &[&str] = &[
+    "DJINN_SCIP_CACHE_MAX_BYTES",
+    "DJINN_SCIP_CACHE_MAX_IDLE_HOURS",
+];
+
+/// Forward the named variables from the server's own environment, skipping any
+/// that are unset or empty. An empty value must not be forwarded: the consumer
+/// treats an unparseable override as "keep the built-in default", and rendering
+/// an empty string would only add noise to every PodSpec.
+fn forwarded_env_vars(
+    names: &[&str],
+    mut get_env: impl FnMut(&str) -> Option<String>,
+) -> Vec<EnvVar> {
+    names
+        .iter()
+        .filter_map(|name| {
+            get_env(name)
+                .filter(|value| !value.trim().is_empty())
+                .map(|value| env_var(name, &value))
+        })
+        .collect()
 }
 
 /// Derive a cargo/nextest parallel-job count from a Kubernetes CPU limit
@@ -2256,6 +2291,40 @@ mod tests {
             warm_env.get("CARGO_BUILD_JOBS"),
             worker_env.get("CARGO_BUILD_JOBS"),
             "each pod type derives CARGO_BUILD_JOBS from its own limit (parity != identical value)"
+        );
+    }
+
+    /// The SCIP cache retention tuning is written by the pods this module
+    /// renders, not by the server, so the chart's values have to arrive as pod
+    /// env. Asserts the rendered `EnvVar`s, and that an unset or blank value
+    /// renders nothing at all rather than an empty override the consumer would
+    /// have to defend against.
+    #[test]
+    fn scip_cache_retention_tuning_is_forwarded_onto_build_pods() {
+        let forwarded = forwarded_env_vars(SCIP_CACHE_FORWARDED_ENV, |name| match name {
+            "DJINN_SCIP_CACHE_MAX_BYTES" => Some("4294967296".to_string()),
+            "DJINN_SCIP_CACHE_MAX_IDLE_HOURS" => Some("168".to_string()),
+            _ => None,
+        });
+        let rendered: BTreeMap<&str, &str> = forwarded
+            .iter()
+            .map(|e| (e.name.as_str(), e.value.as_deref().unwrap_or_default()))
+            .collect();
+        assert_eq!(
+            rendered.get("DJINN_SCIP_CACHE_MAX_BYTES").copied(),
+            Some("4294967296")
+        );
+        assert_eq!(
+            rendered.get("DJINN_SCIP_CACHE_MAX_IDLE_HOURS").copied(),
+            Some("168")
+        );
+
+        // Unset in the server: nothing is rendered, and djinn-graph's own
+        // defaults are what bound the cache.
+        assert!(forwarded_env_vars(SCIP_CACHE_FORWARDED_ENV, |_| None).is_empty());
+        // Blank is not an override.
+        assert!(
+            forwarded_env_vars(SCIP_CACHE_FORWARDED_ENV, |_| Some("  ".to_string())).is_empty()
         );
     }
 


### PR DESCRIPTION
## What this fixes

`$XDG_CACHE_HOME/djinn/scip-indexer` on the shared `/cache` PVC had **no prune, no eviction, and no TTL**. Every distinct cache key minted an entry directory and nothing ever removed one, so the tree grew without limit for as long as warms kept running.

Measured on the production node (`/var/lib/rancher/k3s/storage/pvc-…_djinn_djinn-cache/xdg/019ea3bd-…/djinn/scip-indexer`):

- **4.5 GiB across 40 entries**, accumulated over ~2 days of roughly hourly warms.
- Entry sizes cluster into two families: ~154 MiB (the Rust workspace index) and ~11 MiB (the TypeScript one), plus a couple of KiB-scale ones.
- The filesystem is mounted `relatime`, so `atime > mtime` is proof an entry was read back after it was written. **7 of 40 entries had ever been read; 33 never had.**

At the observed rate (~2.2 GiB/day) this reaches the 76 GiB the cache claim already occupies within about a month, on the same PVC that has repeatedly caused node DiskPressure.

## The 0%-hit-rate premise did not hold — read this before reviewing

The task this branch came from asserted that the djinn server workspace has a **structurally 0%** hit rate, because the key hashes every source file under the workspace root and warms are triggered by a commit that by definition changed those files — making the cache write-only ballast. That premise is **false**, and the production tree disproves it:

- `collect_workspace_hashes` hashes sources under **that workspace's own root**, filtered to **that indexer's extensions** — not the whole repo. A commit touching only `server/**` leaves the `ui/` TypeScript key byte-identical, so the TypeScript workspace hits. That is visible in the data: only 7 TypeScript entries were written over a window in which ~33 Rust entries were, i.e. most TypeScript runs hit rather than wrote.
- The Rust workspace hits too. Two ~154 MiB entries carry `atime > mtime` (written 07-27 07:54, read 14:28; written 17:42, read 18:33), and there is an 8-hour gap in the write sequence around the first of those — hourly warms that hit instead of writing.
- Reuse distances observed: 0.8 h, 0.85 h, 0.9 h, 1.5 h, 6.6 h, and two at ~26 h.
- Everything else in the key is stable across runs: `command_args` embeds only the output path (normalised to `$SCIP_OUTPUT` by `CommandShape::from_plan`), `binary_path` is fixed by the image, and `visit_dirs` prunes `node_modules` / build-output trees. There is no run-unique ingredient.

So there is **no key that provably can never hit**, and therefore no generic structural predicate that could identify one — the property the task asked me to detect does not exist in this key's structure. Shipping a write-skip would have suppressed a cache that demonstrably works, and the most expensive thing it saves is exactly the ~154 MiB Rust index (a full `rust-analyzer scip` pass).

**I did not ship the write-skip.** The retention bound subsumes its intent without the false positive: eviction is ordered by **last use**, so the 33 write-once-never-read entries are precisely what gets reclaimed, while the 7 that keep hitting keep their access times refreshed and survive.

## What is shipped

`server/crates/djinn-graph/src/scip_indexer/cache_gc.rs`, a retention sweep hung off `ScipCacheStore::store_bytes` — the only event that grows the tree, and the one moment every producer (warm Job, task-run Pod, server process) is guaranteed to reach, so it needs no scheduler of its own.

### The bound, and why these defaults

| Bound | Default | Why |
|---|---|---|
| Total size | **4 GiB** | One warm generation of the largest project on the cluster costs ~165 MiB across all its workspaces (154 MiB Rust + 11 MiB TypeScript). 4 GiB retains ~25 generations ≈ 25 h at the measured hourly warm cadence, which sits above the longest reuse distance actually observed (26 h) — so it evicts entries that were already dead, not entries a next run would have hit. It is also ~5 % of the 76 GiB cache claim, against 4.5 GiB-and-climbing for an unbounded tree. |
| Idle window | **7 days** | The size cap binds first for a busy project. This leg exists for the opposite case: a project warmed too rarely to ever reach the cap, whose few entries would otherwise sit on the PVC forever. Measured against **last use**, so an entry that keeps hitting is never idle. |

Both defaults live in the binary (`DEFAULT_MAX_TOTAL_BYTES`, `DEFAULT_MAX_IDLE`). `scipCache.maxBytes` / `scipCache.maxIdleHours` in `values.yaml` are **tuning only** — an older chart, a raw manifest, or a local `cargo run` gets the same finite cache. Only an explicit `0` disables a leg, and only the leg it names; an absent, blank, or unparseable override keeps the shipped default rather than silently unbounding. `defaults_are_on_without_any_environment_configuration` pins that.

The server forwards both vars onto the warm and task-run Pods it dispatches (`djinn_k8s::job::common_cache_env_vars`), because those Pods — not the server — are what write the cache.

### Concurrency: never delete what someone is using

Multiple warm Jobs and task-run Pods mount the same PVC, so a sweep runs against a tree others are reading and writing. Three independent layers:

1. **Publication lock.** A writer in `store_bytes` holds the entry's `.publish.lock` for the whole tmp-write-and-rename. An entry carrying it is never a candidate. The constant is now single-sourced in `cache_gc` so the reader and the writer cannot drift.
2. **In-flight grace.** An entry whose newest `atime`/`mtime` is inside a 30-minute window is never a candidate — covering a reader that has read the manifest but not yet opened the artifact, and any writer whose lock the sweep raced past. Clock skew that puts an entry "in the future" is treated as freshly touched, not infinitely old.
3. **Stage-then-delete.** An eviction `rename(2)`s the entry directory to a sibling `.<name>.evicting.<nanos>.<pid>.tmp` before `remove_dir_all`. The rename is atomic, so a concurrent lookup on that key sees the complete entry or `ENOENT` — never a directory whose manifest outlived its artifact. Both `ENOENT` shapes are already an ordinary miss on the read path (`try_lookup` returns `Ok(false)`), and a POSIX unlink cannot pull bytes from a reader that already holds the fd open. The `.tmp` suffix and pid qualifier follow the `warm_sentinel` convention for partial state; a staging directory left by a sweep that died between rename and delete is reclaimed by the next sweep and is never counted as a live entry.

Sweeps are serialised across processes by a `mkdir`-based lock (with a 1-hour stale-lock reclaim, so one crash cannot disable retention forever) and throttled by a stamp file, so a burst of stores costs one directory walk, not one per store.

On a `noatime` mount `atime` never advances and LRU degrades to least-recently-*written* — still a bound, just a less selective one. Documented in the module header.

### Not touched

`/cache/cargo-target`, `cacheCleanup`, and the `djinn-coordinator` warm-base GC are untouched — a separate agent owns that area.

## How I proved the tests are not vacuous

Three separate neutralisations, each run to confirm the tests go red:

1. **`evict` returns `true` without deleting anything** (reports the eviction, performs none):
   - `sweep_deletes_expired_and_over_cap_entries_and_keeps_the_live_ones` → **FAILED** (`an entry 72 days past the idle window must be gone from …`)
   - `size_cap_smaller_than_one_entry_empties_the_unprotected_tree` → **FAILED**

   Both assert `exists(dir)` / `!exists(dir)` by stat-ing the key path, and re-read the survivors' bytes — not the returned counters. The other 7 tests stayed green, which is correct: they assert *survival*.

2. **`CacheEntry::is_evictable` returns `true` unconditionally** (in-flight protection removed):
   - `an_entry_being_published_survives_a_sweep_that_would_otherwise_evict_it` → **FAILED**
   - `an_entry_touched_inside_the_grace_window_survives` → **FAILED**

   Both policies in those tests condemn the entry on *both* legs, so nothing but the protection keeps it alive.

3. **`| int64` dropped from the Helm template**:
   - `deploy/helm/djinn/tests/scip-cache-retention-render.sh` → **FAILED** (`expected '4294967296', got '4.294967296e+09'`)

   Helm decodes YAML numbers as float64, so a bare `| quote` renders the 4 GiB default in scientific notation, which `parse_u64` rejects and silently replaces with the built-in default — a knob that reads as wired but is not. The render test pins the decimal-integer form, not merely numeric equality.

The load-bearing eviction test writes four entries at distinct points on the LRU axis (exact times set via `utimensat`, no sleeps), runs one sweep, and asserts the idle-expired one and the coldest over-cap one are **gone from disk**, the two live ones are **still there with their bytes intact**, and no staging directory remains visible in the shard.

## Verification

- `cargo test -p djinn-graph` — 647 passed. One failure, `process::linux_supervisor_tests::spawn_failure_returns_original_io_error`, is a pre-existing parallel-execution flake: it passes in isolation, the failing set varies between runs, and it **also fails with this PR's retention hook neutralised to a no-op**. The `canonical_graph` tests that flaked in one run pass 3/3 when run as their own module.
- `cargo clippy -p djinn-graph --no-deps --lib -- -D warnings` — clean. `--all-targets` still reports 12 pre-existing `MutexGuard held across await` errors in `canonical_graph.rs` test code, none in files this PR touches. (`-p djinn-graph` without `--no-deps` also surfaces 2 pre-existing `nonminimal_bool` errors in `djinn-db`.)
- `cargo clippy -p djinn-k8s --no-deps --lib -- -D warnings` — clean.
- `helm lint deploy/helm/djinn` and `bash deploy/helm/djinn/tests/scip-cache-retention-render.sh` — pass, including four schema-rejection cases.

## Note for a follow-up

`scripts/fixtures/cache-cleanup/manifest.sha256` pins SHA-256 digests of `deploy/helm/djinn/{values.yaml,values.schema.json,templates/deployment-server.yaml}`, which this PR edits. That manifest is **already stale on main** — `sha256sum --check` fails for `_helpers.tpl`, `configmap.yaml`, `role-controller.yaml`, `values.local.yaml`, and `cache-cleanup-render.sh`, none of which this branch touches — and `scripts/verify-cache-cleanup.sh` has no CI caller. I left it alone rather than regenerate it, since it belongs to the cache-cleanup area another agent is working in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
