### PR TITLE
fix(cache): give the warm-base sweep reach over unrecognized project trees

### DIFF
--- a/docs/SHARED_CACHE_CLEANUP_RUNBOOK.md
+++ b/docs/SHARED_CACHE_CLEANUP_RUNBOOK.md
@@ -53,6 +53,7 @@ therefore `delete`.
 | `DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO` | `0.15` | Pressure starts below this free-space ratio. |
 | `DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO` | `0.25` | Pressure stops at this free-space ratio. |
 | `DJINN_CACHE_CLEANUP_WARM_PROFILE_MIN_IDLE_HOURS` | `24` | A profile becomes pressure-eligible after this project-idle period; `0` means immediate eligibility. Artifact mtimes do not prove profile idleness. |
+| `DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS` | `7` | A directory inside `/cache/cargo-target/<project_id>/` that is not a canonical `mold-jobs-N` variant is reclaimed once nothing has written anywhere in that tree for this long. Requires no active task run, no in-flight warm Job, and the whole-project warm lock; the idleness is re-proved under that lock. `0` makes any such entry immediately eligible. |
 | `DJINN_CARGO_TARGET_RUNS_MAX_DIRS` | `64` | Maximum run directories. `0` disables **count only**. |
 | `DJINN_CARGO_TARGET_RUNS_MAX_BYTES` | `8589934592` | Maximum allocated bytes (8 GiB). `0` disables **bytes only**. |
 

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc.rs
@@ -27,7 +27,8 @@ mod fingerprint_inventory;
 mod three_rung_plan;
 
 pub use fingerprint_inventory::{
-    FINGERPRINT_DIR, FingerprintUnitEntry, FingerprintUnitInventory, inventory_fingerprint_units,
+    FINGERPRINT_DIR, FingerprintUnitEntry, FingerprintUnitInventory, ProfileRootMeasurement,
+    inventory_fingerprint_units,
 };
 pub use three_rung_plan::{
     PressureBaseSnapshot, PressurePlanDisposition, PressurePlanRetainReason, PressurePlanUnit,
@@ -114,6 +115,386 @@ impl BaseLock for SharedWarmBaseLock {
             }
         }
     }
+}
+
+/// The whole-project lock shared with warm work.
+///
+/// An unrecognized tree is a sibling of the `mold-jobs-N` variants, not one of
+/// them, so a per-variant lock cannot cover it: a variant lock deliberately
+/// "cannot contend with, or authorize mutation of, legacy and sibling bases"
+/// (`WarmBaseLock::acquire_for_jobs`). The identity used here is the worker's
+/// whole-project lock, `<root>/.warm-locks/<project-id>.lock`, which is exactly
+/// what `WarmBaseLock::acquire` takes — the lock any legacy-layout writer of
+/// `<project-id>/debug` would have held.
+pub struct SharedWarmProjectLock;
+
+impl BaseLock for SharedWarmProjectLock {
+    fn try_lock(&self, path: &Path) -> Result<Option<Box<dyn LockGuard>>, String> {
+        let project_id = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or("invalid project id")?;
+        let parsed = Uuid::parse_str(project_id).map_err(|_| "invalid project id")?;
+        if parsed.to_string() != project_id {
+            return Err("invalid project id".into());
+        }
+        let root = path.parent().ok_or("project has no warm root")?;
+        let lock_dir = root.join(".warm-locks");
+        std::fs::create_dir_all(&lock_dir)
+            .map_err(|error| format!("failed to create warm lock directory: {error}"))?;
+        let lock_path = lock_dir.join(format!("{project_id}.lock"));
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| {
+                format!("failed to open warm lock {}: {error}", lock_path.display())
+            })?;
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if rc == 0 {
+            Ok(Some(Box::new(FlockGuard { _file: file })))
+        } else {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::WouldBlock {
+                Ok(None)
+            } else {
+                Err(error.to_string())
+            }
+        }
+    }
+}
+
+/// Why an unrecognized entry was left in place this pass. Every variant is a
+/// bounded enumeration; project ids and paths appear only in logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnrecognizedRetainReason {
+    /// A name the sweep never reclaims (djinn machinery, dot-directories).
+    Reserved,
+    /// The tree could not be measured, so its age is unknown.
+    MeasurementError,
+    /// The tree was written to more recently than the idle threshold.
+    Young,
+    ActivityError,
+    ActiveTaskRun,
+    WarmJobError,
+    WarmJobInFlight,
+    LockBusy,
+    LockError,
+    /// A post-lock recheck disagreed with the planned observation.
+    Changed,
+    DeleteError,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct UnrecognizedReclaimResult {
+    /// Everything the inventory saw, whatever happened to it.
+    pub scanned: Vec<UnrecognizedWarmEntry>,
+    /// Entries that passed every guard in dry-run mode and were only reported.
+    pub dry_run: Vec<UnrecognizedWarmEntry>,
+    pub deleted: Vec<UnrecognizedWarmEntry>,
+    pub retained: Vec<(UnrecognizedWarmEntry, UnrecognizedRetainReason)>,
+    pub reclaimed_bytes: u64,
+}
+
+impl UnrecognizedReclaimResult {
+    pub fn scanned_bytes(&self) -> u64 {
+        self.scanned
+            .iter()
+            .map(|entry| entry.size_bytes)
+            .fold(0u64, u64::saturating_add)
+    }
+}
+
+fn retain_unrecognized(
+    result: &mut UnrecognizedReclaimResult,
+    entry: &UnrecognizedWarmEntry,
+    reason: UnrecognizedRetainReason,
+    mode: crate::context::CacheCleanupMode,
+) {
+    use djinn_telemetry::cache_cleanup as metrics;
+    let outcome = match reason {
+        UnrecognizedRetainReason::Young => metrics::OUTCOME_RETAINED_YOUNG,
+        UnrecognizedRetainReason::ActiveTaskRun => metrics::OUTCOME_RETAINED_ACTIVE,
+        UnrecognizedRetainReason::LockBusy => metrics::OUTCOME_RETAINED_LOCK_BUSY,
+        UnrecognizedRetainReason::Reserved
+        | UnrecognizedRetainReason::WarmJobInFlight
+        | UnrecognizedRetainReason::Changed => metrics::OUTCOME_RETAINED,
+        UnrecognizedRetainReason::MeasurementError
+        | UnrecognizedRetainReason::ActivityError
+        | UnrecognizedRetainReason::WarmJobError
+        | UnrecognizedRetainReason::LockError
+        | UnrecognizedRetainReason::DeleteError => metrics::OUTCOME_ERROR,
+    };
+    metrics::increment_cleanup_total(
+        metrics::COMPONENT_CARGO_WARM_BASE,
+        outcome,
+        mode.as_metric_label(),
+    );
+    tracing::info!(
+        project_id = %entry.project_id,
+        entry = %entry.name,
+        size_bytes = entry.size_bytes,
+        reason = ?reason,
+        "warm-base unrecognized entry retained"
+    );
+    result.retained.push((entry.clone(), reason));
+}
+
+/// Reclaim directories inside a warm project root that no current layout
+/// produces.
+///
+/// This is the reach fix for the whole-base and three-rung sweeps: both walk a
+/// strict `<project-id>/mold-jobs-N` allowlist, so a tree such as
+/// `<project-id>/debug` is not *retained* by them, it is unreachable to them.
+///
+/// The safety posture is the one the existing deletion paths already have, with
+/// one addition. Reclamation requires, in order:
+///
+/// 1. a name outside the reserved namespace;
+/// 2. a successfully measured tree whose newest mtime anywhere is older than
+///    `warm_unrecognized_min_idle_days` — an unmeasurable tree has an unknown
+///    age and is never eligible;
+/// 3. no active task run and no in-flight warm Job for that project;
+/// 4. the whole-project warm lock, taken non-blocking;
+/// 5. a post-lock recheck that re-walks the tree and re-verifies both the
+///    idleness and the canonical containment `root ⊂ project ⊂ target`.
+///
+/// Step 5 is what makes idleness a real guard rather than a planning-time
+/// snapshot: anything that touched the tree between planning and the lock makes
+/// the newest mtime fresh and aborts the removal.
+///
+/// Dry-run reports what it would remove and never opens a lock, because opening
+/// one creates a lock file and mutates fallback mtime state.
+#[allow(clippy::too_many_arguments)]
+pub async fn reclaim_unrecognized_warm_entries(
+    unrecognized: &[UnrecognizedWarmEntry],
+    activity: &dyn ActivityGuard,
+    warm_jobs: &dyn WarmJobGuard,
+    locks: &dyn BaseLock,
+    config: &crate::context::CacheCleanupConfig,
+    clock: &dyn Clock,
+    mode: crate::context::CacheCleanupMode,
+    root: &Path,
+) -> UnrecognizedReclaimResult {
+    use crate::context::CacheCleanupMode;
+    use djinn_telemetry::cache_cleanup as metrics;
+
+    let mut result = UnrecognizedReclaimResult {
+        scanned: unrecognized.to_vec(),
+        ..UnrecognizedReclaimResult::default()
+    };
+    if unrecognized.is_empty() {
+        return result;
+    }
+    metrics::increment_candidates(
+        metrics::COMPONENT_CARGO_WARM_BASE,
+        mode.as_metric_label(),
+        unrecognized.len() as u64,
+    );
+    let min_idle = Duration::from_secs(
+        config
+            .warm_unrecognized_min_idle_days
+            .saturating_mul(24 * 60 * 60),
+    );
+    let now = clock.now();
+
+    for entry in unrecognized {
+        if is_reserved_project_child(&entry.name) {
+            retain_unrecognized(&mut result, entry, UnrecognizedRetainReason::Reserved, mode);
+            continue;
+        }
+        let Some(newest) = entry.newest_mtime else {
+            retain_unrecognized(
+                &mut result,
+                entry,
+                UnrecognizedRetainReason::MeasurementError,
+                mode,
+            );
+            continue;
+        };
+        if !tree_is_idle(now, newest, min_idle) {
+            retain_unrecognized(&mut result, entry, UnrecognizedRetainReason::Young, mode);
+            continue;
+        }
+        let snapshot = match activity.activity(&entry.project_id).await {
+            Ok(snapshot) => snapshot,
+            Err(_) => {
+                retain_unrecognized(
+                    &mut result,
+                    entry,
+                    UnrecognizedRetainReason::ActivityError,
+                    mode,
+                );
+                continue;
+            }
+        };
+        if snapshot.has_active_task_run {
+            retain_unrecognized(
+                &mut result,
+                entry,
+                UnrecognizedRetainReason::ActiveTaskRun,
+                mode,
+            );
+            continue;
+        }
+        match warm_jobs.has_in_flight_warm(&entry.project_id).await {
+            Ok(false) => {}
+            Ok(true) => {
+                retain_unrecognized(
+                    &mut result,
+                    entry,
+                    UnrecognizedRetainReason::WarmJobInFlight,
+                    mode,
+                );
+                continue;
+            }
+            Err(_) => {
+                retain_unrecognized(
+                    &mut result,
+                    entry,
+                    UnrecognizedRetainReason::WarmJobError,
+                    mode,
+                );
+                continue;
+            }
+        }
+        if mode == CacheCleanupMode::DryRun {
+            metrics::increment_cleanup_total(
+                metrics::COMPONENT_CARGO_WARM_BASE,
+                metrics::OUTCOME_DRY_RUN,
+                mode.as_metric_label(),
+            );
+            tracing::info!(
+                project_id = %entry.project_id,
+                entry = %entry.name,
+                size_bytes = entry.size_bytes,
+                "warm-base unrecognized entry would be reclaimed"
+            );
+            result.dry_run.push(entry.clone());
+            continue;
+        }
+        let Some(project_dir) = entry.path.parent() else {
+            retain_unrecognized(&mut result, entry, UnrecognizedRetainReason::Changed, mode);
+            continue;
+        };
+        let guard = match locks.try_lock(project_dir) {
+            Ok(Some(guard)) => guard,
+            Ok(None) => {
+                retain_unrecognized(&mut result, entry, UnrecognizedRetainReason::LockBusy, mode);
+                continue;
+            }
+            Err(_) => {
+                retain_unrecognized(
+                    &mut result,
+                    entry,
+                    UnrecognizedRetainReason::LockError,
+                    mode,
+                );
+                continue;
+            }
+        };
+        let bytes = match recheck_unrecognized_after_lock(entry, root, now, min_idle) {
+            Ok(bytes) => bytes,
+            Err(reason) => {
+                retain_unrecognized(&mut result, entry, reason, mode);
+                drop(guard);
+                continue;
+            }
+        };
+        // A concurrent remover winning the race is idempotent, not a failure.
+        let removed = match std::fs::remove_dir_all(&entry.path) {
+            Ok(()) => true,
+            Err(error) => error.kind() == std::io::ErrorKind::NotFound,
+        };
+        match removed {
+            true => {
+                result.reclaimed_bytes = result.reclaimed_bytes.saturating_add(bytes);
+                result.deleted.push(entry.clone());
+                metrics::increment_cleanup_total(
+                    metrics::COMPONENT_CARGO_WARM_BASE,
+                    metrics::OUTCOME_DELETED,
+                    mode.as_metric_label(),
+                );
+                if bytes > 0 {
+                    metrics::record_reclaimed_bytes(
+                        metrics::COMPONENT_CARGO_WARM_BASE,
+                        mode.as_metric_label(),
+                        bytes,
+                    );
+                }
+                tracing::info!(
+                    project_id = %entry.project_id,
+                    entry = %entry.name,
+                    reclaimed_bytes = bytes,
+                    "warm-base unrecognized entry reclaimed"
+                );
+            }
+            false => {
+                retain_unrecognized(
+                    &mut result,
+                    entry,
+                    UnrecognizedRetainReason::DeleteError,
+                    mode,
+                );
+            }
+        }
+        drop(guard);
+    }
+    result
+}
+
+/// Idle exactly when the newest observed write is at least `min_idle` in the
+/// past. A clock that has gone backwards yields "not idle", never "idle".
+fn tree_is_idle(now: SystemTime, newest: SystemTime, min_idle: Duration) -> bool {
+    match newest.checked_add(min_idle) {
+        Some(cutoff) => now >= cutoff,
+        None => false,
+    }
+}
+
+/// Re-establish every fact the removal depends on while the project lock is
+/// held, and return the freshly measured size.
+fn recheck_unrecognized_after_lock(
+    entry: &UnrecognizedWarmEntry,
+    root: &Path,
+    now: SystemTime,
+    min_idle: Duration,
+) -> Result<u64, UnrecognizedRetainReason> {
+    use UnrecognizedRetainReason::{Changed, MeasurementError};
+
+    let metadata = std::fs::symlink_metadata(&entry.path).map_err(|_| Changed)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(Changed);
+    }
+    let canonical_root = std::fs::canonicalize(root).map_err(|_| Changed)?;
+    let project_dir = entry.path.parent().ok_or(Changed)?;
+    let canonical_project = std::fs::canonicalize(project_dir).map_err(|_| Changed)?;
+    let canonical_target = std::fs::canonicalize(&entry.path).map_err(|_| Changed)?;
+    if !canonical_project.starts_with(&canonical_root)
+        || !canonical_target.starts_with(&canonical_project)
+        || canonical_target == canonical_project
+    {
+        return Err(Changed);
+    }
+    // The name must still be one this layout cannot explain, and still be
+    // outside the reserved namespace.
+    let name = canonical_target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or(Changed)?;
+    if name != entry.name
+        || is_reserved_project_child(name)
+        || canonical_mold_jobs_name(name).is_some()
+    {
+        return Err(Changed);
+    }
+    let (bytes, newest) = measure_tree_fail_closed(&entry.path).map_err(|_| MeasurementError)?;
+    if !tree_is_idle(now, newest, min_idle) {
+        return Err(UnrecognizedRetainReason::Young);
+    }
+    Ok(bytes)
 }
 
 /// Consume the immutable three-rung plan in delete mode. Every operation after
@@ -825,22 +1206,110 @@ pub struct WarmBaseEntry {
     pub size_bytes: u64,
 }
 
+/// A directory that lives directly under a canonical `<project-id>` warm root
+/// but is not a canonical `mold-jobs-N` variant.
+///
+/// Before this existed, every such directory was folded into
+/// [`WarmBaseInventory::ignored`] — a counter written at a dozen sites and read
+/// at none — so an abandoned layout (`<project-id>/debug`, left behind when the
+/// warm base moved to `mold-jobs-N` subdirectories) was invisible to the sweep
+/// *and* to the operator. The 27 GB `debug/` tree that sat untouched beside a
+/// live `mold-jobs-4` on the production cache PVC was not retained by a safety
+/// decision; nothing ever saw it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnrecognizedWarmEntry {
+    pub project_id: String,
+    /// The directory name inside the project root, e.g. `debug`.
+    pub name: String,
+    pub path: PathBuf,
+    /// Measured bytes, or `0` when the tree could not be fully measured.
+    pub size_bytes: u64,
+    /// Newest mtime anywhere in the tree, including the tree root itself.
+    ///
+    /// `None` means the traversal failed, which is deliberately *not* the same
+    /// as "old": an entry with no measured age is never reclaimable.
+    pub newest_mtime: Option<SystemTime>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WarmBaseInventory {
     pub entries: Vec<WarmBaseEntry>,
     pub ignored: usize,
+    /// Non-variant directories found inside canonical project roots.
+    pub unrecognized: Vec<UnrecognizedWarmEntry>,
+}
+
+/// Names inside a project root that the sweep never reclaims regardless of age.
+///
+/// Cargo never creates a dot-directory inside a target dir, so reserving the
+/// whole `.`-prefixed namespace costs nothing and keeps djinn's own machinery
+/// (and anything an operator deliberately parked there) out of reach.
+fn is_reserved_project_child(name: &str) -> bool {
+    name.starts_with('.')
+}
+
+/// Measure a tree's size and newest mtime in one traversal, failing closed.
+///
+/// Any unreadable entry aborts the measurement rather than being skipped: a
+/// partial walk could report a stale newest-mtime and make a live tree look
+/// reclaimable. Symlinks contribute their own `lstat` mtime and are never
+/// descended into (`remove_dir_all` unlinks them without following them).
+fn measure_tree_fail_closed(root: &Path) -> Result<(u64, SystemTime), String> {
+    let root_metadata = std::fs::symlink_metadata(root)
+        .map_err(|error| format!("failed to stat {}: {error}", root.display()))?;
+    let mut newest = root_metadata
+        .modified()
+        .map_err(|error| format!("failed to read mtime for {}: {error}", root.display()))?;
+    let mut total: u64 = 0;
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        let children = std::fs::read_dir(&path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        for child in children {
+            let child = child
+                .map_err(|error| format!("failed to read entry in {}: {error}", path.display()))?;
+            let child_path = child.path();
+            let metadata = std::fs::symlink_metadata(&child_path)
+                .map_err(|error| format!("failed to stat {}: {error}", child_path.display()))?;
+            let mtime = metadata.modified().map_err(|error| {
+                format!("failed to read mtime for {}: {error}", child_path.display())
+            })?;
+            newest = newest.max(mtime);
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            if metadata.is_dir() {
+                pending.push(child_path);
+            } else {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    Ok((total, newest))
 }
 
 /// Inventory canonical `/cache/cargo-target/<project-id>/mold-jobs-N` entries.
 /// Symlinks, legacy unkeyed project contents, and malformed variants are
 /// intentionally ignored rather than being substituted for another `N`.
+///
+/// Non-variant *directories* inside a canonical project root are additionally
+/// reported in [`WarmBaseInventory::unrecognized`] so the sweep can see — and
+/// [`reclaim_unrecognized_warm_entries`] can reclaim — trees no current layout
+/// produces. Anything at the warm root itself that is not a canonical project
+/// UUID stays purely in `ignored`: that level holds reserved machinery such as
+/// `.warm-locks` and is out of this sweep's scope.
 pub fn inventory_under(root: &Path) -> Result<WarmBaseInventory, String> {
     let mut entries = Vec::new();
+    let mut unrecognized = Vec::new();
     let mut ignored = 0;
     let children = match std::fs::read_dir(root) {
         Ok(children) => children,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(WarmBaseInventory { entries, ignored });
+            return Ok(WarmBaseInventory {
+                entries,
+                ignored,
+                unrecognized,
+            });
         }
         Err(error) => return Err(error.to_string()),
     };
@@ -895,6 +1364,20 @@ pub fn inventory_under(root: &Path) -> Result<WarmBaseInventory, String> {
             };
             let Some(mold_jobs) = canonical_mold_jobs_name(&variant_name) else {
                 ignored += 1;
+                // A directory the current layout cannot explain. Report it
+                // instead of dropping it; measurement failures are recorded as
+                // an unknown age, which is never reclaimable.
+                let (size_bytes, newest_mtime) = match measure_tree_fail_closed(&variant.path()) {
+                    Ok((size, newest)) => (size, Some(newest)),
+                    Err(_) => (0, None),
+                };
+                unrecognized.push(UnrecognizedWarmEntry {
+                    project_id: name.clone(),
+                    name: variant_name,
+                    path: variant.path(),
+                    size_bytes,
+                    newest_mtime,
+                });
                 continue;
             };
             let path = variant.path();
@@ -911,7 +1394,16 @@ pub fn inventory_under(root: &Path) -> Result<WarmBaseInventory, String> {
             .cmp(&right.project_id)
             .then_with(|| left.mold_jobs.cmp(&right.mold_jobs))
     });
-    Ok(WarmBaseInventory { entries, ignored })
+    unrecognized.sort_by(|left, right| {
+        left.project_id
+            .cmp(&right.project_id)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    Ok(WarmBaseInventory {
+        entries,
+        ignored,
+        unrecognized,
+    })
 }
 
 fn canonical_mold_jobs_name(name: &str) -> Option<u32> {
@@ -1100,7 +1592,14 @@ pub struct FingerprintSweepReport {
     /// Number of fingerprint units discovered across all passing bases.
     pub candidate_count: u64,
     /// Measured bytes inside all discovered fingerprint units.
+    ///
+    /// This is `.fingerprint/<unit>` metadata only. It is *not* the disk a unit
+    /// occupies — see [`Self::profile_root_bytes`].
     pub projected_bytes: u64,
+    /// Measured bytes of every discovered profile root, including `deps`,
+    /// `build` and `incremental`. Reported alongside `projected_bytes` so the
+    /// unit total cannot be read as the profile's footprint.
+    pub profile_root_bytes: u64,
     /// Always zero while fingerprint sweeping remains report-only.
     pub reclaimed_bytes: u64,
     /// Bases retained by guard failure (active task, warm job, lock, etc.).
@@ -1168,6 +1667,9 @@ pub async fn report_only_fingerprint_sweep(
                     .fold(0u64, u64::saturating_add);
                 report.candidate_count = report.candidate_count.saturating_add(unit_count);
                 report.projected_bytes = report.projected_bytes.saturating_add(projected);
+                report.profile_root_bytes = report
+                    .profile_root_bytes
+                    .saturating_add(inventory.profile_root_bytes());
                 if unit_count > 0 {
                     metrics::increment_candidates(
                         metrics::COMPONENT_CARGO_WARM_BASE_FINGERPRINT,
@@ -1228,6 +1730,7 @@ pub(crate) fn log_fingerprint_sweep_completion(
         outcome = outcome,
         candidate_count = report.candidate_count,
         projected_bytes = report.projected_bytes,
+        profile_root_bytes = report.profile_root_bytes,
         reclaimed_bytes = report.reclaimed_bytes,
         retained = report.retained.len(),
         error_bases = report.error_bases.len(),

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/fingerprint_inventory.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/fingerprint_inventory.rs
@@ -25,11 +25,115 @@ pub struct FingerprintUnitEntry {
     pub projected_bytes: u64,
 }
 
+/// Measured bytes of one profile root, split by the directory Cargo puts them
+/// in.
+///
+/// [`FingerprintUnitEntry::projected_bytes`] only ever counted bytes inside
+/// `.fingerprint/<unit>`, which are metadata stamps of a few kilobytes each.
+/// The artifacts a unit actually costs on disk live in `deps/`, `build/` and
+/// `incremental/` — orders of magnitude more — so a report built from unit
+/// bytes alone understates the profile's real footprint by roughly that ratio.
+/// This measurement is what makes the shortfall visible; it does not attribute
+/// `deps`/`build`/`incremental` bytes back to individual units, which would
+/// require reproducing Cargo's unit-hash-to-artifact mapping.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ProfileRootMeasurement {
+    pub profile_root: PathBuf,
+    pub fingerprint_bytes: u64,
+    pub deps_bytes: u64,
+    pub build_bytes: u64,
+    pub incremental_bytes: u64,
+    /// Everything else directly under the profile root (final binaries, loose
+    /// files, `examples/`, and so on).
+    pub other_bytes: u64,
+}
+
+impl ProfileRootMeasurement {
+    pub fn total_bytes(&self) -> u64 {
+        [
+            self.fingerprint_bytes,
+            self.deps_bytes,
+            self.build_bytes,
+            self.incremental_bytes,
+            self.other_bytes,
+        ]
+        .into_iter()
+        .fold(0u64, u64::saturating_add)
+    }
+}
+
 /// Report-only, side-effect-free inventory of Cargo fingerprint units inside a
 /// warm base.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FingerprintUnitInventory {
     pub units: Vec<FingerprintUnitEntry>,
+    /// Per-profile-root disk measurement. Reported alongside the unit inventory
+    /// so a reader cannot mistake summed unit bytes for the profile's real size.
+    pub profile_roots: Vec<ProfileRootMeasurement>,
+}
+
+impl FingerprintUnitInventory {
+    /// Total measured bytes across every discovered profile root.
+    pub fn profile_root_bytes(&self) -> u64 {
+        self.profile_roots
+            .iter()
+            .map(ProfileRootMeasurement::total_bytes)
+            .fold(0u64, u64::saturating_add)
+    }
+}
+
+/// Measure a profile root's immediate children, bucketed by Cargo's layout.
+fn measure_profile_root(profile_root: &Path) -> Result<ProfileRootMeasurement, String> {
+    let mut measurement = ProfileRootMeasurement {
+        profile_root: profile_root.to_path_buf(),
+        ..ProfileRootMeasurement::default()
+    };
+    let children = std::fs::read_dir(profile_root).map_err(|e| {
+        format!(
+            "failed to read profile root {}: {e}",
+            profile_root.display()
+        )
+    })?;
+    for child in children {
+        let child = child.map_err(|e| {
+            format!(
+                "failed to read directory entry under {}: {e}",
+                profile_root.display()
+            )
+        })?;
+        let kind = child.file_type().map_err(|e| {
+            format!(
+                "failed to read file type for {}: {e}",
+                child.path().display()
+            )
+        })?;
+        if kind.is_dir() {
+            let bytes = directory_size_fail_closed(&child.path())?;
+            let name = child.file_name();
+            match name.to_string_lossy().as_ref() {
+                FINGERPRINT_DIR => {
+                    measurement.fingerprint_bytes =
+                        measurement.fingerprint_bytes.saturating_add(bytes);
+                }
+                "deps" => measurement.deps_bytes = measurement.deps_bytes.saturating_add(bytes),
+                "build" => measurement.build_bytes = measurement.build_bytes.saturating_add(bytes),
+                "incremental" => {
+                    measurement.incremental_bytes =
+                        measurement.incremental_bytes.saturating_add(bytes);
+                }
+                _ => measurement.other_bytes = measurement.other_bytes.saturating_add(bytes),
+            }
+        } else if kind.is_file() {
+            let metadata = child.metadata().map_err(|e| {
+                format!(
+                    "failed to read metadata for {}: {e}",
+                    child.path().display()
+                )
+            })?;
+            measurement.other_bytes = measurement.other_bytes.saturating_add(metadata.len());
+        }
+    }
+    Ok(measurement)
 }
 
 fn is_profile_root_name(name: &str) -> bool {
@@ -196,6 +300,7 @@ pub fn inventory_fingerprint_units(base: &Path) -> Result<FingerprintUnitInvento
     profile_roots.dedup();
 
     let mut units = Vec::new();
+    let mut measurements = Vec::new();
     for profile_root in profile_roots {
         let profile_canonical = std::fs::canonicalize(&profile_root).map_err(|e| {
             format!(
@@ -241,6 +346,14 @@ pub fn inventory_fingerprint_units(base: &Path) -> Result<FingerprintUnitInvento
                 base_canonical.display()
             ));
         }
+
+        // Measure the whole profile root, not just `.fingerprint`. Summed unit
+        // bytes are metadata only; `deps`, `build` and `incremental` hold the
+        // artifacts. This runs after the `.fingerprint` checks so the existing
+        // fail-closed error precedence is unchanged, which also means a profile
+        // root with no `.fingerprint` at all is skipped here exactly as it is
+        // for units.
+        measurements.push(measure_profile_root(&profile_canonical)?);
 
         let unit_entries = std::fs::read_dir(&fingerprint_canonical).map_err(|e| {
             format!(
@@ -300,6 +413,10 @@ pub fn inventory_fingerprint_units(base: &Path) -> Result<FingerprintUnitInvento
             .cmp(&right.profile_root)
             .then_with(|| left.unit_name.cmp(&right.unit_name))
     });
+    measurements.sort_by(|left, right| left.profile_root.cmp(&right.profile_root));
 
-    Ok(FingerprintUnitInventory { units })
+    Ok(FingerprintUnitInventory {
+        units,
+        profile_roots: measurements,
+    })
 }

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests.rs
@@ -65,6 +65,22 @@ fn entry() -> WarmBaseEntry {
         size_bytes: 7,
     }
 }
+/// Build an inventory from its entries alone.
+///
+/// Every test here that constructs an inventory cares only about the entries;
+/// `ignored` and `unrecognized` are inventory-reporting concerns exercised by
+/// `inventory_under` and the `unrecognized_reclaim` module against a real
+/// filesystem. Spelling those fields out at each site meant that adding one
+/// field to `WarmBaseInventory` forced ~34 mechanical edits and pushed this
+/// file through the repository's Rust file-size guard. Constructing through a
+/// helper makes the next field addition free.
+fn warm_inventory(entries: Vec<WarmBaseEntry>) -> WarmBaseInventory {
+    WarmBaseInventory {
+        entries,
+        ignored: 0,
+        unrecognized: Vec::new(),
+    }
+}
 fn snapshot() -> ActivitySnapshot {
     ActivitySnapshot {
         known_project: true,
@@ -107,11 +123,7 @@ async fn classifications_registered_deleted_and_orphaned() {
     let space = Space(Ok(9));
     let warm = Warm(Ok(false));
     let registered = plan(
-        WarmBaseInventory {
-            entries: vec![entry()],
-            ignored: 0,
-            unrecognized: Vec::new(),
-        },
+        warm_inventory(vec![entry()]),
         &Activity(Ok(ActivitySnapshot {
             known_project: true,
             ..snapshot()
@@ -127,11 +139,7 @@ async fn classifications_registered_deleted_and_orphaned() {
     );
 
     let deleted = plan(
-        WarmBaseInventory {
-            entries: vec![entry()],
-            ignored: 0,
-            unrecognized: Vec::new(),
-        },
+        warm_inventory(vec![entry()]),
         &Activity(Ok(ActivitySnapshot {
             known_project: false,
             deleted_project: true,
@@ -148,11 +156,7 @@ async fn classifications_registered_deleted_and_orphaned() {
     );
 
     let orphaned = plan(
-        WarmBaseInventory {
-            entries: vec![entry()],
-            ignored: 0,
-            unrecognized: Vec::new(),
-        },
+        warm_inventory(vec![entry()]),
         &Activity(Ok(ActivitySnapshot {
             known_project: false,
             ..snapshot()
@@ -173,11 +177,7 @@ async fn guards_fail_closed_and_classify() {
     let space = Space(Ok(9));
     let lock = Lock(LockOutcome::Available);
     let initial_plan = plan(
-        WarmBaseInventory {
-            entries: vec![entry()],
-            ignored: 0,
-            unrecognized: Vec::new(),
-        },
+        warm_inventory(vec![entry()]),
         &activity,
         &Warm(Ok(false)),
         &space,
@@ -217,18 +217,7 @@ async fn guards_fail_closed_and_classify() {
         } else {
             Lock(LockOutcome::Available)
         };
-        let planned = plan(
-            WarmBaseInventory {
-                entries: vec![entry()],
-                ignored: 0,
-                unrecognized: Vec::new(),
-            },
-            &active,
-            &warm,
-            &space,
-            &lock,
-        )
-        .await;
+        let planned = plan(warm_inventory(vec![entry()]), &active, &warm, &space, &lock).await;
         assert_eq!(planned.retained[0].1, reason);
     }
 }
@@ -237,11 +226,7 @@ async fn activity_and_measurement_errors_retain() {
     let lock = Lock(LockOutcome::Available);
     let warm = Warm(Ok(false));
     let result = plan(
-        WarmBaseInventory {
-            entries: vec![entry()],
-            ignored: 0,
-            unrecognized: Vec::new(),
-        },
+        warm_inventory(vec![entry()]),
         &Activity(Err("db".into())),
         &warm,
         &Space(Ok(1)),
@@ -250,11 +235,7 @@ async fn activity_and_measurement_errors_retain() {
     .await;
     assert_eq!(result.retained[0].1, RetainReason::ActivityError);
     let result = plan(
-        WarmBaseInventory {
-            entries: vec![entry()],
-            ignored: 0,
-            unrecognized: Vec::new(),
-        },
+        warm_inventory(vec![entry()]),
         &Activity(Ok(snapshot())),
         &warm,
         &Space(Err("stat".into())),
@@ -292,11 +273,7 @@ async fn idle_eviction_deletes_old_registered_base() {
 
     let clock = TestClock::new(future(15), std::time::Instant::now());
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -344,11 +321,7 @@ async fn idle_eviction_retains_young_base_by_mtime() {
         path: base.clone(),
         size_bytes: 1,
     };
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -397,11 +370,7 @@ async fn idle_eviction_db_activity_takes_precedence_over_mtime() {
         path: base.clone(),
         size_bytes: 1,
     };
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -434,11 +403,7 @@ async fn idle_eviction_deletes_deleted_project_base() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: false,
         deleted_project: true,
@@ -471,11 +436,7 @@ async fn idle_eviction_deletes_orphaned_base() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: false,
         deleted_project: false,
@@ -508,11 +469,7 @@ async fn active_task_run_retains_base() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: true,
@@ -546,11 +503,7 @@ async fn in_flight_warm_job_retains_base() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -584,11 +537,7 @@ async fn lock_busy_retains_base() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -626,11 +575,7 @@ async fn post_lock_recheck_retains_base() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     struct FlipActivityGuard {
         first: std::sync::Mutex<Option<ActivitySnapshot>>,
         second: ActivitySnapshot,
@@ -692,11 +637,7 @@ async fn dry_run_and_delete_select_same_candidates() {
         path: base.clone(),
         size_bytes: 42,
     };
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -750,11 +691,7 @@ async fn dry_run_and_delete_parity_with_flock_lock() {
         path: base.clone(),
         size_bytes: 42,
     };
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -810,11 +747,7 @@ async fn activity_error_fails_closed() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Err("db down".into()));
     let warm = Warm(Ok(false));
     let locks = NoopBaseLock;
@@ -843,11 +776,7 @@ async fn lock_error_fails_closed() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -881,11 +810,7 @@ async fn unsafe_path_is_not_deleted() {
     let id = "018f8b9a-0d70-7f0a-8000-000000000001";
     let base = old_base(&temp, id);
     let entry = make_entry(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
         has_active_task_run: false,
@@ -961,11 +886,10 @@ async fn pressure_above_low_watermark_produces_no_candidates() {
         total_bytes: 1000,
         available_bytes: 200,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 100)],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![pressure_entry(
+        "018f8b9a-0d70-7f0a-8000-000000000001",
+        100,
+    )]);
     let activity = Activity(Ok(snapshot_at(Some(old_activity(14)))));
     let warm = Warm(Ok(false));
     let locks = Lock(LockOutcome::Available);
@@ -988,11 +912,10 @@ async fn pressure_at_low_watermark_is_no_op() {
         total_bytes: 1000,
         available_bytes: 150,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 100)],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![pressure_entry(
+        "018f8b9a-0d70-7f0a-8000-000000000001",
+        100,
+    )]);
     let activity = Activity(Ok(snapshot_at(Some(old_activity(14)))));
     let warm = Warm(Ok(false));
     let locks = Lock(LockOutcome::Available);
@@ -1016,15 +939,11 @@ async fn pressure_below_low_selects_minimal_prefix() {
         total_bytes: 1000,
         available_bytes: 100,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000003", 80),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 100),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 60),
-        ],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000003", 80),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 100),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 60),
+    ]);
     // Same activity for all, so ordering is by project ID.
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
@@ -1058,15 +977,11 @@ async fn pressure_orders_by_activity_then_project_id() {
         total_bytes: 1000,
         available_bytes: 100,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000003", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
-        ],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000003", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
+    ]);
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
     let locks = Lock(LockOutcome::Available);
@@ -1099,18 +1014,14 @@ async fn pressure_excluded_candidates_are_not_selected() {
         total_bytes: 1000,
         available_bytes: 100,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000003", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000004", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000005", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000006", 50),
-        ],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000003", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000004", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000005", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000006", 50),
+    ]);
 
     struct GuardActivity;
     #[async_trait]
@@ -1178,11 +1089,10 @@ async fn pressure_excluded_candidates_are_not_selected() {
 async fn pressure_measurement_error_fails_closed() {
     let config = pressure_config(0.15, 0.25);
     let capacity = Capacity(Err("statvfs failed".into()));
-    let inventory = WarmBaseInventory {
-        entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 100)],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![pressure_entry(
+        "018f8b9a-0d70-7f0a-8000-000000000001",
+        100,
+    )]);
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
     let locks = Lock(LockOutcome::Available);
@@ -1206,14 +1116,10 @@ async fn pressure_insufficient_reclaimable_space_selects_all_safe() {
         total_bytes: 1000,
         available_bytes: 100,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 40),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 60),
-        ],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 40),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 60),
+    ]);
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
     let locks = Lock(LockOutcome::Available);
@@ -1238,14 +1144,10 @@ async fn pressure_exact_stop_at_high_watermark() {
         total_bytes: 1000,
         available_bytes: 100,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 150),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
-        ],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 150),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
+    ]);
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
     let locks = Lock(LockOutcome::Available);
@@ -1270,14 +1172,10 @@ async fn pressure_young_base_is_excluded() {
         total_bytes: 1000,
         available_bytes: 100,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
-        ],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
+    ]);
 
     struct YoungActivity;
     #[async_trait]
@@ -1328,11 +1226,10 @@ async fn pressure_fractional_byte_boundary_reaches_high_watermark() {
         total_bytes: 10,
         available_bytes: 1,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 1)],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![pressure_entry(
+        "018f8b9a-0d70-7f0a-8000-000000000001",
+        1,
+    )]);
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
     let locks = Lock(LockOutcome::Available);
@@ -1359,14 +1256,10 @@ async fn pressure_large_capacity_preserves_high_watermark_byte_ceiling() {
         total_bytes: 9_007_199_254_740_993,
         available_bytes: 0,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![pressure_entry(
-            "018f8b9a-0d70-7f0a-8000-000000000001",
-            2_251_799_813_685_248,
-        )],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![pressure_entry(
+        "018f8b9a-0d70-7f0a-8000-000000000001",
+        2_251_799_813_685_248,
+    )]);
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
     let locks = Lock(LockOutcome::Available);
@@ -1389,11 +1282,10 @@ async fn pressure_large_capacity_compares_low_watermark_exactly() {
         total_bytes: 9_007_199_254_740_993,
         available_bytes: 4_503_599_627_370_496,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 1)],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![pressure_entry(
+        "018f8b9a-0d70-7f0a-8000-000000000001",
+        1,
+    )]);
     let plan = plan_pressure_eviction(
         inventory,
         &Activity(Ok(snapshot_at(Some(old_activity(12))))),
@@ -1416,14 +1308,10 @@ async fn pressure_lock_busy_and_error_retained() {
         total_bytes: 1000,
         available_bytes: 100,
     }));
-    let inventory = WarmBaseInventory {
-        entries: vec![
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 50),
-            pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
-        ],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 50),
+        pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
+    ]);
 
     struct BusyLock;
     impl BaseLockGuard for BusyLock {

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests.rs
@@ -110,6 +110,7 @@ async fn classifications_registered_deleted_and_orphaned() {
         WarmBaseInventory {
             entries: vec![entry()],
             ignored: 0,
+            unrecognized: Vec::new(),
         },
         &Activity(Ok(ActivitySnapshot {
             known_project: true,
@@ -129,6 +130,7 @@ async fn classifications_registered_deleted_and_orphaned() {
         WarmBaseInventory {
             entries: vec![entry()],
             ignored: 0,
+            unrecognized: Vec::new(),
         },
         &Activity(Ok(ActivitySnapshot {
             known_project: false,
@@ -149,6 +151,7 @@ async fn classifications_registered_deleted_and_orphaned() {
         WarmBaseInventory {
             entries: vec![entry()],
             ignored: 0,
+            unrecognized: Vec::new(),
         },
         &Activity(Ok(ActivitySnapshot {
             known_project: false,
@@ -173,6 +176,7 @@ async fn guards_fail_closed_and_classify() {
         WarmBaseInventory {
             entries: vec![entry()],
             ignored: 0,
+            unrecognized: Vec::new(),
         },
         &activity,
         &Warm(Ok(false)),
@@ -217,6 +221,7 @@ async fn guards_fail_closed_and_classify() {
             WarmBaseInventory {
                 entries: vec![entry()],
                 ignored: 0,
+                unrecognized: Vec::new(),
             },
             &active,
             &warm,
@@ -235,6 +240,7 @@ async fn activity_and_measurement_errors_retain() {
         WarmBaseInventory {
             entries: vec![entry()],
             ignored: 0,
+            unrecognized: Vec::new(),
         },
         &Activity(Err("db".into())),
         &warm,
@@ -247,6 +253,7 @@ async fn activity_and_measurement_errors_retain() {
         WarmBaseInventory {
             entries: vec![entry()],
             ignored: 0,
+            unrecognized: Vec::new(),
         },
         &Activity(Ok(snapshot())),
         &warm,
@@ -288,6 +295,7 @@ async fn idle_eviction_deletes_old_registered_base() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -339,6 +347,7 @@ async fn idle_eviction_retains_young_base_by_mtime() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -391,6 +400,7 @@ async fn idle_eviction_db_activity_takes_precedence_over_mtime() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -427,6 +437,7 @@ async fn idle_eviction_deletes_deleted_project_base() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: false,
@@ -463,6 +474,7 @@ async fn idle_eviction_deletes_orphaned_base() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: false,
@@ -499,6 +511,7 @@ async fn active_task_run_retains_base() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -536,6 +549,7 @@ async fn in_flight_warm_job_retains_base() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -573,6 +587,7 @@ async fn lock_busy_retains_base() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -614,6 +629,7 @@ async fn post_lock_recheck_retains_base() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     struct FlipActivityGuard {
         first: std::sync::Mutex<Option<ActivitySnapshot>>,
@@ -679,6 +695,7 @@ async fn dry_run_and_delete_select_same_candidates() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -736,6 +753,7 @@ async fn dry_run_and_delete_parity_with_flock_lock() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -795,6 +813,7 @@ async fn activity_error_fails_closed() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Err("db down".into()));
     let warm = Warm(Ok(false));
@@ -827,6 +846,7 @@ async fn lock_error_fails_closed() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -864,6 +884,7 @@ async fn unsafe_path_is_not_deleted() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         known_project: true,
@@ -943,6 +964,7 @@ async fn pressure_above_low_watermark_produces_no_candidates() {
     let inventory = WarmBaseInventory {
         entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 100)],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(snapshot_at(Some(old_activity(14)))));
     let warm = Warm(Ok(false));
@@ -969,6 +991,7 @@ async fn pressure_at_low_watermark_is_no_op() {
     let inventory = WarmBaseInventory {
         entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 100)],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(snapshot_at(Some(old_activity(14)))));
     let warm = Warm(Ok(false));
@@ -1000,6 +1023,7 @@ async fn pressure_below_low_selects_minimal_prefix() {
             pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 60),
         ],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     // Same activity for all, so ordering is by project ID.
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
@@ -1041,6 +1065,7 @@ async fn pressure_orders_by_activity_then_project_id() {
             pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
         ],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
@@ -1084,6 +1109,7 @@ async fn pressure_excluded_candidates_are_not_selected() {
             pressure_entry("018f8b9a-0d70-7f0a-8000-000000000006", 50),
         ],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
 
     struct GuardActivity;
@@ -1155,6 +1181,7 @@ async fn pressure_measurement_error_fails_closed() {
     let inventory = WarmBaseInventory {
         entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 100)],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
@@ -1185,6 +1212,7 @@ async fn pressure_insufficient_reclaimable_space_selects_all_safe() {
             pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 60),
         ],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
@@ -1216,6 +1244,7 @@ async fn pressure_exact_stop_at_high_watermark() {
             pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
         ],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
@@ -1247,6 +1276,7 @@ async fn pressure_young_base_is_excluded() {
             pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
         ],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
 
     struct YoungActivity;
@@ -1301,6 +1331,7 @@ async fn pressure_fractional_byte_boundary_reaches_high_watermark() {
     let inventory = WarmBaseInventory {
         entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 1)],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
@@ -1334,6 +1365,7 @@ async fn pressure_large_capacity_preserves_high_watermark_byte_ceiling() {
             2_251_799_813_685_248,
         )],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(snapshot_at(Some(old_activity(12)))));
     let warm = Warm(Ok(false));
@@ -1360,6 +1392,7 @@ async fn pressure_large_capacity_compares_low_watermark_exactly() {
     let inventory = WarmBaseInventory {
         entries: vec![pressure_entry("018f8b9a-0d70-7f0a-8000-000000000001", 1)],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let plan = plan_pressure_eviction(
         inventory,
@@ -1389,6 +1422,7 @@ async fn pressure_lock_busy_and_error_retained() {
             pressure_entry("018f8b9a-0d70-7f0a-8000-000000000002", 50),
         ],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
 
     struct BusyLock;
@@ -1422,6 +1456,7 @@ mod fingerprint_inventory;
 mod fingerprint_sweep;
 mod idle_variant_lock;
 mod pressure_execution;
+mod unrecognized_reclaim;
 
 /// The warm-base GC root must resolve the server pod's own cache mount.
 ///

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/fingerprint_inventory.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/fingerprint_inventory.rs
@@ -379,3 +379,50 @@ fn inventory_fails_closed_when_nested_profile_root_is_unreadable() {
         "unexpected error: {err}"
     );
 }
+
+/// `projected_bytes` counts only `.fingerprint/<unit>` metadata stamps. The
+/// artifacts those units cost live in `deps`, `build` and `incremental`, so a
+/// report built from unit bytes alone understates the profile by whatever ratio
+/// the artifacts happen to have. The per-profile measurement makes the
+/// shortfall visible.
+#[test]
+fn profile_root_measurement_counts_deps_build_and_incremental() {
+    let (_temp, base) = temp_base();
+    write_file(
+        &base.join("debug/.fingerprint/libcrate-abc123/lib-libcrate.json"),
+        b"{}",
+    );
+    write_file(&base.join("debug/deps/libcrate-abc123.rlib"), &[0u8; 4096]);
+    write_file(
+        &base.join("debug/build/libcrate-abc123/output"),
+        &[0u8; 512],
+    );
+    write_file(
+        &base.join("debug/incremental/crate-1/dep-graph.bin"),
+        &[0u8; 256],
+    );
+    write_file(&base.join("debug/djinn-binary"), &[0u8; 64]);
+
+    let inventory = inventory_fingerprint_units(&base).expect("inventory should succeed");
+
+    let unit_bytes: u64 = inventory
+        .units
+        .iter()
+        .map(|unit| unit.projected_bytes)
+        .sum();
+    assert_eq!(unit_bytes, 2, "unit bytes are metadata only");
+
+    assert_eq!(inventory.profile_roots.len(), 1);
+    let measured = &inventory.profile_roots[0];
+    assert_eq!(measured.fingerprint_bytes, 2);
+    assert_eq!(measured.deps_bytes, 4096);
+    assert_eq!(measured.build_bytes, 512);
+    assert_eq!(measured.incremental_bytes, 256);
+    assert_eq!(measured.other_bytes, 64);
+    assert_eq!(measured.total_bytes(), 4930);
+    assert_eq!(inventory.profile_root_bytes(), 4930);
+    assert!(
+        inventory.profile_root_bytes() > unit_bytes * 100,
+        "the unit total must be visibly smaller than the profile's real footprint"
+    );
+}

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/fingerprint_sweep.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/fingerprint_sweep.rs
@@ -160,6 +160,7 @@ async fn dry_run_and_delete_report_identical_candidates_and_preserve_artifacts()
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
 
     let dry_run = report_only_fingerprint_sweep(
@@ -203,6 +204,7 @@ async fn active_task_run_retains_base() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
     let activity = Activity(Ok(ActivitySnapshot {
         has_active_task_run: true,
@@ -235,6 +237,7 @@ async fn guard_error_retains_base_and_reports_error() {
     let inventory = WarmBaseInventory {
         entries: vec![entry],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
 
     let report = report_only_fingerprint_sweep(
@@ -262,6 +265,7 @@ async fn comprehensive_fixture_has_report_only_mode_parity_and_byte_preservation
     let inventory = WarmBaseInventory {
         entries: vec![fixture_entry(&base)],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
 
     let dry_run = report_only_fingerprint_sweep(
@@ -306,6 +310,7 @@ async fn lock_db_kubernetes_and_traversal_failures_preserve_fixture_and_close_ca
     let inventory = WarmBaseInventory {
         entries: vec![fixture_entry(&base)],
         ignored: 0,
+        unrecognized: Vec::new(),
     };
 
     let lock_busy = report_only_fingerprint_sweep(
@@ -350,6 +355,7 @@ async fn lock_db_kubernetes_and_traversal_failures_preserve_fixture_and_close_ca
         WarmBaseInventory {
             entries: vec![fixture_entry(&traversal_base)],
             ignored: 0,
+            unrecognized: Vec::new(),
         },
         &Activity(Ok(snapshot())),
         &Warm(Ok(false)),

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/fingerprint_sweep.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/fingerprint_sweep.rs
@@ -1,5 +1,5 @@
 use super::super::{LockOutcome, RetainReason, report_only_fingerprint_sweep};
-use super::{Activity, ActivitySnapshot, Lock, Warm, WarmBaseEntry, WarmBaseInventory, snapshot};
+use super::{Activity, ActivitySnapshot, Lock, Warm, WarmBaseEntry, snapshot, warm_inventory};
 use crate::context::CacheCleanupMode;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -157,11 +157,7 @@ async fn dry_run_and_delete_report_identical_candidates_and_preserve_artifacts()
         path: base.clone(),
         size_bytes: 0,
     };
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
 
     let dry_run = report_only_fingerprint_sweep(
         inventory.clone(),
@@ -201,11 +197,7 @@ async fn active_task_run_retains_base() {
         path: PathBuf::from("base"),
         size_bytes: 0,
     };
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
     let activity = Activity(Ok(ActivitySnapshot {
         has_active_task_run: true,
         ..snapshot()
@@ -234,11 +226,7 @@ async fn guard_error_retains_base_and_reports_error() {
         path: PathBuf::from("base"),
         size_bytes: 0,
     };
-    let inventory = WarmBaseInventory {
-        entries: vec![entry],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![entry]);
 
     let report = report_only_fingerprint_sweep(
         inventory,
@@ -262,11 +250,7 @@ async fn comprehensive_fixture_has_report_only_mode_parity_and_byte_preservation
     fs::create_dir(&base).expect("base");
     let expected_projected_bytes = comprehensive_fixture(&base);
     let before = fixture_snapshot(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![fixture_entry(&base)],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![fixture_entry(&base)]);
 
     let dry_run = report_only_fingerprint_sweep(
         inventory.clone(),
@@ -307,11 +291,7 @@ async fn lock_db_kubernetes_and_traversal_failures_preserve_fixture_and_close_ca
     fs::create_dir(&base).expect("base");
     comprehensive_fixture(&base);
     let before = fixture_snapshot(&base);
-    let inventory = WarmBaseInventory {
-        entries: vec![fixture_entry(&base)],
-        ignored: 0,
-        unrecognized: Vec::new(),
-    };
+    let inventory = warm_inventory(vec![fixture_entry(&base)]);
 
     let lock_busy = report_only_fingerprint_sweep(
         inventory.clone(),
@@ -352,11 +332,7 @@ async fn lock_db_kubernetes_and_traversal_failures_preserve_fixture_and_close_ca
         .expect("empty fingerprint unit");
     let traversal_before = fixture_snapshot(&traversal_base);
     let traversal = report_only_fingerprint_sweep(
-        WarmBaseInventory {
-            entries: vec![fixture_entry(&traversal_base)],
-            ignored: 0,
-            unrecognized: Vec::new(),
-        },
+        warm_inventory(vec![fixture_entry(&traversal_base)]),
         &Activity(Ok(snapshot())),
         &Warm(Ok(false)),
         &Lock(LockOutcome::Available),

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/idle_variant_lock.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/idle_variant_lock.rs
@@ -64,11 +64,7 @@ async fn idle_eviction_deletes_only_the_selected_mold_variant() {
         succeed: true,
     };
     let result = evict_idle_warm_bases(
-        WarmBaseInventory {
-            entries: vec![selected],
-            ignored: 0,
-            unrecognized: Vec::new(),
-        },
+        warm_inventory(vec![selected]),
         &Activity(Ok(snapshot())),
         &Warm(Ok(false)),
         &locks,

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/idle_variant_lock.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/idle_variant_lock.rs
@@ -67,6 +67,7 @@ async fn idle_eviction_deletes_only_the_selected_mold_variant() {
         WarmBaseInventory {
             entries: vec![selected],
             ignored: 0,
+            unrecognized: Vec::new(),
         },
         &Activity(Ok(snapshot())),
         &Warm(Ok(false)),

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/unrecognized_reclaim.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/unrecognized_reclaim.rs
@@ -1,0 +1,538 @@
+//! Reclamation of directories inside a warm project root that no current
+//! layout produces.
+//!
+//! The production symptom these cover: a 27 GB `<project-id>/debug` tree, left
+//! behind when the warm base moved to `mold-jobs-N` subdirectories, sitting
+//! untouched for ten days beside a live `<project-id>/mold-jobs-4`. Every
+//! existing phase walks a strict `<project-id>/mold-jobs-N` allowlist, so the
+//! tree was never *retained* by a safety decision — it was unreachable.
+
+use super::*;
+use std::os::fd::AsRawFd;
+
+const PROJECT: &str = "018f8b9a-0d70-7f0a-8000-000000000001";
+
+/// Build `<root>/<PROJECT>/{mold-jobs-4, debug}` with the stale tree aged to
+/// the epoch and the live variant left fresh.
+fn stale_debug_beside_live_variant(root: &Path) -> (PathBuf, PathBuf) {
+    let project = root.join(PROJECT);
+    let live = project.join("mold-jobs-4");
+    let stale = project.join("debug");
+    std::fs::create_dir_all(live.join("deps")).expect("live variant");
+    std::fs::write(live.join("deps").join("libdjinn.rlib"), b"live").expect("live artifact");
+    std::fs::create_dir_all(stale.join("deps")).expect("stale tree");
+    std::fs::write(stale.join("deps").join("libdjinn.rlib"), b"stale bytes").expect("stale");
+    age_tree(&stale, SystemTime::UNIX_EPOCH);
+    (live, stale)
+}
+
+/// Set every mtime in a tree, deepest first, so the root's own mtime is not
+/// refreshed by a later child write.
+fn age_tree(root: &Path, at: SystemTime) {
+    let mut stack = vec![root.to_path_buf()];
+    let mut all = Vec::new();
+    while let Some(path) = stack.pop() {
+        all.push(path.clone());
+        if let Ok(children) = std::fs::read_dir(&path) {
+            for child in children.flatten() {
+                stack.push(child.path());
+            }
+        }
+    }
+    let time = filetime::FileTime::from_system_time(at);
+    for path in all.into_iter().rev() {
+        filetime::set_file_mtime(&path, time).expect("set mtime");
+    }
+}
+
+fn config_with_idle_days(days: u64) -> crate::context::CacheCleanupConfig {
+    crate::context::CacheCleanupConfig {
+        warm_unrecognized_min_idle_days: days,
+        ..default_config()
+    }
+}
+
+async fn reclaim_at(
+    root: &Path,
+    activity: &Activity,
+    warm: &Warm,
+    locks: &dyn BaseLock,
+    config: &crate::context::CacheCleanupConfig,
+    now: SystemTime,
+    mode: crate::context::CacheCleanupMode,
+) -> UnrecognizedReclaimResult {
+    let inventory = inventory_under(root).expect("inventory");
+    reclaim_unrecognized_warm_entries(
+        &inventory.unrecognized,
+        activity,
+        warm,
+        locks,
+        config,
+        &TestClock::new(now, std::time::Instant::now()),
+        mode,
+        root,
+    )
+    .await
+}
+
+#[test]
+fn inventory_reports_the_stale_tree_the_allowlist_cannot_classify() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+
+    let inventory = inventory_under(temp.path()).expect("inventory");
+
+    assert_eq!(inventory.entries.len(), 1, "one canonical variant");
+    assert_eq!(inventory.entries[0].mold_jobs, 4);
+    assert_eq!(
+        inventory
+            .unrecognized
+            .iter()
+            .map(|entry| (entry.project_id.as_str(), entry.name.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(PROJECT, "debug")],
+        "the abandoned layout must appear by name, not only in `ignored`"
+    );
+    let entry = &inventory.unrecognized[0];
+    assert_eq!(entry.path, stale);
+    assert_eq!(
+        entry.size_bytes, 11,
+        "the reported size must be the measured tree, not a placeholder"
+    );
+    assert_eq!(entry.newest_mtime, Some(SystemTime::UNIX_EPOCH));
+}
+
+/// The load-bearing test: the stale tree is gone and the live variant is
+/// untouched, through the real whole-project flock.
+#[tokio::test]
+async fn sweep_reclaims_the_stale_tree_and_keeps_the_live_variant() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (live, stale) = stale_debug_beside_live_variant(temp.path());
+
+    let result = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::Delete,
+    )
+    .await;
+
+    assert!(
+        !stale.exists(),
+        "the stale tree must actually be gone from disk"
+    );
+    assert!(
+        live.join("deps").join("libdjinn.rlib").exists(),
+        "the live mold-jobs-4 variant and its artifacts must survive"
+    );
+    assert_eq!(
+        result
+            .deleted
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["debug"]
+    );
+    assert!(result.retained.is_empty(), "{:?}", result.retained);
+    assert_eq!(
+        result.reclaimed_bytes, 11,
+        "reclaimed bytes must be the measured tree size"
+    );
+
+    // Re-running is a no-op rather than an error: nothing is left to find.
+    let second = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::Delete,
+    )
+    .await;
+    assert!(second.scanned.is_empty());
+    assert_eq!(second.reclaimed_bytes, 0);
+}
+
+#[tokio::test]
+async fn a_tree_younger_than_the_threshold_is_retained() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+    age_tree(&stale, future(14));
+
+    let result = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::Delete,
+    )
+    .await;
+
+    assert!(stale.exists(), "a tree written a day ago must survive");
+    assert!(result.deleted.is_empty());
+    assert_eq!(result.retained[0].1, UnrecognizedRetainReason::Young);
+}
+
+/// A single fresh file deep inside an otherwise ancient tree keeps the whole
+/// tree. The root directory's own mtime is deliberately left old, so this fails
+/// if the age check ever narrows to a top-level `stat`.
+#[tokio::test]
+async fn one_fresh_file_deep_in_the_tree_keeps_the_whole_tree() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+    let deep = stale.join("deps").join("libdjinn.rlib");
+    filetime::set_file_mtime(&deep, filetime::FileTime::from_system_time(future(14)))
+        .expect("touch");
+    filetime::set_file_mtime(
+        &stale,
+        filetime::FileTime::from_system_time(SystemTime::UNIX_EPOCH),
+    )
+    .expect("keep the root old");
+
+    let result = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::Delete,
+    )
+    .await;
+
+    assert!(stale.exists());
+    assert_eq!(result.retained[0].1, UnrecognizedRetainReason::Young);
+}
+
+/// The whole-project warm lock, taken at the worker's own production identity
+/// (`.warm-locks/<project-id>.lock`), blocks reclamation. Acquiring it here
+/// directly rather than through the coordinator adapter is what proves the two
+/// contend on the same inode.
+#[tokio::test]
+async fn a_held_worker_project_lock_blocks_reclamation() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+
+    let lock_dir = temp.path().join(".warm-locks");
+    std::fs::create_dir_all(&lock_dir).expect("lock dir");
+    let lock_path = lock_dir.join(format!("{PROJECT}.lock"));
+    let worker_lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .expect("open worker lock");
+    assert_eq!(
+        unsafe { libc::flock(worker_lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0,
+        "worker-compatible lock must be acquired"
+    );
+
+    let result = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::Delete,
+    )
+    .await;
+
+    assert!(stale.exists(), "a locked project must not be reclaimed");
+    assert!(result.deleted.is_empty());
+    assert_eq!(result.retained[0].1, UnrecognizedRetainReason::LockBusy);
+
+    // Releasing the worker lock lets the very next pass reclaim it, proving the
+    // retention was the lock and not some unrelated guard.
+    drop(worker_lock);
+    let result = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::Delete,
+    )
+    .await;
+    assert!(!stale.exists());
+    assert_eq!(result.deleted.len(), 1);
+}
+
+#[tokio::test]
+async fn every_project_guard_fails_closed() {
+    for (reason, activity, warm) in [
+        (
+            UnrecognizedRetainReason::ActiveTaskRun,
+            Activity(Ok(ActivitySnapshot {
+                has_active_task_run: true,
+                ..snapshot()
+            })),
+            Warm(Ok(false)),
+        ),
+        (
+            UnrecognizedRetainReason::ActivityError,
+            Activity(Err("db down".into())),
+            Warm(Ok(false)),
+        ),
+        (
+            UnrecognizedRetainReason::WarmJobInFlight,
+            Activity(Ok(snapshot())),
+            Warm(Ok(true)),
+        ),
+        (
+            UnrecognizedRetainReason::WarmJobError,
+            Activity(Ok(snapshot())),
+            Warm(Err("apiserver down".into())),
+        ),
+    ] {
+        let temp = tempfile::tempdir().expect("temp");
+        let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+
+        let result = reclaim_at(
+            temp.path(),
+            &activity,
+            &warm,
+            &SharedWarmProjectLock,
+            &config_with_idle_days(7),
+            future(15),
+            crate::context::CacheCleanupMode::Delete,
+        )
+        .await;
+
+        assert!(stale.exists(), "{reason:?} must retain the tree");
+        assert_eq!(result.retained[0].1, reason);
+        assert!(result.deleted.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn a_lock_error_retains_rather_than_deleting() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+
+    let result = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &FailingBaseLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::Delete,
+    )
+    .await;
+
+    assert!(stale.exists());
+    assert_eq!(result.retained[0].1, UnrecognizedRetainReason::LockError);
+}
+
+#[tokio::test]
+async fn dry_run_reports_without_deleting_or_locking() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+
+    let result = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::DryRun,
+    )
+    .await;
+
+    assert!(stale.exists(), "dry-run must never delete");
+    assert!(result.deleted.is_empty());
+    assert_eq!(result.dry_run.len(), 1);
+    assert!(
+        !temp.path().join(".warm-locks").exists(),
+        "dry-run must not create lock state"
+    );
+}
+
+#[tokio::test]
+async fn reserved_dot_directories_are_never_reclaimed() {
+    let temp = tempfile::tempdir().expect("temp");
+    let project = temp.path().join(PROJECT);
+    std::fs::create_dir_all(project.join("mold-jobs-4")).expect("variant");
+    let reserved = project.join(".operator-parked");
+    std::fs::create_dir_all(&reserved).expect("reserved");
+    std::fs::write(reserved.join("keep"), b"keep").expect("file");
+    age_tree(&reserved, SystemTime::UNIX_EPOCH);
+
+    let result = reclaim_at(
+        temp.path(),
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        future(15),
+        crate::context::CacheCleanupMode::Delete,
+    )
+    .await;
+
+    assert!(reserved.exists(), "dot-directories are out of reach");
+    assert_eq!(result.retained[0].1, UnrecognizedRetainReason::Reserved);
+}
+
+/// A tree that changes between the inventory walk and the lock must not be
+/// removed on the strength of the stale observation.
+#[tokio::test]
+async fn a_write_between_planning_and_the_lock_aborts_the_removal() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+
+    // Plan against the ancient tree, then let a "writer" touch it before the
+    // reclaimer takes the lock and rechecks.
+    let inventory = inventory_under(temp.path()).expect("inventory");
+    assert_eq!(inventory.unrecognized.len(), 1);
+    std::fs::write(stale.join("deps").join("fresh.rlib"), b"fresh").expect("write");
+    filetime::set_file_mtime(
+        stale.join("deps").join("fresh.rlib"),
+        filetime::FileTime::from_system_time(future(15)),
+    )
+    .expect("touch");
+
+    let result = reclaim_unrecognized_warm_entries(
+        &inventory.unrecognized,
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        &TestClock::new(future(15), std::time::Instant::now()),
+        crate::context::CacheCleanupMode::Delete,
+        temp.path(),
+    )
+    .await;
+
+    assert!(stale.exists(), "the post-lock recheck must abort");
+    assert!(result.deleted.is_empty());
+    assert_eq!(result.retained[0].1, UnrecognizedRetainReason::Young);
+}
+
+/// A symlink is not a directory, so it is counted in `ignored` and never
+/// becomes a reclamation candidate.
+#[test]
+fn a_symlinked_project_child_is_not_a_reclamation_candidate() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, _stale) = stale_debug_beside_live_variant(temp.path());
+    let outside = temp.path().join("outside");
+    std::fs::create_dir_all(&outside).expect("outside");
+    std::os::unix::fs::symlink(&outside, temp.path().join(PROJECT).join("linked"))
+        .expect("symlink");
+
+    let inventory = inventory_under(temp.path()).expect("inventory");
+
+    assert_eq!(
+        inventory
+            .unrecognized
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["debug"],
+        "a symlink must never become a reclamation candidate"
+    );
+    assert!(outside.exists());
+}
+
+/// Nothing at the warm root itself is a candidate — that level holds reserved
+/// machinery and other roots' namespaces, and stays purely in `ignored`.
+#[test]
+fn warm_root_children_outside_a_project_uuid_are_never_candidates() {
+    let temp = tempfile::tempdir().expect("temp");
+    stale_debug_beside_live_variant(temp.path());
+    std::fs::create_dir_all(temp.path().join(".warm-locks")).expect("locks");
+    std::fs::create_dir_all(temp.path().join("not-a-uuid")).expect("stray");
+    std::fs::write(temp.path().join(".djinn-gc.lock"), b"").expect("lock file");
+
+    let inventory = inventory_under(temp.path()).expect("inventory");
+
+    assert_eq!(
+        inventory
+            .unrecognized
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["debug"]
+    );
+    assert_eq!(
+        inventory.ignored, 4,
+        "three root-level strays plus the project-level `debug`"
+    );
+}
+
+/// An unmeasurable tree has an unknown age, which must never read as "old".
+#[tokio::test]
+async fn an_unmeasurable_tree_is_retained_not_reclaimed() {
+    let temp = tempfile::tempdir().expect("temp");
+    let (_live, stale) = stale_debug_beside_live_variant(temp.path());
+
+    let entries = vec![UnrecognizedWarmEntry {
+        project_id: PROJECT.into(),
+        name: "debug".into(),
+        path: stale.clone(),
+        size_bytes: 0,
+        newest_mtime: None,
+    }];
+    let result = reclaim_unrecognized_warm_entries(
+        &entries,
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        &TestClock::new(future(15), std::time::Instant::now()),
+        crate::context::CacheCleanupMode::Delete,
+        temp.path(),
+    )
+    .await;
+
+    assert!(stale.exists());
+    assert_eq!(
+        result.retained[0].1,
+        UnrecognizedRetainReason::MeasurementError
+    );
+}
+
+/// Containment is re-derived from the filesystem under the lock, so an entry
+/// pointing outside the warm root cannot be removed even if it reaches the
+/// reclaimer with a plausible-looking record.
+#[tokio::test]
+async fn a_target_outside_the_warm_root_is_refused() {
+    let temp = tempfile::tempdir().expect("temp");
+    stale_debug_beside_live_variant(temp.path());
+    let elsewhere = tempfile::tempdir().expect("elsewhere");
+    let victim = elsewhere.path().join(PROJECT).join("debug");
+    std::fs::create_dir_all(&victim).expect("victim");
+    age_tree(&victim, SystemTime::UNIX_EPOCH);
+
+    let entries = vec![UnrecognizedWarmEntry {
+        project_id: PROJECT.into(),
+        name: "debug".into(),
+        path: victim.clone(),
+        size_bytes: 0,
+        newest_mtime: Some(SystemTime::UNIX_EPOCH),
+    }];
+    let result = reclaim_unrecognized_warm_entries(
+        &entries,
+        &Activity(Ok(snapshot())),
+        &Warm(Ok(false)),
+        &SharedWarmProjectLock,
+        &config_with_idle_days(7),
+        &TestClock::new(future(15), std::time::Instant::now()),
+        crate::context::CacheCleanupMode::Delete,
+        temp.path(),
+    )
+    .await;
+
+    assert!(victim.exists(), "a target outside the root must survive");
+    assert_eq!(result.retained[0].1, UnrecognizedRetainReason::Changed);
+}

--- a/server/crates/djinn-coordinator/src/context.rs
+++ b/server/crates/djinn-coordinator/src/context.rs
@@ -243,6 +243,20 @@ pub struct CacheCleanupConfig {
     /// eviction stops. Expressed as a fraction of total available bytes.
     /// Env: `DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO` (default `0.25`).
     pub warm_base_high_free_ratio: f64,
+
+    /// How long a directory inside `/cache/cargo-target/<project_id>/` that is
+    /// not a canonical `mold-jobs-N` variant must go untouched before the sweep
+    /// reclaims it.
+    /// Env: `DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS` (default `7`).
+    ///
+    /// This is deliberately a shipped default rather than an arming flag. An
+    /// unrecognized entry is by definition something the code does not
+    /// understand, so the sweep does not reason about *what* it is — it proves
+    /// nothing has written anywhere in the tree for this long, that the project
+    /// has no active task run or in-flight warm Job, and takes the whole-project
+    /// warm lock. Setting `0` makes any such entry immediately eligible, which
+    /// is why the shipped value is a week rather than zero.
+    pub warm_unrecognized_min_idle_days: u64,
 }
 
 impl Default for CacheCleanupConfig {
@@ -260,6 +274,7 @@ impl Default for CacheCleanupConfig {
             warm_base_grace_period: Duration::from_secs(300),
             warm_base_low_free_ratio: 0.15,
             warm_base_high_free_ratio: 0.25,
+            warm_unrecognized_min_idle_days: 7,
         }
     }
 }
@@ -333,6 +348,12 @@ impl CacheCleanupConfig {
 
         let warm_base_low_free_ratio = warm_base_low_free_ratio.min(warm_base_high_free_ratio);
 
+        let warm_unrecognized_min_idle_days =
+            std::env::var("DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS")
+                .ok()
+                .and_then(|value| parse_unsigned_decimal(&value))
+                .unwrap_or(7);
+
         Self {
             mode,
             sccache_enabled,
@@ -346,6 +367,7 @@ impl CacheCleanupConfig {
             warm_base_grace_period: Duration::from_secs(warm_base_grace_period_secs),
             warm_base_low_free_ratio,
             warm_base_high_free_ratio,
+            warm_unrecognized_min_idle_days,
         }
     }
 
@@ -534,6 +556,35 @@ mod tests {
         assert_eq!(config.warm_base_grace_period, Duration::from_secs(300));
         assert!((config.warm_base_low_free_ratio - 0.15).abs() < f64::EPSILON);
         assert!((config.warm_base_high_free_ratio - 0.25).abs() < f64::EPSILON);
+        // Reclaiming a directory the layout cannot explain is default-on, with
+        // a shipped idle threshold rather than an arming flag an operator has
+        // to remember. A zero here would make any unrecognized entry
+        // immediately eligible.
+        assert_eq!(config.warm_unrecognized_min_idle_days, 7);
+    }
+
+    #[test]
+    fn cache_cleanup_unrecognized_idle_days_falls_back_to_the_shipped_default() {
+        unsafe {
+            std::env::set_var(
+                "DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS",
+                "not-a-number",
+            );
+        }
+        assert_eq!(
+            CacheCleanupConfig::from_env().warm_unrecognized_min_idle_days,
+            7
+        );
+        unsafe {
+            std::env::set_var("DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS", "30");
+        }
+        assert_eq!(
+            CacheCleanupConfig::from_env().warm_unrecognized_min_idle_days,
+            30
+        );
+        unsafe {
+            std::env::remove_var("DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS");
+        }
     }
 
     #[test]

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -4223,6 +4223,31 @@ async fn sweep_cargo_warm_base_guard_under(
             inventory_count,
         );
     }
+    // `ignored` used to be write-only: a dozen assignments and no reader, so a
+    // tree the allowlist could not classify left no trace anywhere. Report it,
+    // and report the unrecognized project-root directories by name, before any
+    // phase runs — a sweep that cannot explain part of the root must say so.
+    if inventory.ignored > 0 || !inventory.unrecognized.is_empty() {
+        let unrecognized_bytes = inventory
+            .unrecognized
+            .iter()
+            .map(|entry| entry.size_bytes)
+            .fold(0u64, u64::saturating_add);
+        tracing::info!(
+            component = metrics::COMPONENT_CARGO_WARM_BASE,
+            mode = config.mode.as_metric_label(),
+            root = %warm_base_root.display(),
+            ignored = inventory.ignored,
+            unrecognized = inventory.unrecognized.len(),
+            unrecognized_bytes,
+            unrecognized_names = ?inventory
+                .unrecognized
+                .iter()
+                .map(|entry| format!("{}/{}", entry.project_id, entry.name))
+                .collect::<Vec<_>>(),
+            "warm-base GC inventory found entries outside the canonical layout"
+        );
+    }
     let clock = SystemClock::new();
     // Idle deletion must serialize with worker warm writes using the exact
     // production variant lock identity under `.warm-locks`. Project activity
@@ -4256,6 +4281,38 @@ async fn sweep_cargo_warm_base_guard_under(
         config.mode,
     )
     .await;
+
+    // Reclaim directories inside a project root that no current layout
+    // produces. The allowlist-driven phases below cannot reach these at all —
+    // they enumerate `<project-id>/mold-jobs-N` and nothing else — so an
+    // abandoned layout is invisible to them rather than retained by them.
+    let unrecognized_result = gc::reclaim_unrecognized_warm_entries(
+        &inventory.unrecognized,
+        &activity,
+        guard.as_ref(),
+        &gc::SharedWarmProjectLock,
+        config,
+        &clock,
+        config.mode,
+        &warm_base_root,
+    )
+    .await;
+    // Reclaimed bytes and per-entry outcomes are emitted inside the reclaimer,
+    // at the point each removal actually succeeds; this is the roll-up log.
+    if !unrecognized_result.scanned.is_empty() {
+        tracing::info!(
+            component = metrics::COMPONENT_CARGO_WARM_BASE,
+            mode = config.mode.as_metric_label(),
+            scanned = unrecognized_result.scanned.len(),
+            scanned_bytes = unrecognized_result.scanned_bytes(),
+            deleted = unrecognized_result.deleted.len(),
+            dry_run = unrecognized_result.dry_run.len(),
+            retained = unrecognized_result.retained.len(),
+            reclaimed_bytes = unrecognized_result.reclaimed_bytes,
+            min_idle_days = config.warm_unrecognized_min_idle_days,
+            "warm-base unrecognized-entry GC completed"
+        );
+    }
 
     let result = gc::evict_idle_warm_bases(
         inventory,
@@ -4345,4 +4402,113 @@ async fn sweep_cargo_warm_base_guard_under(
         remeasurement_failed = pressure.remeasurement_failed,
         "warm-base three-rung pressure GC completed"
     );
+}
+
+#[cfg(test)]
+mod warm_base_unrecognized_sweep_tests {
+    use super::*;
+    use crate::cargo_warm_base_gc as gc;
+    use crate::context::{CacheCleanupConfig, CacheCleanupMode};
+    use std::time::SystemTime;
+
+    struct NoWarmJobs;
+    #[async_trait::async_trait]
+    impl gc::WarmJobGuard for NoWarmJobs {
+        async fn has_in_flight_warm(&self, _: &str) -> Result<bool, String> {
+            Ok(false)
+        }
+    }
+
+    fn age_tree(root: &Path, days: u64) {
+        let mut stack = vec![root.to_path_buf()];
+        let mut all = Vec::new();
+        while let Some(path) = stack.pop() {
+            all.push(path.clone());
+            if let Ok(children) = std::fs::read_dir(&path) {
+                for child in children.flatten() {
+                    stack.push(child.path());
+                }
+            }
+        }
+        let when = filetime::FileTime::from_system_time(
+            SystemTime::now() - Duration::from_secs(days * 24 * 60 * 60),
+        );
+        for path in all.into_iter().rev() {
+            filetime::set_file_mtime(&path, when).expect("set mtime");
+        }
+    }
+
+    /// Reaching the reclaimer from the real maintenance entry point, not just
+    /// from a unit test that calls it directly.
+    ///
+    /// The unit tests prove the reclaimer works; this proves it is *wired*.
+    /// The composition site is where this class of fix usually dies: a correct
+    /// implementation that nothing calls behaves exactly like the bug.
+    #[tokio::test]
+    async fn the_maintenance_sweep_reclaims_a_stale_project_directory() {
+        let db = crate::test_helpers::create_test_db();
+        let project = crate::test_helpers::create_test_project(&db).await;
+        let temp = tempfile::TempDir::new().expect("temp");
+        let root = temp.path().join("cargo-target");
+        let live = root.join(&project.id).join("mold-jobs-4");
+        let stale = root.join(&project.id).join("debug");
+        std::fs::create_dir_all(live.join("deps")).expect("live");
+        std::fs::write(live.join("deps").join("live.rlib"), b"live").expect("live artifact");
+        std::fs::create_dir_all(stale.join("deps")).expect("stale");
+        std::fs::write(stale.join("deps").join("stale.rlib"), b"stale").expect("stale artifact");
+        age_tree(&stale, 10);
+
+        let config = CacheCleanupConfig {
+            mode: CacheCleanupMode::Delete,
+            ..CacheCleanupConfig::default()
+        };
+        sweep_cargo_warm_base_guard_under(
+            &db,
+            &config,
+            Some(Arc::new(NoWarmJobs) as Arc<dyn gc::WarmJobGuard>),
+            &root,
+        )
+        .await;
+
+        assert!(
+            !stale.exists(),
+            "the maintenance sweep must reach the abandoned layout"
+        );
+        assert!(
+            live.join("deps").join("live.rlib").exists(),
+            "the live mold-jobs-4 variant must survive the same pass"
+        );
+    }
+
+    /// The shipped default is a week, so a three-day-old tree survives without
+    /// anyone configuring anything.
+    #[tokio::test]
+    async fn the_maintenance_sweep_keeps_a_recently_written_project_directory() {
+        let db = crate::test_helpers::create_test_db();
+        let project = crate::test_helpers::create_test_project(&db).await;
+        let temp = tempfile::TempDir::new().expect("temp");
+        let root = temp.path().join("cargo-target");
+        let stale = root.join(&project.id).join("debug");
+        std::fs::create_dir_all(root.join(&project.id).join("mold-jobs-4")).expect("live");
+        std::fs::create_dir_all(&stale).expect("stale");
+        std::fs::write(stale.join("artifact"), b"recent").expect("artifact");
+        age_tree(&stale, 3);
+
+        let config = CacheCleanupConfig {
+            mode: CacheCleanupMode::Delete,
+            ..CacheCleanupConfig::default()
+        };
+        sweep_cargo_warm_base_guard_under(
+            &db,
+            &config,
+            Some(Arc::new(NoWarmJobs) as Arc<dyn gc::WarmJobGuard>),
+            &root,
+        )
+        .await;
+
+        assert!(
+            stale.exists(),
+            "a tree written three days ago is inside the shipped idle threshold"
+        );
+    }
 }


### PR DESCRIPTION
## The gap

On the production cache PVC a 27 GB `/cache/cargo-target/<project-uuid>/debug/` tree, left over from the pre-`mold-jobs-N` layout, has sat untouched since 2026-07-17 beside the live `<uuid>/mold-jobs-4`. Every warm-base phase — idle eviction, three-rung pressure, the report-only fingerprint sweep — enumerates `inventory_under`, which walks a strict `<project-uuid>/mold-jobs-N` allowlist. The `debug/` tree was not *retained* by any of them; it was unreachable to all of them.

Anything the allowlist rejected was counted into `WarmBaseInventory::ignored`, a field written at ~12 sites and read at zero. So the tree was invisible to the sweep **and** to the operator: `warm-base idle GC completed deleted=0 retained=0` was a truthful line about a root it could not fully see.

This is a reach defect, not a mode defect. `deploy/helm/djinn/values.yaml` ships `cacheCleanup.mode: delete`, and the fingerprint sweep's `safety_disabled_report_only` outcome is emitted *only* on `CacheCleanupMode::Delete` — positive evidence prod already runs in delete mode. Setting `DJINN_CACHE_CLEANUP_MODE` would have reclaimed nothing.

## What the sweep now reclaims

A directory directly under a canonical `<project-uuid>` warm root that is not a canonical `mold-jobs-N` variant. Reclamation requires **all** of, in order:

1. a name outside the reserved namespace (any `.`-prefixed directory is permanently out of reach);
2. a fully measured tree whose newest mtime **anywhere inside it** is older than `warm_unrecognized_min_idle_days` — an unmeasurable tree has an unknown age and is never eligible;
3. no active task run for that project (`WarmBaseActivityRepository`);
4. no in-flight warm Job (the same `WarmJobLister` the warmer uses; a Kubernetes error fails closed);
5. the whole-project warm lock `<root>/.warm-locks/<project-id>.lock`, taken non-blocking — the exact identity `WarmBaseLock::acquire` uses in `djinn-agent-worker`, i.e. the lock any legacy-layout writer of `<uuid>/debug` would itself have held. A per-variant lock deliberately "cannot contend with, or authorize mutation of, legacy and sibling bases", so it could not have covered a sibling;
6. a post-lock recheck that re-walks the tree, re-proves the idleness, and re-derives canonical containment `root ⊂ project ⊂ target` from the filesystem.

Step 6 is what makes idleness a guard rather than a planning-time snapshot: anything that touches the tree between the inventory walk and the lock makes the newest mtime fresh and aborts the removal.

Everything lives in shipped defaults and shipped code paths. `warm_unrecognized_min_idle_days` defaults to **7 days** in `CacheCleanupConfig::default()`; there is no arming flag, no new Helm value, no runbook step. `DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS` exists only as an escape hatch and is documented in the runbook's defaults table.

Dry-run reports what it would remove and never opens a lock, because opening one creates lock state and mutates fallback mtime state.

## What it still refuses to touch, and why

- **Live `mold-jobs-N` variants.** They are inventory *entries*, never unrecognized entries, and the post-lock recheck refuses any target whose name parses as a canonical variant.
- **Anything at the warm root itself.** Root children that are not canonical project UUIDs stay purely in `ignored` and are logged, never deleted. That level holds `.warm-locks`, `.djinn-gc.lock`, and other roots' namespaces. Establishing scope precisely was the point: the reclaimer only ever operates one level *inside* a directory whose name round-trips through `Uuid::parse_str`.
- **Dot-directories inside a project root.** Cargo never creates one, so reserving the whole namespace is free and keeps djinn's machinery — and anything an operator deliberately parked there — out of reach.
- **Symlinks.** A symlinked project child is not a directory to `read_dir`, so it never becomes a candidate at all; the post-lock recheck refuses a symlinked target as well.
- **Trees held by anything running.** Active task run, in-flight warm Job, held project lock, or any guard *error* all retain. Every failure mode fails closed and is logged with a bounded reason.
- **Trees it cannot measure.** An unknown age never reads as "old".
- **Fingerprint units.** The fingerprint sweep stays report-only; nothing here arms it.

`inventory_under` still maps `NotFound` to an empty inventory — the server pod has no `/cache` — and `inventory_under_a_missing_root_is_an_empty_success_not_an_error` still passes unchanged.

## Telemetry

`ignored` now has a reader. Before any phase runs, the sweep logs the ignored count plus every unrecognized entry by `project/name` and its measured bytes, then a roll-up of scanned/deleted/retained/reclaimed. Per-entry outcomes reuse the existing bounded `djinn_cache_cleanup_total` component and outcome labels — no new label values, so no metric-registration goldens move.

## Secondary gap: fingerprint sizes understated actual disk — fixed

Confirmed: `FingerprintUnitEntry::projected_bytes` measured only `.fingerprint/<unit>`, which holds per-unit metadata stamps of a few kilobytes. The artifacts those units cost live in `deps/`, `build/` and `incremental/`, so the reported total understated the profile by roughly that ratio.

`inventory_fingerprint_units` now also returns a `ProfileRootMeasurement` per profile root, split across `.fingerprint` / `deps` / `build` / `incremental` / other, and the sweep logs `profile_root_bytes` beside `projected_bytes`. The measurement runs after the existing `.fingerprint` checks so the fail-closed error precedence is unchanged.

**Deliberately scoped out:** attributing `deps`/`build`/`incremental` bytes back to *individual* units. That needs Cargo's unit-hash-to-artifact mapping reproduced, and would be reclamation-shaped work on a surface that is report-only by design.

## How I proved the tests are not vacuous

The load-bearing test is `sweep_reclaims_the_stale_tree_and_keeps_the_live_variant`: it builds `<uuid>/debug` beside `<uuid>/mold-jobs-4`, runs the reclaimer through the real `SharedWarmProjectLock`, and asserts `!stale.exists()` **and** that the live variant's artifact still exists.

Two neutralizations, each reverted and the source verified byte-identical afterwards:

1. **Early-return the whole reclamation body.** 11 of 14 tests went red, including `the stale tree must actually be gone from disk`. The 3 that stayed green are the pure-inventory tests, which do not call the reclaimer.
2. **No-op the removal only** (`remove_dir_all` replaced with `Ok(())`, leaving every status field still reporting `deleted`). 12 of 14 stayed green — and the two that failed were the two asserting disk state. This is the one that matters: it proves the assertion is on the side effect, not on the label the code hands itself.

At the composition site, `the_maintenance_sweep_reclaims_a_stale_project_directory` drives the real entry point `sweep_cargo_warm_base_guard_under` against a real database and a temp warm root. Neutralizing the wiring alone (passing `&[]` instead of `&inventory.unrecognized`, leaving the reclaimer itself fully intact) turns it red on `the maintenance sweep must reach the abandoned layout` — a correct implementation nothing calls behaves exactly like the bug, so it gets its own failing-on-neutralization test.

Additional coverage: young tree retained; one fresh file deep in an otherwise ancient tree (with the root's own mtime left old, so it fails if the age check ever narrows to a top-level `stat`); a real worker-held `.warm-locks/<project-id>.lock` blocking, then releasing and the very next pass reclaiming; each of the four project guards failing closed; lock error; dry-run neither deleting nor creating lock state; reserved dot-directories; a write landing between planning and the lock; symlinked children; warm-root strays; an unmeasurable tree; and a target outside the warm root.

## Second commit: the file-size guard

Adding `unrecognized` to `WarmBaseInventory` forced `unrecognized: Vec::new(),` into every struct literal in `cargo_warm_base_gc/tests.rs` — ~34 one-line additions to a file already at 1469 of the guard's 1500 lines on `main`. It landed at 1504 and `Server Guards → Check changed Rust file sizes` failed. (`cargo_warm_base_gc.rs` and `health.rs` passed only because they already carry `djinn:allow-oversize`.)

Fixed by removing the pressure rather than raising the ceiling: a `warm_inventory(entries)` test constructor collapses each 4-line literal to one call. `tests.rs` is now **1392 lines / 44 KB** — 77 lines *below* its pre-existing baseline — and the next field addition to `WarmBaseInventory` costs nothing instead of breaking CI again. No new `djinn:allow-oversize` marker. `scripts/check-file-size.sh --files-from-stdin` reports 0 oversized files over the changed set.

No test was weakened, and I checked that rather than assuming it:

- assertion counts unchanged across all three touched files (119 / 36 / 14, before and after);
- `pressure_entry` call sites (27) and the fixture constants unchanged, so the multi-line `entries: vec![…]` bodies rustfmt re-wrapped kept their contents;
- the same **108** tests pass;
- and all three neutralizations still go red on the refactored tests — early-return of the reclamation body (11/14 red), no-op'ing only `remove_dir_all` while every status field still reports `deleted` (exactly the 2 disk-state assertions red), and cutting the `health.rs` wiring alone.

## Verification

`cargo clippy -p djinn-coordinator --all-targets -- -D warnings` — clean for this crate. (Two pre-existing `nonminimal_bool` warnings in `djinn-db/src/repositories/readiness/mod.rs` come from a newer local clippy and are untouched by this branch.)

`cargo test -p djinn-coordinator` — 2042 passed. `tests::session_reaping::{expired_owner_group_reap_redispatches_after_reaping_each_eligible_group, spawn_failed_dispatch_orphan_reaches_no_pr_terminal_cap_live}` fail identically on a stashed `origin/main` checkout under full-suite parallelism and pass in isolation; `rules::tests::rapid_successive_building_amends_coalesce_to_one_open_reconcile_task` also passes in isolation. All three are the known DB-parallelism flake class, not this change. The whole suite also needs `RUST_MIN_STACK` to avoid a stack overflow that reproduces unchanged on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
