### PR TITLE
ci(quality-gate): run CI self-contracts beside the lanes, not ahead of them

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -126,51 +126,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Verify mold Debian snapshot contracts
-        run: |
-          ./scripts/test-mold-debian-snapshot-contract.sh
-          ./scripts/test-mold-debian-snapshot-contract-regressions.sh
-      - name: Exercise pinned mold apt stanza on current trixie
-        run: ./scripts/image-ci/run-mold-trixie-apt-smoke.sh
-      - name: Verify trixie mold apt smoke contract
-        run: node --test scripts/ci-mold-trixie-apt-smoke.test.mjs
-      - name: Verify routed-scope contract
-        run: node --test scripts/ci-changed-scope.test.mjs
-      - name: Verify cache ownership policy
-        run: node --test scripts/ci-cache-policy.test.mjs
-      - name: Verify qa-smoke workflow contract
-        run: node --test scripts/ci-qa-smoke-workflow.test.mjs
-      - name: Verify release image validation contract
-        run: node --test scripts/ci-release-image-validation.test.mjs
-      - name: Verify shard failure summary contract
-        run: node --test scripts/ci-shard-failure-summary.test.mjs
-      - name: Verify retirement manifest generator contract
-        run: node --test scripts/test-djinn-retirement-manifest.mjs
-      - name: Run retirement manifest strict reconciliation guard
-        run: ./scripts/check-djinn-retirement-manifest.sh
-      - name: Lint all workflow files (actionlint)
-        env:
-          ACTIONLINT_VERSION: 1.7.12
-          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
-        run: |
-          set -euo pipefail
-          # Sibling workflows (release.yml, cla.yml, stale-branches.yml,
-          # memory-qa-nightly.yml) route narrowly in the scope router, so
-          # this always-on lint is their gate. It also catches invalid
-          # triggers that GitHub only surfaces as a red zero-job run on
-          # every subsequent push (e.g. `on: workflow_job`, which is a
-          # webhook event, not a workflow trigger — the exact bug shipped
-          # in #2221's ci-fail-fast.yml).
-          curl --fail --silent --show-error --location \
-            --retry 3 --connect-timeout 10 --max-time 60 \
-            --output "$RUNNER_TEMP/actionlint.tar.gz" \
-            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          printf '%s  %s\n' "$ACTIONLINT_SHA256" "$RUNNER_TEMP/actionlint.tar.gz" | sha256sum --check --strict
-          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
-          # shellcheck/pyflakes deliberately disabled: schema, trigger, and
-          # expression checks only, so run-block style nits cannot wedge
-          # the gate.
-          "$RUNNER_TEMP/actionlint" -shellcheck= -pyflakes= .github/workflows/*.yml
       - name: Compute safe event diff and route it
         id: router
         env:
@@ -217,6 +172,68 @@ jobs:
           path: preflight/manifest.json
           if-no-files-found: error
           retention-days: 30
+  ci-contracts:
+    name: CI Contracts
+    # These verify the CI machinery itself, so they are path-independent: the
+    # same work regardless of what the diff touches. They used to live in
+    # `preflight`, where they cost ~83s of that job's ~98s while the routing
+    # they blocked took ~2s — and because every other job `needs: preflight`,
+    # that was a serial prefix on the critical path of every PR and every
+    # merge-queue entry. Running them beside the lanes instead of ahead of
+    # them removes that prefix without weakening anything: this job carries no
+    # `if:` guard, so it still runs on every event, and `quality-gate` fails
+    # closed on its result below.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify mold Debian snapshot contracts
+        run: |
+          ./scripts/test-mold-debian-snapshot-contract.sh
+          ./scripts/test-mold-debian-snapshot-contract-regressions.sh
+      - name: Exercise pinned mold apt stanza on current trixie
+        run: ./scripts/image-ci/run-mold-trixie-apt-smoke.sh
+      - name: Verify trixie mold apt smoke contract
+        run: node --test scripts/ci-mold-trixie-apt-smoke.test.mjs
+      - name: Verify routed-scope contract
+        run: node --test scripts/ci-changed-scope.test.mjs
+      - name: Verify cache ownership policy
+        run: node --test scripts/ci-cache-policy.test.mjs
+      - name: Verify qa-smoke workflow contract
+        run: node --test scripts/ci-qa-smoke-workflow.test.mjs
+      - name: Verify release image validation contract
+        run: node --test scripts/ci-release-image-validation.test.mjs
+      - name: Verify shard failure summary contract
+        run: node --test scripts/ci-shard-failure-summary.test.mjs
+      - name: Verify retirement manifest generator contract
+        run: node --test scripts/test-djinn-retirement-manifest.mjs
+      - name: Run retirement manifest strict reconciliation guard
+        run: ./scripts/check-djinn-retirement-manifest.sh
+      - name: Lint all workflow files (actionlint)
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          # Sibling workflows (release.yml, cla.yml, stale-branches.yml,
+          # memory-qa-nightly.yml) route narrowly in the scope router, so
+          # this always-on lint is their gate. It also catches invalid
+          # triggers that GitHub only surfaces as a red zero-job run on
+          # every subsequent push (e.g. `on: workflow_job`, which is a
+          # webhook event, not a workflow trigger — the exact bug shipped
+          # in #2221's ci-fail-fast.yml).
+          curl --fail --silent --show-error --location \
+            --retry 3 --connect-timeout 10 --max-time 60 \
+            --output "$RUNNER_TEMP/actionlint.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          printf '%s  %s\n' "$ACTIONLINT_SHA256" "$RUNNER_TEMP/actionlint.tar.gz" | sha256sum --check --strict
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
+          # shellcheck/pyflakes deliberately disabled: schema, trigger, and
+          # expression checks only, so run-block style nits cannot wedge
+          # the gate.
+          "$RUNNER_TEMP/actionlint" -shellcheck= -pyflakes= .github/workflows/*.yml
   local-dev-contracts:
     name: Local Dev Contracts
     needs: preflight
@@ -1831,6 +1848,7 @@ jobs:
     if: always() && github.event_name != 'push'
     needs:
       - preflight
+      - ci-contracts
       - server-guards
       - server-clippy
       - server-aarch64-check
@@ -1846,6 +1864,7 @@ jobs:
       - name: Fail closed on selected work
         env:
           PREFLIGHT: ${{ needs.preflight.result }}
+          CONTRACTS: ${{ needs.ci-contracts.result }}
           GUARDS: |-
             ${{ (needs.preflight.outputs.cargoDeny == 'true'
                || needs.preflight.outputs.size == 'true'
@@ -1866,6 +1885,7 @@ jobs:
         run: |
           set -euo pipefail
           [ "$PREFLIGHT" = success ] || { echo "preflight ended $PREFLIGHT"; exit 1; }
+          [ "$CONTRACTS" = success ] || { echo "ci-contracts ended $CONTRACTS"; exit 1; }
           check() {
             local lane=$1 pair=$2 selected=${2%%:*} result=${2#*:}
             if [ "$selected" = true ] && [ "$result" = success ]; then return; fi

--- a/scripts/ci-mold-trixie-apt-smoke.test.mjs
+++ b/scripts/ci-mold-trixie-apt-smoke.test.mjs
@@ -8,17 +8,24 @@ const smoke = readFileSync(resolve('scripts/image-ci/run-mold-trixie-apt-smoke.s
 const installer = readFileSync(resolve('server/crates/djinn-image-builder/scripts/install-rust.sh'), 'utf8');
 const runtimeDockerfile = readFileSync(resolve('server/docker/djinn-agent-runtime-base.Dockerfile'), 'utf8');
 
-function preflightBlock(source) {
-  const start = source.indexOf('\n  preflight:\n');
-  assert.ok(start >= 0, 'Quality Gate must retain an always-run preflight job');
+// The smoke lives in `ci-contracts`, not `preflight`: it is path-independent,
+// so it runs beside the routed lanes instead of blocking them (every other job
+// `needs: preflight`). What this contract pins is the always-run property, not
+// the job name — the block must exist and must carry no `if:` guard.
+const CONTRACTS_JOB = 'ci-contracts';
+
+function jobBlock(source, job = CONTRACTS_JOB) {
+  const marker = `\n  ${job}:\n`;
+  const start = source.indexOf(marker);
+  assert.ok(start >= 0, `Quality Gate must retain an always-run ${job} job`);
   // Match the next top-level job key: a newline followed by exactly two
   // spaces and a non-whitespace character. This avoids matching the
-  // four-/six-space indented lines inside the preflight job body, which
-  // a bare '\n  ' substring search would incorrectly latch onto.
-  const rest = source.slice(start + 15);
+  // four-/six-space indented lines inside the job body, which a bare
+  // '\n  ' substring search would incorrectly latch onto.
+  const rest = source.slice(start + marker.length);
   const nextRel = rest.search(/\n  \S/);
-  assert.ok(nextRel >= 0, 'Quality Gate must retain a job following preflight');
-  const end = start + 15 + nextRel;
+  assert.ok(nextRel >= 0, `Quality Gate must retain a job following ${job}`);
+  const end = start + marker.length + nextRel;
   return source.slice(start, end);
 }
 
@@ -54,11 +61,17 @@ function assertSmokeContract(source) {
 test('Quality Gate executes the trixie apt smoke for pull requests and merge groups', () => {
   assert.match(workflow, /^  pull_request:/m);
   assert.match(workflow, /^  merge_group:/m);
-  const preflight = preflightBlock(workflow);
-  assert.doesNotMatch(preflight, /^    if:/m,
-    'preflight must not conditionally bypass the required smoke');
-  assert.match(preflight, /name: Exercise pinned mold apt stanza on current trixie/);
-  assert.match(preflight, /run: \.\/scripts\/image-ci\/run-mold-trixie-apt-smoke\.sh/);
+  const contracts = jobBlock(workflow);
+  assert.doesNotMatch(contracts, /^    if:/m,
+    'ci-contracts must not conditionally bypass the required smoke');
+  assert.match(contracts, /name: Exercise pinned mold apt stanza on current trixie/);
+  assert.match(contracts, /run: \.\/scripts\/image-ci\/run-mold-trixie-apt-smoke\.sh/);
+  // The split is only safe while the quality gate still fails closed on this
+  // job — otherwise moving the smoke out of preflight would make it advisory.
+  assert.match(workflow, /^      - ci-contracts$/m,
+    'quality-gate must depend on ci-contracts');
+  assert.match(workflow, /\[ "\$CONTRACTS" = success \]/,
+    'quality-gate must fail closed on the ci-contracts result');
 });
 
 test('trixie apt smoke uses canonical pins, preserves sources, installs, and probes', () => {
@@ -80,8 +93,12 @@ test('contract rejects mutations that turn the smoke into lint or bypass evidenc
   }
 
   assert.throws(
-    () => assert.match(preflightBlock(workflow.replace('run: ./scripts/image-ci/run-mold-trixie-apt-smoke.sh', 'run: true')), /run: \.\/scripts\/image-ci\/run-mold-trixie-apt-smoke\.sh/),
+    () => assert.match(jobBlock(workflow.replace('run: ./scripts/image-ci/run-mold-trixie-apt-smoke.sh', 'run: true')), /run: \.\/scripts\/image-ci\/run-mold-trixie-apt-smoke\.sh/),
     'workflow contract must reject a non-executing smoke step',
+  );
+  assert.throws(
+    () => assert.match(jobBlock(workflow.replace(/^      - ci-contracts\n/m, '')), /^      - ci-contracts$/m),
+    'workflow contract must reject dropping ci-contracts from the quality gate',
   );
   assert.throws(
     () => assert.match(workflow.replace(/^  pull_request:\n/m, ''), /^  pull_request:/m),


### PR DESCRIPTION
## Problem

`preflight` does two unrelated things: it computes the routing manifest that **every** other job gates on (`needs: preflight`), and it runs ~10 path-independent contracts that verify the CI machinery itself.

Step timings from a real `merge_group` run ([job 90157732738](https://github.com/djinnos/djinn/actions/runs/30321356927/job/90157732738)):

| step | time |
|---|---|
| checkout (`fetch-depth: 0`) | 12s |
| **meta-CI contracts** | **83s** — retirement manifest generator 43s, reconciliation guard 28s, mold trixie smoke 12s |
| **routing** (`Compute safe event diff and route it` + upload) | **2s** |
| **total** | **98s** |

Because all 20 jobs hang off `preflight`, those 83s are a serial prefix on the critical path of every PR run and every merge-queue entry. The contracts are path-independent — they do the same work regardless of the diff — so there is no reason for them to block routing.

## Change

Move the contracts into a sibling `ci-contracts` job that runs in parallel with the routed lanes. `preflight` keeps checkout + router + manifest upload, so downstream jobs unblock in ~15s instead of ~98s.

**Nothing is weakened:**
- `ci-contracts` carries no `if:` guard, so it runs on every event exactly as the steps did inside `preflight`.
- `quality-gate` gains `ci-contracts` as a dependency plus a fail-closed assertion on its result, alongside the existing `PREFLIGHT` check.
- Routing is untouched: same 14 outputs, same `preflight-manifest` artifact, same 30-day retention.

`ci-mold-trixie-apt-smoke.test.mjs` deliberately pinned the smoke step inside the `preflight` block and asserted that job carried no `if:` — an anti-bypass guard. Rather than delete it, the block parser is generalised and pointed at `ci-contracts`, preserving the property, with two new assertions so the gate cannot silently stop depending on the new job.

## Verification

All CI self-contracts run locally against the edited workflow:

```
ci-mold-trixie-apt-smoke        PASS
ci-changed-scope                PASS
ci-cache-policy                 PASS
ci-qa-smoke-workflow            PASS
ci-release-image-validation     PASS
ci-shard-failure-summary        PASS
ci-nextest-plan                 PASS
retirement-manifest             PASS
mold-snapshot / regressions     PASS
retirement-guard                PASS
actionlint (pinned 1.7.12)      PASS
```

`run-mold-trixie-apt-smoke.sh` needs Docker and is left to CI.

## Cost

One extra runner slot per run, out of the 60 concurrent jobs the Team plan allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)