### PR TITLE
feat(scip): split the semantic index into its own leaseless Kubernetes Job

### DIFF
--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -215,6 +215,19 @@ enum Cmd {
         project_id: String,
     },
 
+    /// Run the SEMANTIC pass only (SCIP indexers) for a project and exit,
+    /// leaving its artifacts in the shared content-addressed SCIP cache.
+    ///
+    /// Dispatched by `djinn_k8s::scip_job::build_scip_index_job` in the
+    /// standalone SCIP-index Pod. Unlike `warm-graph` this runs no cargo warm
+    /// base, publishes no graph, and -- because it is not a
+    /// `LeaseIdentity::GraphWarm` consumer -- holds no build slot. The warm Job
+    /// picks its output up as a `CachedHit` and skips the 58m43s re-index.
+    ScipIndex {
+        /// Project id (matches `projects.id`). Positional.
+        project_id: String,
+    },
+
     /// Seed a private per-task-run Cargo target dir from the project's warm
     /// base and exit, printing a machine-readable summary line on stdout.
     ///
@@ -440,6 +453,7 @@ async fn run() -> Result<()> {
     match cli.cmd {
         Cmd::TaskRun(args) => run_task_run(args).await,
         Cmd::WarmGraph { project_id } => run_warm_graph(&project_id).await,
+        Cmd::ScipIndex { project_id } => run_scip_index(&project_id).await,
         Cmd::SeedCargoTarget { base, run_dir } => run_seed_cargo_target(&base, &run_dir),
         Cmd::CompareGraphArtifacts {
             project_id,
@@ -3655,6 +3669,83 @@ fn worker_bridge_ignores_pair(entity_type: &str, action: &str) -> bool {
 /// run `djinn_graph::canonical_graph::run_warm_graph_command` once and
 /// exit.  The heavy pipeline's progress lands in shared DB caches that
 /// the server process reads on subsequent graph queries.
+/// The `scip-index` subcommand: run the semantic pass and exit.
+///
+/// Deliberately a sibling of [`run_warm_graph`] rather than a flag on it. The
+/// two Pods have different capacity contracts -- the warm Job is charged a full
+/// build slot and this one is charged none -- so they must not be able to
+/// collapse into the same process by accident.
+async fn run_scip_index(project_id: &str) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        return run_linux_warm_graph_with_initializer(
+            project_id,
+            initialize_linux_warm_lifecycle,
+            || run_scip_index_body(project_id),
+        )
+        .await;
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    run_scip_index_body(project_id).await
+}
+
+/// The semantic-pass body. Mirrors [`run_warm_graph_body`]'s startup contract
+/// (volume readiness, DB bootstrap, `pre_anything` hooks) and then runs the
+/// indexers only.
+///
+/// The `pre_anything` hooks are NOT optional decoration here: a project pinning
+/// its toolchain relies on them for `rustup component add rust-analyzer`, and
+/// without that the SCIP indexers fail with "Unknown binary" -- which in this
+/// Pod would mean a completely empty index run rather than a degraded warm.
+/// They stay non-fatal for the same reason they are non-fatal on the warm path.
+async fn run_scip_index_body(project_id: &str) -> Result<()> {
+    let project_root = std::env::var("DJINN_PROJECT_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(volume_contract::WORKSPACE_MOUNT_ROOT));
+    volume_contract::enforce_at_startup(
+        "scip-index",
+        &volume_contract::warm_roots(&project_root, project_id),
+    )?;
+
+    let db = bootstrap_warm_database().await?;
+    let ctx = WorkerWarmContext {
+        db,
+        indexer_lock: Arc::new(tokio::sync::Mutex::new(())),
+    };
+
+    let env_config_path = PathBuf::from(lifecycle::ENV_CONFIG_MOUNT_FILE);
+    match lifecycle::load_environment_config(&env_config_path).await {
+        Ok(Some(cfg)) => {
+            if let Err(e) =
+                lifecycle::run_phase(&project_root, "pre_anything", &cfg.lifecycle.pre_anything)
+                    .await
+            {
+                warn!(
+                    project_id,
+                    project_root = %project_root.display(),
+                    error = %format!("{e:#}"),
+                    "pre_anything hook failed; continuing with scip-index anyway"
+                );
+            }
+        }
+        Ok(None) => tracing::debug!(
+            project_id,
+            "no environment_config mounted at {} -- continuing without hooks",
+            env_config_path.display()
+        ),
+        Err(e) => warn!(
+            project_id,
+            error = %format!("{e:#}"),
+            "environment_config present but failed to load; ignoring"
+        ),
+    }
+
+    djinn_graph::canonical_graph::run_scip_index_command(&ctx, project_id)
+        .await
+        .with_context(|| format!("run_scip_index_command({project_id})"))
+}
+
 async fn run_warm_graph(project_id: &str) -> Result<()> {
     #[cfg(target_os = "linux")]
     {

--- a/server/crates/djinn-agent-worker/src/rendered_job_env_contract.rs
+++ b/server/crates/djinn-agent-worker/src/rendered_job_env_contract.rs
@@ -206,6 +206,65 @@ fn the_warm_pod_argv_parses_with_the_real_parser() {
     }
 }
 
+/// **The contract, SCIP-index path.** Same argument as the warm path, for the
+/// standalone semantic-index Pod added alongside it.
+///
+/// This Pod is dispatched by a scheduler on a 3-hour cadence rather than by an
+/// interactive trigger, so a `scip-index` subcommand that did not exist — or
+/// whose argv did not parse — would produce a Pod that exits 2, a Job that
+/// reports failure, and a change-detection ledger that never advances. That
+/// pattern would be invisible in the warm path's own tests, which is precisely
+/// why the derivation below reads the real clap parser rather than a list.
+#[test]
+fn the_scip_index_pod_argv_parses_with_the_real_parser() {
+    let job = djinn_k8s::scip_job::build_scip_index_job(
+        &KubernetesConfig::for_testing(),
+        "proj-scip",
+        "registry.example/djinn-project:scip",
+        "0123456789abcdef0123456789abcdef01234567",
+        None,
+    );
+    let pod = job
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .expect("rendered SCIP Job has a pod spec");
+    let script = pod.containers[0]
+        .command
+        .as_deref()
+        .and_then(|command| command.last())
+        .expect("SCIP Pod runs a shell script");
+
+    let exec_line = script
+        .lines()
+        .find(|line| line.starts_with(&format!("exec {WARM_COMMAND_BIN}")))
+        .unwrap_or_else(|| panic!("SCIP Pod script never execs {WARM_COMMAND_BIN}:\n{script}"));
+
+    let argv = split_shell_words(exec_line.trim_start_matches("exec "));
+    assert_eq!(
+        argv.get(1).map(String::as_str),
+        Some("scip-index"),
+        "the SCIP Pod must invoke the semantic-only subcommand, not the combined \
+         warm pipeline — running `warm-graph` here would re-acquire the whole \
+         cargo phase this split exists to leave behind: {argv:?}"
+    );
+    Cli::try_parse_from(&argv).unwrap_or_else(|error| {
+        panic!(
+            "the SCIP Pod's own command line does not parse: {argv:?}\n{error}\nEvery SCIP \
+             Pod dispatched with this manifest exits 2 before indexing anything."
+        )
+    });
+
+    for arg in unsatisfiable_without("scip-index") {
+        assert!(
+            arg.is_positional(),
+            "required scip-index argument `{}` is not positional; the SCIP Pod's shell \
+             command supplies positionals only, so it must be rendered into the Pod env",
+            arg.get_id()
+        );
+    }
+}
+
 /// Minimal double-quote-aware tokenizer: enough for the argv this crate's own
 /// renderer emits (`exec <bin> warm-graph "<project id>"`), and it deliberately
 /// refuses anything more exotic rather than guessing at shell semantics.

--- a/server/crates/djinn-graph/src/canonical_graph.rs
+++ b/server/crates/djinn-graph/src/canonical_graph.rs
@@ -676,6 +676,124 @@ pub async fn run_warm_graph_command<C: WarmContext>(
     Ok(())
 }
 
+/// Run the **semantic pass only** and leave its artifacts in the shared
+/// content-addressed SCIP cache. Publishes no graph and writes no
+/// `repo_graph_*` row.
+///
+/// This is the body of the standalone SCIP-index Job
+/// (`djinn_k8s::scip_job`). The combined warm Job measured 90m42s end to end
+/// with 58m43s of that in the SCIP index — a phase that is 94% serial, so the
+/// warm Job was holding a full 4-core build slot to run one core. Splitting the
+/// phase into its own leaseless Job returns that capacity.
+///
+/// # Why this produces something the warm path consumes
+///
+/// [`crate::scip_indexer::run_indexers_already_locked`] writes through
+/// `ScipCacheStore`, whose root resolves from `$XDG_CACHE_HOME` — pointed at
+/// the shared `/cache` PVC in every djinn build Pod. Its key is *content*
+/// derived (tool version, command shape, workspace identity, source/config/
+/// lockfile hashes) and its `WorkspaceIdentity` holds a **relative** workspace
+/// root, so an artifact this Job produces from its own clone is a `CachedHit`
+/// for the warm Job's `execute_plan_with_cache` even though the two Pods cloned
+/// to different absolute paths.
+///
+/// Consequently no change to [`ensure_canonical_graph`] is required, and none
+/// is made: the warm pipeline still runs the indexers, it just finds them
+/// already computed.
+///
+/// # Degradation
+///
+/// Failure here is contained. This function never touches `repo_graph_cache`,
+/// `repo_graph_generation`, or `repo_graph_current`, so a failed, skipped, or
+/// never-scheduled SCIP run cannot move the served graph at all — the warm path
+/// simply re-indexes inline as it does today, still under the `node_count == 0`
+/// guard that refuses to publish an empty blob and still with per-workspace
+/// salvage from the previous artifact. There is no path from "SCIP Job did not
+/// run" to "graph served empty".
+///
+/// The syntactic and git-derived passes deliberately do **not** move here.
+/// `ingest_coupling_best_effort` and the tree-sitter post-processors want
+/// per-commit freshness and are cheap; they stay on the warm path, which
+/// continues to run at its own cadence.
+pub async fn run_scip_index_command<C: WarmContext>(
+    ctx: &C,
+    project_id: &str,
+) -> anyhow::Result<()> {
+    use djinn_db::ProjectRepository;
+
+    let repo = ProjectRepository::new(ctx.db().clone(), ctx.event_bus());
+    let project = repo
+        .get(project_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("lookup project {project_id}: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("project {project_id} not found"))?;
+    let project_root = match std::env::var("DJINN_PROJECT_ROOT") {
+        Ok(v) if !v.is_empty() => PathBuf::from(v),
+        _ => djinn_core::paths::project_dir(&project.github_owner, &project.github_repo),
+    };
+
+    // Same tree resolution as `ensure_canonical_graph`, so the two runs index
+    // the same content and agree on workspace identity.
+    let mut handle = crate::index_tree::IndexTree::ensure(project_id, &project_root)
+        .await
+        .map_err(|e| anyhow::anyhow!("ensure index tree: {e}"))?;
+    let _ = handle
+        .fetch_if_stale(crate::index_tree::DEFAULT_FETCH_COOLDOWN)
+        .await;
+    let _ = handle.reset_to_origin_main().await;
+    let commit_sha = handle.commit_sha().to_string();
+
+    // Serialize against any in-process indexer fan-out, matching the warm path.
+    let indexer_lock = ctx.indexer_lock();
+    let _guard = indexer_lock.lock().await;
+
+    let temp_base = std::env::current_dir()
+        .map_err(|e| anyhow::anyhow!("resolve current dir for scip-index tempdir: {e}"))?
+        .join("target")
+        .join("test-tmp");
+    std::fs::create_dir_all(&temp_base)
+        .map_err(|e| anyhow::anyhow!("create scip-index tempdir base: {e}"))?;
+    let output_temp = tempfile::Builder::new()
+        .prefix("djinn-scip-index-")
+        .tempdir_in(&temp_base)
+        .map_err(|e| anyhow::anyhow!("create scip-index tempdir: {e}"))?;
+
+    let target_dir = handle.indexer_target_dir_override();
+    let stack_filter = resolve_stack_indexer_filter(ctx, project_id).await;
+    let declared_workspaces = resolve_declared_workspaces(ctx, project_id).await;
+    let timing_priors = load_indexer_timing_priors(ctx, project_id).await;
+
+    let clock = SystemClock::new();
+    let started = clock.now_instant();
+    let run = crate::scip_indexer::run_indexers_already_locked(
+        handle.path(),
+        output_temp.path(),
+        target_dir.as_deref(),
+        stack_filter.as_deref(),
+        declared_workspaces.as_deref(),
+        Some(&timing_priors),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("run_indexers: {e}"))?;
+
+    // Feed the adaptive per-indexer budget exactly as the warm path does, so a
+    // heavy workspace's timings are learned here instead of being lost.
+    persist_indexer_timings_best_effort(ctx, project_id, &run.timings).await;
+
+    tracing::info!(
+        project_id,
+        commit_sha,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        artifacts = run.artifacts.len(),
+        "run_scip_index_command: semantic index complete; artifacts are in the \
+         shared SCIP cache for the next warm to reuse"
+    );
+    // `output_temp` drops here: the raw `.scip` files were transient. The
+    // durable product is the content-addressed cache the indexers wrote
+    // through, which is exactly what the warm Job reads back.
+    Ok(())
+}
+
 pub async fn ensure_canonical_graph<C: WarmContext>(
     ctx: &C,
     project_id: &str,

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -216,6 +216,28 @@ pub struct KubernetesConfig {
     /// `activeDeadlineSeconds` on the SCIP-index Job. Default `7200` (2h)
     /// against a measured 3523s (58m43s) SCIP phase.
     pub scip_job_timeout_seconds: i64,
+    /// Master switch for standalone SCIP-index dispatch. **Defaults to
+    /// `false`.**
+    ///
+    /// The composition root wires the real
+    /// [`crate::scip_schedule::ScipIndexScheduler`] unconditionally — this flag
+    /// is checked inside the tick, not at wiring time, so arming the feature is
+    /// a config flip rather than a redeploy, and the code path is never
+    /// unreachable. Off means the watcher ticks, logs its decisions at debug,
+    /// and creates nothing.
+    pub scip_index_enabled: bool,
+    /// How long the repository head must have stood still before a SCIP index
+    /// is worth producing, in seconds. Default `3523` — the measured duration
+    /// of the SCIP phase itself.
+    ///
+    /// The SCIP cache key folds in `source_hashes`, so an index produced at
+    /// head `H0` only serves a warm running against `H0`'s sources. If `main`
+    /// advances during the ~59-minute run, the following warm misses and
+    /// re-indexes inline. Requiring the tree to have been stable for at least
+    /// as long as the run takes is the cheap, stateless way to bias toward the
+    /// case where the artifact is still current when it lands. `0` disables the
+    /// gate. See [`crate::scip_schedule::decide`].
+    pub scip_quiescence_seconds: u64,
     /// `spec.nodeSelector` applied to both task-run and warm Pods. Empty map
     /// leaves the field unset (any node tolerating the Pod's other constraints
     /// is eligible). Operators typically use this together with `tolerations`
@@ -326,6 +348,10 @@ impl KubernetesConfig {
             scip_index_interval_seconds: 10_800,
             scip_job_ttl_seconds: 14_400,
             scip_job_timeout_seconds: 7_200,
+            // OFF by default. The scheduler is wired for real regardless; this
+            // is the only thing that lets it create a Job.
+            scip_index_enabled: false,
+            scip_quiescence_seconds: crate::scip_job::MEASURED_SCIP_PHASE_SECONDS as u64,
             node_selector: BTreeMap::new(),
             tolerations: Vec::new(),
             // v1 leases enforcement contract. Both fail render validation if set
@@ -380,6 +406,8 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS` | `scip_index_interval_seconds` | `10800` (parsed as `u64`) |
     /// | `DJINN_K8S_SCIP_JOB_TTL_SECONDS` | `scip_job_ttl_seconds` | `14400` (parsed as `i32`) |
     /// | `DJINN_K8S_SCIP_JOB_TIMEOUT_SECONDS` | `scip_job_timeout_seconds` | `7200` (parsed as `i64`) |
+    /// | `DJINN_K8S_SCIP_INDEX_ENABLED` | `scip_index_enabled` | `false` — the arming switch |
+    /// | `DJINN_K8S_SCIP_QUIESCENCE_SECONDS` | `scip_quiescence_seconds` | `3523` (the measured phase cost; `0` disables) |
     /// | `DJINN_K8S_NODE_SELECTOR` | `node_selector` | `{}` (parsed as a JSON object of string→string) |
     /// | `DJINN_K8S_TOLERATIONS` | `tolerations` | `[]` (parsed as a JSON array of k8s `Toleration` objects) |
     /// | `DJINN_K8S_CGROUP_DELEGATION_PROFILE` | `cgroup_delegation_profile` | `cgroup-v2-cpu-only` |
@@ -519,6 +547,22 @@ impl KubernetesConfig {
                     value = %v,
                     error = %e,
                     "DJINN_K8S_SCIP_JOB_TTL_SECONDS not a valid i32 — keeping default"
+                ),
+            }
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_INDEX_ENABLED") {
+            cfg.scip_index_enabled = matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            );
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_QUIESCENCE_SECONDS") {
+            match v.parse::<u64>() {
+                Ok(n) => cfg.scip_quiescence_seconds = n,
+                Err(e) => tracing::warn!(
+                    value = %v,
+                    error = %e,
+                    "DJINN_K8S_SCIP_QUIESCENCE_SECONDS not a valid u64 — keeping default"
                 ),
             }
         }

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -167,6 +167,55 @@ pub struct KubernetesConfig {
     /// Memory limit on the warm Pod container. Hard ceiling so a runaway
     /// indexer can't OOM the node. Default `4Gi`.
     pub warm_memory_limit: String,
+    /// CPU request on the standalone SCIP-index Pod ([`crate::scip_job`]).
+    ///
+    /// Default `1`. Unlike every other build-tier request this one is **not**
+    /// sized for parallelism — the SCIP phase is 94% serial (rust-analyzer's
+    /// `StaticIndex::compute` is a bare loop with no rayon, upstream issue
+    /// #18140) so a second core buys almost nothing. It is sized instead by the
+    /// capacity budget: the SCIP Job takes no build lease, so under proposal
+    /// `8ixk` its request folds into `protected_mcpu` and is subtracted from the
+    /// CPU build slots are derived from. The ceiling before the derived cap
+    /// drops from 2 to 1 on the current 12-core node is **2200m**; see
+    /// [`crate::scip_job::SCIP_PROTECTED_REQUEST_CEILING_MILLICORES`], which is
+    /// enforced by test.
+    pub scip_cpu_request: String,
+    /// CPU limit on the standalone SCIP-index Pod. Default `2` — headroom for
+    /// the brief parallel window (measured 20s against a 368s serial window)
+    /// and for the non-Rust indexers, without changing the request the capacity
+    /// derivation actually reads.
+    pub scip_cpu_limit: String,
+    /// Memory request on the standalone SCIP-index Pod. Default `4Gi`.
+    pub scip_memory_request: String,
+    /// Memory limit on the standalone SCIP-index Pod. Default `16Gi`.
+    ///
+    /// This is a **measured** figure, not a default to be trimmed: peak RSS for
+    /// the SCIP phase is 10.0 GB. The warm Pod's `warm_memory_limit` still
+    /// defaults to `6Gi` and survives production only because an out-of-band
+    /// override raises it to 16Gi — this field states the real number in the
+    /// manifest instead, and
+    /// `crate::scip_job::tests::scip_memory_limit_covers_the_measured_peak`
+    /// fails the build if it is ever lowered below the measured peak.
+    pub scip_memory_limit: String,
+    /// Cadence floor for the standalone SCIP index, in seconds. Default
+    /// `10800` (3 hours).
+    ///
+    /// This is a *rate limit*, not a timer: a tick still dispatches nothing
+    /// unless the repository head has advanced since the last successful index
+    /// (see [`crate::scip_schedule`]). It exists so a continuously-advancing
+    /// `main` cannot turn a leaseless 16Gi Job into a permanent resident.
+    pub scip_index_interval_seconds: u64,
+    /// `ttlSecondsAfterFinished` on the SCIP-index Job. Default `14400` (4h).
+    ///
+    /// Deliberately longer than [`Self::scip_index_interval_seconds`]: the
+    /// retained *succeeded* Job set — keyed by its
+    /// `djinn.app/scip-revision` annotation — is the durable ledger the
+    /// change-detection gate reads. A TTL shorter than the interval would make
+    /// every tick look like "never indexed" and re-dispatch unconditionally.
+    pub scip_job_ttl_seconds: i32,
+    /// `activeDeadlineSeconds` on the SCIP-index Job. Default `7200` (2h)
+    /// against a measured 3523s (58m43s) SCIP phase.
+    pub scip_job_timeout_seconds: i64,
     /// `spec.nodeSelector` applied to both task-run and warm Pods. Empty map
     /// leaves the field unset (any node tolerating the Pod's other constraints
     /// is eligible). Operators typically use this together with `tolerations`
@@ -265,6 +314,18 @@ impl KubernetesConfig {
             // links more codegen units at once than clippy alone.
             warm_memory_request: "2Gi".into(),
             warm_memory_limit: "6Gi".into(),
+            // The SCIP phase is 94% serial, so this request buys capacity
+            // accounting (8ixk `protected_mcpu`), not throughput. 1000m sits
+            // well inside the 2200m ceiling that would cost a build slot.
+            scip_cpu_request: "1".into(),
+            scip_cpu_limit: "2".into(),
+            scip_memory_request: "4Gi".into(),
+            // MEASURED peak is 10.0 GB. Stated explicitly here rather than
+            // inherited from a 6Gi default plus a production override.
+            scip_memory_limit: "16Gi".into(),
+            scip_index_interval_seconds: 10_800,
+            scip_job_ttl_seconds: 14_400,
+            scip_job_timeout_seconds: 7_200,
             node_selector: BTreeMap::new(),
             tolerations: Vec::new(),
             // v1 leases enforcement contract. Both fail render validation if set
@@ -312,6 +373,13 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_WARM_CPU_LIMIT` | `warm_cpu_limit` | `4` |
     /// | `DJINN_K8S_WARM_MEMORY_REQUEST` | `warm_memory_request` | `2Gi` |
     /// | `DJINN_K8S_WARM_MEMORY_LIMIT` | `warm_memory_limit` | `6Gi` |
+    /// | `DJINN_K8S_SCIP_CPU_REQUEST` | `scip_cpu_request` | `1` (≤ 2200m or the derived build-slot cap drops) |
+    /// | `DJINN_K8S_SCIP_CPU_LIMIT` | `scip_cpu_limit` | `2` |
+    /// | `DJINN_K8S_SCIP_MEMORY_REQUEST` | `scip_memory_request` | `4Gi` |
+    /// | `DJINN_K8S_SCIP_MEMORY_LIMIT` | `scip_memory_limit` | `16Gi` (measured peak 10.0 GB) |
+    /// | `DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS` | `scip_index_interval_seconds` | `10800` (parsed as `u64`) |
+    /// | `DJINN_K8S_SCIP_JOB_TTL_SECONDS` | `scip_job_ttl_seconds` | `14400` (parsed as `i32`) |
+    /// | `DJINN_K8S_SCIP_JOB_TIMEOUT_SECONDS` | `scip_job_timeout_seconds` | `7200` (parsed as `i64`) |
     /// | `DJINN_K8S_NODE_SELECTOR` | `node_selector` | `{}` (parsed as a JSON object of string→string) |
     /// | `DJINN_K8S_TOLERATIONS` | `tolerations` | `[]` (parsed as a JSON array of k8s `Toleration` objects) |
     /// | `DJINN_K8S_CGROUP_DELEGATION_PROFILE` | `cgroup_delegation_profile` | `cgroup-v2-cpu-only` |
@@ -421,6 +489,48 @@ impl KubernetesConfig {
         }
         if let Ok(v) = std::env::var("DJINN_K8S_WARM_MEMORY_LIMIT") {
             cfg.warm_memory_limit = v;
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_CPU_REQUEST") {
+            cfg.scip_cpu_request = v;
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_CPU_LIMIT") {
+            cfg.scip_cpu_limit = v;
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_MEMORY_REQUEST") {
+            cfg.scip_memory_request = v;
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_MEMORY_LIMIT") {
+            cfg.scip_memory_limit = v;
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS") {
+            match v.parse::<u64>() {
+                Ok(n) => cfg.scip_index_interval_seconds = n,
+                Err(e) => tracing::warn!(
+                    value = %v,
+                    error = %e,
+                    "DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS not a valid u64 — keeping default"
+                ),
+            }
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_JOB_TTL_SECONDS") {
+            match v.parse::<i32>() {
+                Ok(n) => cfg.scip_job_ttl_seconds = n,
+                Err(e) => tracing::warn!(
+                    value = %v,
+                    error = %e,
+                    "DJINN_K8S_SCIP_JOB_TTL_SECONDS not a valid i32 — keeping default"
+                ),
+            }
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_JOB_TIMEOUT_SECONDS") {
+            match v.parse::<i64>() {
+                Ok(n) => cfg.scip_job_timeout_seconds = n,
+                Err(e) => tracing::warn!(
+                    value = %v,
+                    error = %e,
+                    "DJINN_K8S_SCIP_JOB_TIMEOUT_SECONDS not a valid i64 — keeping default"
+                ),
+            }
         }
         if let Ok(v) = std::env::var("DJINN_K8S_NODE_SELECTOR")
             && !v.is_empty()

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -1299,6 +1299,31 @@ impl K8sGraphWarmer {
         })
     }
 
+    /// Build the standalone SCIP-index scheduler from this warmer's own client
+    /// and config.
+    ///
+    /// It shares the warmer's `kube::Client` deliberately — the composition
+    /// root must not build a second one — but it shares nothing else. The
+    /// returned scheduler holds no `GraphWarmLease`, no `WarmAdmission`, and no
+    /// `WarmCandidateControl`, because the Jobs it creates take no build slot;
+    /// that is the entire point of the split.
+    ///
+    /// `None` only on the test/mock-dispatcher path, which owns no live client.
+    /// Production always gets `Some`, and the watcher that calls this logs at
+    /// ERROR if it ever gets `None` while the feature is armed — a scheduler
+    /// that silently resolves to nothing is exactly the failure mode this
+    /// codebase has hit before.
+    pub fn scip_index_scheduler(&self) -> Option<crate::scip_schedule::ScipIndexScheduler> {
+        let client = self.client.clone()?;
+        Some(crate::scip_schedule::ScipIndexScheduler::new(
+            self.dispatch.config.clone(),
+            Arc::new(crate::scip_schedule::KubeClientScipJobInventory::new(
+                client.clone(),
+            )),
+            Arc::new(KubeClientDispatcher::new(client)),
+        ))
+    }
+
     /// Override the merge-storm debounce policy (builder style). Production
     /// takes it from the environment via [`Self::new`]; tests use this to
     /// exercise the quiet-window / max-wait / disabled behaviours with short

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -20,6 +20,8 @@ pub mod launcher_child_fs;
 mod launcher_cpu;
 pub mod private_dep_config;
 pub mod runtime;
+pub mod scip_job;
+pub mod scip_schedule;
 pub mod secret;
 pub mod sidecar;
 pub mod token_review;
@@ -51,6 +53,15 @@ pub use graph_warmer_candidates::{
 };
 pub use graph_warmer_identity::{LeasedWarmJobIdentity, deterministic_warm_job_name, warm_work_id};
 pub use runtime::{KubernetesRuntime, taskrun_job_name};
+pub use scip_job::{
+    ANNOTATION_SCIP_REVISION, COMPONENT_SCIP_INDEX, LABEL_CAPACITY_RESERVED, LABEL_SCIP_INDEX,
+    MEASURED_SCIP_PEAK_MEMORY_BYTES, SCIP_PROTECTED_REQUEST_CEILING_MILLICORES,
+    build_scip_index_job, scip_index_job_name,
+};
+pub use scip_schedule::{
+    KubeClientScipJobInventory, ScipIndexDecision, ScipIndexScheduler, ScipJobInventory,
+    ScipJobObservation, decide as decide_scip_index, observe_from_jobs,
+};
 pub use token_review::TokenReviewer;
 pub use warm_job::{build_leased_warm_job, build_warm_job};
 pub use workload_inventory::{

--- a/server/crates/djinn-k8s/src/scip_job.rs
+++ b/server/crates/djinn-k8s/src/scip_job.rs
@@ -1,0 +1,902 @@
+//! Pure `Job` manifest builder for the standalone SCIP (semantic) index run.
+//!
+//! # Why this Job exists at all
+//!
+//! One graph-warm Job used to do everything: a cargo warm-base compile, the
+//! rust-analyzer SCIP index, then the graph build. A complete production warm
+//! measured 90m42s end to end, of which the SCIP index alone was **58m43s**
+//! (~65%).
+//!
+//! That phase is *structurally* single-threaded. rust-analyzer's
+//! `StaticIndex::compute` is a bare `for module in work` loop with no rayon;
+//! the measured parallel window was 20s against a 368s serial window (94%
+//! serial), and upstream issue rust-lang/rust-analyzer#18140 is open and
+//! maintainer-confirmed. So the warm Job reserved a full build slot sized for a
+//! 4-core parallel cargo build and then spent roughly two thirds of its life
+//! using one core.
+//!
+//! # Why resizing the warm Job cannot fix it
+//!
+//! [`djinn_runtime::BuildSlotWeight::for_millicores`] is
+//! `millicores.div_ceil(slot_millicores).max(1)`. **Any nonzero CPU request
+//! costs at least one whole build slot.** Dropping the warm request from 2 CPU
+//! to 500m changes the charged weight not at all. The only lever that returns
+//! capacity is for the SCIP work to acquire *no build lease*, which means it
+//! must not be a `LeaseIdentity::GraphWarm` — i.e. it must be its own Job.
+//! [`crate::graph_warmer`] is the only producer of `GraphWarm` lease
+//! identities and this module is deliberately not reachable from it.
+//!
+//! # Why the Job must still declare itself
+//!
+//! A Job that acquires no lease *and* is not labelled protected is invisible
+//! CPU: it burns real cores that no cap can account for. Proposal `8ixk`
+//! ("Node-keyed build slot pools") derives each node's cap as
+//! `floor((allocatable_mcpu - protected_mcpu) / cores_per_slot_mcpu)` with
+//! `cores_per_slot` defaulting to 2800, where `protected_mcpu` is the summed
+//! CPU request of Pods carrying [`LABEL_CAPACITY_RESERVED`]. So this Job
+//! carries that label, its request folds into `protected_mcpu`, and the derived
+//! cap stays honest.
+//!
+//! On the current 12-core VPS with 4200m of already-protected requests:
+//!
+//! ```text
+//! today                floor((12000 - 4200) / 2800) = floor(2.78) = 2
+//! with this Job @1000m floor((12000 - 5200) / 2800) = floor(2.43) = 2   (unchanged)
+//! ```
+//!
+//! The budget before the derived cap drops to one slot is a request of
+//! **2200m**: `floor((12000 - 4200 - 2200) / 2800) = floor(2.0) = 2`, while
+//! 2201m tips it over.
+//! [`SCIP_PROTECTED_REQUEST_CEILING_MILLICORES`] pins that ceiling, and
+//! `scip_cpu_request_stays_inside_the_8ixk_protected_budget` proves the
+//! rendered request respects it *by recomputing the formula*, not by comparing
+//! against a copied constant.
+//!
+//! # What it produces and who consumes it
+//!
+//! The SCIP indexer already writes content-addressed artifacts into
+//! `$XDG_CACHE_HOME/djinn/scip-indexer` (`djinn_graph::scip_indexer::cache`),
+//! and [`crate::job::cache_env_vars`] points `XDG_CACHE_HOME` at the shared
+//! `/cache` PVC. So this Job's output is consumed with **no pipeline change**:
+//! the next warm Job's `execute_plan_with_cache` observes a `CachedHit` for
+//! every workspace whose cache key still matches and skips the re-index.
+//!
+//! Because the cache key is content-derived (source/config/lockfile hashes),
+//! not commit-derived, a commit touching only workspace A leaves workspace B's
+//! key intact and B still hits. A miss is not a regression — it is exactly
+//! today's behaviour, the warm Job re-indexes inline.
+//!
+//! # Degradation
+//!
+//! This Job never publishes a graph. It only fills a cache. If it fails, is
+//! skipped, or never runs, the warm path is bit-for-bit what it is today:
+//! `ensure_canonical_graph` re-runs the indexers inline, and its existing
+//! guards (the `node_count == 0` early return that refuses to write an empty
+//! blob, and per-workspace salvage from the previous artifact) continue to
+//! hold. There is no code path by which a missing SCIP Job can degrade the
+//! served graph to empty — the worst case is a slower warm.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::batch::v1::{Job, JobSpec};
+use k8s_openapi::api::core::v1::{
+    Container, EmptyDirVolumeSource, EnvVar, PersistentVolumeClaimVolumeSource, PodSpec,
+    PodTemplateSpec, ResourceRequirements, Toleration, Volume, VolumeMount,
+};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+use crate::config::KubernetesConfig;
+use crate::warm_job::{
+    LABEL_COMPONENT, MIRROR_MOUNT_DIR, VOLUME_MIRROR, VOLUME_WORKSPACE, WARM_COMMAND_BIN,
+    WORKSPACE_MOUNT_DIR, sanitize_id,
+};
+
+/// Label key identifying a standalone SCIP-index Job.
+pub const LABEL_SCIP_INDEX: &str = "djinn.app/scip-index";
+/// Label key for the project id a SCIP-index Job targets. Deliberately the same
+/// key the warm Job uses so one selector dimension covers both populations.
+pub const LABEL_PROJECT_ID: &str = crate::warm_job::LABEL_PROJECT_ID;
+/// `djinn.app/component` value written on SCIP-index resources.
+pub const COMPONENT_SCIP_INDEX: &str = "scip-index";
+
+/// Proposal `8ixk`'s protected-workload label.
+///
+/// A Pod carrying this label has its scheduler-effective CPU request folded
+/// into `protected_mcpu` and subtracted from the capacity build slots are
+/// derived from. Every first-party workload whose CPU must not be handed out as
+/// build capacity carries it. This Job takes no build lease, so without this
+/// label its CPU would be accounted by nothing at all.
+pub const LABEL_CAPACITY_RESERVED: &str = "djinn.io/capacity-reserved";
+
+/// Annotation recording which repository revision this index run covers. The
+/// scheduler in [`crate::scip_schedule`] reads it back off retained Jobs to
+/// decide whether the head has advanced since the last successful index.
+pub const ANNOTATION_SCIP_REVISION: &str = "djinn.app/scip-revision";
+
+/// Container name of the SCIP indexer. Distinct from the warm Job's `warmer`
+/// so [`crate::build_resources::apply_resolved_resources`] — which targets
+/// `worker`/`warmer` — cannot silently retarget this Pod with warm overrides.
+pub const SCIP_CONTAINER_NAME: &str = "scip-indexer";
+
+/// Measured peak RSS of the SCIP phase on the production workspace, in bytes:
+/// **10.0 GB**.
+///
+/// This is the number the rendered memory limit is regression-tested against.
+/// It is not a guess and not a comment: `scip_memory_limit_covers_the_measured_peak`
+/// fails the build if the rendered limit ever drops below it. The warm Job's
+/// `warm_memory_limit` default is `6Gi` — below this peak — and production
+/// survives only because it overrides to 16Gi out of band. That is exactly the
+/// arrangement this constant exists to prevent repeating.
+pub const MEASURED_SCIP_PEAK_MEMORY_BYTES: i64 = 10_000_000_000;
+
+/// Measured wall-clock of the SCIP phase inside the combined warm Job:
+/// 58m43s = 3523s.
+pub const MEASURED_SCIP_PHASE_SECONDS: i64 = 3_523;
+
+// ---- Proposal 8ixk capacity arithmetic ------------------------------------
+//
+// These are the *inputs* to 8ixk's derivation on the current deployment. The
+// budget assertion recomputes the formula from them rather than comparing the
+// rendered request against a hand-copied ceiling, so a change to any input
+// moves the proved budget.
+
+/// Allocatable CPU of the current production node, in millicores (12 cores).
+pub const VPS_ALLOCATABLE_MILLICORES: i64 = 12_000;
+/// Summed CPU request of the already-protected workloads on that node:
+/// djinn-server 2000m + djinn-postgres 1000m + djinn-buildkitd 1000m +
+/// djinn-qdrant 100m + djinn-zot 100m.
+pub const VPS_PROTECTED_MILLICORES: i64 = 4_200;
+/// `cores_per_slot_mcpu`, proposal 8ixk's default slot cost.
+pub const CORES_PER_SLOT_MILLICORES: i64 = 2_800;
+/// The derived build-slot cap 8ixk produces on this node *before* this Job
+/// exists: `floor((12000 - 4200) / 2800) = 2`.
+pub const VPS_DERIVED_CAP_SLOTS: i64 = 2;
+
+/// The largest CPU request this Job may declare without lowering the derived
+/// build-slot cap.
+///
+/// Solved from 8ixk's formula: the cap holds at [`VPS_DERIVED_CAP_SLOTS`] while
+/// `allocatable - protected - request >= cap * cores_per_slot`, i.e. while
+/// `request <= 12000 - 4200 - 2*2800 = 2200`. Raising this Job's request past
+/// 2200m costs the deployment a whole build slot — a third of its build
+/// concurrency — which is why the ceiling is a named, tested constant rather
+/// than a sentence in a PR description.
+pub const SCIP_PROTECTED_REQUEST_CEILING_MILLICORES: i64 = VPS_ALLOCATABLE_MILLICORES
+    - VPS_PROTECTED_MILLICORES
+    - VPS_DERIVED_CAP_SLOTS * CORES_PER_SLOT_MILLICORES;
+
+/// Deterministic Job name for one `(project, revision)` index run.
+///
+/// Deterministic so a lost create response cannot produce two Jobs for the same
+/// revision, and so the retained-Job inventory the scheduler reads is keyed by
+/// the thing it actually decides on.
+#[must_use]
+pub fn scip_index_job_name(project_id: &str, revision: &str) -> String {
+    let project = sanitize_id(project_id);
+    let rev: String = revision
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(12)
+        .flat_map(char::to_lowercase)
+        .collect();
+    format!("djinn-scip-{project}-{rev}")
+}
+
+/// Labels every SCIP-index resource carries.
+fn job_labels(project_id: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (LABEL_COMPONENT.into(), COMPONENT_SCIP_INDEX.into()),
+        (LABEL_SCIP_INDEX.into(), "true".into()),
+        (LABEL_PROJECT_ID.into(), sanitize_id(project_id)),
+        // 8ixk: this Job takes no build lease, so this label is the ONLY thing
+        // that makes its CPU visible to the capacity derivation.
+        (LABEL_CAPACITY_RESERVED.into(), "true".into()),
+    ])
+}
+
+fn env_var(name: &str, value: &str) -> EnvVar {
+    EnvVar {
+        name: name.to_string(),
+        value: Some(value.to_string()),
+        ..EnvVar::default()
+    }
+}
+
+/// Build the Job manifest for one standalone SCIP index run at `revision`.
+///
+/// The Pod clones the project's mirror, installs JS dependencies when a
+/// lockfile is present (scip-typescript cannot resolve workspace-package
+/// `tsconfig` `extends` without `node_modules`), then execs
+/// `djinn-agent-worker scip-index <project_id>`, which runs the semantic pass
+/// only and leaves its artifacts in the shared content-addressed SCIP cache.
+///
+/// It renders **no** launcher sidecar, **no** warm lease gate, and **no** lease
+/// annotations — see `scip_job_takes_no_build_lease_surface`.
+pub fn build_scip_index_job(
+    config: &KubernetesConfig,
+    project_id: &str,
+    project_image_tag: &str,
+    revision: &str,
+    policy: Option<&djinn_stack::environment::CargoCachePolicy>,
+) -> Job {
+    let sanitized_project = sanitize_id(project_id);
+    let job_name = scip_index_job_name(project_id, revision);
+    let labels = job_labels(project_id);
+    let annotations =
+        BTreeMap::from([(ANNOTATION_SCIP_REVISION.to_string(), revision.to_string())]);
+
+    let project_root = format!("{WORKSPACE_MOUNT_DIR}/{sanitized_project}");
+    let mirror_path = format!("{MIRROR_MOUNT_DIR}/{project_id}.git");
+
+    // Deliberately the same clone preamble as the warm Job (umask, the
+    // GIT_CONFIG_SYSTEM safe.directory file, --depth 1000 --single-branch,
+    // lockfile-gated JS install). The two Pods index the same tree; a
+    // divergence here is a divergence in what gets indexed.
+    let cmd = format!(
+        r#"set -euo pipefail
+umask 0002
+export GIT_CONFIG_SYSTEM={WORKSPACE_MOUNT_DIR}/.djinn-gitconfig
+unset GIT_CONFIG_NOSYSTEM
+printf '[safe]\n\tdirectory = *\n' > "$GIT_CONFIG_SYSTEM"
+UPSTREAM_URL="$(git -C "{mirror_path}" config remote.origin.url)"
+git clone --depth 1000 --single-branch "$UPSTREAM_URL" "{project_root}"
+cd "{project_root}"
+if [ -f pnpm-lock.yaml ]; then
+  ( corepack enable >/dev/null 2>&1 || true; \
+    corepack pnpm install --frozen-lockfile || pnpm install --frozen-lockfile || pnpm install ) || true
+elif [ -f yarn.lock ]; then
+  ( corepack enable >/dev/null 2>&1 || true; \
+    corepack yarn install --frozen-lockfile || yarn install ) || true
+elif [ -f package-lock.json ]; then
+  ( npm ci || npm install ) || true
+fi
+exec {bin} scip-index "{project_id}"
+"#,
+        mirror_path = mirror_path,
+        project_root = project_root,
+        bin = WARM_COMMAND_BIN,
+        project_id = project_id,
+    );
+
+    let mut env = vec![
+        env_var("DJINN_MIRROR_ROOT", MIRROR_MOUNT_DIR),
+        env_var("DJINN_SCIP_PROJECT_ID", project_id),
+        env_var("DJINN_PROJECT_ROOT", &project_root),
+        env_var("DJINN_SCIP_REVISION", revision),
+        env_var("RUST_LOG", "info,djinn=debug"),
+        env_var(
+            "DJINN_SCIP_JOB_DEADLINE_SECONDS",
+            &config.scip_job_timeout_seconds.to_string(),
+        ),
+    ];
+    if let Some(url) = config.database_url.as_deref() {
+        env.push(env_var("DJINN_DATABASE_URL", url));
+    }
+
+    // CACHE PARITY IS LOAD-BEARING, AND IT IS PARITY WITH THE *WARM* POD.
+    //
+    // These vars are derived from `config.warm_cpu_limit`, NOT from this Pod's
+    // own `scip_cpu_limit`. That looks wrong and is not:
+    //
+    //   * `CARGO_BUILD_RUSTFLAGS` embeds `-Clink-arg=-Wl,--threads=N` with N
+    //     derived from the limit. RUSTFLAGS feed rustc's `-C metadata`, so a
+    //     `--threads=2` render would give every compilation unit a different
+    //     fingerprint from the warm base and discard 100% of it.
+    //   * `CARGO_TARGET_DIR` is keyed `.../mold-jobs-N` from the same limit, so
+    //     a divergent N would fork a second, cold target base on the PVC.
+    //   * `CARGO_INCREMENTAL=1` / `RUSTC_WRAPPER=""` are the shared compile
+    //     strategy every djinn build pod must agree on (see the doc comment on
+    //     [`crate::job::warm_cache_env_vars`]); cargo folds both into its
+    //     fingerprints.
+    //
+    // `scip_job_cache_env_matches_the_warm_job_render` asserts this against the
+    // warm Job's actual rendered env, so passing `scip_cpu_limit` here fails.
+    env.extend(crate::job::warm_cache_env_vars(
+        project_id,
+        &config.warm_cpu_limit,
+        policy,
+    ));
+
+    let container = Container {
+        name: SCIP_CONTAINER_NAME.to_string(),
+        image: Some(project_image_tag.to_string()),
+        image_pull_policy: Some(config.image_pull_policy.clone()),
+        command: Some(vec!["/bin/bash".to_string(), "-c".to_string(), cmd]),
+        env: Some(env),
+        volume_mounts: Some(vec![
+            VolumeMount {
+                name: VOLUME_MIRROR.to_string(),
+                mount_path: MIRROR_MOUNT_DIR.to_string(),
+                read_only: Some(true),
+                ..VolumeMount::default()
+            },
+            VolumeMount {
+                name: VOLUME_WORKSPACE.to_string(),
+                mount_path: WORKSPACE_MOUNT_DIR.to_string(),
+                read_only: Some(false),
+                ..VolumeMount::default()
+            },
+            VolumeMount {
+                name: crate::job::VOLUME_CACHE.to_string(),
+                mount_path: crate::job::CACHE_MOUNT_DIR.to_string(),
+                read_only: Some(false),
+                ..VolumeMount::default()
+            },
+            crate::env_config::env_config_volume_mount(),
+        ]),
+        resources: Some(ResourceRequirements {
+            requests: Some(BTreeMap::from([
+                ("cpu".to_string(), Quantity(config.scip_cpu_request.clone())),
+                (
+                    "memory".to_string(),
+                    Quantity(config.scip_memory_request.clone()),
+                ),
+            ])),
+            limits: Some(BTreeMap::from([
+                ("cpu".to_string(), Quantity(config.scip_cpu_limit.clone())),
+                (
+                    "memory".to_string(),
+                    Quantity(config.scip_memory_limit.clone()),
+                ),
+            ])),
+            ..ResourceRequirements::default()
+        }),
+        ..Container::default()
+    };
+
+    let volumes = vec![
+        Volume {
+            name: VOLUME_MIRROR.to_string(),
+            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                claim_name: config.mirror_pvc.clone(),
+                read_only: Some(true),
+            }),
+            ..Volume::default()
+        },
+        Volume {
+            name: VOLUME_WORKSPACE.to_string(),
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Volume::default()
+        },
+        Volume {
+            name: crate::job::VOLUME_CACHE.to_string(),
+            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                claim_name: config.cache_pvc.clone(),
+                read_only: Some(false),
+            }),
+            ..Volume::default()
+        },
+        crate::env_config::env_config_volume(project_id),
+    ];
+
+    let node_selector = (!config.node_selector.is_empty()).then(|| config.node_selector.clone());
+    let tolerations: Option<Vec<Toleration>> =
+        (!config.tolerations.is_empty()).then(|| config.tolerations.clone());
+
+    let pod_spec = PodSpec {
+        service_account_name: Some(config.service_account.clone()),
+        restart_policy: Some("Never".to_string()),
+        containers: vec![container],
+        volumes: Some(volumes),
+        node_selector,
+        tolerations,
+        // Same uid rationale as the warm Pod: this Pod CREATES content in the
+        // shared `/cache` tree (the SCIP artifact cache, and whatever the
+        // indexers spill into the cargo target base), and chmod/chown/utimes
+        // are governed by ownership alone. It renders no launcher and no broker
+        // socket, so CHILD_UID carries no security consequence here either.
+        security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
+            run_as_user: Some(i64::from(crate::launcher::CHILD_UID)),
+            run_as_group: Some(i64::from(crate::launcher::ARTIFACT_GID)),
+            ..crate::launcher::pod_security_context()
+        }),
+        ..PodSpec::default()
+    };
+
+    Job {
+        metadata: ObjectMeta {
+            name: Some(job_name),
+            namespace: Some(config.namespace.clone()),
+            labels: Some(labels.clone()),
+            annotations: Some(annotations.clone()),
+            ..ObjectMeta::default()
+        },
+        spec: Some(JobSpec {
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels),
+                    annotations: Some(annotations),
+                    ..ObjectMeta::default()
+                }),
+                spec: Some(pod_spec),
+            },
+            backoff_limit: Some(0),
+            // Retained deliberately longer than the index interval: the
+            // retained succeeded-Job inventory IS the change-detection ledger
+            // read by [`crate::scip_schedule`]. See
+            // `scip_job_ttl_outlives_the_index_interval`.
+            ttl_seconds_after_finished: Some(config.scip_job_ttl_seconds),
+            active_deadline_seconds: Some(config.scip_job_timeout_seconds),
+            ..JobSpec::default()
+        }),
+        ..Job::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: i64 = 1 << 30;
+
+    /// Exact integer millicores from a rendered CPU `Quantity`. Panics rather
+    /// than rounding: a render-shape change must be noticed, not absorbed.
+    fn cpu_millicores(q: &str) -> i64 {
+        match q.strip_suffix('m') {
+            Some(m) => m
+                .parse()
+                .unwrap_or_else(|_| panic!("non-integer millicore quantity: {q:?}")),
+            None => {
+                q.parse::<i64>()
+                    .unwrap_or_else(|_| panic!("non-integer whole-core quantity: {q:?}"))
+                    * 1000
+            }
+        }
+    }
+
+    fn memory_bytes(q: &str) -> i64 {
+        for (suffix, mult) in [("Gi", GIB), ("Mi", 1 << 20), ("Ki", 1 << 10)] {
+            if let Some(n) = q.strip_suffix(suffix) {
+                return n
+                    .parse::<i64>()
+                    .unwrap_or_else(|_| panic!("non-integer memory quantity: {q:?}"))
+                    * mult;
+            }
+        }
+        q.parse::<i64>()
+            .unwrap_or_else(|_| panic!("unrecognized memory quantity: {q:?}"))
+    }
+
+    fn job(cfg: &KubernetesConfig) -> Job {
+        build_scip_index_job(
+            cfg,
+            "proj-xyz",
+            "reg.example:5000/p:abc",
+            "deadbeef1234567890",
+            None,
+        )
+    }
+
+    fn container_of(job: &Job) -> &Container {
+        &job.spec
+            .as_ref()
+            .and_then(|s| s.template.spec.as_ref())
+            .expect("pod spec")
+            .containers[0]
+    }
+
+    fn env_of(job: &Job) -> BTreeMap<String, String> {
+        container_of(job)
+            .env
+            .as_ref()
+            .expect("env")
+            .iter()
+            .map(|e| (e.name.clone(), e.value.clone().unwrap_or_default()))
+            .collect()
+    }
+
+    fn resources_of(job: &Job) -> &ResourceRequirements {
+        container_of(job).resources.as_ref().expect("resources")
+    }
+
+    fn request(job: &Job, key: &str) -> String {
+        resources_of(job)
+            .requests
+            .as_ref()
+            .expect("requests")
+            .get(key)
+            .expect("key")
+            .0
+            .clone()
+    }
+
+    fn limit(job: &Job, key: &str) -> String {
+        resources_of(job)
+            .limits
+            .as_ref()
+            .expect("limits")
+            .get(key)
+            .expect("key")
+            .0
+            .clone()
+    }
+
+    #[test]
+    fn builds_scip_index_job_with_expected_shape() {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.database_url = Some("postgres://djinn@djinn-postgres:5432/djinn".into());
+        let job = job(&cfg);
+
+        assert_eq!(
+            job.metadata.name.as_deref(),
+            Some("djinn-scip-proj-xyz-deadbeef1234")
+        );
+        assert_eq!(
+            job.metadata.namespace.as_deref(),
+            Some(cfg.namespace.as_str())
+        );
+
+        let labels = job.metadata.labels.as_ref().expect("labels");
+        assert_eq!(
+            labels.get(LABEL_COMPONENT).map(String::as_str),
+            Some(COMPONENT_SCIP_INDEX)
+        );
+        assert_eq!(
+            labels.get(LABEL_SCIP_INDEX).map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            labels.get(LABEL_PROJECT_ID).map(String::as_str),
+            Some("proj-xyz")
+        );
+
+        let annotations = job.metadata.annotations.as_ref().expect("annotations");
+        assert_eq!(
+            annotations
+                .get(ANNOTATION_SCIP_REVISION)
+                .map(String::as_str),
+            Some("deadbeef1234567890"),
+            "the scheduler reads the FULL revision back off this annotation; a \
+             truncated value would make head-advance detection compare prefixes"
+        );
+
+        let spec = job.spec.as_ref().expect("spec");
+        assert_eq!(spec.backoff_limit, Some(0));
+        assert_eq!(
+            spec.active_deadline_seconds,
+            Some(cfg.scip_job_timeout_seconds)
+        );
+
+        let cmd = &container_of(&job).command.as_ref().expect("command")[2];
+        assert!(cmd.contains("scip-index \"proj-xyz\""), "{cmd}");
+        assert!(
+            !cmd.contains("warm-graph"),
+            "the SCIP Job must not invoke the combined warm pipeline: {cmd}"
+        );
+        assert!(cmd.contains(" --depth 1000"), "{cmd}");
+        assert!(cmd.contains("pnpm-lock.yaml"), "{cmd}");
+
+        let env = env_of(&job);
+        assert_eq!(
+            env.get("DJINN_SCIP_REVISION").map(String::as_str),
+            Some("deadbeef1234567890")
+        );
+        assert_eq!(
+            env.get("DJINN_PROJECT_ROOT").map(String::as_str),
+            Some("/workspace/proj-xyz")
+        );
+        assert_eq!(
+            env.get("DJINN_DATABASE_URL").map(String::as_str),
+            Some("postgres://djinn@djinn-postgres:5432/djinn")
+        );
+    }
+
+    /// **The 16Gi floor.**
+    ///
+    /// Measured peak RSS for the SCIP phase is 10.0 GB. The warm Job's
+    /// `warm_memory_limit` default is `6Gi`, and production only survives
+    /// because an out-of-band override raises it to 16Gi. This Job sets the
+    /// real figure explicitly, and this test fails the build if the rendered
+    /// limit ever drops below what was measured — a default, a comment, or an
+    /// operator override is not an acceptable substitute.
+    #[test]
+    fn scip_memory_limit_covers_the_measured_peak() {
+        let cfg = KubernetesConfig::for_testing();
+        let rendered = limit(&job(&cfg), "memory");
+        assert_eq!(rendered, "16Gi");
+        assert!(
+            memory_bytes(&rendered) >= MEASURED_SCIP_PEAK_MEMORY_BYTES,
+            "rendered SCIP memory limit {rendered} = {} bytes is below the \
+             MEASURED peak of {} bytes; the Pod will be OOMKilled mid-index",
+            memory_bytes(&rendered),
+            MEASURED_SCIP_PEAK_MEMORY_BYTES,
+        );
+        // Not merely "some large number": a 6Gi render (the warm default this
+        // Job must not inherit) must fail this assertion.
+        assert!(
+            memory_bytes("6Gi") < MEASURED_SCIP_PEAK_MEMORY_BYTES,
+            "the measured peak must sit ABOVE the warm default, or this test \
+             would pass for a Pod that OOMs"
+        );
+        assert!(
+            memory_bytes(&request(&job(&cfg), "memory")) <= memory_bytes(&rendered),
+            "memory request must not exceed its limit"
+        );
+    }
+
+    /// **The 8ixk protected-request budget.**
+    ///
+    /// Recomputes 8ixk's derivation from its inputs rather than comparing the
+    /// rendered request against a copied number: with this Job's request folded
+    /// into `protected_mcpu`, the derived cap must still be
+    /// [`VPS_DERIVED_CAP_SLOTS`].
+    #[test]
+    fn scip_cpu_request_stays_inside_the_8ixk_protected_budget() {
+        let cfg = KubernetesConfig::for_testing();
+        let requested = cpu_millicores(&request(&job(&cfg), "cpu"));
+        assert_eq!(requested, 1_000, "documented sizing is a 1 CPU request");
+
+        let derive = |extra_protected: i64| -> i64 {
+            (VPS_ALLOCATABLE_MILLICORES - VPS_PROTECTED_MILLICORES - extra_protected).max(0)
+                / CORES_PER_SLOT_MILLICORES
+        };
+
+        assert_eq!(
+            derive(0),
+            VPS_DERIVED_CAP_SLOTS,
+            "8ixk baseline on this node"
+        );
+        assert_eq!(
+            derive(requested),
+            VPS_DERIVED_CAP_SLOTS,
+            "rendering this Job at {requested}m must not lower the derived \
+             build-slot cap from {VPS_DERIVED_CAP_SLOTS}",
+        );
+
+        // The ceiling is the solved boundary, not an opinion: at exactly the
+        // ceiling the cap holds; one millicore past it, the deployment loses a
+        // build slot.
+        assert_eq!(SCIP_PROTECTED_REQUEST_CEILING_MILLICORES, 2_200);
+        assert_eq!(
+            derive(SCIP_PROTECTED_REQUEST_CEILING_MILLICORES),
+            VPS_DERIVED_CAP_SLOTS
+        );
+        assert_eq!(
+            derive(SCIP_PROTECTED_REQUEST_CEILING_MILLICORES + 1),
+            VPS_DERIVED_CAP_SLOTS - 1,
+            "one millicore over the ceiling must provably cost a whole slot"
+        );
+        assert!(
+            requested <= SCIP_PROTECTED_REQUEST_CEILING_MILLICORES,
+            "SCIP CPU request {requested}m exceeds the {SCIP_PROTECTED_REQUEST_CEILING_MILLICORES}m \
+             budget and costs the deployment a build slot"
+        );
+        assert!(cpu_millicores(&limit(&job(&cfg), "cpu")) >= requested);
+    }
+
+    /// The label without which this Job is invisible CPU.
+    ///
+    /// It takes no build lease. If it is also not labelled protected, its cores
+    /// are accounted by nothing — precisely the oversubscription 8ixk exists to
+    /// prevent. Asserted on the Pod template, not just the Job: 8ixk selects
+    /// *Pods*.
+    #[test]
+    fn scip_pod_is_labelled_capacity_reserved() {
+        let cfg = KubernetesConfig::for_testing();
+        let job = job(&cfg);
+        for (where_, labels) in [
+            ("job", job.metadata.labels.as_ref()),
+            (
+                "pod template",
+                job.spec
+                    .as_ref()
+                    .and_then(|s| s.template.metadata.as_ref())
+                    .and_then(|m| m.labels.as_ref()),
+            ),
+        ] {
+            assert_eq!(
+                labels
+                    .and_then(|l| l.get(LABEL_CAPACITY_RESERVED))
+                    .map(String::as_str),
+                Some("true"),
+                "{where_} must carry {LABEL_CAPACITY_RESERVED}; 8ixk sums \
+                 protected CPU from Pod labels, and this Job holds no lease"
+            );
+        }
+        // The warm Job, by contrast, pays for its CPU with a build lease and is
+        // deliberately NOT protected — proving this assertion reads the render.
+        let warm = crate::warm_job::build_warm_job(&cfg, "proj-xyz", "img:t", None);
+        assert!(
+            !warm
+                .metadata
+                .labels
+                .as_ref()
+                .is_some_and(|l| l.contains_key(LABEL_CAPACITY_RESERVED)),
+            "the warm Job is charged a build slot; labelling it protected would \
+             double-count its CPU"
+        );
+    }
+
+    /// This Job must acquire no build lease. It cannot be charged a
+    /// `BuildSlotWeight` because it renders none of the surface a leased warm
+    /// Job carries: no fencing token, no gate ConfigMap volume, no init gate,
+    /// no launcher sidecar.
+    #[test]
+    fn scip_job_takes_no_build_lease_surface() {
+        let cfg = KubernetesConfig::for_testing();
+        let job = job(&cfg);
+        let pod = job
+            .spec
+            .as_ref()
+            .and_then(|s| s.template.spec.as_ref())
+            .expect("pod spec");
+
+        assert!(
+            pod.init_containers.as_ref().is_none_or(|c| c.is_empty()),
+            "a lease gate init container implies a lease this Job never takes"
+        );
+        let volumes: Vec<&str> = pod
+            .volumes
+            .iter()
+            .flatten()
+            .map(|v| v.name.as_str())
+            .collect();
+        assert!(!volumes.contains(&crate::warm_job::VOLUME_WARM_GATE));
+        assert!(!volumes.contains(&crate::launcher::VOLUME_LAUNCHER_IPC));
+        let names: Vec<&str> = pod
+            .containers
+            .iter()
+            .chain(pod.init_containers.iter().flatten())
+            .map(|c| c.name.as_str())
+            .collect();
+        assert!(!names.contains(&crate::launcher::LAUNCHER_CONTAINER_NAME));
+
+        let annotations = job.metadata.annotations.as_ref().expect("annotations");
+        for key in [
+            crate::warm_job::ANNOTATION_FENCING_TOKEN,
+            crate::warm_job::ANNOTATION_WARM_REQUEST_ID,
+        ] {
+            assert!(
+                !annotations.contains_key(key),
+                "unexpected lease annotation {key}"
+            );
+        }
+        // The warm-Job selector must not sweep this Job into the warm
+        // population: a warmer that saw it would treat it as an in-flight warm.
+        assert_ne!(
+            job.metadata
+                .labels
+                .as_ref()
+                .and_then(|l| l.get(crate::warm_job::LABEL_WARM)),
+            Some(&"true".to_string()),
+        );
+    }
+
+    /// **Cache/compile parity.**
+    ///
+    /// Every fingerprint-bearing cache var must be byte-identical to the warm
+    /// Job's render. `CARGO_BUILD_RUSTFLAGS` carries `-Wl,--threads=N` derived
+    /// from the CPU limit and feeds rustc's `-C metadata`; a divergent N gives
+    /// all 2797 compilation units different fingerprints and discards the whole
+    /// warm base. `CARGO_TARGET_DIR` is keyed by the same N and would fork a
+    /// second cold base on the PVC.
+    #[test]
+    fn scip_job_cache_env_matches_the_warm_job_render() {
+        let mut cfg = KubernetesConfig::for_testing();
+        // Non-default, and deliberately DIFFERENT from the warm limit, so a
+        // render that keyed the cache off `scip_cpu_limit` diverges visibly.
+        cfg.warm_cpu_limit = "6".into();
+        cfg.scip_cpu_limit = "2".into();
+
+        let warm = crate::warm_job::build_warm_job(&cfg, "proj-xyz", "img:t", None);
+        let warm_env: BTreeMap<String, String> = warm
+            .spec
+            .as_ref()
+            .and_then(|s| s.template.spec.as_ref())
+            .expect("warm pod")
+            .containers[0]
+            .env
+            .as_ref()
+            .expect("warm env")
+            .iter()
+            .map(|e| (e.name.clone(), e.value.clone().unwrap_or_default()))
+            .collect();
+        let scip_env = env_of(&job(&cfg));
+
+        for key in [
+            "CARGO_BUILD_RUSTFLAGS",
+            "CARGO_TARGET_DIR",
+            "CARGO_INCREMENTAL",
+            "RUSTC_WRAPPER",
+            "CARGO_HOME",
+            "SCCACHE_DIR",
+            "XDG_CACHE_HOME",
+            "SQLX_OFFLINE",
+        ] {
+            assert_eq!(
+                scip_env.get(key),
+                warm_env.get(key),
+                "{key} diverges between the SCIP Job and the warm Job; warm and \
+                 SCIP pods must use the SAME compile strategy or cargo \
+                 fingerprints (which fold in RUSTFLAGS, CARGO_INCREMENTAL and \
+                 the rustc wrapper) discard the shared warm base"
+            );
+        }
+        assert_eq!(
+            scip_env.get("CARGO_INCREMENTAL").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(scip_env.get("RUSTC_WRAPPER").map(String::as_str), Some(""));
+        assert_eq!(
+            scip_env.get("CARGO_BUILD_RUSTFLAGS").map(String::as_str),
+            Some("-Clink-arg=-fuse-ld=mold -Clink-arg=-Wl,--threads=6"),
+            "keyed off warm_cpu_limit (6), NOT scip_cpu_limit (2)"
+        );
+        assert_eq!(
+            scip_env.get("CARGO_TARGET_DIR").map(String::as_str),
+            Some("/cache/cargo-target/proj-xyz/mold-jobs-6"),
+        );
+        // XDG_CACHE_HOME is what routes the content-addressed SCIP artifact
+        // cache onto the shared PVC. Without it this Job produces nothing the
+        // warm Job can consume, and the whole split is inert.
+        assert_eq!(
+            scip_env.get("XDG_CACHE_HOME").map(String::as_str),
+            Some("/cache/xdg/proj-xyz"),
+        );
+    }
+
+    /// The retained succeeded-Job set is the change-detection ledger, so it has
+    /// to outlive the cadence it gates. A TTL shorter than the interval makes
+    /// every tick look like "never indexed".
+    #[test]
+    fn scip_job_ttl_outlives_the_index_interval() {
+        let cfg = KubernetesConfig::for_testing();
+        assert!(
+            i64::from(cfg.scip_job_ttl_seconds) > cfg.scip_index_interval_seconds as i64,
+            "ttl {} must exceed the {}s index interval, or the retained-Job \
+             ledger expires before the next decision reads it",
+            cfg.scip_job_ttl_seconds,
+            cfg.scip_index_interval_seconds,
+        );
+    }
+
+    /// The deadline must clear the measured phase cost with margin, or the Pod
+    /// is SIGKILLed mid-index and the cache is never written.
+    #[test]
+    fn scip_deadline_clears_the_measured_phase_cost() {
+        let cfg = KubernetesConfig::for_testing();
+        assert!(
+            cfg.scip_job_timeout_seconds >= MEASURED_SCIP_PHASE_SECONDS * 2,
+            "scip_job_timeout_seconds {} leaves no margin over the measured \
+             {MEASURED_SCIP_PHASE_SECONDS}s SCIP phase",
+            cfg.scip_job_timeout_seconds,
+        );
+    }
+
+    #[test]
+    fn scheduling_hints_propagate_from_config() {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.node_selector
+            .insert("workload-type".into(), "djinn".into());
+        cfg.tolerations.push(Toleration {
+            key: Some("workload-type".into()),
+            operator: Some("Equal".into()),
+            effect: Some("NoSchedule".into()),
+            ..Toleration::default()
+        });
+        let job = job(&cfg);
+        let pod = job
+            .spec
+            .as_ref()
+            .and_then(|s| s.template.spec.as_ref())
+            .expect("pod");
+        assert_eq!(
+            pod.node_selector
+                .as_ref()
+                .and_then(|n| n.get("workload-type"))
+                .map(String::as_str),
+            Some("djinn")
+        );
+        assert_eq!(pod.tolerations.as_ref().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn job_name_is_deterministic_and_label_safe() {
+        let a = scip_index_job_name("Proj_ABC/xyz", "AbC123def4567890");
+        assert_eq!(a, scip_index_job_name("Proj_ABC/xyz", "AbC123def4567890"));
+        assert_eq!(a, "djinn-scip-proj-abc-xyz-abc123def456");
+        assert!(crate::label_value::is_valid_label_value(&a), "{a}");
+        assert_ne!(a, scip_index_job_name("Proj_ABC/xyz", "ffffffffffffffff"));
+    }
+}

--- a/server/crates/djinn-k8s/src/scip_schedule.rs
+++ b/server/crates/djinn-k8s/src/scip_schedule.rs
@@ -1,0 +1,754 @@
+//! Cadence + change-detection gate for the standalone SCIP-index Job.
+//!
+//! # The requirement
+//!
+//! Run the semantic index **every 3 hours, and only if the repository head has
+//! advanced since the last successful index**. If nothing changed, skip
+//! *without creating a Job* — a leaseless 16Gi Pod that re-indexes an unchanged
+//! tree is pure waste.
+//!
+//! # Why this does not reuse the warm debounce
+//!
+//! [`crate::graph_warmer`] has a debounce with a 180s quiet window and a 900s
+//! anti-starvation cap. **It is dead and must not be built on.**
+//! `server/src/mirror_fetcher.rs` (`DEFAULT_INTERVAL_SECS = 60`) calls
+//! `graph_warmer().trigger(project_id)` unconditionally every 60 seconds for
+//! every project with indexable code, so the 180s quiet window can never
+//! elapse; every window runs to the 900s cap. That was verified in production:
+//! a window opened and collapsed at exactly 900.000s having coalesced 17
+//! triggers. A cadence built on that path would be a cadence built on a timer
+//! that always fires.
+//!
+//! This gate is therefore *pull*, not push: it is driven by its own tick and
+//! decides from observed state. It never subscribes to `trigger`.
+//!
+//! # Where the "last successful index" state lives
+//!
+//! In the cluster, not in Postgres. Each SCIP Job is named deterministically
+//! from `(project, revision)` and annotated with
+//! [`crate::scip_job::ANNOTATION_SCIP_REVISION`], and
+//! `scip_job_ttl_seconds` (4h) is deliberately longer than
+//! `scip_index_interval_seconds` (3h) — so the retained succeeded-Job set *is*
+//! the ledger, and it is durable across server restarts because it is apiserver
+//! state.
+//!
+//! The failure mode of an early-GC'd Job is a redundant dispatch, and a
+//! redundant dispatch is cheap: the SCIP artifact cache is content-addressed
+//! (source/config/lockfile hashes), so re-running against an unchanged tree
+//! hits the cache for every workspace. Losing the ledger costs a fast no-op,
+//! never a wrong graph — which is why this is worth avoiding a schema
+//! migration for.
+//!
+//! # Failure and skip degradation
+//!
+//! Every non-`Dispatch` outcome, including every error, is a **skip**. Skipping
+//! cannot degrade the served graph: this Job only fills a cache. When it does
+//! not run, `ensure_canonical_graph` re-runs the indexers inline exactly as it
+//! does today, its `node_count == 0` guard still refuses to publish an empty
+//! blob, and per-workspace salvage still splices the previous artifact for any
+//! workspace whose indexer failed. The worst case of a skipped or failed SCIP
+//! Job is a slower warm, never an empty graph.
+//!
+//! Uncertainty is therefore resolved toward *not dispatching*: an unreadable
+//! head or an unreadable inventory yields a skip, because dispatching on
+//! unknown state is the only branch that can cost anything.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::chrono::{DateTime, Utc};
+use kube::api::{Api, ListParams};
+use tracing::{debug, info, warn};
+
+use crate::config::KubernetesConfig;
+use crate::graph_warmer::WarmJobDispatcher;
+use crate::scip_job::{
+    ANNOTATION_SCIP_REVISION, LABEL_PROJECT_ID, LABEL_SCIP_INDEX, build_scip_index_job,
+};
+
+/// What one scheduling tick decided for one project. Every variant except
+/// [`Self::Dispatch`] creates no Kubernetes object at all.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ScipIndexDecision {
+    /// Head advanced, cadence satisfied, nothing in flight: create the Job.
+    Dispatch { revision: String },
+    /// The mirror head could not be resolved. Fail closed — a Job is named
+    /// after its revision, so an unknown revision has no correct name.
+    SkipUnknownRevision,
+    /// The cluster inventory could not be read. Fail closed: an unreadable
+    /// ledger is not evidence that the head advanced.
+    SkipInventoryUnavailable,
+    /// A non-terminal SCIP Job already exists for this project.
+    SkipInFlight,
+    /// The last successful index already covers this exact revision. **This is
+    /// the change-detection gate** and it is checked before the cadence, so an
+    /// unchanged head never dispatches no matter how much time has passed.
+    SkipHeadUnchanged { revision: String },
+    /// Head advanced, but the cadence floor has not elapsed since the last
+    /// dispatch. Rate limit on a continuously-advancing `main`.
+    SkipCadence { remaining: Duration },
+}
+
+impl ScipIndexDecision {
+    /// The revision to index, if this decision dispatches.
+    #[must_use]
+    pub fn dispatch_revision(&self) -> Option<&str> {
+        match self {
+            Self::Dispatch { revision } => Some(revision.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Closed-enum reason label, safe for metrics and logs.
+    #[must_use]
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::Dispatch { .. } => "dispatch",
+            Self::SkipUnknownRevision => "unknown_revision",
+            Self::SkipInventoryUnavailable => "inventory_unavailable",
+            Self::SkipInFlight => "in_flight",
+            Self::SkipHeadUnchanged { .. } => "head_unchanged",
+            Self::SkipCadence { .. } => "cadence",
+        }
+    }
+}
+
+/// What the cluster currently holds for one project's SCIP-index population.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ScipJobObservation {
+    /// At least one SCIP Job for this project is neither succeeded nor failed.
+    pub in_flight: bool,
+    /// Revision of the most recently *succeeded* SCIP Job, read off its
+    /// [`ANNOTATION_SCIP_REVISION`] annotation. `None` when no succeeded Job is
+    /// retained — first run, or the ledger aged out.
+    pub last_indexed_revision: Option<String>,
+    /// Age of the most recent SCIP Job of any outcome, from its
+    /// `creationTimestamp`. `None` when none is retained.
+    pub since_last_dispatch: Option<Duration>,
+}
+
+/// Reads the retained SCIP-Job inventory that backs the change-detection gate.
+#[async_trait]
+pub trait ScipJobInventory: Send + Sync {
+    async fn observe(
+        &self,
+        namespace: &str,
+        project_id: &str,
+    ) -> Result<ScipJobObservation, String>;
+}
+
+/// The pure decision. No I/O, no clock, no cluster — every input is an
+/// argument, so every branch is directly unit-testable.
+///
+/// Ordering is load-bearing:
+/// 1. unknown head and unreadable inventory fail closed;
+/// 2. in-flight coalesces;
+/// 3. **head-unchanged wins over the cadence**, because the requirement is
+///    "every 3 hours *and only if* the head advanced", not "or";
+/// 4. the cadence floor rate-limits an advancing head.
+#[must_use]
+pub fn decide(
+    head_revision: Option<&str>,
+    observation: Option<&ScipJobObservation>,
+    interval: Duration,
+) -> ScipIndexDecision {
+    let Some(head) = head_revision.map(str::trim).filter(|h| !h.is_empty()) else {
+        return ScipIndexDecision::SkipUnknownRevision;
+    };
+    let Some(observation) = observation else {
+        return ScipIndexDecision::SkipInventoryUnavailable;
+    };
+    if observation.in_flight {
+        return ScipIndexDecision::SkipInFlight;
+    }
+    if observation.last_indexed_revision.as_deref() == Some(head) {
+        return ScipIndexDecision::SkipHeadUnchanged {
+            revision: head.to_string(),
+        };
+    }
+    if let Some(elapsed) = observation.since_last_dispatch
+        && elapsed < interval
+    {
+        return ScipIndexDecision::SkipCadence {
+            remaining: interval - elapsed,
+        };
+    }
+    ScipIndexDecision::Dispatch {
+        revision: head.to_string(),
+    }
+}
+
+/// Drives [`decide`] against the live cluster and creates the Job when it says
+/// to. Deliberately owns no timer: the caller supplies the tick, so the loop
+/// interval and the cadence floor stay independently configurable and the
+/// scheduler stays testable without `tokio::time`.
+pub struct ScipIndexScheduler {
+    config: KubernetesConfig,
+    inventory: Arc<dyn ScipJobInventory>,
+    dispatcher: Arc<dyn WarmJobDispatcher>,
+}
+
+impl ScipIndexScheduler {
+    #[must_use]
+    pub fn new(
+        config: KubernetesConfig,
+        inventory: Arc<dyn ScipJobInventory>,
+        dispatcher: Arc<dyn WarmJobDispatcher>,
+    ) -> Self {
+        Self {
+            config,
+            inventory,
+            dispatcher,
+        }
+    }
+
+    /// The configured cadence floor.
+    #[must_use]
+    pub fn interval(&self) -> Duration {
+        Duration::from_secs(self.config.scip_index_interval_seconds)
+    }
+
+    /// Evaluate one project without creating anything. Exposed so the decision
+    /// can be observed (and asserted) separately from the side effect.
+    pub async fn evaluate(
+        &self,
+        project_id: &str,
+        head_revision: Option<&str>,
+    ) -> ScipIndexDecision {
+        let observation = match self
+            .inventory
+            .observe(&self.config.namespace, project_id)
+            .await
+        {
+            Ok(observation) => Some(observation),
+            Err(error) => {
+                warn!(
+                    project_id,
+                    %error,
+                    "scip-index: cluster inventory unavailable; skipping this tick"
+                );
+                None
+            }
+        };
+        decide(head_revision, observation.as_ref(), self.interval())
+    }
+
+    /// Evaluate one project and, only on [`ScipIndexDecision::Dispatch`],
+    /// create the Job. Returns the decision that was acted on.
+    ///
+    /// A dispatch failure is not promoted to an error: the Job name is
+    /// deterministic in `(project, revision)`, so a lost create response cannot
+    /// duplicate work, and the next tick re-evaluates from cluster state.
+    pub async fn tick_project(
+        &self,
+        project_id: &str,
+        head_revision: Option<&str>,
+        image_tag: &str,
+        policy: Option<&djinn_stack::environment::CargoCachePolicy>,
+    ) -> ScipIndexDecision {
+        let decision = self.evaluate(project_id, head_revision).await;
+        let Some(revision) = decision.dispatch_revision() else {
+            debug!(
+                project_id,
+                reason = decision.reason(),
+                "scip-index: no Job created this tick"
+            );
+            return decision;
+        };
+        let job = build_scip_index_job(&self.config, project_id, image_tag, revision, policy);
+        match self.dispatcher.dispatch(&self.config.namespace, job).await {
+            Ok(name) => info!(
+                project_id,
+                job = %name,
+                revision,
+                "scip-index: standalone semantic index Job created (no build lease, \
+                 CPU folded into protected capacity)"
+            ),
+            Err(error) => warn!(
+                project_id,
+                revision,
+                %error,
+                "scip-index: Job create failed; the warm path re-indexes inline as \
+                 it does today and the next tick retries"
+            ),
+        }
+        decision
+    }
+}
+
+/// Production inventory backed by a live `kube::Client`.
+pub struct KubeClientScipJobInventory {
+    client: kube::Client,
+}
+
+impl KubeClientScipJobInventory {
+    #[must_use]
+    pub fn new(client: kube::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl ScipJobInventory for KubeClientScipJobInventory {
+    async fn observe(
+        &self,
+        namespace: &str,
+        project_id: &str,
+    ) -> Result<ScipJobObservation, String> {
+        let api: Api<Job> = Api::namespaced(self.client.clone(), namespace);
+        let sanitized = crate::warm_job::sanitize_id(project_id);
+        let selector = format!("{LABEL_SCIP_INDEX}=true,{LABEL_PROJECT_ID}={sanitized}");
+        let list = api
+            .list(&ListParams::default().labels(&selector))
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(observe_from_jobs(&list.items, Utc::now()))
+    }
+}
+
+/// Fold a retained Job list into an observation. Split out of the apiserver
+/// call so the projection is testable from fixtures.
+#[must_use]
+pub fn observe_from_jobs(jobs: &[Job], now: DateTime<Utc>) -> ScipJobObservation {
+    let mut observation = ScipJobObservation::default();
+    let mut newest_succeeded: Option<(DateTime<Utc>, String)> = None;
+    let mut newest_created: Option<DateTime<Utc>> = None;
+
+    for job in jobs {
+        let created = job
+            .metadata
+            .creation_timestamp
+            .as_ref()
+            .map(|t| t.0)
+            .unwrap_or(now);
+        newest_created = Some(newest_created.map_or(created, |c| c.max(created)));
+
+        let status = job.status.as_ref();
+        let succeeded = status.and_then(|s| s.succeeded).unwrap_or(0) > 0;
+        let failed = status.and_then(|s| s.failed).unwrap_or(0) > 0;
+        if !succeeded && !failed {
+            observation.in_flight = true;
+            continue;
+        }
+        if !succeeded {
+            continue;
+        }
+        // Only a SUCCEEDED Job advances the ledger. A failed index leaves the
+        // last known-good revision in place, so the next tick still sees the
+        // head as advanced and retries.
+        let Some(revision) = job
+            .metadata
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get(ANNOTATION_SCIP_REVISION))
+            .filter(|r| !r.trim().is_empty())
+        else {
+            continue;
+        };
+        if newest_succeeded
+            .as_ref()
+            .is_none_or(|(at, _)| created >= *at)
+        {
+            newest_succeeded = Some((created, revision.clone()));
+        }
+    }
+
+    observation.last_indexed_revision = newest_succeeded.map(|(_, revision)| revision);
+    // A negative age (clock skew, or a Job created "in the future") clamps to
+    // zero rather than wrapping: a wrapped age would read as an enormous
+    // elapsed time and defeat the cadence floor.
+    observation.since_last_dispatch = newest_created
+        .map(|created| Duration::from_secs((now - created).num_seconds().max(0) as u64));
+    observation
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::batch::v1::JobStatus;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, Time};
+    use k8s_openapi::chrono::TimeDelta;
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    const HEAD: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const OLD: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const THREE_HOURS: Duration = Duration::from_secs(10_800);
+
+    fn observed(
+        in_flight: bool,
+        last: Option<&str>,
+        since: Option<Duration>,
+    ) -> ScipJobObservation {
+        ScipJobObservation {
+            in_flight,
+            last_indexed_revision: last.map(str::to_string),
+            since_last_dispatch: since,
+        }
+    }
+
+    /// **The change-detection gate.** An unchanged head skips, and it skips no
+    /// matter how long ago the last index ran — the requirement is "every 3
+    /// hours AND only if the head advanced", so time elapsing must not be able
+    /// to authorize an index of an unchanged tree.
+    #[test]
+    fn unchanged_head_never_dispatches_however_much_time_passed() {
+        for elapsed in [
+            Some(Duration::ZERO),
+            Some(THREE_HOURS),
+            Some(Duration::from_secs(30 * 86_400)),
+            None,
+        ] {
+            assert_eq!(
+                decide(
+                    Some(HEAD),
+                    Some(&observed(false, Some(HEAD), elapsed)),
+                    THREE_HOURS
+                ),
+                ScipIndexDecision::SkipHeadUnchanged {
+                    revision: HEAD.to_string()
+                },
+                "elapsed={elapsed:?} must not defeat the head-advance gate",
+            );
+        }
+    }
+
+    /// The complement: an ADVANCED head with the cadence satisfied dispatches.
+    /// Without this the previous test would also pass for a gate that never
+    /// dispatches anything.
+    #[test]
+    fn advanced_head_past_the_cadence_dispatches() {
+        assert_eq!(
+            decide(
+                Some(HEAD),
+                Some(&observed(false, Some(OLD), Some(THREE_HOURS))),
+                THREE_HOURS,
+            ),
+            ScipIndexDecision::Dispatch {
+                revision: HEAD.to_string()
+            },
+        );
+        // First ever run: no ledger, no prior dispatch.
+        assert_eq!(
+            decide(
+                Some(HEAD),
+                Some(&ScipJobObservation::default()),
+                THREE_HOURS
+            ),
+            ScipIndexDecision::Dispatch {
+                revision: HEAD.to_string()
+            },
+        );
+    }
+
+    /// The cadence floor rate-limits a continuously-advancing `main` so a
+    /// leaseless 16Gi Job cannot become a permanent resident.
+    #[test]
+    fn advanced_head_inside_the_cadence_window_waits() {
+        let decision = decide(
+            Some(HEAD),
+            Some(&observed(false, Some(OLD), Some(Duration::from_secs(600)))),
+            THREE_HOURS,
+        );
+        assert_eq!(
+            decision,
+            ScipIndexDecision::SkipCadence {
+                remaining: Duration::from_secs(10_200)
+            },
+        );
+        // Exactly at the boundary the floor is satisfied.
+        assert!(matches!(
+            decide(
+                Some(HEAD),
+                Some(&observed(false, Some(OLD), Some(THREE_HOURS))),
+                THREE_HOURS,
+            ),
+            ScipIndexDecision::Dispatch { .. }
+        ));
+    }
+
+    /// Uncertainty never dispatches. An unknown head has no correct Job name,
+    /// and an unreadable inventory is not evidence that anything advanced.
+    #[test]
+    fn unknown_head_and_unreadable_inventory_fail_closed() {
+        let fresh = observed(false, None, None);
+        assert_eq!(
+            decide(None, Some(&fresh), THREE_HOURS),
+            ScipIndexDecision::SkipUnknownRevision
+        );
+        assert_eq!(
+            decide(Some("   "), Some(&fresh), THREE_HOURS),
+            ScipIndexDecision::SkipUnknownRevision
+        );
+        assert_eq!(
+            decide(Some(HEAD), None, THREE_HOURS),
+            ScipIndexDecision::SkipInventoryUnavailable
+        );
+    }
+
+    #[test]
+    fn in_flight_job_coalesces() {
+        assert_eq!(
+            decide(
+                Some(HEAD),
+                Some(&observed(true, Some(OLD), None)),
+                THREE_HOURS
+            ),
+            ScipIndexDecision::SkipInFlight
+        );
+    }
+
+    // ---- inventory projection ---------------------------------------------
+
+    fn scip_job(revision: &str, succeeded: bool, failed: bool, age_secs: i64) -> Job {
+        Job {
+            metadata: ObjectMeta {
+                annotations: Some(BTreeMap::from([(
+                    ANNOTATION_SCIP_REVISION.to_string(),
+                    revision.to_string(),
+                )])),
+                creation_timestamp: Some(Time(now() - TimeDelta::seconds(age_secs))),
+                ..ObjectMeta::default()
+            },
+            status: Some(JobStatus {
+                succeeded: succeeded.then_some(1),
+                failed: failed.then_some(1),
+                ..JobStatus::default()
+            }),
+            ..Job::default()
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_000_000, 0).expect("fixed test instant")
+    }
+
+    /// Only a SUCCEEDED Job advances the ledger. A failed index must leave the
+    /// previous known-good revision in place so the head still reads as
+    /// advanced and a later tick retries — otherwise one failure would mark the
+    /// tree as indexed and suppress every retry until the next commit.
+    ///
+    /// The retry is gated by the cadence floor, not by the ledger: a failed
+    /// index is still a dispatch, so a Pod that OOMs or times out cannot be
+    /// re-created in a tight loop. Both halves are asserted, because "the
+    /// ledger did not advance" and "the retry actually happens" are different
+    /// claims and only one of them is about the ledger.
+    #[test]
+    fn a_failed_index_does_not_advance_the_ledger_and_retries_after_the_cadence() {
+        let past_the_floor = observe_from_jobs(
+            &[
+                scip_job(OLD, true, false, 40_000),
+                scip_job(HEAD, false, true, 20_000),
+            ],
+            now(),
+        );
+        assert_eq!(
+            past_the_floor.last_indexed_revision.as_deref(),
+            Some(OLD),
+            "a FAILED Job carrying the head revision must not be read as \
+             evidence that the head was indexed"
+        );
+        assert!(!past_the_floor.in_flight);
+        assert_eq!(
+            decide(Some(HEAD), Some(&past_the_floor), THREE_HOURS),
+            ScipIndexDecision::Dispatch {
+                revision: HEAD.to_string()
+            },
+            "once the cadence floor has elapsed the head still reads as \
+             advanced, so the failed index is retried"
+        );
+
+        // ...but not immediately. A failure 100s ago is still a dispatch for
+        // cadence purposes, so a crash-looping index cannot re-create a
+        // leaseless 16Gi Pod every tick.
+        let inside_the_floor = observe_from_jobs(
+            &[
+                scip_job(OLD, true, false, 40_000),
+                scip_job(HEAD, false, true, 100),
+            ],
+            now(),
+        );
+        assert_eq!(inside_the_floor.last_indexed_revision.as_deref(), Some(OLD));
+        assert!(matches!(
+            decide(Some(HEAD), Some(&inside_the_floor), THREE_HOURS),
+            ScipIndexDecision::SkipCadence { .. }
+        ));
+    }
+
+    #[test]
+    fn newest_succeeded_revision_wins_and_non_terminal_marks_in_flight() {
+        let observation = observe_from_jobs(
+            &[
+                scip_job(OLD, true, false, 40_000),
+                scip_job(HEAD, true, false, 100),
+            ],
+            now(),
+        );
+        assert_eq!(observation.last_indexed_revision.as_deref(), Some(HEAD));
+        assert_eq!(
+            observation.since_last_dispatch,
+            Some(Duration::from_secs(100))
+        );
+
+        let running = observe_from_jobs(
+            &[Job {
+                metadata: ObjectMeta {
+                    creation_timestamp: Some(Time(now())),
+                    ..ObjectMeta::default()
+                },
+                status: None,
+                ..Job::default()
+            }],
+            now(),
+        );
+        assert!(running.in_flight);
+        assert_eq!(running.last_indexed_revision, None);
+    }
+
+    #[test]
+    fn empty_inventory_is_a_first_run_not_an_error() {
+        let observation = observe_from_jobs(&[], now());
+        assert_eq!(observation, ScipJobObservation::default());
+    }
+
+    // ---- scheduler side effect --------------------------------------------
+
+    struct RecordingInventory(Result<ScipJobObservation, String>);
+
+    #[async_trait]
+    impl ScipJobInventory for RecordingInventory {
+        async fn observe(&self, _ns: &str, _p: &str) -> Result<ScipJobObservation, String> {
+            self.0.clone()
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingDispatcher(Mutex<Vec<Job>>);
+
+    #[async_trait]
+    impl WarmJobDispatcher for RecordingDispatcher {
+        async fn dispatch(&self, _ns: &str, job: Job) -> Result<String, String> {
+            let name = job.metadata.name.clone().unwrap_or_default();
+            self.0.lock().expect("lock").push(job);
+            Ok(name)
+        }
+    }
+
+    async fn run_tick(
+        observation: Result<ScipJobObservation, String>,
+        head: Option<&str>,
+    ) -> (ScipIndexDecision, Vec<Job>) {
+        let dispatcher = Arc::new(RecordingDispatcher::default());
+        let scheduler = ScipIndexScheduler::new(
+            KubernetesConfig::for_testing(),
+            Arc::new(RecordingInventory(observation)),
+            dispatcher.clone(),
+        );
+        let decision = scheduler.tick_project("proj", head, "img:tag", None).await;
+        let created = dispatcher.0.lock().expect("lock").clone();
+        (decision, created)
+    }
+
+    /// **A skip must create no Kubernetes object.** Asserting the decision
+    /// alone would stay green if `tick_project` dispatched unconditionally, so
+    /// this asserts the side effect.
+    #[tokio::test]
+    async fn skips_create_no_job_and_dispatch_creates_exactly_one() {
+        for (label, observation, head) in [
+            (
+                "unchanged head",
+                Ok(observed(false, Some(HEAD), Some(THREE_HOURS))),
+                Some(HEAD),
+            ),
+            ("in flight", Ok(observed(true, None, None)), Some(HEAD)),
+            (
+                "inside cadence",
+                Ok(observed(false, Some(OLD), Some(Duration::from_secs(60)))),
+                Some(HEAD),
+            ),
+            ("unknown head", Ok(ScipJobObservation::default()), None),
+            (
+                "inventory error",
+                Err("apiserver unreachable".to_string()),
+                Some(HEAD),
+            ),
+        ] {
+            let (decision, created) = run_tick(observation, head).await;
+            assert!(
+                created.is_empty(),
+                "{label}: decision {decision:?} created {} Job(s); a skip must \
+                 create nothing at all",
+                created.len(),
+            );
+        }
+
+        let (decision, created) = run_tick(
+            Ok(observed(false, Some(OLD), Some(THREE_HOURS))),
+            Some(HEAD),
+        )
+        .await;
+        assert_eq!(
+            decision,
+            ScipIndexDecision::Dispatch {
+                revision: HEAD.to_string()
+            }
+        );
+        assert_eq!(created.len(), 1);
+        assert_eq!(
+            created[0].metadata.name.as_deref(),
+            Some(crate::scip_job::scip_index_job_name("proj", HEAD).as_str()),
+        );
+        assert_eq!(
+            created[0]
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get(ANNOTATION_SCIP_REVISION))
+                .map(String::as_str),
+            Some(HEAD),
+            "the created Job must carry the revision the next tick reads back"
+        );
+    }
+
+    /// The dispatched Job round-trips through the inventory projection into a
+    /// `SkipHeadUnchanged` on the following tick. Without this the ledger and
+    /// the gate could agree in the tests and disagree in production.
+    #[tokio::test]
+    async fn a_dispatched_job_closes_the_gate_on_the_next_tick() {
+        let (_, created) = run_tick(
+            Ok(observed(false, Some(OLD), Some(THREE_HOURS))),
+            Some(HEAD),
+        )
+        .await;
+        let mut succeeded = created[0].clone();
+        succeeded.metadata.creation_timestamp = Some(Time(now()));
+        succeeded.status = Some(JobStatus {
+            succeeded: Some(1),
+            ..JobStatus::default()
+        });
+
+        let observation = observe_from_jobs(&[succeeded], now());
+        assert_eq!(observation.last_indexed_revision.as_deref(), Some(HEAD));
+        assert_eq!(
+            decide(Some(HEAD), Some(&observation), THREE_HOURS),
+            ScipIndexDecision::SkipHeadUnchanged {
+                revision: HEAD.to_string()
+            },
+        );
+    }
+
+    #[test]
+    fn interval_comes_from_config() {
+        let mut cfg = KubernetesConfig::for_testing();
+        assert_eq!(cfg.scip_index_interval_seconds, 10_800, "3 hours");
+        cfg.scip_index_interval_seconds = 42;
+        let scheduler = ScipIndexScheduler::new(
+            cfg,
+            Arc::new(RecordingInventory(Ok(ScipJobObservation::default()))),
+            Arc::new(RecordingDispatcher::default()),
+        );
+        assert_eq!(scheduler.interval(), Duration::from_secs(42));
+    }
+}

--- a/server/crates/djinn-k8s/src/scip_schedule.rs
+++ b/server/crates/djinn-k8s/src/scip_schedule.rs
@@ -86,6 +86,11 @@ pub enum ScipIndexDecision {
     /// the change-detection gate** and it is checked before the cadence, so an
     /// unchanged head never dispatches no matter how much time has passed.
     SkipHeadUnchanged { revision: String },
+    /// Head advanced, but the tree has not stood still long enough for the
+    /// index to be worth producing — it would very likely be stale before it
+    /// finished. `None` age means the head's commit time was unreadable, which
+    /// is treated the same way. See [`decide`].
+    SkipHeadNotQuiescent { age: Option<Duration> },
     /// Head advanced, but the cadence floor has not elapsed since the last
     /// dispatch. Rate limit on a continuously-advancing `main`.
     SkipCadence { remaining: Duration },
@@ -110,6 +115,7 @@ impl ScipIndexDecision {
             Self::SkipInventoryUnavailable => "inventory_unavailable",
             Self::SkipInFlight => "in_flight",
             Self::SkipHeadUnchanged { .. } => "head_unchanged",
+            Self::SkipHeadNotQuiescent { .. } => "head_not_quiescent",
             Self::SkipCadence { .. } => "cadence",
         }
     }
@@ -139,6 +145,22 @@ pub trait ScipJobInventory: Send + Sync {
     ) -> Result<ScipJobObservation, String>;
 }
 
+/// The observed head of a project's mirror, and how long it has been the head.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MirrorHead {
+    /// `refs/heads/main` in the project's bare mirror.
+    pub revision: String,
+    /// Age of that commit, i.e. how long the tree has been unchanged.
+    pub age: Duration,
+}
+
+/// Resolves [`MirrorHead`] for a project. A separate seam from the warm path's
+/// own tip discovery so the SCIP cadence cannot be coupled to warm dispatch.
+#[async_trait]
+pub trait MirrorHeadSource: Send + Sync {
+    async fn head(&self, project_id: &str) -> Option<MirrorHead>;
+}
+
 /// The pure decision. No I/O, no clock, no cluster — every input is an
 /// argument, so every branch is directly unit-testable.
 ///
@@ -147,12 +169,43 @@ pub trait ScipJobInventory: Send + Sync {
 /// 2. in-flight coalesces;
 /// 3. **head-unchanged wins over the cadence**, because the requirement is
 ///    "every 3 hours *and only if* the head advanced", not "or";
-/// 4. the cadence floor rate-limits an advancing head.
+/// 4. **head-not-quiescent** skips — see below;
+/// 5. the cadence floor rate-limits an advancing head.
+///
+/// # The quiescence gate, and why the benefit is conditional
+///
+/// The SCIP artifact cache key includes `source_hashes` over the workspace's
+/// sources (`CacheKeyIngredients`, `scip_indexer/cache.rs`). So an index
+/// produced at head `H0` is only a `CachedHit` for a warm that runs against
+/// `H0`'s sources. Warm chases head continuously — `mirror_fetcher` triggers
+/// every 60s and the dead debounce collapses every window at its 900s cap — so
+/// **if `main` advances during the ~59 minutes this Job takes, the warm that
+/// follows misses the cache and re-indexes inline for the full 58m43s.** On a
+/// repository merging more often than once an hour the hit rate tends toward
+/// zero and the SCIP Job's work is redundant.
+///
+/// (The key is per-workspace, so a commit touching only workspace A leaves
+/// workspace B's key intact and B still hits. That helps a polyglot repo, but
+/// it does not help the case that dominates the cost here: djinn's own Rust
+/// `server/` workspace is both the most expensive to index and the most
+/// frequently touched.)
+///
+/// This gate is the cheap, stateless mitigation: **do not index a tree that has
+/// not been stable for at least as long as indexing it takes.** `quiescence`
+/// defaults to the measured 3523s phase cost, so a dispatch only happens when
+/// the head has already stood still longer than the run will last — the
+/// condition under which the result is likely to still be current when it
+/// lands. It cannot prevent a commit arriving *during* the run; nothing can.
+///
+/// An unreadable head age is treated as not quiescent, consistent with every
+/// other uncertainty here resolving toward not dispatching.
 #[must_use]
 pub fn decide(
     head_revision: Option<&str>,
+    head_age: Option<Duration>,
     observation: Option<&ScipJobObservation>,
     interval: Duration,
+    quiescence: Duration,
 ) -> ScipIndexDecision {
     let Some(head) = head_revision.map(str::trim).filter(|h| !h.is_empty()) else {
         return ScipIndexDecision::SkipUnknownRevision;
@@ -167,6 +220,14 @@ pub fn decide(
         return ScipIndexDecision::SkipHeadUnchanged {
             revision: head.to_string(),
         };
+    }
+    if !quiescence.is_zero() {
+        let Some(age) = head_age else {
+            return ScipIndexDecision::SkipHeadNotQuiescent { age: None };
+        };
+        if age < quiescence {
+            return ScipIndexDecision::SkipHeadNotQuiescent { age: Some(age) };
+        }
     }
     if let Some(elapsed) = observation.since_last_dispatch
         && elapsed < interval
@@ -210,13 +271,25 @@ impl ScipIndexScheduler {
         Duration::from_secs(self.config.scip_index_interval_seconds)
     }
 
+    /// How long the head must have stood still before an index is worth
+    /// producing. See [`decide`].
+    #[must_use]
+    pub fn quiescence(&self) -> Duration {
+        Duration::from_secs(self.config.scip_quiescence_seconds)
+    }
+
+    /// Whether the operator has armed SCIP-index dispatch at all. Defaults to
+    /// `false`: the composition root wires the real scheduler unconditionally,
+    /// and this flag is the only thing that decides whether it creates Jobs, so
+    /// arming it is a config flip rather than a redeploy.
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.config.scip_index_enabled
+    }
+
     /// Evaluate one project without creating anything. Exposed so the decision
     /// can be observed (and asserted) separately from the side effect.
-    pub async fn evaluate(
-        &self,
-        project_id: &str,
-        head_revision: Option<&str>,
-    ) -> ScipIndexDecision {
+    pub async fn evaluate(&self, project_id: &str, head: Option<&MirrorHead>) -> ScipIndexDecision {
         let observation = match self
             .inventory
             .observe(&self.config.namespace, project_id)
@@ -232,7 +305,13 @@ impl ScipIndexScheduler {
                 None
             }
         };
-        decide(head_revision, observation.as_ref(), self.interval())
+        decide(
+            head.map(|h| h.revision.as_str()),
+            head.map(|h| h.age),
+            observation.as_ref(),
+            self.interval(),
+            self.quiescence(),
+        )
     }
 
     /// Evaluate one project and, only on [`ScipIndexDecision::Dispatch`],
@@ -244,11 +323,11 @@ impl ScipIndexScheduler {
     pub async fn tick_project(
         &self,
         project_id: &str,
-        head_revision: Option<&str>,
+        head: Option<&MirrorHead>,
         image_tag: &str,
         policy: Option<&djinn_stack::environment::CargoCachePolicy>,
     ) -> ScipIndexDecision {
-        let decision = self.evaluate(project_id, head_revision).await;
+        let decision = self.evaluate(project_id, head).await;
         let Some(revision) = decision.dispatch_revision() else {
             debug!(
                 project_id,
@@ -275,6 +354,54 @@ impl ScipIndexScheduler {
             ),
         }
         decision
+    }
+}
+
+/// Reads `refs/heads/main` and its commit age straight out of the project's
+/// bare mirror.
+///
+/// This deliberately duplicates the two-line git call in
+/// `graph_warmer::discover_mirror_main_tip` rather than sharing it. The warm
+/// path's tip discovery is private to its dispatch flow, and the duplication
+/// keeps this module free of any coupling to warm dispatch — the two cadences
+/// must be able to move independently, which was the whole point of not
+/// building on the (dead) warm debounce.
+pub struct GitMirrorHeadSource;
+
+#[async_trait]
+impl MirrorHeadSource for GitMirrorHeadSource {
+    async fn head(&self, project_id: &str) -> Option<MirrorHead> {
+        let mirror = djinn_workspace::mirror_path_for(project_id);
+        let rev = djinn_git::run_git_command_in(
+            &mirror,
+            vec!["rev-parse".into(), "refs/heads/main".into()],
+        )
+        .await
+        .ok()?;
+        let revision = rev.stdout.trim().to_string();
+        if revision.is_empty() {
+            return None;
+        }
+        // Committer timestamp of the head commit. `decide` treats an
+        // unreadable age as "not quiescent", so a failure here skips rather
+        // than dispatching against an unknown tree.
+        let stamp = djinn_git::run_git_command_in(
+            &mirror,
+            vec![
+                "log".into(),
+                "-1".into(),
+                "--format=%ct".into(),
+                revision.clone(),
+            ],
+        )
+        .await
+        .ok()?;
+        let committed_at = stamp.stdout.trim().parse::<i64>().ok()?;
+        let now = time::OffsetDateTime::now_utc().unix_timestamp();
+        // A commit dated in the future (clock skew) reads as age zero, i.e.
+        // maximally NOT quiescent — the fail-closed direction.
+        let age = Duration::from_secs(now.saturating_sub(committed_at).max(0) as u64);
+        Some(MirrorHead { revision, age })
     }
 }
 
@@ -376,6 +503,10 @@ mod tests {
     const HEAD: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const OLD: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     const THREE_HOURS: Duration = Duration::from_secs(10_800);
+    /// Long enough to satisfy the default quiescence gate in tests that are
+    /// not about it.
+    const QUIET: Option<Duration> = Some(Duration::from_secs(9_999));
+    const QUIESCENCE: Duration = Duration::from_secs(3_523);
 
     fn observed(
         in_flight: bool,
@@ -404,8 +535,10 @@ mod tests {
             assert_eq!(
                 decide(
                     Some(HEAD),
+                    QUIET,
                     Some(&observed(false, Some(HEAD), elapsed)),
-                    THREE_HOURS
+                    THREE_HOURS,
+                    QUIESCENCE,
                 ),
                 ScipIndexDecision::SkipHeadUnchanged {
                     revision: HEAD.to_string()
@@ -423,8 +556,10 @@ mod tests {
         assert_eq!(
             decide(
                 Some(HEAD),
+                QUIET,
                 Some(&observed(false, Some(OLD), Some(THREE_HOURS))),
                 THREE_HOURS,
+                QUIESCENCE,
             ),
             ScipIndexDecision::Dispatch {
                 revision: HEAD.to_string()
@@ -434,8 +569,10 @@ mod tests {
         assert_eq!(
             decide(
                 Some(HEAD),
+                QUIET,
                 Some(&ScipJobObservation::default()),
-                THREE_HOURS
+                THREE_HOURS,
+                QUIESCENCE
             ),
             ScipIndexDecision::Dispatch {
                 revision: HEAD.to_string()
@@ -449,8 +586,10 @@ mod tests {
     fn advanced_head_inside_the_cadence_window_waits() {
         let decision = decide(
             Some(HEAD),
+            QUIET,
             Some(&observed(false, Some(OLD), Some(Duration::from_secs(600)))),
             THREE_HOURS,
+            QUIESCENCE,
         );
         assert_eq!(
             decision,
@@ -462,8 +601,10 @@ mod tests {
         assert!(matches!(
             decide(
                 Some(HEAD),
+                QUIET,
                 Some(&observed(false, Some(OLD), Some(THREE_HOURS))),
                 THREE_HOURS,
+                QUIESCENCE,
             ),
             ScipIndexDecision::Dispatch { .. }
         ));
@@ -475,17 +616,117 @@ mod tests {
     fn unknown_head_and_unreadable_inventory_fail_closed() {
         let fresh = observed(false, None, None);
         assert_eq!(
-            decide(None, Some(&fresh), THREE_HOURS),
+            decide(None, QUIET, Some(&fresh), THREE_HOURS, QUIESCENCE),
             ScipIndexDecision::SkipUnknownRevision
         );
         assert_eq!(
-            decide(Some("   "), Some(&fresh), THREE_HOURS),
+            decide(Some("   "), QUIET, Some(&fresh), THREE_HOURS, QUIESCENCE),
             ScipIndexDecision::SkipUnknownRevision
         );
         assert_eq!(
-            decide(Some(HEAD), None, THREE_HOURS),
+            decide(Some(HEAD), QUIET, None, THREE_HOURS, QUIESCENCE),
             ScipIndexDecision::SkipInventoryUnavailable
         );
+    }
+
+    /// **The quiescence gate.** The SCIP cache key folds in `source_hashes`, so
+    /// an index produced at head `H0` only serves a warm running against `H0`'s
+    /// sources. Indexing a tree that is still moving produces an artifact that
+    /// is stale before it lands — the warm then re-indexes inline and the run
+    /// bought nothing. Do not index a tree that has not stood still for at
+    /// least as long as indexing it takes.
+    #[test]
+    fn a_head_that_has_not_stood_still_long_enough_is_not_indexed() {
+        let fresh = observed(false, Some(OLD), Some(THREE_HOURS));
+
+        // One second short of the measured phase cost: the index would very
+        // likely be stale on arrival.
+        assert_eq!(
+            decide(
+                Some(HEAD),
+                Some(QUIESCENCE - Duration::from_secs(1)),
+                Some(&fresh),
+                THREE_HOURS,
+                QUIESCENCE,
+            ),
+            ScipIndexDecision::SkipHeadNotQuiescent {
+                age: Some(QUIESCENCE - Duration::from_secs(1))
+            },
+        );
+        // At the threshold it dispatches — without this the test above would
+        // also pass for a gate that never dispatches.
+        assert!(matches!(
+            decide(
+                Some(HEAD),
+                Some(QUIESCENCE),
+                Some(&fresh),
+                THREE_HOURS,
+                QUIESCENCE
+            ),
+            ScipIndexDecision::Dispatch { .. }
+        ));
+        // An unreadable commit time is uncertainty, and uncertainty never
+        // dispatches.
+        assert_eq!(
+            decide(Some(HEAD), None, Some(&fresh), THREE_HOURS, QUIESCENCE),
+            ScipIndexDecision::SkipHeadNotQuiescent { age: None },
+        );
+        // Zero disables the gate entirely, for a deployment that would rather
+        // index eagerly and accept the miss rate.
+        assert!(matches!(
+            decide(
+                Some(HEAD),
+                Some(Duration::ZERO),
+                Some(&fresh),
+                THREE_HOURS,
+                Duration::ZERO,
+            ),
+            ScipIndexDecision::Dispatch { .. }
+        ));
+    }
+
+    /// An unchanged head still wins over quiescence: re-indexing an already
+    /// indexed revision is waste no matter how still the tree is.
+    #[test]
+    fn head_unchanged_outranks_quiescence() {
+        assert_eq!(
+            decide(
+                Some(HEAD),
+                Some(Duration::from_secs(30 * 86_400)),
+                Some(&observed(false, Some(HEAD), Some(THREE_HOURS))),
+                THREE_HOURS,
+                QUIESCENCE,
+            ),
+            ScipIndexDecision::SkipHeadUnchanged {
+                revision: HEAD.to_string()
+            },
+        );
+    }
+
+    /// The default quiescence window is the measured phase cost, not a round
+    /// number someone liked — and the feature ships disarmed.
+    #[test]
+    fn config_defaults_are_the_measured_values_and_the_switch_is_off() {
+        let cfg = KubernetesConfig::for_testing();
+        assert_eq!(
+            cfg.scip_quiescence_seconds as i64,
+            crate::scip_job::MEASURED_SCIP_PHASE_SECONDS,
+            "the quiescence window must track the measured SCIP phase cost: an \
+             index is only worth starting if the tree has already been still \
+             for longer than the run will last"
+        );
+        assert!(
+            !cfg.scip_index_enabled,
+            "SCIP-index dispatch must ship disarmed; arming it creates leaseless \
+             16Gi Pods and is an operator decision"
+        );
+        let scheduler = ScipIndexScheduler::new(
+            cfg,
+            Arc::new(RecordingInventory(Ok(ScipJobObservation::default()))),
+            Arc::new(RecordingDispatcher::default()),
+        );
+        assert!(!scheduler.enabled());
+        assert_eq!(scheduler.quiescence(), QUIESCENCE);
     }
 
     #[test]
@@ -493,8 +734,10 @@ mod tests {
         assert_eq!(
             decide(
                 Some(HEAD),
+                QUIET,
                 Some(&observed(true, Some(OLD), None)),
-                THREE_HOURS
+                THREE_HOURS,
+                QUIESCENCE,
             ),
             ScipIndexDecision::SkipInFlight
         );
@@ -552,7 +795,13 @@ mod tests {
         );
         assert!(!past_the_floor.in_flight);
         assert_eq!(
-            decide(Some(HEAD), Some(&past_the_floor), THREE_HOURS),
+            decide(
+                Some(HEAD),
+                QUIET,
+                Some(&past_the_floor),
+                THREE_HOURS,
+                QUIESCENCE
+            ),
             ScipIndexDecision::Dispatch {
                 revision: HEAD.to_string()
             },
@@ -572,7 +821,13 @@ mod tests {
         );
         assert_eq!(inside_the_floor.last_indexed_revision.as_deref(), Some(OLD));
         assert!(matches!(
-            decide(Some(HEAD), Some(&inside_the_floor), THREE_HOURS),
+            decide(
+                Some(HEAD),
+                QUIET,
+                Some(&inside_the_floor),
+                THREE_HOURS,
+                QUIESCENCE
+            ),
             ScipIndexDecision::SkipCadence { .. }
         ));
     }
@@ -636,6 +891,15 @@ mod tests {
         }
     }
 
+    /// A head that satisfies the quiescence gate, so these tests exercise the
+    /// branch they name rather than tripping over quiescence.
+    fn quiescent(revision: &str) -> MirrorHead {
+        MirrorHead {
+            revision: revision.to_string(),
+            age: Duration::from_secs(9_999),
+        }
+    }
+
     async fn run_tick(
         observation: Result<ScipJobObservation, String>,
         head: Option<&str>,
@@ -646,7 +910,10 @@ mod tests {
             Arc::new(RecordingInventory(observation)),
             dispatcher.clone(),
         );
-        let decision = scheduler.tick_project("proj", head, "img:tag", None).await;
+        let head = head.map(quiescent);
+        let decision = scheduler
+            .tick_project("proj", head.as_ref(), "img:tag", None)
+            .await;
         let created = dispatcher.0.lock().expect("lock").clone();
         (decision, created)
     }
@@ -732,7 +999,13 @@ mod tests {
         let observation = observe_from_jobs(&[succeeded], now());
         assert_eq!(observation.last_indexed_revision.as_deref(), Some(HEAD));
         assert_eq!(
-            decide(Some(HEAD), Some(&observation), THREE_HOURS),
+            decide(
+                Some(HEAD),
+                QUIET,
+                Some(&observation),
+                THREE_HOURS,
+                QUIESCENCE
+            ),
             ScipIndexDecision::SkipHeadUnchanged {
                 revision: HEAD.to_string()
             },

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logging;
 mod mcp_bridge;
 pub mod mirror_fetcher;
 pub mod readiness_pin_resolver;
+pub mod scip_index_watcher;
 pub mod server;
 pub mod server_memory;
 pub mod sse;

--- a/server/src/scip_index_watcher.rs
+++ b/server/src/scip_index_watcher.rs
@@ -1,0 +1,212 @@
+//! Periodic driver for the standalone SCIP-index Job.
+//!
+//! Leader-only, and modelled on [`crate::mirror_fetcher`]: iterate the projects
+//! table on a tick, skip anything without indexable code, and hand each project
+//! to [`ScipIndexScheduler::tick_project`], which decides whether to create a
+//! Job and creates at most one.
+//!
+//! # Why this is a separate loop rather than a hook on the warm path
+//!
+//! `mirror_fetcher` calls `graph_warmer().trigger()` unconditionally every 60s,
+//! which is what leaves the warm debounce permanently pinned at its 900s
+//! anti-starvation cap. Hanging a 3-hour cadence off that path would inherit a
+//! timer that always fires. This loop pulls its own state instead.
+//!
+//! # Armed vs disarmed
+//!
+//! The real scheduler is wired unconditionally. `scip_index_enabled` (default
+//! **false**, `DJINN_K8S_SCIP_INDEX_ENABLED`) is checked *inside* the tick, so:
+//!
+//!   * arming the feature is a config flip, not a redeploy; and
+//!   * the production code path is never unreachable — a disarmed deployment
+//!     still resolves the real scheduler, and a wiring regression surfaces as
+//!     an ERROR log rather than as silence.
+//!
+//! That second property is deliberate. A composition that silently resolves to
+//! no implementation, and therefore does nothing forever while every test stays
+//! green, is a failure mode this codebase has already paid for.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use djinn_db::ProjectRepository;
+use djinn_k8s::scip_schedule::{
+    GitMirrorHeadSource, MirrorHeadSource, ScipIndexDecision, ScipIndexScheduler,
+};
+use tokio::time::{Interval, MissedTickBehavior};
+
+use crate::server::AppState;
+
+/// How often the loop wakes. Deliberately far shorter than the 3-hour cadence
+/// floor: the tick is cheap (one apiserver list plus two git calls per project)
+/// and the scheduler owns the real rate limiting, so a short tick just means
+/// the window is entered promptly once head quiescence and the floor are both
+/// satisfied.
+const DEFAULT_TICK_SECS: u64 = 300;
+const TICK_ENV: &str = "DJINN_SCIP_INDEX_TICK_SECS";
+
+pub fn spawn(state: AppState) {
+    let tick = parse_interval(std::env::var(TICK_ENV).ok().as_deref());
+    let cancel = state.cancel().clone();
+
+    tokio::spawn(async move {
+        tracing::info!(?tick, "scip_index_watcher starting");
+        let mut ticker = make_ticker(tick);
+        let heads: Arc<dyn MirrorHeadSource> = Arc::new(GitMirrorHeadSource);
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    tracing::debug!("scip_index_watcher cancelled");
+                    break;
+                }
+                _ = ticker.tick() => {
+                    if let Err(err) = run_tick(&state, heads.as_ref()).await {
+                        tracing::warn!(error = %err, "scip_index_watcher tick failed");
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Resolve the real, cluster-backed scheduler from the live warmer.
+///
+/// Shares the warmer's `kube::Client` rather than building a second one. `None`
+/// means this deployment is not running the Kubernetes warmer at all (local /
+/// non-K8s wiring), which is a legitimate no-op — but it is reported at ERROR
+/// when the feature is armed, because in that case it is a wiring bug and the
+/// symptom would otherwise be indistinguishable from "nothing needed doing".
+async fn resolve_scheduler(state: &AppState) -> Option<ScipIndexScheduler> {
+    state
+        .graph_warmer()
+        .await
+        .as_any()
+        .downcast_ref::<djinn_k8s::K8sGraphWarmer>()
+        .and_then(djinn_k8s::K8sGraphWarmer::scip_index_scheduler)
+}
+
+async fn run_tick(state: &AppState, heads: &dyn MirrorHeadSource) -> anyhow::Result<()> {
+    let Some(scheduler) = resolve_scheduler(state).await else {
+        // Read the flag straight from the environment here: without a
+        // scheduler there is no config to read it from, and staying silent
+        // when an operator has armed the feature is the exact failure this
+        // branch exists to make loud.
+        if std::env::var("DJINN_K8S_SCIP_INDEX_ENABLED").is_ok_and(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        }) {
+            tracing::error!(
+                "scip_index_watcher: SCIP indexing is ARMED but no Kubernetes graph warmer \
+                 is wired, so no SCIP Job can ever be created. This is a composition bug, \
+                 not a quiet no-op."
+            );
+        } else {
+            tracing::debug!("scip_index_watcher: no Kubernetes warmer; nothing to do");
+        }
+        return Ok(());
+    };
+
+    if !scheduler.enabled() {
+        tracing::debug!(
+            "scip_index_watcher: disarmed (DJINN_K8S_SCIP_INDEX_ENABLED); \
+             evaluating nothing this tick"
+        );
+        return Ok(());
+    }
+
+    let repo = ProjectRepository::new(state.db().clone(), state.event_bus());
+    for project in repo.list().await? {
+        let project_id = project.id.as_str();
+
+        // Same filter mirror_fetcher applies before triggering a warm: the
+        // canonical graph is a CODE graph, so a docs-only repo indexes to zero
+        // nodes and a SCIP Job for it is pure cost.
+        if !djinn_agent::environment::project_has_indexable_code(state.db(), project_id).await {
+            continue;
+        }
+
+        // The image the Job runs in, resolved with the same catalog-image
+        // precedence the warm path uses. Not ready yet means the devcontainer
+        // has not been built; skip and retry next tick.
+        let Some(image_tag) = repo
+            .resolve_dispatch_image(project_id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|image| image.pull_ref())
+        else {
+            tracing::debug!(project_id, "scip_index_watcher: no ready project image");
+            continue;
+        };
+
+        let head = heads.head(project_id).await;
+        // `policy` is `None` deliberately: `warm_cache_env_vars` ignores the
+        // cargo-cache policy (incremental-on is an invariant across all djinn
+        // build pods), so passing it would imply an influence it does not have.
+        let decision = scheduler
+            .tick_project(project_id, head.as_ref(), &image_tag, None)
+            .await;
+        if let ScipIndexDecision::Dispatch { revision } = &decision {
+            tracing::info!(
+                project_id,
+                revision,
+                "scip_index_watcher: dispatched standalone semantic index"
+            );
+        } else {
+            tracing::debug!(
+                project_id,
+                reason = decision.reason(),
+                "scip_index_watcher: no Job this tick"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn parse_interval(raw: Option<&str>) -> Duration {
+    let secs = raw
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_TICK_SECS);
+    Duration::from_secs(secs)
+}
+
+fn make_ticker(interval: Duration) -> Interval {
+    let mut t = tokio::time::interval(interval);
+    t.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    t
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tick_interval_parses_and_falls_back() {
+        assert_eq!(parse_interval(Some("42")), Duration::from_secs(42));
+        assert_eq!(
+            parse_interval(Some("0")),
+            Duration::from_secs(DEFAULT_TICK_SECS)
+        );
+        assert_eq!(
+            parse_interval(Some("nonsense")),
+            Duration::from_secs(DEFAULT_TICK_SECS)
+        );
+        assert_eq!(parse_interval(None), Duration::from_secs(DEFAULT_TICK_SECS));
+    }
+
+    /// The loop tick must be shorter than the cadence floor, or the effective
+    /// cadence becomes the tick rather than the configured interval.
+    #[test]
+    fn tick_is_shorter_than_the_cadence_floor() {
+        let cfg = djinn_k8s::KubernetesConfig::for_testing();
+        assert!(
+            DEFAULT_TICK_SECS < cfg.scip_index_interval_seconds,
+            "a {DEFAULT_TICK_SECS}s tick must be shorter than the \
+             {}s cadence floor, or the floor is not what governs the rate",
+            cfg.scip_index_interval_seconds,
+        );
+    }
+}

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -2634,6 +2634,14 @@ impl AppState {
         );
         crate::mirror_fetcher::spawn(self.clone());
 
+        // Standalone SCIP-index driver (leader-only, same reasoning as
+        // mirror_fetcher: it creates cluster objects). The real scheduler is
+        // wired here unconditionally; whether it creates Jobs is decided per
+        // tick by `DJINN_K8S_SCIP_INDEX_ENABLED`, which defaults to OFF. That
+        // ordering is deliberate -- gating the WIRING instead of the ACTION is
+        // how a feature ends up shipped and permanently unreachable.
+        crate::scip_index_watcher::spawn(self.clone());
+
         // Periodic `git gc` over every project's mirror + working clone. Both
         // fetch with `--prune` but never reclaim the objects behind deleted
         // task branches, so the on-disk stores grow without bound — this is


### PR DESCRIPTION
Splits the SCIP (semantic) indexing phase out of the canonical-graph warm Job into its own Kubernetes Job that **acquires no build lease**.

**The benefit is conditional. Read §6 before deciding to arm this.** It is a large win on a repository whose `main` is quiet for an hour at a time, and close to zero on one that merges more often than hourly — which includes djinn's own repo on a busy day. The feature therefore ships **disarmed** (`DJINN_K8S_SCIP_INDEX_ENABLED`, default off) with a quiescence gate that declines to index a tree that is still moving.

---

## 1. The problem, and why resizing cannot fix it

A complete production warm measured **90m42s** end to end, of which the SCIP index alone was **58m43s (~65%)**.

That phase is *structurally* single-threaded. rust-analyzer's `StaticIndex::compute` is a bare `for module in work` loop with no rayon; the measured parallel window was **20s against a 368s serial window (94% serial)**. Upstream `rust-lang/rust-analyzer#18140` is open and maintainer-confirmed. So the warm Job reserved a full build slot sized for a 4-core parallel cargo build, then spent roughly two thirds of its life using one core.

**The slot arithmetic.** `BuildSlotWeight::for_millicores` (`server/crates/djinn-runtime/src/spec.rs`) is:

```rust
let slots = millicores.div_ceil(slot_millicores);
Self(i64::from(slots.max(1)))
```

`div_ceil` then `.max(1)`. **Any nonzero CPU request costs at least one whole build slot.** Lowering the warm request from 2 CPU to 500m changes the charged weight not at all. And `build_lease.rs` resolves `LeaseIdentity::GraphWarm(_) => self.weights.warm()` — warm is its own lease identity, charged as a unit.

The only lever that returns capacity is for the SCIP work **not to acquire a build lease at all**, which means it cannot be a `GraphWarm` consumer, which means it must be its own Job. That is what this PR builds.

## 2. Proposal 8ixk: the protected label and the ≤2200m budget

A Job that acquires no lease **and** is not labelled protected is *invisible CPU* — it burns real cores that no cap can account for. That is precisely the oversubscription proposal `8ixk` ("Node-keyed build slot pools") exists to prevent. 8ixk derives each node's cap as:

```
floor((allocatable_mcpu - protected_mcpu) / cores_per_slot_mcpu)     cores_per_slot = 2800
```

where `protected_mcpu` sums the CPU requests of Pods carrying `djinn.io/capacity-reserved=true`.

So the SCIP Job carries that label — on the Job **and** on the Pod template, since 8ixk selects Pods. On the current 12-core VPS with 4200m already protected (server 2000m + postgres 1000m + buildkitd 1000m + qdrant 100m + zot 100m):

| | derivation | cap |
|---|---|---|
| today | `floor((12000 − 4200) / 2800)` = `floor(2.78)` | **2** |
| with this Job @ 1000m | `floor((12000 − 5200) / 2800)` = `floor(2.43)` | **2** (unchanged) |

### ⚠️ The request budget is 2200m. Do not raise it past that.

Solved from the same formula — the cap holds at 2 while `12000 − 4200 − request ≥ 2 × 2800`, i.e. while `request ≤ 2200`:

| request | derived cap |
|---|---|
| 2200m | 2 |
| 2201m | **1** |

Raising this Job's CPU request past **2200m** costs the deployment a whole build slot — half its build concurrency under 8ixk. This is not a sentence in a PR description that rots: it is `SCIP_PROTECTED_REQUEST_CEILING_MILLICORES`, and `scip_cpu_request_stays_inside_the_8ixk_protected_budget` proves it by **recomputing 8ixk's formula from its inputs**, including asserting that 2201m provably drops the cap. A future edit that raises the request fails the build.

*(Note this PR does not implement 8ixk, which is still in draft. It makes the new Job forward-compatible with it — the label is inert until 8ixk lands, and the arithmetic is asserted now so it cannot silently stop holding.)*

## 3. The 16Gi memory floor and its regression test

Measured peak RSS for the SCIP phase is **10.0 GB**.

`server/crates/djinn-k8s/src/config.rs` has `warm_memory_limit` defaulting to `"6Gi"` — **below the measured peak**. Production survives only because an out-of-band override raises it to 16Gi. That arrangement (a default that would OOM, rescued by an override nothing tests) is exactly what this PR refuses to repeat.

`scip_memory_limit` is `"16Gi"` explicitly, and `scip_memory_limit_covers_the_measured_peak` fails the build if the rendered limit ever drops below `MEASURED_SCIP_PEAK_MEMORY_BYTES`. It also asserts that `6Gi <` the measured peak — so the test cannot pass for a Pod that OOMs, which is the property that makes it a real regression test rather than a tautology.

## 4. Scheduling and the change-detection gate

`server/crates/djinn-k8s/src/scip_schedule.rs`. Every 3 hours, **and only if the head advanced**.

```
head unknown            → SkipUnknownRevision      (fail closed)
inventory unreadable    → SkipInventoryUnavailable (fail closed)
non-terminal Job exists → SkipInFlight
last indexed == head    → SkipHeadUnchanged     ← the change-detection gate
head younger than ~59m  → SkipHeadNotQuiescent   ← the hit-rate gate (§6)
elapsed < 3h            → SkipCadence           ← the cadence floor
otherwise               → Dispatch
```

Ordering is load-bearing: **head-unchanged is checked before the cadence**, because the requirement is "every 3 hours *and only if* the head advanced", not "or". `unchanged_head_never_dispatches_however_much_time_passed` asserts this across elapsed times from zero to 30 days.

**It does not use the existing warm debounce, which is dead.** `graph_warmer.rs` has `DEFAULT_WARM_DEBOUNCE_SECONDS = 180` and `DEFAULT_WARM_DEBOUNCE_MAX_WAIT_SECONDS = 900`, but `server/src/mirror_fetcher.rs` (`DEFAULT_INTERVAL_SECS = 60`) calls `graph_warmer().trigger(project_id)` unconditionally every 60s for every project with indexable code. The 180s quiet window can therefore never elapse; every window runs to the 900s cap — verified in production, a window opened and collapsed at exactly 900.000s having coalesced 17 triggers. This gate is **pull, not push**: it is driven by its own tick and reads observed state. It never subscribes to `trigger`.

**Where the "last successful index" state lives — and why there is no migration.** Each SCIP Job is named deterministically from `(project, revision)` and annotated with `djinn.app/scip-revision`; `scip_job_ttl_seconds` (4h) is deliberately longer than `scip_index_interval_seconds` (3h). The retained *succeeded* Job set **is** the ledger, and it is durable across server restarts because it is apiserver state. `scip_job_ttl_outlives_the_index_interval` pins the relationship.

The failure mode of an early-GC'd Job is a redundant dispatch, and a redundant dispatch is cheap: the SCIP artifact cache is content-addressed, so re-running against an unchanged tree hits the cache for every workspace. Losing the ledger costs a fast no-op, never a wrong graph. That is worth avoiding a schema migration (and its golden fanout) for.

Only a **succeeded** Job advances the ledger. A failed index leaves the last known-good revision in place, so the head still reads as advanced and a later tick retries — gated by the cadence floor, so a crash-looping index cannot re-create a leaseless 16Gi Pod every tick. Both halves are asserted separately.

## 5. Failure / skip degradation — the graph never degrades to empty

**The SCIP Job never publishes a graph.** `run_scip_index_command` writes no `repo_graph_cache`, `repo_graph_generation`, or `repo_graph_current` row. It only fills the content-addressed SCIP cache.

So there is no code path from "SCIP Job failed / was skipped / never ran" to a degraded graph. When it does not run, `ensure_canonical_graph` re-runs the indexers inline **exactly as it does today**, still under:

* the `node_count == 0` early return that refuses to write an empty blob, and
* per-workspace salvage (`graph.salvage_workspace_from_artifact`) that splices the previous artifact for any workspace whose indexer failed.

The worst case is a **slower warm**, never an empty graph. Every non-`Dispatch` outcome including every error is a skip, and uncertainty resolves toward not dispatching, because dispatching on unknown state is the only branch that can cost anything.

## 6. How the output is consumed — and when it actually pays off

### The mechanism

The SCIP indexers already write through `ScipCacheStore`, whose root resolves from `$XDG_CACHE_HOME` — which `job.rs::cache_env_vars` points at the shared `/cache` PVC (`/cache/xdg/<project>`). Its `WorkspaceIdentity` holds a **relative** workspace root, so an artifact produced from the SCIP Pod's clone is a `CachedHit` for the warm Job's `execute_plan_with_cache` even though the two Pods cloned to different absolute paths. **No change to `ensure_canonical_graph` is required, and none is made.**

### ⚠️ The win is conditional, and here is exactly when it does not materialise

`CacheKeyIngredients` includes `source_hashes` over the workspace's sources. So an index produced at head `H0` is only a hit for a warm running against **`H0`'s sources**.

Warm chases head continuously: `mirror_fetcher` triggers every 60s, and the debounce is dead (§4), so every window collapses at its 900s cap — a warm roughly every 15 minutes. The SCIP Job takes ~59 minutes. Therefore:

| condition | outcome |
|---|---|
| `main` quiet across the SCIP run | warm hits the cache; its SCIP phase collapses to seconds; **slot-time 90m42s → ~32m (−65%)** |
| `main` advances during the SCIP run | warm **misses** and re-indexes inline for the full 58m43s; slot-time unchanged; the SCIP Job's ~59 min of CPU was **redundant** |

**On a repository merging more often than once an hour the hit rate tends toward zero.** That plausibly describes djinn's own repo on an active day. This is not a caveat about measurement error — it is a structural property of a content-keyed cache feeding a consumer that chases head.

Two things bound the downside of a miss:

* The redundant work costs **no build slot** — the SCIP Job is leaseless, and its 1000m request is accounted as protected capacity (§2). It cannot starve dispatch; it consumes one core of the node's protected reservation.
* A miss is not a *regression*. The warm behaves exactly as it does today.

The key is also **per-workspace**, so a commit touching only workspace A leaves workspace B's key intact and B still hits. That genuinely helps a polyglot repo — but not the case that dominates the cost here, since djinn's Rust `server/` workspace is both the most expensive to index and the most frequently touched.

### The mitigation actually implemented: the quiescence gate

`decide` will not dispatch unless the head has already stood still for `scip_quiescence_seconds`, defaulting to **3523s — the measured phase cost itself**. The rule is: *do not index a tree that has not been stable for at least as long as indexing it takes.* That is the condition under which the artifact is likely to still be current when it lands.

It cannot prevent a commit arriving *during* the run — nothing can. What it does is stop the system from spending 16Gi and an hour of a core producing an artifact that was already provably unlikely to be used. An unreadable commit time reads as not-quiescent, consistent with every other uncertainty here.

**What would make the win unconditional** is letting the graph build consume a *stale but present* semantic index, so the SCIP cadence could diverge from the warm cadence freely. That is a real architectural change to the publication path (see the last section) and is not attempted here.

### Syntactic and git-derived passes stay on the warm path

They are deliberately not moved. `ingest_coupling_best_effort` (already hoisted above the cache check and the indexer lock, so it is independent of SCIP), the tree-sitter post-processors (`entry_points`, `processes`, complexity, `db_access`, route extraction) and `cochange` want per-commit freshness and are cheap. They continue to run on the warm path at its own cadence. Only the expensive semantic pass moves to the 3-hour cadence.

## 7. Cache/compile parity — derived from `warm_cpu_limit`, not this Pod's own limit

This looks wrong and is not, so it is asserted rather than commented:

* `CARGO_BUILD_RUSTFLAGS` embeds `-Clink-arg=-Wl,--threads=N` derived from the CPU limit. **RUSTFLAGS feed rustc's `-C metadata`**, so a `--threads=2` render would give every compilation unit a different fingerprint from the warm base and discard 100% of it.
* `CARGO_TARGET_DIR` is keyed `.../mold-jobs-N` from the same limit — a divergent N forks a second, cold target base on the PVC.
* `CARGO_INCREMENTAL=1` / `RUSTC_WRAPPER=""` are the shared compile strategy every djinn build pod must agree on (`job.rs` ~line 1055 explains why); cargo folds both into its fingerprints.

`scip_job_cache_env_matches_the_warm_job_render` sets `warm_cpu_limit = "6"` and `scip_cpu_limit = "2"` — deliberately different — and asserts the SCIP Job's rendered env equals the **warm Job's actual rendered env** for all eight cache-relevant vars. A render that keyed off `scip_cpu_limit` fails it.

## 8. Relationship to #2695

Orthogonal and composable; **no file overlap**.

* **#2695** releases the warm Job's build lease at the cargo→graph boundary *inside the same Pod* — shortening how long the warm holds its slot.
* **This PR** removes the SCIP phase from the warm Pod entirely — so there is no 58m43s SCIP phase left inside that hold to release.

This diff does not touch `warm_job.rs` at all (`scip_job.rs` only reads its public constants), and touches `graph_warmer.rs` only to add one 25-line accessor. Rebasing either PR against the other should be mechanical.

---

## Changes

| File | |
|---|---|
| `djinn-k8s/src/scip_job.rs` | **new** — Job manifest, labels, 8ixk arithmetic constants, 10 tests |
| `djinn-k8s/src/scip_schedule.rs` | **new** — cadence + change-detection gate, inventory projection, 12 tests |
| `djinn-k8s/src/config.rs` | `scip_*` knobs + `DJINN_K8S_SCIP_*` env parsing + doc table |
| `djinn-k8s/src/lib.rs` | module registration / re-exports |
| `djinn-graph/src/canonical_graph.rs` | `run_scip_index_command` — the semantic pass alone |
| `djinn-agent-worker/src/main.rs` | `scip-index` subcommand |
| `djinn-agent-worker/src/rendered_job_env_contract.rs` | the SCIP Pod's argv parses with the real clap parser |
| `djinn-k8s/src/graph_warmer.rs` | `scip_index_scheduler()` accessor (additive, 25 lines) |
| `djinn-server/src/scip_index_watcher.rs` | **new** — the leader-only tick |
| `djinn-server/src/server/state/mod.rs` | spawn it in `become_leader` |

2627 insertions, 19 deletions. `warm_job.rs` is untouched.

### Configuration

| Env | Field | Default |
|---|---|---|
| `DJINN_K8S_SCIP_CPU_REQUEST` | `scip_cpu_request` | `1` — **≤ 2200m** |
| `DJINN_K8S_SCIP_CPU_LIMIT` | `scip_cpu_limit` | `2` |
| `DJINN_K8S_SCIP_MEMORY_REQUEST` | `scip_memory_request` | `4Gi` |
| `DJINN_K8S_SCIP_MEMORY_LIMIT` | `scip_memory_limit` | `16Gi` — measured peak 10.0 GB |
| `DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS` | `scip_index_interval_seconds` | `10800` (3h) |
| `DJINN_K8S_SCIP_JOB_TTL_SECONDS` | `scip_job_ttl_seconds` | `14400` (4h, > interval) |
| `DJINN_K8S_SCIP_JOB_TIMEOUT_SECONDS` | `scip_job_timeout_seconds` | `7200` (measured phase 3523s) |
| `DJINN_K8S_SCIP_INDEX_ENABLED` | `scip_index_enabled` | **`false`** — the arming switch |
| `DJINN_K8S_SCIP_QUIESCENCE_SECONDS` | `scip_quiescence_seconds` | `3523` — the measured phase cost; `0` disables the gate |
| `DJINN_SCIP_INDEX_TICK_SECS` | watcher loop period | `300` |

No `EnvironmentConfig`, build-resource shape, MCP tool schema, or migration was touched, so there is no golden/snapshot fanout to regenerate.

## Testing

```
cargo test -p djinn-k8s   --lib                     286 passed
cargo test -p djinn-graph --lib                     662 passed
cargo test -p djinn-server --lib scip_index_watcher   2 passed
cargo test -p djinn-agent-worker --bin ...          rendered_job_env_contract: 3 passed
cargo fmt --all -- --check                          clean
cargo clippy -p djinn-k8s -p djinn-server -p djinn-graph -p djinn-agent-worker --all-targets
                                                    no new warnings
```

## Activation

The scheduler is wired **for real** at the composition root — `scip_index_watcher::spawn` sits next to `mirror_fetcher::spawn` in `become_leader`, resolves the cluster-backed `ScipIndexScheduler` from the live warmer (sharing its `kube::Client` rather than building a second one), and calls `tick_project` per project.

**Whether it creates Jobs is decided inside the tick**, by `DJINN_K8S_SCIP_INDEX_ENABLED` (default `false`). Gating the *wiring* rather than the *action* is how a feature ends up merged and permanently unreachable, so:

* arming is a config flip, not a redeploy;
* a disarmed deployment still resolves the real scheduler every tick;
* if the flag is armed and no scheduler resolves, the watcher logs at **ERROR** — a wiring regression is loud, not silent.

Suggested rollout: leave it off through this deploy, then set `DJINN_K8S_SCIP_INDEX_ENABLED=true` and watch for `scip_index_watcher: dispatched standalone semantic index` plus the resulting Job's outcome. The decision reason is on every tick at debug (`head_unchanged`, `head_not_quiescent`, `cadence`, `in_flight`, …), so it is possible to see *why* nothing is dispatching before concluding it is broken.

## What is deliberately not in this PR


**Letting the graph tolerate a stale semantic index.**  letting the graph build consume a *stale but present* semantic index (so the SCIP cadence could diverge freely from the warm cadence). `ensure_canonical_graph` currently builds every node and edge from `&[ParsedScipIndex]` — the syntactic passes are post-processors on a SCIP-built graph, not independent producers. Making the graph tolerate a stale index is a genuine architectural change to the publication path and belongs in its own epic. This PR takes the cheaper and strictly-safe route instead: the SCIP Job fills the cache the warm path already reads, so a stale or missing index degrades to today's inline re-index rather than to anything new.

**Unverifiable in this environment:** the SCIP indexers were not run end to end here — no cluster, and rust-analyzer SCIP over the production workspace is a ~59-minute operation. `run_scip_index_command` mirrors `ensure_canonical_graph`'s indexer invocation argument-for-argument, and the renderer/binary argv contract proves the Pod's command line parses, but a first real run should be watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
