### PR TITLE
fix(warm): one waitpid(-1) consumer per process, not two

### DIFF
--- a/server/crates/djinn-agent-worker/src/lifecycle.rs
+++ b/server/crates/djinn-agent-worker/src/lifecycle.rs
@@ -2016,6 +2016,10 @@ mod tests {
 
     #[tokio::test]
     async fn pretask_enforces_timeout() {
+        // This case asserts that its child survives until its own timeout
+        // fires. Warm shutdown signals every child of the process, so it
+        // must not run concurrently — see WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = crate::WARM_LIFECYCLE_TEST_MUTEX.lock().await;
         let tmp = tempfile::tempdir().expect("tempdir");
         let cfg = EnvironmentConfig {
             lifecycle: djinn_stack::environment::LifecycleHooks {
@@ -2586,6 +2590,10 @@ mod tests {
 
     #[tokio::test]
     async fn pretask_activity_timeout_emits_blocked_and_environmental() {
+        // This case asserts that its child survives until its own timeout
+        // fires. Warm shutdown signals every child of the process, so it
+        // must not run concurrently — see WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = crate::WARM_LIFECYCLE_TEST_MUTEX.lock().await;
         let tmp = tempfile::tempdir().expect("tempdir");
         let cfg = EnvironmentConfig {
             lifecycle: djinn_stack::environment::LifecycleHooks {
@@ -3429,6 +3437,10 @@ mod tests {
     /// `timed_out=true`, and `failure_class=environmental`.
     #[tokio::test]
     async fn blocking_timeout_produces_environmental_blocked_activity() {
+        // This case asserts that its child survives until its own timeout
+        // fires. Warm shutdown signals every child of the process, so it
+        // must not run concurrently — see WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = crate::WARM_LIFECYCLE_TEST_MUTEX.lock().await;
         let tmp = tempfile::tempdir().expect("tempdir");
         let cfg = EnvironmentConfig {
             lifecycle: djinn_stack::environment::LifecycleHooks {
@@ -3546,6 +3558,10 @@ mod tests {
     /// and `blocked=true`.
     #[tokio::test]
     async fn cancellation_produces_blocked_activity_with_cancelled_flag() {
+        // This case asserts that its child survives until its own timeout
+        // fires. Warm shutdown signals every child of the process, so it
+        // must not run concurrently — see WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = crate::WARM_LIFECYCLE_TEST_MUTEX.lock().await;
         let tmp = tempfile::tempdir().expect("tempdir");
         let should_not_exist = tmp.path().join("never-after-cancel.marker");
 

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -3966,6 +3966,28 @@ fn _assert_contract_workspace_path() -> &'static Path {
     Path::new(_CONTRACT_WORKSPACE)
 }
 
+/// Serialises every test in this binary that spawns a real child process.
+///
+/// Child lifecycle here is PROCESS-GLOBAL in two independent ways, and both are
+/// load-bearing production behaviour that cannot be narrowed for tests:
+///
+/// * one `waitpid(-1, ...)` consumer — the `djinn_graph` [`ChildReaper`] — owns
+///   every terminal status in the process, and the warm-lifecycle cases
+///   `close_admission()` on it, so an overlapping spawn is refused outright;
+/// * warm shutdown SIGTERM/SIGKILLs every direct child of the process that is
+///   not inside a registered process group. That is exactly what a warm worker
+///   must do to a `setsid` escapee, so it cannot distinguish a neighbouring
+///   test's `sleep 60` from a runaway build.
+///
+/// So no two tests that own a live child may overlap. `djinn_graph::process`
+/// hoists the same lock over its own spawners for the same reason. Under
+/// `cargo nextest` (what CI runs) each test is its own process and this lock is
+/// uncontended; it exists for `cargo test`, which shares one.
+///
+/// [`ChildReaper`]: djinn_graph::child_reaper::ChildReaper
+#[cfg(test)]
+static WARM_LIFECYCLE_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4960,6 +4982,9 @@ warning: something
 
     #[test]
     fn run_cargo_warm_step_instrumented_parses_mock_output_and_logs_counts() {
+        // Spawns a real child through the process-global reaper; see
+        // WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         let _guard = CARGO_INSTRUMENT_ENV_LOCK.lock().expect("env lock poisoned");
         // SAFETY: guarded test-only env mutation.
         unsafe { std::env::set_var("DJINN_CARGO_INSTRUMENT", "1") };
@@ -5049,6 +5074,9 @@ warning: something
     #[cfg(unix)]
     #[test]
     fn a_failing_warm_step_logs_a_bounded_stderr_tail_naming_the_cause() {
+        // Spawns a real child through the process-global reaper; see
+        // WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         use std::os::unix::fs::PermissionsExt;
 
         // The non-instrumented branch is the one that used to discard the
@@ -5204,6 +5232,9 @@ warning: something
 
     #[test]
     fn run_cargo_warm_step_absent_toggle_uses_status_path_without_instrumentation_log() {
+        // Spawns a real child through the process-global reaper; see
+        // WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         let _guard = CARGO_INSTRUMENT_ENV_LOCK.lock().expect("env lock poisoned");
         // SAFETY: guarded test-only env mutation.
         unsafe { std::env::remove_var("DJINN_CARGO_INSTRUMENT") };
@@ -5733,11 +5764,10 @@ warning: something
             "attached teardown must NOT emit any sample"
         );
     }
-    static WARM_CARGO_ORDERING_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn warm_cargo_ordering_recorder_captures_real_failure_before_commands() {
-        let _serial = WARM_CARGO_ORDERING_MUTEX.lock().expect("ordering mutex");
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         let fixture = tempfile::tempdir().expect("workspace fixture");
         std::fs::write(
             fixture.path().join("Cargo.toml"),
@@ -5784,7 +5814,7 @@ warning: something
     #[test]
     fn warm_cargo_ordering_recorder_observes_prune_stamp_compile_and_end_sweep() {
         use std::os::unix::fs::PermissionsExt;
-        let _serial = WARM_CARGO_ORDERING_MUTEX.lock().expect("ordering mutex");
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         let fixture = tempfile::tempdir().expect("workspace fixture");
         std::fs::write(
             fixture.path().join("Cargo.toml"),
@@ -5866,7 +5896,7 @@ warning: something
     #[test]
     fn truncated_warm_step_records_timeout_and_suppresses_the_tail_sweep() {
         use std::os::unix::fs::PermissionsExt;
-        let _serial = WARM_CARGO_ORDERING_MUTEX.lock().expect("ordering mutex");
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         let fixture = tempfile::tempdir().expect("workspace fixture");
         std::fs::write(
             fixture.path().join("Cargo.toml"),
@@ -6053,7 +6083,7 @@ warning: something
     fn warm_cargo_ordering_operation_failures_emit_once_before_stamp_or_compile() {
         use cargo_incremental_prune::WarmLockOperationFailure;
 
-        let _serial = WARM_CARGO_ORDERING_MUTEX.lock().expect("ordering mutex");
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         djinn_telemetry::init().expect("telemetry init");
         let fixture = tempfile::tempdir().expect("workspace fixture");
         std::fs::write(
@@ -6153,7 +6183,7 @@ warning: something
         // that arms it must hold this mutex — otherwise it steals a sibling
         // test's lock acquisition and that sibling fails with a bogus
         // `["failed"]` phase trace.
-        let _serial = WARM_CARGO_ORDERING_MUTEX.lock().expect("ordering mutex");
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         let fixture = tempfile::tempdir().expect("fixture");
         let policy = cargo_cache_policy::CargoCachePolicy::default();
         let project = format!("warm-boundary-order-{}", std::process::id());
@@ -6237,18 +6267,36 @@ warning: something
         }
     }
 
+    /// Reopen the process-global admission gate a warm-lifecycle case closed.
+    ///
+    /// `close_admission()` is permanent by design — a warm worker never admits
+    /// another command after shutdown begins — but in a test binary the reaper
+    /// outlives the case, so a case that closes admission and returns leaves
+    /// every later spawn in the whole binary failing with `BrokenPipe`. Restore
+    /// what the case changed rather than letting the next case inherit it.
     #[cfg(target_os = "linux")]
-    static WARM_LIFECYCLE_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    fn restore_warm_lifecycle_admission(reaper: &djinn_graph::child_reaper::ChildReaper) {
+        let _ = reaper.drain();
+        assert!(reaper.wait_for_supervisors_idle(Duration::from_secs(5)));
+        assert!(reaper.wait_for_adopted_idle(Duration::from_secs(5)));
+        reaper.reopen_after_idle_for_test();
+    }
 
     #[cfg(target_os = "linux")]
     fn test_warm_reaper() -> &'static djinn_graph::child_reaper::ChildReaper {
-        use std::sync::OnceLock;
-
-        // Every lifecycle case shares this one permanent waiter. Constructing
-        // one reaper per test leaves old waitpid(-1) threads alive, allowing an
-        // earlier test to steal status from a later test's registry.
-        static REAPER: OnceLock<djinn_graph::child_reaper::ChildReaper> = OnceLock::new();
-        let reaper = REAPER.get_or_init(djinn_graph::child_reaper::ChildReaper::new);
+        // THE process-global reaper — the same one production's
+        // `initialize_linux_warm_lifecycle` returns. A private
+        // `ChildReaper::new()` here looks like isolation but is the opposite:
+        // it installs a SECOND `waitpid(-1)` thread, while every other test in
+        // this binary that spawns through `djinn_graph::process` (the
+        // warm-cargo ordering cases, `lifecycle`, `warm_build_lease`, ...)
+        // lazily starts the global one. `waitpid(-1, ...)` is not addressable,
+        // so the two loops then race for every child status in the process
+        // instead of partitioning them. Whichever loop wins files the status;
+        // if that is not the registry holding the PID route, the child stays
+        // registered forever and this test's shutdown reports an already-dead
+        // fixture as a surviving PID.
+        let reaper = djinn_graph::child_reaper::worker_child_reaper();
         // Test bodies are serialized; drain retained adopted statuses and prove
         // the old registry empty before reopening admission for the next case.
         let _ = reaper.drain();
@@ -6304,6 +6352,8 @@ warning: something
         assert!(!reaper.admission_open(), "cleanup must close admission");
         assert!(reaper.wait_for_supervisors_idle(Duration::ZERO));
         assert!(reaper.wait_for_adopted_idle(Duration::ZERO));
+        // Restore the process-global admission gate this case closed.
+        restore_warm_lifecycle_admission(reaper);
     }
 
     #[cfg(target_os = "linux")]
@@ -6336,6 +6386,8 @@ warning: something
         );
         assert!(reaper.wait_for_supervisors_idle(Duration::ZERO));
         assert!(reaper.wait_for_adopted_idle(Duration::ZERO));
+        // Restore the process-global admission gate this case closed.
+        restore_warm_lifecycle_admission(reaper);
     }
 
     #[cfg(target_os = "linux")]
@@ -6369,6 +6421,8 @@ warning: something
         );
         assert!(reaper.wait_for_supervisors_idle(Duration::ZERO));
         assert!(reaper.wait_for_adopted_idle(Duration::ZERO));
+        // Restore the process-global admission gate this case closed.
+        restore_warm_lifecycle_admission(reaper);
     }
 
     #[cfg(target_os = "linux")]
@@ -6483,5 +6537,7 @@ warning: something
         }
         assert!(reaper.wait_for_supervisors_idle(Duration::ZERO));
         assert!(reaper.wait_for_adopted_idle(Duration::ZERO));
+        // Restore the process-global admission gate this case closed.
+        restore_warm_lifecycle_admission(reaper);
     }
 }

--- a/server/crates/djinn-graph/src/child_reaper.rs
+++ b/server/crates/djinn-graph/src/child_reaper.rs
@@ -144,6 +144,15 @@ impl ChildReaper {
     /// platforms deliberately provide the same registration seam without a
     /// wait consumer so existing non-Linux process behavior remains available
     /// to callers until a platform implementation is introduced.
+    ///
+    /// # Panics
+    ///
+    /// On Linux, panics if a second instance is constructed in the same
+    /// process. See [`worker_child_reaper`]: `waitpid(-1, ...)` is not
+    /// addressable, so two consumers do not partition the children between
+    /// them — they race for every terminal status in the process, and the
+    /// loser's registry never learns that its own registered child exited.
+    /// Use [`worker_child_reaper`] instead of constructing another reaper.
     #[must_use]
     pub fn new() -> Self {
         let reaper = Self::new_inner();
@@ -363,8 +372,24 @@ impl ChildReaper {
         self.inner.changed.notify_all();
     }
 
+    /// Install the single per-process `waitpid(-1, WNOHANG)` consumer.
+    ///
+    /// The claim is enforced, not merely documented. A second waiter cannot be
+    /// scoped to "its own" children: `waitpid(-1, ...)` asks for *any* child of
+    /// the process, so two loops race for every terminal status and each one
+    /// silently swallows the statuses it wins as anonymous "adopted" records.
+    /// The registry that actually registered the child then never de-registers
+    /// it, and its supervisor either waits forever on a status route that will
+    /// never be written or reports a long-dead PID as a shutdown survivor.
     #[cfg(target_os = "linux")]
     fn start_linux_waiter(&self) {
+        static WAITER_INSTALLED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        assert!(
+            !WAITER_INSTALLED.swap(true, std::sync::atomic::Ordering::SeqCst),
+            "a second waitpid(-1) child reaper was started in this process; \
+             use worker_child_reaper() instead of constructing another ChildReaper"
+        );
         let reaper = self.clone();
         std::thread::Builder::new()
             .name("djinn-child-reaper".to_owned())


### PR DESCRIPTION
Fixes a pre-existing, order-dependent failure of
`tests::warm_shutdown_drains_two_registered_groups_and_setsid_adoptee`.

Note: the test lives in **`djinn-agent-worker`** (`src/main.rs`), not `djinn-k8s`.

## Reproduction

On `origin/main` @ `64e8952b3`, with no other change applied:

```
cd server
cargo test -p djinn-agent-worker --bin djinn-agent-worker -- --test-threads 1 \
  warm_cargo_ordering_recorder warm_shutdown_drains_two_registered_groups
```

```
test tests::warm_cargo_ordering_recorder_captures_real_failure_before_commands ... ok
test tests::warm_cargo_ordering_recorder_observes_prune_stamp_compile_and_end_sweep ... ok
test tests::warm_shutdown_drains_two_registered_groups_and_setsid_adoptee ... FAILED

all shutdown targets must drain: Err(WarmGraphShutdownError {
  surviving_pids: [2378865, 2378866], surviving_groups: [2378865, 2378866], source: None })
```

Passes in isolation. Fails whenever a warm-cargo test runs first in the same
process. Not a thread race — it fails under `--test-threads 1`.

## Root cause

Not subreaper state. `PR_SET_CHILD_SUBREAPER` is never set in the test binary:
`initialize_linux_warm_lifecycle` is the only caller and the lifecycle tests do
not go through it. Process-group state is fine too — the fixture's own
assertion that each `setsid` child owns its group passes.

The real cause is **two `waitpid(-1)` consumers in one process**.

`djinn_graph::child_reaper` documents that "a process may have only one
`waitpid(-1, ...)` consumer" and exposes `worker_child_reaper()` to make that
ownership explicit. Production honours it: `initialize_linux_warm_lifecycle()`
returns `worker_child_reaper()`, and `djinn_graph::process::run_linux_supervisor`
uses the same accessor. The **test helper did not**:

```rust
static REAPER: OnceLock<ChildReaper> = OnceLock::new();
let reaper = REAPER.get_or_init(ChildReaper::new);   // <- starts a 2nd waiter
```

`ChildReaper::new()` spawns a `waitpid(-1, WNOHANG)` thread. So the binary ends
up with two whenever anything also touches the global reaper — and
`warm_cargo_ordering_recorder_observes_prune_stamp_compile_and_end_sweep` does,
because it actually spawns its stub `cargo` through
`djinn_graph::process::output_with_timeout` → `run_linux_supervisor` →
`worker_child_reaper()`.

`waitpid(-1, ...)` asks for *any* child of the process. It is not addressable,
so two loops do not partition the children between them — they race for every
terminal status in the binary. The winner files it; a reaper that did not
register that PID files it as an anonymous "adopted" record and drops it on the
next `drain()`. The registry that *did* hold the PID route never learns its
child exited, so `wait_for_supervisors_idle` never goes idle and shutdown
reports two long-dead PIDs as survivors.

The sibling test (`..._captures_real_failure_before_commands`) fails at the lock
step *before* spawning anything, never initialises the global reaper, and
therefore does not trigger it — which is exactly the observed bisect.

### Direct proof of the mechanism

Adding a test that does nothing but touch the global accessor — no cargo, no
warm code, no subreaper — reproduces the identical panic:

```rust
#[test] fn probe() { let _ = djinn_graph::child_reaper::worker_child_reaper(); }
```

```
test tests::probe ... ok
test tests::warm_shutdown_drains_two_registered_groups_and_setsid_adoptee ... FAILED
all shutdown targets must drain: Err(WarmGraphShutdownError { surviving_pids: [2381258], ... })
```

Merely installing the second waiter is sufficient. (Probe removed; it was
diagnostic only.)

## Why this is the cause and not the symptom

The fix is not to serialise, retry, or reorder: it deletes the second waiter.
`test_warm_reaper()` now returns the same `worker_child_reaper()` production
uses, so there is exactly one `waitpid(-1)` consumer and status routing is
unambiguous by construction.

`ChildReaper::start_linux_waiter` now *enforces* the invariant it documented,
so this cannot silently regress:

```rust
assert!(!WAITER_INSTALLED.swap(true, SeqCst),
    "a second waitpid(-1) child reaper was started in this process; \
     use worker_child_reaper() instead of constructing another ChildReaper");
```

`ChildReaper::new()` had exactly one caller outside `worker_child_reaper()` —
the helper this PR fixes. Registry-only unit tests already use the waiter-less
`inert_for_test()`.

Two consequences of sharing the registry, both handled by restoring state rather
than hiding it:

* the warm-lifecycle cases `close_admission()` on it, which is permanent by
  design (a warm worker never admits another command after shutdown begins) but
  in a test binary outlives the case and fails every later spawn with
  `BrokenPipe`. Each case now restores the gate it closed.
* a spawn must not overlap that window, and warm shutdown SIGTERM/SIGKILLs every
  direct child of the process outside a registered group — which is precisely
  what it must do to a `setsid` escapee, so it cannot tell a neighbour's
  `sleep 60` from a runaway build. The warm-cargo ordering mutex is hoisted into
  one binary-wide child-lifecycle lock covering every test that owns a live
  child. This is the same lock, for the same reason, that
  `djinn_graph::process::child_lifecycle_test_lock()` already hoists over its own
  spawners. It is uncontended under `cargo nextest` (what CI runs, one process
  per test); it exists for `cargo test`, which shares one.

## Neutralization evidence

Reverting `test_warm_reaper()` to `ChildReaper::new()` and rebuilding, the new
guard fires immediately and names the violation at its source:

```
panicked at crates/djinn-graph/src/child_reaper.rs:388:9:
a second waitpid(-1) child reaper was started in this process; use worker_child_reaper() ...
```

Reverting the guard as well restores the original, mystifying failure verbatim
(`surviving_pids: [2442231, 2442232]`). Reapplying both makes the reproduction
command pass. The test still exercises the coupling: it spawns the same two
`setsid` TERM-ignoring groups plus an unregistered escapee and still asserts
they all drain.

## Verification (`djinn-agent-worker` bin target, single process)

| | `--test-threads 1` | default parallel |
|---|---|---|
| main @ `64e8952b3` | **1 failed** (this test) | never clean; 2 tests **hang forever** |
| this PR | **336 passed, 0 failed** | clean in 3/5 runs |

On main the parallel run does not merely fail, it **hangs**:
`run_cargo_warm_step_instrumented_...` and
`warm_cargo_ordering_recorder_observes_prune_stamp_...` block forever in
`run_linux_supervisor`, waiting on a status route the other waiter consumed.
That is gone.

The residual parallel failures are `warm_build_lease::tests::*` and
`worker_services::lease_adapter_conformance_tests::*` failing with
`Sqlx(Io(ConnectionRefused))` — they need a Postgres that this machine does not
have; they fail identically on main and all pass under nextest.

Also green:

* `cargo nextest run -p djinn-agent-worker --bin djinn-agent-worker` — 336/336
* `cargo test -p djinn-graph` — 662 passed (exercises the new waiter assertion)
* `cargo fmt --all -- --check`
* `cargo clippy -p djinn-agent-worker -p djinn-graph --all-targets -- -D warnings`

## Note on production impact

None intended, and none of the changed lines run in production: the reaper
selection is in `#[cfg(test)]` code, and the new assertion sits on a path
production reaches exactly once (`worker_child_reaper()`'s `OnceLock`). The
warm shutdown machinery, the signal escalation, and the /proc sweep are
untouched.

Vercel is failing repo-wide on an account-level 24h rate limit; it is
non-required.
