### PR TITLE
fix(scip): stop the subreaper stealing git's exit status, and say why git failed

### DIFF
--- a/server/crates/djinn-agent-worker/src/lifecycle.rs
+++ b/server/crates/djinn-agent-worker/src/lifecycle.rs
@@ -860,17 +860,31 @@ async fn run_pre_task_command(
     let timeout = Duration::from_secs(cmd.timeout_seconds);
 
     // Spawn the child in its own process group for clean group-kill.
-    let mut child = match tokio::process::Command::new("/bin/sh")
-        .arg("-c")
-        .arg(&cmd.command)
-        .current_dir(project_root)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .process_group(0)
-        .kill_on_drop(true)
-        .spawn()
-    {
-        Ok(c) => c,
+    //
+    // Through `spawn_owned` because this function waits on the child itself.
+    // Any process that has run a graph command has a `waitpid`-based child
+    // reaper running (`djinn_graph::process` starts it lazily via
+    // `worker_child_reaper`), and an unclaimed PID is collected by that loop
+    // first — after which tokio reports ECHILD and this command is recorded as
+    // failed despite having run fine. With a `failure_policy` of `abort` that
+    // would end the task run.
+    let spawned = djinn_core::child_ownership::spawn_owned(
+        || {
+            tokio::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg(&cmd.command)
+                .current_dir(project_root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .process_group(0)
+                .kill_on_drop(true)
+                .spawn()
+        },
+        tokio::process::Child::id,
+    );
+    // Held until this function returns, i.e. past every wait below.
+    let (mut child, _ownership) = match spawned {
+        Ok(pair) => pair,
         Err(e) => {
             let elapsed = start.elapsed();
             warn!(name = %name, error = %e, "pre-task: failed to spawn command");

--- a/server/crates/djinn-core/src/child_ownership.rs
+++ b/server/crates/djinn-core/src/child_ownership.rs
@@ -1,0 +1,191 @@
+//! Which child PIDs are already owned by an in-process waiter.
+//!
+//! # The bug this exists to prevent
+//!
+//! `djinn-agent-worker` runs as a Linux subreaper (`PR_SET_CHILD_SUBREAPER`)
+//! with one background thread calling `waitpid(-1, WNOHANG)` in a loop, so that
+//! processes reparented onto the worker are reaped instead of accumulating as
+//! zombies (see `djinn_graph::child_reaper`).
+//!
+//! `waitpid(-1, ...)` does not distinguish "an orphan that was reparented onto
+//! me" from "a child *I* spawned and am already waiting on". A process may have
+//! only one consumer of a given child's terminal status, and `tokio::process`
+//! is such a consumer: on Linux it opens a `pidfd` for every child it spawns,
+//! and once that fd signals readiness it calls `waitpid(pid, WNOHANG)` to
+//! collect the status. If the reaper's `waitpid(-1, ...)` gets there first, the
+//! zombie is gone and tokio's call fails with **`ECHILD` ("No child
+//! processes")** — surfacing as an I/O error on a subprocess that in fact ran
+//! perfectly.
+//!
+//! Measured on this codebase's reaper against `git rev-parse HEAD`:
+//!
+//! ```text
+//! reaper idle-polling at 10ms   ~0.2% of spawns stolen  (≈10 in 6000)
+//! reaper not sleeping           100%  of spawns stolen  (200 in 200)
+//! ```
+//!
+//! The reaper skips its sleep whenever the previous pass reaped something, so
+//! *while it is draining adopted orphans it is effectively spinning* — and any
+//! subprocess that exits inside that window is stolen with near-certainty. That
+//! is why this is not a benign flake: it is quiet when the process is idle and
+//! near-deterministic in exactly the moments a process tree is tearing down.
+//!
+//! # The contract
+//!
+//! A spawner that intends to wait on its own child registers the PID here for
+//! as long as it holds wait rights. The reaper consults [`is_owned`] and
+//! refuses to consume a registered PID, leaving it for its rightful waiter.
+//!
+//! Registration must be atomic with respect to a reaper pass, or a child that
+//! forks and exits before its PID lands in the set is still stealable.
+//! [`spawn_owned`] therefore performs the spawn *and* the registration while
+//! holding [`SPAWN_GATE`] shared, and the reaper takes it exclusively around
+//! one wait pass. The gate is uncontended in practice: a reaper pass is a
+//! couple of syscalls.
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock, RwLock, RwLockWriteGuard};
+
+/// PIDs whose terminal status belongs to an in-process waiter.
+fn owned() -> &'static Mutex<HashSet<u32>> {
+    static OWNED: OnceLock<Mutex<HashSet<u32>>> = OnceLock::new();
+    OWNED.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Serializes "spawn + register" against a reaper pass. Held **shared** by
+/// spawners and **exclusively** by the reaper, so a forked-but-unregistered
+/// child cannot be observed by a wait pass.
+fn spawn_gate() -> &'static RwLock<()> {
+    static GATE: OnceLock<RwLock<()>> = OnceLock::new();
+    GATE.get_or_init(|| RwLock::new(()))
+}
+
+/// Exclusive access for the duration of one reaper wait pass.
+///
+/// Held by `djinn_graph::child_reaper`'s Linux waiter so that no spawn can
+/// interleave between another thread's `fork` and its [`spawn_owned`]
+/// registration.
+pub fn reaper_pass() -> RwLockWriteGuard<'static, ()> {
+    spawn_gate().write().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Whether `pid`'s terminal status belongs to an in-process waiter, meaning a
+/// reaper must not consume it.
+#[must_use]
+pub fn is_owned(pid: u32) -> bool {
+    owned()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .contains(&pid)
+}
+
+/// Number of currently registered PIDs. Diagnostics and tests only.
+#[must_use]
+pub fn owned_count() -> usize {
+    owned().lock().unwrap_or_else(|e| e.into_inner()).len()
+}
+
+/// Wait rights over one child PID. Deregisters on drop, so a panic or an early
+/// return cannot strand a PID that the reaper would then never collect.
+#[derive(Debug)]
+pub struct OwnedChild {
+    pid: Option<u32>,
+}
+
+impl OwnedChild {
+    /// A guard over no PID. Used when a spawn produced no usable PID (the
+    /// child was already reaped by the platform layer), which is not an error —
+    /// there is simply nothing to protect.
+    #[must_use]
+    pub fn none() -> Self {
+        Self { pid: None }
+    }
+
+    /// The protected PID, if any.
+    #[must_use]
+    pub fn pid(&self) -> Option<u32> {
+        self.pid
+    }
+
+    /// Release wait rights early. Equivalent to dropping the guard.
+    pub fn release(mut self) {
+        self.deregister();
+    }
+
+    fn deregister(&mut self) {
+        if let Some(pid) = self.pid.take() {
+            owned()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&pid);
+        }
+    }
+}
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        self.deregister();
+    }
+}
+
+/// Spawn a child and claim wait rights over it in one atomic step.
+///
+/// `spawn` is invoked while the reaper is held out, and `pid_of` extracts the
+/// new child's PID from whatever handle `spawn` produced (`std::process::Child`
+/// and `tokio::process::Child` both expose one). The returned [`OwnedChild`]
+/// must be held until the child has been waited on.
+///
+/// Callers that spawn a child and then wait on it themselves **must** go
+/// through this function; a bare `Command::spawn` in a process that also runs a
+/// `waitpid(-1, ...)` reaper is racing that reaper for its own child's exit
+/// status.
+pub fn spawn_owned<T, E>(
+    spawn: impl FnOnce() -> Result<T, E>,
+    pid_of: impl FnOnce(&T) -> Option<u32>,
+) -> Result<(T, OwnedChild), E> {
+    let _gate = spawn_gate().read().unwrap_or_else(|e| e.into_inner());
+    let child = spawn()?;
+    let pid = pid_of(&child);
+    if let Some(pid) = pid {
+        owned()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(pid);
+    }
+    Ok((child, OwnedChild { pid }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_registers_and_deregisters() {
+        let (pid, guard) = spawn_owned(|| Ok::<_, ()>(4_242_001_u32), |p| Some(*p)).unwrap();
+        assert!(is_owned(pid), "pid must be protected while the guard lives");
+        drop(guard);
+        assert!(!is_owned(pid), "dropping the guard must release the pid");
+    }
+
+    #[test]
+    fn release_is_equivalent_to_drop() {
+        let (pid, guard) = spawn_owned(|| Ok::<_, ()>(4_242_002_u32), |p| Some(*p)).unwrap();
+        assert!(is_owned(pid));
+        guard.release();
+        assert!(!is_owned(pid));
+    }
+
+    #[test]
+    fn a_spawn_failure_registers_nothing() {
+        let before = owned_count();
+        let result = spawn_owned(|| Err::<u32, _>("boom"), |p| Some(*p));
+        assert!(result.is_err());
+        assert_eq!(owned_count(), before);
+    }
+
+    #[test]
+    fn a_pidless_child_yields_an_inert_guard() {
+        let (_child, guard) = spawn_owned(|| Ok::<_, ()>(()), |()| None).unwrap();
+        assert_eq!(guard.pid(), None);
+    }
+}

--- a/server/crates/djinn-core/src/lib.rs
+++ b/server/crates/djinn-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth_context;
 pub mod cargo_target_runs;
+pub mod child_ownership;
 pub mod clock;
 pub mod commands;
 pub mod doctor;

--- a/server/crates/djinn-git/src/lib.rs
+++ b/server/crates/djinn-git/src/lib.rs
@@ -564,6 +564,43 @@ pub struct MergeResult {
     pub commit_sha: String,
 }
 
+/// `Command::output()` that first claims wait rights over the spawned child.
+///
+/// Every git subprocess must go through this (or [`spawn_owned_child`]) rather
+/// than calling `output()` directly. `djinn-agent-worker` runs a
+/// `waitpid(-1, ...)` subreaper loop, and an unclaimed child is stolen from
+/// under `tokio::process`, which then reports `ECHILD` ("No child processes")
+/// for a git command that in fact ran fine. See
+/// [`djinn_core::child_ownership`].
+async fn output_owned(cmd: &mut tokio::process::Command) -> std::io::Result<std::process::Output> {
+    let (child, ownership) =
+        djinn_core::child_ownership::spawn_owned(|| cmd.spawn(), tokio::process::Child::id)?;
+    let output = child.wait_with_output().await;
+    // Explicit: wait rights are released only after the status is collected.
+    drop(ownership);
+    output
+}
+
+/// Synchronous counterpart to [`output_owned`].
+fn output_owned_std(cmd: &mut std::process::Command) -> std::io::Result<std::process::Output> {
+    let (child, ownership) =
+        djinn_core::child_ownership::spawn_owned(|| cmd.spawn(), |c| Some(c.id()))?;
+    let output = child.wait_with_output();
+    drop(ownership);
+    output
+}
+
+/// `Command::spawn()` that claims wait rights over the child, for callers that
+/// drive `wait()` themselves. The returned guard must outlive the wait.
+fn spawn_owned_child(
+    cmd: &mut tokio::process::Command,
+) -> std::io::Result<(
+    tokio::process::Child,
+    djinn_core::child_ownership::OwnedChild,
+)> {
+    djinn_core::child_ownership::spawn_owned(|| cmd.spawn(), tokio::process::Child::id)
+}
+
 pub async fn run_git_command(path: PathBuf, args: Vec<String>) -> Result<CommandOutput, GitError> {
     use std::process::Stdio;
     let mut cmd = git_command();
@@ -573,7 +610,7 @@ pub async fn run_git_command(path: PathBuf, args: Vec<String>) -> Result<Command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     lower_process_priority(&mut cmd);
-    let output = cmd.output().await?;
+    let output = output_owned(&mut cmd).await?;
 
     let code = output.status.code().unwrap_or(-1);
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -613,7 +650,7 @@ pub async fn run_git_command_with_timeout(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     lower_process_priority(&mut cmd);
-    let mut child = cmd.spawn()?;
+    let (mut child, _ownership) = spawn_owned_child(&mut cmd)?;
 
     // Take stdout/stderr handles so we can read them concurrently with wait,
     // avoiding deadlocks if the child fills a pipe buffer, while still being
@@ -857,7 +894,7 @@ pub async fn run_git_command_allow_failure(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     lower_process_priority(&mut cmd);
-    let output = cmd.output().await?;
+    let output = output_owned(&mut cmd).await?;
     Ok(CommandOutput {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -893,7 +930,7 @@ pub async fn run_git_command_in_with_env_allow_failure(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     lower_process_priority(&mut cmd);
-    let output = cmd.output().await?;
+    let output = output_owned(&mut cmd).await?;
     Ok(CommandOutput {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -917,7 +954,7 @@ pub fn run_git_command_binary_in(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     lower_process_priority_sync(&mut cmd);
-    let output = cmd.output()?;
+    let output = output_owned_std(&mut cmd)?;
     let code = output.status.code().unwrap_or(-1);
     if !output.status.success() {
         return Err(GitError::CommandFailed {
@@ -957,7 +994,7 @@ pub async fn run_git_command_in_with_env(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     lower_process_priority(&mut cmd);
-    let output = cmd.output().await?;
+    let output = output_owned(&mut cmd).await?;
 
     let code = output.status.code().unwrap_or(-1);
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();

--- a/server/crates/djinn-graph/src/canonical_graph.rs
+++ b/server/crates/djinn-graph/src/canonical_graph.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Context as _;
 use tokio::sync::RwLock;
 
 use crate::WarmContext;
@@ -676,6 +677,24 @@ pub async fn run_warm_graph_command<C: WarmContext>(
     Ok(())
 }
 
+/// Scratch directory for one indexer run's raw `.scip` output.
+///
+/// The durable product of an indexer run is the content-addressed SCIP cache
+/// under `$XDG_CACHE_HOME`; the `.scip` files themselves are transient and are
+/// deleted when the returned handle drops.
+///
+/// Rooted at the process temp directory, deliberately. Both the warm and the
+/// SCIP call site previously built this as
+/// `std::env::current_dir()?.join("target").join("test-tmp")`, which is wrong
+/// twice over: `target/test-tmp` is the workspace's *test* scratch convention
+/// (see `.gitignore` and `test_helpers::workspace_tempdir`), and deriving a
+/// production path from the process CWD makes the output location a property of
+/// how the binary happened to be launched. In both Pods it resolved inside the
+/// cloned repository — the very tree being indexed.
+fn indexer_output_tempdir(prefix: &str) -> std::io::Result<tempfile::TempDir> {
+    tempfile::Builder::new().prefix(prefix).tempdir()
+}
+
 /// Run the **semantic pass only** and leave its artifacts in the shared
 /// content-addressed SCIP cache. Publishes no graph and writes no
 /// `repo_graph_*` row.
@@ -734,9 +753,13 @@ pub async fn run_scip_index_command<C: WarmContext>(
 
     // Same tree resolution as `ensure_canonical_graph`, so the two runs index
     // the same content and agree on workspace identity.
+    // `.context(..)`, not `anyhow!("...: {e}")`: the latter renders only the
+    // outermost message of `e` and drops its source, which is how the first
+    // production run of this Job reported `ensure index tree: git rev-parse
+    // HEAD in ...` with the git exit code and stderr nowhere in the log.
     let mut handle = crate::index_tree::IndexTree::ensure(project_id, &project_root)
         .await
-        .map_err(|e| anyhow::anyhow!("ensure index tree: {e}"))?;
+        .context("ensure index tree")?;
     let _ = handle
         .fetch_if_stale(crate::index_tree::DEFAULT_FETCH_COOLDOWN)
         .await;
@@ -747,16 +770,8 @@ pub async fn run_scip_index_command<C: WarmContext>(
     let indexer_lock = ctx.indexer_lock();
     let _guard = indexer_lock.lock().await;
 
-    let temp_base = std::env::current_dir()
-        .map_err(|e| anyhow::anyhow!("resolve current dir for scip-index tempdir: {e}"))?
-        .join("target")
-        .join("test-tmp");
-    std::fs::create_dir_all(&temp_base)
-        .map_err(|e| anyhow::anyhow!("create scip-index tempdir base: {e}"))?;
-    let output_temp = tempfile::Builder::new()
-        .prefix("djinn-scip-index-")
-        .tempdir_in(&temp_base)
-        .map_err(|e| anyhow::anyhow!("create scip-index tempdir: {e}"))?;
+    let output_temp =
+        indexer_output_tempdir("djinn-scip-index-").context("create scip-index tempdir")?;
 
     let target_dir = handle.indexer_target_dir_override();
     let stack_filter = resolve_stack_indexer_filter(ctx, project_id).await;
@@ -818,7 +833,11 @@ pub async fn ensure_canonical_graph<C: WarmContext>(
 
     let mut handle = crate::index_tree::IndexTree::ensure(project_id, project_root)
         .await
-        .map_err(|e| format!("ensure index tree: {e}"))?;
+        // `{e:#}`, not `{e}`: this arm collapses an `anyhow::Error` into a
+        // `String`, and the plain form keeps only the outermost context — which
+        // is how a failing `git rev-parse` here reports the call it made and
+        // never the exit code or stderr that says why it failed.
+        .map_err(|e| format!("ensure index tree: {e:#}"))?;
     let _ = handle
         .fetch_if_stale(crate::index_tree::DEFAULT_FETCH_COOLDOWN)
         .await;
@@ -951,15 +970,7 @@ pub async fn ensure_canonical_graph<C: WarmContext>(
         );
     }
 
-    let temp_base = std::env::current_dir()
-        .map_err(|e| format!("resolve current dir for canonical-graph tempdir: {e}"))?
-        .join("target")
-        .join("test-tmp");
-    std::fs::create_dir_all(&temp_base)
-        .map_err(|e| format!("create canonical-graph tempdir base: {e}"))?;
-    let output_temp = tempfile::Builder::new()
-        .prefix("djinn-canonical-graph-")
-        .tempdir_in(&temp_base)
+    let output_temp = indexer_output_tempdir("djinn-canonical-graph-")
         .map_err(|e| format!("create canonical-graph tempdir: {e}"))?;
     let output_dir = output_temp.path().to_path_buf();
     // In the K8s warm-Pod path this resolves to `None` when the Pod already

--- a/server/crates/djinn-graph/src/child_reaper.rs
+++ b/server/crates/djinn-graph/src/child_reaper.rs
@@ -1,11 +1,22 @@
 //! Worker-scoped child lifecycle registry.
 //!
-//! On Linux this module owns the worker's `waitpid(-1, ...)` loop.  Code which
+//! On Linux this module owns the worker's child-reaping loop.  Code which
 //! registers a direct child must never call `Child::{wait,try_wait}` itself:
 //! the terminal status is delivered through the [`DirectChild`] receiver.
 //! Unrecognised statuses are retained as adopted-child records, rather than
 //! being silently discarded because they do not belong to a known process
 //! group.  This matters when the warm worker is a Linux subreaper.
+//!
+//! ## What the loop will not reap
+//!
+//! The loop **peeks** with `waitid(P_ALL, .., WNOWAIT)` and only then collects
+//! the PID it saw. It used to call `waitpid(-1, WNOHANG)` directly, which
+//! consumes a status before the caller can see whose it was — including the
+//! status of a child `tokio::process` spawned and is itself waiting on. Tokio's
+//! own `waitpid` then fails with `ECHILD` and reports a subprocess that ran
+//! perfectly as an I/O error. PIDs registered in
+//! [`djinn_core::child_ownership`] are therefore skipped while admission is
+//! open; see that module for the measurements.
 
 use std::collections::HashMap;
 use std::io;
@@ -372,15 +383,53 @@ impl ChildReaper {
         self.inner.changed.notify_all();
     }
 
-    /// Install the single per-process `waitpid(-1, WNOHANG)` consumer.
+    /// Peek at the next child whose terminal status is collectable, **without**
+    /// consuming it (`WNOWAIT`).
+    ///
+    /// This is what makes the wait loop able to decline a PID. `waitpid(-1, ..)`
+    /// consumes before the caller can see whose status it took, which is
+    /// precisely how this reaper used to steal `tokio::process`'s children (see
+    /// [`djinn_core::child_ownership`]).
+    ///
+    /// `Some(pid)` when a child is waitable, `None` when none is or when there
+    /// are no children at all.
+    #[cfg(target_os = "linux")]
+    fn peek_waitable() -> Option<u32> {
+        // SAFETY: an all-zero `siginfo_t` is a valid initialized value, and the
+        // kernel leaves `si_pid` at 0 when WNOHANG finds nothing — so it must be
+        // zeroed before the call for the "nothing ready" case to be detectable.
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        // SAFETY: `info` is valid writable memory for the duration of the call.
+        let rc = unsafe {
+            libc::waitid(
+                libc::P_ALL,
+                0,
+                &mut info,
+                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+            )
+        };
+        if rc != 0 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() != Some(libc::ECHILD) && err.raw_os_error() != Some(libc::EINTR) {
+                tracing::warn!(error = %err, "child reaper waitid failed");
+            }
+            return None;
+        }
+        // SAFETY: `si_pid` is initialized for a successful `waitid`.
+        let pid = unsafe { info.si_pid() };
+        (pid > 0).then_some(pid as u32)
+    }
+
+    /// Install the single per-process child-reaping consumer.
     ///
     /// The claim is enforced, not merely documented. A second waiter cannot be
-    /// scoped to "its own" children: `waitpid(-1, ...)` asks for *any* child of
-    /// the process, so two loops race for every terminal status and each one
-    /// silently swallows the statuses it wins as anonymous "adopted" records.
-    /// The registry that actually registered the child then never de-registers
-    /// it, and its supervisor either waits forever on a status route that will
-    /// never be written or reports a long-dead PID as a shutdown survivor.
+    /// scoped to "its own" children: the peek behind this loop asks for *any*
+    /// child of the process, so two loops race for every terminal status and
+    /// each one silently swallows the statuses it wins as anonymous "adopted"
+    /// records. The registry that actually registered the child then never
+    /// de-registers it, and its supervisor either waits forever on a status
+    /// route that will never be written or reports a long-dead PID as a
+    /// shutdown survivor.
     #[cfg(target_os = "linux")]
     fn start_linux_waiter(&self) {
         static WAITER_INSTALLED: std::sync::atomic::AtomicBool =
@@ -397,19 +446,40 @@ impl ChildReaper {
                 loop {
                     let mut reaped_any = false;
                     loop {
+                        // Held for the whole pass so no other thread can be
+                        // between `fork` and its ownership registration while
+                        // this loop decides what to collect.
+                        let _pass = djinn_core::child_ownership::reaper_pass();
+                        let Some(pid) = Self::peek_waitable() else {
+                            break;
+                        };
+                        // Someone in this process is already waiting on this
+                        // child. Collecting it here would leave that waiter's
+                        // `waitpid` returning ECHILD for a subprocess that ran
+                        // fine. Leave it; its owner collects it in microseconds
+                        // and the next pass moves on.
+                        //
+                        // Shutdown is the exception: `close_admission` means no
+                        // new command can start, so nothing is legitimately
+                        // waiting any more and the loop must be able to drain
+                        // everything or cleanup would never reach idle.
+                        if reaper.admission_open() && djinn_core::child_ownership::is_owned(pid) {
+                            break;
+                        }
                         let mut raw_status = 0;
-                        // SAFETY: `raw_status` is valid writable memory and -1 with
-                        // WNOHANG asks the kernel for any child of this worker.
-                        let pid = unsafe { libc::waitpid(-1, &mut raw_status, libc::WNOHANG) };
-                        if pid > 0 {
+                        // SAFETY: `raw_status` is valid writable memory; the PID
+                        // came from the peek above and is still unwaited.
+                        let reaped =
+                            unsafe { libc::waitpid(pid as i32, &mut raw_status, libc::WNOHANG) };
+                        if reaped > 0 {
                             reaped_any = true;
                             reaper.record_terminal(TerminalStatus {
-                                pid: pid as u32,
+                                pid: reaped as u32,
                                 raw_status,
                             });
                             continue;
                         }
-                        if pid < 0 {
+                        if reaped < 0 {
                             let err = io::Error::last_os_error();
                             if err.raw_os_error() != Some(libc::ECHILD)
                                 && err.raw_os_error() != Some(libc::EINTR)

--- a/server/crates/djinn-graph/src/index_tree.rs
+++ b/server/crates/djinn-graph/src/index_tree.rs
@@ -332,9 +332,17 @@ async fn run_git(cwd: &Path, args: &[&str]) -> Result<String> {
     // on non-zero exit, so a successful `Ok` here means git exited 0 — we
     // surface its trimmed stdout regardless of stderr (git often emits
     // advisory hints to stderr on a successful run).
+    //
+    // The context deliberately does NOT say "spawn": a non-zero exit and a
+    // failure to launch arrive through the same `Err`, and calling both a spawn
+    // failure sent the first production run of the standalone SCIP Job to a
+    // diagnosis that could not be reached. `GitError`'s own `Display` carries
+    // the exit code, stdout and stderr, so the only requirement here is that
+    // the source chain survives — `anyhow!("...: {e}")` at a caller flattens it
+    // to this line alone and throws the cause away.
     let CommandOutput { stdout, .. } = djinn_git::run_git_command_in(cwd, owned_args)
         .await
-        .with_context(|| format!("spawn git {} in {}", args.join(" "), cwd.display()))?;
+        .with_context(|| format!("git {} in {}", args.join(" "), cwd.display()))?;
     Ok(stdout.trim().to_string())
 }
 
@@ -425,6 +433,49 @@ mod tests {
             .await
             .unwrap();
         project_root
+    }
+
+    /// A failing git command must arrive in the log with the exit code and
+    /// stderr that say *why*.
+    ///
+    /// The first production run of the standalone SCIP-index Job reported
+    /// exactly one line — `ensure index tree: spawn git rev-parse HEAD in
+    /// /workspace/<project>` — and nothing else. Two separate defects produced
+    /// that: this context claimed "spawn" for what is also the non-zero-exit
+    /// path, and the caller rendered the error with `{e}`, which prints only the
+    /// outermost message and discards the `GitError` carrying the exit status
+    /// and stderr.
+    #[tokio::test]
+    async fn a_failing_git_command_surfaces_its_exit_code_and_stderr() {
+        let tmp = workspace_tempdir("index-tree-error-legibility-");
+        let repo = tmp.path().join("no-commits");
+        tokio::fs::create_dir_all(&repo).await.unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]).await.unwrap();
+
+        // A repository with no commits: `rev-parse HEAD` exits 128.
+        let err = read_head_sha(&repo)
+            .await
+            .expect_err("rev-parse HEAD must fail in a repo with no commits");
+        // `{:#}` is how djinn-agent-worker renders a fatal error.
+        let rendered = format!("{err:#}");
+
+        assert!(
+            rendered.contains("git rev-parse HEAD in"),
+            "the failing command and its cwd must be named: {rendered}"
+        );
+        assert!(
+            !rendered.contains("spawn git"),
+            "a non-zero exit is not a spawn failure; that wording sent a real \
+             production diagnosis down the wrong path: {rendered}"
+        );
+        assert!(
+            rendered.contains("exit 128"),
+            "git's exit code must reach the log: {rendered}"
+        );
+        assert!(
+            rendered.contains("ambiguous argument"),
+            "git's stderr must reach the log: {rendered}"
+        );
     }
 
     #[tokio::test]

--- a/server/crates/djinn-graph/tests/child_reaper_ownership.rs
+++ b/server/crates/djinn-graph/tests/child_reaper_ownership.rs
@@ -1,0 +1,156 @@
+//! The worker's subreaper must not steal a child that an in-process waiter
+//! already owns.
+//!
+//! Regression test for the first production run of the standalone SCIP-index
+//! Job, which failed with
+//!
+//! ```text
+//! ensure index tree: spawn git rev-parse HEAD in /workspace/<project>
+//! ```
+//!
+//! `djinn-agent-worker` sets `PR_SET_CHILD_SUBREAPER` and runs one
+//! `waitpid(-1, WNOHANG)` loop. That call cannot tell an adopted orphan from a
+//! child this process spawned and is already waiting on, so it could collect
+//! the zombie of a `tokio::process` child first — after which tokio's own
+//! `waitpid` returns `ECHILD` and a `git` command that ran perfectly is
+//! reported as an I/O failure.
+//!
+//! Its own integration binary on purpose: the reaper installs a process-wide
+//! child-status consumer, which would reap other tests' subprocesses if it
+//! shared a binary with them.
+
+#![cfg(target_os = "linux")]
+
+use std::time::Duration;
+
+use djinn_graph::child_reaper::{ChildReaper, worker_child_reaper};
+
+/// Is `pid` a collectable zombie right now? Uses `WNOWAIT` so the check itself
+/// never consumes the status it is looking for.
+fn is_waitable(pid: u32) -> bool {
+    // SAFETY: an all-zero siginfo_t is valid; the kernel leaves si_pid at 0 when
+    // WNOHANG finds nothing, so it must start zeroed to be readable as "none".
+    let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+    // SAFETY: `info` is valid writable memory for the duration of the call.
+    let rc = unsafe {
+        libc::waitid(
+            libc::P_PID,
+            pid,
+            &mut info,
+            libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+        )
+    };
+    // SAFETY: si_pid is initialized on a successful waitid.
+    rc == 0 && unsafe { info.si_pid() } as u32 == pid
+}
+
+/// Wait until `pid` is a collectable zombie. Only meaningful for a PID the
+/// reaper is bound to leave alone — an unclaimed child is collected so quickly
+/// that it is never observed in this state.
+async fn await_zombie(reaper: &ChildReaper, pid: u32) {
+    for _ in 0..500 {
+        if is_waitable(pid) {
+            return;
+        }
+        assert!(
+            !reaped_pids(reaper).contains(&pid),
+            "the reaper collected pid {pid} out from under its owner — this is \
+             the ECHILD bug: the owner's next wait will report \"No child \
+             processes\" for a subprocess that ran fine"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("child {pid} never became collectable and was never reaped");
+}
+
+/// Wait until the reaper has recorded `pid` as an adopted child.
+async fn await_reaped(reaper: &ChildReaper, pid: u32) -> bool {
+    for _ in 0..500 {
+        if reaped_pids(reaper).contains(&pid) {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    false
+}
+
+/// Let the reaper complete at least two full wait passes, so "it did not take
+/// this pid" means it looked and declined rather than that it never looked.
+fn let_the_reaper_look(reaper: &ChildReaper) {
+    for _ in 0..2 {
+        assert!(
+            reaper.quiesce(Duration::from_secs(10)),
+            "the reaper never completed a wait pass"
+        );
+    }
+}
+
+fn spawn_true() -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new("/bin/true");
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    cmd
+}
+
+fn reaped_pids(reaper: &ChildReaper) -> Vec<u32> {
+    reaper
+        .adopted_children()
+        .into_iter()
+        .map(|record| record.status.pid)
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_reaper_declines_an_owned_child_and_still_collects_an_unowned_one() {
+    // SAFETY: changes this process's reparenting policy, exactly as the warm /
+    // SCIP worker does at startup.
+    assert_eq!(
+        unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1) },
+        0,
+        "PR_SET_CHILD_SUBREAPER must be available for this test to mean anything"
+    );
+    let reaper = worker_child_reaper();
+
+    // ---- owned: the reaper must leave this child's status for its waiter ----
+    let (mut owned_child, ownership) = djinn_core::child_ownership::spawn_owned(
+        || spawn_true().spawn(),
+        tokio::process::Child::id,
+    )
+    .expect("spawn owned child");
+    let owned_pid = ownership.pid().expect("owned child must have a pid");
+    await_zombie(reaper, owned_pid).await;
+    let_the_reaper_look(reaper);
+
+    assert!(
+        !reaped_pids(reaper).contains(&owned_pid),
+        "the reaper collected pid {owned_pid} despite it being registered as \
+         owned; its waiter will now see ECHILD"
+    );
+    // The assertion that actually matters: the owner can still collect it.
+    let status = owned_child
+        .wait()
+        .await
+        .expect("the owner must be able to wait on its own child");
+    assert!(status.success(), "/bin/true should exit 0, got {status:?}");
+    drop(ownership);
+
+    // ---- unowned: the reaper must still do its job -------------------------
+    //
+    // Without this half, the test above would also pass against a reaper that
+    // had simply stopped reaping anything at all.
+    let mut unowned_child = spawn_true().spawn().expect("spawn unowned child");
+    let unowned_pid = unowned_child.id().expect("unowned child must have a pid");
+
+    assert!(
+        await_reaped(reaper, unowned_pid).await,
+        "the reaper must still collect a child no in-process waiter claimed \
+         (adopted orphans are the whole reason it exists)"
+    );
+    assert!(
+        unowned_child.wait().await.is_err(),
+        "an unclaimed child IS taken by the reaper — if this ever starts \
+         succeeding, the reaper stopped reaping and the owned-child assertion \
+         above proves nothing"
+    );
+}

--- a/server/crates/djinn-k8s/src/scip_job.rs
+++ b/server/crates/djinn-k8s/src/scip_job.rs
@@ -114,6 +114,15 @@ pub const LABEL_CAPACITY_RESERVED: &str = "djinn.io/capacity-reserved";
 /// decide whether the head has advanced since the last successful index.
 pub const ANNOTATION_SCIP_REVISION: &str = "djinn.app/scip-revision";
 
+/// Env key under which the enclosing Job's `activeDeadlineSeconds` is projected
+/// into the Pod.
+///
+/// Named for the reader, not the writer: `djinn_graph::scip_indexer::budget`
+/// and `djinn_agent_worker::warm_step_budget` both look up this exact string to
+/// find "the deadline that will kill the Pod I am in". A SCIP-specific key
+/// would render fine, pass every manifest test, and be read by nobody.
+pub const SCIP_JOB_DEADLINE_ENV: &str = "DJINN_WARM_JOB_DEADLINE_SECONDS";
+
 /// Container name of the SCIP indexer. Distinct from the warm Job's `warmer`
 /// so [`crate::build_resources::apply_resolved_resources`] — which targets
 /// `worker`/`warmer` — cannot silently retarget this Pod with warm overrides.
@@ -265,8 +274,22 @@ exec {bin} scip-index "{project_id}"
         env_var("DJINN_PROJECT_ROOT", &project_root),
         env_var("DJINN_SCIP_REVISION", revision),
         env_var("RUST_LOG", "info,djinn=debug"),
+        // THE KEY IS THE CONTRACT, AND THE READER NAMED IT.
+        //
+        // `djinn_graph::scip_indexer::budget` bounds each indexer's timeout by
+        // the enclosing Job's deadline, and it reads exactly
+        // `DJINN_WARM_JOB_DEADLINE_SECONDS`. The value is this Job's own
+        // `activeDeadlineSeconds`, not the warm Job's — only the *name* is
+        // shared, because the budget's question ("what deadline will kill the
+        // Pod I am running in?") is the same in both Pods.
+        //
+        // This originally rendered as `DJINN_SCIP_JOB_DEADLINE_SECONDS`, which
+        // nothing reads. With the key unread the budget falls back to its
+        // unenclosed 4h ceiling while the kubelet kills this Pod at
+        // `scip_job_timeout_seconds` — turning an observable `timed_out`
+        // indexer status into an unexplained SIGKILL with no artifacts written.
         env_var(
-            "DJINN_SCIP_JOB_DEADLINE_SECONDS",
+            SCIP_JOB_DEADLINE_ENV,
             &config.scip_job_timeout_seconds.to_string(),
         ),
     ];
@@ -861,6 +884,43 @@ mod tests {
             "scip_job_timeout_seconds {} leaves no margin over the measured \
              {MEASURED_SCIP_PHASE_SECONDS}s SCIP phase",
             cfg.scip_job_timeout_seconds,
+        );
+    }
+
+    /// The deadline must reach the indexer budget, which means it must be
+    /// projected under the key that budget reads.
+    ///
+    /// A rendered-but-unread key is indistinguishable from a correct one in the
+    /// manifest, and its only symptom is a Pod the kubelet kills partway
+    /// through an index that believed it had four hours.
+    #[test]
+    fn scip_deadline_is_projected_under_the_key_the_indexer_budget_reads() {
+        let cfg = KubernetesConfig::for_testing();
+        let env = env_of(&job(&cfg));
+
+        assert_eq!(
+            SCIP_JOB_DEADLINE_ENV, "DJINN_WARM_JOB_DEADLINE_SECONDS",
+            "this is the literal string `djinn_graph::scip_indexer::budget` \
+             looks up; changing it here without changing it there silently \
+             unbounds the budget"
+        );
+        assert_eq!(
+            env.get(SCIP_JOB_DEADLINE_ENV).map(String::as_str),
+            Some(cfg.scip_job_timeout_seconds.to_string().as_str()),
+            "the projected deadline must be THIS Job's activeDeadlineSeconds"
+        );
+        assert_eq!(
+            job(&cfg)
+                .spec
+                .as_ref()
+                .and_then(|s| s.active_deadline_seconds),
+            Some(cfg.scip_job_timeout_seconds),
+            "…and it must equal the deadline the kubelet actually enforces"
+        );
+        assert!(
+            !env.contains_key("DJINN_SCIP_JOB_DEADLINE_SECONDS"),
+            "the SCIP-specific key is read by nothing; rendering it back would \
+             restore the unbounded budget this test exists to prevent"
         );
     }
 


### PR DESCRIPTION
## What broke

The first production run of the standalone SCIP-index Job (#2697, v0.7.19) exited 1 after ~49s with a single line and no cause:

```
ERROR djinn_agent_worker: djinn-agent-worker failed
  error=run_scip_index_command(019ea3bd-…): ensure index tree: spawn git rev-parse HEAD in /workspace/019ea3bd-…
```

## Root cause: the worker's subreaper steals its own children's exit statuses

`djinn-agent-worker` sets `PR_SET_CHILD_SUBREAPER` and runs one `waitpid(-1, WNOHANG)` loop. **That call is not addressable**: it cannot distinguish an adopted orphan from a child this process spawned and is already waiting on. `tokio::process` is such a waiter — on Linux (tokio 1.52) it opens a `pidfd` per child and calls `waitpid(pid, WNOHANG)` when the fd signals. If the reaper collects the zombie first, tokio's call returns **`ECHILD` ("No child processes")**, and a `git` command that ran perfectly is reported as an I/O error.

`ECHILD` from `run_git_command_in` is a `GitError::Io`, which `index_tree::run_git` labelled `spawn git …`. That is the exact string production logged.

### Evidence

A minimal reproduction — the reaper loop copied verbatim, driving `git rev-parse HEAD` through `tokio::process` exactly as `djinn_git::run_git_command` does:

| reaper state | spawns | failures | error |
|---|---|---|---|
| absent | 300 | 0 | — |
| idle-polling at 10ms | 6000 | 10 (~0.17%) | `No child processes (os error 10)` |
| **not sleeping** | 200 | **200 (100%)** | `No child processes (os error 10)` |

Every failure was `ECHILD`, and the reaper's stolen-PID count equalled the failure count exactly — it reaped nothing *but* stolen children.

### Why this bites the SCIP Job and not warm

The loop **skips its 10ms sleep whenever the previous pass reaped something**, so while it drains adopted orphans it is effectively spinning — the 100% row above. The two Pods differ only in *when* they reach the same `IndexTree::ensure`:

- **SCIP**: `pre_anything` hooks run, and `IndexTree::ensure` spawns `git` immediately afterwards — inside the window where the hook process tree is tearing down and the reaper is draining its orphans.
- **warm**: the same call happens after `normalize_mtimes` and the multi-minute cargo phase, tens of minutes later, with the reaper long settled into 10ms idle polling (~0.2%).

The production log's `reaped adopted child pid=37` immediately before the error is the reaper announcing the theft. That line is not evidence *against* the reaper — in the reproduction, the stolen `git` child is reported as exactly such a record, because an unregistered PID is by definition "adopted" to this registry.

**Correcting the leading hypothesis in the report.** The idea that `scip-index` skips worker setup that `warm-graph` performs is wrong, and both observations behind it have a different explanation:

- `environment_config loaded from …` is missing because `run_scip_index_body`'s `Ok(Some(cfg))` arm simply has no `info!` — it loads the config and runs `pre_anything` identically (`main.rs`).
- `normalize_mtimes` is warm-only by design: it exists to align cargo fingerprints before the cargo phase, which the SCIP Job does not run.

Both paths go through the same `run_linux_warm_graph_with_initializer(_, initialize_linux_warm_lifecycle, …)`, the same `volume_contract::enforce_at_startup`, the same `bootstrap_warm_database`, and reach a byte-identical `IndexTree::ensure(project_id, &project_root)`. The difference is timing, not setup.

## The fix

**1. The reaper declines PIDs an in-process waiter already owns.** New `djinn_core::child_ownership`: `djinn-git` claims each PID across (`fork` + register) under a shared gate; the reaper takes that gate exclusively for one pass, peeks with `waitid(P_ALL, …, WNOWAIT)`, and refuses to consume a claimed PID. Adopted orphans are still collected — that is the whole reason the loop exists — and once `close_admission()` has run the reaper drains everything, so shutdown cannot stall behind a claim.

The same claim is applied to the one other in-process waiter that spawns `tokio::process` children directly, `lifecycle::run_pre_task_command`. That is the task-run path rather than this Pod, but it is the same defect: **every** process that has run a graph command has this reaper running (`djinn_graph::process` starts it lazily via `worker_child_reaper`), and a stolen status there records a command that ran fine as failed — with a `failure_policy` of `abort`, ending the task run. The `pre_anything` hooks are already safe: they route through `djinn_graph::process::output_with_timeout`, which registers with the reaper and never calls `Child::wait` itself.

**2. The error path stops destroying evidence.** Two independent defects produced a one-line report:
- `run_git`'s context said `spawn git …`, but `run_git_command_in` returns `Err` on a non-zero exit too. Now `git <args> in <cwd>`.
- Both callers rendered the failure with `anyhow!("…: {e}")` / `format!("…: {e}")`, which prints only the outermost message and **drops the source** — so the `GitError` carrying exit code, stdout and stderr never reached the log. Now `.context(…)` / `{e:#}`.

**3. A second, unrelated defect in the same Job.** It projected its deadline as `DJINN_SCIP_JOB_DEADLINE_SECONDS`, which **no code reads**. `djinn_graph::scip_indexer::budget` reads `DJINN_WARM_JOB_DEADLINE_SECONDS`; with the key unread the budget falls back to its unenclosed **4h** ceiling while the kubelet kills the Pod at `scip_job_timeout_seconds` (**~1.96h**) — an observable `timed_out` indexer status turned into an unexplained SIGKILL with no artifacts written. This would have bitten the *next* run even with the git bug fixed.

**4. `target/test-tmp` on a production path.** Both indexer call sites (SCIP *and* warm — the SCIP one was copied from warm) built scratch as `current_dir()?/target/test-tmp`: the workspace's *test* scratch convention, resolved against the process CWD, which in both Pods landed inside the very repository being indexed. Replaced by one helper rooted at the process temp dir.

## Tests

`crates/djinn-graph/tests/child_reaper_ownership.rs` — its own binary, since the reaper is a process-wide consumer. Asserts the side effect, both directions:

- an **owned** child is left alone and **its owner's `wait()` succeeds**;
- an **unowned** child is still collected, and its owner's `wait()` **fails** — without which the first assertion would also pass against a reaper that had stopped reaping entirely.

**Verified by neutralization.** With the skip removed (`if false && …`) the test fails with:

```
the reaper collected pid 2567808 out from under its owner — this is the ECHILD bug:
the owner's next wait will report "No child processes" for a subprocess that ran fine
```

Also added: `index_tree::a_failing_git_command_surfaces_its_exit_code_and_stderr` (asserts `exit 128` and git's stderr reach the rendered error, and that the word "spawn" is gone), and `scip_job::scip_deadline_is_projected_under_the_key_the_indexer_budget_reads`.

`cargo fmt --all -- --check` clean; clippy clean on `djinn-core`, `djinn-git`, `djinn-graph`, `djinn-k8s`, `djinn-agent-worker`. `-p djinn-graph` 684 pass, `-p djinn-k8s` 319 pass, `-p djinn-git` 38 pass.

The 8 failures in a *full* `-p djinn-agent-worker` run (`warm_build_lease` ×6, `lease_adapter_conformance`, one `lifecycle` DB fixture) **reproduce identically on unmodified `origin/main@5eb4ba0ba`** and pass in isolation — a pre-existing shared-test-DB collision, not this change. The particular `lifecycle::tests::nondjinn_*` variant that fails alternates between runs, which is the signature.

## Constraints held

Asserted by existing tests that still pass: the Job stays leaseless (`scip_job_takes_no_build_lease_surface`), keeps `djinn.io/capacity-reserved=true` (`scip_pod_is_labelled_capacity_reserved`), and its 1000m request stays under the recomputed 2200m 8ixk ceiling (`scip_cpu_request_stays_inside_the_8ixk_protected_budget`). `run_scip_index_command` still touches no `repo_graph_cache` / `repo_graph_generation` / `repo_graph_current`. The scheduler's cadence and quiescence gates are untouched.

## What I could not verify

**I have no cluster, so nothing here is confirmed against the real failure.** Specifically:

- I proved the mechanism *can* produce this exact error and measured its rate, but I **cannot prove it produced this one** — the original error text was destroyed by defect 2, which is precisely why that fix comes first. A different cause (a genuine non-zero `git` exit, a signal) would have produced the same log line.
- The "why SCIP and not warm" argument rests on the reaper being in its non-sleeping state during the `pre_anything` teardown window. I demonstrated 100% theft in that state; I did **not** instrument the production Pod to confirm it was in that state at that instant.
- The `waitid(WNOWAIT)` peek can head-of-line block on a claimed PID until its owner collects it (microseconds in the reproduction). Not observed as a problem; not proven at production scale.

**The real proof is the next production run.** If the SCIP Job still fails, the log will now carry git's exit code and stderr, and that will say whether this diagnosis was right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
