### PR TITLE
fix(scip): serialise the SCIP and warm indexers across Pods

### DIFF
--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -3741,9 +3741,18 @@ async fn run_scip_index_body(project_id: &str) -> Result<()> {
         ),
     }
 
-    djinn_graph::canonical_graph::run_scip_index_command(&ctx, project_id)
+    let outcome = djinn_graph::canonical_graph::run_scip_index_command(&ctx, project_id)
         .await
-        .with_context(|| format!("run_scip_index_command({project_id})"))
+        .with_context(|| format!("run_scip_index_command({project_id})"))?;
+    // A skip is a success: the Job publishes nothing either way, and exiting 0
+    // lets the scheduler's retained-Job ledger record this revision as covered
+    // — which it is, by whichever Pod holds the claim.
+    info!(
+        project_id,
+        outcome = outcome.reason(),
+        "scip-index command finished"
+    );
+    Ok(())
 }
 
 async fn run_warm_graph(project_id: &str) -> Result<()> {

--- a/server/crates/djinn-graph/src/canonical_graph.rs
+++ b/server/crates/djinn-graph/src/canonical_graph.rs
@@ -677,6 +677,36 @@ pub async fn run_warm_graph_command<C: WarmContext>(
     Ok(())
 }
 
+/// What one [`run_scip_index_command`] invocation actually did.
+///
+/// Returned rather than logged so the skip is **observable**: a test can assert
+/// that the standalone Job declined to duplicate an in-flight index without
+/// having to infer it from the absence of a side effect, and a caller that
+/// stopped consulting the cross-Pod claim could no longer produce
+/// [`Self::SkippedConcurrentIndex`] at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScipIndexOutcome {
+    /// The indexers ran; `artifacts` semantic artifacts are now in the shared
+    /// content-addressed cache.
+    Indexed { artifacts: usize },
+    /// Another live process holds the semantic-index claim for this exact tree,
+    /// so this run did nothing. Nothing was published either way — this Job
+    /// never touches `repo_graph_cache`, `repo_graph_generation` or
+    /// `repo_graph_current`.
+    SkippedConcurrentIndex { holder: String },
+}
+
+impl ScipIndexOutcome {
+    /// Closed-enum label, safe for logs and metrics.
+    #[must_use]
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::Indexed { .. } => "indexed",
+            Self::SkippedConcurrentIndex { .. } => "skipped_concurrent_index",
+        }
+    }
+}
+
 /// Scratch directory for one indexer run's raw `.scip` output.
 ///
 /// The durable product of an indexer run is the content-addressed SCIP cache
@@ -716,9 +746,20 @@ fn indexer_output_tempdir(prefix: &str) -> std::io::Result<tempfile::TempDir> {
 /// for the warm Job's `execute_plan_with_cache` even though the two Pods cloned
 /// to different absolute paths.
 ///
-/// Consequently no change to [`ensure_canonical_graph`] is required, and none
-/// is made: the warm pipeline still runs the indexers, it just finds them
-/// already computed.
+/// The warm pipeline still runs the indexers; it just finds them already
+/// computed.
+///
+/// # Why the two Pods have to agree before either starts
+///
+/// "Already computed" only holds if this Job **finished** before the warm
+/// started. Nothing made that true: the `indexer_lock` below is an in-process
+/// mutex and the two runs are separate Pods, so on 2026-07-28 they indexed the
+/// same workspace at the same commit concurrently, at 10.2 GB and 9.5 GB RSS.
+/// [`crate::semantic_index_claim`] is the cross-Pod exclusion that closes that
+/// gap: an advisory `flock` on the shared `/cache` PVC keyed by
+/// `(project, commit)`. This Job skips when the claim is held — it publishes
+/// nothing, so skipping is free — and the warm path instead waits a bounded
+/// time and then indexes regardless.
 ///
 /// # Degradation
 ///
@@ -737,7 +778,7 @@ fn indexer_output_tempdir(prefix: &str) -> std::io::Result<tempfile::TempDir> {
 pub async fn run_scip_index_command<C: WarmContext>(
     ctx: &C,
     project_id: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ScipIndexOutcome> {
     use djinn_db::ProjectRepository;
 
     let repo = ProjectRepository::new(ctx.db().clone(), ctx.event_bus());
@@ -766,9 +807,61 @@ pub async fn run_scip_index_command<C: WarmContext>(
     let _ = handle.reset_to_origin_main().await;
     let commit_sha = handle.commit_sha().to_string();
 
-    // Serialize against any in-process indexer fan-out, matching the warm path.
+    // Serialize against any in-process indexer fan-out. This is an *in-process*
+    // mutex and it does nothing about the other Pod: the cross-Pod exclusion is
+    // the claim taken below.
     let indexer_lock = ctx.indexer_lock();
     let _guard = indexer_lock.lock().await;
+
+    // --- Cross-Pod exclusion -------------------------------------------------
+    //
+    // This Job and the warm Job are separate Pods, so `indexer_lock` cannot
+    // serialise them; on 2026-07-28 both ran `rust-analyzer scip` over the same
+    // workspace at the same commit, peaking at 10.2 GB and 9.5 GB RSS at once.
+    // The claim is an advisory `flock` on the shared `/cache` PVC keyed by the
+    // same tree the artifact cache is keyed by — see
+    // [`crate::semantic_index_claim`].
+    //
+    // This Job may SKIP on contention, and the warm path may not, because this
+    // Job publishes nothing: it never touches `repo_graph_cache`,
+    // `repo_graph_generation` or `repo_graph_current`, so declining to run
+    // cannot move the served graph. The holder is indexing the identical tree
+    // into the identical content-addressed cache, so its artifacts are the ones
+    // this run would have produced.
+    //
+    // Exiting 0 (rather than failing) is deliberate: the scheduler's ledger is
+    // the retained succeeded-Job set, so a skip records this revision as
+    // covered — which it is, by the holder. If the holder's run fails, the warm
+    // path re-indexes inline exactly as it does today.
+    let cache_store = crate::scip_indexer::cache::ScipCacheStore::from_environment();
+    let claim =
+        crate::semantic_index_claim::try_claim(cache_store.cache_root(), project_id, &commit_sha);
+    let _claim = match claim {
+        crate::semantic_index_claim::ClaimOutcome::HeldByAnother { holder } => {
+            tracing::info!(
+                project_id,
+                commit_sha,
+                holder = %holder,
+                "run_scip_index_command: another process is already indexing this \
+                 exact tree into the shared SCIP cache; skipping rather than \
+                 running a duplicate index. No graph state is touched either way."
+            );
+            return Ok(ScipIndexOutcome::SkippedConcurrentIndex { holder });
+        }
+        crate::semantic_index_claim::ClaimOutcome::Unavailable { reason } => {
+            // Fail OPEN. An unusable coordination surface must never be read as
+            // "someone else has it" — that would silently stop indexing.
+            tracing::warn!(
+                project_id,
+                commit_sha,
+                reason = %reason,
+                "run_scip_index_command: cross-Pod claim unavailable; indexing \
+                 anyway (duplicate work is possible, a missing index is not)"
+            );
+            None
+        }
+        crate::semantic_index_claim::ClaimOutcome::Held(guard) => Some(guard),
+    };
 
     let output_temp =
         indexer_output_tempdir("djinn-scip-index-").context("create scip-index tempdir")?;
@@ -806,7 +899,9 @@ pub async fn run_scip_index_command<C: WarmContext>(
     // `output_temp` drops here: the raw `.scip` files were transient. The
     // durable product is the content-addressed cache the indexers wrote
     // through, which is exactly what the warm Job reads back.
-    Ok(())
+    Ok(ScipIndexOutcome::Indexed {
+        artifacts: run.artifacts.len(),
+    })
 }
 
 pub async fn ensure_canonical_graph<C: WarmContext>(
@@ -946,12 +1041,49 @@ pub async fn ensure_canonical_graph<C: WarmContext>(
         }
     }
 
+    let sentinel_cache_root = crate::scip_indexer::cache::ScipCacheStore::from_environment();
+
+    // --- Cross-Pod exclusion (semantic_index_claim) ---
+    //
+    // `indexer_lock` above is in-process only. The standalone SCIP Job runs the
+    // same `rust-analyzer scip` fan-out over the same workspace in a DIFFERENT
+    // Pod, so nothing in this process can serialise the two — and on 2026-07-28
+    // nothing did: both indexed the same commit concurrently at ~10 GB RSS
+    // each, which is precisely the duplicate the Job split exists to avoid.
+    //
+    // Taken BEFORE the sentinel recovery below, not after: recovery sweeps
+    // orphaned `.tmp` files out of the shared cache root, which would be
+    // another Pod's in-flight staging if one is mid-write.
+    //
+    // The warm path may never skip — it is the only producer of the served
+    // graph. So on contention it WAITS: when the holder finishes, this run's
+    // own fan-out finds a content-addressed cache hit for every workspace at
+    // this tree, which is the reuse the split was supposed to deliver. If the
+    // budget expires, or coordination is unavailable at all, it indexes inline
+    // exactly as it did before this existed.
+    let index_claim = crate::semantic_index_claim::claim_waiting(
+        sentinel_cache_root.cache_root(),
+        project_id,
+        &commit_sha,
+        crate::semantic_index_claim::wait_budget_from_env(),
+    )
+    .await;
+    if let crate::semantic_index_claim::ClaimOutcome::Unavailable { reason } = &index_claim {
+        tracing::warn!(
+            project_id,
+            commit_sha = %commit_sha,
+            reason = %reason,
+            "ensure_canonical_graph: cross-Pod index claim unavailable; \
+             proceeding to index (fail open)"
+        );
+    }
+    let index_claim = index_claim.into_guard();
+
     // --- Crash-sentinel contract (warm_sentinel) ---
     // Before entering the file-based cache-mutating section, check whether a
     // previous warm run crashed mid-mutation. If so, force a full rebuild
     // (skip parse cache reuse), clean up orphaned tmp artifacts, and log a
     // clear recovery message. See `warm_sentinel` module-level docs.
-    let sentinel_cache_root = crate::scip_indexer::cache::ScipCacheStore::from_environment();
     let force_full_rebuild =
         crate::warm_sentinel::observe_and_recover(sentinel_cache_root.cache_root());
     if force_full_rebuild {
@@ -1010,6 +1142,12 @@ pub async fn ensure_canonical_graph<C: WarmContext>(
 
     // Record this run's elapsed timings for the next warm's adaptive budget.
     persist_indexer_timings_best_effort(ctx, project_id, &run.timings).await;
+
+    // The claim covers the indexer fan-out only. Everything after this point
+    // (parse, graph build, publication) contends for nothing the SCIP Job
+    // touches, so holding it longer would just make a waiting Job wait for
+    // work that cannot help it.
+    drop(index_claim);
 
     let output_dir_for_blocking = output_dir.clone();
     let artifacts = run.artifacts;
@@ -4593,6 +4731,255 @@ edition = "2024"
         // --- Parity gate: cold and warm blobs must match ---
         crate::graph_parity::assert_graph_artifact_blob_parity(&cold_blob, &warm_blob)
             .expect("incremental == full parity violation: cold and warm blobs must match");
+    }
+
+    /// A git project with the minimum shape the RustAnalyzer indexer's
+    /// workspace discovery accepts, so the fake indexer actually runs.
+    async fn make_rust_project(tmp: &std::path::Path) -> std::path::PathBuf {
+        let project_root = make_project(tmp).await;
+        tokio::fs::write(
+            project_root.join("Cargo.toml"),
+            "[package]\nname = \"claim_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n[workspace]\n",
+        )
+        .await
+        .expect("write Cargo.toml");
+        tokio::fs::create_dir_all(project_root.join("src"))
+            .await
+            .expect("create src dir");
+        tokio::fs::write(
+            project_root.join("src/lib.rs"),
+            "pub fn answer() -> u32 { 42 }\n",
+        )
+        .await
+        .expect("write src/lib.rs");
+        for args in [
+            vec!["add".to_string(), "-A".to_string()],
+            vec![
+                "commit".to_string(),
+                "-q".to_string(),
+                "-m".to_string(),
+                "rust fixture".to_string(),
+            ],
+        ] {
+            let out = djinn_git::run_git_command_in(&project_root, args)
+                .await
+                .expect("git");
+            assert_eq!(out.code, 0, "git fixture step failed: {out:?}");
+        }
+        project_root
+    }
+
+    /// **The standalone SCIP Job must not duplicate an index another Pod is
+    /// already running.**
+    ///
+    /// This is the production gap, exercised through the production entry
+    /// point: `run_scip_index_command` takes `ctx.indexer_lock()`, an
+    /// *in-process* mutex, while the warm run it collides with lives in another
+    /// Pod. On 2026-07-28 the two ran `rust-analyzer scip` over the same
+    /// workspace at the same commit simultaneously, at 10.2 GB and 9.5 GB RSS.
+    ///
+    /// Both halves are asserted, because "it skipped" and "it can still index"
+    /// are different claims: a `run_scip_index_command` whose body did nothing
+    /// at all would satisfy the first on its own.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn the_scip_job_declines_to_duplicate_an_index_another_pod_is_running() {
+        let _env_lock = lock_pipeline_env().await;
+        let tmp = workspace_tempdir("scip-claim-skip-");
+        let project_root = make_rust_project(tmp.path()).await;
+
+        let (fake_bin, fixture_path) = write_fake_rust_analyzer(tmp.path());
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let joined_path =
+            std::env::join_paths(std::iter::once(fake_bin).chain(std::env::split_paths(&path)))
+                .expect("join PATH");
+        let _path_guard = EnvVarGuard::set("PATH", joined_path);
+        let _fixture_guard = EnvVarGuard::set("DJINN_TEST_SCIP_FIXTURE", &fixture_path);
+
+        let cache_root = tmp.path().join("scip-cache");
+        let _cache_guard = EnvVarGuard::set("DJINN_SCIP_CACHE_DIR", &cache_root);
+        let _root_guard = EnvVarGuard::set("DJINN_PROJECT_ROOT", &project_root);
+
+        let db = create_test_db();
+        let ctx = TestWarmContext::new(db.clone());
+        let proj_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+        let project = proj_repo
+            .create("test-scip-claim", "test", "test-scip-claim")
+            .await
+            .expect("create project");
+        let commit_sha = djinn_git::head_commit_sha(&project_root)
+            .await
+            .expect("resolve HEAD commit");
+
+        // Stand in for the warm Pod: hold the cross-Pod claim for this exact
+        // tree. Nothing in this process shares state with the command below
+        // except the shared cache directory — which is the point.
+        let holder = crate::semantic_index_claim::try_claim(&cache_root, &project.id, &commit_sha);
+        assert!(
+            matches!(holder, crate::semantic_index_claim::ClaimOutcome::Held(_)),
+            "test setup failed to take the claim: {holder:?}"
+        );
+
+        let outcome = run_scip_index_command(&ctx, &project.id)
+            .await
+            .expect("scip-index command");
+        assert!(
+            matches!(outcome, ScipIndexOutcome::SkippedConcurrentIndex { .. }),
+            "the SCIP Job must decline while another process holds this tree's \
+             claim, got {outcome:?}"
+        );
+        // A skip must remain invisible to the served graph.
+        let cache_repo = RepoGraphCacheRepository::new(db.clone());
+        assert!(
+            cache_repo
+                .get(&project.id, &commit_sha)
+                .await
+                .expect("query graph cache")
+                .is_none(),
+            "the SCIP Job must never write repo_graph_cache — skipped or not"
+        );
+
+        // Release, and the very same call indexes. Without this the assertion
+        // above would also pass for a command that never indexes anything.
+        drop(holder);
+        let outcome = run_scip_index_command(&ctx, &project.id)
+            .await
+            .expect("scip-index command");
+        match outcome {
+            ScipIndexOutcome::Indexed { artifacts } => assert!(
+                artifacts > 0,
+                "an uncontended run must produce artifacts for the shared cache"
+            ),
+            other => panic!("uncontended run must index, got {other:?}"),
+        }
+        assert!(
+            cache_repo
+                .get(&project.id, &commit_sha)
+                .await
+                .expect("query graph cache")
+                .is_none(),
+            "indexing must still not publish a graph — that is the warm path's job"
+        );
+    }
+
+    /// **The warm path takes the claim, and never skips because of it.**
+    ///
+    /// Two properties in one run, because they constrain each other:
+    ///
+    /// 1. The warm path really participates in the cross-Pod protocol — proved
+    ///    by the claim file it can only have created by taking the claim, and
+    ///    by that claim being free again afterwards (a warm that died holding
+    ///    it would still free it; a warm that never took it would leave no
+    ///    file).
+    /// 2. Contention can never stop the warm from publishing. The warm is the
+    ///    only producer of the served graph, so the degradation for "someone
+    ///    else is indexing" must be a bounded wait and then an inline index —
+    ///    never a skip, and never a stale or empty publication.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn the_warm_path_takes_the_claim_and_publishes_even_when_it_cannot_get_it() {
+        let _env_lock = lock_pipeline_env().await;
+        let tmp = workspace_tempdir("warm-claim-");
+        let project_root = make_rust_project(tmp.path()).await;
+
+        let (fake_bin, fixture_path) = write_fake_rust_analyzer(tmp.path());
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let joined_path =
+            std::env::join_paths(std::iter::once(fake_bin).chain(std::env::split_paths(&path)))
+                .expect("join PATH");
+        let _path_guard = EnvVarGuard::set("PATH", joined_path);
+        let _fixture_guard = EnvVarGuard::set("DJINN_TEST_SCIP_FIXTURE", &fixture_path);
+
+        let cache_root = tmp.path().join("scip-cache");
+        let _cache_guard = EnvVarGuard::set("DJINN_SCIP_CACHE_DIR", &cache_root);
+        // Zero budget: the waiting behaviour itself is covered by
+        // `semantic_index_claim`'s own tests; what matters here is that a warm
+        // which cannot get the claim still indexes and still publishes.
+        let _wait_guard = EnvVarGuard::set(crate::semantic_index_claim::WAIT_ENV, "0");
+
+        let db = create_test_db();
+        let ctx = TestWarmContext::new(db.clone());
+        let proj_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+        let project = proj_repo
+            .create("test-warm-claim", "test", "test-warm-claim")
+            .await
+            .expect("create project");
+        let cache_repo = RepoGraphCacheRepository::new(db.clone());
+        let commit_sha = djinn_git::head_commit_sha(&project_root)
+            .await
+            .expect("resolve HEAD commit");
+        let claim_file =
+            crate::semantic_index_claim::claim_path(&cache_root, &project.id, &commit_sha);
+
+        clear_test_caches().await;
+        ensure_canonical_graph(
+            &ctx,
+            &project.id,
+            &project_root,
+            ArchitectWarmToken::for_tests(),
+        )
+        .await
+        .expect("uncontended warm");
+
+        assert!(
+            claim_file.exists(),
+            "the warm path did not take the cross-Pod claim at all — {} was \
+             never created, so nothing serialises it against the SCIP Job",
+            claim_file.display(),
+        );
+        let reclaimed =
+            crate::semantic_index_claim::try_claim(&cache_root, &project.id, &commit_sha);
+        assert!(
+            matches!(
+                reclaimed,
+                crate::semantic_index_claim::ClaimOutcome::Held(_)
+            ),
+            "the warm path must release its claim when its indexer phase ends, \
+             got {reclaimed:?}"
+        );
+        assert!(
+            cache_repo
+                .get(&project.id, &commit_sha)
+                .await
+                .expect("query graph cache")
+                .is_some(),
+            "the uncontended warm must publish a graph"
+        );
+
+        // Now hold the claim (as another Pod would) and force a rebuild. The
+        // warm must publish anyway.
+        let _holder = reclaimed;
+        clear_test_caches().await;
+        cache_repo
+            .upsert(RepoGraphCacheInsert {
+                project_id: &project.id,
+                commit_sha: &commit_sha,
+                graph_blob: b"poisoned blob that forces a rebuild",
+            })
+            .await
+            .expect("poison cache row");
+        clear_test_caches().await;
+
+        ensure_canonical_graph(
+            &ctx,
+            &project.id,
+            &project_root,
+            ArchitectWarmToken::for_tests(),
+        )
+        .await
+        .expect("contended warm must still succeed");
+
+        let republished = cache_repo
+            .get(&project.id, &commit_sha)
+            .await
+            .expect("query graph cache")
+            .expect("contended warm must still publish")
+            .graph_blob;
+        assert_ne!(
+            republished, b"poisoned blob that forces a rebuild",
+            "a warm that could not take the claim must still rebuild and \
+             republish — contention may cost duplicated work, never a stale graph"
+        );
     }
 
     fn write_fake_rust_analyzer(tmp: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {

--- a/server/crates/djinn-graph/src/lib.rs
+++ b/server/crates/djinn-graph/src/lib.rs
@@ -42,6 +42,7 @@ pub mod repo_graph;
 pub mod route_extraction;
 pub mod scip_indexer;
 pub mod scip_parser;
+pub mod semantic_index_claim;
 pub mod warm_sentinel;
 pub mod ykcg_parity;
 

--- a/server/crates/djinn-graph/src/semantic_index_claim.rs
+++ b/server/crates/djinn-graph/src/semantic_index_claim.rs
@@ -1,0 +1,726 @@
+//! Cross-Pod mutual exclusion for the semantic (SCIP) index phase.
+//!
+//! # The gap this closes
+//!
+//! `run_scip_index_command` and `ensure_canonical_graph` both take
+//! `WarmContext::indexer_lock`, a `tokio::sync::Mutex` living in the process's
+//! own address space. Since the standalone SCIP index became its own
+//! Kubernetes Job (PR #2697) the two indexer fan-outs run in **different Pods,
+//! in different processes**, so that mutex serialises nothing between them.
+//!
+//! It was observed doing exactly nothing on 2026-07-28: the warm Job and the
+//! SCIP Job ran `rust-analyzer scip` concurrently on the same node, against the
+//! same workspace at the same commit, peaking at 10.2 GB and 9.5 GB RSS
+//! simultaneously. Both completed, so the cost was waste rather than an outage
+//! — but the whole point of the split is that the warm Job *skips* the index
+//! because the SCIP Job already filled the shared cache, and instead the node
+//! paid for the same index twice.
+//!
+//! # What this is
+//!
+//! An advisory `flock(2)` on a file in the **shared `/cache` PVC**, keyed by
+//! `(project_id, commit_sha)` — the tree identity that decides whether one
+//! run's artifacts can serve the other, since the SCIP artifact cache key folds
+//! in `source_hashes` over that same tree.
+//!
+//! The lock file lives under the SCIP cache root
+//! (`$XDG_CACHE_HOME/djinn/scip-indexer`, i.e. `/cache/xdg/<project>/…` in every
+//! djinn build Pod), which is deliberate: **the mutex lives on the same
+//! filesystem as the resource it protects.** Two Pods that cannot see each
+//! other's cache root have no shared cache to duplicate work into, and two Pods
+//! that can see it can also see each other's lock.
+//!
+//! # Why a file lock and not a Postgres lease row
+//!
+//! Because of how it is released. This codebase has repeatedly been bitten by
+//! coordination state that outlives its holder — occupancy rows that no reaper
+//! reclaims, wedging the thing they were meant to protect. An advisory `flock`
+//! has no reclamation problem to get wrong: the kernel drops it when the file
+//! description closes, which happens on `close`, on `exit`, and on `SIGKILL`
+//! alike. A crashed or OOM-killed indexer Pod releases its claim *immediately*,
+//! with no expiry to tune, no heartbeat to miss and no janitor to schedule.
+//! `.warm-locks/<project>.lock` (task `t6g0`) already uses this primitive for
+//! the sibling problem of two warm Pods sharing one cargo base.
+//!
+//! A Postgres session advisory lock was the alternative. It is node-independent,
+//! which this is not (see *Limitations*), but it would have to be held on a
+//! dedicated connection for the ~59 minutes of an index, and a Pod that dies
+//! with a half-open TCP connection keeps its lock until the server's keepalives
+//! notice — which is precisely the "stale holder" failure mode being avoided.
+//!
+//! # Degradation is fail-open, in both directions
+//!
+//! * [`ClaimOutcome::Unavailable`] — no cache root, unwritable directory,
+//!   `flock` unsupported by the filesystem, anything else. **Index anyway.**
+//!   That is today's behaviour: wasteful when it duplicates, never wrong.
+//! * [`ClaimOutcome::HeldByAnother`] — someone else is indexing this exact
+//!   tree. The standalone SCIP Job may skip (it publishes nothing, so skipping
+//!   cannot degrade the served graph). The warm path may **not** skip; it waits
+//!   a bounded time for the holder to finish — which converts the duplicate
+//!   index into a cache hit — and then proceeds regardless.
+//!
+//! No caller ever blocks indefinitely: [`claim_waiting`] takes a wait budget and
+//! returns when it expires, whether or not the claim was obtained.
+//!
+//! # Limitations, stated plainly
+//!
+//! * `flock` is enforced per kernel. On the single-node production VPS, where
+//!   both Pods run against the same local-path PVC, that is exactly the scope
+//!   needed. On a multi-node cluster with a network filesystem whose `flock`
+//!   is not cluster-coherent, two Pods on different nodes could both believe
+//!   they hold the claim — degrading to today's duplicate-index behaviour, not
+//!   to anything unsafe.
+//! * The claim is keyed on the commit. Two indexers running at *different*
+//!   commits do not contend and can still overlap in memory. Serialising those
+//!   would mean making one of them wait for work that cannot help it; the
+//!   scheduler-side gate (`djinn_k8s::scip_schedule`, which declines to dispatch
+//!   while a warm Job is in flight) is what reduces that case.
+//! * The identity written into the lock file is **diagnostic only**. Nothing
+//!   reads it to decide anything, because a stale identity record must never be
+//!   able to block or authorise an index. The `flock` is the whole protocol.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use djinn_core::clock::{Clock, SystemClock};
+
+/// Directory under the SCIP cache root holding one lock file per claimed tree.
+///
+/// Dotted so the cache retention sweep — which identifies cache entries by the
+/// presence of a `manifest.json` — never mistakes it for an evictable entry.
+pub const CLAIM_DIR: &str = ".index-claims";
+
+/// How long the warm path waits for another Pod's in-flight index of the same
+/// tree before giving up and indexing inline itself.
+///
+/// Bounded by the warm Job's own deadline, and by the fact that the wait can be
+/// a total loss. `warm_job_timeout_seconds` is 7200s and one complete measured
+/// warm is 5442s end to end, so a warm that waits the full budget, gains
+/// nothing and then does every phase itself must still fit:
+/// `900 + 5442 = 6342 <= 7200`, with ~14 minutes of margin.
+/// `the_claim_wait_budget_fits_inside_the_warm_job_deadline` in
+/// `djinn_server::scip_index_watcher` proves that arithmetic against the real
+/// config, from the crate that can see both constants.
+///
+/// When the wait *does* pay off it is strictly cheaper than the alternative:
+/// waiting costs one idle process, while the duplicate it avoids costs a core
+/// and ~10 GB of RSS for the same wall-clock window.
+pub const DEFAULT_WAIT_SECONDS: u64 = 900;
+
+/// Operator override for [`DEFAULT_WAIT_SECONDS`]. `0` disables waiting: the
+/// warm path then behaves exactly as it did before this module existed.
+pub const WAIT_ENV: &str = "DJINN_SCIP_CLAIM_WAIT_SECONDS";
+
+/// Poll cadence while waiting for a claim.
+///
+/// Polling rather than a blocking `flock(LOCK_EX)`: a blocking acquisition
+/// cannot be bounded without a signal, and an unbounded wait on a lock held by
+/// another Pod is the stall this module is required not to introduce.
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// An exclusive advisory claim on one `(project, commit)` semantic index.
+///
+/// Dropping it closes the descriptor, which releases the lock. Process death —
+/// including `SIGKILL` and an OOM kill — has the same kernel-guaranteed effect,
+/// which is the entire reason this is an `flock` and not a row.
+#[derive(Debug)]
+pub struct SemanticIndexClaim {
+    file: File,
+    path: PathBuf,
+}
+
+impl SemanticIndexClaim {
+    /// Path of the lock file backing this claim.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for SemanticIndexClaim {
+    fn drop(&mut self) {
+        // Explicit unlock first so the release is observable even if the
+        // descriptor somehow outlives this value; closing it releases the lock
+        // regardless.
+        let _ = flock(&self.file, libc::LOCK_UN);
+    }
+}
+
+/// Result of trying to claim one tree's semantic index.
+#[derive(Debug)]
+pub enum ClaimOutcome {
+    /// This process holds the claim until the guard is dropped.
+    Held(SemanticIndexClaim),
+    /// Another live process holds it. `holder` is a best-effort, purely
+    /// diagnostic description of who — never trusted for a decision.
+    HeldByAnother { holder: String },
+    /// Coordination could not be established. Callers must fail open and index
+    /// anyway; `reason` says what went wrong.
+    Unavailable { reason: String },
+}
+
+impl ClaimOutcome {
+    /// Closed-enum label, safe for logs and metrics.
+    #[must_use]
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::Held(_) => "held",
+            Self::HeldByAnother { .. } => "held_by_another",
+            Self::Unavailable { .. } => "unavailable",
+        }
+    }
+
+    /// True only when another live process demonstrably holds this exact tree's
+    /// claim. This is the ONLY outcome that authorises a caller to skip
+    /// indexing, and only for callers that publish nothing.
+    #[must_use]
+    pub fn is_held_by_another(&self) -> bool {
+        matches!(self, Self::HeldByAnother { .. })
+    }
+
+    /// Take the guard, if this outcome carries one, so the caller can bind it
+    /// for the duration of its indexer run.
+    #[must_use]
+    pub fn into_guard(self) -> Option<SemanticIndexClaim> {
+        match self {
+            Self::Held(claim) => Some(claim),
+            _ => None,
+        }
+    }
+}
+
+/// Wait budget for [`claim_waiting`], from [`WAIT_ENV`] or the default.
+#[must_use]
+pub fn wait_budget_from_env() -> Duration {
+    wait_budget_from(std::env::var(WAIT_ENV).ok().as_deref())
+}
+
+fn wait_budget_from(raw: Option<&str>) -> Duration {
+    match raw.map(str::trim).filter(|v| !v.is_empty()) {
+        Some(value) => match value.parse::<u64>() {
+            Ok(seconds) => Duration::from_secs(seconds),
+            Err(_) => Duration::from_secs(DEFAULT_WAIT_SECONDS),
+        },
+        None => Duration::from_secs(DEFAULT_WAIT_SECONDS),
+    }
+}
+
+/// Lock-file path for one `(project, commit)` tree under `cache_root`.
+///
+/// The commit is the bulk of the identity; the project is included because a
+/// development deployment can point several projects at one `XDG_CACHE_HOME`.
+/// A digest of the raw project id is appended so two project ids that sanitize
+/// to the same string still get different files.
+#[must_use]
+pub fn claim_path(cache_root: &Path, project_id: &str, commit_sha: &str) -> PathBuf {
+    use sha2::{Digest, Sha256};
+    let digest = hex::encode(Sha256::digest(project_id.as_bytes()));
+    cache_root.join(CLAIM_DIR).join(format!(
+        "{}-{}.{}.lock",
+        sanitize(project_id, 48),
+        &digest[..8],
+        sanitize(commit_sha, 40),
+    ))
+}
+
+fn sanitize(value: &str, max_len: usize) -> String {
+    let cleaned: String = value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .take(max_len)
+        .collect();
+    if cleaned.is_empty() {
+        "unnamed".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Try to claim this tree's semantic index without waiting.
+///
+/// Never blocks. Every failure mode that is not "someone else holds it" is
+/// reported as [`ClaimOutcome::Unavailable`], because a caller that cannot
+/// coordinate must still index.
+#[must_use]
+pub fn try_claim(cache_root: &Path, project_id: &str, commit_sha: &str) -> ClaimOutcome {
+    if commit_sha.trim().is_empty() {
+        // Without a tree identity there is nothing to serialise on, and
+        // serialising on the project alone would make two runs at different
+        // commits wait for work that cannot help either of them.
+        return ClaimOutcome::Unavailable {
+            reason: "no commit sha to key the claim on".to_string(),
+        };
+    }
+    let path = claim_path(cache_root, project_id, commit_sha);
+    let Some(dir) = path.parent() else {
+        return ClaimOutcome::Unavailable {
+            reason: format!("claim path {} has no parent", path.display()),
+        };
+    };
+    if let Err(error) = std::fs::create_dir_all(dir) {
+        return ClaimOutcome::Unavailable {
+            reason: format!("create {}: {error}", dir.display()),
+        };
+    }
+    // `truncate(false)`: the file's *content* is diagnostic and must survive
+    // being read by a contender; the lock is the flock, not the bytes.
+    let file = match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(error) => {
+            return ClaimOutcome::Unavailable {
+                reason: format!("open {}: {error}", path.display()),
+            };
+        }
+    };
+    match flock(&file, libc::LOCK_EX | libc::LOCK_NB) {
+        Ok(()) => {
+            let claim = SemanticIndexClaim { file, path };
+            record_holder(&claim, project_id, commit_sha);
+            ClaimOutcome::Held(claim)
+        }
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => ClaimOutcome::HeldByAnother {
+            holder: read_holder(&path),
+        },
+        Err(error) => ClaimOutcome::Unavailable {
+            reason: format!("flock {}: {error}", path.display()),
+        },
+    }
+}
+
+/// Claim this tree's semantic index, waiting up to `wait` for a current holder
+/// to finish.
+///
+/// Returns as soon as the outcome is decided, and **always** returns by `wait`:
+/// a holder that never finishes costs the caller its budget, not its run. A
+/// holder that dies frees the claim within one [`POLL_INTERVAL`], because the
+/// kernel — not a reaper — releases it.
+///
+/// The wait is worth taking only because the holder's product is shared: when
+/// it finishes, the content-addressed SCIP cache holds artifacts for this exact
+/// tree, so the waiter's own indexer fan-out becomes a cache hit per workspace
+/// instead of a second 59-minute index.
+pub async fn claim_waiting(
+    cache_root: &Path,
+    project_id: &str,
+    commit_sha: &str,
+    wait: Duration,
+) -> ClaimOutcome {
+    claim_waiting_with_poll(cache_root, project_id, commit_sha, wait, POLL_INTERVAL).await
+}
+
+/// [`claim_waiting`] with an explicit poll cadence. Exists so the waiting
+/// behaviour can be tested at millisecond scale against the production loop
+/// rather than against a re-implementation of it.
+pub(crate) async fn claim_waiting_with_poll(
+    cache_root: &Path,
+    project_id: &str,
+    commit_sha: &str,
+    wait: Duration,
+    poll: Duration,
+) -> ClaimOutcome {
+    let clock = SystemClock::new();
+    let started = clock.now_instant();
+    let mut outcome = try_claim(cache_root, project_id, commit_sha);
+    if !outcome.is_held_by_another() || wait.is_zero() {
+        return outcome;
+    }
+    tracing::info!(
+        project_id,
+        commit_sha,
+        wait_secs = wait.as_secs(),
+        holder = %holder_of(&outcome),
+        "semantic index claim is held by another process for this exact tree; \
+         waiting rather than running a duplicate index"
+    );
+    loop {
+        let elapsed = started.elapsed();
+        if elapsed >= wait {
+            tracing::warn!(
+                project_id,
+                commit_sha,
+                waited_secs = elapsed.as_secs(),
+                holder = %holder_of(&outcome),
+                "semantic index claim wait budget exhausted; indexing anyway \
+                 (fail open — duplicated work, never a stalled or stale graph)"
+            );
+            return outcome;
+        }
+        let remaining = wait - elapsed;
+        tokio::time::sleep(poll.min(remaining)).await;
+        outcome = try_claim(cache_root, project_id, commit_sha);
+        if !outcome.is_held_by_another() {
+            tracing::info!(
+                project_id,
+                commit_sha,
+                waited_secs = started.elapsed().as_secs(),
+                outcome = outcome.reason(),
+                "semantic index claim wait finished"
+            );
+            return outcome;
+        }
+    }
+}
+
+fn holder_of(outcome: &ClaimOutcome) -> &str {
+    match outcome {
+        ClaimOutcome::HeldByAnother { holder } => holder.as_str(),
+        _ => "",
+    }
+}
+
+/// Write a diagnostic record of who holds the claim. Best effort in every
+/// respect: nothing reads it to make a decision, so a failure here is not worth
+/// surfacing, and a stale record left by a dead holder cannot mislead anyone.
+fn record_holder(claim: &SemanticIndexClaim, project_id: &str, commit_sha: &str) {
+    let record = serde_json::json!({
+        "pid": std::process::id(),
+        "project_id": project_id,
+        "commit_sha": commit_sha,
+        "claimed_at": chrono::Utc::now().to_rfc3339(),
+    })
+    .to_string();
+    // Truncate through the already-open descriptor: reopening could race with a
+    // contender that has just acquired the lock after this process released it.
+    let _ = claim.file.set_len(0);
+    let _ = write_all_at_start(&claim.file, record.as_bytes());
+}
+
+fn write_all_at_start(file: &File, bytes: &[u8]) -> io::Result<()> {
+    use std::io::{Seek, SeekFrom, Write};
+    let mut handle = file;
+    handle.seek(SeekFrom::Start(0))?;
+    handle.write_all(bytes)?;
+    handle.flush()
+}
+
+fn read_holder(path: &Path) -> String {
+    match std::fs::read_to_string(path) {
+        Ok(contents) if !contents.trim().is_empty() => contents.trim().chars().take(300).collect(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn flock(file: &File, operation: libc::c_int) -> io::Result<()> {
+    loop {
+        // SAFETY: `file` owns a valid descriptor for the duration of the call;
+        // flock takes no ownership and requires no aliasing guarantees.
+        let result = unsafe { libc::flock(file.as_raw_fd(), operation) };
+        if result == 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use tempfile::TempDir;
+
+    const PROJECT: &str = "proj-xyz";
+    const COMMIT: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const OTHER_COMMIT: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    fn root() -> TempDir {
+        TempDir::new().expect("cache root")
+    }
+
+    /// **The property the in-process mutex could not provide.**
+    ///
+    /// Two independent acquisitions of the same tree's claim cannot both
+    /// succeed. `flock` is scoped to the open file *description*, so two
+    /// separate `open`s contend even inside one process — which is what makes
+    /// this assertion about the same kernel primitive that separates two Pods.
+    #[test]
+    fn two_claims_on_the_same_tree_cannot_both_be_held() {
+        let root = root();
+        let first = try_claim(root.path(), PROJECT, COMMIT);
+        assert!(
+            matches!(first, ClaimOutcome::Held(_)),
+            "first claim must be granted, got {first:?}"
+        );
+
+        let second = try_claim(root.path(), PROJECT, COMMIT);
+        assert!(
+            second.is_held_by_another(),
+            "a second claim on the same tree must be refused, got {second:?}"
+        );
+        assert!(
+            second.into_guard().is_none(),
+            "a refused claim must carry no guard"
+        );
+
+        // Releasing hands the claim straight to the next caller — without this
+        // the assertion above would also pass for a claim nobody can ever take.
+        drop(first);
+        assert!(matches!(
+            try_claim(root.path(), PROJECT, COMMIT),
+            ClaimOutcome::Held(_)
+        ));
+    }
+
+    /// Different trees are different claims. Serialising them would make one
+    /// run wait for an index whose artifacts cannot serve it — the cache key
+    /// folds in `source_hashes`, so only the same tree helps.
+    #[test]
+    fn different_commits_and_projects_do_not_contend() {
+        let root = root();
+        let held = try_claim(root.path(), PROJECT, COMMIT);
+        assert!(matches!(held, ClaimOutcome::Held(_)));
+        assert!(matches!(
+            try_claim(root.path(), PROJECT, OTHER_COMMIT),
+            ClaimOutcome::Held(_)
+        ));
+        assert!(matches!(
+            try_claim(root.path(), "other-project", COMMIT),
+            ClaimOutcome::Held(_)
+        ));
+        assert_ne!(
+            claim_path(root.path(), PROJECT, COMMIT),
+            claim_path(root.path(), "other-project", COMMIT),
+        );
+    }
+
+    /// **Stale state must not block.** A lock file left behind by a previous
+    /// run — with a dead pid and an ancient timestamp inside it — is not a
+    /// holder. The `flock` is the entire protocol; the recorded identity is
+    /// diagnostic, and nothing may read it to decide anything.
+    #[test]
+    fn a_stale_lock_file_left_by_a_dead_holder_does_not_block() {
+        let root = root();
+        let path = claim_path(root.path(), PROJECT, COMMIT);
+        std::fs::create_dir_all(path.parent().expect("claim dir")).expect("create claim dir");
+        std::fs::write(
+            &path,
+            br#"{"pid":1,"claimed_at":"1999-01-01T00:00:00Z","project_id":"proj-xyz"}"#,
+        )
+        .expect("stale record");
+
+        let outcome = try_claim(root.path(), PROJECT, COMMIT);
+        assert!(
+            matches!(outcome, ClaimOutcome::Held(_)),
+            "a leftover lock FILE is not a held lock: {outcome:?}"
+        );
+        // …and the fresh holder replaced the stale record rather than leaving a
+        // lie on disk for the next reader to log.
+        let recorded = std::fs::read_to_string(&path).expect("read record");
+        assert!(
+            recorded.contains(&format!("\"pid\":{}", std::process::id())),
+            "holder record was not refreshed: {recorded}"
+        );
+        assert!(!recorded.contains("1999-01-01"));
+    }
+
+    /// Coordination that cannot be established must fail **open**: index
+    /// anyway. A caller that treats `Unavailable` as "someone else has it"
+    /// would skip an index it was required to run.
+    #[test]
+    fn unusable_coordination_state_is_unavailable_not_contended() {
+        // A cache root that cannot be created (a regular file where the
+        // directory must go) is the general shape of "coordination is broken".
+        let root = root();
+        let blocked = root.path().join("not-a-dir");
+        std::fs::write(&blocked, b"x").expect("write file");
+        let outcome = try_claim(&blocked, PROJECT, COMMIT);
+        assert!(
+            matches!(outcome, ClaimOutcome::Unavailable { .. }),
+            "unwritable claim directory must be Unavailable, got {outcome:?}"
+        );
+        assert!(
+            !outcome.is_held_by_another(),
+            "Unavailable must never authorise a skip"
+        );
+
+        // An unidentifiable tree is the same class of answer.
+        let no_commit = try_claim(root.path(), PROJECT, "   ");
+        assert!(matches!(no_commit, ClaimOutcome::Unavailable { .. }));
+        assert!(!no_commit.is_held_by_another());
+    }
+
+    /// The waiter returns by its budget even when the holder never finishes,
+    /// and it returns `HeldByAnother` — the caller then indexes anyway. An
+    /// unbounded wait here would be a cross-Pod deadlock.
+    #[tokio::test]
+    async fn a_wait_against_a_holder_that_never_finishes_ends_at_its_budget() {
+        let root = root();
+        let _held = try_claim(root.path(), PROJECT, COMMIT);
+        assert!(matches!(_held, ClaimOutcome::Held(_)));
+
+        let clock = SystemClock::new();
+        let started = clock.now_instant();
+        let outcome = claim_waiting_with_poll(
+            root.path(),
+            PROJECT,
+            COMMIT,
+            Duration::from_millis(120),
+            Duration::from_millis(20),
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            outcome.is_held_by_another(),
+            "the holder never released, so the wait must end contended: {outcome:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "the wait must end at its budget, not at the holder's convenience \
+             (took {elapsed:?})"
+        );
+    }
+
+    /// The wait pays off when the holder finishes: the waiter takes the claim
+    /// rather than starting a duplicate index.
+    #[tokio::test]
+    async fn a_wait_ends_early_when_the_holder_releases() {
+        let root = root();
+        let held = try_claim(root.path(), PROJECT, COMMIT);
+        assert!(matches!(held, ClaimOutcome::Held(_)));
+        let releaser = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            drop(held);
+        });
+
+        let outcome = claim_waiting_with_poll(
+            root.path(),
+            PROJECT,
+            COMMIT,
+            Duration::from_secs(30),
+            Duration::from_millis(20),
+        )
+        .await;
+        releaser.await.expect("releaser");
+        assert!(
+            matches!(outcome, ClaimOutcome::Held(_)),
+            "a released claim must be granted to the waiter: {outcome:?}"
+        );
+    }
+
+    /// A zero budget disables waiting entirely — the pre-existing behaviour,
+    /// available as an operator lever.
+    #[tokio::test]
+    async fn a_zero_wait_budget_does_not_wait() {
+        let root = root();
+        let _held = try_claim(root.path(), PROJECT, COMMIT);
+        let outcome = claim_waiting(root.path(), PROJECT, COMMIT, Duration::ZERO).await;
+        assert!(outcome.is_held_by_another());
+    }
+
+    #[test]
+    fn wait_budget_parses_and_falls_back() {
+        assert_eq!(wait_budget_from(Some("42")), Duration::from_secs(42));
+        assert_eq!(wait_budget_from(Some("0")), Duration::ZERO);
+        assert_eq!(
+            wait_budget_from(Some("nonsense")),
+            Duration::from_secs(DEFAULT_WAIT_SECONDS)
+        );
+        assert_eq!(
+            wait_budget_from(None),
+            Duration::from_secs(DEFAULT_WAIT_SECONDS)
+        );
+    }
+
+    // ---- the crash story, proved with a real process ------------------------
+
+    const ROLE_ENV: &str = "DJINN_CLAIM_CONTRACT_ROLE";
+    const ROOT_ENV: &str = "DJINN_CLAIM_CONTRACT_ROOT";
+
+    /// **A holder that is SIGKILLed must not wedge the index.**
+    ///
+    /// This is the failure mode every expiry-based scheme has to engineer
+    /// around, and the reason this claim is an `flock`: the kernel releases it
+    /// when the process dies. Proved against a real, separately-scheduled
+    /// process — a same-process guard drop would prove only that `Drop` runs,
+    /// which is exactly what a `SIGKILL` denies you.
+    #[test]
+    fn a_holder_killed_mid_index_releases_its_claim_immediately() {
+        let root = root();
+        let mut holder = Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "semantic_index_claim::tests::claim_contract_child",
+                "--exact",
+                "--nocapture",
+            ])
+            .env(ROLE_ENV, "holder")
+            .env(ROOT_ENV, root.path())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn holder");
+
+        wait_for(&root.path().join("holder-acquired"));
+        let contended = try_claim(root.path(), PROJECT, COMMIT);
+        assert!(
+            contended.is_held_by_another(),
+            "the child must really hold the claim before it is killed: {contended:?}"
+        );
+
+        holder.kill().expect("kill holder");
+        holder.wait().expect("reap holder");
+
+        // No unlock ran in the killed process. The kernel released it.
+        let after = try_claim(root.path(), PROJECT, COMMIT);
+        assert!(
+            matches!(after, ClaimOutcome::Held(_)),
+            "a claim held by a SIGKILLed process must be immediately \
+             reclaimable — no expiry, no reaper: {after:?}"
+        );
+    }
+
+    /// Re-exec'd child of the test above. Inert unless [`ROLE_ENV`] is set, so
+    /// it is a no-op in a normal test run.
+    #[test]
+    fn claim_contract_child() {
+        let Ok(role) = std::env::var(ROLE_ENV) else {
+            return;
+        };
+        let root = PathBuf::from(std::env::var(ROOT_ENV).expect("claim root"));
+        let claim = try_claim(&root, PROJECT, COMMIT);
+        assert!(
+            matches!(claim, ClaimOutcome::Held(_)),
+            "child failed to acquire: {claim:?}"
+        );
+        std::fs::write(root.join(format!("{role}-acquired")), b"acquired").expect("marker");
+        // Hold until killed. `std::mem::forget` is deliberate belt-and-braces:
+        // nothing in this process may release the claim, so the parent's
+        // assertion can only be satisfied by the kernel.
+        std::mem::forget(claim);
+        loop {
+            thread::sleep(Duration::from_secs(1));
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)] // test-only spin-wait deadline
+    fn wait_for(path: &Path) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while !path.exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for {}",
+                path.display()
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+}

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -7,6 +7,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::launcher::CgroupLauncherMode;
 
+/// The measured end-to-end cost of one complete production warm Job
+/// (2026-07-27): 5442s — 1798s of cargo and 3644s of graph phase, of which the
+/// SCIP index was 3523s.
+///
+/// Public because it is the floor two independent decisions are checked
+/// against: [`KubernetesConfig::warm_job_timeout_seconds`] must exceed it, and
+/// any time the warm path is allowed to *wait* (see
+/// `djinn_graph::semantic_index_claim::DEFAULT_WAIT_SECONDS`) has to fit in
+/// what is left over, because a wait that does not pay off still has to be
+/// followed by the whole warm.
+pub const MEASURED_FULL_WARM_SECONDS: i64 = 5_442;
+
 /// Configuration for `KubernetesRuntime`.
 ///
 /// Loaded once at djinn-server boot and cloned into the runtime. Fields
@@ -238,6 +250,23 @@ pub struct KubernetesConfig {
     /// case where the artifact is still current when it lands. `0` disables the
     /// gate. See [`crate::scip_schedule::decide`].
     pub scip_quiescence_seconds: u64,
+    /// How long the **warm** Pod waits for another Pod's in-flight semantic
+    /// index of the same tree before indexing inline itself, in seconds.
+    /// Default `900`.
+    ///
+    /// Projected into the warm Job under
+    /// [`crate::warm_job::WARM_SCIP_CLAIM_WAIT_ENV`], which is the key
+    /// `djinn_graph::semantic_index_claim` reads. Rendering it is what makes
+    /// this an operator lever at all: the warm Pod's environment is exactly
+    /// what this manifest puts in it, so a value that is never rendered is a
+    /// value that can never be set.
+    ///
+    /// The bound exists because the wait can be a total loss — the holder may
+    /// outlast it — and the warm still has to run every phase itself
+    /// afterwards, inside the same `activeDeadlineSeconds`. `0` disables
+    /// waiting; the warm then indexes immediately, duplicating the in-flight
+    /// run exactly as it did before the claim existed.
+    pub scip_claim_wait_seconds: u64,
     /// `spec.nodeSelector` applied to both task-run and warm Pods. Empty map
     /// leaves the field unset (any node tolerating the Pod's other constraints
     /// is eligible). Operators typically use this together with `tolerations`
@@ -352,6 +381,11 @@ impl KubernetesConfig {
             // is the only thing that lets it create a Job.
             scip_index_enabled: false,
             scip_quiescence_seconds: crate::scip_job::MEASURED_SCIP_PHASE_SECONDS as u64,
+            // 900s. Must equal `djinn_graph::semantic_index_claim`'s own
+            // default, which applies wherever this manifest is not what builds
+            // the environment; `djinn_server::scip_index_watcher` asserts the
+            // two agree, from the crate that can see both.
+            scip_claim_wait_seconds: 900,
             node_selector: BTreeMap::new(),
             tolerations: Vec::new(),
             // v1 leases enforcement contract. Both fail render validation if set
@@ -408,6 +442,7 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_SCIP_JOB_TIMEOUT_SECONDS` | `scip_job_timeout_seconds` | `7200` (parsed as `i64`) |
     /// | `DJINN_K8S_SCIP_INDEX_ENABLED` | `scip_index_enabled` | `false` — the arming switch |
     /// | `DJINN_K8S_SCIP_QUIESCENCE_SECONDS` | `scip_quiescence_seconds` | `3523` (the measured phase cost; `0` disables) |
+    /// | `DJINN_K8S_SCIP_CLAIM_WAIT_SECONDS` | `scip_claim_wait_seconds` | `900` (warm's bounded wait for an in-flight index of the same tree; `0` disables waiting) |
     /// | `DJINN_K8S_NODE_SELECTOR` | `node_selector` | `{}` (parsed as a JSON object of string→string) |
     /// | `DJINN_K8S_TOLERATIONS` | `tolerations` | `[]` (parsed as a JSON array of k8s `Toleration` objects) |
     /// | `DJINN_K8S_CGROUP_DELEGATION_PROFILE` | `cgroup_delegation_profile` | `cgroup-v2-cpu-only` |
@@ -563,6 +598,16 @@ impl KubernetesConfig {
                     value = %v,
                     error = %e,
                     "DJINN_K8S_SCIP_QUIESCENCE_SECONDS not a valid u64 — keeping default"
+                ),
+            }
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_SCIP_CLAIM_WAIT_SECONDS") {
+            match v.parse::<u64>() {
+                Ok(n) => cfg.scip_claim_wait_seconds = n,
+                Err(e) => tracing::warn!(
+                    value = %v,
+                    error = %e,
+                    "DJINN_K8S_SCIP_CLAIM_WAIT_SECONDS not a valid u64 — keeping default"
                 ),
             }
         }
@@ -731,9 +776,6 @@ mod tests {
     /// The floor is therefore the measured requirement, not the cargo estimate.
     #[test]
     fn warm_job_timeout_default_accommodates_the_whole_warm_job() {
-        /// The measured end-to-end cost of the 2026-07-27 production warm.
-        const MEASURED_FULL_WARM_SECONDS: i64 = 5442;
-
         let cfg = KubernetesConfig::for_testing();
         assert!(
             cfg.warm_job_timeout_seconds >= MEASURED_FULL_WARM_SECONDS,

--- a/server/crates/djinn-k8s/src/scip_schedule.rs
+++ b/server/crates/djinn-k8s/src/scip_schedule.rs
@@ -82,6 +82,11 @@ pub enum ScipIndexDecision {
     SkipInventoryUnavailable,
     /// A non-terminal SCIP Job already exists for this project.
     SkipInFlight,
+    /// A non-terminal **warm** Job already exists for this project. The warm
+    /// Job runs the same `rust-analyzer scip` fan-out inline, so dispatching
+    /// here would put two ~10 GB indexers on one node to compute the same
+    /// artifacts. See the gate's rationale on [`decide`].
+    SkipWarmInFlight,
     /// The last successful index already covers this exact revision. **This is
     /// the change-detection gate** and it is checked before the cadence, so an
     /// unchanged head never dispatches no matter how much time has passed.
@@ -114,6 +119,7 @@ impl ScipIndexDecision {
             Self::SkipUnknownRevision => "unknown_revision",
             Self::SkipInventoryUnavailable => "inventory_unavailable",
             Self::SkipInFlight => "in_flight",
+            Self::SkipWarmInFlight => "warm_in_flight",
             Self::SkipHeadUnchanged { .. } => "head_unchanged",
             Self::SkipHeadNotQuiescent { .. } => "head_not_quiescent",
             Self::SkipCadence { .. } => "cadence",
@@ -126,6 +132,11 @@ impl ScipIndexDecision {
 pub struct ScipJobObservation {
     /// At least one SCIP Job for this project is neither succeeded nor failed.
     pub in_flight: bool,
+    /// At least one **warm** Job for this project is neither succeeded nor
+    /// failed. Read through the same `djinn.app/warm=true` predicate the warm
+    /// dispatcher itself uses ([`crate::graph_warmer::WarmJobLister`]), so the
+    /// two populations cannot drift apart in what "in flight" means.
+    pub warm_in_flight: bool,
     /// Revision of the most recently *succeeded* SCIP Job, read off its
     /// [`ANNOTATION_SCIP_REVISION`] annotation. `None` when no succeeded Job is
     /// retained — first run, or the ledger aged out.
@@ -166,11 +177,36 @@ pub trait MirrorHeadSource: Send + Sync {
 ///
 /// Ordering is load-bearing:
 /// 1. unknown head and unreadable inventory fail closed;
-/// 2. in-flight coalesces;
+/// 2. in-flight coalesces — a SCIP Job, and equally a **warm** Job;
 /// 3. **head-unchanged wins over the cadence**, because the requirement is
 ///    "every 3 hours *and only if* the head advanced", not "or";
 /// 4. **head-not-quiescent** skips — see below;
 /// 5. the cadence floor rate-limits an advancing head.
+///
+/// # Why an in-flight warm Job blocks a dispatch
+///
+/// The warm Job runs the identical `rust-analyzer scip` fan-out inline. On
+/// 2026-07-28 the first successful standalone run overlapped a warm by ~57
+/// seconds and both indexed the same workspace at the same commit, peaking at
+/// 10.2 GB and 9.5 GB RSS simultaneously — the split's entire purpose is that
+/// the warm *skips* the index, and instead the node paid for it twice.
+///
+/// Not dispatching into a running warm is the cheapest possible fix for the
+/// common case, and it is stateless: it reads the same cluster inventory this
+/// module already reads. It is **not** sufficient on its own — a warm Job
+/// created one second after this list is racy, and the warm dispatcher is
+/// driven by a 60s `mirror_fetcher` tick — so the authoritative exclusion is
+/// `djinn_graph::semantic_index_claim`, a cross-Pod `flock` on the shared cache
+/// PVC that both Pods take around their indexer fan-out. This gate keeps the
+/// leaseless 16Gi Pod from being created at all in the case that gate can see.
+///
+/// It cannot wedge: it is re-evaluated every tick and a warm Job is bounded by
+/// its own `activeDeadlineSeconds`, so "warm in flight" is self-clearing state
+/// owned by the apiserver, not something this module has to reclaim. It does
+/// mean a project whose warm Job is almost always running dispatches SCIP
+/// rarely — which is the correct trade: while a warm is indexing this project
+/// inline, a standalone index of it is either the same work twice or a second
+/// ~10 GB indexer on the same node.
 ///
 /// # The quiescence gate, and why the benefit is conditional
 ///
@@ -215,6 +251,9 @@ pub fn decide(
     };
     if observation.in_flight {
         return ScipIndexDecision::SkipInFlight;
+    }
+    if observation.warm_in_flight {
+        return ScipIndexDecision::SkipWarmInFlight;
     }
     if observation.last_indexed_revision.as_deref() == Some(head) {
         return ScipIndexDecision::SkipHeadUnchanged {
@@ -408,12 +447,32 @@ impl MirrorHeadSource for GitMirrorHeadSource {
 /// Production inventory backed by a live `kube::Client`.
 pub struct KubeClientScipJobInventory {
     client: kube::Client,
+    /// The warm-Job predicate, deliberately **reused** rather than
+    /// reimplemented: "is a warm in flight" must mean the same thing here as it
+    /// does to the dispatcher that creates warm Jobs, or the two views drift
+    /// and this gate stops gating.
+    warm: Arc<dyn crate::graph_warmer::WarmJobLister>,
 }
 
 impl KubeClientScipJobInventory {
     #[must_use]
     pub fn new(client: kube::Client) -> Self {
-        Self { client }
+        Self {
+            warm: Arc::new(crate::graph_warmer::KubeClientWarmJobLister::new(
+                client.clone(),
+            )),
+            client,
+        }
+    }
+
+    /// Construct with an explicit warm-Job lister. Exists so the warm gate can
+    /// be exercised without a cluster.
+    #[must_use]
+    pub fn with_warm_lister(
+        client: kube::Client,
+        warm: Arc<dyn crate::graph_warmer::WarmJobLister>,
+    ) -> Self {
+        Self { client, warm }
     }
 }
 
@@ -431,12 +490,46 @@ impl ScipJobInventory for KubeClientScipJobInventory {
             .list(&ListParams::default().labels(&selector))
             .await
             .map_err(|e| e.to_string())?;
-        Ok(observe_from_jobs(&list.items, Utc::now()))
+        observe_including_warm(
+            &list.items,
+            self.warm.as_ref(),
+            namespace,
+            project_id,
+            Utc::now(),
+        )
+        .await
     }
 }
 
-/// Fold a retained Job list into an observation. Split out of the apiserver
-/// call so the projection is testable from fixtures.
+/// Fold the SCIP-Job projection together with the warm-Job predicate.
+///
+/// Split from the apiserver call so everything except the single `list` line is
+/// testable without a cluster — in particular that the production inventory
+/// *does* consult the warm population, which is the difference between this
+/// gate existing and this gate being inert.
+pub(crate) async fn observe_including_warm(
+    scip_jobs: &[Job],
+    warm: &dyn crate::graph_warmer::WarmJobLister,
+    namespace: &str,
+    project_id: &str,
+    now: DateTime<Utc>,
+) -> Result<ScipJobObservation, String> {
+    let mut observation = observe_from_jobs(scip_jobs, now);
+    // An unreadable warm population is an unreadable inventory: `decide` turns
+    // that into `SkipInventoryUnavailable`, because dispatching on unknown
+    // state is the only branch here that can cost anything.
+    observation.warm_in_flight = warm
+        .has_in_flight_warm(namespace, project_id)
+        .await
+        .map_err(|e| format!("list warm Jobs: {e}"))?;
+    Ok(observation)
+}
+
+/// Fold a retained **SCIP** Job list into an observation. Split out of the
+/// apiserver call so the projection is testable from fixtures.
+///
+/// Leaves `warm_in_flight` at its default: warm Jobs are a different label
+/// selector and a different population, folded in by the caller.
 #[must_use]
 pub fn observe_from_jobs(jobs: &[Job], now: DateTime<Utc>) -> ScipJobObservation {
     let mut observation = ScipJobObservation::default();
@@ -517,6 +610,7 @@ mod tests {
             in_flight,
             last_indexed_revision: last.map(str::to_string),
             since_last_dispatch: since,
+            ..ScipJobObservation::default()
         }
     }
 
@@ -743,6 +837,55 @@ mod tests {
         );
     }
 
+    /// **The duplicate-index gate.** A warm Job in flight is already running
+    /// the same `rust-analyzer scip` fan-out over the same workspace; a SCIP
+    /// Job created now puts two ~10 GB indexers on one node to produce the same
+    /// artifacts. That is what happened on 2026-07-28.
+    ///
+    /// It must hold under conditions that would otherwise be a textbook
+    /// dispatch — advanced head, quiescent tree, cadence long satisfied — or
+    /// the gate is not a gate.
+    #[test]
+    fn a_warm_job_in_flight_blocks_the_dispatch() {
+        let mut warming = observed(false, Some(OLD), Some(THREE_HOURS));
+        warming.warm_in_flight = true;
+        assert_eq!(
+            decide(Some(HEAD), QUIET, Some(&warming), THREE_HOURS, QUIESCENCE),
+            ScipIndexDecision::SkipWarmInFlight,
+        );
+        assert_eq!(
+            ScipIndexDecision::SkipWarmInFlight.reason(),
+            "warm_in_flight"
+        );
+        assert!(
+            ScipIndexDecision::SkipWarmInFlight
+                .dispatch_revision()
+                .is_none()
+        );
+
+        // The identical observation WITHOUT a warm in flight dispatches, so the
+        // assertion above is about the warm flag and nothing else.
+        warming.warm_in_flight = false;
+        assert!(matches!(
+            decide(Some(HEAD), QUIET, Some(&warming), THREE_HOURS, QUIESCENCE),
+            ScipIndexDecision::Dispatch { .. }
+        ));
+    }
+
+    /// The warm gate must create no Kubernetes object. Asserting the decision
+    /// alone would stay green if `tick_project` dispatched regardless.
+    #[tokio::test]
+    async fn a_warm_in_flight_tick_creates_no_job() {
+        let mut warming = observed(false, Some(OLD), Some(THREE_HOURS));
+        warming.warm_in_flight = true;
+        let (decision, created) = run_tick(Ok(warming), Some(HEAD)).await;
+        assert_eq!(decision, ScipIndexDecision::SkipWarmInFlight);
+        assert!(
+            created.is_empty(),
+            "a warm-gated tick must create no leaseless 16Gi Pod"
+        );
+    }
+
     // ---- inventory projection ---------------------------------------------
 
     fn scip_job(revision: &str, succeeded: bool, failed: bool, age_secs: i64) -> Job {
@@ -866,6 +1009,79 @@ mod tests {
     fn empty_inventory_is_a_first_run_not_an_error() {
         let observation = observe_from_jobs(&[], now());
         assert_eq!(observation, ScipJobObservation::default());
+    }
+
+    /// A recording warm lister: proves the production inventory *asks*, and
+    /// with which arguments. A gate that never queries would pass every
+    /// decision test above and gate nothing in the cluster.
+    struct RecordingWarmLister {
+        answer: Result<bool, ()>,
+        seen: Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl crate::graph_warmer::WarmJobLister for RecordingWarmLister {
+        async fn has_in_flight_warm(
+            &self,
+            namespace: &str,
+            project_id: &str,
+        ) -> Result<bool, kube::Error> {
+            self.seen
+                .lock()
+                .expect("lock")
+                .push((namespace.to_string(), project_id.to_string()));
+            self.answer.map_err(|()| {
+                kube::Error::Api(kube::error::ErrorResponse {
+                    status: "Failure".into(),
+                    message: "apiserver unreachable".into(),
+                    reason: "InternalError".into(),
+                    code: 500,
+                })
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn the_production_inventory_consults_the_warm_population() {
+        let lister = RecordingWarmLister {
+            answer: Ok(true),
+            seen: Mutex::new(Vec::new()),
+        };
+        let observation = observe_including_warm(
+            &[scip_job(OLD, true, false, 40_000)],
+            &lister,
+            "ns",
+            "proj",
+            now(),
+        )
+        .await
+        .expect("observation");
+        assert!(
+            observation.warm_in_flight,
+            "the warm answer must reach the observation `decide` reads"
+        );
+        assert_eq!(observation.last_indexed_revision.as_deref(), Some(OLD));
+        assert_eq!(
+            lister.seen.lock().expect("lock").as_slice(),
+            [("ns".to_string(), "proj".to_string())],
+            "the warm population must be queried for THIS namespace and project"
+        );
+
+        // An unreadable warm population is an unreadable inventory, and an
+        // unreadable inventory never dispatches.
+        let failing = RecordingWarmLister {
+            answer: Err(()),
+            seen: Mutex::new(Vec::new()),
+        };
+        let error = observe_including_warm(&[], &failing, "ns", "proj", now()).await;
+        assert!(
+            error.is_err(),
+            "a warm list failure must not read as absent"
+        );
+        assert_eq!(
+            decide(Some(HEAD), QUIET, None, THREE_HOURS, QUIESCENCE),
+            ScipIndexDecision::SkipInventoryUnavailable,
+        );
     }
 
     // ---- scheduler side effect --------------------------------------------

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -46,6 +46,18 @@ pub const ANNOTATION_FENCING_TOKEN: &str = "djinn.app/fencing-token";
 pub const GATE_AUTHORIZATION_KEY: &str = "authorization";
 pub const VOLUME_WARM_GATE: &str = "warm-gate";
 
+/// Env key under which the warm Pod's bounded wait for another Pod's in-flight
+/// semantic index is projected.
+///
+/// **The key is the contract, and the reader named it.**
+/// `djinn_graph::semantic_index_claim` looks up exactly this string to size the
+/// wait it takes when the SCIP Job already holds this tree's claim. A key
+/// rendered under any other name renders fine, passes every manifest test, and
+/// is read by nobody — leaving the operator lever inert and the default in
+/// force forever. `djinn_server::scip_index_watcher` asserts this constant
+/// equals the one the reader uses, from the crate that can see both.
+pub const WARM_SCIP_CLAIM_WAIT_ENV: &str = "DJINN_SCIP_CLAIM_WAIT_SECONDS";
+
 /// Durable build-lease consumer id (the lease's `warm_request_id`), projected
 /// into the WARMER container so the in-Pod worker can hand the build slot back
 /// the moment its cargo phase ends.
@@ -203,6 +215,14 @@ exec {bin} warm-graph "{project_id}"
         env_var(
             "DJINN_WARM_JOB_DEADLINE_SECONDS",
             &config.warm_job_timeout_seconds.to_string(),
+        ),
+        // How long this Pod may wait for the standalone SCIP Job's in-flight
+        // index of the same tree before indexing inline itself. The warm Pod's
+        // environment is exactly what this manifest puts in it, so an
+        // unrendered lever is an unsettable one.
+        env_var(
+            WARM_SCIP_CLAIM_WAIT_ENV,
+            &config.scip_claim_wait_seconds.to_string(),
         ),
     ];
     // Forward the server's DB connection so `bootstrap_warm_database` in

--- a/server/crates/djinn-k8s/src/warm_job_tests.rs
+++ b/server/crates/djinn-k8s/src/warm_job_tests.rs
@@ -198,6 +198,13 @@ fn builds_warm_job_manifest_with_expected_shape() {
         envs.get("DJINN_WARM_JOB_DEADLINE_SECONDS").copied(),
         Some(cfg.warm_job_timeout_seconds.to_string().as_str()),
     );
+    // The bounded wait for another Pod's in-flight semantic index of the same
+    // tree. Rendered here or settable nowhere: the warm Pod's environment is
+    // exactly what this manifest puts in it.
+    assert_eq!(
+        envs.get(WARM_SCIP_CLAIM_WAIT_ENV).copied(),
+        Some(cfg.scip_claim_wait_seconds.to_string().as_str()),
+    );
     // DJINN_SERVER_ADDR is intentionally absent — `warm-graph` lives
     // on a disjoint subcommand whose `WorkerDefaultArgs` are not
     // parsed, so any residual envs would only be noise.

--- a/server/src/scip_index_watcher.rs
+++ b/server/src/scip_index_watcher.rs
@@ -197,6 +197,62 @@ mod tests {
         assert_eq!(parse_interval(None), Duration::from_secs(DEFAULT_TICK_SECS));
     }
 
+    /// **The warm path's claim wait has to fit inside the warm Job's own
+    /// deadline.**
+    ///
+    /// When a SCIP Job is already indexing this exact tree, the warm path waits
+    /// for it rather than starting a duplicate ~10 GB index. That wait can be a
+    /// total loss — the holder may run past the budget — in which case the warm
+    /// still has to do every phase itself. So the budget plus one whole
+    /// measured warm must fit in `activeDeadlineSeconds`, or the mitigation for
+    /// a wasteful warm becomes a warm that publishes no graph at all.
+    ///
+    /// This lives here because it is the only crate that can see both numbers:
+    /// the budget is `djinn-graph`'s, the deadline is `djinn-k8s`'s.
+    #[test]
+    fn the_claim_wait_budget_fits_inside_the_warm_job_deadline() {
+        let cfg = djinn_k8s::KubernetesConfig::for_testing();
+        let wait = djinn_graph::semantic_index_claim::DEFAULT_WAIT_SECONDS as i64;
+        let worst_case = wait + djinn_k8s::config::MEASURED_FULL_WARM_SECONDS;
+        assert!(
+            worst_case <= cfg.warm_job_timeout_seconds,
+            "a warm that waits its full {wait}s claim budget, gains nothing and \
+             then runs the whole {}s warm itself needs {worst_case}s, but \
+             activeDeadlineSeconds is {}s — the Pod would be SIGKILLed before \
+             publishing",
+            djinn_k8s::config::MEASURED_FULL_WARM_SECONDS,
+            cfg.warm_job_timeout_seconds,
+        );
+        // …and the budget is not zero, which would silently disable the wait
+        // and leave the duplicate index in place.
+        assert!(wait > 0);
+    }
+
+    /// **The rendered key must be the key the reader reads, and the two
+    /// defaults must agree.**
+    ///
+    /// The warm Pod's environment is exactly what `build_warm_job` puts in it,
+    /// so a claim-wait rendered under any other name is an operator lever that
+    /// silently does nothing — the failure mode this repository has already
+    /// paid for with `DJINN_SCIP_JOB_DEADLINE_SECONDS`. Only this crate can see
+    /// both the writer (`djinn-k8s`) and the reader (`djinn-graph`), so the
+    /// contract is asserted here instead of being duplicated as a literal.
+    #[test]
+    fn the_warm_job_renders_the_claim_wait_under_the_key_the_worker_reads() {
+        assert_eq!(
+            djinn_k8s::warm_job::WARM_SCIP_CLAIM_WAIT_ENV,
+            djinn_graph::semantic_index_claim::WAIT_ENV,
+            "the warm Job renders one key and the in-Pod claim reads another; \
+             the wait would be unconfigurable and the default silently permanent"
+        );
+        assert_eq!(
+            djinn_k8s::KubernetesConfig::for_testing().scip_claim_wait_seconds,
+            djinn_graph::semantic_index_claim::DEFAULT_WAIT_SECONDS,
+            "the rendered default and the compiled-in default must agree, or a \
+             warm Pod and an in-process warm wait for different lengths of time"
+        );
+    }
+
     /// The loop tick must be shorter than the cadence floor, or the effective
     /// cadence becomes the tick rather than the configured interval.
     #[test]


### PR DESCRIPTION
## Root cause (verified in the code, observed in production)

PR #2697 split the semantic index into its own Job whose stated purpose is *"artifacts are in the shared SCIP cache for the next warm to reuse"*. That only holds if the SCIP Job **finishes before** the warm starts. Nothing made that true.

Both `run_scip_index_command` and `ensure_canonical_graph` guard their indexer fan-out with `ctx.indexer_lock()` — `WarmContext::indexer_lock` returns an `Arc<tokio::sync::Mutex<()>>`, a **process-local** mutex whose documented job is protecting the `CARGO_TARGET_DIR` env mutation inside one server process (`scip_indexer/indexing.rs`, `CargoTargetDirGuard`). The SCIP Job and the warm Job are separate Pods, separate processes. The comment "Serialize against any in-process indexer fan-out, matching the warm path" is accurate and irrelevant to the collision. **There was no cross-Pod coordination of any kind.**

Observed 2026-07-28, first successful standalone run:

```
10:39 elapsed  rust-analyzer scip . --output /tmp/djinn-canonical-graph-SbuxBN/...  (warm Job)
09:42 elapsed  rust-analyzer scip . --output /tmp/djinn-scip-index-WNveKI/...       (SCIP Job)
```

Same workspace, same commit, 10.2 GB and 9.5 GB RSS at once. Both finished, so this was waste and risk rather than an outage — but the index was paid for twice, which is exactly what the split was supposed to stop.

## Design

Two layers. The second is the correctness one; the first just stops the leaseless 16Gi Pod being created in the case that is actually observable from outside.

### 1. `djinn_graph::semantic_index_claim` — an advisory `flock` on the shared `/cache` PVC (authoritative)

Keyed by `(project_id, commit_sha)` and living at `<scip cache root>/.index-claims/…`, i.e. **on the same filesystem as the resource it protects**. Both Pods resolve that root from the same `XDG_CACHE_HOME=/cache/xdg/<project>` the artifact cache uses (asserted today by `scip_job_cache_env_matches_the_warm_job_render`). Two Pods that cannot see each other's cache root have no shared cache to duplicate work into; two that can, can also see each other's lock.

Roles differ because the two callers' obligations differ:

| Outcome | SCIP Job | Warm path |
| --- | --- | --- |
| `Held` | index, holding the claim | index, holding the claim |
| `HeldByAnother` | **skip**, exit 0 | wait ≤ 900s, then **index anyway** |
| `Unavailable` (unwritable dir, `flock` unsupported, no commit, …) | **index anyway** | **index anyway** |

The SCIP Job may skip because it publishes nothing — it never touches `repo_graph_cache`, `repo_graph_generation` or `repo_graph_current`, and the holder is producing the identical artifacts into the identical content-addressed cache. The warm path may never skip: it is the only producer of the served graph, so its degradation is a bounded wait and then an inline index. Everything uncertain fails **open**.

### 2. `scip_schedule`: decline to dispatch while a warm Job is in flight

The observed collision was a warm that started ~57s *before* the SCIP Job. `ScipJobObservation` gains `warm_in_flight`, read through `graph_warmer::WarmJobLister` — the warm dispatcher's own predicate, reused rather than reimplemented so the two views of "in flight" cannot drift. A warm-list failure is an unreadable inventory, which this module already resolves to `SkipInventoryUnavailable`. Cadence and quiescence semantics are untouched; the new gate sits with `SkipInFlight`.

This gate is racy by construction (a warm created one second after the list; `mirror_fetcher` triggers every 60s), which is why it is not the mechanism, only the cheap common-case one.

### Why `flock` over the alternatives

- **Postgres lease row keyed by (project, workspace, commit)** — rejected. It needs an expiry, a heartbeat and a reaper, and this codebase has repeatedly been wedged by exactly that: occupancy rows nobody reclaims. A 59-minute index makes the expiry hard to pick — too short and it fires mid-run, too long and a crash blocks the next hour.
- **Postgres session advisory lock** — the serious contender, and node-independent, which `flock` is not. Rejected because the release story is worse where it matters: it would be held on a dedicated pooled connection for ~59 minutes, and a Pod that dies with a half-open TCP connection keeps the lock until the server's keepalives notice. `flock` is released by the kernel on `close`, `exit` and `SIGKILL` alike — there is no reclamation code to get wrong. `.warm-locks/<project>.lock` (task `t6g0`) already uses this primitive for the sibling problem of two warm Pods sharing one cargo base.
- **Warm waits for / reuses the in-flight SCIP result** — adopted, as the warm side of the same claim.
- **Scheduler declines while a warm is in flight** — adopted as layer 2, not as the mechanism.

### No deadlock, no indefinite stall

- The waiter always returns by its budget, whether or not it got the claim.
- A dead holder frees the claim within one 5s poll — the kernel does it, not a reaper.
- A leftover lock *file* is not a held lock. The JSON identity written into it (pid, commit, timestamp) is diagnostic only; nothing reads it to decide anything, precisely so a stale record can neither block nor authorise an index.
- The warm-in-flight gate is re-evaluated every tick against apiserver state bounded by the warm Job's own `activeDeadlineSeconds`.

### The wait budget is bounded by the warm Job's deadline

900s, rendered into the warm Job from `KubernetesConfig::scip_claim_wait_seconds` under `DJINN_SCIP_CLAIM_WAIT_SECONDS`. A warm that waits the full budget, gains nothing, and then runs every phase itself needs `900 + 5442 = 6342s` against `activeDeadlineSeconds = 7200`. `MEASURED_FULL_WARM_SECONDS` was promoted from a test-local constant to a public one so that arithmetic is asserted rather than asserted-about.

The env key is rendered by `djinn-k8s` and read by `djinn-graph`; the warm Pod's environment is exactly what the manifest puts in it, so an unrendered lever is an unsettable one — the `DJINN_SCIP_JOB_DEADLINE_SECONDS` mistake this module already paid for. `djinn_server::scip_index_watcher` asserts the writer's constant equals the reader's, and that the two defaults agree, from the crate that can see both.

## On the narrow useful window — the limitation, stated

The claim keys on the commit because the cache keys on `source_hashes`, so a run at a different tree cannot help a warm at this one. That has two consequences worth being explicit about:

- **The split still does not always pay off.** If `main` advances between the SCIP run and the warm, the warm misses and re-indexes inline for the full ~59 minutes. The existing quiescence gate biases against that; nothing eliminates it. This PR does not change those odds.
- **What it does add is the same-tree case, which previously did not work at all.** A warm arriving while the SCIP Job is indexing *its* tree now waits and then finds a per-workspace cache hit, instead of starting a second ~10 GB indexer. That is the reuse the split was supposed to deliver, and it is the honest scope of the improvement.
- Two indexers at **different** commits still do not contend and can still overlap in memory. Serialising them would mean making one wait for work that cannot help it; layer 2 is what reduces that case.

## Tests

Failure modes, proved rather than asserted:

- `a_holder_killed_mid_index_releases_its_claim_immediately` — a re-exec'd child takes the claim (`std::mem::forget`s the guard so nothing in that process can release it), the parent confirms real contention, `SIGKILL`s it, and reclaims. A same-process guard drop would only prove `Drop` runs, which is what a `SIGKILL` denies you.
- `a_stale_lock_file_left_by_a_dead_holder_does_not_block` — a leftover file with pid 1 and a 1999 timestamp is not a holder.
- `two_claims_on_the_same_tree_cannot_both_be_held` — both start at once, exactly one proceeds (`flock` is per open file description, so two `open`s contend even in one process — the same kernel primitive that separates two Pods).
- `a_wait_against_a_holder_that_never_finishes_ends_at_its_budget` / `a_wait_ends_early_when_the_holder_releases` / `a_zero_wait_budget_does_not_wait`.
- `unusable_coordination_state_is_unavailable_not_contended` — and `Unavailable` never authorises a skip.

Wiring, through the production entry points:

- `the_scip_job_declines_to_duplicate_an_index_another_pod_is_running` — holds the claim externally, calls `run_scip_index_command`, asserts `SkippedConcurrentIndex` **and** that `repo_graph_cache` is untouched; then releases and asserts the same call indexes (`artifacts: 1`). `run_scip_index_command` now returns `ScipIndexOutcome` so the skip is an observable value rather than an absence.
- `the_warm_path_takes_the_claim_and_publishes_even_when_it_cannot_get_it` — asserts the claim file the warm can only have created by participating, that it is released when the indexer phase ends, and that a warm which cannot get the claim still rebuilds and republishes.
- `a_warm_job_in_flight_blocks_the_dispatch` (with the complement: the identical observation without the warm flag dispatches) and `a_warm_in_flight_tick_creates_no_job`.
- `the_production_inventory_consults_the_warm_population` — a recording lister proves the real inventory *asks*, and with which namespace/project; a gate that never queried would pass every decision test and gate nothing.

Both wiring tests were verified by neutralization: deleting the skip arm makes the first fail with `got Indexed { artifacts: 1 }`; replacing the warm claim with a constant `Unavailable` makes the second fail on the missing claim file.

`cargo fmt --all -- --check`, `cargo clippy --all-targets` (djinn-graph, djinn-k8s, djinn-agent-worker, djinn-server), `cargo nextest run -p djinn-graph -p djinn-k8s` (1018 passed), the server watcher tests, `check-file-size.sh` and `check_boundaries.py` — all clean.

## What I could not verify

**I have no cluster.** Everything above is proved on a local filesystem and in unit tests. Specifically unverified:

- That `flock` behaves as assumed on the production `/cache` PVC. It is enforced per kernel; on the single-node k3s VPS with a local-path PVC both Pods share one kernel, which is the scope needed. On a multi-node cluster with a network filesystem whose `flock` is not cluster-coherent, two Pods on different nodes could both believe they hold the claim — which degrades to today's duplicate-index behaviour, not to anything unsafe.
- That both Pods can create `.index-claims/` under the shared cache root. They run as the same uid/gid with `umask 0002` and both already write that tree, so this should hold, but it is inferred from the manifests, not observed.
- The real timing of the wait paying off: no production run of a warm waiting on an in-flight SCIP Job has happened.
- One consequence worth watching after deploy: a SCIP Job that skips still exits 0, so the scheduler's retained-Job ledger records that revision as covered. That is correct — the holder is indexing it — but if the holder's run then fails, no SCIP Job re-runs for that revision and the next warm re-indexes inline. Documented at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
