### PR TITLE
fix(admission): reconcile build admission on a leader timer, not only at boot

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
@@ -31,10 +31,11 @@ use tokio::sync::RwLock;
 
 use crate::build_admission::{
     BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, BuildAdmissionReadiness,
-    BuildAdmissionRequest, BuildWorkloadKind, CapacitySource, DenialCause,
+    BuildAdmissionRequest, BuildSlotAuthority, BuildWorkloadKind, CapacitySource, DenialCause,
 };
 use crate::build_admission_capacity_support::{CapacityHarness, attach_capacity};
 use crate::build_admission_inventory::BuildAdmissionReconciler;
+use crate::build_slot_authority::BuildLeaseDispatchAuthority;
 
 const PREDECESSOR_EPOCH: &str = "epoch-before-the-restart";
 const REPLACEMENT_EPOCH: &str = "epoch-after-the-restart";
@@ -544,6 +545,153 @@ async fn current_epoch_and_unsettled_rows_are_never_reclaimed() {
         "an unsettled row is not yet safe to judge by a listing"
     );
     assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 1);
+}
+
+/// The 2026-07-28 production wedge, end to end: the startup pass alone is not
+/// enough, and a later pass is what heals it.
+///
+/// A rolling deploy kills the outgoing pod mid-create. Its row is marked
+/// `CreateUnknown` with no object uid, and the incoming pod's startup
+/// reconciliation runs seconds later — correctly refusing to judge a row the
+/// API server could still be admitting. `CreateUnknown` feeds
+/// `create_unknown_pending`, which `readiness()` reports as
+/// `CreateUnknownHealth`, which fails Enforce closed for *every* admission
+/// before any capacity is measured. One such row halted the whole board.
+///
+/// [`current_epoch_and_unsettled_rows_are_never_reclaimed`] proves the skip is
+/// correct and stops there. This test continues the story, and the first half
+/// is the load-bearing part: it pins that the startup pass leaves the board
+/// wedged, so a *periodic* reconciliation pass
+/// ([`crate`]'s caller in `djinn-server`'s `build_admission_reconcile`) is
+/// required for recovery and not merely an optimisation.
+#[tokio::test]
+async fn a_settled_create_unknown_row_is_reclaimed_by_a_later_pass_and_unwedges_enforce() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+
+    // The outgoing pod POSTs a create and dies before learning the outcome.
+    // Its harness owns the one capacity authority for this database; the
+    // successor below reaches capacity through that same authority, exactly as
+    // two successive processes share one durable lease table in production.
+    let outgoing = replacement(&db, &journal, 3).await;
+    let doomed = Arc::clone(&outgoing.controller);
+    doomed.mark_ready();
+    let project_id = seed_project(&db, "killed-mid-create").await;
+    let warmer = K8sGraphWarmer::with_dispatcher(
+        KubernetesConfig::for_testing(),
+        db.clone(),
+        Arc::new(LostResponseDispatcher),
+        Arc::new(NeverTerminalWatcher {
+            uid: "unused".into(),
+        }),
+    )
+    .with_warm_admission(doomed.clone());
+    warmer.trigger(&project_id).await;
+    let work_id = warm_work_id(&project_id, "unknown");
+    await_state(&journal, &work_id, AdmissionState::CreateUnknown).await;
+
+    // The successor boots under a fresh epoch, reaching capacity through the
+    // production lease authority so its denials and admissions are the real
+    // ones. Recovery seeds the predecessor's orphan row.
+    let authority: Arc<dyn BuildSlotAuthority> = Arc::new(BuildLeaseDispatchAuthority::new(
+        Arc::clone(&outgoing.lease),
+    ));
+    let successor = Arc::new(
+        BuildAdmissionController::new(
+            Arc::clone(&journal),
+            BuildAdmissionMode::Enforce,
+            3,
+            "epoch-after-the-rolling-deploy",
+        )
+        .with_slot_authority(authority),
+    );
+    successor.recover_all_predecessors_and_seed().await.unwrap();
+    successor.mark_inventory_ready();
+    successor.mark_topology_ready();
+    assert!(
+        matches!(
+            successor.readiness(),
+            BuildAdmissionReadiness::CreateUnknownHealth
+        ),
+        "one orphaned CreateUnknown row must fail the successor closed: {:?}",
+        successor.readiness()
+    );
+
+    // Startup reconciliation, inside the settle window — exactly the timing a
+    // rolling deploy produces. The row is correctly skipped, and the board is
+    // now wedged with nothing scheduled to look at it again.
+    let startup_pass = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&successor),
+        Arc::new(NamespaceInventory::empty()),
+        Duration::from_secs(3600),
+    )
+    .reconcile()
+    .await;
+    assert_eq!(
+        startup_pass.reclaimed, 0,
+        "an unsettled row is not yet safe to judge by a listing"
+    );
+    assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 1);
+    assert!(
+        matches!(
+            successor.readiness(),
+            BuildAdmissionReadiness::CreateUnknownHealth
+        ),
+        "the startup pass alone leaves Enforce fail-closed: {:?}",
+        successor.readiness()
+    );
+    let denied = successor
+        .admit(build_request("blocked-by-the-orphan"))
+        .await
+        .expect("a denial is a decision, not an error");
+    assert!(
+        matches!(
+            denied,
+            BuildAdmissionDecision::Denied {
+                occupancy: None,
+                cause: DenialCause::ControllerNotAdmitting,
+                ..
+            }
+        ),
+        "the wedge denies before measuring any occupancy: {denied:?}"
+    );
+
+    // A later pass, once the row has settled. Nothing else about the world
+    // changed: same journal, same empty namespace, same controller.
+    let later_pass = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&successor),
+        Arc::new(NamespaceInventory::empty()),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+    assert!(
+        later_pass.blockers.is_empty(),
+        "unexpected blockers: {:?}",
+        later_pass.blockers
+    );
+    assert_eq!(
+        later_pass.reclaimed, 1,
+        "the settled orphan is proven absent and retired"
+    );
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        0,
+        "no occupying row survives the pass"
+    );
+    assert!(
+        matches!(successor.readiness(), BuildAdmissionReadiness::Healthy),
+        "reclaiming the orphan must clear the startup gate: {:?}",
+        successor.readiness()
+    );
+    let admitted = successor
+        .admit(build_request("board-runs-again"))
+        .await
+        .expect("admission must succeed once the orphan is retired");
+    assert!(
+        matches!(admitted, BuildAdmissionDecision::Permitted { .. }),
+        "the board must run again after reclamation: {admitted:?}"
+    );
 }
 
 /// One task's durable generation history, written through the journal

--- a/server/src/build_admission_reconcile.rs
+++ b/server/src/build_admission_reconcile.rs
@@ -1,0 +1,166 @@
+//! Periodic build-admission reconciliation — the pass that retires occupying
+//! journal rows whose Kubernetes objects are gone.
+//!
+//! ## The wedge this exists to prevent
+//!
+//! [`BuildAdmissionReconciler`](djinn_coordinator::build_admission_inventory::BuildAdmissionReconciler)
+//! is what terminalizes an occupying admission row whose object the API server
+//! no longer has. Until this loop existed it ran **only** from
+//! [`AppState::become_leader`](crate::server::AppState::become_leader) and the
+//! startup path, so a row that was not reclaimable during that single pass
+//! stayed occupying until the next process restart.
+//!
+//! One clause of `is_reclaimable` makes that a live production hazard rather
+//! than a theoretical one: a row is only a reclamation candidate once it has
+//! **settled** past
+//! [`DEFAULT_RECLAIM_SETTLE_WINDOW`](djinn_coordinator::build_admission_inventory::DEFAULT_RECLAIM_SETTLE_WINDOW)
+//! (300s), because before then the API server could still be admitting a create
+//! the dead process POSTed. A rolling deploy produces exactly such a row — the
+//! outgoing pod is killed mid-create, its row is marked `CreateUnknown` with a
+//! null object uid — and the incoming pod's one and only reconciliation runs
+//! seconds later, well inside the settle window. The row is correctly skipped,
+//! and then nothing ever looks at it again.
+//!
+//! A single such row is enough to halt the entire board. `CreateUnknown` rows
+//! feed `create_unknown_pending`, which `readiness()` reports as
+//! `CreateUnknownHealth`, which fails Enforce closed for **every** admission —
+//! not at capacity, but before any capacity is measured. Observed in production
+//! on 2026-07-28: one orphaned row from a rolled pod denied every dispatch for
+//! ~20 minutes until the server was restarted by hand.
+//!
+//! This loop closes that gap. It is the same reconciliation pass on a timer, so
+//! a row that was too young to reclaim during the startup pass is reclaimed by
+//! the first tick after it settles.
+//!
+//! ## Why leader-only
+//!
+//! Reconciliation writes to the durable admission journal (retiring rows,
+//! adopting live objects). The single-active-writer invariant that the topology
+//! gate exists to enforce is exactly what would break if standby HTTP-only pods
+//! ran this concurrently, so — like [`crate::git_maintenance`] and
+//! [`crate::graph_retention`] — it is started exclusively from `become_leader`
+//! and runs until the process-wide `CancellationToken` fires.
+//!
+//! ## Fail-closed semantics are unchanged
+//!
+//! A pass that cannot prove the inventory marks the controller
+//! `InventoryPending`, and Enforce denies until a later pass succeeds. That is
+//! the pre-existing contract of the reconciler and this loop does not soften
+//! it — it only makes it recoverable. Before this loop a failed inventory at
+//! startup was permanent; now the next tick clears it.
+
+use std::time::Duration;
+
+use tokio::time::MissedTickBehavior;
+
+use crate::server::AppState;
+
+/// Environment variable overriding the reconciliation cadence, in seconds.
+pub const INTERVAL_ENV: &str = "DJINN_BUILD_ADMISSION_RECONCILE_INTERVAL_SECS";
+
+/// Default cadence: 120s. Deliberately shorter than the 300s settle window so
+/// that a row becomes reclaimable and is then reclaimed within roughly one
+/// window rather than two — the failure this loop repairs is a total board
+/// halt, so time-to-heal is the property being tuned.
+const DEFAULT_INTERVAL_SECS: u64 = 120;
+/// Floor, so a misconfigured tiny value cannot hot-loop the API server with
+/// LIST/GET traffic.
+const MIN_INTERVAL_SECS: u64 = 30;
+/// Ceiling, so a misconfigured huge value cannot silently restore the
+/// startup-only behaviour this loop exists to remove.
+const MAX_INTERVAL_SECS: u64 = 60 * 60;
+
+/// Spawn the periodic build-admission reconciliation task. Leader-only
+/// (started from `become_leader`), runs until `state.cancel()` fires.
+pub fn spawn(state: AppState) {
+    let interval = parse_interval(std::env::var(INTERVAL_ENV).ok().as_deref());
+    let cancel = state.cancel().clone();
+
+    tokio::spawn(async move {
+        tracing::info!(
+            ?interval,
+            "build_admission_reconcile loop starting (leader-only)"
+        );
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        // The first tick fires immediately; consume it. `become_leader` has
+        // just run a reconciliation pass of its own, so reconciling again in
+        // the same breath would only duplicate API-server traffic during the
+        // leadership transition.
+        ticker.tick().await;
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    tracing::debug!("build_admission_reconcile loop cancelled");
+                    break;
+                }
+                _ = ticker.tick() => {
+                    // Off (no controller) and non-Kubernetes runtimes make this
+                    // a cheap no-op inside the call itself; there is no
+                    // separate gate here to drift out of sync with that one.
+                    state.reconcile_build_admission_inventory().await;
+                }
+            }
+        }
+    });
+}
+
+/// Parse and bound the configured interval. Anything unparseable or out of
+/// range falls back to the default rather than disabling the loop: a typo in an
+/// env var must not be able to reinstate the startup-only wedge.
+fn parse_interval(raw: Option<&str>) -> Duration {
+    let secs = raw
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|secs| (MIN_INTERVAL_SECS..=MAX_INTERVAL_SECS).contains(secs))
+        .unwrap_or(DEFAULT_INTERVAL_SECS);
+    Duration::from_secs(secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_interval_uses_the_default() {
+        assert_eq!(
+            parse_interval(None),
+            Duration::from_secs(DEFAULT_INTERVAL_SECS)
+        );
+    }
+
+    #[test]
+    fn a_valid_interval_is_adopted() {
+        assert_eq!(parse_interval(Some("300")), Duration::from_secs(300));
+        assert_eq!(
+            parse_interval(Some(" 45 ")),
+            Duration::from_secs(45),
+            "surrounding whitespace should not defeat a valid value"
+        );
+    }
+
+    #[test]
+    fn out_of_range_and_unparseable_values_fall_back_to_the_default() {
+        let default = Duration::from_secs(DEFAULT_INTERVAL_SECS);
+        for raw in ["0", "1", "99999", "not-a-number", "", "-5"] {
+            assert_eq!(
+                parse_interval(Some(raw)),
+                default,
+                "{raw:?} must fall back to the default rather than disable the loop"
+            );
+        }
+    }
+
+    #[test]
+    fn the_default_cadence_is_shorter_than_the_reclaim_settle_window() {
+        // The loop's whole purpose is to reclaim rows that the startup pass had
+        // to skip because they had not settled yet. A cadence at or above the
+        // settle window would let a row wait two full windows before any pass
+        // looked at it again.
+        let settle =
+            djinn_coordinator::build_admission_inventory::DEFAULT_RECLAIM_SETTLE_WINDOW.as_secs();
+        assert!(
+            DEFAULT_INTERVAL_SECS < settle,
+            "default cadence {DEFAULT_INTERVAL_SECS}s must be shorter than the {settle}s settle window"
+        );
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod admin;
 pub mod allocator;
+pub mod build_admission_reconcile;
 pub mod codex_keepalive;
 pub mod db;
 pub mod error;

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -1167,6 +1167,24 @@ impl AppState {
         );
     }
 
+    /// Re-run the Kubernetes inventory reconciliation pass on an already-booted
+    /// leader.
+    ///
+    /// This is [`Self::initialize_build_admission_inventory`] under a name that
+    /// says what it does outside startup. It exists because reclamation of an
+    /// occupying row whose object is gone is gated on that row having settled
+    /// past the reclaim settle window: a row created moments before a rolling
+    /// deploy is skipped by the successor's startup pass, and with no later
+    /// pass it holds shared capacity — or, for a `CreateUnknown` row, fails
+    /// every admission closed — until the next restart.
+    ///
+    /// Leader-only by construction: the caller is spawned from
+    /// [`Self::become_leader`], preserving the single-active-writer invariant
+    /// the topology gate enforces.
+    pub(crate) async fn reconcile_build_admission_inventory(&self) {
+        self.initialize_build_admission_inventory().await;
+    }
+
     /// Run the broad Kubernetes build-capable inventory and advance the
     /// Enforce readiness gate.
     ///
@@ -1184,6 +1202,11 @@ impl AppState {
     /// retires Reserved rows and converts CreateInFlight into occupying
     /// CreateUnknown, so without a reconciliation pass every occupying row
     /// whose object died with its creator holds shared capacity permanently.
+    ///
+    /// Startup is not the only caller: [`crate::build_admission_reconcile`]
+    /// re-runs this on a leader-only timer via
+    /// [`Self::reconcile_build_admission_inventory`], because a row that had
+    /// not settled during the startup pass is otherwise never looked at again.
     async fn initialize_build_admission_inventory(&self) {
         let Some(admission) = self.inner.build_admission.clone() else {
             // Off: no controller, no readiness coupling.
@@ -2613,6 +2636,15 @@ impl AppState {
             self.cancel().clone(),
         );
         crate::mirror_fetcher::spawn(self.clone());
+
+        // Periodic build-admission reconciliation. The startup pass above
+        // cannot reclaim an occupying row that has not yet settled past the
+        // reclaim settle window — and a rolling deploy is precisely what
+        // creates such a row, seconds before the successor's only pass ran.
+        // Left alone, one `CreateUnknown` row from the outgoing pod fails
+        // every admission closed until the next restart. Writes the durable
+        // journal, so leader-only for the same reason as the loops above.
+        crate::build_admission_reconcile::spawn(self.clone());
 
         // Standalone SCIP-index driver (leader-only, same reasoning as
         // mirror_fetcher: it creates cluster objects). The real scheduler is


### PR DESCRIPTION
## The incident

On 2026-07-28 the entire board halted. Every ready task was denied at admission, on every 30s tick:

```
build admission denied; leaving task queued
  task_id=7mq0  cap=3  occupancy="unmeasured"  cause="controller_not_admitting"
```

`occupancy: unmeasured` is the tell — nothing was measured, because `admit()` short-circuits before consulting capacity when Enforce is not ready. Readiness never left `CreateUnknownHealth` from boot:

```
recovered durable journal and seeded controller  seeded_rows=5  readiness="CreateUnknownHealth"
inventory reconciliation complete  adopted=2 released=4 stale=4  readiness="CreateUnknownHealth"
single-active topology confirmed                                 readiness="CreateUnknownHealth"
```

The cause was **one** journal row, left by the pod that the v0.7.21 rollout had just replaced:

| work_id | state | creator epoch | object_name | uid |
|---|---|---|---|---|
| `019fa6f3-cc93…` | `create_unknown` | `djinn-server-85cb9f64f8-xzvpz` (dead) | `task-run-019fa6f3-…-0` | **NULL** |

That Job did not exist (`NotFound`) and never would. Recovery was by hand: restart the server.

## Why it could not self-heal

Two individually-correct rules compose into a permanent wedge.

1. `is_reclaimable` only retires an occupying row once it has **settled** past `DEFAULT_RECLAIM_SETTLE_WINDOW` (300s) — before then, the API server could still be admitting a create the dead process POSTed. Correct.
2. `BuildAdmissionReconciler` is the only thing that terminalizes a row whose object is gone, and it ran **exclusively** from `become_leader` / the startup path.

A rolling deploy produces precisely the row that falls between them. The outgoing pod is killed mid-create → `CreateUnknown`, null uid. The incoming pod's one and only reconciliation runs seconds later, deep inside the settle window → correctly skipped. Nothing ever looks again.

`CreateUnknown` feeds `create_unknown_pending`, which `readiness()` reports as `CreateUnknownHealth`, which fails Enforce closed for **every** admission. One row halts the board — and a rolling deploy is exactly the event that creates one.

## The change

Run the same reconciliation pass on a leader-only timer.

- `server/src/build_admission_reconcile.rs` — new loop, following the `git_maintenance` / `graph_retention` idiom. Default 120s (deliberately under the 300s settle window), `DJINN_BUILD_ADMISSION_RECONCILE_INTERVAL_SECS`, bounded 30s..1h. An unparseable or out-of-range value falls back to the default rather than disabling the loop — a typo must not be able to reinstate the wedge.
- Spawned from `become_leader`, alongside the other loops that mutate shared state. It writes the durable journal, so the single-active-writer invariant the topology gate protects requires leader-only.
- `reconcile_build_admission_inventory()` names the existing startup pass for use outside startup; the pass itself is unchanged.

**Fail-closed semantics are unchanged.** A pass that cannot prove the inventory still marks `InventoryPending` and Enforce still denies. This only makes that state *recoverable* — before, a failed inventory at startup was equally permanent.

## Test

`a_settled_create_unknown_row_is_reclaimed_by_a_later_pass_and_unwedges_enforce` picks up where `current_epoch_and_unsettled_rows_are_never_reclaimed` stops. That test proves the skip is correct and ends there; this one continues the story:

1. The outgoing pod dies mid-create via the production `K8sGraphWarmer` path → real `CreateUnknown` row.
2. The successor boots, recovers, and reconciles **inside** the settle window → `reclaimed == 0`, readiness `CreateUnknownHealth`, and `admit()` returns `Denied { occupancy: None, cause: ControllerNotAdmitting }`. **This half is load-bearing**: it pins that the startup pass alone leaves the board wedged, which is what makes a periodic pass required rather than an optimisation.
3. A later pass over the same journal and the same empty namespace → `reclaimed == 1`, readiness `Healthy`, `admit()` returns `Permitted`.

Verified by neutralization: widening the second pass's settle window (simulating "no later pass ever runs") fails the test at `the settled orphan is proven absent and retired`.

Locally green: `cargo test -p djinn-coordinator build_admission` (111 passed), the new `djinn-server` module tests (4 passed), `cargo fmt --check`, and `cargo clippy -p djinn-server -p djinn-coordinator --all-targets -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
