### PR TITLE
fix(refinement): resolve human review against the run's captured snapshot

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -1584,9 +1584,14 @@ impl CoordinatorActor {
             Ok(Some(proposal)) => proposal.latest_revision_seq,
             _ => return,
         };
+        let captured_snapshot_seq = repo
+            .refinement_run_captured_snapshot_seq(run_id)
+            .await
+            .unwrap_or_default();
         let mut state =
             super::refinement::RefinementLoopState::new(&exact.proposal_id, revision_seq)
-                .with_run_identity(exact.snapshot.run.run_id.clone(), exact.generation);
+                .with_run_identity(exact.snapshot.run.run_id.clone(), exact.generation)
+                .with_captured_snapshot_seq(captured_snapshot_seq);
         if let Some(park) = &exact.snapshot.park {
             state.phase = match park.kind {
                 RefinementParkKind::AwaitingReview => {

--- a/server/crates/djinn-coordinator/src/refinement.rs
+++ b/server/crates/djinn-coordinator/src/refinement.rs
@@ -263,6 +263,19 @@ impl RefinementLoopState {
         self
     }
 
+    /// Restore the pre-refinement snapshot revision captured when the run was
+    /// admitted. Every projection rebuilt from the durable ledger must call
+    /// this: `new` seeds the snapshot from the proposal head, which by then has
+    /// advanced past the tribunal's own revisions, and the resulting projection
+    /// would report the refined spec as its own `before` side. `None` (no
+    /// durable start revision) leaves the head-derived seed in place.
+    pub fn with_captured_snapshot_seq(mut self, snapshot_revision_seq: Option<i32>) -> Self {
+        if let Some(seq) = snapshot_revision_seq.filter(|seq| *seq > 0) {
+            self.snapshot_revision_seq = seq;
+        }
+        self
+    }
+
     /// Attribute this refinement run to a specific user (owner of the spawned
     /// refinement tasks + scope for per-user model resolution). Builder-style so
     /// the existing `new`/`with_config` constructors stay source-compatible.
@@ -1121,6 +1134,23 @@ mod tests {
         assert_eq!(state.current_round, 3);
         assert_eq!(state.attributed_user_id.as_deref(), Some("user-9"));
         assert_eq!(state.stop_reason, Some(StopReason::RoundCap));
+    }
+
+    /// Every ledger-driven rebuild seeds the projection from the proposal's
+    /// *current* head, which has already absorbed the tribunal's revisions. The
+    /// durable captured seq must win, or the rebuilt projection reports the
+    /// refined spec as its own pre-refinement snapshot.
+    #[test]
+    fn captured_snapshot_seq_overrides_the_head_derived_seed() {
+        let state = RefinementLoopState::new("p1", 7).with_captured_snapshot_seq(Some(1));
+        assert_eq!(state.snapshot_revision_seq, 1);
+        assert_eq!(state.current_revision_seq, 7);
+
+        // A run with no durable start revision keeps the head-derived seed.
+        for absent in [None, Some(0), Some(-1)] {
+            let state = RefinementLoopState::new("p1", 7).with_captured_snapshot_seq(absent);
+            assert_eq!(state.snapshot_revision_seq, 7);
+        }
     }
 
     #[test]

--- a/server/crates/djinn-coordinator/src/refinement_inflight.rs
+++ b/server/crates/djinn-coordinator/src/refinement_inflight.rs
@@ -113,8 +113,16 @@ impl CoordinatorActor {
         // projection rebuilt alongside a fresh in-flight session must agree with
         // it, or the outcome correlation fence rejects every observation and the
         // run stalls exactly as it did before.
+        let captured_snapshot_seq = djinn_db::ProposalRepository::new(
+            self.db.clone(),
+            crate::events::event_bus_for(&self.events_tx),
+        )
+        .refinement_run_captured_snapshot_seq(run_id)
+        .await
+        .unwrap_or_default();
         let mut state = RefinementLoopState::new(&proposal.id, proposal.latest_revision_seq)
             .with_run_identity(run_id.to_owned(), generation)
+            .with_captured_snapshot_seq(captured_snapshot_seq)
             .with_attributed_user(proposal.refinement_owner_user_id.clone());
         state.phase = phase;
         state.current_round = round;

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -832,7 +832,6 @@ impl CoordinatorActor {
             .resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
                 run_id: state.run_id.clone(),
                 generation: state.generation,
-                snapshot_revision_seq: state.snapshot_revision_seq,
                 accept,
             })
             .await

--- a/server/crates/djinn-coordinator/src/refinement_recovery.rs
+++ b/server/crates/djinn-coordinator/src/refinement_recovery.rs
@@ -77,9 +77,14 @@ impl CoordinatorActor {
                 Ok(Some(proposal)) => proposal,
                 Ok(None) | Err(_) => continue,
             };
+            let captured_snapshot_seq = proposal_repo
+                .refinement_run_captured_snapshot_seq(&run.run_id)
+                .await
+                .unwrap_or_default();
             let mut state =
                 RefinementLoopState::new(&exact.proposal_id, proposal.latest_revision_seq)
                     .with_run_identity(run.run_id.clone(), exact.generation)
+                    .with_captured_snapshot_seq(captured_snapshot_seq)
                     .with_attributed_user(proposal.refinement_owner_user_id.clone());
 
             if let Some(park) = exact.snapshot.park.as_ref() {

--- a/server/crates/djinn-db/src/repositories/refinement_run.rs
+++ b/server/crates/djinn-db/src/repositories/refinement_run.rs
@@ -145,7 +145,6 @@ pub struct TerminalRefinementRunFromIntentRequest {
 pub struct ResolveRefinementHumanReviewRequest {
     pub run_id: String,
     pub generation: i32,
-    pub snapshot_revision_seq: i32,
     pub accept: bool,
 }
 /// A named durable append boundary that is permitted to move the heartbeat.

--- a/server/crates/djinn-db/src/repositories/refinement_run_lifecycle.rs
+++ b/server/crates/djinn-db/src/repositories/refinement_run_lifecycle.rs
@@ -33,6 +33,29 @@ impl ProposalRepository {
             .collect())
     }
 
+    /// The spec revision this run was admitted from — the pre-refinement
+    /// snapshot the human's reject reverts to, and the `before` side of the
+    /// reviewed diff.
+    ///
+    /// Disposable in-memory projections must read it from here rather than from
+    /// the proposal's current head: the head advances with every revision the
+    /// tribunal writes, so a projection rebuilt mid-run would otherwise adopt
+    /// the refined spec as its own "pre-refinement" snapshot.
+    pub async fn refinement_run_captured_snapshot_seq(
+        &self,
+        run_id: &str,
+    ) -> IntentMutationResult<Option<i32>> {
+        self.db().ensure_initialized().await?;
+        Ok(sqlx::query_scalar::<_, i32>(
+            "SELECT start.seq FROM refinement_runs r \
+             JOIN proposal_revisions start ON start.id = r.source_start_revision_id \
+             WHERE r.id = $1",
+        )
+        .bind(run_id)
+        .fetch_optional(self.db().pool())
+        .await?)
+    }
+
     /// Discover durable running runs without changing leases or heartbeat.
     pub async fn load_active_refinement_runs(
         &self,
@@ -230,13 +253,9 @@ impl ProposalRepository {
         &self,
         request: ResolveRefinementHumanReviewRequest,
     ) -> IntentMutationResult<bool> {
-        if request.run_id.trim().is_empty()
-            || request.generation <= 0
-            || request.snapshot_revision_seq <= 0
-        {
+        if request.run_id.trim().is_empty() || request.generation <= 0 {
             return Err(RefinementIntentMutationError::InvalidRequest(
-                "exact run, positive generation, and captured snapshot revision are required"
-                    .into(),
+                "exact run and positive generation are required".into(),
             ));
         }
         self.db().ensure_initialized().await?;
@@ -268,11 +287,14 @@ impl ProposalRepository {
                 "human review resolution requires an exact awaiting-review park".into(),
             ));
         }
-        if run.get::<i32, _>("captured_seq") != request.snapshot_revision_seq {
-            return Err(RefinementIntentMutationError::InvalidRequest(
-                "human review snapshot does not match the captured run snapshot".into(),
-            ));
-        }
+        // The run row itself is the only authority for which revision the
+        // refinement started from. Callers hold a disposable in-memory
+        // projection that is rebuilt from the *live* proposal head whenever the
+        // coordinator restarts or re-hydrates mid-run, so any caller-supplied
+        // snapshot seq drifts forward with every tribunal revision. Comparing
+        // against it wedged parked runs permanently: neither accept nor reject
+        // could ever match once a projection had been rebuilt.
+        let captured_seq: i32 = run.get("captured_seq");
         let proposal_id: String = run.get("proposal_id");
         let reason = if request.accept {
             djinn_core::refinement_liveness::RefinementStopReason::HumanAccepted
@@ -296,7 +318,7 @@ impl ProposalRepository {
                  ORDER BY created_at DESC, id DESC LIMIT 1",
             )
             .bind(&proposal_id)
-            .bind(request.snapshot_revision_seq)
+            .bind(captured_seq)
             .fetch_optional(&mut *tx)
             .await?
             .ok_or_else(|| {
@@ -340,7 +362,7 @@ impl ProposalRepository {
             .bind(&body)
             .bind(&body_format)
             .bind(&acceptance_criteria)
-            .bind(serde_json::json!({"source":"human_review_rejection","snapshot_revision_seq":request.snapshot_revision_seq}))
+            .bind(serde_json::json!({"source":"human_review_rejection","snapshot_revision_seq":captured_seq}))
             .execute(&mut *tx)
             .await?;
         }

--- a/server/crates/djinn-db/tests/refinement_run_repository.rs
+++ b/server/crates/djinn-db/tests/refinement_run_repository.rs
@@ -72,7 +72,6 @@ async fn human_review_acceptance_and_rejection_failures_are_atomic_and_retryable
         repo.resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
             run_id: run_id.clone(),
             generation,
-            snapshot_revision_seq: 1,
             accept: true
         })
         .await
@@ -129,7 +128,6 @@ async fn human_review_acceptance_and_rejection_failures_are_atomic_and_retryable
             repo.resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
                 run_id: run_id.clone(),
                 generation,
-                snapshot_revision_seq: 1,
                 accept: false
             })
             .await
@@ -150,7 +148,6 @@ async fn human_review_acceptance_and_rejection_failures_are_atomic_and_retryable
             repo.resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
                 run_id,
                 generation,
-                snapshot_revision_seq: 1,
                 accept: false
             })
             .await
@@ -182,7 +179,6 @@ async fn human_review_acceptance_and_rejection_failures_are_atomic_and_retryable
         repo.resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
             run_id: run_id.clone(),
             generation: generation + 1,
-            snapshot_revision_seq: 1,
             accept: false
         })
         .await
@@ -195,13 +191,98 @@ async fn human_review_acceptance_and_rejection_failures_are_atomic_and_retryable
         repo.resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
             run_id,
             generation,
-            snapshot_revision_seq: 1,
             accept: false
         })
         .await
         .is_err()
     );
     assert_eq!(durable_shape(&db, &proposal_id).await, before);
+}
+
+/// The tribunal writes a spec revision every round, so by the time a run parks
+/// for human review the proposal head is far ahead of the revision the run was
+/// admitted from. Resolution used to compare the caller's projected snapshot
+/// seq against the run's captured one; a projection rebuilt from the live head
+/// (every coordinator restart or wake re-hydration does exactly that) then
+/// matched neither accept nor reject, and the park could never be resolved.
+#[tokio::test]
+async fn human_review_resolves_after_the_head_advances_past_the_captured_snapshot() {
+    for accept in [true, false] {
+        let (db, repo, proposal_id) = fixture().await;
+        sqlx::query("INSERT INTO proposal_revisions (id, proposal_id, seq, title, body, body_format, acceptance_criteria, event_kind) VALUES ($1, $2, 1, 'captured', 'captured body', 'markdown', '[]', 'spec_revision')").bind(uuid::Uuid::now_v7().to_string()).bind(&proposal_id).execute(db.pool()).await.unwrap();
+        let admitted = repo
+            .admit_refinement_run(demand(
+                proposal_id.clone(),
+                format!("drifted-head-{accept}"),
+            ))
+            .await
+            .unwrap();
+        let (run_id, generation) = match admitted {
+            RefinementAdmissionOutcome::Admitted {
+                run_id, generation, ..
+            } => (run_id, generation),
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            repo.refinement_run_captured_snapshot_seq(&run_id)
+                .await
+                .unwrap(),
+            Some(1)
+        );
+        // Three tribunal rounds of Advocate revisions land on top of the
+        // captured snapshot.
+        for seq in 2..=7 {
+            sqlx::query("INSERT INTO proposal_revisions (id, proposal_id, seq, title, body, body_format, acceptance_criteria, event_kind) VALUES ($1, $2, $3, 'refined', 'refined body', 'markdown', '[]', 'spec_revision')").bind(uuid::Uuid::now_v7().to_string()).bind(&proposal_id).bind(seq).execute(db.pool()).await.unwrap();
+        }
+        sqlx::query("UPDATE proposals SET title='refined', body='refined body', status='in_review', latest_revision_seq=7 WHERE id=$1").bind(&proposal_id).execute(db.pool()).await.unwrap();
+        sqlx::query(
+            "UPDATE refinement_runs SET state='parked', park_kind='awaiting_review', parked_at=$2 WHERE id=$1",
+        )
+        .bind(&run_id)
+        .bind(OLD)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        assert!(
+            repo.resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
+                run_id: run_id.clone(),
+                generation,
+                accept,
+            })
+            .await
+            .unwrap(),
+            "a park must resolve regardless of how far the head has advanced"
+        );
+        assert_eq!(
+            sqlx::query_scalar::<_, String>("SELECT stop_tag FROM refinement_runs WHERE id=$1")
+                .bind(&run_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap(),
+            if accept {
+                "human_accepted"
+            } else {
+                "human_rejected"
+            }
+        );
+        // Reject reverts to the run's own captured revision, not to whatever
+        // seq the caller happened to project.
+        let (title, body): (String, String) =
+            sqlx::query_as("SELECT title, body FROM proposals WHERE id=$1")
+                .bind(&proposal_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        if accept {
+            assert_eq!((title.as_str(), body.as_str()), ("refined", "refined body"));
+        } else {
+            assert_eq!(
+                (title.as_str(), body.as_str()),
+                ("captured", "captured body")
+            );
+        }
+    }
 }
 
 #[tokio::test]
@@ -877,7 +958,6 @@ async fn human_rejection_reverts_snapshot_and_terminalizes_atomically() {
         repo.resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
             run_id: run_id.clone(),
             generation,
-            snapshot_revision_seq: 1,
             accept: false
         })
         .await
@@ -906,7 +986,6 @@ async fn human_rejection_reverts_snapshot_and_terminalizes_atomically() {
             .resolve_refinement_human_review(ResolveRefinementHumanReviewRequest {
                 run_id,
                 generation,
-                snapshot_revision_seq: 1,
                 accept: false
             })
             .await


### PR DESCRIPTION
## What breaks

Proposal [v342](https://code.djinnai.io/proposals/019fa606-2abd-7380-8043-7ab4fa44c482) converged and parked for human review. Both decisions fail:

```
proposal_refinement_resolve(decision="accept")
→ coordinator could not resolve review: failed to resolve exact human review
  transition: invalid refinement intent mutation: human review snapshot does
  not match the captured run snapshot
```

The park is unresolvable — no accept, no reject, forever.

## Root cause

`resolve_refinement_human_review` fenced the transition on
`captured_seq == request.snapshot_revision_seq`. The request value is threaded
from the coordinator's in-memory `RefinementLoopState.snapshot_revision_seq`,
and all three sites that rebuild that projection from the durable ledger seed it
with `proposal.latest_revision_seq`:

- `refinement_recovery.rs:81` — startup recovery
- `actor.rs:1588` — `hydrate_refinement_wake`
- `refinement_inflight.rs:116` — durable in-flight registration (every tick a
  session projection is untracked)

The tribunal writes a spec revision every round, so the head has moved by the
time any of those run. v342 was admitted at seq 1 and parked at head 7: the
rebuilt projection sent 7, the run had captured 1, and the fence rejected it.
Any run whose projection is rebuilt after round 1 is wedged the same way — the
guard could only ever pass for a run that was never re-hydrated.

The same drift silently mis-aims rejection: the revert reads the snapshot spec
at the caller's seq, which after a rebuild is the refined head — a "reject" that
reverts to the refined spec.

## Fix

1. **The run row is the authority.** The resolution transaction already selects
   `start.seq AS captured_seq`; it now uses that value for the revert lookup and
   the recorded metadata, and `ResolveRefinementHumanReviewRequest` no longer
   carries a seq at all. There is nothing left for a caller to drift, and the
   identity fence (run id + generation + `parked`/`awaiting_review`) is unchanged.
2. **The projection stops lying.** New
   `ProposalRepository::refinement_run_captured_snapshot_seq(run_id)`; all three
   rebuild sites pass it through `with_captured_snapshot_seq`, so park metadata
   and the reviewed diff's `before` side name the revision the run actually
   started from. A run with no durable start revision keeps the head-derived seed.

## Tests

- `human_review_resolves_after_the_head_advances_past_the_captured_snapshot` —
  admits at seq 1, lands six revisions, parks, and resolves both decisions.
  Reject must still land the *captured* spec while the head holds the refined
  one, so re-aiming the revert at the head fails the test.
- `captured_snapshot_seq_overrides_the_head_derived_seed` — the durable seq wins
  over the head seed; absent/invalid leaves the seed intact.

`cargo clippy -p djinn-db -p djinn-coordinator --tests` clean;
`refinement_run_repository` (10) and `djinn-coordinator` refinement (146) green.

## Deploy note

The fix is server-only — no migration. Parked runs wedged today (v342) resolve
as soon as the fixed server is running; nothing needs to be repaired by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
