### PR TITLE
fix(coordinator): stop trigger B escalating on cancelled sessions

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/cycling_intervention.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/cycling_intervention.rs
@@ -1,0 +1,223 @@
+//! Trigger B — the same-role cycling gate.
+//!
+//! Extracted from `crate::types` (which sits close to the guard's byte ceiling)
+//! so the whole trigger-B arming decision — its threshold, the prior session's
+//! terminal disposition, and the gate itself — lives in one place next to its
+//! only production caller in [`super::task_dispatch`]. `crate::types`
+//! re-exports all three names, so every existing `use super::*` call site is
+//! unchanged.
+
+/// Consecutive same-role failed dispatch attempts after which the task is
+/// routed to a Planner intervention (trigger B) instead of only riding the
+/// cooldown ladder toward [`crate::types::MAX_DISPATCH_FAILURES`].
+///
+/// Trigger A (`reopen_count >= REOPEN_INTERVENTION_THRESHOLD`) only sees loops
+/// that pass through `open`: a reviewer rejection reopens the task and bumps
+/// the count. A review-cycle livelock never reopens — the task bounces
+/// `needs_task_review → in_progress → needs_task_review`, each cycle a
+/// same-role reappearance, `reopen_count` pinned at 0 — so the only
+/// bound was the terminal close at streak 10, which force-closes a task whose
+/// worker output may be perfectly fine (the t9wi/32bk wedge, 2026-06-11:
+/// streaks of 7-8 with 30-min cooldowns while the reviewer stage never ran).
+/// Trigger B hands that loop to the Planner for the same decompose / rescope /
+/// close decision the reopen path gets, well before the terminal close.
+///
+/// Rationale for `4`: the original attempt plus three same-role cycles — with
+/// the ladder that already spans well over an hour of wall clock, comparable
+/// depth to the reopen threshold of 3 — without firing on a one-off pod kill
+/// or a transient infra blip that the first cooldown rungs absorb.
+pub(crate) const STREAK_INTERVENTION_THRESHOLD: u32 = 4;
+
+/// What the prior same-role run's session actually did, as proved by the
+/// terminal `task_attempts` row the dispatch pass reads back
+/// (`CoordinatorActor::latest_attempt_strike_decision`).
+///
+/// This is a statement about the SESSION's terminal disposition, never about
+/// wall-clock duration and never about the task's status: a 10-minute run and a
+/// 10-second run are indistinguishable here, and both `open` and
+/// `needs_task_review` loops can contain either kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PriorSessionDisposition {
+    /// The run reached its own terminal decision — it submitted, completed,
+    /// was reopened by a reviewer, crashed, or failed to spawn. Trigger B's
+    /// premise ("each run finishes and the task lands right back where it
+    /// was") holds for this reappearance.
+    Concluded,
+    /// The session was cancelled or reclaimed by the platform before the run
+    /// could conclude (attempt outcome `cancelled` / `timed_out` /
+    /// `interrupted` — see
+    /// [`TaskAttemptOutcome::is_cancelled_or_reclaimed`](djinn_core::models::task_attempt::TaskAttemptOutcome::is_cancelled_or_reclaimed)).
+    CancelledOrReclaimed,
+}
+
+impl PriorSessionDisposition {
+    /// Classify a `task_attempts.outcome` string. Unknown/unparseable outcomes
+    /// fail CLOSED to [`Self::Concluded`] so a storage or vocabulary drift can
+    /// never silently disarm trigger B for a genuine review-cycle livelock.
+    pub(crate) fn from_attempt_outcome(outcome: &str) -> Self {
+        match outcome.parse::<djinn_core::models::task_attempt::TaskAttemptOutcome>() {
+            Ok(parsed) if parsed.is_cancelled_or_reclaimed() => Self::CancelledOrReclaimed,
+            _ => Self::Concluded,
+        }
+    }
+}
+
+/// Trigger-B gate: should a same-role failure streak route this dispatch to a
+/// Planner intervention?
+///
+/// Only "the run keeps completing but the task never moves" loops qualify:
+///
+/// - `had_provider_failure` excludes reappearances explained by a typed
+///   provider fault (throttle, auth, server error) — those are provider
+///   problems, already bounded by the breaker/failover and the cooldown
+///   ladder, not task-shape problems a Planner can fix. Trigger D
+///   (`maybe_escalate_provider_failure_streak`) owns that class.
+/// - `prior_session` excludes reappearances whose prior session was CANCELLED
+///   or reclaimed before the run could conclude. Trigger B asserts, in its own
+///   user-facing reason, that "each run finishes and the task lands right back
+///   where it was" — an infrastructure cancellation makes that false, and it is
+///   no evidence whatsoever that the task's scope or acceptance criteria are
+///   wrong. Task 7mq0 (2026-07-28) rode four consecutive `session cancelled` +
+///   coordinator-recovery cycles into this gate; the Planner it summoned had no
+///   lever but reshaping the work, so an infra timeout permanently narrowed a
+///   healthy task. Coordinator stall kills keep their own truthful escalation
+///   (`STALL_CANCEL_ESCALATION_THRESHOLD` in `session_recovery`).
+/// - worker/reviewer roles only: a planner-role task must never escalate to
+///   another Planner (recursive intervention), and lead/architect loops have
+///   their own routing.
+///
+/// The genuine review-cycle livelock this trigger exists to catch (the
+/// t9wi/32bk wedge) is untouched: those runs terminalize their attempts
+/// `completed` / `submitted` / `reopened`, which classify as
+/// [`PriorSessionDisposition::Concluded`].
+pub(crate) fn should_route_cycling_intervention(
+    role: &str,
+    next_streak: u32,
+    had_provider_failure: bool,
+    prior_session: PriorSessionDisposition,
+) -> bool {
+    !had_provider_failure
+        && prior_session == PriorSessionDisposition::Concluded
+        && next_streak >= STREAK_INTERVENTION_THRESHOLD
+        && matches!(role, "worker" | "reviewer")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::MAX_DISPATCH_FAILURES;
+
+    #[test]
+    fn trigger_b_gate_arms_on_clean_same_role_streak_only() {
+        use PriorSessionDisposition::{CancelledOrReclaimed, Concluded};
+
+        // The review-cycle livelock shape: reviewer-role reappearances with no
+        // provider failure, streak at the threshold → arm the Planner route.
+        assert!(
+            should_route_cycling_intervention(
+                "reviewer",
+                STREAK_INTERVENTION_THRESHOLD,
+                false,
+                Concluded
+            ),
+            "a clean reviewer streak at the threshold must arm trigger B \
+             (the t9wi/32bk review-cycle bounce)"
+        );
+        assert!(should_route_cycling_intervention(
+            "worker",
+            STREAK_INTERVENTION_THRESHOLD + 3,
+            false,
+            Concluded
+        ));
+
+        // Below the threshold: the ordinary ladder rungs absorb one-off pod
+        // kills / infra blips without burning a Planner session.
+        assert!(!should_route_cycling_intervention(
+            "reviewer",
+            STREAK_INTERVENTION_THRESHOLD - 1,
+            false,
+            Concluded
+        ));
+
+        // A typed provider failure explains the reappearance — that's a
+        // provider problem (breaker/failover territory), not a task-shape
+        // problem a Planner can fix.
+        assert!(!should_route_cycling_intervention(
+            "reviewer",
+            STREAK_INTERVENTION_THRESHOLD,
+            true,
+            Concluded
+        ));
+
+        // A cancelled / infrastructure-reclaimed session never finished, so the
+        // reappearance says nothing about the task's shape either (task 7mq0).
+        assert!(!should_route_cycling_intervention(
+            "worker",
+            STREAK_INTERVENTION_THRESHOLD,
+            false,
+            CancelledOrReclaimed
+        ));
+        assert!(!should_route_cycling_intervention(
+            "worker",
+            STREAK_INTERVENTION_THRESHOLD + 6,
+            false,
+            CancelledOrReclaimed
+        ));
+
+        // Planner-role tasks must never recursively escalate to a Planner.
+        assert!(!should_route_cycling_intervention(
+            "planner",
+            STREAK_INTERVENTION_THRESHOLD,
+            false,
+            Concluded
+        ));
+
+        // Trigger B must arm strictly before the terminal close so the
+        // Planner gets its pass before a force-close can fire.
+        const {
+            assert!(
+                STREAK_INTERVENTION_THRESHOLD < MAX_DISPATCH_FAILURES,
+                "intervention must precede the terminal-close backstop"
+            );
+        }
+    }
+
+    /// The disposition is derived from the session's terminal `task_attempts`
+    /// outcome — the only signal the gate is allowed to use. A run that reached
+    /// its own terminal decision (including a genuine crash or a spawn failure)
+    /// stays `Concluded`; only cancellation/reclamation disarms trigger B. An
+    /// unknown outcome string fails CLOSED so vocabulary drift cannot silently
+    /// disable the escalation.
+    #[test]
+    fn prior_session_disposition_only_excludes_cancelled_or_reclaimed_outcomes() {
+        for outcome in [
+            "cancelled",   // session cancellation token fired (task 7mq0)
+            "timed_out",   // coordinator stall kill reclaimed a live session
+            "interrupted", // deploy/rollout/reap environmental interruption
+        ] {
+            assert_eq!(
+                PriorSessionDisposition::from_attempt_outcome(outcome),
+                PriorSessionDisposition::CancelledOrReclaimed,
+                "`{outcome}` must not count as a concluded run"
+            );
+        }
+
+        for outcome in [
+            "completed",
+            "submitted",
+            "reopened",
+            "force_closed",
+            "loop_guard_tripped",
+            "crashed",
+            "spawn_failed",
+            "pending",
+            "not_a_real_outcome",
+        ] {
+            assert_eq!(
+                PriorSessionDisposition::from_attempt_outcome(outcome),
+                PriorSessionDisposition::Concluded,
+                "`{outcome}` must keep trigger B armed"
+            );
+        }
+    }
+}

--- a/server/crates/djinn-coordinator/src/dispatch/mod.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/mod.rs
@@ -1,5 +1,8 @@
 mod admission;
 pub(crate) mod attempt_lifecycle;
+/// Trigger B: the same-role cycling gate (threshold, prior-session terminal
+/// disposition, and the arming decision). Re-exported through `crate::types`.
+pub(crate) mod cycling_intervention;
 pub(crate) mod lane_resolution_log;
 pub(crate) mod liveness;
 mod outcome;

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -20,6 +20,12 @@ pub(crate) struct DispatchStrikeDecision {
     pub exempted: bool,
     pub decision: &'static str,
     pub source: &'static str,
+    /// Terminal disposition of the session behind this attempt: did the run
+    /// conclude on its own, or was it cancelled / reclaimed by the platform?
+    /// Consumed by the trigger-B gate
+    /// ([`should_route_cycling_intervention`]), which must not treat a
+    /// cancelled session as "the run finished and the task didn't move".
+    pub prior_session: PriorSessionDisposition,
 }
 
 impl CoordinatorActor {
@@ -89,7 +95,37 @@ impl CoordinatorActor {
                 djinn_telemetry::dispatch::STRIKE_DECISION_COUNTED
             },
             source: exempt_source.unwrap_or(source),
+            prior_session: PriorSessionDisposition::from_attempt_outcome(&attempt.outcome),
         })
+    }
+
+    /// Terminal `task_attempts.outcome` strings for the most recent same-role
+    /// attempts on a task, newest first, for truthful escalation reasons.
+    ///
+    /// Guard-only rows (`deferred`) and PR adoptions (`adopted_pr`) are skipped
+    /// — they are bookkeeping, not sessions — matching the filter
+    /// [`Self::latest_attempt_strike_decision`] uses to pick the attempt behind
+    /// a reappearance. Returns an empty vec on any lookup error: the reason
+    /// text then says the outcomes were unavailable rather than inventing them.
+    pub(crate) async fn recent_same_role_attempt_outcomes(
+        &self,
+        task_id: &str,
+        role: &str,
+        limit: usize,
+    ) -> Vec<String> {
+        TaskAttemptRepository::new(self.db.clone())
+            .list_for_task(task_id)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|attempt| {
+                attempt.role == role
+                    && attempt.outcome != TaskAttemptOutcome::Deferred.as_str()
+                    && attempt.outcome != TaskAttemptOutcome::AdoptedPr.as_str()
+            })
+            .take(limit.clamp(1, 8))
+            .map(|attempt| attempt.outcome)
+            .collect()
     }
 }
 
@@ -508,10 +544,17 @@ impl CoordinatorActor {
     /// bound was the terminal close at [`MAX_DISPATCH_FAILURES`], which
     /// force-closes a task whose durable worker output may be perfectly fine
     /// (the t9wi/32bk wedge, 2026-06-11). When the streak crosses
-    /// [`STREAK_INTERVENTION_THRESHOLD`] with no typed provider failure to
-    /// blame (gated by `should_route_cycling_intervention` at the call site),
-    /// hand the loop to the Planner for the same decompose / rescope / close
-    /// decision instead.
+    /// [`STREAK_INTERVENTION_THRESHOLD`] with no typed provider failure and no
+    /// cancelled/reclaimed session to blame (both gated by
+    /// `should_route_cycling_intervention` at the call site), hand the loop to
+    /// the Planner for the same decompose / rescope / close decision instead.
+    ///
+    /// The premise is that the RUNS CONCLUDE and the task still does not move.
+    /// A session cancelled by infrastructure never concluded, says nothing about
+    /// the task's scope, and must not reach here — see
+    /// [`PriorSessionDisposition`]. The reason emitted below therefore names the
+    /// terminal `task_attempts` outcomes actually observed instead of asserting
+    /// completion the coordinator never checked (task 7mq0, 2026-07-28).
     ///
     /// Shares all of trigger A's machinery — second-strike terminal park,
     /// reopen-count-keyed idempotency marker (stable across a review-cycle
@@ -528,14 +571,29 @@ impl CoordinatorActor {
         role: &'static str,
         streak: u32,
     ) -> bool {
+        let observed = self
+            .recent_same_role_attempt_outcomes(&task.id, role, streak as usize)
+            .await;
+        let observed_evidence = if observed.is_empty() {
+            "No `task_attempts` rows were readable for this role, so the per-session outcomes \
+             behind the streak could not be shown."
+                .to_owned()
+        } else {
+            format!(
+                "Observed session outcomes for `{role}`, newest first: {}. Sessions cancelled or \
+                 reclaimed by infrastructure (`cancelled` / `timed_out` / `interrupted`) do NOT \
+                 advance this streak, so every run counted above reached its own terminal \
+                 decision and the task still landed right back where it was.",
+                observed.join(", ")
+            )
+        };
         let reason = format!(
             "Task is cycling without converging: {streak} consecutive `{role}` redispatches \
-             completed without the task changing status (status `{}`, reopen_count={} — the \
-             loop never passes through `open`, so the reopen-based escalation never saw it). \
-             Each run finishes and the task lands right back where it was. Decide how to \
-             unstick this: DECOMPOSE into focused subtasks, RESCOPE/clarify the acceptance \
-             criteria and re-dispatch, or CLOSE if the durable work on the task branch is \
-             already sufficient or the task is moot/duplicate.",
+             without the task changing status (status `{}`, reopen_count={} — the loop never \
+             passes through `open`, so the reopen-based escalation never saw it). \
+             {observed_evidence} Decide how to unstick this: DECOMPOSE into focused subtasks, \
+             RESCOPE/clarify the acceptance criteria and re-dispatch, or CLOSE if the durable \
+             work on the task branch is already sufficient or the task is moot/duplicate.",
             task.status, task.reopen_count
         );
         self.route_planner_intervention(task, role, &reason, None, task.reopen_count)

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -2381,10 +2381,27 @@ impl CoordinatorActor {
                             // Planner was already routed for this loop (idempotency
                             // marker) — the terminal close then remains the final
                             // backstop.
+                            //
+                            // A reappearance whose prior session was CANCELLED or
+                            // reclaimed before the run could conclude is excluded
+                            // for the same reason a typed provider failure is:
+                            // the run did not finish, so its reappearance is not
+                            // evidence about the task's scope or acceptance
+                            // criteria, and a Planner handed that loop has no
+                            // lever but reshaping healthy work (task 7mq0,
+                            // 2026-07-28). The disposition comes from the prior
+                            // attempt's terminal outcome — never from wall clock
+                            // and never from the task's status alone. No attempt
+                            // evidence fails CLOSED to `Concluded`, preserving the
+                            // t9wi/32bk review-cycle protection.
+                            let prior_session = strike_decision
+                                .map(|decision| decision.prior_session)
+                                .unwrap_or(PriorSessionDisposition::Concluded);
                             if should_route_cycling_intervention(
                                 role,
                                 next_streak,
                                 provider_failure.is_some(),
+                                prior_session,
                             ) && self
                                 .maybe_intervene_on_cycling_task(&task, role, next_streak)
                                 .await

--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -122,6 +122,49 @@ impl InterventionChaosHarness {
         (handled, refreshed)
     }
 
+    /// Terminalize a `task_attempts` row for this task/role with `outcome`,
+    /// exactly as the supervisor's terminal run report does
+    /// (`attempt_outcome_for_terminal_report`): a cancelled session lands
+    /// `cancelled`, a run that concluded lands `completed`/`reopened`/etc.
+    /// This is the durable evidence the dispatch pass reads back through
+    /// `latest_attempt_strike_decision` on the next reappearance.
+    async fn record_terminal_attempt(
+        &self,
+        role: &'static str,
+        outcome: djinn_core::models::TaskAttemptOutcome,
+    ) {
+        let attempt_repo = TaskAttemptRepository::new(self.db.clone());
+        let attempt_id = uuid::Uuid::now_v7().to_string();
+        let attempt = attempt_repo
+            .create_or_get_pending(CreateTaskAttemptParams {
+                id: &attempt_id,
+                task_id: &self.task_id,
+                role,
+                dispatch_key: &format!("trigger-b-cycle:{attempt_id}"),
+                session_id: None,
+                attempt_seq: None,
+                dispatch_owner_incarnation_id: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .unwrap();
+        attempt_repo
+            .advance_to_terminal(TerminalTaskAttemptParams {
+                id: &attempt.id,
+                outcome,
+                pr_url: None,
+                submit_ref: None,
+                checkpoint_ref: None,
+                mirror_head_sha: None,
+                github_head_sha: None,
+                summary: None,
+                summary_json: None,
+                log_tail: None,
+            })
+            .await
+            .unwrap();
+    }
+
     async fn dispatch_same_role_reappearance_like_dispatch(
         &mut self,
         role: &'static str,
@@ -139,7 +182,17 @@ impl InterventionChaosHarness {
         let task = self.task().await;
         self.actor.last_dispatched.remove(&task.id);
 
-        if should_route_cycling_intervention(role, next_streak, had_provider_failure)
+        // Mirrors the dispatch pass: the prior session's terminal disposition
+        // comes from the same production read the SameRoleFailure arm performs,
+        // and falls back to `Concluded` when there is no attempt evidence.
+        let prior_session = self
+            .actor
+            .latest_attempt_strike_decision(&task.id, role)
+            .await
+            .map(|decision| decision.prior_session)
+            .unwrap_or(PriorSessionDisposition::Concluded);
+
+        if should_route_cycling_intervention(role, next_streak, had_provider_failure, prior_session)
             && self
                 .actor
                 .maybe_intervene_on_cycling_task(&task, role, next_streak)
@@ -201,6 +254,25 @@ impl InterventionChaosHarness {
     ) -> (bool, djinn_core::models::Task) {
         let mut last = (false, self.task().await);
         for _ in 0..cycles {
+            last = self
+                .dispatch_same_role_reappearance_like_dispatch(role, false)
+                .await;
+        }
+        last
+    }
+
+    /// `cycles` same-role redispatches, each preceded by a terminal attempt row
+    /// carrying `outcome` — i.e. each reappearance is explained by a session
+    /// that ended that way.
+    async fn dispatch_same_role_reappearances_after_sessions(
+        &mut self,
+        role: &'static str,
+        outcome: djinn_core::models::TaskAttemptOutcome,
+        cycles: u32,
+    ) -> (bool, djinn_core::models::Task) {
+        let mut last = (false, self.task().await);
+        for _ in 0..cycles {
+            self.record_terminal_attempt(role, outcome).await;
             last = self
                 .dispatch_same_role_reappearance_like_dispatch(role, false)
                 .await;
@@ -802,17 +874,20 @@ async fn same_role_cycling_trigger_b_chaos_intervenes_then_terminally_closes() {
     assert!(should_route_cycling_intervention(
         role,
         STREAK_INTERVENTION_THRESHOLD,
-        false
+        false,
+        PriorSessionDisposition::Concluded
     ));
     assert!(!should_route_cycling_intervention(
         role,
         STREAK_INTERVENTION_THRESHOLD,
-        true
+        true,
+        PriorSessionDisposition::Concluded
     ));
     assert!(!should_route_cycling_intervention(
         "planner",
         STREAK_INTERVENTION_THRESHOLD,
-        false
+        false,
+        PriorSessionDisposition::Concluded
     ));
 
     let (below_handled, below_threshold) = harness
@@ -915,6 +990,126 @@ async fn same_role_cycling_trigger_b_chaos_intervenes_then_terminally_closes() {
     provider_guard
         .assert_same_role_backoff_after_reappearance(STREAK_INTERVENTION_THRESHOLD)
         .await;
+}
+
+/// Regression for task 7mq0 (2026-07-28): four consecutive `worker` sessions
+/// were cancelled (`session cancelled`, ~10 min each) and the coordinator
+/// recovered the task `in_progress → open` every time. On the fourth, trigger B
+/// fired and summoned a Planner remediation whose reason claimed "each run
+/// finishes and the task lands right back where it was". The Planner correctly
+/// diagnosed an infrastructure-cancellation loop, but its only levers are
+/// decompose / rescope / close — so it force-closed a healthy task as `reshape`
+/// and replaced it with two narrower ones whose acceptance criteria forbid the
+/// worker from compiling. An infra timeout permanently damaged the board.
+///
+/// A cancelled session never concluded, so it must not advance the streak into
+/// trigger B at all — the same exclusion typed provider failures already get.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelled_sessions_do_not_route_the_cycling_planner_intervention() {
+    let mut harness = InterventionChaosHarness::new(0).await;
+    let role = "worker";
+
+    assert_eq!(
+        STREAK_INTERVENTION_THRESHOLD, 4,
+        "the 7mq0 regression is pinned to the production threshold"
+    );
+
+    // Exactly the 7mq0 shape: four same-role redispatches, each explained by a
+    // session the platform cancelled before the run could conclude.
+    let (handled, task) = harness
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::Cancelled,
+            STREAK_INTERVENTION_THRESHOLD,
+        )
+        .await;
+
+    assert!(
+        !handled,
+        "four cancelled sessions must NOT route a Planner intervention — the runs \
+         never finished, so the streak is no evidence about the task's scope"
+    );
+    assert_eq!(
+        task.status, "open",
+        "the source task must stay dispatchable, not be handed to a Planner"
+    );
+    harness.assert_planner_marker_count(0).await;
+    harness.assert_open_planner_review_count(0).await;
+    harness
+        .assert_same_role_backoff_after_reappearance(STREAK_INTERVENTION_THRESHOLD)
+        .await;
+
+    // Well past the threshold the exclusion still holds — it is not a one-cycle
+    // grace period that the next cancelled session walks straight through.
+    let (still_excluded, still_open) = harness
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::Cancelled,
+            3,
+        )
+        .await;
+    assert!(
+        !still_excluded,
+        "the cancellation exclusion must not decay as the streak grows"
+    );
+    assert_eq!(still_open.status, "open");
+    harness.assert_planner_marker_count(0).await;
+    harness.assert_open_planner_review_count(0).await;
+}
+
+/// The other half of the contract: trigger B must keep firing at 4 on the
+/// review-cycle livelock it exists to catch (the t9wi/32bk wedge), whose runs
+/// DO conclude — and the reason it emits must name the session outcomes it
+/// actually observed rather than asserting completion it never checked.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn completed_same_role_redispatches_still_route_the_cycling_planner_intervention() {
+    let mut harness = InterventionChaosHarness::new(0).await;
+    let role = "worker";
+
+    let (below_handled, below) = harness
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::Completed,
+            STREAK_INTERVENTION_THRESHOLD - 1,
+        )
+        .await;
+    assert!(!below_handled, "below threshold only seeds backoff");
+    assert_eq!(below.status, "open");
+    harness.assert_planner_marker_count(0).await;
+
+    let (handled, routed) = harness
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::Completed,
+            1,
+        )
+        .await;
+    assert!(
+        handled,
+        "four concluded same-role redispatches must still route the Planner \
+         intervention — the fix must not weaken trigger B for genuine livelocks"
+    );
+    assert_eq!(routed.status, "open", "the source task stays open");
+    harness.assert_planner_marker_count(1).await;
+    harness.assert_open_planner_review_count(1).await;
+
+    // The escalation the Planner reads must describe the evidence truthfully.
+    let reviews = harness.open_planner_intervention_reviews().await;
+    let description = reviews
+        .first()
+        .map(|review| review.description.clone())
+        .expect("trigger B must create a Planner remediation review task");
+    assert!(
+        description.contains(
+            "Observed session outcomes for `worker`, newest first: \
+             completed, completed, completed, completed"
+        ),
+        "the reason must report the session outcomes it counted, got: {description}"
+    );
+    assert!(
+        !description.contains("Each run finishes"),
+        "the reason must not assert completion it never verified, got: {description}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -620,100 +620,19 @@ pub(super) const MAX_DISPATCH_FAILURES: u32 = 10;
 /// a persisting single-candidate exhaustion is worth an operator's attention.
 pub(super) const SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD: u32 = 3;
 
-/// Consecutive same-role failed dispatch attempts after which the task is
-/// routed to a Planner intervention (trigger B) instead of only riding the
-/// cooldown ladder toward [`MAX_DISPATCH_FAILURES`].
-///
-/// Trigger A (`reopen_count >= REOPEN_INTERVENTION_THRESHOLD`) only sees loops
-/// that pass through `open`: a reviewer rejection reopens the task and bumps
-/// the count. A review-cycle livelock never reopens — the task bounces
-/// `needs_task_review → in_progress → needs_task_review`, each cycle a
-/// same-role reappearance, `reopen_count` pinned at 0 — so the only
-/// bound was the terminal close at streak 10, which force-closes a task whose
-/// worker output may be perfectly fine (the t9wi/32bk wedge, 2026-06-11:
-/// streaks of 7-8 with 30-min cooldowns while the reviewer stage never ran).
-/// Trigger B hands that loop to the Planner for the same decompose / rescope /
-/// close decision the reopen path gets, well before the terminal close.
-///
-/// Rationale for `4`: the original attempt plus three same-role cycles — with
-/// the ladder that already spans well over an hour of wall clock, comparable
-/// depth to the reopen threshold of 3 — without firing on a one-off pod kill
-/// or a transient infra blip that the first cooldown rungs absorb.
-pub(super) const STREAK_INTERVENTION_THRESHOLD: u32 = 4;
-
-/// What the prior same-role run's session actually did, as proved by the
-/// terminal `task_attempts` row the dispatch pass reads back
-/// (`CoordinatorActor::latest_attempt_strike_decision`).
-///
-/// This is a statement about the SESSION's terminal disposition, never about
-/// wall-clock duration and never about the task's status: a 10-minute run and a
-/// 10-second run are indistinguishable here, and both `open` and
-/// `needs_task_review` loops can contain either kind.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum PriorSessionDisposition {
-    /// The run reached its own terminal decision — it submitted, completed,
-    /// was reopened by a reviewer, crashed, or failed to spawn. Trigger B's
-    /// premise ("each run finishes and the task lands right back where it
-    /// was") holds for this reappearance.
-    Concluded,
-    /// The session was cancelled or reclaimed by the platform before the run
-    /// could conclude (attempt outcome `cancelled` / `timed_out` /
-    /// `interrupted` — see
-    /// [`TaskAttemptOutcome::is_cancelled_or_reclaimed`](djinn_core::models::task_attempt::TaskAttemptOutcome::is_cancelled_or_reclaimed)).
-    CancelledOrReclaimed,
-}
-
-impl PriorSessionDisposition {
-    /// Classify a `task_attempts.outcome` string. Unknown/unparseable outcomes
-    /// fail CLOSED to [`Self::Concluded`] so a storage or vocabulary drift can
-    /// never silently disarm trigger B for a genuine review-cycle livelock.
-    pub(super) fn from_attempt_outcome(outcome: &str) -> Self {
-        match outcome.parse::<djinn_core::models::task_attempt::TaskAttemptOutcome>() {
-            Ok(parsed) if parsed.is_cancelled_or_reclaimed() => Self::CancelledOrReclaimed,
-            _ => Self::Concluded,
-        }
-    }
-}
-
-/// Trigger-B gate: should a same-role failure streak route this dispatch to a
-/// Planner intervention?
-///
-/// Only "the run keeps completing but the task never moves" loops qualify:
-///
-/// - `had_provider_failure` excludes reappearances explained by a typed
-///   provider fault (throttle, auth, server error) — those are provider
-///   problems, already bounded by the breaker/failover and the cooldown
-///   ladder, not task-shape problems a Planner can fix. Trigger D
-///   (`maybe_escalate_provider_failure_streak`) owns that class.
-/// - `prior_session` excludes reappearances whose prior session was CANCELLED
-///   or reclaimed before the run could conclude. Trigger B asserts, in its own
-///   user-facing reason, that "each run finishes and the task lands right back
-///   where it was" — an infrastructure cancellation makes that false, and it is
-///   no evidence whatsoever that the task's scope or acceptance criteria are
-///   wrong. Task 7mq0 (2026-07-28) rode four consecutive `session cancelled` +
-///   coordinator-recovery cycles into this gate; the Planner it summoned had no
-///   lever but reshaping the work, so an infra timeout permanently narrowed a
-///   healthy task. Coordinator stall kills keep their own truthful escalation
-///   (`STALL_CANCEL_ESCALATION_THRESHOLD` in `session_recovery`).
-/// - worker/reviewer roles only: a planner-role task must never escalate to
-///   another Planner (recursive intervention), and lead/architect loops have
-///   their own routing.
-///
-/// The genuine review-cycle livelock this trigger exists to catch (the
-/// t9wi/32bk wedge) is untouched: those runs terminalize their attempts
-/// `completed` / `submitted` / `reopened`, which classify as
-/// [`PriorSessionDisposition::Concluded`].
-pub(super) fn should_route_cycling_intervention(
-    role: &str,
-    next_streak: u32,
-    had_provider_failure: bool,
-    prior_session: PriorSessionDisposition,
-) -> bool {
-    !had_provider_failure
-        && prior_session == PriorSessionDisposition::Concluded
-        && next_streak >= STREAK_INTERVENTION_THRESHOLD
-        && matches!(role, "worker" | "reviewer")
-}
+/// Threshold companion of the gate above. Referenced by the coordinator's
+/// intervention tests and by doc links rather than by non-test dispatch code,
+/// so the re-export carries the same `unused_imports` allowance the sibling
+/// test-only re-exports in [`crate::dispatch`] use.
+#[allow(unused_imports)]
+pub(super) use crate::dispatch::cycling_intervention::STREAK_INTERVENTION_THRESHOLD;
+/// The trigger-B cycling gate — its threshold, the prior session's terminal
+/// disposition, and the arming decision — lives in
+/// [`crate::dispatch::cycling_intervention`] next to its only production
+/// caller. Re-exported here so `use types::*` call sites are unchanged.
+pub(super) use crate::dispatch::cycling_intervention::{
+    PriorSessionDisposition, should_route_cycling_intervention,
+};
 
 /// A task that becomes dispatch-ready again (with no active session) within
 /// this window of its last dispatch is treated as a failed attempt and backed
@@ -946,120 +865,6 @@ mod cooldown_tests {
             apply_provider_retry_floor(ladder, Some(absurd_ms)),
             PROVIDER_RETRY_AFTER_MAX
         );
-    }
-
-    #[test]
-    fn trigger_b_gate_arms_on_clean_same_role_streak_only() {
-        use PriorSessionDisposition::{CancelledOrReclaimed, Concluded};
-
-        // The review-cycle livelock shape: reviewer-role reappearances with no
-        // provider failure, streak at the threshold → arm the Planner route.
-        assert!(
-            should_route_cycling_intervention(
-                "reviewer",
-                STREAK_INTERVENTION_THRESHOLD,
-                false,
-                Concluded
-            ),
-            "a clean reviewer streak at the threshold must arm trigger B \
-             (the t9wi/32bk review-cycle bounce)"
-        );
-        assert!(should_route_cycling_intervention(
-            "worker",
-            STREAK_INTERVENTION_THRESHOLD + 3,
-            false,
-            Concluded
-        ));
-
-        // Below the threshold: the ordinary ladder rungs absorb one-off pod
-        // kills / infra blips without burning a Planner session.
-        assert!(!should_route_cycling_intervention(
-            "reviewer",
-            STREAK_INTERVENTION_THRESHOLD - 1,
-            false,
-            Concluded
-        ));
-
-        // A typed provider failure explains the reappearance — that's a
-        // provider problem (breaker/failover territory), not a task-shape
-        // problem a Planner can fix.
-        assert!(!should_route_cycling_intervention(
-            "reviewer",
-            STREAK_INTERVENTION_THRESHOLD,
-            true,
-            Concluded
-        ));
-
-        // A cancelled / infrastructure-reclaimed session never finished, so the
-        // reappearance says nothing about the task's shape either (task 7mq0).
-        assert!(!should_route_cycling_intervention(
-            "worker",
-            STREAK_INTERVENTION_THRESHOLD,
-            false,
-            CancelledOrReclaimed
-        ));
-        assert!(!should_route_cycling_intervention(
-            "worker",
-            STREAK_INTERVENTION_THRESHOLD + 6,
-            false,
-            CancelledOrReclaimed
-        ));
-
-        // Planner-role tasks must never recursively escalate to a Planner.
-        assert!(!should_route_cycling_intervention(
-            "planner",
-            STREAK_INTERVENTION_THRESHOLD,
-            false,
-            Concluded
-        ));
-
-        // Trigger B must arm strictly before the terminal close so the
-        // Planner gets its pass before a force-close can fire.
-        const {
-            assert!(
-                STREAK_INTERVENTION_THRESHOLD < MAX_DISPATCH_FAILURES,
-                "intervention must precede the terminal-close backstop"
-            );
-        }
-    }
-
-    /// The disposition is derived from the session's terminal `task_attempts`
-    /// outcome — the only signal the gate is allowed to use. A run that reached
-    /// its own terminal decision (including a genuine crash or a spawn failure)
-    /// stays `Concluded`; only cancellation/reclamation disarms trigger B. An
-    /// unknown outcome string fails CLOSED so vocabulary drift cannot silently
-    /// disable the escalation.
-    #[test]
-    fn prior_session_disposition_only_excludes_cancelled_or_reclaimed_outcomes() {
-        for outcome in [
-            "cancelled",   // session cancellation token fired (task 7mq0)
-            "timed_out",   // coordinator stall kill reclaimed a live session
-            "interrupted", // deploy/rollout/reap environmental interruption
-        ] {
-            assert_eq!(
-                PriorSessionDisposition::from_attempt_outcome(outcome),
-                PriorSessionDisposition::CancelledOrReclaimed,
-                "`{outcome}` must not count as a concluded run"
-            );
-        }
-
-        for outcome in [
-            "completed",
-            "submitted",
-            "reopened",
-            "force_closed",
-            "loop_guard_tripped",
-            "crashed",
-            "spawn_failed",
-            "pending",
-            "not_a_real_outcome",
-        ] {
-            assert_eq!(
-                PriorSessionDisposition::from_attempt_outcome(outcome),
-                PriorSessionDisposition::Concluded,
-                "`{outcome}` must keep trigger B armed"
-            );
-        }
     }
 }
 

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -641,6 +641,40 @@ pub(super) const SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD: u32 = 3;
 /// or a transient infra blip that the first cooldown rungs absorb.
 pub(super) const STREAK_INTERVENTION_THRESHOLD: u32 = 4;
 
+/// What the prior same-role run's session actually did, as proved by the
+/// terminal `task_attempts` row the dispatch pass reads back
+/// (`CoordinatorActor::latest_attempt_strike_decision`).
+///
+/// This is a statement about the SESSION's terminal disposition, never about
+/// wall-clock duration and never about the task's status: a 10-minute run and a
+/// 10-second run are indistinguishable here, and both `open` and
+/// `needs_task_review` loops can contain either kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PriorSessionDisposition {
+    /// The run reached its own terminal decision — it submitted, completed,
+    /// was reopened by a reviewer, crashed, or failed to spawn. Trigger B's
+    /// premise ("each run finishes and the task lands right back where it
+    /// was") holds for this reappearance.
+    Concluded,
+    /// The session was cancelled or reclaimed by the platform before the run
+    /// could conclude (attempt outcome `cancelled` / `timed_out` /
+    /// `interrupted` — see
+    /// [`TaskAttemptOutcome::is_cancelled_or_reclaimed`](djinn_core::models::task_attempt::TaskAttemptOutcome::is_cancelled_or_reclaimed)).
+    CancelledOrReclaimed,
+}
+
+impl PriorSessionDisposition {
+    /// Classify a `task_attempts.outcome` string. Unknown/unparseable outcomes
+    /// fail CLOSED to [`Self::Concluded`] so a storage or vocabulary drift can
+    /// never silently disarm trigger B for a genuine review-cycle livelock.
+    pub(super) fn from_attempt_outcome(outcome: &str) -> Self {
+        match outcome.parse::<djinn_core::models::task_attempt::TaskAttemptOutcome>() {
+            Ok(parsed) if parsed.is_cancelled_or_reclaimed() => Self::CancelledOrReclaimed,
+            _ => Self::Concluded,
+        }
+    }
+}
+
 /// Trigger-B gate: should a same-role failure streak route this dispatch to a
 /// Planner intervention?
 ///
@@ -649,16 +683,34 @@ pub(super) const STREAK_INTERVENTION_THRESHOLD: u32 = 4;
 /// - `had_provider_failure` excludes reappearances explained by a typed
 ///   provider fault (throttle, auth, server error) — those are provider
 ///   problems, already bounded by the breaker/failover and the cooldown
-///   ladder, not task-shape problems a Planner can fix.
+///   ladder, not task-shape problems a Planner can fix. Trigger D
+///   (`maybe_escalate_provider_failure_streak`) owns that class.
+/// - `prior_session` excludes reappearances whose prior session was CANCELLED
+///   or reclaimed before the run could conclude. Trigger B asserts, in its own
+///   user-facing reason, that "each run finishes and the task lands right back
+///   where it was" — an infrastructure cancellation makes that false, and it is
+///   no evidence whatsoever that the task's scope or acceptance criteria are
+///   wrong. Task 7mq0 (2026-07-28) rode four consecutive `session cancelled` +
+///   coordinator-recovery cycles into this gate; the Planner it summoned had no
+///   lever but reshaping the work, so an infra timeout permanently narrowed a
+///   healthy task. Coordinator stall kills keep their own truthful escalation
+///   (`STALL_CANCEL_ESCALATION_THRESHOLD` in `session_recovery`).
 /// - worker/reviewer roles only: a planner-role task must never escalate to
 ///   another Planner (recursive intervention), and lead/architect loops have
 ///   their own routing.
+///
+/// The genuine review-cycle livelock this trigger exists to catch (the
+/// t9wi/32bk wedge) is untouched: those runs terminalize their attempts
+/// `completed` / `submitted` / `reopened`, which classify as
+/// [`PriorSessionDisposition::Concluded`].
 pub(super) fn should_route_cycling_intervention(
     role: &str,
     next_streak: u32,
     had_provider_failure: bool,
+    prior_session: PriorSessionDisposition,
 ) -> bool {
     !had_provider_failure
+        && prior_session == PriorSessionDisposition::Concluded
         && next_streak >= STREAK_INTERVENTION_THRESHOLD
         && matches!(role, "worker" | "reviewer")
 }
@@ -898,17 +950,25 @@ mod cooldown_tests {
 
     #[test]
     fn trigger_b_gate_arms_on_clean_same_role_streak_only() {
+        use PriorSessionDisposition::{CancelledOrReclaimed, Concluded};
+
         // The review-cycle livelock shape: reviewer-role reappearances with no
         // provider failure, streak at the threshold → arm the Planner route.
         assert!(
-            should_route_cycling_intervention("reviewer", STREAK_INTERVENTION_THRESHOLD, false),
+            should_route_cycling_intervention(
+                "reviewer",
+                STREAK_INTERVENTION_THRESHOLD,
+                false,
+                Concluded
+            ),
             "a clean reviewer streak at the threshold must arm trigger B \
              (the t9wi/32bk review-cycle bounce)"
         );
         assert!(should_route_cycling_intervention(
             "worker",
             STREAK_INTERVENTION_THRESHOLD + 3,
-            false
+            false,
+            Concluded
         ));
 
         // Below the threshold: the ordinary ladder rungs absorb one-off pod
@@ -916,7 +976,8 @@ mod cooldown_tests {
         assert!(!should_route_cycling_intervention(
             "reviewer",
             STREAK_INTERVENTION_THRESHOLD - 1,
-            false
+            false,
+            Concluded
         ));
 
         // A typed provider failure explains the reappearance — that's a
@@ -925,14 +986,31 @@ mod cooldown_tests {
         assert!(!should_route_cycling_intervention(
             "reviewer",
             STREAK_INTERVENTION_THRESHOLD,
-            true
+            true,
+            Concluded
+        ));
+
+        // A cancelled / infrastructure-reclaimed session never finished, so the
+        // reappearance says nothing about the task's shape either (task 7mq0).
+        assert!(!should_route_cycling_intervention(
+            "worker",
+            STREAK_INTERVENTION_THRESHOLD,
+            false,
+            CancelledOrReclaimed
+        ));
+        assert!(!should_route_cycling_intervention(
+            "worker",
+            STREAK_INTERVENTION_THRESHOLD + 6,
+            false,
+            CancelledOrReclaimed
         ));
 
         // Planner-role tasks must never recursively escalate to a Planner.
         assert!(!should_route_cycling_intervention(
             "planner",
             STREAK_INTERVENTION_THRESHOLD,
-            false
+            false,
+            Concluded
         ));
 
         // Trigger B must arm strictly before the terminal close so the
@@ -941,6 +1019,45 @@ mod cooldown_tests {
             assert!(
                 STREAK_INTERVENTION_THRESHOLD < MAX_DISPATCH_FAILURES,
                 "intervention must precede the terminal-close backstop"
+            );
+        }
+    }
+
+    /// The disposition is derived from the session's terminal `task_attempts`
+    /// outcome — the only signal the gate is allowed to use. A run that reached
+    /// its own terminal decision (including a genuine crash or a spawn failure)
+    /// stays `Concluded`; only cancellation/reclamation disarms trigger B. An
+    /// unknown outcome string fails CLOSED so vocabulary drift cannot silently
+    /// disable the escalation.
+    #[test]
+    fn prior_session_disposition_only_excludes_cancelled_or_reclaimed_outcomes() {
+        for outcome in [
+            "cancelled",   // session cancellation token fired (task 7mq0)
+            "timed_out",   // coordinator stall kill reclaimed a live session
+            "interrupted", // deploy/rollout/reap environmental interruption
+        ] {
+            assert_eq!(
+                PriorSessionDisposition::from_attempt_outcome(outcome),
+                PriorSessionDisposition::CancelledOrReclaimed,
+                "`{outcome}` must not count as a concluded run"
+            );
+        }
+
+        for outcome in [
+            "completed",
+            "submitted",
+            "reopened",
+            "force_closed",
+            "loop_guard_tripped",
+            "crashed",
+            "spawn_failed",
+            "pending",
+            "not_a_real_outcome",
+        ] {
+            assert_eq!(
+                PriorSessionDisposition::from_attempt_outcome(outcome),
+                PriorSessionDisposition::Concluded,
+                "`{outcome}` must keep trigger B armed"
             );
         }
     }

--- a/server/crates/djinn-core/src/models/task_attempt.rs
+++ b/server/crates/djinn-core/src/models/task_attempt.rs
@@ -133,6 +133,33 @@ impl TaskAttemptOutcome {
         matches!(self, Self::Interrupted)
     }
 
+    /// True if this terminal outcome proves the session was CANCELLED or
+    /// reclaimed by the platform before the agent's run could conclude, rather
+    /// than the run reaching its own terminal decision.
+    ///
+    /// - `Cancelled` — the session's cancellation token fired (operator, host,
+    ///   arbiter, or the session cap); the supervisor reports
+    ///   `TaskRunOutcome::Interrupted` and the coordinator's stuck-task sweep
+    ///   releases the task back to `open` / `needs_task_review`.
+    /// - `TimedOut` — a coordinator stall kill reclaimed a live session.
+    /// - `Interrupted` — an environmental deploy/rollout/reap interruption.
+    ///
+    /// This is deliberately NARROWER than [`is_infra`](Self::is_infra): a
+    /// `Crashed` or `SpawnFailed` attempt did reach its own terminal decision
+    /// (it is a genuine failure of the run) and is therefore excluded here.
+    ///
+    /// Used by the coordinator's cycling gate (trigger B), whose whole premise
+    /// is "each run FINISHES and the task lands right back where it was". A
+    /// cancelled session never finished, so it is no evidence at all about the
+    /// task's scope or acceptance criteria and must not arm a Planner
+    /// remediation (task 7mq0, 2026-07-28: four ~10-minute worker sessions in a
+    /// row ended `session cancelled` + coordinator recovery, trigger B fired on
+    /// the fourth, and the Planner — with no lever but reshaping the work —
+    /// force-closed a healthy task and replaced it with narrower ones).
+    pub fn is_cancelled_or_reclaimed(&self) -> bool {
+        matches!(self, Self::Cancelled | Self::TimedOut | Self::Interrupted)
+    }
+
     /// Lifecycle rank used for forward-only ordering.
     ///
     /// Non-terminal outcomes are ordered before terminal outcomes. Within each


### PR DESCRIPTION
## The bug

Trigger B (`maybe_intervene_on_cycling_task`) escalates a task to a Planner remediation when `STREAK_INTERVENTION_THRESHOLD` (=4) consecutive same-role redispatches complete without the task changing status. Its docstring and its user-facing reason string both assert the runs *finished*:

> Each run finishes and the task lands right back where it was.

That is false for infrastructure-cancelled sessions, and it fired on them.

## Production evidence — task 7mq0, 2026-07-28

Four consecutive `worker` sessions, each ~10 minutes, every one ending identically:

```
11:23:46 status_changed  open -> in_progress          (actor: supervisor)
11:33:28 session_error   {"error":"session cancelled","agent_type":"worker"}   (actor: agent-supervisor)
11:33:38 status_changed  in_progress -> open
         reason: "Recovered by coordinator: no active slot session for in_progress"
```

Repeated at 11:35→11:45, 11:54→12:04, 12:06→12:16. Session rows show `status: "failed"`, durations 9m35s–9m53s — the ~10-minute session cap, not an agent that ran to completion.

On the 4th, trigger B fired and created Planner remediation task `srcy`. The Planner correctly wrote in its own comment "this is an infrastructure-cancellation loop, not a review failure" — but its only levers are decompose / rescope / close, so it force-closed 7mq0 as `reshape` and replaced it with two narrower tasks whose acceptance criteria now **forbid the worker from running cargo** and hand compilation to CI. An infra timeout caused permanent scope damage to the board.

## Approach chosen — gate at the call site (option b)

I gated the trigger rather than suppressing the streak increment, because that is exactly how the existing exclusion is expressed. `should_route_cycling_intervention` already takes `had_provider_failure` and refuses to arm on a typed provider fault (trigger D owns that class). Coordinator-side cancellation is the same kind of fact, so it becomes a sibling argument on the same gate:

```rust
pub(super) fn should_route_cycling_intervention(
    role: &str,
    next_streak: u32,
    had_provider_failure: bool,
    prior_session: PriorSessionDisposition,
) -> bool
```

`PriorSessionDisposition` is derived from the **prior attempt's terminal `task_attempts.outcome`** — the session's own terminal disposition, never wall-clock duration and never the task's status:

| attempt outcome | disposition | trigger B |
|---|---|---|
| `cancelled` (session cancellation token fired — the 7mq0 shape) | `CancelledOrReclaimed` | disarmed |
| `timed_out` (coordinator stall kill reclaimed a live session) | `CancelledOrReclaimed` | disarmed |
| `interrupted` (deploy / rollout / reap) | `CancelledOrReclaimed` | disarmed |
| `completed` / `submitted` / `reopened` / `force_closed` / `loop_guard_tripped` | `Concluded` | armed |
| `crashed` / `spawn_failed` | `Concluded` | armed |
| unknown string, or no attempt evidence at all | `Concluded` (fails **closed**) | armed |

Notes on the boundaries:

- **`crashed` and `spawn_failed` stay counted.** They are genuine failures of the run reaching their own terminal decision — deliberately narrower than the existing `is_infra()` set.
- **`timed_out` is excluded because a truthful trigger already owns it**: the stall-cancel escalation in `session_recovery` fires at `STALL_CANCEL_ESCALATION_THRESHOLD` with a reason that accurately says "stall-cancelled on N consecutive sessions". Same shape as trigger B deferring to trigger D on provider faults.
- **Nothing fails open.** Missing or unparseable attempt evidence classifies as `Concluded`, so storage drift or a vocabulary change can never silently disable the escalation.

No lever was touched that weakens the t9wi/32bk review-cycle wedge: the threshold is unchanged at 4, and a task genuinely bouncing `needs_task_review → in_progress → needs_task_review` terminalizes its attempts `completed` / `submitted` / `reopened`, which classify as `Concluded` and still escalate at 4.

The disposition rides on `DispatchStrikeDecision`, which the dispatch pass **already** computes on this exact branch (`latest_attempt_strike_decision`) for the environmental-interrupt exemption — so this adds no new DB read on the hot path.

### Truthful reason

The emitted reason previously reported `status` and `reopen_count` but not the session outcomes it was actually counting, and asserted completion the coordinator never checked. It now names the evidence:

> Task is cycling without converging: 4 consecutive `worker` redispatches without the task changing status (status `open`, reopen_count=0 — the loop never passes through `open`, so the reopen-based escalation never saw it). **Observed session outcomes for `worker`, newest first: completed, completed, completed, completed. Sessions cancelled or reclaimed by infrastructure (`cancelled` / `timed_out` / `interrupted`) do NOT advance this streak, so every run counted above reached its own terminal decision and the task still landed right back where it was.** Decide how to unstick this: DECOMPOSE …

When the attempt rows cannot be read, it says so rather than inventing outcomes.

## Regression test + neutralization

`server/crates/djinn-coordinator/src/tests/intervention.rs`:

- `cancelled_sessions_do_not_route_the_cycling_planner_intervention` — the exact 7mq0 shape: 4 same-role redispatches, each preceded by a `cancelled` terminal attempt row. Asserts no planner marker, no remediation review task, task stays `open`, backoff still accrues; then 3 more cycles prove the exclusion does not decay as the streak grows.
- `completed_same_role_redispatches_still_route_the_cycling_planner_intervention` — 4 `completed` attempts still route at exactly 4, and the created remediation task's description contains the observed-outcomes line and no longer contains "Each run finishes".

Both drive the production functions (`latest_attempt_strike_decision` + `should_route_cycling_intervention`) the way the dispatch loop does, in the harness style this file already uses.

Also in `types.rs`: `prior_session_disposition_only_excludes_cancelled_or_reclaimed_outcomes` pins the whole outcome vocabulary including the fail-closed unknown case, and the existing `trigger_b_gate_arms_on_clean_same_role_streak_only` gained the cancelled cases.

**Neutralization result** (required before claiming the test works): I removed only the `&& prior_session == PriorSessionDisposition::Concluded` clause from the gate body, kept the tests, and re-ran:

```
test tests::intervention::cancelled_sessions_do_not_route_the_cycling_planner_intervention ... FAILED
test tests::intervention::completed_same_role_redispatches_still_route_the_cycling_planner_intervention ... ok

panicked at crates/djinn-coordinator/src/tests/intervention.rs:1031:5:
four cancelled sessions must NOT route a Planner intervention — the runs never
finished, so the streak is no evidence about the task's scope
```

The first test fails on its own assertion, the second stays green (proving it is not merely coupled to the gate signature). The clause was then restored and both pass.

## Verification

- `cargo test -p djinn-coordinator --lib -- tests::intervention:: types::cooldown_tests` → 82 passed, 0 failed.
- `cargo clippy -p djinn-coordinator -p djinn-core --all-targets` → clean; `cargo fmt --check` clean.
- The full `-p djinn-coordinator` run has 3–4 failures that vary run to run (`tests::session_reaping::*` global-telemetry-label contamination, `context::tests::cache_cleanup_config_from_env_*` env races, `wave::tests::…`). I reproduced the same class of failures on unmodified `main` and confirmed all of them pass in isolation with this change applied — pre-existing parallel-execution flakes, not caused by this diff.

## Residual (not fixed here, deliberately out of scope)

A cancelled session still advances `dispatch_failure_streak` toward the `MAX_DISPATCH_FAILURES` (=10) terminal close. That backstop is unchanged by this PR, and giving cancellation its own bounded escalation (the way stall kills and provider faults have one) is a separate change to the intervention ladder.
