### PR TITLE
perf(warm): reuse the warm base's incremental cache, and fix three process-global test collisions

### DIFF
--- a/server/crates/djinn-agent-worker/src/lifecycle.rs
+++ b/server/crates/djinn-agent-worker/src/lifecycle.rs
@@ -3037,7 +3037,7 @@ mod tests {
     // * No-op compatibility for missing/empty `lifecycle.pre_task`.
     // * Ordered execution of multiple commands with a realistic generic
     //   non-djinn command shape that reads an injected service connection
-    //   env var such as `TEST_POSTGRES_URL` and writes an observable
+    //   env var such as `DJINN_FIXTURE_SERVICE_URL` and writes an observable
     //   marker — with no dependency on djinn-core template bootstrap code.
     // * Best-effort failure continuation, blocking failure
     //   stop-before-session, and environmental non-attempt/no-session
@@ -3118,7 +3118,7 @@ mod tests {
 
     /// AC2: Ordered execution of multiple commands with a realistic
     /// generic non-djinn command shape.  The first command reads an
-    /// injected service connection env var (`TEST_POSTGRES_URL`) and
+    /// injected service connection env var (`DJINN_FIXTURE_SERVICE_URL`) and
     /// writes an observable marker file; the second command verifies the
     /// marker was written.  No djinn-core template bootstrap code is
     /// invoked — the commands are plain `/bin/sh -c` scripts.
@@ -3128,7 +3128,7 @@ mod tests {
         // the value being a real Postgres URL — we only prove the env var
         // is visible inside the pre-task command's shell.
         let sentinel_url = "postgres://test-user:test-pass@127.0.0.1:5432/testdb?sslmode=disable";
-        let _guard = TestEnvGuard::set("TEST_POSTGRES_URL", sentinel_url);
+        let _guard = TestEnvGuard::set("DJINN_FIXTURE_SERVICE_URL", sentinel_url).await;
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let marker = tmp.path().join("pretask-connected.marker");
@@ -3142,7 +3142,7 @@ mod tests {
                     PreTaskCommand {
                         name: Some("check-db-connection".into()),
                         command: format!(
-                            "printf '%s' \"${{TEST_POSTGRES_URL}}\" > {}",
+                            "printf '%s' \"${{DJINN_FIXTURE_SERVICE_URL}}\" > {}",
                             marker.to_string_lossy()
                         ),
                         timeout_seconds: 30,
@@ -3190,7 +3190,7 @@ mod tests {
         let marker_content = std::fs::read_to_string(&marker).unwrap();
         assert_eq!(
             marker_content, sentinel_url,
-            "the TEST_POSTGRES_URL env var value should be visible inside the pre-task shell"
+            "the DJINN_FIXTURE_SERVICE_URL env var value should be visible inside the pre-task shell"
         );
 
         // Activity events: one per started command, both with the stable
@@ -3503,7 +3503,7 @@ mod tests {
         // Inject a secret-looking env var with a value longer than 4 chars
         // (the redaction threshold).
         let secret_value = "sk-generic-api-key-1234567890";
-        let _guard = TestEnvGuard::set("GENERIC_API_KEY", secret_value);
+        let _guard = TestEnvGuard::set("GENERIC_API_KEY", secret_value).await;
 
         let tmp = tempfile::tempdir().expect("tempdir");
         let cfg = EnvironmentConfig {
@@ -3689,7 +3689,7 @@ mod tests {
     //
     // Proves a non-djinn-shaped target repo can prepare a test database
     // purely through `EnvironmentConfig.lifecycle.pre_task` plus an injected
-    // service connection env var (`TEST_POSTGRES_URL`), without invoking
+    // service connection env var (`DJINN_FIXTURE_SERVICE_URL`), without invoking
     // djinn-core template bootstrap or any djinn-db-specific branch.
     //
     // The fixture models a generic repo carrying `schema.sql` and a
@@ -3701,7 +3701,7 @@ mod tests {
 
     /// AC: A worker regression models a non-djinn target repo database
     /// preparation command declared through `EnvironmentConfig.lifecycle.pre_task`,
-    /// consuming an injected `TEST_POSTGRES_URL` env var.  The command runs
+    /// consuming an injected `DJINN_FIXTURE_SERVICE_URL` env var.  The command runs
     /// from the repo root and is driven by generic config only — no
     /// djinn-db/template-bootstrap special case or target-repo code path
     /// is added to core runtime code.
@@ -3723,13 +3723,13 @@ mod tests {
         )
         .expect("write schema.sql");
 
-        // prepare-test-db.sh — shell helper that consumes $TEST_POSTGRES_URL
+        // prepare-test-db.sh — shell helper that consumes $DJINN_FIXTURE_SERVICE_URL
         // and "runs" the schema.  In a real repo this might be
-        //   psql "$TEST_POSTGRES_URL" -f schema.sql
+        //   psql "$DJINN_FIXTURE_SERVICE_URL" -f schema.sql
         // or `rails db:prepare` or `npx prisma db push`.
         //
         // The deterministic stand-in:
-        //   1. Reads TEST_POSTGRES_URL from the environment.
+        //   1. Reads DJINN_FIXTURE_SERVICE_URL from the environment.
         //   2. Verifies schema.sql exists at the repo root.
         //   3. Writes a proof marker containing the connection string,
         //      the resolved repo root, and the schema content — proving
@@ -3744,7 +3744,7 @@ mod tests {
                 r#"#!/bin/sh
 set -e
 # Read the injected connection env var (produced by the service sidecar).
-CONN_URL="${{TEST_POSTGRES_URL:?TEST_POSTGRES_URL not set}}"
+CONN_URL="${{DJINN_FIXTURE_SERVICE_URL:?DJINN_FIXTURE_SERVICE_URL not set}}"
 REPO_ROOT="$(pwd)"
 
 # Verify the schema file is present at the repo root.
@@ -3768,7 +3768,7 @@ EOF
 
         // ---- 2. Inject the service connection env var -------------------
         let sentinel_url = "postgres://test-user:test-pass@127.0.0.1:5432/testdb?sslmode=disable";
-        let _guard = TestEnvGuard::set("TEST_POSTGRES_URL", sentinel_url);
+        let _guard = TestEnvGuard::set("DJINN_FIXTURE_SERVICE_URL", sentinel_url).await;
 
         // ---- 3. Declare the pre-task command through pure config ---------
         // No djinn-core template bootstrap, no djinn-db branch — just a
@@ -3838,7 +3838,7 @@ EOF
         let marker_content = std::fs::read_to_string(&proof_marker).expect("read marker");
         assert!(
             marker_content.contains(sentinel_url),
-            "marker must contain the injected TEST_POSTGRES_URL value; got: {marker_content}"
+            "marker must contain the injected DJINN_FIXTURE_SERVICE_URL value; got: {marker_content}"
         );
         assert!(
             marker_content.contains(&format!("repo_root={}", repo_root.path().display())),
@@ -3945,7 +3945,7 @@ EOF
 
     /// AC: Multi-command database preparation — a generic repo declares
     /// a two-step preparation (schema application + seed data) through
-    /// `lifecycle.pre_task`, both consuming `TEST_POSTGRES_URL`.  The
+    /// `lifecycle.pre_task`, both consuming `DJINN_FIXTURE_SERVICE_URL`.  The
     /// second command depends on the first (verifies the proof marker
     /// written by the first).  This proves sequential multi-command
     /// database preparation is config-driven with no djinn special case.
@@ -3970,7 +3970,7 @@ EOF
 
         // Step 1: apply schema, write proof.
         let step1_cmd = format!(
-            "test -n \"$TEST_POSTGRES_URL\" && test -f schema.sql && echo schema_applied > {marker}",
+            "test -n \"$DJINN_FIXTURE_SERVICE_URL\" && test -f schema.sql && echo schema_applied > {marker}",
             marker = proof_marker.to_string_lossy(),
         );
 
@@ -3981,7 +3981,7 @@ EOF
         );
 
         let sentinel_url = "postgres://app:secret@db.example.com:5432/myapp";
-        let _guard = TestEnvGuard::set("TEST_POSTGRES_URL", sentinel_url);
+        let _guard = TestEnvGuard::set("DJINN_FIXTURE_SERVICE_URL", sentinel_url).await;
 
         let cfg = EnvironmentConfig {
             lifecycle: djinn_stack::environment::LifecycleHooks {
@@ -4069,7 +4069,7 @@ EOF
         let empty_repo = tempfile::tempdir().expect("tempdir");
 
         let sentinel_url = "postgres://test:test@127.0.0.1:5432/empty";
-        let _guard = TestEnvGuard::set("TEST_POSTGRES_URL", sentinel_url);
+        let _guard = TestEnvGuard::set("DJINN_FIXTURE_SERVICE_URL", sentinel_url).await;
 
         // Same command shape as the success test, but in a repo root that
         // has no schema.sql — the script should fail.
@@ -4118,20 +4118,55 @@ EOF
     /// Sets a variable on construction and restores the original value
     /// (or removes it) on drop.  This prevents test env mutations from
     /// leaking across tests when running in the same binary.
+    /// Sets a process-global env var for the lifetime of one test.
+    ///
+    /// The scope is TEMPORAL, not thread-local: the variable is visible to every
+    /// other test running in parallel in this binary, and Drop restores it on a
+    /// schedule those tests cannot observe. So the KEY must be one that nothing
+    /// else in the process reads.
+    ///
+    /// This is not hypothetical. These fixtures used to inject a sentinel URL
+    /// under `TEST_POSTGRES_URL` — which is exactly the variable
+    /// `djinn_db::test_database_base_url()` reads to locate the real test
+    /// Postgres. Every DB-backed test that called `Database::open_in_memory()`
+    /// inside the guard's window resolved its "test database" to the sentinel's
+    /// `db.example.com:5432` and died with `ConnectionRefused`. That produced
+    /// 0-8 failures per run of this crate's suite, scaling with `--test-threads`
+    /// and landing on whichever tests happened to overlap — the classic shape of
+    /// a flake blamed on the DB or on whatever PR was in flight. Use a key with
+    /// a `DJINN_FIXTURE_` prefix unless the test is specifically about a real
+    /// variable's production meaning.
     struct TestEnvGuard {
         key: String,
         original: Option<String>,
+        /// Held for the guard's whole lifetime, and released only after Drop has
+        /// restored the variable.
+        ///
+        /// A unique key stops this guard from corrupting another test's *reads*,
+        /// but `set_var` is unsound in a multithreaded process regardless of key:
+        /// glibc may reallocate `environ`, so a concurrent `execve` can hand a
+        /// child a torn environment. Several tests here spawn `sh -c`, and a
+        /// child that loses `PATH` fails to resolve the shell at all — which
+        /// surfaced as `nondjinn_multistep_db_preparation_fixture` failing its
+        /// `all_succeeded()` assertion for no attributable reason. Serializing
+        /// against the same mutex the warm tests use (they mutate `PATH`) keeps
+        /// mutation and process spawning from overlapping.
+        _serial: tokio::sync::MutexGuard<'static, ()>,
     }
 
     impl TestEnvGuard {
-        fn set(key: &str, value: &str) -> Self {
+        async fn set(key: &str, value: &str) -> Self {
+            let serial = crate::WARM_LIFECYCLE_TEST_MUTEX.lock().await;
             let original = std::env::var(key).ok();
-            // SAFETY: single-test-binary; each test that mutates env does
-            // so within its own body and restores via Drop.
+            // SAFETY: the process-wide mutex above is held for the guard's
+            // lifetime, so no sibling test mutates the environment or spawns a
+            // child concurrently with this write. See the type-level note: the
+            // key must also be one nothing else in the process reads.
             unsafe { std::env::set_var(key, value) };
             Self {
                 key: key.to_string(),
                 original,
+                _serial: serial,
             }
         }
     }
@@ -4368,7 +4403,7 @@ EOF
     #[tokio::test]
     async fn pretask_activity_output_tail_bounded_with_redaction_after_serialization() {
         let secret_value = "sk-compat-regression-long-secret-key-1234567890";
-        let _guard = TestEnvGuard::set("COMPAT_REGRESSION_SECRET", secret_value);
+        let _guard = TestEnvGuard::set("COMPAT_REGRESSION_SECRET", secret_value).await;
 
         let tmp = tempfile::tempdir().expect("tempdir");
         // ~24 KiB of non-secret filler (each line ~80 chars, 300 lines)

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -1287,6 +1287,37 @@ fn resolve_cargo_workspace_dir(
 /// same way before it compiles — without matching mtimes the base's fingerprints
 /// won't match task-run's fresh clone and reuse never hits.
 ///
+/// # The base's `debug/incremental` is retained across cycles
+///
+/// This used to prune `debug/incremental` unconditionally before every compile,
+/// which was strictly lose-lose. Pruning does not invalidate artifacts or
+/// fingerprints, so the base still reused its `.rlib`/`.rmeta`; the only effect
+/// was that every unit cargo *did* have to rebuild paid a full rustc codegen
+/// instead of a partial one, because its query cache had just been deleted. And
+/// the disk was never actually saved: the compile below immediately regenerates
+/// the directory (measured at 13 GB for djinn's own base), which then sits on
+/// the PVC until the next cycle deletes it. We paid the space and threw away the
+/// speedup.
+///
+/// Retaining it is safe because nothing else consumes this directory:
+///
+/// * Task-run pods never see it — `cargo_target_seed::classify_cargo_target_path`
+///   returns `Skip` for anything under `incremental`, so it is neither hardlinked
+///   (which would corrupt the shared base) nor copied (which would cost more than
+///   it saves for a throwaway run dir).
+/// * warm↔task-run fingerprint parity is unaffected. Parity depends on the
+///   *value* `CARGO_INCREMENTAL=1` being identical on both sides (it folds into
+///   `-C metadata`), not on whether this directory is populated.
+/// * The warm holds the per-variant `WarmBaseLock` for the whole cycle, so it is
+///   the sole writer.
+///
+/// Disk is bounded by the coordinator's cache-cleanup sweep outside this Pod,
+/// whose first pressure rung removes exactly this directory once free space
+/// falls below the low watermark — a demand-driven reclaim instead of an
+/// unconditional one. The only in-Pod prune left is the self-heal below, which
+/// fires when a cycle compiled nothing at all so a poisoned incremental cache
+/// cannot wedge the base indefinitely.
+///
 /// Best-effort throughout: a missing cargo workspace (non-Rust repo) or any
 /// compile failure logs and returns — it never fails the graph warm.
 async fn warm_cargo_target_base(
@@ -1308,12 +1339,6 @@ async fn warm_cargo_target_base(
     // above deliberately preserves the graph warmer's inexpensive non-Rust
     // path. For Rust workspaces, acquire before any stamp or compiler can
     // touch the base and retain the guard through the final gated sweep.
-    // Start the observable attempt before the primitive opens or probes the
-    // lock file. The terminal counter/event below remains exactly-once.
-    info!(
-        project_id,
-        "cargo_metrics: warm incremental prune attempt started"
-    );
     let mold_jobs = cargo_build_jobs_variant();
     let _warm_base_guard = match acquire_warm_base_lock(project_id, mold_jobs) {
         Ok(guard) => {
@@ -1326,34 +1351,6 @@ async fn warm_cargo_target_base(
             return;
         }
     };
-    #[cfg(test)]
-    let prune_result = match WARM_CARGO_TEST_ROOT
-        .lock()
-        .expect("warm test root poisoned")
-        .clone()
-    {
-        Some(root) => cargo_incremental_prune::prune_warm_incremental_for_root(
-            project_id,
-            Path::new(&std::env::var_os(CARGO_TARGET_DIR_ENV).unwrap_or_default()),
-            &root,
-        ),
-        None => cargo_incremental_prune::prune_warm_incremental_for_jobs(project_id, mold_jobs),
-    };
-    #[cfg(not(test))]
-    let prune_result =
-        cargo_incremental_prune::prune_warm_incremental_for_jobs(project_id, mold_jobs);
-    match prune_result {
-        Ok(result) => {
-            warm_cargo_test_phase(result.outcome.as_str());
-            record_warm_incremental_prune_success(project_id, result)
-        }
-        Err(error) => {
-            warm_cargo_test_phase("failed");
-            record_warm_incremental_prune_failure(project_id, error.kind);
-            warn!(project_id, error = %error, "cargo warm: incremental prune failed; skipping Cargo warm");
-            return;
-        }
-    }
 
     // Canonicalize once so every structured event and metric for this warm
     // shares the same absolute workspace_dir. Cargo fingerprints embed
@@ -1541,6 +1538,28 @@ async fn warm_cargo_target_base(
         "cargo warm: warm-base convergence delta for this cycle"
     );
 
+    // Self-heal: a cycle in which NOTHING compiled is the one signature a
+    // poisoned incremental cache produces, and it is the only case where
+    // retaining the cache could wedge the base indefinitely. rustc validates and
+    // discards its own cache on mismatch, so this is a backstop rather than the
+    // expected path — but without it a persistent ICE would repeat every cycle
+    // forever. Dropping the directory here means the NEXT cycle starts from a
+    // clean incremental cache; we deliberately do not re-run the compile in
+    // this cycle, because the warm Job's deadline has no room for a second full
+    // pass (the tail-reserve clamp already truncates the test step under load).
+    //
+    // Truncated steps are excluded: a step killed at its budget proves nothing
+    // about cache health, and discarding a 13 GB cache every time the deadline
+    // bites would reinstate the unconditional prune under a different name.
+    if !any_step_ok && !any_step_truncated {
+        warn!(
+            project_id,
+            "cargo warm: no step compiled; discarding the incremental cache so \
+             the next cycle starts clean"
+        );
+        prune_warm_incremental_state(project_id, mold_jobs);
+    }
+
     // Prune the warm base of everything the compile above did not touch. Safe by
     // construction *only when the compile phase actually ran to completion*:
     // cargo-sweep removes whole artifact files older than the stamp, and its
@@ -1554,8 +1573,8 @@ async fn warm_cargo_target_base(
     // the failure mode this task was opened for, and the base ping-ponged
     // instead of converging. Truncation therefore skips the sweep: the base
     // keeps last cycle's artifacts and the next cycle resumes from more
-    // progress. Disk is still bounded by the incremental prune above and by the
-    // cache-cleanup sweep outside this Pod.
+    // progress. Disk is still bounded by the cache-cleanup sweep outside this
+    // Pod, whose first pressure rung reclaims `debug/incremental` on demand.
     // Truncation is checked before "nothing succeeded" because it is the more
     // specific and more actionable explanation: a cycle whose only compile step
     // was killed at its budget satisfies both predicates, and reporting it as
@@ -1721,6 +1740,54 @@ fn warm_cargo_take_injected_lock_failure()
 
 #[cfg(not(test))]
 fn warm_cargo_test_phase(_: &'static str) {}
+
+/// Discard the warm base's `debug/incremental` through the checked prune
+/// primitive, recording the same terminal telemetry the flow has always
+/// emitted. Callers must already hold the warm base lock for `mold_jobs`.
+///
+/// This is the self-heal path only — see `warm_cargo_target_base` for why the
+/// base otherwise retains its incremental cache across cycles. A prune failure
+/// is logged and swallowed: the cycle's compile has already happened by the
+/// time this runs, so there is nothing left to fail closed on, and the
+/// coordinator's pressure sweep can still reclaim the directory.
+fn prune_warm_incremental_state(project_id: &str, mold_jobs: usize) {
+    info!(
+        project_id,
+        "cargo_metrics: warm incremental prune attempt started"
+    );
+    #[cfg(test)]
+    let prune_result = match WARM_CARGO_TEST_ROOT
+        .lock()
+        .expect("warm test root poisoned")
+        .clone()
+    {
+        Some(root) => cargo_incremental_prune::prune_warm_incremental_for_root(
+            project_id,
+            Path::new(&std::env::var_os(CARGO_TARGET_DIR_ENV).unwrap_or_default()),
+            &root,
+        ),
+        None => cargo_incremental_prune::prune_warm_incremental_for_jobs(project_id, mold_jobs),
+    };
+    #[cfg(not(test))]
+    let prune_result =
+        cargo_incremental_prune::prune_warm_incremental_for_jobs(project_id, mold_jobs);
+    match prune_result {
+        Ok(result) => {
+            warm_cargo_test_phase(result.outcome.as_str());
+            record_warm_incremental_prune_success(project_id, result);
+        }
+        Err(error) => {
+            warm_cargo_test_phase("failed");
+            record_warm_incremental_prune_failure(project_id, error.kind);
+            warn!(
+                project_id,
+                error = %error,
+                "cargo warm: self-heal incremental prune failed; the pressure \
+                 sweep remains the reclaim path"
+            );
+        }
+    }
+}
 
 /// Production acquires through this terminal recorder. Tests replace only the
 /// probe/acquire filesystem operation in the same acquisition seam; they do
@@ -5910,9 +5977,18 @@ warning: something
         );
     }
 
+    /// A healthy cycle must retain the base's incremental cache.
+    ///
+    /// The fixture seeds `debug/incremental/stale` and asserts it is still there
+    /// afterwards, because the phase list alone cannot distinguish "we stopped
+    /// pruning" from "the prune ran and the recorder label changed". Pruning
+    /// this directory never saved disk — the compile regenerates it immediately
+    /// (13 GB on djinn's own base) and it then sits on the PVC until the next
+    /// cycle — while costing a full rustc codegen for every unit that did need
+    /// rebuilding. Reclaim is the coordinator pressure sweep's job.
     #[cfg(unix)]
     #[test]
-    fn warm_cargo_ordering_recorder_observes_prune_stamp_compile_and_end_sweep() {
+    fn healthy_warm_cycle_retains_the_incremental_cache_and_never_prunes() {
         use std::os::unix::fs::PermissionsExt;
         let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         let fixture = tempfile::tempdir().expect("workspace fixture");
@@ -5977,7 +6053,111 @@ warning: something
         }
         assert_eq!(
             *WARM_CARGO_PHASES.lock().expect("recorder"),
-            ["lock", "pruned", "stamp", "compile", "end-sweep"]
+            ["lock", "stamp", "compile", "end-sweep"],
+            "a healthy cycle must not prune the incremental cache"
+        );
+        // The side effect, not the label: the cache the previous cycle left
+        // behind is what this cycle's rustc gets to reuse.
+        assert_eq!(
+            std::fs::read(target.join("debug/incremental/stale")).expect("incremental retained"),
+            b"stale",
+            "a healthy warm cycle must leave debug/incremental intact"
+        );
+        let _ = std::fs::remove_dir_all(target);
+    }
+
+    /// The self-heal backstop: a cycle in which nothing compiled discards the
+    /// incremental cache so the next cycle starts clean.
+    ///
+    /// Without this, retaining the cache would let one poisoned session wedge
+    /// the base indefinitely — rustc validates its own cache and normally
+    /// recovers, but "normally" is not a guarantee to hang a shared build base
+    /// on. The prune happens AFTER the compile, not before: the next cycle pays
+    /// for it, not this one, because the warm Job's deadline has no room for a
+    /// second full pass.
+    #[cfg(unix)]
+    #[test]
+    fn warm_cycle_that_compiled_nothing_discards_the_incremental_cache() {
+        use std::os::unix::fs::PermissionsExt;
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
+        let fixture = tempfile::tempdir().expect("workspace fixture");
+        std::fs::write(
+            fixture.path().join("Cargo.toml"),
+            "[package]\nname=\"ordering-red\"\nversion=\"0.1.0\"\nedition=\"2024\"\n",
+        )
+        .expect("manifest");
+        // Every cargo invocation fails, so no warm step succeeds and none is
+        // truncated — the exact predicate the self-heal is gated on.
+        let cargo = fixture.path().join("cargo");
+        std::fs::write(&cargo, "#!/bin/sh\nexit 1\n").expect("fake cargo");
+        let mut permissions = std::fs::metadata(&cargo)
+            .expect("cargo metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&cargo, permissions).expect("fake cargo executable");
+        let project = format!("warm-ordering-red-{}", std::process::id());
+        let warm_root = fixture.path().join("warm-base");
+        let target = warm_root.join(&project);
+        std::fs::create_dir_all(target.join("debug/incremental")).expect("warm target");
+        std::fs::write(target.join("debug/incremental/poisoned"), b"poisoned")
+            .expect("incremental fixture");
+        let previous_target = std::env::var_os(CARGO_TARGET_DIR_ENV);
+        let previous_path = std::env::var_os("PATH").expect("PATH");
+        unsafe { std::env::set_var(CARGO_TARGET_DIR_ENV, &target) };
+        *WARM_CARGO_TEST_ROOT.lock().expect("warm test root") = Some(warm_root);
+        unsafe {
+            std::env::set_var(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    fixture.path().display(),
+                    previous_path.to_string_lossy()
+                ),
+            )
+        };
+        WARM_CARGO_PHASES.lock().expect("recorder").clear();
+        let policy = cargo_cache_policy::CargoCachePolicy {
+            workspace: false,
+            features: Vec::new(),
+            all_features: false,
+            warm_commands: vec![cargo_cache_policy::CargoWarmCommand {
+                label: "check",
+                args: vec!["check".to_string()],
+                feature_args: Vec::new(),
+            }],
+        };
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+            .block_on(warm_cargo_target_base(
+                &project,
+                fixture.path(),
+                &policy,
+                None,
+            ));
+        *WARM_CARGO_TEST_ROOT.lock().expect("warm test root") = None;
+        unsafe { std::env::set_var("PATH", previous_path) };
+        match previous_target {
+            Some(value) => unsafe { std::env::set_var(CARGO_TARGET_DIR_ENV, value) },
+            None => unsafe { std::env::remove_var(CARGO_TARGET_DIR_ENV) },
+        }
+        let phases = WARM_CARGO_PHASES.lock().expect("recorder").clone();
+        assert!(
+            phases.contains(&"pruned"),
+            "a cycle that compiled nothing must self-heal the cache: {phases:?}"
+        );
+        // The prune must follow the compile, never precede it: this cycle keeps
+        // whatever reuse it had, and only the next one starts clean.
+        let compile = phases.iter().position(|phase| *phase == "compile");
+        let pruned = phases.iter().position(|phase| *phase == "pruned");
+        assert!(
+            compile < pruned,
+            "the self-heal prune must run after the compile: {phases:?}"
+        );
+        assert!(
+            !target.join("debug/incremental").exists(),
+            "the poisoned incremental cache must be gone"
         );
         let _ = std::fs::remove_dir_all(target);
     }
@@ -6092,10 +6272,15 @@ warning: something
             }
         }
 
+        // No `pruned`: a step killed at its budget proves nothing about the
+        // incremental cache's health, so it must not trigger the self-heal.
+        // Discarding the cache every time the deadline bites would reinstate
+        // the unconditional prune under another name.
         assert_eq!(
             *WARM_CARGO_PHASES.lock().expect("recorder"),
-            ["lock", "pruned", "stamp", "compile"],
-            "a truncated compile step must not reach the tail sweep"
+            ["lock", "stamp", "compile"],
+            "a truncated compile step must not reach the tail sweep, and must \
+             not discard the incremental cache"
         );
 
         let logs = logs.take();

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -4823,6 +4823,8 @@ mod tests {
     /// It is not used by production worker or checkpoint logic.
     #[tokio::test]
     async fn checkpoint_commits_and_pushes_uncommitted_work() {
+        // Spawns real `git` children — see WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.lock().await;
         let origin = tempfile::TempDir::new().expect("origin");
         let op = origin.path();
         git(op, &["init", "--bare", "-b", "main"]);
@@ -4875,6 +4877,8 @@ mod tests {
     /// committed-but-unpushed work (the common case: workers commit via shell).
     #[tokio::test]
     async fn checkpoint_pushes_committed_but_unpushed_work() {
+        // Spawns real `git` children — see WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.lock().await;
         let origin = tempfile::TempDir::new().expect("origin");
         let op = origin.path();
         git(op, &["init", "--bare", "-b", "main"]);
@@ -4938,6 +4942,8 @@ mod tests {
     /// `git rev-parse`; an absent branch resolves to `None` (skip-this-tick).
     #[tokio::test]
     async fn resolve_branch_sha_reads_local_head_and_handles_absent_branch() {
+        // Spawns real `git` children — see WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.lock().await;
         let clone = tempfile::TempDir::new().expect("clone");
         let cp = clone.path();
         git(cp, &["init", "-b", "main"]);
@@ -4959,6 +4965,8 @@ mod tests {
     /// seam. Drives one tick by stubbing the tick logic the loop runs.
     #[tokio::test]
     async fn periodic_push_pushes_committed_work_without_committing() {
+        // Spawns real `git` children — see WARM_LIFECYCLE_TEST_MUTEX.
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.lock().await;
         let origin = tempfile::TempDir::new().expect("origin");
         let op = origin.path();
         git(op, &["init", "--bare", "-b", "main"]);


### PR DESCRIPTION
## 1. The warm base discarded its incremental cache every cycle

`warm_cargo_target_base` pruned `debug/incremental` unconditionally before every compile. That was strictly lose-lose:

* **It saved no disk.** The compile in the same cycle regenerates the directory — measured on prod at `pruned_bytes=13026896525` (13.0 GB) — which then sits on the PVC untouched until the next cycle deletes it. We paid the space *and* threw away the speedup.
* **It did not reduce rebuild scope.** Pruning does not invalidate artifacts or fingerprints, so the base still reused its `.rlib`/`.rmeta`. The only effect was that every unit cargo *did* have to rebuild paid a full rustc codegen instead of a partial one. The observed cycle rebuilt a real delta (fingerprint units 1376 → 1730, dep files 3133 → 4018), and each of those units paid it.

Retaining the cache is safe because nothing else consumes the directory:

* Task-run pods never see it — `classify_cargo_target_path` returns `Skip` for anything under `incremental`, so it is neither hardlinked (which would corrupt the shared base) nor copied (too expensive for a throwaway run dir).
* warm↔task-run fingerprint parity is unaffected: parity depends on the *value* `CARGO_INCREMENTAL=1` being identical on both sides (it folds into `-C metadata`), not on whether the directory is populated.
* The warm holds the per-variant `WarmBaseLock` for the whole cycle, so it is the sole writer.

Reclaim moves to the mechanism already built for it: the coordinator's cache-cleanup sweep, whose first pressure rung removes exactly this directory once free space drops below the low watermark. Demand-driven instead of unconditional.

The only in-Pod prune left is a **self-heal** for cycles that compiled nothing at all, so a poisoned incremental cache cannot wedge the base indefinitely. It runs *after* the compile, not before, because the warm Job's deadline has no room for a second full pass. Truncated steps are excluded: a step killed at its budget proves nothing about cache health, and discarding the cache whenever the deadline bites would reinstate the unconditional prune under another name.

### Context on why this matters now

The warm Job is tight on time — the observed cycle spent 2812s indexing + 2184s in cargo (clippy 649s, nextest 1535s) against a 7200s deadline, with `budget_clamped_by_job_deadline=true` on the test step. Faster compiles buy headroom against the truncation that has previously left partial deposits.

Also worth recording: `debug/incremental` is **not** what fills the disk any more. Measured the same day, the node was at 316G/484G with **143 G of containerd images + 86 G of zot** = 72% of the disk in accumulated image builds; the whole djinn-cache PVC was 64 G and `cargo-target-runs` was under 1 G.

## 2. Three process-global collisions flaking `cargo test -p djinn-agent-worker`

Found while validating the above. The suite failed on **roughly 80% of runs**, 0-8 tests at a time, landing on whichever tests happened to overlap.

Failures scaled monotonically with concurrency — 16 threads → 0-8 failures, `--test-threads=4` → 0-1, `--test-threads=1` → 0 — which is what identified these as collisions rather than logic bugs.

1. **`TEST_POSTGRES_URL` had two unrelated meanings in one process.** Four lifecycle fixtures injected a sentinel `postgres://app:secret@db.example.com:5432/myapp` under that name to prove env injection reaches a pre-task shell — but it is also what `djinn_db::test_database_base_url()` reads to locate the real test Postgres. Every DB-backed test calling `Database::open_in_memory()` inside the guard's window resolved its "test database" to `db.example.com:5432` and died with `ConnectionRefused`, which reads as a broken database rather than a test collision. The sentinel name is arbitrary to those fixtures, so it moves to `DJINN_FIXTURE_SERVICE_URL`, which nothing reads.

2. **`TestEnvGuard` mutated the environment without serialization.** Its safety comment claimed each test "mutates env within its own body", but that scopes the write in TIME, not per-thread: `set_var` may reallocate `environ`, so a concurrent `execve` hands the child a torn environment. Tests here spawn `sh -c`, and a child that loses `PATH` cannot resolve the shell at all — which is why `nondjinn_multistep_db_preparation_fixture` failed `all_succeeded()` with nothing attributable. The guard now holds `WARM_LIFECYCLE_TEST_MUTEX` for its lifetime, released only after `Drop` restores the variable.

3. **Four git-spawning tests never took that mutex**, whose own documentation says it "serialises every test in this binary that spawns a real child process" — the process-global `waitpid(-1)` `ChildReaper` owns every terminal status, so an overlapping spawn loses the race and reports ECHILD as `spawn git: No child processes`. Same signature as the bug fixed in #2700, reached through tests that were simply never serialized.

Note CI runs `cargo nextest` (a process per test), which hides all three — they only bite `cargo test`, i.e. local runs. "Green in CI" was never evidence here.

## Verification

* `healthy_warm_cycle_retains_the_incremental_cache_and_never_prunes` seeds `debug/incremental/stale` and asserts it survives the cycle — the **side effect**, not the phase label, so it cannot pass if the prune merely gets relabelled.
* `warm_cycle_that_compiled_nothing_discards_the_incremental_cache` asserts the directory is gone after a fully-red cycle, and that `pruned` follows `compile` in the phase order.
* Both verified by **neutralization**: forcing the self-heal condition to `false` fails the second test; the first fails if the prune is restored.
* `truncated_warm_step_records_timeout_and_suppresses_the_tail_sweep` now pins the *absence* of a prune on the truncated path.
* Flakiness: **0 failures in 25 consecutive full-concurrency runs**, against a 1-in-5-clean baseline.
* `cargo clippy -p djinn-agent-worker --all-targets` and `-p djinn-coordinator --all-targets` clean; `djinn-coordinator` warm-base GC tests 108 passed.

## Not covered here

The warm change is verified through unit tests and the coordinator suite, **not** against a live warm cycle. The actual payoff — how much of that 36 min of compile the retained cache buys back — is only observable on the first warm run after this deploys. Worth watching `elapsed_ms` on the clippy and nextest steps.
