### PR TITLE
chore(cargo): drop the dead build.features key and refresh its stale docs

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -747,11 +747,10 @@ jobs:
       #      is serving this lane, several thousand means it is not.
       #   2. `workspaces[].cargo_features` in the djinn project's environment
       #      config — since #2677 the warm reads its `--features` from there,
-      #      NOT from `server/.cargo/config.toml`, whose `[build] features` key
-      #      that PR deleted. That config has never set it, so the warm
-      #      currently runs with NO features while this lane uses
-      #      `--features qdrant`. It needs `["qdrant"]` for the parity this
-      #      step assumes to actually hold.
+      #      NOT from `server/.cargo/config.toml`. That config now declares
+      #      `["qdrant"]` for the `server` workspace, so it matches this lane.
+      #      If the `--features` on the line below ever changes, change it
+      #      there too or the warm silently stops serving this lane.
       - name: Clippy
         run: cargo clippy --workspace --all-targets --features qdrant --keep-going -- -D warnings
       - name: Fingerprint census (after clippy)

--- a/server/.cargo/config.toml
+++ b/server/.cargo/config.toml
@@ -1,21 +1,13 @@
 [build]
-# Feature set djinn's warm-cache pre-build compiles with, so the warm base
-# matches what CI and task-run pods actually build.
-#
-# `djinn-agent-worker::cargo_cache_policy` reads this key to derive the warm
-# job's `--features` args; without it the warm base is built with NO features
-# while CI (`.github/workflows/quality-gate.yml`) and worker commands use
-# `--features qdrant`. Feature resolution differs, so every unit whose
-# resolution depends on it misses the warm base and recompiles.
-#
-# This is djinn's own convention, NOT a cargo key: cargo emits
-# `warning: unused config key build.features` and ignores it. That warning is
-# expected — do not "fix" it by deleting this, and do not move the feature list
-# into the platform, which is deliberately repo-agnostic and reads it from here.
-#
-# Keep in sync with the `--features` used by the Server Clippy / Server Test
-# jobs in `.github/workflows/quality-gate.yml`.
-features = ["qdrant"]
+# NOTE: do NOT re-add a `features = [...]` key here. It is not a cargo key —
+# cargo ignores it and emits `warning: unused config key build.features` on
+# every invocation. It was djinn's own convention until #2677 moved the warm
+# job's feature set to `workspaces[*].cargo_features` in the djinn project's
+# environment config, which `djinn-agent-worker::cargo_cache_policy` reads.
+# That config now declares `["qdrant"]` for the `server` workspace, matching
+# the `--features` used by the Server Clippy / Server Test jobs in
+# `.github/workflows/quality-gate.yml`. Change the feature set there, not here;
+# a key in this file has no effect on anything.
 
 # NOTE: `rustc-wrapper = "sccache"` is intentionally NOT set here. The djinn
 # platform (warm/worker pods) reuses a warm, main-based per-project

--- a/server/crates/djinn-agent-worker/src/cargo_cache_policy.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_cache_policy.rs
@@ -1,7 +1,8 @@
 //! Cargo cache policy resolver — project-agnostic detection of per-project
 //! cargo build strategy.
 //!
-//! Detects from workspace layout and `.cargo/config.toml`.  Pure/unit-
+//! Detects from workspace layout and the project's `EnvironmentConfig`
+//! (`workspaces[*].cargo_features` / `cargo_all_features`).  Pure/unit-
 //! testable; never mutates any project file.
 
 use std::path::{Path, PathBuf};
@@ -34,7 +35,8 @@ impl CargoCachePolicy {
     ///
     /// * Empty vec → default features (no extra flags).
     /// * `["--all-features"]` → all features enabled.
-    /// * `["--features", "foo,bar"]` → named features from `.cargo/config.toml`.
+    /// * `["--features", "foo,bar"]` → named features from the project's
+    ///   `EnvironmentConfig` (`workspaces[*].cargo_features`).
     pub fn features(&self) -> Vec<String> {
         if self.all_features {
             vec!["--all-features".to_string()]


### PR DESCRIPTION
## What

`server/.cargo/config.toml` carried `[build] features = ["qdrant"]`, which is not a cargo key. Cargo ignores it and prints on **every** invocation, including in CI logs:

```
warning: unused config key `build.features` in `/home/runner/work/djinn/djinn/server/.cargo/config.toml`
```

## Why it is safe to delete

The key was djinn's own convention, and its comment block said in so many words *"do not fix this by deleting it."* That instruction is now out of date:

- **#2677** moved the warm job's feature set to `workspaces[*].cargo_features` in the djinn project's environment config. `djinn-agent-worker::cargo_cache_policy` reads it from `EnvironmentConfig` — it does not parse `.cargo/config.toml` for features at all.
- That environment config **now declares `["qdrant"]`** for the `server` workspace (verified against the live project config), matching the `--features qdrant` used by the Server Clippy / Server Test lanes.

So the key is pure residue — nothing in the workspace parses it, and removing it changes no build.

## Also fixed: three comments pointing at the deleted key

Left alone, these would send the next reader to a file that has no effect:

- **`quality-gate.yml`** asserted the environment config *"has never set it, so the warm currently runs with NO features."* It is set now, so the claim is stale and alarming. Rewritten as the drift warning it was meant to be: if the lane's `--features` changes, change the environment config too.
- **`cargo_cache_policy.rs`** — module doc and `features()` doc both attributed the feature source to `.cargo/config.toml`. They now name `EnvironmentConfig`.

The `[build]` table keeps its existing notes (no `rustc-wrapper = "sccache"`, no `target-dir`) and gains a short one recording why `features` must not be re-added.

## Verification

- `cargo metadata --no-deps` in `server/` → exit 0, **empty stderr** (warning gone; it was present before).
- `cargo check -p djinn-agent-worker` → passes.
- Grepped the tree for surviving `build.features` references: only the new explanatory comment and unrelated git-merge test fixtures in `djinn-workspace` (arbitrary file content, not a consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)