### PR TITLE
fix(ui): the coverage banner said "not indexed" when the workspace was stale

### DIFF
--- a/ui/src/api/codeGraph.ts
+++ b/ui/src/api/codeGraph.ts
@@ -127,6 +127,12 @@ export interface CodeGraphWorkspace {
   root?: string;
   language?: string;
   status?: string;
+  /** Nodes this workspace contributes to the served graph. `0`/undefined
+   * means the galaxy currently shows nothing for it. */
+  nodeCount?: number;
+  /** Commit the workspace's nodes came from. For a salvaged workspace this
+   * trails the rest of the graph — that difference IS the staleness. */
+  commitSha?: string;
 }
 
 type RouteSelector =
@@ -156,6 +162,12 @@ function nonEmptyString(value: unknown): string | undefined {
     : undefined;
 }
 
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
 function normalizeWorkspaceEntry(value: unknown): CodeGraphWorkspace | null {
   if (!isRecord(value)) return null;
   const slug = nonEmptyString(value.slug ?? value.workspace_slug ?? value.id);
@@ -168,6 +180,8 @@ function normalizeWorkspaceEntry(value: unknown): CodeGraphWorkspace | null {
     root: nonEmptyString(value.root ?? value.root_path ?? value.path),
     language: nonEmptyString(value.language ?? value.indexer),
     status: nonEmptyString(value.status ?? value.warm_status),
+    nodeCount: finiteNumber(value.node_count),
+    commitSha: nonEmptyString(value.commit_sha),
   };
 }
 
@@ -180,6 +194,13 @@ export interface CoverageGapWorkspace {
   /** indexer_failed | timed_out | unsupported_language. */
   status: string;
   detail?: string;
+  /** Candidate source files found under the workspace root. */
+  discoveredFiles?: number;
+  /** Files this workspace actually contributed to the merged graph — `0` on
+   * every gap status, which is why staleness has to come from elsewhere. */
+  indexedFiles?: number;
+  /** When the last index attempt for this workspace ran (ISO-8601 UTC). */
+  attemptedAt?: string;
 }
 
 /** Parsed `coverage` op payload — the pieces the galaxy HUD needs. */
@@ -198,6 +219,9 @@ function normalizeCoverageGap(value: unknown): CoverageGapWorkspace | null {
     language: nonEmptyString(value.language) ?? "unknown",
     status: nonEmptyString(value.status) ?? "indexer_failed",
     detail: nonEmptyString(value.detail),
+    discoveredFiles: finiteNumber(value.discovered_files),
+    indexedFiles: finiteNumber(value.indexed_files),
+    attemptedAt: nonEmptyString(value.warmed_at),
   };
 }
 
@@ -212,12 +236,43 @@ export function parseCoverageResponse(value: unknown): CodeGraphCoverage {
           (w) => isRecord(w) && (w.is_gap === true || w.status === "timed_out"),
         )
       : [];
+  // `unindexed_source_roots` names the gaps but carries no extent/timing; the
+  // full `workspaces` table does. Merge the two on (slug, language) so the
+  // banner can say WHEN the attempt was and how much it covered, instead of a
+  // bare "not indexed" that reads as permanent.
+  const detailBySlugLang = new Map<string, Record<string, unknown>>();
+  if (Array.isArray(value.workspaces)) {
+    for (const entry of value.workspaces) {
+      if (!isRecord(entry)) continue;
+      const slug = nonEmptyString(entry.workspace_slug ?? entry.slug);
+      if (!slug) continue;
+      detailBySlugLang.set(
+        `${slug}::${nonEmptyString(entry.language) ?? "unknown"}`,
+        entry,
+      );
+    }
+  }
   const gaps = rootsRaw.flatMap((entry) => {
     const g = normalizeCoverageGap(entry);
-    return g ? [g] : [];
+    if (!g) return [];
+    const row = detailBySlugLang.get(`${g.slug}::${g.language}`);
+    const full = row ? normalizeCoverageGap(row) : null;
+    if (!full) return [g];
+    // The gap entry stays authoritative for identity and status; the
+    // workspaces row only fills fields the gap entry does not carry.
+    return [
+      {
+        ...g,
+        detail: g.detail ?? full.detail,
+        discoveredFiles: g.discoveredFiles ?? full.discoveredFiles,
+        indexedFiles: g.indexedFiles ?? full.indexedFiles,
+        attemptedAt: g.attemptedAt ?? full.attemptedAt,
+      },
+    ];
   });
   const hasGaps =
-    value.has_gaps === true || (value.has_gaps === undefined && gaps.length > 0);
+    value.has_gaps === true ||
+    (value.has_gaps === undefined && gaps.length > 0);
   return { hasGaps, gaps };
 }
 
@@ -308,29 +363,23 @@ export function fetchNeighbors(
 export function fetchImpact(
   project: string,
   key: string,
-  args: Pick<CodeGraphArgs, "limit" | "group_by" | "min_confidence" | "direction"> = {},
+  args: Pick<
+    CodeGraphArgs,
+    "limit" | "group_by" | "min_confidence" | "direction"
+  > = {},
 ) {
   return callCodeGraph(project, "impact", { key, ...args });
 }
 
-export function fetchRouteMap(
-  project: string,
-  args: RouteMapArgs = {},
-) {
+export function fetchRouteMap(project: string, args: RouteMapArgs = {}) {
   return callCodeGraph(project, "route_map", args);
 }
 
-export function fetchShapeCheck(
-  project: string,
-  args: ShapeCheckArgs,
-) {
+export function fetchShapeCheck(project: string, args: ShapeCheckArgs) {
   return callCodeGraph(project, "shape_check", args);
 }
 
-export function fetchApiImpact(
-  project: string,
-  args: ApiImpactArgs,
-) {
+export function fetchApiImpact(project: string, args: ApiImpactArgs) {
   return callCodeGraph(project, "api_impact", args);
 }
 

--- a/ui/src/components/codegraph/CoverageGapBanner.test.tsx
+++ b/ui/src/components/codegraph/CoverageGapBanner.test.tsx
@@ -2,23 +2,153 @@ import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { CoverageGapBanner } from "./CoverageGapBanner";
-import type { CodeGraphCoverage } from "@/api/codeGraph";
+import { relativeAge } from "./coverageAdvisory";
+import type { CodeGraphCoverage, CodeGraphWorkspace } from "@/api/codeGraph";
+
+/** 2026-07-28T14:06:50Z — the warm attempt the fixtures below describe. */
+const ATTEMPT = "2026-07-28T14:06:50.434Z";
+/** Two hours after ATTEMPT. */
+const NOW = Date.parse("2026-07-28T16:10:00.000Z");
 
 describe("CoverageGapBanner", () => {
-  it("names unindexed workspaces when coverage has gaps", () => {
+  it("reports a timed-out workspace as stale, naming the commit still on screen", () => {
     const coverage: CodeGraphCoverage = {
       hasGaps: true,
       gaps: [
-        { slug: "server", language: "rust", status: "timed_out" },
-        { slug: "legacy", language: "ruby", status: "unsupported_language" },
+        {
+          slug: "server",
+          language: "rust",
+          status: "timed_out",
+          attemptedAt: ATTEMPT,
+          discoveredFiles: 1439,
+          indexedFiles: 0,
+        },
       ],
     };
-    render(<CoverageGapBanner coverage={coverage} />);
+    // `server` carries nodes from an older commit than its healthy peers —
+    // that difference is the staleness.
+    const workspaces: CodeGraphWorkspace[] = [
+      { slug: "server", nodeCount: 1457, commitSha: "f355d753b735" },
+      { slug: "ui", nodeCount: 19367, commitSha: "068b947fb081" },
+      { slug: "website", nodeCount: 170, commitSha: "068b947fb081" },
+    ];
+    render(
+      <CoverageGapBanner
+        coverage={coverage}
+        workspaces={workspaces}
+        now={NOW}
+      />,
+    );
 
     const banner = screen.getByRole("status", { name: /index coverage gap/i });
-    expect(banner).toHaveTextContent("2 workspaces not indexed");
     expect(banner).toHaveTextContent("server (rust)");
-    expect(banner).toHaveTextContent("legacy (ruby)");
+    expect(banner).toHaveTextContent("index timed out 2h ago");
+    expect(banner).toHaveTextContent("showing f355d75");
+    // The claim the old copy made and could not support.
+    expect(banner).not.toHaveTextContent("not indexed");
+  });
+
+  it("says not-in-the-graph only when the workspace really contributes nothing", () => {
+    const coverage: CodeGraphCoverage = {
+      hasGaps: true,
+      gaps: [
+        {
+          slug: "legacy",
+          language: "ruby",
+          status: "unsupported_language",
+          attemptedAt: ATTEMPT,
+        },
+      ],
+    };
+    render(
+      <CoverageGapBanner
+        coverage={coverage}
+        workspaces={[{ slug: "legacy", nodeCount: 0 }]}
+        now={NOW}
+      />,
+    );
+
+    const banner = screen.getByRole("status", { name: /index coverage gap/i });
+    expect(banner).toHaveTextContent("legacy (ruby): no indexer");
+    expect(banner).toHaveTextContent("not in the graph");
+    // A permanent gap must not promise a retry that will never come.
+    expect(banner.getAttribute("title")).toContain(
+      "will not resolve on its own",
+    );
+  });
+
+  it("tells a retriable gap apart from a permanent one in the tooltip", () => {
+    render(
+      <CoverageGapBanner
+        coverage={{
+          hasGaps: true,
+          gaps: [
+            {
+              slug: "server",
+              language: "rust",
+              status: "timed_out",
+              discoveredFiles: 1439,
+            },
+          ],
+        }}
+        workspaces={[
+          { slug: "server", nodeCount: 1457, commitSha: "aaa" },
+          { slug: "ui", nodeCount: 10, commitSha: "bbb" },
+        ]}
+        now={NOW}
+      />,
+    );
+    const title =
+      screen
+        .getByRole("status", { name: /index coverage gap/i })
+        .getAttribute("title") ?? "";
+    expect(title).toContain("re-attempts on its own schedule");
+    expect(title).toContain("0 of 1439 files");
+    expect(title).toContain("grep");
+  });
+
+  it("falls back to the alarming reading when no workspace data is available", () => {
+    render(
+      <CoverageGapBanner
+        coverage={{
+          hasGaps: true,
+          gaps: [
+            { slug: "server", language: "rust", status: "indexer_failed" },
+          ],
+        }}
+        now={NOW}
+      />,
+    );
+    const banner = screen.getByRole("status", { name: /index coverage gap/i });
+    expect(banner).toHaveTextContent("indexer failed");
+    expect(banner).toHaveTextContent("not in the graph");
+  });
+
+  it("lists several gaps compactly", () => {
+    render(
+      <CoverageGapBanner
+        coverage={{
+          hasGaps: true,
+          gaps: [
+            { slug: "server", language: "rust", status: "timed_out" },
+            {
+              slug: "legacy",
+              language: "ruby",
+              status: "unsupported_language",
+            },
+          ],
+        }}
+        workspaces={[
+          { slug: "server", nodeCount: 1457, commitSha: "aaa" },
+          { slug: "ui", nodeCount: 10, commitSha: "bbb" },
+        ]}
+        now={NOW}
+      />,
+    );
+    const banner = screen.getByRole("status", { name: /index coverage gap/i });
+    expect(banner).toHaveTextContent("2 workspaces degraded");
+    expect(banner).toHaveTextContent("server (rust, index timed out, stale)");
+    expect(banner).toHaveTextContent("legacy (ruby, no indexer, not in graph)");
   });
 
   it("renders nothing when coverage is clean", () => {
@@ -31,5 +161,21 @@ describe("CoverageGapBanner", () => {
   it("renders nothing when coverage is null", () => {
     const { container } = render(<CoverageGapBanner coverage={null} />);
     expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("relativeAge", () => {
+  const now = Date.parse("2026-07-28T16:00:00.000Z");
+
+  it("renders each magnitude compactly", () => {
+    expect(relativeAge("2026-07-28T15:59:30.000Z", now)).toBe("30s");
+    expect(relativeAge("2026-07-28T15:30:00.000Z", now)).toBe("30m");
+    expect(relativeAge("2026-07-28T14:00:00.000Z", now)).toBe("2h");
+    expect(relativeAge("2026-07-25T16:00:00.000Z", now)).toBe("3d");
+  });
+
+  it("omits the clause rather than inventing one", () => {
+    expect(relativeAge(undefined, now)).toBeUndefined();
+    expect(relativeAge("not a date", now)).toBeUndefined();
   });
 });

--- a/ui/src/components/codegraph/CoverageGapBanner.tsx
+++ b/ui/src/components/codegraph/CoverageGapBanner.tsx
@@ -2,15 +2,25 @@
  * CoverageGapBanner (proposal glqk) — the galaxy HUD's index-coverage advisory.
  *
  * The code graph is best-effort: SCIP indexers fail per-workspace and the warm
- * succeeds with whatever remains. This chip names the workspaces that are NOT
- * indexed so a viewer never reads a silent false negative (dead code / no
+ * succeeds with whatever remains. This chip names the workspaces whose index is
+ * NOT current so a viewer never reads a silent false negative (dead code / no
  * callers / impact) off the galaxy. Renders nothing when coverage is clean.
+ *
+ * All the phrasing decisions — cause, fallback, staleness, retriability — live
+ * in `./coverageAdvisory`, which documents why a gap is usually "stale" rather
+ * than "not indexed". This file is presentation only.
  *
  * Chip styling voice mirrors GalaxyView's HUD_CHIP, in the amber the canvas
  * already uses for its "showing N of M" honesty span.
  */
 
-import type { CodeGraphCoverage } from "@/api/codeGraph";
+import type { CodeGraphCoverage, CodeGraphWorkspace } from "@/api/codeGraph";
+import {
+  fallbackFor,
+  summarize,
+  summarizeMany,
+  tooltipFor,
+} from "./coverageAdvisory";
 
 /** Same chip voice as GalaxyView's HUD_CHIP, tinted amber for the advisory. */
 const COVERAGE_CHIP =
@@ -18,33 +28,40 @@ const COVERAGE_CHIP =
 
 export function CoverageGapBanner({
   coverage,
+  workspaces = [],
+  now,
 }: {
   coverage: CodeGraphCoverage | null;
+  /** From the `workspaces` op — supplies the fallback (node count + commit)
+   * that separates "stale" from "missing". Omitted, every gap reads as
+   * missing, which is the pre-existing, more alarming behaviour. */
+  workspaces?: CodeGraphWorkspace[];
+  /** Wall clock at fetch time, supplied by the caller so this component stays
+   * pure and the age does not silently tick between re-renders. Omitted, the
+   * "N ago" clause is dropped rather than guessed. */
+  now?: number;
 }) {
   if (!coverage || !coverage.hasGaps || coverage.gaps.length === 0) {
     return null;
   }
 
-  const names = coverage.gaps
-    .map((g) => `${g.slug} (${g.language})`)
-    .join(", ");
-  const count = coverage.gaps.length;
+  const fallbacks = coverage.gaps.map((g) => fallbackFor(g.slug, workspaces));
+  // One gap gets the full sentence; several get a list, because the chip is a
+  // single HUD line and the detail lives in the tooltip either way.
+  const text =
+    coverage.gaps.length === 1
+      ? summarize(coverage.gaps[0], fallbacks[0], now)
+      : summarizeMany(coverage.gaps, fallbacks);
 
   return (
     <div
       className={COVERAGE_CHIP}
       role="status"
       aria-label="Index coverage gap"
-      title={
-        "These workspaces are not indexed — dead-code / no-callers / impact " +
-        "results may be false negatives. Verify with grep before trusting an absence."
-      }
+      title={tooltipFor(coverage.gaps, fallbacks)}
     >
       <span aria-hidden="true">⚠</span>
-      <span className="font-semibold">
-        {count} workspace{count === 1 ? "" : "s"} not indexed:
-      </span>
-      <span className="text-amber-200/90">{names}</span>
+      <span className="text-amber-200/90">{text}</span>
     </div>
   );
 }

--- a/ui/src/components/codegraph/GalaxyView.tsx
+++ b/ui/src/components/codegraph/GalaxyView.tsx
@@ -80,6 +80,12 @@ export function GalaxyView({ projectId }: { projectId: string }) {
   const [workspaces, setWorkspaces] = useState<CodeGraphWorkspace[]>([]);
   const [workspaceSlug, setWorkspaceSlug] = useState<string | null>(null);
   const [coverage, setCoverage] = useState<CodeGraphCoverage | null>(null);
+  // Wall clock captured when coverage landed. The banner renders "N ago" off
+  // this instead of reading the clock during render, so the chip stays pure and
+  // the age is anchored to the data it describes.
+  const [coverageFetchedAt, setCoverageFetchedAt] = useState<
+    number | undefined
+  >(undefined);
   const [showHotspots, setShowHotspots] = useState(false);
   const [hotspotSelection, setHotspotSelection] =
     useState<GalaxyHotspot | null>(null);
@@ -122,9 +128,12 @@ export function GalaxyView({ projectId }: { projectId: string }) {
     // unindexed workspaces so the galaxy never lies by omission. Best-effort:
     // a failure just hides the banner.
     setCoverage(null);
+    setCoverageFetchedAt(undefined);
     void fetchCoverage(projectId)
       .then((cov) => {
-        if (!cancelled) setCoverage(cov);
+        if (cancelled) return;
+        setCoverage(cov);
+        setCoverageFetchedAt(Date.now());
       })
       .catch(() => {
         if (!cancelled) setCoverage(null);
@@ -132,7 +141,9 @@ export function GalaxyView({ projectId }: { projectId: string }) {
 
     void (async () => {
       try {
-        const artifact = await fetchGalaxyArtifact(projectId, { signal: controller.signal });
+        const artifact = await fetchGalaxyArtifact(projectId, {
+          signal: controller.signal,
+        });
         if (cancelled) return;
         let snapshot;
         if (artifact.kind === "artifact") {
@@ -184,7 +195,9 @@ export function GalaxyView({ projectId }: { projectId: string }) {
         setState({
           phase: "error",
           message:
-            error instanceof Error ? error.message : "Failed to load the galaxy.",
+            error instanceof Error
+              ? error.message
+              : "Failed to load the galaxy.",
         });
       }
     })();
@@ -203,7 +216,9 @@ export function GalaxyView({ projectId }: { projectId: string }) {
     const nodes = full.nodes.filter(
       (n) =>
         (!hideTests || !n.isTest) &&
-        (!workspaceSlug || n.workspace === undefined || n.workspace === workspaceSlug),
+        (!workspaceSlug ||
+          n.workspace === undefined ||
+          n.workspace === workspaceSlug),
     );
     const kept = new Set(nodes.map((n) => n.id));
     const edges = full.edges.filter(
@@ -218,7 +233,9 @@ export function GalaxyView({ projectId }: { projectId: string }) {
     return state.hotspots.filter(
       (h) =>
         (!hideTests || !h.isTest) &&
-        (!workspaceSlug || h.workspace === undefined || h.workspace === workspaceSlug),
+        (!workspaceSlug ||
+          h.workspace === undefined ||
+          h.workspace === workspaceSlug),
     );
   }, [state, hideTests, workspaceSlug]);
 
@@ -233,7 +250,13 @@ export function GalaxyView({ projectId }: { projectId: string }) {
               aria-label="Loading galaxy"
             />
           )}
-          <p>{state.phase === "error" ? state.message : state.phase === "loading" ? state.message : null}</p>
+          <p>
+            {state.phase === "error"
+              ? state.message
+              : state.phase === "loading"
+                ? state.message
+                : null}
+          </p>
         </div>
       </div>
     );
@@ -244,7 +267,13 @@ export function GalaxyView({ projectId }: { projectId: string }) {
       data={visibleData}
       focusIds={focusIds}
       focusPrimaryId={hotspotSelection?.fileId ?? null}
-      banner={<CoverageGapBanner coverage={coverage} />}
+      banner={
+        <CoverageGapBanner
+          coverage={coverage}
+          workspaces={workspaces}
+          now={coverageFetchedAt}
+        />
+      }
       sidePanel={
         showHotspots ? (
           <HotspotPanel
@@ -286,11 +315,15 @@ export function GalaxyView({ projectId }: { projectId: string }) {
                 }
               }}
             >
-              <SelectTrigger size="sm" aria-label="Workspace" className={HUD_CHIP}>
+              <SelectTrigger
+                size="sm"
+                aria-label="Workspace"
+                className={HUD_CHIP}
+              >
                 <span>
                   {workspaceSlug
-                    ? (workspaces.find((w) => w.slug === workspaceSlug)?.display ??
-                      workspaceSlug)
+                    ? (workspaces.find((w) => w.slug === workspaceSlug)
+                        ?.display ?? workspaceSlug)
                     : "All"}
                 </span>
               </SelectTrigger>

--- a/ui/src/components/codegraph/coverageAdvisory.ts
+++ b/ui/src/components/codegraph/coverageAdvisory.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure phrasing logic behind [`CoverageGapBanner`] (proposal glqk).
+ *
+ * # Why this says more than "not indexed"
+ *
+ * The semantic index is no longer a step that either ran or didn't. It is a
+ * standalone, content-keyed, retried pipeline, and a gap has two independent
+ * axes the old wording collapsed into one scary word:
+ *
+ * * **cause** — `timed_out` is a budget that was too small and grows itself on
+ *   the next attempt; `indexer_failed` is a real error; `unsupported_language`
+ *   will never resolve on its own. Only the last is permanent.
+ * * **fallback** — a failed attempt does NOT empty the workspace. The warm
+ *   salvages the previous artifact, so the galaxy usually still shows that
+ *   workspace's symbols, just pinned to an older commit. "Not indexed" claims
+ *   an absence that is generally false; "stale" is the truth, and it is a much
+ *   weaker warning.
+ *
+ * Both axes are derivable from data the HUD already fetches: `coverage` gives
+ * cause + extent + attempt time, and `workspaces` gives the node count and the
+ * commit those nodes came from. A workspace carrying nodes at a commit behind
+ * the rest of the graph is stale, not missing.
+ *
+ * Lives outside the component file so the component module exports only a
+ * component (react-refresh) and so this logic is unit-testable without a DOM.
+ */
+
+import type { CodeGraphCoverage, CodeGraphWorkspace } from "@/api/codeGraph";
+
+type Gap = CodeGraphCoverage["gaps"][number];
+
+/** Short human cause per coverage status. Unknown statuses stay generic rather
+ * than asserting a cause the server never claimed. */
+export function causeLabel(status: string): string {
+  switch (status) {
+    case "timed_out":
+      return "index timed out";
+    case "indexer_failed":
+      return "indexer failed";
+    case "unsupported_language":
+      return "no indexer";
+    default:
+      return "not indexed";
+  }
+}
+
+/** `true` when the status resolves itself on a later attempt. A timeout grows
+ * its own budget; a crash gets retried. A missing indexer never will. */
+export function retriable(status: string): boolean {
+  return status !== "unsupported_language";
+}
+
+/** Compact relative age, e.g. `30s`, `30m`, `2h`, `3d`. Returns undefined for an
+ * absent/unparseable timestamp OR an unknown `now`, so callers omit the clause
+ * entirely instead of rendering an invented age. */
+export function relativeAge(
+  iso: string | undefined,
+  now: number | undefined,
+): string | undefined {
+  if (!iso || now === undefined) return undefined;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return undefined;
+  const secs = Math.max(0, Math.round((now - then) / 1000));
+  if (secs < 90) return `${secs}s`;
+  const mins = Math.round(secs / 60);
+  if (mins < 90) return `${mins}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 36) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+/** What the galaxy is actually showing for a gap workspace right now. */
+export type Fallback =
+  | { kind: "stale"; commit: string; nodes: number }
+  | { kind: "present"; nodes: number }
+  | { kind: "missing" };
+
+/**
+ * Decide what the viewer is looking at for this workspace.
+ *
+ * `stale` requires positive evidence on both legs: the workspace contributes
+ * nodes AND its commit differs from the commit the rest of the graph settled
+ * on. Without a comparable peer commit we say `present` — we know there is
+ * data, we cannot prove it is behind — rather than guessing either way.
+ */
+export function fallbackFor(
+  slug: string,
+  workspaces: CodeGraphWorkspace[],
+): Fallback {
+  const row = workspaces.find((w) => w.slug === slug);
+  const nodes = row?.nodeCount ?? 0;
+  if (!row || nodes <= 0) return { kind: "missing" };
+  // The graph's commit is the one the healthy workspaces agree on. Mode, not
+  // max: shas do not order, and the gap workspace itself must not vote.
+  const tally = new Map<string, number>();
+  for (const w of workspaces) {
+    if (w.slug === slug || !w.commitSha) continue;
+    tally.set(w.commitSha, (tally.get(w.commitSha) ?? 0) + 1);
+  }
+  let graphCommit: string | undefined;
+  let best = 0;
+  for (const [sha, count] of tally) {
+    if (count > best) {
+      best = count;
+      graphCommit = sha;
+    }
+  }
+  if (row.commitSha && graphCommit && row.commitSha !== graphCommit) {
+    return { kind: "stale", commit: row.commitSha.slice(0, 7), nodes };
+  }
+  return { kind: "present", nodes };
+}
+
+/** The one-line chip text for a single gap. */
+export function summarize(
+  gap: Gap,
+  fallback: Fallback,
+  now: number | undefined,
+): string {
+  const age = relativeAge(gap.attemptedAt, now);
+  const cause = `${causeLabel(gap.status)}${age ? ` ${age} ago` : ""}`;
+  switch (fallback.kind) {
+    case "stale":
+      return `${gap.slug} (${gap.language}): ${cause} — showing ${fallback.commit}`;
+    case "present":
+      return `${gap.slug} (${gap.language}): ${cause} — showing last good index`;
+    case "missing":
+      return `${gap.slug} (${gap.language}): ${cause} — not in the graph`;
+  }
+}
+
+/** The compact multi-gap list: one clause per workspace, cause + fallback. */
+export function summarizeMany(gaps: Gap[], fallbacks: Fallback[]): string {
+  const parts = gaps.map(
+    (g, i) =>
+      `${g.slug} (${g.language}, ${causeLabel(g.status)}${
+        fallbacks[i].kind === "missing" ? ", not in graph" : ", stale"
+      })`,
+  );
+  return `${gaps.length} workspaces degraded: ${parts.join(", ")}`;
+}
+
+/** The hover explanation: what is wrong, what you are seeing, what happens next. */
+export function tooltipFor(gaps: Gap[], fallbacks: Fallback[]): string {
+  const anyFallback = fallbacks.some((f) => f.kind !== "missing");
+  const anyRetriable = gaps.some((g) => retriable(g.status));
+  const extent = gaps
+    .filter((g) => g.discoveredFiles !== undefined)
+    .map((g) => `${g.slug}: 0 of ${g.discoveredFiles} files re-indexed`)
+    .join("; ");
+  return [
+    anyFallback
+      ? "The last index attempt for these workspaces did not complete, so the galaxy is serving the previous index for them. Symbols added or moved since that commit are missing — dead-code / no-callers / impact results can be false negatives. Verify with grep before trusting an absence."
+      : "These workspaces contribute nothing to the graph — dead-code / no-callers / impact results for them are false negatives by construction. Verify with grep before trusting an absence.",
+    extent,
+    anyRetriable
+      ? "The semantic indexer re-attempts on its own schedule and grows a timed-out workspace's budget each round; no action is needed unless this persists."
+      : "This will not resolve on its own — no indexer exists for that language.",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}


### PR DESCRIPTION
## What prompted this

The galaxy HUD showed `⚠ 1 workspace not indexed: server (rust)`. Investigating whether the new standalone SCIP indexer had failed turned up two separate things: the banner's claim was wrong, and the pipeline behind it recovered on its own. This PR fixes the banner. The pipeline finding is written up at the bottom — it is **not** addressed here.

## The banner was asserting an absence that was false

At the moment of the screenshot the graph was serving **1457 salvaged `server` nodes from commit `f355d753`** while the rest of the graph sat at `068b947f`. A failed SCIP attempt does not empty a workspace — the warm salvages the previous artifact — so "not indexed" overstates the damage. "Stale" is the truth, and it is a much weaker warning.

A gap has two independent axes the old copy collapsed into one scary word:

- **cause** — `timed_out` is a budget that was too small and grows itself on the next attempt; `indexer_failed` is a real error; `unsupported_language` will never resolve on its own. Only the last is permanent.
- **fallback** — stale (nodes present, at a commit behind the rest of the graph) vs genuinely missing (no nodes at all).

```
before   ⚠ 1 workspace not indexed: server (rust)

after    ⚠ server (rust): index timed out 2h ago — showing f355d75
         ⚠ legacy (ruby): no indexer — not in the graph
```

The tooltip now says what you are looking at, the extent (`0 of 1439 files re-indexed`), and that a retriable gap re-attempts on its own and grows its budget each round — while never promising a retry for `unsupported_language`.

## No server change was needed

Every field this needs was already on the wire and being discarded by the UI parsers:

- `coverage` carries `status`, `detail`, `discovered_files`, `indexed_files`, `warmed_at` — the parser kept only the first two, and `unindexed_source_roots` (the list it reads) carries no extent or timing at all, so gaps are now merged with the full `workspaces` table on `(slug, language)`.
- `workspaces` carries `node_count` and `commit_sha` — both dropped by `normalizeWorkspaceEntry`. These are what separate "stale" from "missing".

## Judgement calls worth reviewing

- **Staleness needs a peer.** It is decided by majority vote over the healthy workspaces' commits, with the gap workspace itself excluded from the vote (shas do not order, so "newest" is not computable client-side). On a single-workspace project there is no peer, so the chip says "showing last good index" without naming a sha. Deliberate — the commit only appears on polyglot repos.
- **No workspace data ⇒ old behaviour.** If the `workspaces` fetch fails, every gap reads as missing, i.e. the previous, more alarming wording. Failing toward the louder warning is the right default here.
- **The clock is injected.** `GalaxyView` captures `Date.now()` when coverage lands and passes it down, so the component stays pure and the age is anchored to the data it describes rather than ticking between re-renders. Omitted, the "N ago" clause is dropped rather than invented.
- **`coverageAdvisory.ts` is new** so the component module exports only a component (react-refresh) and the phrasing logic is unit-testable without a DOM.

## Testing

`ui`: 177 tests pass across `src/components/codegraph` + `src/api`; `tsc --noEmit`, eslint and prettier clean.

The full UI suite has 21 pre-existing failures across 7 files (`CodeGraphPage`, `MemoryGraphCanvas`, `ProposalRefinement`, `ProposalHistory`, `ProposalsPage`, `TaskDetailPanel`). Verified identical on clean `main` with these changes stashed — `CodeGraphPage`'s 7 fail with `Galaxy artifact request failed: fetch failed` in both trees. Not touched by this PR.

## Not fixed here: the 3h SCIP Job's cache almost never hits

The gap this banner reported was real, and it self-healed while I was looking at it:

| time (UTC) | what ran | result |
|---|---|---|
| 11:34–12:22 | standalone SCIP Job @ `95dc2969` | succeeded, `server` indexed in 2811s, 4/4 artifacts cached |
| 14:06 | warm @ `068b947f` | **cache miss** → inline re-index, budget 3648s, killed. rust-analyzer's own log: `Generating SCIP finished 3617.0s` — ~30s short |
| 14:38–16:17 | warm @ `b2ef0b9d` | budget **5477s** (1.5× the 3651s high-water), succeeded at 3722s, 4/4 |

The Job's artifacts are content-keyed and it fires every 3h gated on head-advance. On this repo `server/` changes almost every merge, so the key is stale by warm time and the warm re-indexes inline anyway — on whatever remains of the 7200s Job deadline after clippy and nextest (3648s), which is *less* than the dedicated Job gives itself (4558s). The heaviest workspace gets the least time on the path most likely to run it. The adaptive budget does climb out, but each step costs a wasted ~1h warm.

Worth its own proposal: dispatch the index on head-advance immediately before a warm, or have the warm wait on an in-flight index — `scip_claim_wait_seconds` (900s) already exists for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
