### PR TITLE
fix(agent): stop the invocation journal killing its own pod every ~600s

### DIFF
--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -527,11 +527,18 @@ impl LeaseInvocationRunner {
             invocation_id: uuid::Uuid::now_v7().to_string(),
         };
         let lease = LeaseIdentity::TaskInvocation(identity.clone());
-        if let Some(journal) = &self.journal {
-            journal
-                .record_at(&identity, None, false, self.clock.now())
-                .map_err(LeaseInvocationError::Launcher)?;
-        }
+        // NOT journalled here. The journal exists to recover a lease that this
+        // pod may have created at the coordinator; an invocation that never
+        // escalates never calls `queue_lease`, so it owns no durable coordinator
+        // state and there is nothing to recover. Writing here anyway made every
+        // cheap command (`git status`, a grep) leave a record that the terminal
+        // path below could not clear — the clear is gated on `queued` — and the
+        // pod-local recovery sweep then read that permanently-unresolved record
+        // as an orphan and fired the exact-pod watchdog against its OWN pod.
+        // With a 300s `WATCHDOG_GRACE` and a 300s sweep tick, every worker pod
+        // deleted itself ~600s after start, mid-session, and its task bounced
+        // `in_progress -> open` forever. The write-ahead record is now taken at
+        // the escalation point below, immediately before the `queue_lease` RPC.
         // Resolve the durable admission decision ONCE, before the leaf exists.
         //
         // This read used to happen only after a successful bind, which made it
@@ -626,6 +633,17 @@ impl LeaseInvocationRunner {
                 // are the only evidence available in the pod.
                 let queued_deadlines = self.lease_deadlines(&config);
                 queue_deadline_ms = queued_deadlines.queue_deadline_ms;
+                // Write-ahead: the record must be durable BEFORE the request
+                // goes out, so a pod that dies mid-`queue_lease` still leaves
+                // evidence a successor can reconcile. This is the first point
+                // at which durable coordinator state can exist for this
+                // invocation, and therefore the earliest point at which the
+                // record is anything but garbage.
+                if let Some(journal) = &self.journal {
+                    journal
+                        .record_at(&identity, None, false, self.clock.now())
+                        .map_err(LeaseInvocationError::Launcher)?;
+                }
                 match await_lease_or_terminal(
                     self.services.queue_lease(LeaseQueueRequest {
                         identity: lease.clone(),
@@ -963,7 +981,11 @@ impl LeaseInvocationRunner {
             }
             tokio::task::yield_now().await;
         };
-        if let Some(journal) = &self.journal {
+        // Gated on `queued` for the same reason as the write-ahead record: a
+        // non-escalated invocation has no record to advance to terminal, and an
+        // unconditional write here would simply re-create the leaked record the
+        // clear below cannot remove.
+        if queued && let Some(journal) = &self.journal {
             journal
                 .record_at(&identity, fence.clone(), true, self.clock.now())
                 .map_err(LeaseInvocationError::Launcher)?;

--- a/server/crates/djinn-agent/src/process/tests/process_lease_recovery_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_recovery_tests.rs
@@ -544,3 +544,122 @@ async fn watchdog_targets_recorded_identity_exactly_once_across_pod_reconstructi
     assert_eq!(records.len(), 1);
     assert!(records[0].watchdog_notified);
 }
+
+/// Regression: a non-escalating invocation must leave NO journal record.
+///
+/// The journal exists to recover a lease this pod may have created at the
+/// coordinator. An invocation whose CPU never crosses
+/// `cpu_usage_threshold_usec` never calls `queue_lease`, so it owns no durable
+/// coordinator state and has nothing to recover.
+///
+/// Production (2026-07-28) wrote the record unconditionally at the top of
+/// `output()` while the terminal clear stayed gated on `queued`. Every cheap
+/// command therefore left a permanently-unresolved record; the pod-local
+/// recovery sweep read it as an orphan and fired the exact-pod watchdog against
+/// its OWN pod. With a 300s grace and a 300s sweep tick, every worker pod
+/// deleted itself ~600s after start and its task bounced `in_progress -> open`
+/// forever.
+///
+/// Asserting `unresolved()` is empty is the side effect that matters: it is
+/// exactly what the sweep reads. `queue_calls == 0` pins the precondition, so
+/// this cannot pass by the invocation quietly having escalated.
+#[tokio::test]
+async fn non_escalating_invocation_leaves_no_journal_record() {
+    let directory = tempfile::tempdir().unwrap();
+    let journal =
+        Arc::new(InvocationJournal::new(directory.path().to_path_buf(), "pod-uid".into()).unwrap());
+    let services = Arc::new(ScriptedServices::new(vec![], vec![], vec![]));
+    // CPU stays two orders of magnitude below the escalation threshold, and the
+    // child exits naturally after a couple of polls.
+    let launcher = Arc::new(FixtureLauncher::new(500, Some(2)));
+    let runner = LeaseInvocationRunner::new(
+        services.clone(),
+        services.clone(),
+        launcher.clone(),
+        clock(),
+    )
+    .with_journal(journal.clone());
+
+    let output = runner
+        .output(
+            // `command()`, not `cmd_from(..)`: the fixture drives escalation
+            // from `FixtureLauncher`'s CPU sample, so the command string is
+            // decorative — but a real child still spawns. `command()` is the
+            // process-group-isolated `sleep` this file already uses; a literal
+            // `cargo build` here would contend for the target-dir lock with the
+            // harness's own cargo and flake the timeout-sensitive tests.
+            command(),
+            config_with_threshold(1_000_000),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("a cheap command runs to natural exit");
+
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+    assert_eq!(
+        services.queue_calls.load(Ordering::SeqCst),
+        0,
+        "precondition: this invocation must never have escalated to the lease authority"
+    );
+    assert!(
+        journal.unresolved().unwrap().is_empty(),
+        "a non-escalating invocation must leave nothing for the recovery sweep to \
+         mistake for an orphaned pod; a record here re-arms the ~600s exact-pod watchdog"
+    );
+}
+
+/// The write-ahead property the journal exists for: for an invocation that DOES
+/// escalate, the record must be durable *before* the `queue_lease` request goes
+/// out, so a pod that dies mid-request still leaves evidence to reconcile.
+///
+/// Proven by pausing the queue response and reading the journal while the RPC is
+/// genuinely in flight — moving the write any later than the request would make
+/// this observation empty.
+#[tokio::test]
+async fn escalating_invocation_journals_before_the_queue_request() {
+    let directory = tempfile::tempdir().unwrap();
+    let journal =
+        Arc::new(InvocationJournal::new(directory.path().to_path_buf(), "pod-uid".into()).unwrap());
+    let services = Arc::new(ScriptedServices::new(vec![], vec![], vec![]));
+    services.pause_queue.store(true, Ordering::SeqCst);
+    // CPU is above the threshold on the first sample, so the invocation
+    // escalates immediately and blocks on the paused queue response.
+    let launcher = Arc::new(FixtureLauncher::new(5_000, None));
+    let test_clock = clock();
+    let runner = LeaseInvocationRunner::new(
+        services.clone(),
+        services.clone(),
+        launcher.clone(),
+        test_clock.clone(),
+    )
+    .with_journal(journal.clone());
+
+    let run_services = services.clone();
+    let run = tokio::spawn(async move {
+        runner
+            .output(
+                // Process-group-isolated `sleep`, never a real `cargo build` —
+                // see the note in the sibling test above.
+                command(),
+                config_with_threshold(1_000),
+                CancellationToken::new(),
+            )
+            .await
+    });
+
+    poll_until(move || run_services.queue_calls.load(Ordering::SeqCst) >= 1).await;
+    let in_flight = journal.unresolved().unwrap();
+    assert_eq!(
+        in_flight.len(),
+        1,
+        "the record must already be durable while the queue_lease RPC is in flight"
+    );
+    assert!(
+        !in_flight[0].terminal_intent,
+        "the write-ahead record is not terminal yet"
+    );
+
+    // Let the paused invocation fall through its deadline and finish cleanly.
+    test_clock.advance_mono(Duration::from_secs(120));
+    let _ = run.await.expect("join");
+}


### PR DESCRIPTION
## What was happening

Every worker pod deleted itself ~10 minutes after start, mid-session, and its task bounced `in_progress -> open` forever. Measured across four production pods today: **10m05s, 10m06s, 10m08s, 10m23s** — the worker container exiting `0/Completed` while its Job was already gone.

Downstream the coordinator saw `reply loop error: session cancelled`, classified it `protocol_violation` / `NonzeroExitNonterminal` / `Crash`, terminalized the attempt and recovered the task to `open`. Tasks accumulated sessions doing nothing else: `kziu` 12 sessions, `mz8f` 12, `3iir` 10 — all `failed`/`interrupted`, token shape ~0.5–1.6M in against ~10k out. `3iir` reached intervention **streak 9** on healthy work, and the human-park rung declined to park and redispatched into the same grinder.

## Root cause

`LeaseInvocationRunner::output` wrote a journal record **unconditionally** at the top of the call:

```rust
let lease = LeaseIdentity::TaskInvocation(identity.clone());
if let Some(journal) = &self.journal {
    journal.record_at(&identity, None, false, self.clock.now())?;   // every invocation
}
```

but the terminal clear is gated on `queued`:

```rust
if queued && reconcile_terminal_lease(..).await && let Some(journal) = &self.journal {
    journal.clear(&identity)?;
}
```

and `queued` is set **only** by the local CPU sample crossing the escalation threshold:

```rust
} else if !queued && cpu.usage_usec >= config.cpu_usage_threshold_usec {
    queued = true;
```

So every cheap command — `git status`, a grep, an `ls` — left a record nothing could ever clear. The pod-local `InvocationRecovery` sweep read that permanently-unresolved record as an orphaned pod and fired the exact-pod watchdog **against its own pod**. With `WATCHDOG_GRACE = 300s` and a 300s sweep tick, the first cheap command of a session detonates at the second sweep — ~600s, exactly the observed lifetime.

The production log line at the moment of death:

```
ERROR exact-pod watchdog termination failed; retaining durable record and counted lease
      pod_uid=72a798c1-... error=rpc roundtrip cancelled before reply
```

## The fix

The journal exists to recover a lease this pod may have created at the coordinator. An invocation that never escalates never calls `queue_lease`, so it owns **no durable coordinator state and there is nothing to recover** — the record was pure garbage whose only effect was arming the watchdog.

- Take the write-ahead record at the **escalation point**, immediately before the `queue_lease` RPC. It is still durable before the request goes out, so a pod dying mid-request stays recoverable.
- Gate the **terminal** record write on `queued` too, so it cannot re-create the leaked row the clear cannot remove.

Heavy commands are unaffected: they escalate, so they journal and clear exactly as before.

## Tests

Two regressions in `process_lease_recovery_tests.rs`:

- `non_escalating_invocation_leaves_no_journal_record` — asserts `unresolved()` is empty, which is precisely what the sweep reads, and pins `queue_calls == 0` so it cannot pass by quietly having escalated. **Verified to fail on the pre-fix code** with the intended message.
- `escalating_invocation_journals_before_the_queue_request` — pauses the queue response and reads the journal while the RPC is genuinely in flight, proving the write-ahead ordering. Moving the write later than the request makes this observation empty.

`cargo test -p djinn-agent --lib process::tests::lease_runner_tests` → 51 passed. `cargo clippy -p djinn-agent --lib --tests --no-deps` clean. `cargo fmt` clean.

## Known unrelated flake

While stressing, `extension::tests::jit_trace_tests::jit_pitfalls_trace_serialization_failure_is_fail_open` fails intermittently. It is **pre-existing on main — reproduced 1/10 runs on a clean `origin/main` checkout** with the same panic. Cause: `DJINN_JIT_PITFALLS_ROLLOUT` is a process-global env var, so while a JIT test enables it, concurrent write-path tests in other files (which do not hold `JIT_PITFALLS_ENV_LOCK`) also take the JIT branch and bump the shared `djinn_jit_pitfall_hints_total{outcome="eligible_search"}` counter, corrupting the delta assertion (`left: 3, right: 1`). A failure then poisons the `std::sync::Mutex` and cascades.

Not fixed here to keep this hotfix minimal; follow-up PR to cover the flag with a lock shared by every test that reads it.