### PR TITLE
test(agent): widen the JIT rollout env lock to every test that reads it

### DIFF
--- a/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/edit_tests.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/edit_tests.rs
@@ -2,8 +2,10 @@ use super::*;
 
 // ─── AC 1: truncated read denies worker edit, leaves edit_forced unset ──
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn truncated_read_denies_worker_edit() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-trunc-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "fn main() {\n    println!(\"hello\");\n}\n")
@@ -65,8 +67,10 @@ async fn truncated_read_denies_worker_edit() {
 
 // ─── AC 1: uncovered read denies worker edit, leaves edit_forced unset ──
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn uncovered_read_denies_worker_edit() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-uncovered-");
     let file = worktree.path().join("svc.rs");
     // File content: "AAAA" at bytes 0-4, "\n" at 4-5, "BBBB" at 5-9.
@@ -127,8 +131,10 @@ async fn uncovered_read_denies_worker_edit() {
 
 // ─── AC 2: first covered worker edit returns investigation prompt ───────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn first_covered_worker_edit_returns_investigation_prompt() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-first-edit-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "fn main() {\n    services();\n}\n")
@@ -204,8 +210,10 @@ async fn first_covered_worker_edit_returns_investigation_prompt() {
 
 // ─── AC 2: retry after re-read is allowed when edit_forced is set ───────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn worker_edit_allowed_after_investigation_prompt_and_reread() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-retry-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -273,8 +281,10 @@ async fn worker_edit_allowed_after_investigation_prompt_and_reread() {
 
 // ─── AC 2: third/subsequent edits are not re-gated ──────────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn worker_subsequent_edits_not_regated_after_investigation() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-steady-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\nlet b = helper;\n")
@@ -359,8 +369,10 @@ async fn worker_subsequent_edits_not_regated_after_investigation() {
 
 // ─── AC 3: non-worker roles bypass GateGuard entirely ───────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn reviewer_role_bypasses_gate_guard() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-reviewer-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -408,8 +420,10 @@ async fn reviewer_role_bypasses_gate_guard() {
     );
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn missing_role_bypasses_gate_guard() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-norole-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -445,8 +459,10 @@ async fn missing_role_bypasses_gate_guard() {
 
 // ─── Identical retries keep denying until covering read ─────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn identical_truncated_retries_keep_denying() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-retry-trunc-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "fn main() {\n    println!(\"hello\");\n}\n")
@@ -507,8 +523,10 @@ async fn identical_truncated_retries_keep_denying() {
 
 // ─── Re-read after truncated denial resolves the gate ───────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn non_truncated_reread_after_truncated_denial_resolves_gate() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-resolve-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")

--- a/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/patch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/patch_tests.rs
@@ -9,8 +9,10 @@ use super::*;
 /// Windowed (Range) read that does not cover the edit match span denies
 /// the worker, leaves `edit_forced` empty in `gateguard_snapshot`, and
 /// does NOT mutate the file.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn windowed_read_denies_worker_edit_and_keeps_gateguard_clean() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-win-edit-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "AAAA\nBBBB\n").await.expect("seed");
@@ -72,8 +74,10 @@ async fn windowed_read_denies_worker_edit_and_keeps_gateguard_clean() {
 
 /// Identical uncovered/windowed retries for `call_edit` keep denying
 /// until a covering non-truncated read occurs.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn identical_windowed_read_retries_keep_denying_for_edit() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-win-retry-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "AAAA\nBBBB\n").await.expect("seed");
@@ -151,8 +155,10 @@ async fn identical_windowed_read_retries_keep_denying_for_edit() {
 /// After a windowed-read denial, a covering non-truncated full-file read
 /// transitions the denial to the normal first-edit FORCE investigation
 /// prompt (not continued UNCOVERED denial).
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn full_read_after_windowed_denial_transitions_edit_to_investigation() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-win-full-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -248,8 +254,10 @@ async fn full_read_after_windowed_denial_transitions_edit_to_investigation() {
 
 /// Windowed (Range) read denies worker write to existing file.
 /// Write overwrites the entire file so requires full coverage.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn windowed_read_denies_worker_write_and_keeps_gateguard_clean() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-win-write-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "line one\nline two\nline three\n")
@@ -311,8 +319,10 @@ async fn windowed_read_denies_worker_write_and_keeps_gateguard_clean() {
 
 /// After a windowed-read denial on write, a full non-truncated read
 /// transitions to the first-edit FORCE investigation prompt.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn full_read_after_windowed_denial_transitions_write_to_investigation() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-win-wtrans-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -407,8 +417,10 @@ async fn full_read_after_windowed_denial_transitions_write_to_investigation() {
 
 /// Windowed (Range) read denies worker patch update. The conservative
 /// gate uses `0..usize::MAX` so only `ReadCoverage::Full` can pass.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn windowed_read_denies_worker_patch_update_and_keeps_gateguard_clean() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-win-pupd-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "existing content\n")
@@ -472,8 +484,10 @@ async fn windowed_read_denies_worker_patch_update_and_keeps_gateguard_clean() {
 
 /// Truncated read denies worker patch delete. The file must not be
 /// deleted, and `edit_forced` must remain empty.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn truncated_read_denies_worker_patch_delete_no_mutation() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-trunc-pdel-");
     let file = worktree.path().join("doomed.rs");
     tokio::fs::write(&file, "I must not be deleted\n")
@@ -532,8 +546,10 @@ async fn truncated_read_denies_worker_patch_delete_no_mutation() {
 
 /// Windowed (Range) read denies worker patch delete. Same behavior as
 /// truncated: conservatively requires full-file coverage for delete ops.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn windowed_read_denies_worker_patch_delete_no_mutation() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-win-pdel-");
     let file = worktree.path().join("doomed.rs");
     tokio::fs::write(&file, "line one\nline two\n")
@@ -595,8 +611,10 @@ async fn windowed_read_denies_worker_patch_delete_no_mutation() {
 
 /// After a truncated patch denial, a full non-truncated re-read
 /// transitions the patch gate to the investigation prompt.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn full_read_after_truncated_denial_transitions_patch_to_investigation() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-trunc-ptrans-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -679,8 +697,10 @@ async fn full_read_after_truncated_denial_transitions_patch_to_investigation() {
 /// inserts the path into `edit_forced`. Then verify that a covering
 /// non-truncated read + first-edit investigation is the *only* path
 /// that populates `edit_forced`.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn gateguard_snapshot_proves_no_edit_forced_from_deficient_reads() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-snap-proof-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "AAAA\nBBBB\nCCCC\n")

--- a/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/write_tests.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/write_tests.rs
@@ -6,8 +6,10 @@ use super::*;
 
 // ─── AC 1: truncated read denies worker write, edit_forced unset ─────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn truncated_read_denies_worker_write() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-write-trunc-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "existing content\n")
@@ -62,8 +64,10 @@ async fn truncated_read_denies_worker_write() {
 
 // ─── AC 2: first covered write returns investigation prompt ──────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn first_covered_worker_write_returns_investigation_prompt() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-write-first-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -126,8 +130,10 @@ async fn first_covered_worker_write_returns_investigation_prompt() {
 
 // ─── AC 2: retry after re-read is allowed ───────────────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn worker_write_allowed_after_investigation_and_reread() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-write-retry-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -192,8 +198,10 @@ async fn worker_write_allowed_after_investigation_and_reread() {
 
 // ─── AC 2: third/subsequent writes are not re-gated ──────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn worker_subsequent_writes_not_regated_after_investigation() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-write-steady-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -276,8 +284,10 @@ async fn worker_subsequent_writes_not_regated_after_investigation() {
 
 // ─── AC 3/4: non-worker roles bypass GateGuard for write ─────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn reviewer_bypasses_gate_guard_for_write() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-write-reviewer-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -326,8 +336,10 @@ async fn reviewer_bypasses_gate_guard_for_write() {
 
 // ─── AC 4: new file write bypasses GateGuard ─────────────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn new_file_write_bypasses_gate_guard() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-write-newfile-");
     let session_id = worktree.path().display().to_string();
 
@@ -367,8 +379,10 @@ async fn new_file_write_bypasses_gate_guard() {
 
 // ─── Identical truncated write retries keep denying ───────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn identical_truncated_write_retries_keep_denying() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-write-retry-trunc-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "existing\n").await.expect("seed");
@@ -430,8 +444,10 @@ async fn identical_truncated_write_retries_keep_denying() {
 
 // ─── AC 3: truncated read denies worker patch update ──────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn truncated_read_denies_worker_patch_update() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-patch-trunc-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "existing content\n")
@@ -484,8 +500,10 @@ async fn truncated_read_denies_worker_patch_update() {
 
 // ─── AC 3: first covered patch update returns investigation prompt ────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn first_covered_worker_patch_update_returns_investigation_prompt() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-patch-first-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -547,8 +565,10 @@ async fn first_covered_worker_patch_update_returns_investigation_prompt() {
 
 // ─── AC 3: patch retry after re-read is allowed ──────────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn worker_patch_allowed_after_investigation_and_reread() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-patch-retry-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -612,8 +632,10 @@ async fn worker_patch_allowed_after_investigation_and_reread() {
 
 // ─── AC 3: non-worker roles bypass GateGuard for patch ───────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn reviewer_bypasses_gate_guard_for_patch() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-patch-reviewer-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -661,8 +683,10 @@ async fn reviewer_bypasses_gate_guard_for_patch() {
 
 // ─── AC 4: add-file patch operation bypasses GateGuard ────────────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn add_file_patch_bypasses_gate_guard() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-patch-addfile-");
     let session_id = worktree.path().display().to_string();
 
@@ -700,8 +724,10 @@ async fn add_file_patch_bypasses_gate_guard() {
 
 // ─── AC 4: missing role bypasses GateGuard for write and patch ────────
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn missing_role_bypasses_gate_guard_for_write() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-write-norole-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -734,8 +760,10 @@ async fn missing_role_bypasses_gate_guard_for_write() {
     assert_eq!(response["ok"], serde_json::json!(true));
 }
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn missing_role_bypasses_gate_guard_for_patch() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup_worktree("gg-patch-norole-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")

--- a/server/crates/djinn-agent/src/extension/tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests.rs
@@ -59,6 +59,7 @@ mod brokered_shell_program_tests;
 mod code_graph_tests;
 mod compatibility_fallback_tests;
 mod edit_dispatch_tests;
+mod edit_dispatch_unicode_tests;
 mod epic_extension_tests;
 mod evidence_spike_dispatch_tests;
 mod gate_guard_dispatch_tests;

--- a/server/crates/djinn-agent/src/extension/tests/edit_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/edit_dispatch_tests.rs
@@ -7,8 +7,10 @@ use super::*;
 /// (which produced "context mismatch" and an infinite retry loop). The
 /// read record is invalidated on every successful modify so the model is
 /// forced to re-read and rebuild its patch from current content.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn apply_patch_twice_without_reread_forces_reread() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-patch-reread-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "fn main() {\n    services();\n}\n")
@@ -67,8 +69,10 @@ async fn apply_patch_twice_without_reread_forces_reread() {
 
 /// read -> edit -> edit (no intervening re-read) must force a re-read on
 /// the second edit. Same invalidate-on-modify contract as apply_patch.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_twice_without_reread_forces_reread() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-reread-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -132,8 +136,10 @@ async fn edit_twice_without_reread_forces_reread() {
 
 /// `call_edit` without any prior read fails with the read-before-edit
 /// guidance and does NOT reach the matcher at all (no file write occurs).
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_without_prior_read_fails_with_guidance() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-noread-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = 1;\n")
@@ -175,8 +181,10 @@ async fn edit_without_prior_read_fails_with_guidance() {
 /// `call_edit` with typed matcher: success response includes `edit_match`
 /// metadata with strategy, byte/line ranges, byte counts, reindented flag,
 /// and match note.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_success_includes_edit_match_metadata() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-match-meta-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\nlet b = 42;\n")
@@ -250,8 +258,10 @@ async fn edit_success_includes_edit_match_metadata() {
 
 /// `call_edit` with a line-trimmed match includes a match_note
 /// and the strategy in edit_match.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_fuzzy_match_includes_strategy_and_note() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-fuzzy-");
     let file = worktree.path().join("svc.rs");
     // Content has trailing whitespace that prevents exact match but allows
@@ -305,8 +315,10 @@ async fn edit_fuzzy_match_includes_strategy_and_note() {
 }
 
 /// `call_edit` ambiguous outcome: file is NOT modified, error is returned.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_ambiguous_does_not_modify_file() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-ambig-");
     let file = worktree.path().join("svc.rs");
     let content = "foo bar\nfoo bar\n";
@@ -361,8 +373,10 @@ async fn edit_ambiguous_does_not_modify_file() {
 
 /// `call_edit` no-match outcome: file is NOT modified, error is returned
 /// with leading compatibility text and structured nearest_miss.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_no_match_does_not_modify_file() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-nomatch-");
     let file = worktree.path().join("svc.rs");
     let content = "let a = 1;\n";
@@ -422,8 +436,10 @@ async fn edit_no_match_does_not_modify_file() {
 /// `call_edit` guard-rejected outcome: file is NOT modified, error is
 /// returned with leading compatibility text and structured guard details.
 /// Uses CRLF content with LF old_text to trigger the CRLF preservation guard.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_guard_rejected_does_not_modify_file() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-guard-");
     let file = worktree.path().join("svc.rs");
     // Content uses CRLF line endings.
@@ -483,8 +499,10 @@ async fn edit_guard_rejected_does_not_modify_file() {
 }
 
 /// `call_edit` success preserves read-before-edit freshness guard.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_success_preserves_read_before_edit_freshness() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-fresh-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "fn main() {}\n")
@@ -647,8 +665,10 @@ where
 
 /// Success outcome emits `edit_match_outcome` and `edit_match_strategy`
 /// events with all expected fields populated.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_success_emits_telemetry_events() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-telem-success-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -747,8 +767,10 @@ async fn edit_success_emits_telemetry_events() {
 }
 
 /// No-match outcome emits `edit_match_outcome` but NOT `edit_match_strategy`.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_no_match_emits_telemetry_outcome_only() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-telem-nomatch-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = 1;\n")
@@ -827,8 +849,10 @@ async fn edit_no_match_emits_telemetry_outcome_only() {
 
 /// Guard-rejected outcome emits `edit_match_outcome` but NOT
 /// `edit_match_strategy`. Verifies guard and candidate_count fields.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_guard_rejected_emits_telemetry_outcome_only() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-telem-guard-");
     let file = worktree.path().join("svc.rs");
     // CRLF content triggers guard rejection.
@@ -912,8 +936,10 @@ async fn edit_guard_rejected_emits_telemetry_outcome_only() {
 
 /// Telemetry events for a successful edit include the `session_id` field
 /// and do NOT leak the full file path or file content.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_telemetry_success_includes_session_id_and_no_leaks() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-teem-leak-");
     let file = worktree.path().join("sensitive_data.rs");
     let content = "const SECRET: &str = \"hunter2\";\n";
@@ -994,8 +1020,10 @@ async fn edit_telemetry_success_includes_session_id_and_no_leaks() {
 
 /// Telemetry events for a non-success outcome also do NOT leak the full
 /// file path or file content.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_telemetry_no_match_no_leaks() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-teem-noleak-");
     let file = worktree.path().join("credentials.rs");
     let content = "const API_KEY: &str = \"supersecret\";\n";
@@ -1075,424 +1103,3 @@ async fn edit_telemetry_no_match_no_leaks() {
 }
 
 // ── Unicode dispatch-level tests ─────────────────────────────────────────
-
-/// Unicode dispatch-level test: multi-byte characters in unchanged spans
-/// are preserved byte-for-byte after a successful edit. The match uses an
-/// exact ASCII word that sits between multi-byte Unicode content.
-#[tokio::test]
-async fn edit_unicode_success_preserves_multibyte_unchanged_spans() {
-    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-unicode-dsp-");
-    let file = worktree.path().join("comment.rs");
-    // Content: multi-byte Unicode in prefix and suffix, ASCII target in middle.
-    let content = "// \u{201C}smart\u{201D} \u{2014} note\nlet x = target;\nlet y = \u{4E16};\n";
-    tokio::fs::write(&file, content).await.expect("seed file");
-
-    let state =
-        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
-
-    let read_args = Some(
-        serde_json::json!({ "file_path": "comment.rs" })
-            .as_object()
-            .expect("obj")
-            .clone(),
-    );
-    call_read(&state, &read_args, worktree.path())
-        .await
-        .expect("read");
-
-    // Exact match for the ASCII word — no Unicode normalization needed.
-    // The point is that multi-byte surrounding chars survive the replacement.
-    let edit_args = Some(
-        serde_json::json!({
-            "path": "comment.rs",
-            "old_text": "target",
-            "new_text": "done",
-        })
-        .as_object()
-        .expect("obj")
-        .clone(),
-    );
-    let response = call_edit(&state, &edit_args, worktree.path(), None, None, None)
-        .await
-        .expect("edit should succeed");
-
-    assert_eq!(response["ok"], serde_json::json!(true));
-
-    // Verify the file preserves multi-byte chars in unchanged spans.
-    let after = tokio::fs::read_to_string(&file).await.expect("read back");
-    assert!(
-        after.contains('\u{201C}'),
-        "left smart quote must be preserved in output: {after:?}"
-    );
-    assert!(
-        after.contains('\u{201D}'),
-        "right smart quote must be preserved in output: {after:?}"
-    );
-    assert!(
-        after.contains('\u{2014}'),
-        "em dash must be preserved in output: {after:?}"
-    );
-    assert!(
-        after.contains('\u{4E16}'),
-        "CJK character must be preserved in output: {after:?}"
-    );
-    assert!(after.contains("done"), "replacement must be applied");
-
-    // Byte offsets in edit_match must be valid UTF-8 boundaries.
-    let em = response.get("edit_match").expect("must have edit_match");
-    let range = em["matched_byte_range"]
-        .as_array()
-        .expect("matched_byte_range is array");
-    let start = range[0].as_u64().unwrap() as usize;
-    let end = range[1].as_u64().unwrap() as usize;
-    assert!(
-        content.is_char_boundary(start),
-        "matched_byte_range.start ({start}) must be a UTF-8 char boundary"
-    );
-    assert!(
-        content.is_char_boundary(end),
-        "matched_byte_range.end ({end}) must be a UTF-8 char boundary"
-    );
-}
-
-// ── CRLF dispatch-level tests ────────────────────────────────────────────
-
-/// CRLF file with exact CRLF match at dispatch level: success and CRLF
-/// preserved in written output (no silent LF conversion).
-#[tokio::test]
-async fn edit_crlf_success_preserves_crlf_in_output() {
-    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-crlf-dsp-");
-    let file = worktree.path().join("data.txt");
-    let content = "line one\r\nline two\r\nline three\r\n";
-    tokio::fs::write(&file, content).await.expect("seed file");
-
-    let state =
-        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
-
-    let read_args = Some(
-        serde_json::json!({ "file_path": "data.txt" })
-            .as_object()
-            .expect("obj")
-            .clone(),
-    );
-    call_read(&state, &read_args, worktree.path())
-        .await
-        .expect("read");
-
-    // old_text uses CRLF (exact match). new_text also uses CRLF.
-    let edit_args = Some(
-        serde_json::json!({
-            "path": "data.txt",
-            "old_text": "line one\r\nline two\r\n",
-            "new_text": "replaced\r\n",
-        })
-        .as_object()
-        .expect("obj")
-        .clone(),
-    );
-    let response = call_edit(&state, &edit_args, worktree.path(), None, None, None)
-        .await
-        .expect("exact CRLF edit should succeed");
-
-    assert_eq!(response["ok"], serde_json::json!(true));
-
-    // File must retain CRLF in unchanged spans.
-    let after = tokio::fs::read_to_string(&file).await.expect("read back");
-    assert!(
-        after.contains("line three\r\n"),
-        "CRLF must be preserved in unchanged suffix: {after:?}"
-    );
-    assert!(
-        after.contains("replaced\r\n"),
-        "replacement with CRLF applied: {after:?}"
-    );
-    // No bare LF in the suffix (LF must always follow CR).
-    if let Some(idx) = after.find("line three") {
-        let suffix = &after[idx..];
-        assert!(
-            !suffix.contains("\n\r"),
-            "no reversed CRLF sequences: {suffix:?}"
-        );
-    }
-}
-
-/// CRLF guard rejection at dispatch level: file is NOT modified.
-#[tokio::test]
-async fn edit_crlf_guard_rejected_does_not_modify_file() {
-    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-crlf-guard-dsp-");
-    let file = worktree.path().join("data.txt");
-    let content = "line one\r\nline two\r\n";
-    tokio::fs::write(&file, content).await.expect("seed file");
-
-    let state =
-        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
-
-    let read_args = Some(
-        serde_json::json!({ "file_path": "data.txt" })
-            .as_object()
-            .expect("obj")
-            .clone(),
-    );
-    call_read(&state, &read_args, worktree.path())
-        .await
-        .expect("read");
-
-    // old_text uses LF — guard must reject because CRLF would be silently
-    // rewritten to LF in unchanged spans.
-    let edit_args = Some(
-        serde_json::json!({
-            "path": "data.txt",
-            "old_text": "line one\nline two",
-            "new_text": "replaced",
-        })
-        .as_object()
-        .expect("obj")
-        .clone(),
-    );
-    let err = call_edit(&state, &edit_args, worktree.path(), None, None, None)
-        .await
-        .expect_err("CRLF guard rejection must return error");
-
-    assert!(
-        err.contains("rejected by safety guard"),
-        "error must mention guard rejection: {err}"
-    );
-    assert!(
-        err.contains("\"guard_rejected\""),
-        "structured guard_rejected outcome: {err}"
-    );
-
-    // File must NOT be modified.
-    let after = tokio::fs::read_to_string(&file).await.expect("read back");
-    assert_eq!(
-        after, content,
-        "file must not be modified on guard rejection"
-    );
-}
-
-// ── Escape guard rejection at dispatch level ─────────────────────────────
-
-/// Escape guard rejection at dispatch level: quote imbalance causes guard
-/// rejection; file is NOT modified.
-#[tokio::test]
-async fn edit_escape_guard_rejected_does_not_modify_file() {
-    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-esc-guard-");
-    let file = worktree.path().join("str.rs");
-    // Content has escaped quotes; the old_text crosses a quote boundary.
-    let content = "let a = \"x\"; let b = \\\"x\\\";\n";
-    tokio::fs::write(&file, content).await.expect("seed file");
-
-    let state =
-        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
-
-    let read_args = Some(
-        serde_json::json!({ "file_path": "str.rs" })
-            .as_object()
-            .expect("obj")
-            .clone(),
-    );
-    call_read(&state, &read_args, worktree.path())
-        .await
-        .expect("read");
-
-    // old_text crosses an escape boundary → guard rejects.
-    let edit_args = Some(
-        serde_json::json!({
-            "path": "str.rs",
-            "old_text": "\"x\"; let b = \"x\"",
-            "new_text": "replaced",
-        })
-        .as_object()
-        .expect("obj")
-        .clone(),
-    );
-    let err = call_edit(&state, &edit_args, worktree.path(), None, None, None)
-        .await
-        .expect_err("escape guard rejection must return error");
-
-    assert!(
-        err.contains("rejected by safety guard"),
-        "error must mention guard rejection: {err}"
-    );
-
-    // File must NOT be modified.
-    let after = tokio::fs::read_to_string(&file).await.expect("read back");
-    assert_eq!(
-        after, content,
-        "file must not be modified on escape guard rejection"
-    );
-}
-
-// ── Ambiguous non-exact at dispatch level ─────────────────────────────────
-
-/// Ambiguous at a non-exact strategy (trimmed_boundary): file is NOT modified.
-#[tokio::test]
-async fn edit_ambiguous_trimmed_boundary_does_not_modify_file() {
-    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-ambig-tb-");
-    let file = worktree.path().join("dup.rs");
-    // Inner content "let x = 1;" appears twice; old_text has boundary
-    // whitespace lines that defeat exact match → trimmed_boundary ambiguity.
-    let content = "let x = 1;\n\nlet x = 1;\n";
-    tokio::fs::write(&file, content).await.expect("seed file");
-
-    let state =
-        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
-
-    let read_args = Some(
-        serde_json::json!({ "file_path": "dup.rs" })
-            .as_object()
-            .expect("obj")
-            .clone(),
-    );
-    call_read(&state, &read_args, worktree.path())
-        .await
-        .expect("read");
-
-    let edit_args = Some(
-        serde_json::json!({
-            "path": "dup.rs",
-            "old_text": "   \n\nlet x = 1;\n   \n",
-            "new_text": "replaced",
-        })
-        .as_object()
-        .expect("obj")
-        .clone(),
-    );
-    let err = call_edit(&state, &edit_args, worktree.path(), None, None, None)
-        .await
-        .expect_err("ambiguous trimmed-boundary edit must return error");
-
-    assert!(
-        err.contains("appears") && err.contains("times"),
-        "error must contain ambiguity info: {err}"
-    );
-    assert!(
-        err.contains("\"ambiguous\""),
-        "structured ambiguous outcome: {err}"
-    );
-
-    // File must NOT be modified.
-    let after = tokio::fs::read_to_string(&file).await.expect("read back");
-    assert_eq!(after, content, "file must not be modified on ambiguity");
-}
-
-// ── No-match nearest-miss metadata at dispatch level ─────────────────────
-
-/// No-match at dispatch level: verify nearest_miss score is a reasonable
-/// number (between 0 and 1) and file is not modified.
-#[tokio::test]
-async fn edit_no_match_nearest_miss_score_is_reasonable() {
-    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-nomatch-score-");
-    let file = worktree.path().join("svc.rs");
-    let content = "function process_data(input) {\n    return input;\n}\n";
-    tokio::fs::write(&file, content).await.expect("seed file");
-
-    let state =
-        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
-
-    let read_args = Some(
-        serde_json::json!({ "file_path": "svc.rs" })
-            .as_object()
-            .expect("obj")
-            .clone(),
-    );
-    call_read(&state, &read_args, worktree.path())
-        .await
-        .expect("read");
-
-    // Close but not matching — should have a high nearest_miss score.
-    let edit_args = Some(
-        serde_json::json!({
-            "path": "svc.rs",
-            "old_text": "function process_data(output) {\n    return output;\n}",
-            "new_text": "replaced",
-        })
-        .as_object()
-        .expect("obj")
-        .clone(),
-    );
-    let err = call_edit(&state, &edit_args, worktree.path(), None, None, None)
-        .await
-        .expect_err("no-match edit must return error");
-
-    assert!(err.contains("not found"), "error must say not found: {err}");
-    assert!(
-        err.contains("nearest_miss"),
-        "error must include nearest_miss: {err}"
-    );
-
-    // Parse the structured details to verify the score is reasonable.
-    // The error format is: "old_text not found in file: <path> {json}"
-    let json_start = err.find('{').expect("error must contain JSON details");
-    let details: serde_json::Value =
-        serde_json::from_str(&err[json_start..]).expect("must parse JSON details");
-    let score = details["edit_match"]["nearest_miss"]
-        .as_f64()
-        .expect("nearest_miss must be a float");
-    assert!(
-        (0.0..=1.0).contains(&score),
-        "nearest_miss score must be in [0, 1]: {score}"
-    );
-    assert!(
-        score > 0.3,
-        "partial overlap should have score > 0.3: {score}"
-    );
-
-    // File must NOT be modified.
-    let after = tokio::fs::read_to_string(&file).await.expect("read back");
-    assert_eq!(after, content, "file must not be modified on no-match");
-}
-
-/// Regression: `call_apply_patch` accepts `session_task_id` and `session_role`
-/// (plumbed consistently with `call_edit`). GateGuard denies the first worker
-/// edit; retry after re-read succeeds. Full gate-guard behaviour is covered in
-/// `gate_guard::tests`.
-#[tokio::test]
-async fn apply_patch_accepts_worker_role_plumbing() {
-    let worktree = crate::test_helpers::test_tempdir("djinn-ext-patch-worker-");
-    let file = worktree.path().join("svc.rs");
-    tokio::fs::write(&file, "fn main() {\n    old();\n}\n")
-        .await
-        .expect("seed");
-    let state =
-        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
-    let read_args = Some(
-        serde_json::json!({"file_path":"svc.rs"})
-            .as_object()
-            .expect("o")
-            .clone(),
-    );
-    call_read(&state, &read_args, worktree.path())
-        .await
-        .expect("read");
-    let patch_args = Some(serde_json::json!({"patch":"*** Begin Patch\n*** Update File: svc.rs\n@@ fn main() @@\n fn main() {\n-    old();\n+    new();\n }\n*** End Patch"}).as_object().expect("o").clone());
-    // First call: GateGuard FORCE prompt (plumbed params hit the gate).
-    let err = call_apply_patch(
-        &state,
-        &patch_args,
-        worktree.path(),
-        None,
-        Some("task-abc"),
-        Some("worker"),
-    )
-    .await
-    .expect_err("GateGuard must deny");
-    assert!(err.contains("GateGuard"), "must mention GateGuard: {err}");
-    // Re-read + retry: succeeds (edit_forced set).
-    call_read(&state, &read_args, worktree.path())
-        .await
-        .expect("re-read");
-    let response = call_apply_patch(
-        &state,
-        &patch_args,
-        worktree.path(),
-        None,
-        Some("task-abc"),
-        Some("worker"),
-    )
-    .await
-    .expect("retry succeeds");
-    assert_eq!(response.get("ok").and_then(|v| v.as_bool()), Some(true));
-    let after = tokio::fs::read_to_string(&file).await.expect("read back");
-    assert!(after.contains("new()"), "patched content missing: {after}");
-}

--- a/server/crates/djinn-agent/src/extension/tests/edit_dispatch_unicode_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/edit_dispatch_unicode_tests.rs
@@ -1,0 +1,441 @@
+//! Unicode / CRLF / guard-rejection and apply_patch role-plumbing cases for the
+//! edit dispatch path. Split out of `edit_dispatch_tests.rs` to stay within the
+//! repository file-size guard (MAX_LINES=1500 / MAX_BYTES=51200); shares the same
+//! harness via `use super::*`.
+
+use super::*;
+
+/// Unicode dispatch-level test: multi-byte characters in unchanged spans
+/// are preserved byte-for-byte after a successful edit. The match uses an
+/// exact ASCII word that sits between multi-byte Unicode content.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn edit_unicode_success_preserves_multibyte_unchanged_spans() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-unicode-dsp-");
+    let file = worktree.path().join("comment.rs");
+    // Content: multi-byte Unicode in prefix and suffix, ASCII target in middle.
+    let content = "// \u{201C}smart\u{201D} \u{2014} note\nlet x = target;\nlet y = \u{4E16};\n";
+    tokio::fs::write(&file, content).await.expect("seed file");
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let read_args = Some(
+        serde_json::json!({ "file_path": "comment.rs" })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("read");
+
+    // Exact match for the ASCII word — no Unicode normalization needed.
+    // The point is that multi-byte surrounding chars survive the replacement.
+    let edit_args = Some(
+        serde_json::json!({
+            "path": "comment.rs",
+            "old_text": "target",
+            "new_text": "done",
+        })
+        .as_object()
+        .expect("obj")
+        .clone(),
+    );
+    let response = call_edit(&state, &edit_args, worktree.path(), None, None, None)
+        .await
+        .expect("edit should succeed");
+
+    assert_eq!(response["ok"], serde_json::json!(true));
+
+    // Verify the file preserves multi-byte chars in unchanged spans.
+    let after = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert!(
+        after.contains('\u{201C}'),
+        "left smart quote must be preserved in output: {after:?}"
+    );
+    assert!(
+        after.contains('\u{201D}'),
+        "right smart quote must be preserved in output: {after:?}"
+    );
+    assert!(
+        after.contains('\u{2014}'),
+        "em dash must be preserved in output: {after:?}"
+    );
+    assert!(
+        after.contains('\u{4E16}'),
+        "CJK character must be preserved in output: {after:?}"
+    );
+    assert!(after.contains("done"), "replacement must be applied");
+
+    // Byte offsets in edit_match must be valid UTF-8 boundaries.
+    let em = response.get("edit_match").expect("must have edit_match");
+    let range = em["matched_byte_range"]
+        .as_array()
+        .expect("matched_byte_range is array");
+    let start = range[0].as_u64().unwrap() as usize;
+    let end = range[1].as_u64().unwrap() as usize;
+    assert!(
+        content.is_char_boundary(start),
+        "matched_byte_range.start ({start}) must be a UTF-8 char boundary"
+    );
+    assert!(
+        content.is_char_boundary(end),
+        "matched_byte_range.end ({end}) must be a UTF-8 char boundary"
+    );
+}
+
+// ── CRLF dispatch-level tests ────────────────────────────────────────────
+
+/// CRLF file with exact CRLF match at dispatch level: success and CRLF
+/// preserved in written output (no silent LF conversion).
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn edit_crlf_success_preserves_crlf_in_output() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-crlf-dsp-");
+    let file = worktree.path().join("data.txt");
+    let content = "line one\r\nline two\r\nline three\r\n";
+    tokio::fs::write(&file, content).await.expect("seed file");
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let read_args = Some(
+        serde_json::json!({ "file_path": "data.txt" })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("read");
+
+    // old_text uses CRLF (exact match). new_text also uses CRLF.
+    let edit_args = Some(
+        serde_json::json!({
+            "path": "data.txt",
+            "old_text": "line one\r\nline two\r\n",
+            "new_text": "replaced\r\n",
+        })
+        .as_object()
+        .expect("obj")
+        .clone(),
+    );
+    let response = call_edit(&state, &edit_args, worktree.path(), None, None, None)
+        .await
+        .expect("exact CRLF edit should succeed");
+
+    assert_eq!(response["ok"], serde_json::json!(true));
+
+    // File must retain CRLF in unchanged spans.
+    let after = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert!(
+        after.contains("line three\r\n"),
+        "CRLF must be preserved in unchanged suffix: {after:?}"
+    );
+    assert!(
+        after.contains("replaced\r\n"),
+        "replacement with CRLF applied: {after:?}"
+    );
+    // No bare LF in the suffix (LF must always follow CR).
+    if let Some(idx) = after.find("line three") {
+        let suffix = &after[idx..];
+        assert!(
+            !suffix.contains("\n\r"),
+            "no reversed CRLF sequences: {suffix:?}"
+        );
+    }
+}
+
+/// CRLF guard rejection at dispatch level: file is NOT modified.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn edit_crlf_guard_rejected_does_not_modify_file() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-crlf-guard-dsp-");
+    let file = worktree.path().join("data.txt");
+    let content = "line one\r\nline two\r\n";
+    tokio::fs::write(&file, content).await.expect("seed file");
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let read_args = Some(
+        serde_json::json!({ "file_path": "data.txt" })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("read");
+
+    // old_text uses LF — guard must reject because CRLF would be silently
+    // rewritten to LF in unchanged spans.
+    let edit_args = Some(
+        serde_json::json!({
+            "path": "data.txt",
+            "old_text": "line one\nline two",
+            "new_text": "replaced",
+        })
+        .as_object()
+        .expect("obj")
+        .clone(),
+    );
+    let err = call_edit(&state, &edit_args, worktree.path(), None, None, None)
+        .await
+        .expect_err("CRLF guard rejection must return error");
+
+    assert!(
+        err.contains("rejected by safety guard"),
+        "error must mention guard rejection: {err}"
+    );
+    assert!(
+        err.contains("\"guard_rejected\""),
+        "structured guard_rejected outcome: {err}"
+    );
+
+    // File must NOT be modified.
+    let after = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert_eq!(
+        after, content,
+        "file must not be modified on guard rejection"
+    );
+}
+
+// ── Escape guard rejection at dispatch level ─────────────────────────────
+
+/// Escape guard rejection at dispatch level: quote imbalance causes guard
+/// rejection; file is NOT modified.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn edit_escape_guard_rejected_does_not_modify_file() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-esc-guard-");
+    let file = worktree.path().join("str.rs");
+    // Content has escaped quotes; the old_text crosses a quote boundary.
+    let content = "let a = \"x\"; let b = \\\"x\\\";\n";
+    tokio::fs::write(&file, content).await.expect("seed file");
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let read_args = Some(
+        serde_json::json!({ "file_path": "str.rs" })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("read");
+
+    // old_text crosses an escape boundary → guard rejects.
+    let edit_args = Some(
+        serde_json::json!({
+            "path": "str.rs",
+            "old_text": "\"x\"; let b = \"x\"",
+            "new_text": "replaced",
+        })
+        .as_object()
+        .expect("obj")
+        .clone(),
+    );
+    let err = call_edit(&state, &edit_args, worktree.path(), None, None, None)
+        .await
+        .expect_err("escape guard rejection must return error");
+
+    assert!(
+        err.contains("rejected by safety guard"),
+        "error must mention guard rejection: {err}"
+    );
+
+    // File must NOT be modified.
+    let after = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert_eq!(
+        after, content,
+        "file must not be modified on escape guard rejection"
+    );
+}
+
+// ── Ambiguous non-exact at dispatch level ─────────────────────────────────
+
+/// Ambiguous at a non-exact strategy (trimmed_boundary): file is NOT modified.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn edit_ambiguous_trimmed_boundary_does_not_modify_file() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-ambig-tb-");
+    let file = worktree.path().join("dup.rs");
+    // Inner content "let x = 1;" appears twice; old_text has boundary
+    // whitespace lines that defeat exact match → trimmed_boundary ambiguity.
+    let content = "let x = 1;\n\nlet x = 1;\n";
+    tokio::fs::write(&file, content).await.expect("seed file");
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let read_args = Some(
+        serde_json::json!({ "file_path": "dup.rs" })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("read");
+
+    let edit_args = Some(
+        serde_json::json!({
+            "path": "dup.rs",
+            "old_text": "   \n\nlet x = 1;\n   \n",
+            "new_text": "replaced",
+        })
+        .as_object()
+        .expect("obj")
+        .clone(),
+    );
+    let err = call_edit(&state, &edit_args, worktree.path(), None, None, None)
+        .await
+        .expect_err("ambiguous trimmed-boundary edit must return error");
+
+    assert!(
+        err.contains("appears") && err.contains("times"),
+        "error must contain ambiguity info: {err}"
+    );
+    assert!(
+        err.contains("\"ambiguous\""),
+        "structured ambiguous outcome: {err}"
+    );
+
+    // File must NOT be modified.
+    let after = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert_eq!(after, content, "file must not be modified on ambiguity");
+}
+
+// ── No-match nearest-miss metadata at dispatch level ─────────────────────
+
+/// No-match at dispatch level: verify nearest_miss score is a reasonable
+/// number (between 0 and 1) and file is not modified.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn edit_no_match_nearest_miss_score_is_reasonable() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-edit-nomatch-score-");
+    let file = worktree.path().join("svc.rs");
+    let content = "function process_data(input) {\n    return input;\n}\n";
+    tokio::fs::write(&file, content).await.expect("seed file");
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let read_args = Some(
+        serde_json::json!({ "file_path": "svc.rs" })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("read");
+
+    // Close but not matching — should have a high nearest_miss score.
+    let edit_args = Some(
+        serde_json::json!({
+            "path": "svc.rs",
+            "old_text": "function process_data(output) {\n    return output;\n}",
+            "new_text": "replaced",
+        })
+        .as_object()
+        .expect("obj")
+        .clone(),
+    );
+    let err = call_edit(&state, &edit_args, worktree.path(), None, None, None)
+        .await
+        .expect_err("no-match edit must return error");
+
+    assert!(err.contains("not found"), "error must say not found: {err}");
+    assert!(
+        err.contains("nearest_miss"),
+        "error must include nearest_miss: {err}"
+    );
+
+    // Parse the structured details to verify the score is reasonable.
+    // The error format is: "old_text not found in file: <path> {json}"
+    let json_start = err.find('{').expect("error must contain JSON details");
+    let details: serde_json::Value =
+        serde_json::from_str(&err[json_start..]).expect("must parse JSON details");
+    let score = details["edit_match"]["nearest_miss"]
+        .as_f64()
+        .expect("nearest_miss must be a float");
+    assert!(
+        (0.0..=1.0).contains(&score),
+        "nearest_miss score must be in [0, 1]: {score}"
+    );
+    assert!(
+        score > 0.3,
+        "partial overlap should have score > 0.3: {score}"
+    );
+
+    // File must NOT be modified.
+    let after = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert_eq!(after, content, "file must not be modified on no-match");
+}
+
+/// Regression: `call_apply_patch` accepts `session_task_id` and `session_role`
+/// (plumbed consistently with `call_edit`). GateGuard denies the first worker
+/// edit; retry after re-read succeeds. Full gate-guard behaviour is covered in
+/// `gate_guard::tests`.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn apply_patch_accepts_worker_role_plumbing() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-patch-worker-");
+    let file = worktree.path().join("svc.rs");
+    tokio::fs::write(&file, "fn main() {\n    old();\n}\n")
+        .await
+        .expect("seed");
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+    let read_args = Some(
+        serde_json::json!({"file_path":"svc.rs"})
+            .as_object()
+            .expect("o")
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("read");
+    let patch_args = Some(serde_json::json!({"patch":"*** Begin Patch\n*** Update File: svc.rs\n@@ fn main() @@\n fn main() {\n-    old();\n+    new();\n }\n*** End Patch"}).as_object().expect("o").clone());
+    // First call: GateGuard FORCE prompt (plumbed params hit the gate).
+    let err = call_apply_patch(
+        &state,
+        &patch_args,
+        worktree.path(),
+        None,
+        Some("task-abc"),
+        Some("worker"),
+    )
+    .await
+    .expect_err("GateGuard must deny");
+    assert!(err.contains("GateGuard"), "must mention GateGuard: {err}");
+    // Re-read + retry: succeeds (edit_forced set).
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("re-read");
+    let response = call_apply_patch(
+        &state,
+        &patch_args,
+        worktree.path(),
+        None,
+        Some("task-abc"),
+        Some("worker"),
+    )
+    .await
+    .expect("retry succeeds");
+    assert_eq!(response.get("ok").and_then(|v| v.as_bool()), Some(true));
+    let after = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert!(after.contains("new()"), "patched content missing: {after}");
+}

--- a/server/crates/djinn-agent/src/extension/tests/gate_guard_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/gate_guard_dispatch_tests.rs
@@ -23,8 +23,10 @@ fn setup(prefix: &str) -> (tempfile::TempDir, crate::context::AgentContext) {
 /// prompt and sets edit_forced.  A re-read + retry succeeds (FileTime freshness
 /// is restored but edit_forced is preserved).  A third edit on the same file
 /// succeeds without re-gating.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn edit_worker_first_deny_second_allow_third_no_regate() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-edit-steady-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\nlet b = helper;\nlet c = util;\n")
@@ -131,8 +133,10 @@ async fn edit_worker_first_deny_second_allow_third_no_regate() {
 /// First worker write to an existing fully covered file returns the FORCE
 /// investigation prompt.  After re-read + retry the write succeeds.
 /// A subsequent write on the same path is not re-gated.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn write_worker_first_deny_second_allow_third_no_regate() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-write-steady-");
     let file = worktree.path().join("config.json");
     tokio::fs::write(&file, "{ \"key\": \"old\" }\n")
@@ -224,8 +228,10 @@ async fn write_worker_first_deny_second_allow_third_no_regate() {
 
 /// First worker apply_patch (update operation) on a fully covered file returns
 /// the investigation prompt.  After re-read + retry it succeeds.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn patch_update_worker_first_deny_second_allow() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-patch-steady-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "fn main() {\n    services();\n}\n")
@@ -296,8 +302,10 @@ async fn patch_update_worker_first_deny_second_allow() {
 
 /// First worker apply_patch with a DELETE operation on a fully covered file
 /// returns the investigation prompt.  After re-read + retry it succeeds.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn patch_delete_worker_first_deny_second_allow() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-patch-del-");
     let file = worktree.path().join("deprecated.rs");
     tokio::fs::write(&file, "// remove me\nfn old() {}\n")
@@ -361,8 +369,10 @@ async fn patch_delete_worker_first_deny_second_allow() {
 // ─── AC 3: role bypass — reviewer ────────────────────────────────────────
 
 /// Reviewer edits succeed without GateGuard interference on all three surfaces.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn reviewer_bypasses_gate_guard_all_surfaces() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-reviewer-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -464,8 +474,10 @@ async fn reviewer_bypasses_gate_guard_all_surfaces() {
 // ─── AC 3: role bypass — planner ─────────────────────────────────────────
 
 /// Planner edit succeeds without GateGuard.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn planner_bypasses_gate_guard() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-planner-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -515,8 +527,10 @@ async fn planner_bypasses_gate_guard() {
 // ─── AC 3: role bypass — architect ───────────────────────────────────────
 
 /// Architect apply_patch succeeds without GateGuard.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn architect_bypasses_gate_guard() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-arch-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "fn main() {\n    services();\n}\n")
@@ -563,8 +577,10 @@ async fn architect_bypasses_gate_guard() {
 // ─── AC 3: role bypass — missing role (None) ─────────────────────────────
 
 /// Missing role (None) succeeds without GateGuard for all three surfaces.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn missing_role_bypasses_gate_guard_all_surfaces() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-norole-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -647,8 +663,10 @@ async fn missing_role_bypasses_gate_guard_all_surfaces() {
 /// The investigation prompt must explicitly demand importers/callers, public
 /// functions/types, data schema/shape, and the verbatim task instruction —
 /// not just a generic "you can't edit yet" message.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn force_prompt_demands_all_four_facts() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-prompt-");
     let file = worktree.path().join("svc.rs");
     tokio::fs::write(&file, "let a = services;\n")
@@ -706,8 +724,10 @@ async fn force_prompt_demands_all_four_facts() {
 }
 
 /// Same fact-demand check for the write surface.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn force_prompt_demands_facts_for_write() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-prompt-w-");
     let file = worktree.path().join("config.rs");
     tokio::fs::write(&file, "let x = 1;\n").await.expect("seed");
@@ -761,8 +781,10 @@ async fn force_prompt_demands_facts_for_write() {
 }
 
 /// Same fact-demand check for the apply_patch surface.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn force_prompt_demands_facts_for_patch() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let (worktree, state) = setup("gged-prompt-p-");
     let file = worktree.path().join("mod.rs");
     tokio::fs::write(&file, "fn main() {\n    run();\n}\n")

--- a/server/crates/djinn-agent/src/extension/tests/jit_trace_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/jit_trace_tests.rs
@@ -2,11 +2,12 @@ use super::*;
 
 // ─── F2: just-in-time pitfall retrieval on first write (gated) ────────────
 
-/// Env-lock for the `DJINN_JIT_PITFALLS_ROLLOUT` rollout gate. Held across `.await` on
-/// purpose: the flag is process-global, so concurrent JIT tests must not
-/// observe each other's env mutation. Same pattern as the auto-code-context
-/// env tests in `helpers.rs`.
-static JIT_PITFALLS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+// These tests are the *writers* for the `DJINN_JIT_PITFALLS_ROLLOUT` gate —
+// they mutate the process-global env — so they take the exclusive side via
+// `test_helpers::jit_env_write_guard()`, held across `.await` on purpose. The
+// lock lives in `test_helpers` because the gate is read on the whole
+// write/edit/apply_patch tool path, not just by JIT tests; see the doc comment
+// there for the flake this scoping fixes.
 
 const JIT_PITFALL_OUTCOMES: [&str; 7] = [
     "disabled_default_off",
@@ -102,7 +103,7 @@ async fn latest_jit_trace(
 async fn jit_pitfalls_trace_preserves_top_two_output_and_candidate_outcomes() {
     use djinn_db::repositories::retrieval_trace::{CandidateOutcome, SkippedReason};
 
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
         std::env::set_var("DJINN_JIT_PITFALLS_ROLLOUT", "cohort");
@@ -202,7 +203,7 @@ async fn jit_pitfalls_trace_preserves_top_two_output_and_candidate_outcomes() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_search_error_persists_error_trace_and_consumes_session() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
         std::env::set_var("DJINN_JIT_PITFALLS_ROLLOUT", "enabled");
@@ -337,7 +338,7 @@ async fn jit_pitfalls_search_error_persists_error_trace_and_consumes_session() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_trace_insert_failure_is_fail_open_for_rendered_hint() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
         std::env::set_var("DJINN_JIT_PITFALLS_ROLLOUT", "enabled");
@@ -397,7 +398,7 @@ async fn jit_pitfalls_trace_insert_failure_is_fail_open_for_rendered_hint() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_trace_serialization_failure_is_fail_open() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
         std::env::set_var("DJINN_JIT_PITFALLS_ROLLOUT", "enabled");
@@ -467,7 +468,7 @@ async fn jit_pitfalls_trace_serialization_failure_is_fail_open() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_suppression_insert_failure_is_fail_open() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
         std::env::set_var("DJINN_JIT_PITFALLS_ROLLOUT", "off");
@@ -603,7 +604,7 @@ async fn jit_pitfalls_suppression_insert_failure_is_fail_open() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_off_by_default_no_hint() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     // SAFETY: single-threaded section guarded by the env-lock mutex.
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS_ROLLOUT");
@@ -654,7 +655,7 @@ async fn jit_pitfalls_off_by_default_no_hint() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_kill_switch_overrides_legacy_opt_in() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     // SAFETY: single-threaded section guarded by the env-lock mutex.
     unsafe {
         std::env::set_var("DJINN_JIT_PITFALLS", "1");
@@ -710,7 +711,7 @@ async fn jit_pitfalls_kill_switch_overrides_legacy_opt_in() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_on_first_write_appends_then_not_again() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     // SAFETY: single-threaded section guarded by the env-lock mutex.
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
@@ -789,7 +790,7 @@ async fn jit_pitfalls_on_first_write_appends_then_not_again() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_on_miss_leaves_write_succeeding() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     // SAFETY: single-threaded section guarded by the env-lock mutex.
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
@@ -841,7 +842,7 @@ async fn jit_pitfalls_on_miss_leaves_write_succeeding() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_on_missing_project_id_leaves_write_succeeding() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     // SAFETY: single-threaded section guarded by the env-lock mutex.
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
@@ -882,7 +883,7 @@ async fn jit_pitfalls_on_missing_project_id_leaves_write_succeeding() {
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn jit_pitfalls_on_edit_first_modification_appends() {
-    let _guard = JIT_PITFALLS_ENV_LOCK.lock().unwrap();
+    let _guard = crate::test_helpers::jit_env_write_guard();
     // SAFETY: single-threaded section guarded by the env-lock mutex.
     unsafe {
         std::env::remove_var("DJINN_JIT_PITFALLS");
@@ -945,8 +946,13 @@ async fn jit_pitfalls_on_edit_first_modification_appends() {
 /// when invoked with a worker role. This proves the widened signature
 /// compiles and is callable through the worker-role plumbing path without
 /// changing runtime behavior.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn write_accepts_worker_role_plumbing() {
+    // Lives in this file but is NOT a rollout-gate test: it drives the real
+    // write path, so it must hold the shared read side or it can bump the
+    // outcome counters while a JIT test above is asserting their deltas.
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-write-worker-");
     tokio::fs::create_dir_all(worktree.path().join("src"))
         .await

--- a/server/crates/djinn-agent/src/extension/tests/tool_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/tool_dispatch_tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn write_rejects_symlink_escape_outside_worktree() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-worktree-");
     let outside = crate::test_helpers::test_tempdir("djinn-ext-outside-");
     let link = worktree.path().join("escape-link");
@@ -32,8 +34,10 @@ async fn write_rejects_symlink_escape_outside_worktree() {
 /// the dispatcher hands us a `project_id`. Verifies the write-nudge
 /// wire-up end-to-end: threshold (`co_edits >= 2`), exclusion filter,
 /// and top-5 cap.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn call_write_emits_related_files_when_coupling_data_exists() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     use djinn_db::{CommitFileChange, CommitFileChangeRepository};
 
     let db = create_test_db();
@@ -124,8 +128,10 @@ async fn call_write_emits_related_files_when_coupling_data_exists() {
 /// coupling data for the project — the field is omitted rather than
 /// serialized as `null` or `[]` to keep the JSON shape stable for
 /// day-one projects.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn call_write_omits_related_files_when_coupling_empty() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
     let db = create_test_db();
     let project = create_test_project(&db).await;
     let worktree = crate::test_helpers::test_tempdir("djinn-ext-coupling-empty-");

--- a/server/crates/djinn-agent/src/test_helpers.rs
+++ b/server/crates/djinn-agent/src/test_helpers.rs
@@ -457,6 +457,56 @@ impl LlmProvider for FailingProvider {
     }
 }
 
+/// Serialises access to the process-global JIT-pitfalls rollout env vars
+/// (`DJINN_JIT_PITFALLS_ROLLOUT`, `DJINN_JIT_PITFALLS`).
+///
+/// # Why this lives here and not beside the JIT tests
+///
+/// It used to be a private `Mutex` inside `extension/tests/jit_trace_tests.rs`,
+/// scoped — per its own comment — so that "concurrent JIT tests must not observe
+/// each other's env mutation". That scope was too narrow, and the suite flaked
+/// about 1 run in 10 on `main`.
+///
+/// The gate is read by `rollout_mode_from_env()` at call time, on the *write
+/// tool path* — not only by JIT tests. So while a JIT test has the rollout set
+/// to `enabled`, every other concurrently-running test that calls `call_write`
+/// (in `gate_guard/tests/{patch,write}_tests.rs`,
+/// `tests/gate_guard_dispatch_tests.rs`, `tests/tool_dispatch_tests.rs`) also
+/// takes the JIT branch and bumps the shared
+/// `djinn_jit_pitfall_hints_total{outcome="eligible_search"}` counter. That
+/// corrupts the before/after delta assertion in
+/// `assert_jit_pitfall_outcome_deltas` — observed as `left: 3, right: 1` — and
+/// because the old guard was a `Mutex`, the resulting panic poisoned it and
+/// cascaded into every other JIT test in the same run.
+///
+/// # Why `RwLock` rather than `Mutex`
+///
+/// Only the JIT tests *mutate* the env; everyone else merely needs the value to
+/// hold still. Writers (env mutators) take [`std::sync::RwLock::write`] and are
+/// therefore exclusive against all readers; the many write-path tests take
+/// [`std::sync::RwLock::read`] and still run concurrently with each other, so
+/// covering them costs no suite wall-clock.
+///
+/// Any test that reads or writes those env vars — directly, or indirectly by
+/// invoking the write tool path — must hold this lock.
+pub static JIT_PITFALLS_ENV_LOCK: std::sync::RwLock<()> = std::sync::RwLock::new(());
+
+/// Shared read side of [`JIT_PITFALLS_ENV_LOCK`], for the write/edit/apply_patch
+/// tests that merely need the gate to hold still. These stay concurrent with
+/// each other and are excluded only while a JIT test is mutating the env.
+pub fn jit_env_read_guard() -> std::sync::RwLockReadGuard<'static, ()> {
+    JIT_PITFALLS_ENV_LOCK
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Exclusive side, for the JIT tests that mutate the rollout env vars.
+pub fn jit_env_write_guard() -> std::sync::RwLockWriteGuard<'static, ()> {
+    JIT_PITFALLS_ENV_LOCK
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[cfg(test)]
 mod tests {
     use std::panic::{AssertUnwindSafe, catch_unwind};


### PR DESCRIPTION
Follow-up to #2725, which flagged this flake but deliberately left it out of that hotfix.

## The flake

`extension::tests::jit_trace_tests::*` fails intermittently. **Reproduced 1 run in 10 against a clean `origin/main` checkout** of the djinn-agent lib suite — this is pre-existing and not introduced by any recent change:

```
assertion `left == right` failed: unexpected JIT Prometheus delta for eligible_search
  left: 3
 right: 1
```

## Root cause

`JIT_PITFALLS_ENV_LOCK` was a file-private `Mutex` in `jit_trace_tests.rs`, scoped — per its own comment — so that *"concurrent JIT tests must not observe each other's env mutation"*. That scope was too narrow in two independent ways.

**1. The gate is read far outside the JIT tests.** `rollout_mode_from_env()` reads `DJINN_JIT_PITFALLS_ROLLOUT` at call time, and `maybe_append_pitfall_hint` runs on **three** handler paths — `call_write`, `call_edit`, and `call_apply_patch`. While a JIT test has the rollout `enabled`, every concurrently-running test on any of those paths also takes the JIT branch and bumps the shared process-global counter `djinn_jit_pitfall_hints_total{outcome="eligible_search"}`, corrupting the before/after delta in `assert_jit_pitfall_outcome_deltas`.

**2. Failures cascaded.** Because the guard was a `Mutex`, the first panic poisoned it and every subsequent JIT test panicked on `.lock().unwrap()`. One observed run reported 5 failures and another 3 — all from a single root failure, which badly obscures triage.

## Fix

Move the lock into `test_helpers` and make it an `RwLock`:

- JIT tests **mutate** the env → exclusive `write()`.
- The **68** write/edit/apply_patch tests across six files → shared `read()`, so they still run concurrently with each other and the added coverage costs no suite wall-clock.
- Both sides use `PoisonError::into_inner`, so a failure reports as itself instead of cascading.

No production code changes; the rollout gate itself is untouched.

## Verification

**25 consecutive full-suite runs clean** (`cargo test -p djinn-agent --lib`), against a baseline that fails ~1 in 10 — so ~2–3 failures would be expected over that many runs.

Worth recording: an earlier pass of this fix covered only `call_write` and **still failed on iteration 5**. That failure is what surfaced the `call_edit` / `call_apply_patch` paths. Stressing to 25 runs rather than stopping at the first few green runs is what made the difference.

`cargo clippy -p djinn-agent --lib --tests --no-deps` clean, `cargo fmt` clean.