### PR TITLE
fix(agent): stop the watchdog killing a pod whose command is still running

### DIFF
--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -10,6 +10,7 @@
 //!
 //! `std::process::Command` avoids this by not touching the reactor at all.
 
+use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
 use std::future::Future;
 use std::io::{self, Write};
@@ -131,6 +132,21 @@ pub struct InvocationJournal {
     directory: PathBuf,
     pod_uid: String,
     update_lock: Mutex<()>,
+    /// Invocations this process is executing RIGHT NOW.
+    ///
+    /// A durable record exists for the whole life of an escalated command, and
+    /// the recovery sweep cannot tell from the file alone whether that command
+    /// is still running or was orphaned by a dead predecessor. Reading it as an
+    /// orphan is how the exact-pod watchdog came to terminate the very pod that
+    /// was doing the work: any `cargo build`/`cargo test` outliving the 300s
+    /// `WATCHDOG_GRACE` got its own Pod deleted mid-compile, which on this
+    /// workspace is most of them.
+    ///
+    /// Liveness is only ever asserted by the process that owns the invocation,
+    /// so this stays a fail-safe signal: a reconstructed pod starts with an
+    /// empty set and therefore still reaps every record a predecessor left
+    /// behind.
+    live: Mutex<HashSet<String>>,
 }
 impl InvocationJournal {
     /// Open (creating if needed) the pod-local journal directory.
@@ -162,7 +178,36 @@ impl InvocationJournal {
             directory,
             pod_uid,
             update_lock: Mutex::new(()),
+            live: Mutex::new(HashSet::new()),
         })
+    }
+
+    /// Assert that this process is executing `identity` right now, so the
+    /// recovery sweep leaves its record (and this Pod) alone. Balanced by
+    /// [`InvocationJournal::finish_live`], which the runner calls from a drop
+    /// guard so every early return and `?` still releases the claim.
+    fn begin_live(&self, identity: &TaskInvocationLeaseIdentity) {
+        self.live
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(identity.invocation_id.clone());
+    }
+
+    fn finish_live(&self, invocation_id: &str) {
+        self.live
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(invocation_id);
+    }
+
+    /// True while this process owns a running invocation with that id. Only the
+    /// owning process ever reports `true`, so a reconstructed Pod still reaps a
+    /// predecessor's records.
+    fn is_live(&self, invocation_id: &str) -> bool {
+        self.live
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(invocation_id)
     }
     fn record_at(
         &self,
@@ -318,6 +363,24 @@ fn parse_unresolved(content: &str) -> io::Result<UnresolvedInvocation> {
     })
 }
 
+/// Releases an invocation's liveness claim on every exit path from
+/// `LeaseInvocationRunner::output` — natural return, `?`, or cancellation.
+///
+/// The claim MUST be released even when the command fails, otherwise a stale
+/// claim would suppress the watchdog forever and re-open the orphan hole the
+/// journal exists to close. A drop guard is the only shape that survives the
+/// `?`s scattered through the invocation loop.
+struct LiveInvocationGuard {
+    journal: Arc<InvocationJournal>,
+    invocation_id: String,
+}
+
+impl Drop for LiveInvocationGuard {
+    fn drop(&mut self) {
+        self.journal.finish_live(&self.invocation_id);
+    }
+}
+
 /// Explicit recovery seams keep restart grace and watchdog delivery testable.
 pub struct InvocationRecovery<'a> {
     pub journal: &'a InvocationJournal,
@@ -341,6 +404,16 @@ impl<'a> InvocationRecovery<'a> {
         Fut: Future<Output = ()>,
     {
         for record in self.journal.unresolved()? {
+            // A record whose invocation is still executing in THIS process is
+            // not evidence of an orphan — it is evidence of work in progress.
+            // Skipped before the status RPC because there is nothing to
+            // reconcile and nothing to reap: the command owns the record and
+            // will resolve it at terminal. Without this, any escalated command
+            // outliving `WATCHDOG_GRACE` (every non-trivial `cargo` build on
+            // this workspace) made the sweep delete its own Pod mid-compile.
+            if self.journal.is_live(&record.identity.invocation_id) {
+                continue;
+            }
             let lease = LeaseIdentity::TaskInvocation(record.identity.clone());
             // Always query the coordinator's durable view. An unavailable reply
             // is ambiguous and never proves that local descendants are gone.
@@ -586,6 +659,10 @@ impl LeaseInvocationRunner {
         let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
         let mut deadline = self.clock.now_instant() + config.timeout;
         let (mut queued, mut fence, mut credit_used, mut lease_error) = (false, None, false, None);
+        // Held from escalation until this invocation leaves `output`. Never
+        // read: it exists purely for its `Drop`, which releases the liveness
+        // claim on every exit path.
+        let mut _live_guard: Option<LiveInvocationGuard> = None;
         let mut unavailable_responses = 0_u8;
         // Set when this invocation can no longer be escalated: either the
         // durable queue ended without capacity for it (`lease_failure`), or the
@@ -640,6 +717,14 @@ impl LeaseInvocationRunner {
                 // invocation, and therefore the earliest point at which the
                 // record is anything but garbage.
                 if let Some(journal) = &self.journal {
+                    // Claim liveness BEFORE the record exists, so there is no
+                    // instant in which a durable record is visible to the sweep
+                    // without its owner being known.
+                    journal.begin_live(&identity);
+                    _live_guard = Some(LiveInvocationGuard {
+                        journal: journal.clone(),
+                        invocation_id: identity.invocation_id.clone(),
+                    });
                     journal
                         .record_at(&identity, None, false, self.clock.now())
                         .map_err(LeaseInvocationError::Launcher)?;

--- a/server/crates/djinn-agent/src/process/tests/process_lease_recovery_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_recovery_tests.rs
@@ -663,3 +663,121 @@ async fn escalating_invocation_journals_before_the_queue_request() {
     test_clock.advance_mono(Duration::from_secs(120));
     let _ = run.await.expect("join");
 }
+
+/// Regression: the sweep must not reap an invocation this process is still
+/// executing.
+///
+/// A durable record exists for the whole life of an escalated command. The
+/// sweep cannot tell from the file whether that command is running or was
+/// orphaned by a dead predecessor, so it read every long `cargo` build as an
+/// orphan and fired the exact-pod watchdog against its OWN Pod. Production
+/// (2026-07-28) killed workers mid-compile this way even after the
+/// non-escalated record leak was fixed: `kziu` died at 15m and `3iir` at 10m,
+/// both on live cargo invocations.
+///
+/// The record is deliberately recorded far beyond the grace and the clock
+/// advanced past it, so the ONLY thing standing between this record and a
+/// termination request is the liveness claim.
+#[tokio::test]
+async fn a_live_invocation_is_never_reaped_by_its_own_watchdog() {
+    let directory = tempfile::tempdir().unwrap();
+    let identity = TaskInvocationLeaseIdentity {
+        task_id: "task".into(),
+        task_run_id: "run".into(),
+        invocation_id: "long-running-cargo".into(),
+    };
+    let journal = InvocationJournal::new(directory.path().to_path_buf(), "pod-uid".into()).unwrap();
+    journal.begin_live(&identity);
+    journal
+        .record_at(
+            &identity,
+            Some(LeaseFencingToken(11)),
+            false,
+            SystemTime::UNIX_EPOCH,
+        )
+        .unwrap();
+
+    let services = ScriptedServices::new(vec![], vec![], vec![]);
+    let clock = TestClock::new(SystemTime::UNIX_EPOCH, Instant::now());
+    clock.advance_wall(Duration::from_secs(3_600));
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    InvocationRecovery {
+        journal: &journal,
+        services: &services,
+        clock: &clock,
+        watchdog_grace: Duration::from_secs(300),
+    }
+    .run(|request| {
+        calls.lock().unwrap().push(request.pod_uid.clone());
+        std::future::ready(())
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        calls.lock().unwrap().is_empty(),
+        "a command still running in this process must never make its own Pod a \
+         watchdog target, however long it has been compiling"
+    );
+    let retained = journal.unresolved().unwrap();
+    assert_eq!(
+        retained.len(),
+        1,
+        "the live record is retained, not cleared"
+    );
+    assert!(
+        !retained[0].watchdog_notified,
+        "no notification bit may be burned on a live invocation — that bit is \
+         one-shot, so setting it here would forfeit the real reap later"
+    );
+}
+
+/// The complement, and the reason the claim is a drop guard: once the
+/// invocation finishes, its record is reapable again. Without this the fix
+/// would trade a false kill for a permanently disarmed watchdog, which is the
+/// orphan hole the journal exists to close.
+#[tokio::test]
+async fn a_finished_invocations_record_becomes_reapable_again() {
+    let directory = tempfile::tempdir().unwrap();
+    let identity = TaskInvocationLeaseIdentity {
+        task_id: "task".into(),
+        task_run_id: "run".into(),
+        invocation_id: "finished-cargo".into(),
+    };
+    let journal = InvocationJournal::new(directory.path().to_path_buf(), "pod-uid".into()).unwrap();
+    journal.begin_live(&identity);
+    journal
+        .record_at(
+            &identity,
+            Some(LeaseFencingToken(12)),
+            false,
+            SystemTime::UNIX_EPOCH,
+        )
+        .unwrap();
+    // The command exited; the drop guard released the claim.
+    journal.finish_live(&identity.invocation_id);
+
+    let services = ScriptedServices::new(vec![], vec![], vec![]);
+    let clock = TestClock::new(SystemTime::UNIX_EPOCH, Instant::now());
+    clock.advance_wall(Duration::from_secs(3_600));
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    InvocationRecovery {
+        journal: &journal,
+        services: &services,
+        clock: &clock,
+        watchdog_grace: Duration::from_secs(300),
+    }
+    .run(|request| {
+        calls.lock().unwrap().push(request.pod_uid.clone());
+        std::future::ready(())
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        calls.lock().unwrap().len(),
+        1,
+        "a grace-expired record with no live owner is exactly the orphan the \
+         watchdog exists for"
+    );
+}


### PR DESCRIPTION
Second half of the worker-pod suicide bug. #2725 fixed one of the two ways the invocation journal armed the exact-pod watchdog against its own Pod; this is the other, and the more damaging one.

## Evidence from production after v0.7.23

#2725 worked, and measurably so — a six-minute-old pod had an **empty** journal directory (cheap commands no longer leak records), and pods sailed past the ~10m cliff that had previously killed 100% of them. But tasks still weren't reaching review: `kziu` died at **15m**, `3iir` at **10m**.

Inspecting live pods showed why. Each held exactly one unresolved record:

```
invocation_id=019faa20-2e7b-...  fence=2458  terminal_intent=false
recorded_at_ms=1785266037561   → 93s old and counting
```

A `fence` means the invocation escalated, was granted, and was lifted — a live `cargo` command, mid-flight. `terminal_intent=false` means it hasn't finished.

## Root cause

An escalated command holds its durable record for its entire run. `InvocationRecovery::run` cannot tell from the file whether that command is executing or was orphaned by a dead predecessor, so any record older than the 300s `WATCHDOG_GRACE` becomes a termination request against **this** Pod. Every compile longer than five minutes — most of them on this workspace — killed its own worker mid-build.

This is not the narrow "reconcile failed" edge I first assumed when filing #2725. It is the common path.

## Fix

Track the invocations this process is executing and skip them in the sweep. A record with a live owner is evidence of work in progress, not of an orphan.

- The claim is taken **before** the write-ahead record exists, so there is no instant where a durable record is visible to the sweep without its owner being known.
- It is released by a **drop guard**, so every early return, `?`, and cancellation re-arms the watchdog. A stale claim would forfeit the orphan reap the journal exists for, so this must not depend on the happy path.
- Liveness is asserted only by the owning process. A reconstructed Pod starts with an empty set and still reaps every record a predecessor left behind — the fail-safe direction is preserved.

## Tests

Both directions, because a fix that only suppressed the kill would trade a false positive for a permanently disarmed watchdog:

- `a_live_invocation_is_never_reaped_by_its_own_watchdog` — record aged 3600s against a 300s grace, so the liveness claim is the only thing preventing termination. Also asserts the one-shot `watchdog_notified` bit is **not** burned, since burning it would forfeit the real reap later.
- `a_finished_invocations_record_becomes_reapable_again` — after the guard drops, the same grace-expired record *is* reaped.

Verified by mutation: neutering `is_live()` to always return `false` makes the first test fail, confirming it genuinely depends on the new behavior rather than passing incidentally.

`cargo test -p djinn-agent --lib process::tests::lease_runner_tests` → 53 passed. Clippy and fmt clean.