### PR TITLE
fix(admission): stop the build-admission gate arming itself against its own healthy dispatches

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -1975,13 +1975,53 @@ impl BuildAdmissionController {
         seed_filter: &mut impl FnMut(&AdmissionJournalRow) -> bool,
     ) -> Result<AdmissionSeedReport, WarmAdmissionError> {
         let mut seeded = 0u64;
-        // The CreateUnknown startup gate reflects every active recovered row,
-        // not only the ones seeded into memory: an unseeded CreateUnknown row
-        // still occupies durable capacity and still gates Enforce readiness.
+        // The CreateUnknown startup gate counts RECOVERED unknowns — rows whose
+        // creator process is gone — and deliberately nothing else.
+        //
+        // `CreateUnknown` means two entirely different things depending on who
+        // wrote the row:
+        //
+        // * A PREDECESSOR's row is a genuine unknown. The process that POSTed
+        //   the create died without learning the outcome, nothing in this
+        //   process is waiting on it, and only reconciliation against the API
+        //   server can resolve it. Enforce must fail closed until it does.
+        // * THIS process's own row is the ordinary intermediate state of a
+        //   healthy dispatch. `finish_task_run_build_admission` writes
+        //   `CreateUnknown` ("slot-pool accepted create without object UID")
+        //   for *every* task-run the moment the pool accepts it, and it stays
+        //   that way until the `("session","started")` callback supplies the
+        //   UID. A warm Job is the same between its POST and `job_uid()`.
+        //
+        // Counting the second kind is what halted the board for five hours on
+        // 2026-07-29. This seed runs at the tail of EVERY periodic
+        // reconciliation pass (see `build_admission_inventory::reconcile`,
+        // 120s since #2711), so a tick that lands inside one normal dispatch's
+        // POST→session window armed `CreateUnknownHealth` against the live
+        // process's own healthy in-flight work — denying every admission
+        // before any capacity was measured. It normally cleared on the next
+        // tick; that day the worker never registered a session, so `mark_live`
+        // never ran and the row stayed. And `is_reclaimable` refuses to retire
+        // a row under this process's own epoch (correctly — see
+        // `BuildAdmissionReconciler::is_reclaimable`), so the gate had no
+        // reachable clearing path at all. Only a restart, which reclassifies
+        // the row as a predecessor's, could clear it.
+        //
+        // Arming and reclamation must therefore agree on the same population:
+        // the gate is armed by exactly the rows the reclaimer is allowed to
+        // retire. A row this process is mid-creating is not a *recovered*
+        // unknown, and it is not evidence that this process cannot be trusted
+        // to admit.
+        let is_recovered_unknown = |row: &AdmissionJournalRow| {
+            row.state == AdmissionState::CreateUnknown
+                && row.creator_server_epoch != self.creator_server_epoch
+        };
+        // Every active recovered row counts, not only the ones seeded into
+        // memory: an unseeded recovered CreateUnknown row still occupies
+        // durable capacity and still gates Enforce readiness.
         let create_unknown_rows = recovery
             .active_rows
             .iter()
-            .filter(|row| row.state == AdmissionState::CreateUnknown)
+            .filter(|row| is_recovered_unknown(row))
             .count() as u64;
         {
             let mut permits = self.permits.lock().await;
@@ -2014,7 +2054,13 @@ impl BuildAdmissionController {
                         object_name: row.object_name.clone(),
                         durable: true,
                         released: false,
-                        create_unknown_outstanding: row.state == AdmissionState::CreateUnknown,
+                        // Exactly the rows that armed the gate above. This flag
+                        // is what `transition` decrements the gate on when the
+                        // row is adopted into Live, so seeding it for a row
+                        // that never contributed to the count would let one
+                        // healthy own-epoch dispatch clear a gate a
+                        // predecessor's row is still holding — fail-open.
+                        create_unknown_outstanding: is_recovered_unknown(row),
                         // A recovered row's capacity was acquired by the
                         // predecessor process, but the lease row it acquired
                         // survives the restart in `build_leases` and is

--- a/server/crates/djinn-coordinator/src/build_admission_inventory.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory.rs
@@ -38,14 +38,15 @@ pub struct InventoryReport {
     pub adopted: usize,
     pub released: usize,
     /// Occupying rows in a pre-Live state that were retired because their
-    /// Kubernetes object was proven absent.
+    /// Kubernetes object was proven absent, or proven already finished.
     pub reclaimed: usize,
-    /// Rows whose object was proven absent, counted before any reclamation.
-    /// This is the size of the stale population, not the size of the fix.
+    /// Rows whose object was proven absent — or proven finished — counted
+    /// before any reclamation. This is the size of the stale population, not
+    /// the size of the fix.
     pub stale: usize,
     /// Reclamations refused because the row changed after its absence proof.
     pub fenced: usize,
-    /// Named per-row reclamation failures, bounded by
+    /// Named per-row journal failures (retirement or adoption), bounded by
     /// [`MAX_NAMED_RECLAIM_FAILURES`]. See `reclaim_failure_count` for the
     /// exact total.
     ///
@@ -55,7 +56,7 @@ pub struct InventoryReport {
     /// not fail the whole pass and must not gate Enforce on the namespace's
     /// history instead of its current state.
     pub reclaim_failures: Vec<String>,
-    /// Exact number of per-row reclamation failures, named or not.
+    /// Exact number of per-row journal failures, named or not.
     pub reclaim_failure_count: usize,
     /// Pass-level failures. A non-empty `blockers` means the pass could not be
     /// trusted at all (unusable listing, unreadable journal, failed seeding)
@@ -69,15 +70,21 @@ pub struct InventoryReport {
 pub const MAX_NAMED_RECLAIM_FAILURES: usize = 5;
 
 impl InventoryReport {
-    /// Record one per-row reclamation failure without failing the pass.
-    fn reclaim_failure(&mut self, row: &AdmissionJournalRow, error: &str) {
+    /// Record one per-row journal failure without failing the pass.
+    fn row_failure(&mut self, label: &str, error: &str) {
         self.reclaim_failure_count += 1;
         if self.reclaim_failures.len() < MAX_NAMED_RECLAIM_FAILURES {
-            self.reclaim_failures.push(format!(
-                "{}:{}:{}: {error}",
-                row.key.work_id, row.key.generation, row.object_name
-            ));
+            self.reclaim_failures.push(format!("{label}: {error}"));
         }
+    }
+
+    /// Record one per-row reclamation failure without failing the pass.
+    fn reclaim_failure(&mut self, row: &AdmissionJournalRow, error: &str) {
+        let label = format!(
+            "{}:{}:{}",
+            row.key.work_id, row.key.generation, row.object_name
+        );
+        self.row_failure(&label, error);
     }
 }
 fn identity(key: &AdmissionJournalKey) -> String {
@@ -217,7 +224,23 @@ impl BuildAdmissionReconciler {
     ///
     /// * the row's creator epoch is not this process, so no in-process dispatch
     ///   can still be mid-create for it — the only process that could have
-    ///   finished this create is gone;
+    ///   finished this create is gone. This clause looks redundant against the
+    ///   settle window below and is NOT: the two clauses below are
+    ///   *structurally vacuous* for `task_observation` rows. Only warm Jobs are
+    ///   stamped with an admission identity (`stamp_admission_identity` is
+    ///   called from the warm path alone), a task-run Job is named
+    ///   `djinn-taskrun-{task_run_id}` while its journal row records
+    ///   `object_name = task-run-{task_id}-{reopen}`, and `classify` maps a
+    ///   real task-run Job to a work id that is the task-RUN id. So the LIST
+    ///   never contains the row's `object_name` and the GET always answers
+    ///   `Absent` — even while the task-run is running happily. For those rows
+    ///   the creator epoch is the only evidence that no live work depends on
+    ///   the row, and dropping it would retire the admission row of every
+    ///   task-run whose POST→session-started gap exceeds the settle window (a
+    ///   pending pod or a slow image pull), releasing capacity for work that is
+    ///   still running. The 2026-07-29 board halt was NOT caused by this fence:
+    ///   it was caused by `seed_from_recovery` ARMING `CreateUnknownHealth`
+    ///   from rows this fence is right to refuse. See the arming comment there;
     /// * the row has settled, so the API server can no longer be admitting a
     ///   create the dead process POSTed;
     /// * the authoritative LIST that just succeeded contains no object under
@@ -248,6 +271,53 @@ impl BuildAdmissionReconciler {
             == ObjectPresence::Absent
     }
 
+    /// Retire one pre-Live occupying row whose Kubernetes evidence is
+    /// conclusive: either its object is provably absent, or its object exists
+    /// and has already finished. Both are proofs that no lifecycle callback is
+    /// coming, and `reclaim_absent_object` is the only journal primitive that
+    /// can terminalize a pre-Live row (`mark_terminal` accepts a create whose
+    /// UID was never observed, but a pre-Live row that was superseded by a
+    /// later generation is rejected by the latest-generation fence every
+    /// lifecycle mutation carries).
+    ///
+    /// The write is fenced by a compare-and-set on the full observed identity,
+    /// so anything that changed between the proof and the write yields
+    /// `Fenced` and writes nothing.
+    async fn retire_pre_live_row(&self, out: &mut InventoryReport, row: &AdmissionJournalRow) {
+        out.stale += 1;
+        let input = ReclaimAbsentInput {
+            key: row.key.clone(),
+            observed_state: row.state,
+            observed_creator_server_epoch: row.creator_server_epoch.clone(),
+            observed_object_name: row.object_name.clone(),
+            observed_object_uid: row.object_uid.clone(),
+        };
+        match self
+            .controller
+            .journal()
+            .reclaim_absent_object(&input)
+            .await
+        {
+            Ok(ReclaimAbsentOutcome::Reclaimed(_)) => {
+                out.reclaimed += 1;
+                self.controller.release_notifier().notify_one();
+            }
+            Ok(ReclaimAbsentOutcome::AlreadyTerminal(_)) => {}
+            Ok(ReclaimAbsentOutcome::Fenced { reason }) => {
+                out.fenced += 1;
+                tracing::warn!(
+                    work_id = %row.key.work_id,
+                    generation = row.key.generation,
+                    object = %row.object_name,
+                    %reason,
+                    "build_admission: refused to reclaim an admission row that changed \
+                     after its absence proof"
+                );
+            }
+            Err(error) => self.record_reclaim_failure(out, row, &error),
+        }
+    }
+
     /// Classify one failed retirement of a single occupying row.
     ///
     /// A rejected transition is a decision about that one row: its own identity
@@ -271,6 +341,46 @@ impl BuildAdmissionReconciler {
                 object = %row.object_name,
                 %error,
                 "build_admission: one occupying row could not be retired; reclamation continues"
+            );
+            return;
+        }
+        self.controller.mark_journal_unhealthy();
+        out.blockers.push(error.to_string());
+    }
+
+    /// Classify one failed adoption of a single live Kubernetes object.
+    ///
+    /// Symmetric with [`Self::record_reclaim_failure`], and for the same
+    /// reason. `adopt_live` returns `InvalidTransition("inventory identity
+    /// collision")` for a routine identity mismatch — an object whose
+    /// admission labels resolve to a journal key that already holds a
+    /// different object name or UID. That is a decision about one object.
+    /// Treating it as a pass-level blocker cost the whole pass: it marked the
+    /// journal unhealthy (failing Enforce closed on `JournalUnhealthy`) and,
+    /// because the tail seed used to run only when `blockers` was empty, it
+    /// also froze `journal_recovered`, `journal_healthy`,
+    /// `create_unknown_pending` and `over_cap` at whatever they last were —
+    /// four gates held hostage by one mislabelled object, indefinitely.
+    fn record_adopt_failure(
+        &self,
+        out: &mut InventoryReport,
+        workload: &ClassifiedWorkload,
+        error: &djinn_db::Error,
+    ) {
+        if matches!(error, djinn_db::Error::InvalidTransition(_)) {
+            out.row_failure(
+                &format!(
+                    "{}:{}:{}",
+                    workload.key.work_id, workload.key.generation, workload.object.name
+                ),
+                &error.to_string(),
+            );
+            tracing::warn!(
+                work_id = %workload.key.work_id,
+                generation = workload.key.generation,
+                object = %workload.object.name,
+                %error,
+                "build_admission: one live object could not be adopted; the pass continues"
             );
             return;
         }
@@ -319,6 +429,9 @@ impl BuildAdmissionReconciler {
         }
         for c in &cs {
             if c.object.terminal {
+                // Adopting a finished object into `Live` would be a lie. The
+                // row loop below retires the pre-Live row this object belongs
+                // to instead — see the `finished` branch there.
                 continue;
             }
             let Some(uid) = c.object.uid.as_ref() else {
@@ -335,10 +448,7 @@ impl BuildAdmissionReconciler {
             };
             match self.controller.journal().adopt_live(&x).await {
                 Ok(_) => out.adopted += 1,
-                Err(e) => {
-                    self.controller.mark_journal_unhealthy();
-                    out.blockers.push(e.to_string());
-                }
+                Err(e) => self.record_adopt_failure(&mut out, c, &e),
             }
         }
         let active = match self
@@ -460,72 +570,75 @@ impl BuildAdmissionReconciler {
             // object is gone. Those rows occupy the shared cap forever, which
             // is how a fleet accumulates a stale population large enough to
             // deny every admission the moment the cap is armed.
+            let classified = by.get(&id).copied();
+            // The object EXISTS and has already FINISHED, under this row's own
+            // admission identity and its own recorded name. That row was
+            // previously in a hole with no exit at all: adoption skips a
+            // terminal object (adopting a finished Job into `Live` would be a
+            // lie), reclamation refuses it (`classified.is_some()` — the
+            // object is not absent, so the absence proof cannot be made), and
+            // the `Live` branch's completion handling never applies because
+            // the row is not `Live`. So the create landed, the workload ran,
+            // the workload finished, and the row occupied capacity forever
+            // while every pass reported `stale:0`.
+            //
+            // A finished object is a strictly stronger proof than absence: the
+            // work is over, and no lifecycle callback is coming for a row that
+            // never went Live. Retire it.
+            let finished =
+                classified.is_some_and(|c| c.object.terminal && c.object.name == row.object_name);
+            if finished {
+                self.retire_pre_live_row(&mut out, row).await;
+                continue;
+            }
             if !self
-                .is_reclaimable(row, &by.get(&id).copied(), &listed_names, &settled)
+                .is_reclaimable(row, &classified, &listed_names, &settled)
                 .await
             {
                 continue;
             }
-            out.stale += 1;
-            let input = ReclaimAbsentInput {
-                key: row.key.clone(),
-                observed_state: row.state,
-                observed_creator_server_epoch: row.creator_server_epoch.clone(),
-                observed_object_name: row.object_name.clone(),
-                observed_object_uid: row.object_uid.clone(),
-            };
-            match self
-                .controller
-                .journal()
-                .reclaim_absent_object(&input)
-                .await
-            {
-                Ok(ReclaimAbsentOutcome::Reclaimed(_)) => {
-                    out.reclaimed += 1;
-                    self.controller.release_notifier().notify_one();
-                }
-                Ok(ReclaimAbsentOutcome::AlreadyTerminal(_)) => {}
-                Ok(ReclaimAbsentOutcome::Fenced { reason }) => {
-                    out.fenced += 1;
-                    tracing::warn!(
-                        work_id = %row.key.work_id,
-                        generation = row.key.generation,
-                        object = %row.object_name,
-                        %reason,
-                        "build_admission: refused to reclaim an admission row that changed \
-                         after its absence proof"
-                    );
-                }
-                Err(error) => self.record_reclaim_failure(&mut out, row, &error),
-            }
+            self.retire_pre_live_row(&mut out, row).await;
         }
-        if out.blockers.is_empty() {
-            let rows = match self.controller.journal().list_active_rows().await {
-                Ok(rows) => rows,
-                Err(error) => {
-                    self.controller.mark_journal_unhealthy();
-                    self.controller.mark_inventory_pending();
-                    out.blockers.push(error.to_string());
-                    self.controller.publish_metrics().await;
-                    return out;
-                }
-            };
-            let recovery = AdmissionRecoveryResult {
-                retired_reserved: 0,
-                marked_create_unknown: 0,
-                active_rows: rows,
-            };
-            if let Err(error) = self
-                .controller
-                .seed_from_recovery(&recovery, &mut |_| true)
-                .await
-            {
+        // The tail seed re-derives `journal_recovered`, `journal_healthy`,
+        // `create_unknown_pending` and `over_cap` from the journal. It is the
+        // ONLY in-process re-derivation of those four gates, and it only
+        // READS: whatever this pass could or could not do to Kubernetes, the
+        // journal's current contents are still the journal's current contents.
+        //
+        // It used to run only `if out.blockers.is_empty()`, which meant any
+        // standing blocker — one unclassifiable Job, one duplicate identity,
+        // one adoption collision — froze all four gates at their last values
+        // for as long as the blocker stood. A gate that had latched closed
+        // could never re-open, because the only code that could re-open it was
+        // gated on the condition being absent. Only `mark_inventory_ready`
+        // belongs behind `blockers`: that gate is a statement about THIS
+        // pass's Kubernetes evidence, and it is the one that must stay
+        // fail-closed when the evidence is incomplete.
+        let rows = match self.controller.journal().list_active_rows().await {
+            Ok(rows) => rows,
+            Err(error) => {
                 self.controller.mark_journal_unhealthy();
                 self.controller.mark_inventory_pending();
                 out.blockers.push(error.to_string());
-            } else {
-                self.controller.mark_inventory_ready();
+                self.controller.publish_metrics().await;
+                return out;
             }
+        };
+        let recovery = AdmissionRecoveryResult {
+            retired_reserved: 0,
+            marked_create_unknown: 0,
+            active_rows: rows,
+        };
+        if let Err(error) = self
+            .controller
+            .seed_from_recovery(&recovery, &mut |_| true)
+            .await
+        {
+            self.controller.mark_journal_unhealthy();
+            self.controller.mark_inventory_pending();
+            out.blockers.push(error.to_string());
+        } else if out.blockers.is_empty() {
+            self.controller.mark_inventory_ready();
         } else {
             self.controller.mark_inventory_pending();
         }

--- a/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
@@ -17,14 +17,15 @@ use std::time::Duration;
 use async_trait::async_trait;
 use djinn_core::events::EventBus;
 use djinn_db::{
-    AdmissionDomain, AdmissionJournalKey, AdmissionJournalRepository, AdmissionState,
-    AdmissionWorkloadKind, CreateStartedInput, Database, ImageRepository, ProjectRepository,
-    ReserveAdmissionInput, TerminalAdmissionInput, UidFencedAdmissionInput,
+    AdmissionDomain, AdmissionJournalKey, AdmissionJournalRepository, AdmissionJournalRow,
+    AdmissionState, AdmissionWorkloadKind, CreateStartedInput, Database, ImageRepository,
+    ProjectRepository, ReserveAdmissionInput, TerminalAdmissionInput, UidFencedAdmissionInput,
 };
 use djinn_k8s::{
     K8sGraphWarmer, KubernetesConfig, ObjectPresence, UidGetResult, WarmAdmission,
-    WarmAdmissionError, WarmAdmissionRequest, WarmJobDispatcher, WarmJobManifest, WarmJobWatcher,
-    WarmTerminalOutcome, WorkloadInventory, WorkloadObjectKind, WorkloadRecord, warm_work_id,
+    WarmAdmissionError, WarmAdmissionRequest, WarmAdmissionTransition, WarmJobDispatcher,
+    WarmJobManifest, WarmJobWatcher, WarmTerminalOutcome, WorkloadInventory, WorkloadObjectKind,
+    WorkloadRecord, warm_work_id,
 };
 use djinn_runtime::GraphWarmerService;
 use tokio::sync::RwLock;
@@ -265,6 +266,46 @@ fn warm_request(id: &str) -> WarmAdmissionRequest {
     }
 }
 
+/// A Kubernetes object carrying the admission identity of `row`, under the
+/// exact name the row recorded. This is what the dispatch path stamps on a warm
+/// Job (`stamp_admission_identity`), so `classify` resolves it back to the
+/// row's own journal key.
+fn admission_labeled_object(
+    row: &AdmissionJournalRow,
+    terminal: bool,
+    uid: &str,
+) -> WorkloadRecord {
+    let domain = match row.key.domain {
+        AdmissionDomain::TaskObservation => "task_observation",
+        AdmissionDomain::WarmBuild => "warm_build",
+        AdmissionDomain::InvocationBuild => "invocation_build",
+    };
+    WorkloadRecord {
+        kind: WorkloadObjectKind::Job,
+        name: row.object_name.clone(),
+        uid: Some(uid.to_owned()),
+        labels: [
+            (
+                djinn_k8s::LABEL_ADMISSION_DOMAIN.to_string(),
+                domain.to_string(),
+            ),
+            (
+                djinn_k8s::LABEL_ADMISSION_WORK_ID.to_string(),
+                row.key.work_id.clone(),
+            ),
+            (
+                djinn_k8s::LABEL_ADMISSION_GENERATION.to_string(),
+                row.key.generation.to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        terminal,
+        images: vec!["djinn:test".into()],
+        commands: vec!["djinn-warm".into()],
+    }
+}
+
 /// The production build-admission entry point the warm trait wraps, so the
 /// bounded decision (and its occupancy arithmetic) is directly observable.
 fn build_request(id: &str) -> BuildAdmissionRequest {
@@ -487,9 +528,26 @@ async fn reclamation_never_releases_work_that_is_still_fenced() {
 }
 
 /// A row created by THIS process may be mid-create right now, and an API server
-/// that cannot answer is not evidence of anything. Neither may be reclaimed.
+/// that cannot answer is not evidence of anything. Neither may be reclaimed —
+/// and neither may wedge the board.
+///
+/// The second half of that sentence is the 2026-07-29 outage, and this test
+/// used to certify the bug rather than catch it. It constructed exactly the
+/// production state (a live controller's own `CreateUnknown` row, an empty
+/// namespace, a zero settle window so only the epoch fence remains), asserted
+/// `reclaimed == 0`, and stopped — never once looking at `readiness()`. It was
+/// the label, not the side effect.
+///
+/// The side effect: the tail `seed_from_recovery` in every reconciliation pass
+/// counted that row into `create_unknown_pending`, which `readiness()` reports
+/// as `CreateUnknownHealth`, which denies EVERY admission before any capacity
+/// is measured. `finish_task_run_build_admission` writes a `CreateUnknown` row
+/// for every task-run the moment the slot pool accepts it, so any 120s pass
+/// landing inside a normal dispatch's POST→session window halted the entire
+/// board — while `is_reclaimable` (correctly) refused to retire the row that
+/// armed the gate. Arming and reclamation must agree on the same population.
 #[tokio::test]
-async fn current_epoch_and_unsettled_rows_are_never_reclaimed() {
+async fn current_epoch_and_unsettled_rows_are_never_reclaimed_and_never_wedge_the_board() {
     let db = Database::open_in_memory().unwrap();
     let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
 
@@ -523,6 +581,23 @@ async fn current_epoch_and_unsettled_rows_are_never_reclaimed() {
         "a row this process created may still be mid-create"
     );
     assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 1);
+    // The row the reconciler may not touch must not arm a gate the reconciler
+    // is the only thing that could clear. This is the whole outage.
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::Healthy,
+        "this process's own in-flight create is not a RECOVERED unknown; it must \
+         not fail Enforce closed against work this process is actively doing"
+    );
+    let admitted = controller
+        .admit(build_request("board-keeps-running"))
+        .await
+        .expect("a decision, not an error");
+    assert!(
+        matches!(admitted, BuildAdmissionDecision::Permitted { .. }),
+        "the board must keep dispatching while one of its own creates is in \
+         flight: {admitted:?}"
+    );
 
     // Same rows, seen by a replacement process, but inside the settle window:
     // the API server could still be admitting a create the dead process POSTed.
@@ -545,6 +620,15 @@ async fn current_epoch_and_unsettled_rows_are_never_reclaimed() {
         "an unsettled row is not yet safe to judge by a listing"
     );
     assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 1);
+    // The fail-closed direction, unchanged: the SAME row seen by a process
+    // that did not create it IS a recovered unknown — nobody is mid-creating
+    // it, nothing in this process is waiting on it, and only reconciliation
+    // can resolve it. That must still gate Enforce.
+    assert_eq!(
+        successor.readiness(),
+        BuildAdmissionReadiness::CreateUnknownHealth,
+        "a predecessor's unresolved create must still fail Enforce closed"
+    );
 }
 
 /// The 2026-07-28 production wedge, end to end: the startup pass alone is not
@@ -916,5 +1000,300 @@ async fn one_unreclaimable_row_costs_one_row_and_the_sweep_continues() {
         journal.count_task_or_warm_occupancy().await.unwrap(),
         1,
         "only the unreclaimable row keeps occupying"
+    );
+}
+
+/// A pre-Live row whose object EXISTS and has already FINISHED had no exit at
+/// all, and one of them wedges the board permanently.
+///
+/// Adoption skips a terminal object (adopting a finished Job into `Live` would
+/// be a lie), reclamation refuses it (the object is not absent, so the absence
+/// proof cannot be made), and the `Live` branch's completion handling never
+/// applies because the row is not `Live`. So the create landed, the workload
+/// ran, the workload finished — and the row occupied the shared cap forever
+/// while every pass reported `stale:0` and readiness stayed
+/// `CreateUnknownHealth`.
+///
+/// This is not exotic. Every dispatched task-run is put into `CreateUnknown`
+/// ("slot-pool accepted create without object UID") until its UID callback
+/// lands, and every warm Job whose `job_uid()` could not be observed is too. A
+/// single lost UID callback on a workload that then completed normally is
+/// enough, and a restart does not clear it: recovery retains an existing
+/// `create_unknown` row verbatim.
+#[tokio::test]
+async fn a_pre_live_row_whose_object_already_finished_is_retired() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    accumulate_production_stale_population(&db, &journal, 1, 0).await;
+    let rows = journal.list_active_rows().await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = rows[0].clone();
+    assert_eq!(row.state, AdmissionState::CreateUnknown);
+
+    // The create DID land: the Job exists under the name the journal recorded,
+    // carries this row's admission identity, and has already completed.
+    let finished = admission_labeled_object(&row, true, "the-create-did-land");
+
+    let controller = Arc::clone(&replacement(&db, &journal, 3).await.controller);
+    controller
+        .recover_all_predecessors_and_seed()
+        .await
+        .unwrap();
+    controller.mark_topology_ready();
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::CreateUnknownHealth,
+        "the unresolved create must fail Enforce closed before reconciliation"
+    );
+
+    // An hour-long settle window, so nothing here can be attributed to the
+    // absence path: this row's object is PRESENT, and the only proof available
+    // is that it has finished.
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::holding(vec![finished])),
+        Duration::from_secs(3600),
+    )
+    .reconcile()
+    .await;
+
+    assert!(
+        report.blockers.is_empty(),
+        "unexpected blockers: {:?}",
+        report.blockers
+    );
+    assert_eq!(
+        report.adopted, 0,
+        "a finished object must never be adopted into Live"
+    );
+    assert_eq!(
+        report.reclaimed, 1,
+        "a finished object is a stronger proof than absence: no lifecycle \
+         callback is coming for a row that never went Live"
+    );
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        0,
+        "the row must stop occupying the shared cap"
+    );
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::Healthy,
+        "retiring the row must clear the gate it armed"
+    );
+}
+
+/// One standing blocker must not freeze four gates forever.
+///
+/// The tail `seed_from_recovery` is the ONLY in-process re-derivation of
+/// `journal_recovered`, `journal_healthy`, `create_unknown_pending` and
+/// `over_cap`, and it used to run only when `blockers` was empty. So any
+/// standing blocker — one unclassifiable Job in the namespace is enough, and it
+/// stands for as long as that object exists — pinned all four gates at
+/// whatever they last were. A gate that had latched closed could never re-open,
+/// because the only code that could re-open it was gated on the blocker being
+/// absent.
+///
+/// Here the reclamation the pass performs is real and the blocker is unrelated
+/// to it, so `CreateUnknownHealth` after the pass would be a gate reporting a
+/// row that no longer exists.
+#[tokio::test]
+async fn a_standing_blocker_cannot_freeze_the_journal_derived_gates() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    accumulate_production_stale_population(&db, &journal, 1, 0).await;
+
+    // A workload this reconciler cannot classify. It is a genuine pass-level
+    // blocker — the inventory is not fully understood, so Enforce must stay
+    // fail-closed on the INVENTORY gate — and it says nothing whatsoever about
+    // the journal.
+    let unclassifiable = WorkloadRecord {
+        kind: WorkloadObjectKind::Job,
+        name: "djinn-something-new".into(),
+        uid: Some("uid-something-new".into()),
+        labels: [(
+            "djinn.app/component".to_string(),
+            "a-component-this-build-does-not-know".to_string(),
+        )]
+        .into_iter()
+        .collect(),
+        terminal: false,
+        images: vec!["djinn:test".into()],
+        commands: vec!["something".into()],
+    };
+
+    let controller = Arc::clone(&replacement(&db, &journal, 3).await.controller);
+    controller
+        .recover_all_predecessors_and_seed()
+        .await
+        .unwrap();
+    controller.mark_topology_ready();
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::CreateUnknownHealth
+    );
+
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::holding(vec![unclassifiable])),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+
+    assert!(
+        !report.blockers.is_empty(),
+        "an unclassifiable workload is still a pass-level blocker"
+    );
+    assert_eq!(
+        report.reclaimed, 1,
+        "the blocker is about one object; the settled orphan is still retired"
+    );
+    assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 0);
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::InventoryPending,
+        "the inventory gate must stay fail-closed on incomplete Kubernetes \
+         evidence — but the journal-derived gates must re-derive from the \
+         journal, which the pass only READ. CreateUnknownHealth here would mean \
+         a gate frozen at a value the retired row no longer justifies, with no \
+         code path left that could ever clear it"
+    );
+}
+
+/// An adoption identity collision costs one object, not the whole pass.
+///
+/// `adopt_live` returns `InvalidTransition("inventory identity collision")` for
+/// a routine mismatch — an object whose admission labels resolve to a journal
+/// key that already records a different object name. Reclamation has treated
+/// that class of rejection as a per-row fact since #2597; adoption did not. It
+/// marked the journal unhealthy (failing Enforce closed on `JournalUnhealthy`,
+/// which is a claim about the DATABASE) and pushed a pass-level blocker, which
+/// then also froze the journal-derived gates.
+#[tokio::test]
+async fn an_adoption_identity_collision_costs_one_object_not_the_whole_pass() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    accumulate_production_stale_population(&db, &journal, 1, 0).await;
+    let row = journal.list_active_rows().await.unwrap()[0].clone();
+
+    // A live object carrying this row's admission identity under a DIFFERENT
+    // name: the row cannot adopt it, and the object is not the row's object.
+    let mut colliding = admission_labeled_object(&row, false, "uid-collides");
+    colliding.name = format!("{}-renamed", row.object_name);
+
+    let controller = Arc::clone(&replacement(&db, &journal, 3).await.controller);
+    controller
+        .recover_all_predecessors_and_seed()
+        .await
+        .unwrap();
+    controller.mark_topology_ready();
+
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::holding(vec![colliding])),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+
+    assert!(
+        report.blockers.is_empty(),
+        "a rejected adoption is a decision about one object: {:?}",
+        report.blockers
+    );
+    assert_eq!(report.adopted, 0);
+    assert_eq!(report.reclaim_failure_count, 1);
+    assert!(
+        report.reclaim_failures[0].contains("inventory identity collision"),
+        "the failure must name the row and its cause: {:?}",
+        report.reclaim_failures
+    );
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::CreateUnknownHealth,
+        "a mislabelled object is not evidence that the journal is unhealthy; the \
+         only gate that may still be closed is the one the unresolved create \
+         genuinely arms"
+    );
+}
+
+/// Adopting one of THIS process's own creates must not hand back a gate that
+/// only a predecessor's row armed.
+///
+/// This is the fail-open edge of counting only recovered unknowns. The tail
+/// seed re-seeds every active row on every pass, including this process's own,
+/// and `transition` decrements `create_unknown_pending` when a seeded row with
+/// `create_unknown_outstanding` is adopted into Live. If that flag were set for
+/// rows that never contributed to the count, one healthy own-epoch dispatch
+/// going Live would clear a gate a predecessor's unresolved create is still
+/// holding — admitting against occupancy nobody has proven.
+#[tokio::test]
+async fn adopting_this_process_own_create_cannot_clear_a_predecessors_gate() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    accumulate_production_stale_population(&db, &journal, 1, 0).await;
+
+    // Observe, so this process can still start work of its own while the
+    // recovered unknown holds the gate closed.
+    let controller = Arc::new(BuildAdmissionController::new(
+        Arc::clone(&journal),
+        BuildAdmissionMode::Observe,
+        3,
+        REPLACEMENT_EPOCH,
+    ));
+    controller
+        .recover_all_predecessors_and_seed()
+        .await
+        .unwrap();
+    controller.mark_inventory_ready();
+    controller.mark_topology_ready();
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::CreateUnknownHealth
+    );
+
+    // This process starts a create of its own and cannot confirm the UID.
+    let permit = WarmAdmission::admit(controller.as_ref(), warm_request("own-create"))
+        .await
+        .expect("Observe never denies");
+    controller
+        .transition(&permit, WarmAdmissionTransition::CreateStarted)
+        .await
+        .unwrap();
+    controller
+        .transition(
+            &permit,
+            WarmAdmissionTransition::CreateUnknown {
+                diagnostic: "connection reset while awaiting the create response".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // A reconciliation pass re-seeds every active row, this one included.
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::empty()),
+        Duration::from_secs(3600),
+    )
+    .reconcile()
+    .await;
+    assert_eq!(report.reclaimed, 0, "nothing has settled yet");
+
+    // The own create resolves. It must hand back only what it took.
+    controller
+        .transition(
+            &permit,
+            WarmAdmissionTransition::Live {
+                uid: "the-uid-arrived-late".into(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::CreateUnknownHealth,
+        "the predecessor's unresolved create still occupies and still gates"
     );
 }

--- a/server/crates/djinn-db/src/repositories/admission_journal.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal.rs
@@ -447,6 +447,27 @@ impl AdmissionJournalRepository {
                     "Kubernetes UID does not match admission row".into(),
                 ));
             }
+            // A create whose object UID was never observed still ends.
+            //
+            // This arm used to fall through to the catch-all and be rejected,
+            // which left `CreateUnknown` with no lifecycle exit whatsoever:
+            // `mark_live` needs a UID that will never arrive,
+            // `mark_definitive_create_failure` accepts only
+            // Reserved/CreateInFlight, and `mark_terminal` — the one callback
+            // that actually observed the work end — refused the row. The only
+            // thing that could retire it was reconciliation proving the object
+            // absent, and until then it occupied the shared cap.
+            //
+            // There is no UID fence to apply here and nothing to contradict: a
+            // `CreateUnknown` row carries no `object_uid` (only `mark_live`
+            // and `adopt_live` write one, and both leave the row `Live`), so
+            // the terminal observation's UID is the first and only identity
+            // the row has ever had. The latest-generation fence in
+            // `current_row_for_update` still applies, so a late callback for a
+            // superseded generation is still rejected.
+            AdmissionState::CreateUnknown => {
+                update_state(&mut tx, &input.key, "terminal", input.object_uid.as_deref()).await?
+            }
             state => return Err(invalid_state("mark terminal", state)),
         };
         tx.commit().await?;
@@ -521,7 +542,9 @@ impl AdmissionJournalRepository {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
         let retired_reserved = sqlx::query("UPDATE admission_journal SET state = 'terminal', terminal_at = now(), updated_at = now() WHERE creator_server_epoch = $1 AND state = 'reserved'").bind(predecessor_epoch).execute(&mut *tx).await?.rows_affected();
-        let marked_create_unknown = sqlx::query("UPDATE admission_journal SET state = 'create_unknown', updated_at = now() WHERE creator_server_epoch = $1 AND state = 'create_in_flight'").bind(predecessor_epoch).execute(&mut *tx).await?.rows_affected();
+        // `updated_at` is deliberately NOT touched. See
+        // [`Self::recover_all_predecessors`].
+        let marked_create_unknown = sqlx::query("UPDATE admission_journal SET state = 'create_unknown' WHERE creator_server_epoch = $1 AND state = 'create_in_flight'").bind(predecessor_epoch).execute(&mut *tx).await?.rows_affected();
         let rows = active_rows(&mut *tx).await?;
         tx.commit().await?;
         Ok(AdmissionRecoveryResult {
@@ -557,8 +580,28 @@ impl AdmissionJournalRepository {
         .execute(&mut *tx)
         .await?
         .rows_affected();
+        // `updated_at` is deliberately NOT touched here.
+        //
+        // This UPDATE is a RELABEL, not a write to the work item: the row is
+        // being reclassified from "a create this process is attempting" to "a
+        // create nobody is attempting any more", and nothing about the
+        // Kubernetes object changed. `updated_at` is what
+        // `list_active_rows_with_settlement` measures the 300s reclaim settle
+        // window against, and that window exists to answer exactly one
+        // question — could the API server still be admitting a create someone
+        // POSTed? For a row this recovery just adopted, that create was POSTed
+        // by a process that is already gone, so the answer is decided by when
+        // the ROW was last written, not by when this process happened to boot.
+        //
+        // Stamping `now()` here re-armed the window on every restart, which is
+        // why the 2026-07-29 board halt survived its own remedy: the operator
+        // restarted the server, recovery relabelled the wedged row and reset
+        // its clock, and the reconciliation pass that would otherwise have
+        // retired it immediately had to wait out a fresh 300s window (the pass
+        // at t+296.2s missed by 3.8 seconds, costing another full 120s tick).
+        // A restart must not be able to make a stale row look fresh.
         let marked_create_unknown = sqlx::query(
-            "UPDATE admission_journal SET state = 'create_unknown', updated_at = now() \
+            "UPDATE admission_journal SET state = 'create_unknown' \
              WHERE creator_server_epoch <> $1 AND state = 'create_in_flight'",
         )
         .bind(current_server_epoch)

--- a/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
@@ -619,3 +619,120 @@ async fn settlement_flags_rows_against_the_database_clock() {
     );
     assert!(repo.list_active_rows_with_settlement(-1).await.is_err());
 }
+
+/// Recovery RELABELS a predecessor's create; it does not touch the work item,
+/// so it must not touch the settle clock.
+///
+/// `updated_at` is what `list_active_rows_with_settlement` measures the reclaim
+/// settle window against, and that window exists to answer one question: could
+/// the API server still be admitting a create somebody POSTed? Stamping `now()`
+/// on the relabel answers it with this process's boot time instead of the row's
+/// own age, so a stale row looked freshly created on every restart. That is why
+/// the 2026-07-29 board halt survived its own remedy — the restart reset the
+/// clock on the very row the restart had made reclaimable, and the board stayed
+/// down another ten minutes.
+#[tokio::test]
+async fn recovery_relabels_a_predecessor_create_without_resetting_the_settle_clock() {
+    let repo = AdmissionJournalRepository::new(Database::open_in_memory().unwrap());
+    let flight = input(AdmissionDomain::WarmBuild, "settle-clock", 0);
+    repo.reserve(&flight).await.unwrap();
+    let before = repo
+        .mark_create_started(&create_started(&flight))
+        .await
+        .unwrap();
+    assert_eq!(before.state, AdmissionState::CreateInFlight);
+
+    let report = repo
+        .recover_all_predecessors("replacement-epoch")
+        .await
+        .unwrap();
+    assert_eq!(report.marked_create_unknown, 1);
+    let after = report
+        .active_rows
+        .iter()
+        .find(|row| row.key == flight.key)
+        .expect("the recovered row is still active");
+    assert_eq!(after.state, AdmissionState::CreateUnknown);
+    assert_eq!(
+        after.updated_at, before.updated_at,
+        "a state relabel is not a write to the work item; the settle clock must \
+         keep measuring the age of the CREATE, not the age of the recovery"
+    );
+
+    // The same must hold for the single-epoch variant.
+    let single = input(AdmissionDomain::WarmBuild, "settle-clock-single", 0);
+    repo.reserve(&single).await.unwrap();
+    let before_single = repo
+        .mark_create_started(&create_started(&single))
+        .await
+        .unwrap();
+    let single_report = repo.recover_predecessor_epoch("epoch-1").await.unwrap();
+    let after_single = single_report
+        .active_rows
+        .iter()
+        .find(|row| row.key == single.key)
+        .expect("the recovered row is still active");
+    assert_eq!(after_single.state, AdmissionState::CreateUnknown);
+    assert_eq!(after_single.updated_at, before_single.updated_at);
+}
+
+/// A create whose object UID was never observed still ends, and the callback
+/// that observed it ending must be able to say so.
+///
+/// `CreateUnknown` used to have no lifecycle exit at all: `mark_live` needs a
+/// UID that will never arrive, `mark_definitive_create_failure` accepts only
+/// Reserved/CreateInFlight, and `mark_terminal` rejected the row outright. The
+/// only thing that could retire it was reconciliation proving the object
+/// absent — and until then it occupied the shared cap. Every dispatched
+/// task-run passes through `CreateUnknown` on its way to `Live`, so one lost
+/// UID callback on a workload that then completed normally was permanent.
+#[tokio::test]
+async fn a_terminal_callback_retires_a_create_whose_uid_was_never_observed() {
+    let repo = AdmissionJournalRepository::new(Database::open_in_memory().unwrap());
+    let unknown = input(AdmissionDomain::TaskObservation, "no-uid-ever", 0);
+    repo.reserve(&unknown).await.unwrap();
+    repo.mark_create_started(&create_started(&unknown))
+        .await
+        .unwrap();
+    repo.mark_create_unknown(&unknown.key).await.unwrap();
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
+
+    let retired = repo
+        .mark_terminal(&TerminalAdmissionInput {
+            key: unknown.key.clone(),
+            object_uid: Some("observed-only-at-the-end".into()),
+        })
+        .await
+        .expect("a terminal observation must be able to retire an unresolved create");
+    assert_eq!(retired.state, AdmissionState::Terminal);
+    assert_eq!(
+        retired.object_uid.as_deref(),
+        Some("observed-only-at-the-end"),
+        "the terminal observation's UID is the first identity the row ever had"
+    );
+    assert_eq!(
+        repo.count_task_or_warm_occupancy().await.unwrap(),
+        0,
+        "the row must stop occupying the shared cap"
+    );
+
+    // Replaying the same callback is idempotent, and a contradicting UID is
+    // still refused.
+    assert!(
+        repo.mark_terminal(&TerminalAdmissionInput {
+            key: unknown.key.clone(),
+            object_uid: Some("observed-only-at-the-end".into()),
+        })
+        .await
+        .is_ok()
+    );
+    assert!(
+        repo.mark_terminal(&TerminalAdmissionInput {
+            key: unknown.key.clone(),
+            object_uid: Some("a-different-object".into()),
+        })
+        .await
+        .is_err(),
+        "a terminal callback for a different object must not rewrite the row"
+    );
+}

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -930,6 +930,40 @@ impl WarmDispatch {
                 )
                 .await
         {
+            // Record the create outcome BEFORE returning.
+            //
+            // This early return used to leave the admission row exactly where
+            // `CreateStarted` put it: `create_in_flight`, under the live
+            // server epoch, with the Job already POSTed. Nothing observes a
+            // `create_in_flight` row — it is not a recovered unknown and no
+            // reconciliation pass can judge it — so the leak is invisible for
+            // the whole life of the process, and then the next restart's
+            // `recover_all_predecessors` relabels it `create_unknown`, where
+            // it occupies the cap and gates readiness until reconciliation can
+            // prove its object absent. A leak whose bill arrives at the next
+            // deploy is the worst possible shape for one.
+            //
+            // The create genuinely IS unknown here: the POST returned (or its
+            // response was lost), the object may well exist under the
+            // deterministic name, and we simply could not confirm a unique
+            // bound Pod for it. `CreateUnknown` is the honest record, and it
+            // is the state reconciliation knows how to resolve in either
+            // direction — adoption if the object shows up, retirement once its
+            // absence is proven.
+            if let (Some(admission), Some(permit)) = (self.admission.as_ref(), permit.as_ref())
+                && let Err(error) = admission
+                    .transition(
+                        permit,
+                        WarmAdmissionTransition::CreateUnknown {
+                            diagnostic: "Kubernetes create was POSTed but no unique bound Pod \
+                                         could be confirmed for the leased candidate"
+                                .to_string(),
+                        },
+                    )
+                    .await
+            {
+                warn!(project_id, error = %error, "K8sGraphWarmer: failed to record unconfirmed create outcome");
+            }
             self.schedule_admission_retry(project_id, notify.clone());
             return;
         }


### PR DESCRIPTION
## The outage

On 2026-07-29 the entire board stopped dispatching for **5 hours** (06:22:57Z → 11:37Z). Every dispatch, once per coordinator tick:

```
build admission denied; leaving task queued  occupancy="unmeasured" cap=3 cause="controller_not_admitting"
```

`occupancy: "unmeasured"` is the discriminator: `admit()` short-circuits on `readiness()` *before* capacity is consulted. The controller was latched at `CreateUnknownHealth` for 152 consecutive reconciliation passes.

## Root cause

Two rules that are each individually correct, composed into a permanent latch:

- `seed_from_recovery` counted **all** active `CreateUnknown` rows with no epoch filter and unconditionally `store`d that count into `create_unknown_pending`.
- `is_reclaimable` refuses any row whose `creator_server_epoch == server_epoch()` — a process may not reclaim rows it created itself.

`task_dispatch.rs` writes `CreateUnknown` ("slot-pool accepted create without object UID") on **every** dispatch, for the whole interval between the Job POST and the UID callback. So the gate was armed by rows representing healthy in-flight work, which the reclaimer is forbidden to retire. Confirmed trigger: `06:22:29Z` Job POSTed and row written → `06:22:57Z` tick reads it, `store(1)`, gate armed. It normally clears on the next tick; it latched for 5h because that worker never registered a session, so `mark_live` never ran, the Job was TTL-reaped, and the fence blocked the only remaining exit.

**#2711 introduced this failure mode.** The `store` predates it, but before #2711 `reconcile()` ran only at startup/`become_leader`, so the gate could only ever be armed from *predecessor* rows. #2711 made it re-derive every 120s against the live process's own journal — it made the gate re-derivable without making the reclaimer able to retire the rows the gate is now derived from.

Proof by natural experiment: the same row, same object, same absence, was unreclaimable for 5 hours and then reclaimed by the first pass after a restart. The only variable that changed was the epoch.

## The fix is on the arming side, not the fence

**The own-epoch fence is deliberately left untouched.** It is load-bearing correctness, not a bug: `stamp_admission_identity` is called only for warm Jobs, so task-run Jobs carry no admission labels. The real Job is `djinn-taskrun-{task_run_id}` while the row records `task-run-{task_id}-{reopen}`, so for task-observation rows the LIST and GET clauses of `is_reclaimable` are structurally vacuous — `presence()` 404s even while the Job is running. The epoch is the only remaining evidence that no live work depends on the row. Relaxing the fence to "own epoch AND settled" would reclaim capacity out from under any run whose POST→session window exceeds 300s. A comment at the fence now records this.

`create_unknown_pending` now counts only rows whose `creator_server_epoch != self.creator_server_epoch`. Arming and reclamation finally describe one population.

## Also fixed, same family

- **A pre-Live row whose object exists but is terminal** was neither adopted (adoption skips terminal objects) nor reclaimed (reclamation refuses a classified object). Now retired via a shared `retire_pre_live_row` helper.
- **A standing blocker froze four gates at once.** The tail seed — the only in-process re-derivation of `journal_recovered`, `journal_healthy`, `create_unknown_pending` and `over_cap` — ran only `if blockers.is_empty()`. It only *reads*, so it now runs whenever `list_active_rows()` succeeded; only `mark_inventory_ready` stays gated. `adopt_live` errors now get `record_adopt_failure`, mirroring reclamation: an `InvalidTransition` (e.g. a routine identity collision) costs one row, not the whole pass.
- **Recovery reset the settle clock.** `recover_all_predecessors` stamped `updated_at = now()` on a pure `create_in_flight → create_unknown` relabel, re-arming the gate on restart and pushing the earliest heal 300s out. This is why the board stayed down ~10 minutes past the restart — a pass at t+296.2s missed the window by 3.8 seconds. A relabel is not a new create; `updated_at` is preserved.
- **`mark_terminal` rejected a `CreateUnknown` row**, so a task-run dying before its session registered had no lifecycle exit at all. It now accepts one.
- **`graph_warmer` leaked `create_in_flight` rows**: the leased-candidate early return recorded no admission transition, leaving a row mid-create — invisible for the life of the process, then relabelled into occupying `create_unknown` by the next restart's recovery.

## Tests

The suite previously *certified* the bug. `current_epoch_and_unsettled_rows_are_never_reclaimed` built exactly the production failure state and asserted `reclaimed == 0` **while never inspecting `readiness()`** — its sibling's doc comment says it "proves the skip is correct and stops there". It is amended (not supplemented) to `..._and_never_wedge_the_board`, now asserting `readiness() == Healthy` and that `admit()` still returns `Permitted`, with a second half pinning the fail-**closed** direction for a predecessor's row. No existing assertion was weakened.

New: `a_pre_live_row_whose_object_already_finished_is_retired`, `a_standing_blocker_cannot_freeze_the_journal_derived_gates`, `an_adoption_identity_collision_costs_one_object_not_the_whole_pass`, `adopting_this_process_own_create_cannot_clear_a_predecessors_gate`, `recovery_relabels_a_predecessor_create_without_resetting_the_settle_clock`, `a_terminal_callback_retires_a_create_whose_uid_was_never_observed`.

Fail-before verified by reverting only the source files and keeping the tests: 4 failures in `djinn-coordinator`, 2 in `djinn-db`, each with the expected assertion diff.

`cargo nextest run -p djinn-coordinator --lib` → 2058 passed. `cargo nextest run -p djinn-db -p djinn-k8s` → 1875 passed, 4 skipped. Clippy clean on all three crates.

## Reviewer attention

1. `create_unknown_outstanding` moved onto the same predicate as the count. The tail seed re-seeds every active row each pass including own-epoch ones, and `transition` decrements the gate when a seeded row with that flag goes Live — left as-is, one healthy own-epoch dispatch would have decremented a gate only a predecessor's row armed (fail-open). `adopting_this_process_own_create_cannot_clear_a_predecessors_gate` pins it; that test passes before and after by design.
2. The terminal-object retirement branch is deliberately epoch- and settle-agnostic — a finished object is a stronger proof than absence, and the write is CAS-fenced on the full observed identity. It can retire a same-epoch row whose in-process watcher is about to record Terminal itself; that later transition then warns instead of writing. Cannot resurrect or double-release, but it is a real behaviour change.
3. `mark_terminal`'s new `CreateUnknown` arm has **no production caller yet**. The task-id fallback was deliberately not added: `current_task_run_permit` returns the task's *current* generation, so a late terminal callback for run N could terminalize a live generation N+1. The honest fix is plumbing `task_run_id` out of the slot pool, which `DispatchOutcome::Dispatched` being a unit variant blocks. The state-machine gap is closed; the caller gap is not.

## Known-adjacent, tracked separately

The identity mismatch that makes the fence load-bearing also appears to make the **Live** branch's absence proof vacuous for task rows, which would mean live task rows are retired roughly every 120s. Under investigation in a follow-up; deliberately not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
