### PR TITLE
fix(admission): supervise, bound, and surface the build-admission recovery machinery

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -588,6 +588,17 @@ impl CoordinatorActor {
                 db.clone(),
             )),
         );
+        // Leader-local build-admission health. This constructor runs only on
+        // the pod that won coordinator leadership, so the controller handle
+        // below is the one that actually decides admission — a standby never
+        // registers this check at all, which reads as "not registered" rather
+        // than as a check that silently always passes.
+        crate::doctor::register_build_admission_health_check(
+            djinn_core::doctor::registry(),
+            Arc::new(crate::doctor::ControllerBuildAdmissionHealthSource::new(
+                build_admission.clone(),
+            )),
+        );
 
         Self {
             receiver,

--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -5,10 +5,10 @@
 //! workload classification before dispatch and translates controller facts into
 //! the data-only graph-warmer protocol.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicI64, AtomicU8, AtomicU64, Ordering},
 };
 use std::time::Instant;
 
@@ -408,6 +408,98 @@ impl BuildAdmissionReadiness {
     pub fn is_healthy(self) -> bool {
         matches!(self, Self::Healthy)
     }
+
+    /// Stable snake_case label. Bounded and closed, so it is safe as a metric
+    /// label, a doctor-finding field, and an operator-facing string all at
+    /// once — an operator reading a finding sees the SAME token the code
+    /// branches on.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::JournalRecoveryIncomplete => "journal_recovery_incomplete",
+            Self::JournalUnhealthy => "journal_unhealthy",
+            Self::CreateUnknownHealth => "create_unknown_health",
+            Self::SeededOccupancyAboveCap => "seeded_occupancy_above_cap",
+            Self::InventoryPending => "inventory_pending",
+            Self::TopologyPending => "topology_pending",
+            Self::ShutdownDraining => "shutdown_draining",
+            Self::Healthy => "healthy",
+        }
+    }
+
+    const fn as_u8(self) -> u8 {
+        match self {
+            Self::JournalRecoveryIncomplete => 0,
+            Self::JournalUnhealthy => 1,
+            Self::CreateUnknownHealth => 2,
+            Self::SeededOccupancyAboveCap => 3,
+            Self::InventoryPending => 4,
+            Self::TopologyPending => 5,
+            Self::ShutdownDraining => 6,
+            Self::Healthy => 7,
+        }
+    }
+}
+
+/// Snake_case label for an admission domain, stable enough to appear in an
+/// operator-facing identity string.
+const fn domain_label(domain: AdmissionDomain) -> &'static str {
+    match domain {
+        AdmissionDomain::TaskObservation => "task_observation",
+        AdmissionDomain::WarmBuild => "warm_build",
+        AdmissionDomain::InvocationBuild => "invocation_build",
+    }
+}
+
+/// The operator-facing identity of one admission-journal row.
+///
+/// Mirrors the `identity=dispatch:{task_id}:{generation}` convention the
+/// sibling `build_lease_reclaim` path already logs, extended with the object
+/// name so the row can be looked up in Kubernetes without a database at all.
+#[must_use]
+pub fn blocking_identity(key: &AdmissionJournalKey, object_name: &str) -> String {
+    format!(
+        "{}:{}:{}@{}",
+        domain_label(key.domain),
+        key.work_id,
+        key.generation,
+        object_name
+    )
+}
+
+/// Sentinel for "no readiness has been reported yet", distinct from every
+/// [`BuildAdmissionReadiness`] discriminant so the very first report always
+/// fires an edge.
+const READINESS_NEVER_REPORTED: u8 = u8::MAX;
+
+/// How many blocking row identities a single report or snapshot names before it
+/// switches to a count. Bounded for the same reason `named_reclaim_failures`
+/// is: a log line and a doctor finding must stay a fixed size no matter how
+/// large the wedge is.
+pub const MAX_NAMED_BLOCKING_IDENTITIES: usize = 16;
+
+/// Operator-facing description of why build admission is (not) open.
+///
+/// Assembled from process-local state only, and cheap enough to build on the
+/// synchronous `DoctorCheck::run` seam: readiness is derived from atomics and
+/// the identity set is a bounded in-memory set.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BuildAdmissionHealthReport {
+    /// The current bounded readiness reason.
+    pub readiness: BuildAdmissionReadiness,
+    /// The configured/effective admission mode.
+    pub mode: BuildAdmissionMode,
+    /// Whether the shutdown-draining latch is set.
+    pub draining: bool,
+    /// How many recovered rows still occupy as CreateUnknown.
+    pub create_unknown_pending: u64,
+    /// Bounded identities of those rows — WHICH rows are wedging the board.
+    pub blocking_identities: Vec<String>,
+    /// Identities elided by [`MAX_NAMED_BLOCKING_IDENTITIES`].
+    pub blocking_identities_elided: usize,
+    /// Seconds since the last blocker-free reconciliation pass, or `None` if no
+    /// pass has ever completed in this process.
+    pub seconds_since_last_reconcile: Option<i64>,
 }
 
 #[derive(Clone, Debug)]
@@ -508,6 +600,33 @@ pub struct BuildAdmissionController {
     /// the durable journal; adopting a seeded CreateUnknown row into Live
     /// decrements it exactly once. Enforce stays closed while it is non-zero.
     create_unknown_pending: AtomicU64,
+    /// WHICH rows are holding [`BuildAdmissionReadiness::CreateUnknownHealth`]
+    /// closed, as bounded `{domain}:{work_id}:{generation}@{object_name}`
+    /// identities.
+    ///
+    /// A count alone is what made the 2026-07-29 outage cost five hours: every
+    /// build-admission log line reported `stale`/`reclaimed`/`create_unknown`
+    /// as NUMBERS, so an operator could see that exactly one row was denying
+    /// every dispatch and had no non-SQL way to learn which one. The sibling
+    /// `build_lease_reclaim` path already logs `identity=dispatch:…`; this is
+    /// the same convention for the admission journal.
+    ///
+    /// Maintained on exactly the edges that maintain `create_unknown_pending`,
+    /// so the two never disagree about whether the gate is held.
+    create_unknown_identities: std::sync::Mutex<BTreeSet<String>>,
+    /// Unix seconds at which a reconciliation pass last completed WITHOUT
+    /// blockers. Zero means "never in this process".
+    ///
+    /// The single most valuable signal added after the outage: nothing anywhere
+    /// asserted that a reconciliation pass had completed within the last N
+    /// seconds, so a reconciler that had silently died looked exactly like one
+    /// that was working. Read by
+    /// [`Self::seconds_since_last_reconcile`], exported as a gauge, and
+    /// surfaced to operators by the `build_admission_health` doctor check.
+    last_reconcile_success_unix: AtomicI64,
+    /// The readiness reason last reported by [`Self::report_readiness_edge`],
+    /// so the loud gate report is edge-triggered rather than once per publish.
+    last_reported_readiness: AtomicU8,
     /// Seeded durable occupancy exceeded the configured cap at recovery.
     /// Cleared when a terminal release brings occupancy back within the cap.
     over_cap: AtomicBool,
@@ -577,6 +696,9 @@ impl BuildAdmissionController {
             journal_recovered: AtomicBool::new(true),
             journal_healthy: AtomicBool::new(true),
             create_unknown_pending: AtomicU64::new(0),
+            create_unknown_identities: std::sync::Mutex::new(BTreeSet::new()),
+            last_reconcile_success_unix: AtomicI64::new(0),
+            last_reported_readiness: AtomicU8::new(READINESS_NEVER_REPORTED),
             over_cap: AtomicBool::new(false),
             over_cap_alarm_active: AtomicBool::new(false),
             inventory_ready: AtomicBool::new(true),
@@ -663,9 +785,16 @@ impl BuildAdmissionController {
         self.journal_recovered.store(true, Ordering::Release);
         self.journal_healthy.store(true, Ordering::Release);
         self.create_unknown_pending.store(0, Ordering::Release);
+        self.clear_blocking_identities();
         self.over_cap.store(false, Ordering::Release);
         self.inventory_ready.store(true, Ordering::Release);
         self.topology_ready.store(true, Ordering::Release);
+        // `readiness()` checks the draining latch FIRST, ahead of every gate
+        // this method satisfies. Leaving the latch set here would make
+        // "mark ready" a method that provably does not make the controller
+        // ready — the exact class of silent contradiction that produced the
+        // 2026-07-19 `occupancy 0 reached cap 3` wedge.
+        self.draining.store(false, Ordering::Release);
     }
 
     /// Promote this controller to emergency Enforce and reset every startup
@@ -677,9 +806,14 @@ impl BuildAdmissionController {
         self.journal_recovered.store(false, Ordering::Release);
         self.journal_healthy.store(true, Ordering::Release);
         self.create_unknown_pending.store(0, Ordering::Release);
+        self.clear_blocking_identities();
         self.over_cap.store(false, Ordering::Release);
         self.inventory_ready.store(false, Ordering::Release);
         self.topology_ready.store(false, Ordering::Release);
+        // The draining latch is deliberately NOT cleared here. This path is
+        // emergency promotion of a possibly-live process; a process that is
+        // genuinely shutting down must not be talked back into admitting work
+        // by a handoff tick that happens to land during teardown.
     }
 
     /// Release emergency authority only after a committed invocation-primary
@@ -742,6 +876,143 @@ impl BuildAdmissionController {
         BuildAdmissionReadiness::Healthy
     }
 
+    /// Bounded, sync, allocation-light description of why admission is (not)
+    /// open, including WHICH rows are responsible.
+    ///
+    /// Deliberately synchronous and journal-free: the `DoctorCheck::run` seam
+    /// is synchronous, and a health report that needs a database round-trip is
+    /// a health report that stops working exactly when the database is the
+    /// problem.
+    #[must_use]
+    pub fn health_report(&self) -> BuildAdmissionHealthReport {
+        let (blocking_identities, blocking_identities_elided) = self.named_blocking_identities();
+        BuildAdmissionHealthReport {
+            readiness: self.readiness(),
+            mode: self.mode(),
+            draining: self.draining.load(Ordering::Acquire),
+            create_unknown_pending: self.create_unknown_pending.load(Ordering::Acquire),
+            blocking_identities,
+            blocking_identities_elided,
+            seconds_since_last_reconcile: self.seconds_since_last_reconcile(),
+        }
+    }
+
+    /// Replace the set of identities holding the CreateUnknown gate closed.
+    /// Called on exactly the edge that stores `create_unknown_pending`.
+    fn set_blocking_identities(&self, identities: BTreeSet<String>) {
+        *self
+            .create_unknown_identities
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = identities;
+    }
+
+    /// Drop one identity as its row is adopted into Live. Called on exactly the
+    /// edge that decrements `create_unknown_pending`, so the count and the
+    /// named set never disagree about whether the gate is still held.
+    fn clear_blocking_identity(&self, identity: &str) {
+        self.create_unknown_identities
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(identity);
+    }
+
+    fn clear_blocking_identities(&self) {
+        self.create_unknown_identities
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+    }
+
+    /// Report a readiness change exactly once per episode, NAMING the rows
+    /// responsible when the reason is one that has named rows.
+    ///
+    /// Before this, every build-admission line carried counts only. During the
+    /// 2026-07-29 outage an operator could see `create_unknown=1` — one row
+    /// denying every dispatch on the board — and had no way short of raw SQL on
+    /// the production database to learn which row it was. Five hours.
+    fn report_readiness_edge(&self) {
+        let readiness = self.readiness();
+        let previous = self
+            .last_reported_readiness
+            .swap(readiness.as_u8(), Ordering::AcqRel);
+        if previous == readiness.as_u8() {
+            return;
+        }
+        if readiness.is_healthy() {
+            tracing::info!(
+                readiness = readiness.as_str(),
+                mode = ?self.mode(),
+                "build_admission: readiness is healthy; admission is open"
+            );
+            return;
+        }
+        let (identities, elided) = self.named_blocking_identities();
+        tracing::error!(
+            readiness = readiness.as_str(),
+            mode = ?self.mode(),
+            create_unknown_pending = self.create_unknown_pending.load(Ordering::Acquire),
+            blocking_identities = ?identities,
+            blocking_identities_elided = elided,
+            seconds_since_last_reconcile = ?self.seconds_since_last_reconcile(),
+            "build_admission: readiness is NOT healthy; every Enforce admission is \
+             denied until it clears. `blocking_identities` names the admission-journal \
+             rows responsible as {{domain}}:{{work_id}}:{{generation}}@{{object_name}}."
+        );
+    }
+
+    /// The bounded head of the blocking-identity set plus how many were elided.
+    fn named_blocking_identities(&self) -> (Vec<String>, usize) {
+        let guard = self
+            .create_unknown_identities
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let named: Vec<String> = guard
+            .iter()
+            .take(MAX_NAMED_BLOCKING_IDENTITIES)
+            .cloned()
+            .collect();
+        let elided = guard.len().saturating_sub(named.len());
+        (named, elided)
+    }
+
+    /// Record that a reconciliation pass completed with no blockers.
+    ///
+    /// The caller is the composition root that knows whether the pass actually
+    /// proved anything (`server::AppState::initialize_build_admission_inventory`),
+    /// because a pass that RAN and a pass that SUCCEEDED are different facts and
+    /// only the second one means occupancy is being reclaimed.
+    pub fn note_reconcile_success(&self) {
+        self.note_reconcile_success_at(::time::OffsetDateTime::now_utc().unix_timestamp());
+    }
+
+    /// [`Self::note_reconcile_success`] with an injected wall clock, so a test
+    /// can assert on the AGE rather than on the fact that a setter was called.
+    pub fn note_reconcile_success_at(&self, unix_seconds: i64) {
+        self.last_reconcile_success_unix
+            .store(unix_seconds, Ordering::Release);
+    }
+
+    /// Unix seconds of the last blocker-free reconciliation pass, or `None` if
+    /// none has completed in this process.
+    #[must_use]
+    pub fn last_reconcile_success_unix(&self) -> Option<i64> {
+        match self.last_reconcile_success_unix.load(Ordering::Acquire) {
+            0 => None,
+            stamp => Some(stamp),
+        }
+    }
+
+    /// How long ago the last blocker-free reconciliation pass completed.
+    ///
+    /// `None` means no pass has EVER completed in this process, which is a
+    /// louder condition than a large age, not a quieter one — the caller must
+    /// not silently treat it as healthy.
+    #[must_use]
+    pub fn seconds_since_last_reconcile(&self) -> Option<i64> {
+        self.last_reconcile_success_unix()
+            .map(|stamp| (::time::OffsetDateTime::now_utc().unix_timestamp() - stamp).max(0))
+    }
+
     /// The configured admission mode.
     #[must_use]
     pub fn mode(&self) -> BuildAdmissionMode {
@@ -768,6 +1039,31 @@ impl BuildAdmissionController {
         self.finish_all_queued_waits(djinn_telemetry::build_slot_queue::OUTCOME_SHUTDOWN);
         if self.process_metrics_enabled() {
             djinn_telemetry::build_slot_occupancy::set_slots_queued(0);
+        }
+    }
+
+    /// Clear the shutdown-draining latch.
+    ///
+    /// `begin_draining` used to be an ABSOLUTE latch: nothing anywhere stored
+    /// `false`, and neither [`Self::mark_ready`] nor [`Self::require_enforcement`]
+    /// cleared it. That was safe only by convention — one production caller, on
+    /// the shutdown path — while the method stayed reachable on `AppState`. A
+    /// single mistaken call would have denied every admission for the life of
+    /// the process with no in-process recovery of any kind, which is precisely
+    /// the failure shape this whole hardening pass exists to remove.
+    ///
+    /// It is deliberately loud: on the real shutdown path nothing calls this,
+    /// so a line here always means a drain was entered that should not have
+    /// been.
+    pub fn end_draining(&self) {
+        if self.draining.swap(false, Ordering::AcqRel) {
+            tracing::warn!(
+                mode = ?self.mode(),
+                readiness = self.readiness().as_str(),
+                "build_admission: shutdown-draining latch CLEARED; new Enforce \
+                 reservations are unblocked. On a real shutdown nothing clears this, \
+                 so reaching here means the drain was entered outside teardown."
+            );
         }
     }
 
@@ -851,6 +1147,25 @@ impl BuildAdmissionController {
     /// Export bounded admission metrics from the durable journal snapshot.
     /// InvocationBuild rows are intentionally excluded from all v0 views.
     pub async fn publish_metrics(&self) {
+        // Refresh the over-cap GATE before anything about telemetry is decided.
+        //
+        // This used to live further down, inside the metrics body, where its
+        // value was computed correctly on every pass and then thrown away into
+        // a gauge. That left `over_cap` with only ONE downward edge: a durable
+        // terminal transition. A total denial starves itself of exactly that
+        // input — nothing is admitted, so nothing goes terminal, so the gate
+        // that caused the denial can never fall. Re-deriving it here gives the
+        // latch a way down that does not depend on the traffic it is blocking.
+        //
+        // It is deliberately ABOVE the `process_metrics_enabled` early return:
+        // this is admission state, not telemetry, and it must not be silently
+        // disabled by a flag whose entire purpose is to keep test binaries out
+        // of a process-global Prometheus registry.
+        self.refresh_over_cap_gate().await;
+        // Loud, edge-triggered, row-naming readiness report. Also above the
+        // early return: an operator must be able to learn WHY admission is shut
+        // from the log stream alone, in every build.
+        self.report_readiness_edge();
         // Every emission below targets the process-global registry; a
         // controller that has not opted in stays out of it entirely. The body
         // is pure export — a journal read plus gauge writes — so skipping it
@@ -926,15 +1241,16 @@ impl BuildAdmissionController {
         // so there is no cap to exceed. An authority that IS installed but
         // unreadable reports false rather than inventing an alarm: the reachable
         // degradation is already surfaced by the journal/inventory gauges.
-        let over_cap = match self.slot_authority.as_ref() {
-            None => false,
-            Some(authority) => authority
-                .occupancy()
-                .await
-                .is_some_and(|slots| slots > authority.cap()),
-        };
+        // Already re-derived and stored at the top of this method; read the
+        // gate rather than recomputing it, so the gauge and the gate can never
+        // disagree about the same pass.
+        let over_cap = self.over_cap.load(Ordering::Acquire);
         self.report_over_cap_edge(over_cap, occupied);
         djinn_telemetry::build_slot_occupancy::set_slots_in_use(occupied);
+        djinn_telemetry::build_admission::set_seconds_since_reconcile(
+            mode,
+            self.seconds_since_last_reconcile(),
+        );
         djinn_telemetry::build_slot_occupancy::set_slots_queued(queued);
         djinn_telemetry::build_admission::set_health(
             mode,
@@ -946,6 +1262,29 @@ impl BuildAdmissionController {
             self.create_unknown_pending.load(Ordering::Acquire) > 0,
             over_cap,
         );
+    }
+
+    /// Re-derive the over-cap gate from the ONE capacity authority.
+    ///
+    /// Returns the value now in force. Only a READABLE authority moves the
+    /// gate: an installed-but-unreadable authority leaves it exactly as it was
+    /// (conservative in both directions), and no authority at all means this
+    /// controller is not capacity-gated, so there is no cap to exceed.
+    async fn refresh_over_cap_gate(&self) -> bool {
+        match self.slot_authority.as_ref() {
+            None => {
+                self.over_cap.store(false, Ordering::Release);
+                false
+            }
+            Some(authority) => match authority.occupancy().await {
+                Some(slots) => {
+                    let over_cap = slots > authority.cap();
+                    self.over_cap.store(over_cap, Ordering::Release);
+                    over_cap
+                }
+                None => self.over_cap.load(Ordering::Acquire),
+            },
+        }
     }
 
     /// Log the over-cap alarm exactly once per episode, in both directions.
@@ -1815,17 +2154,20 @@ impl BuildAdmissionController {
                 match permits.get_mut(permit) {
                     Some(state) if state.create_unknown_outstanding => {
                         state.create_unknown_outstanding = false;
-                        true
+                        // Carry the identity out so the named set is dropped on
+                        // exactly the edge that decrements the count.
+                        Some(blocking_identity(&state.key, &state.object_name))
                     }
-                    Some(_) | None => false,
+                    Some(_) | None => None,
                 }
             };
-            if cleared {
+            if let Some(identity) = cleared {
                 self.create_unknown_pending
                     .fetch_update(Ordering::AcqRel, Ordering::Acquire, |value| {
                         Some(value.saturating_sub(1))
                     })
                     .ok();
+                self.clear_blocking_identity(&identity);
                 // CreateUnknown resolution changes a bounded health signal;
                 // publish immediately so the gauge reflects the new state
                 // rather than waiting for an unrelated terminal event.
@@ -1983,6 +2325,15 @@ impl BuildAdmissionController {
             .iter()
             .filter(|row| row.state == AdmissionState::CreateUnknown)
             .count() as u64;
+        // Capture WHICH rows those are, from the same iteration that counts
+        // them, so the count and the named set can never come from different
+        // views of the journal.
+        let create_unknown_identities: BTreeSet<String> = recovery
+            .active_rows
+            .iter()
+            .filter(|row| row.state == AdmissionState::CreateUnknown)
+            .map(|row| blocking_identity(&row.key, &row.object_name))
+            .collect();
         {
             let mut permits = self.permits.lock().await;
             let mut by_key = self.permits_by_key.lock().await;
@@ -2052,6 +2403,7 @@ impl BuildAdmissionController {
             self.journal_healthy.store(true, Ordering::Release);
             self.create_unknown_pending
                 .store(create_unknown_rows, Ordering::Release);
+            self.set_blocking_identities(create_unknown_identities);
             // Compare BUILD SLOTS to a build-slot cap.
             //
             // This used to compare `count_task_or_warm_occupancy()` -- a count
@@ -5057,6 +5409,310 @@ mod tests {
             queue_histogram_value(&rendered, "cancelled", "count") - before_cancelled,
             2.0,
             "duplicate cancel must not emit additional observations"
+        );
+    }
+
+    // ─── Recovery-machinery hardening (2026-07-29 five-hour board outage) ───
+
+    /// Fake capacity authority whose occupancy is settable, so the over-cap
+    /// gate can be driven in both directions without a lease service.
+    struct SettableAuthority {
+        occupancy: std::sync::Mutex<Option<i64>>,
+        cap: i64,
+    }
+
+    impl SettableAuthority {
+        fn new(occupancy: Option<i64>, cap: i64) -> Self {
+            Self {
+                occupancy: std::sync::Mutex::new(occupancy),
+                cap,
+            }
+        }
+
+        fn set(&self, occupancy: Option<i64>) {
+            *self.occupancy.lock().unwrap() = occupancy;
+        }
+    }
+
+    #[async_trait]
+    impl BuildSlotAuthority for SettableAuthority {
+        async fn acquire_dispatch_slot(
+            &self,
+            _task_id: &str,
+            _generation: i64,
+        ) -> DispatchSlotOutcome {
+            DispatchSlotOutcome::Granted
+        }
+        async fn release_dispatch_slot(&self, _task_id: &str, _generation: i64) {}
+        async fn abandon_queued_dispatch(&self, _task_id: &str) {}
+        async fn occupancy(&self) -> Option<i64> {
+            *self.occupancy.lock().unwrap()
+        }
+        fn cap(&self) -> i64 {
+            self.cap
+        }
+    }
+
+    fn over_cap_controller(authority: Arc<SettableAuthority>) -> BuildAdmissionController {
+        BuildAdmissionController::new(
+            Arc::new(AdmissionJournalRepository::new(
+                Database::open_in_memory().unwrap(),
+            )),
+            BuildAdmissionMode::Enforce,
+            3,
+            "epoch",
+        )
+        .with_slot_authority(authority)
+    }
+
+    /// L7. The over-cap latch's only downward edge was a durable terminal
+    /// transition — and a total denial admits nothing, so nothing ever goes
+    /// terminal, so the gate that caused the denial could never fall. Meanwhile
+    /// `publish_metrics` computed the correct current value on every single
+    /// pass and threw it away into a gauge.
+    #[tokio::test]
+    async fn the_over_cap_gate_falls_on_its_own_once_occupancy_is_back_within_the_cap() {
+        let authority = Arc::new(SettableAuthority::new(Some(9), 3));
+        let controller = over_cap_controller(Arc::clone(&authority));
+        controller.mark_ready();
+
+        // Latch the gate the way recovery does: a known occupancy above the cap.
+        controller.publish_metrics().await;
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::SeededOccupancyAboveCap,
+            "a known occupancy above the cap must shut admission"
+        );
+
+        // Occupancy comes back within the cap. No terminal transition happens,
+        // because a denied board produces none.
+        authority.set(Some(1));
+        controller.publish_metrics().await;
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::Healthy,
+            "the over-cap gate must be able to fall without the terminal traffic it is blocking"
+        );
+    }
+
+    /// An authority that cannot be read is not evidence of anything, in either
+    /// direction: it must not clear a latched gate and it must not raise one.
+    #[tokio::test]
+    async fn an_unreadable_authority_leaves_the_over_cap_gate_exactly_as_it_was() {
+        let authority = Arc::new(SettableAuthority::new(Some(9), 3));
+        let controller = over_cap_controller(Arc::clone(&authority));
+        controller.mark_ready();
+        controller.publish_metrics().await;
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::SeededOccupancyAboveCap
+        );
+
+        authority.set(None);
+        controller.publish_metrics().await;
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::SeededOccupancyAboveCap,
+            "an unreadable authority must not clear a latched over-cap gate"
+        );
+
+        let healthy_authority = Arc::new(SettableAuthority::new(None, 3));
+        let healthy = over_cap_controller(Arc::clone(&healthy_authority));
+        healthy.mark_ready();
+        healthy.publish_metrics().await;
+        assert_eq!(
+            healthy.readiness(),
+            BuildAdmissionReadiness::Healthy,
+            "an unreadable authority must not invent an over-cap denial either"
+        );
+    }
+
+    /// L6. `begin_draining` stored `true` and NOTHING anywhere stored `false`.
+    #[tokio::test]
+    async fn the_shutdown_draining_latch_can_be_cleared() {
+        let controller = ungated_controller(BuildAdmissionMode::Enforce, 4);
+        controller.mark_ready();
+        assert_eq!(controller.readiness(), BuildAdmissionReadiness::Healthy);
+
+        controller.begin_draining();
+        assert!(controller.is_draining());
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::ShutdownDraining
+        );
+
+        controller.end_draining();
+        assert!(!controller.is_draining());
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::Healthy,
+            "a drain entered outside teardown must be recoverable in-process"
+        );
+        // Idempotent.
+        controller.end_draining();
+        assert_eq!(controller.readiness(), BuildAdmissionReadiness::Healthy);
+    }
+
+    /// `readiness()` checks the draining latch ahead of every gate `mark_ready`
+    /// satisfies, so leaving it set made `mark_ready` a method that provably did
+    /// not make the controller ready.
+    #[tokio::test]
+    async fn mark_ready_clears_the_draining_latch() {
+        let controller = ungated_controller(BuildAdmissionMode::Enforce, 4);
+        controller.begin_draining();
+        controller.mark_ready();
+        assert!(!controller.is_draining());
+        assert_eq!(controller.readiness(), BuildAdmissionReadiness::Healthy);
+    }
+
+    /// Emergency promotion of a possibly-live process must NOT talk a genuinely
+    /// terminating process back into admitting work.
+    #[tokio::test]
+    async fn require_enforcement_does_not_clear_the_draining_latch() {
+        let controller = ungated_controller(BuildAdmissionMode::Observe, 4);
+        controller.begin_draining();
+        controller.require_enforcement();
+        assert!(
+            controller.is_draining(),
+            "a handoff tick landing during teardown must not reopen admission"
+        );
+    }
+
+    /// L4. Nothing anywhere asserted "a reconcile pass completed within the last
+    /// N seconds", and that missing assertion is what turned a five-minute event
+    /// into a five-hour one.
+    #[tokio::test]
+    async fn the_last_successful_reconcile_age_is_readable() {
+        let controller = ungated_controller(BuildAdmissionMode::Enforce, 4);
+        assert_eq!(
+            controller.seconds_since_last_reconcile(),
+            None,
+            "a process that has never reconciled must say so, not report age zero"
+        );
+        assert_eq!(controller.last_reconcile_success_unix(), None);
+
+        let now = ::time::OffsetDateTime::now_utc().unix_timestamp();
+        controller.note_reconcile_success_at(now - 900);
+        assert_eq!(controller.last_reconcile_success_unix(), Some(now - 900));
+        let age = controller
+            .seconds_since_last_reconcile()
+            .expect("a completed pass has an age");
+        assert!(
+            (890..=910).contains(&age),
+            "the reported age must be real elapsed wall time, got {age}"
+        );
+
+        controller.note_reconcile_success();
+        let fresh = controller
+            .seconds_since_last_reconcile()
+            .expect("a completed pass has an age");
+        assert!(
+            fresh <= 2,
+            "a just-completed pass must report ~0s, got {fresh}"
+        );
+    }
+
+    /// Counts alone are what cost five hours: an operator could see that ONE row
+    /// was denying every dispatch and had no non-SQL way to learn which row.
+    #[tokio::test]
+    async fn a_wedging_create_unknown_row_is_named_not_just_counted() {
+        let journal = Arc::new(AdmissionJournalRepository::new(
+            Database::open_in_memory().unwrap(),
+        ));
+        journal
+            .reserve(&predecessor_input("wedger", 7, "old-epoch"))
+            .await
+            .unwrap();
+        journal
+            .mark_create_started(&djinn_db::CreateStartedInput {
+                key: djinn_db::AdmissionJournalKey {
+                    domain: AdmissionDomain::WarmBuild,
+                    work_id: "wedger".into(),
+                    generation: 7,
+                },
+                creator_server_epoch: "old-epoch".into(),
+                object_name: "warm-wedger-7".into(),
+            })
+            .await
+            .unwrap();
+
+        let controller =
+            BuildAdmissionController::new_closed(Arc::clone(&journal), 4, "replacement-epoch");
+        let report = controller
+            .recover_all_predecessors_and_seed()
+            .await
+            .unwrap();
+        assert_eq!(
+            report.readiness,
+            BuildAdmissionReadiness::CreateUnknownHealth,
+            "an orphaned CreateUnknown row shuts admission for the whole board"
+        );
+
+        let health = controller.health_report();
+        assert_eq!(
+            health.readiness,
+            BuildAdmissionReadiness::CreateUnknownHealth
+        );
+        assert_eq!(health.create_unknown_pending, 1);
+        assert_eq!(
+            health.blocking_identities,
+            vec!["warm_build:wedger:7@warm-wedger-7".to_owned()],
+            "the report must name the row, not only count it"
+        );
+        assert_eq!(health.blocking_identities_elided, 0);
+    }
+
+    /// The named set and the count must never disagree about whether the gate is
+    /// still held, or the report would keep accusing an already-adopted row.
+    #[tokio::test]
+    async fn adopting_the_row_into_live_drops_its_name_and_its_count_together() {
+        let journal = Arc::new(AdmissionJournalRepository::new(
+            Database::open_in_memory().unwrap(),
+        ));
+        journal
+            .reserve(&predecessor_input("wedger", 0, "old-epoch"))
+            .await
+            .unwrap();
+        journal
+            .mark_create_started(&djinn_db::CreateStartedInput {
+                key: djinn_db::AdmissionJournalKey {
+                    domain: AdmissionDomain::WarmBuild,
+                    work_id: "wedger".into(),
+                    generation: 0,
+                },
+                creator_server_epoch: "old-epoch".into(),
+                object_name: "warm-wedger-0".into(),
+            })
+            .await
+            .unwrap();
+
+        let controller =
+            BuildAdmissionController::new_closed(Arc::clone(&journal), 4, "replacement-epoch");
+        controller
+            .recover_all_predecessors_and_seed()
+            .await
+            .unwrap();
+        assert_eq!(controller.health_report().blocking_identities.len(), 1);
+
+        let permit = controller
+            .permit_for_key(AdmissionDomain::WarmBuild, "wedger", 0)
+            .await
+            .expect("the recovered row seeded an addressable permit");
+        controller
+            .transition(
+                &permit,
+                WarmAdmissionTransition::Live {
+                    uid: "uid-wedger".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let health = controller.health_report();
+        assert_eq!(health.create_unknown_pending, 0);
+        assert!(
+            health.blocking_identities.is_empty(),
+            "an adopted row must stop being named the moment it stops being counted"
         );
     }
 }

--- a/server/crates/djinn-coordinator/src/doctor/build_admission_health.rs
+++ b/server/crates/djinn-coordinator/src/doctor/build_admission_health.rs
@@ -1,0 +1,640 @@
+//! Operator-facing doctor check for a wedged build-admission controller.
+//!
+//! ## Why this check exists
+//!
+//! On 2026-07-29 the whole board stopped dispatching for five hours. The
+//! build-admission controller had latched a fail-closed readiness state and
+//! nothing in the running process could clear it. What made it FIVE HOURS
+//! rather than five minutes was not the latch — it was that no operator-facing
+//! surface said so:
+//!
+//! * `board_health` reported every starved task with `gate_verdict:
+//!   "unexplained"` and `reasons: []`, because the dispatch gate it evaluates
+//!   knows nothing about admission readiness;
+//! * the `stranded_ready` doctor check therefore fired once per VICTIM and
+//!   never once about the CAUSE;
+//! * the actual reason existed only as a process-local enum on the leader, and
+//!   the only way to see it was to grep container logs on the node.
+//!
+//! This check reports the cause directly, and NAMES the admission-journal rows
+//! responsible rather than reporting a count.
+//!
+//! ## Can this check actually observe the readiness? — yes, and here is why
+//!
+//! Readiness is process-local in-memory state on the LEADER, so a check that
+//! ran on a standby would either see a different controller or none at all.
+//! That is not what happens here, and the reason is structural rather than
+//! incidental:
+//!
+//! * every coordinator doctor check is registered from
+//!   [`crate::actor::CoordinatorActor::new`];
+//! * the actor is constructed only by `AppState::initialize_agents`;
+//! * which is called only from `AppState::become_leader`.
+//!
+//! So the registry that contains this check is, by construction, the LEADER's
+//! registry, and the `Arc<BuildAdmissionController>` this check reads is the
+//! same handle the leader admits through — [`CoordinatorDeps::build_admission`]
+//! is threaded into the actor for exactly that purpose. A standby pod does not
+//! register the check at all, so it reports "not registered" rather than
+//! silently passing. That distinction matters: an absent check is visible, a
+//! check that always passes is not.
+//!
+//! [`CoordinatorDeps::build_admission`]: crate::types::CoordinatorDeps
+//!
+//! ## What is NOT covered
+//!
+//! `create_unknown_pending` is separately derivable from a single SQL count
+//! over `admission_journal`, so that one gate could also be observed durably
+//! from any pod. The other readiness variants (inventory, topology, journal
+//! recovery, over-cap, draining) are process-local with no durable projection,
+//! and giving them one would need a heartbeat row and a migration. This check
+//! covers all of them for the leader, which is the process whose readiness
+//! decides admission; it does not make them observable from a standby.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use djinn_core::clock::{Clock, SystemClock};
+use djinn_core::doctor::{
+    DoctorCheck, DoctorCheckCadence, DoctorResult, Finding, FindingSeverity, ResolverSnapshot,
+};
+use serde_json::json;
+
+use crate::build_admission::{
+    BuildAdmissionController, BuildAdmissionHealthReport, BuildAdmissionMode,
+};
+
+pub const BUILD_ADMISSION_HEALTH_CHECK_NAME: &str = "build_admission_health";
+
+/// How long admission may be continuously non-`Healthy` before it is a finding.
+///
+/// Startup legitimately walks through several non-healthy readiness reasons,
+/// and a rolling deploy legitimately parks a row inside the 300s reclaim settle
+/// window, so the window has to clear both. Anything past it is a wedge.
+pub const DEFAULT_UNHEALTHY_WARN_SECONDS: i64 = 300;
+pub const DEFAULT_UNHEALTHY_ERROR_SECONDS: i64 = 900;
+pub const DEFAULT_UNHEALTHY_CRITICAL_SECONDS: i64 = 1800;
+
+/// How long the last blocker-free reconciliation pass may be, before the
+/// reconciler itself is reported as dead or hung. Comfortably above the 120s
+/// default cadence plus one 300s pass budget.
+pub const DEFAULT_RECONCILE_STALE_SECONDS: i64 = 900;
+
+/// Reason labels. Bounded and closed so an alert can key on them.
+pub const REASON_ADMISSION_WEDGED: &str = "build_admission_not_ready";
+pub const REASON_RECONCILE_STALE: &str = "build_admission_reconcile_stale";
+
+/// One sample of leader-local build-admission health.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BuildAdmissionHealthObservation {
+    /// The controller's own bounded report.
+    pub report: BuildAdmissionHealthReport,
+    /// How long readiness has continuously held its current non-healthy value.
+    /// Zero while healthy.
+    pub unhealthy_for_seconds: i64,
+    /// How long this source has been observing. Used to keep a freshly-elected
+    /// leader from reporting "no reconciliation has ever completed" before the
+    /// first tick could possibly have run.
+    pub observed_for_seconds: i64,
+}
+
+/// Source of a build-admission health sample.
+///
+/// Production wraps the leader's live controller; tests provide an in-memory
+/// double so the severity and window logic is hermetic.
+pub trait BuildAdmissionHealthSource: Send + Sync {
+    /// `None` means this process has no admission controller at all (mode Off,
+    /// or a runtime with no admission coupling), which is not a finding.
+    fn snapshot(&self) -> Option<BuildAdmissionHealthObservation>;
+}
+
+fn severity_for_unhealthy(elapsed_seconds: i64) -> FindingSeverity {
+    if elapsed_seconds >= DEFAULT_UNHEALTHY_CRITICAL_SECONDS {
+        FindingSeverity::Critical
+    } else if elapsed_seconds >= DEFAULT_UNHEALTHY_ERROR_SECONDS {
+        FindingSeverity::Error
+    } else {
+        FindingSeverity::Warn
+    }
+}
+
+/// Cheap, read-only doctor check over leader-local build-admission health.
+pub struct BuildAdmissionHealthCheck {
+    source: Arc<dyn BuildAdmissionHealthSource>,
+}
+
+impl BuildAdmissionHealthCheck {
+    pub fn new(source: Arc<dyn BuildAdmissionHealthSource>) -> Self {
+        Self { source }
+    }
+
+    fn wedged_finding(observation: &BuildAdmissionHealthObservation) -> Option<Finding> {
+        let report = &observation.report;
+        if report.readiness.is_healthy() {
+            return None;
+        }
+        // Off never gates admission, so a non-healthy reason there denies
+        // nothing and must not raise an alarm.
+        if report.mode == BuildAdmissionMode::Off {
+            return None;
+        }
+        if observation.unhealthy_for_seconds < DEFAULT_UNHEALTHY_WARN_SECONDS {
+            return None;
+        }
+        let severity = severity_for_unhealthy(observation.unhealthy_for_seconds);
+        let identities = json!(report.blocking_identities);
+        let inputs = json!({
+            "readiness": report.readiness.as_str(),
+            "mode": format!("{:?}", report.mode),
+            "unhealthy_for_seconds": observation.unhealthy_for_seconds,
+            "create_unknown_pending": report.create_unknown_pending,
+            "blocking_identities": identities,
+            "blocking_identities_elided": report.blocking_identities_elided,
+            "seconds_since_last_reconcile": report.seconds_since_last_reconcile,
+        });
+        let outputs = json!({
+            "reason": REASON_ADMISSION_WEDGED,
+            "severity": severity.as_str(),
+            "readiness": report.readiness.as_str(),
+            "admission_open": false,
+        });
+        // The detail names the rows. A finding that says
+        // "CreateUnknownHealth for 14 minutes" leaves an operator exactly where
+        // the outage left them; one that names the work_id does not.
+        let named = if report.blocking_identities.is_empty() {
+            "no journal row identities are recorded for this reason".to_owned()
+        } else {
+            let mut rendered = report.blocking_identities.join(", ");
+            if report.blocking_identities_elided > 0 {
+                rendered.push_str(&format!(" (+{} more)", report.blocking_identities_elided));
+            }
+            format!("blocking admission-journal rows: {rendered}")
+        };
+        let detail = format!(
+            "build admission has been non-healthy for {}s with readiness `{}` (mode {:?}); \
+             every Enforce admission is denied until it clears — {named}",
+            observation.unhealthy_for_seconds,
+            report.readiness.as_str(),
+            report.mode,
+        );
+        let snapshot = ResolverSnapshot::new("resolve_build_admission_health", inputs, outputs);
+        Some(
+            Finding::new(
+                severity,
+                BUILD_ADMISSION_HEALTH_CHECK_NAME,
+                snapshot,
+                detail,
+            )
+            .with_entity_id("readiness", report.readiness.as_str())
+            .with_evidence(json!({
+                "reason": REASON_ADMISSION_WEDGED,
+                "readiness": report.readiness.as_str(),
+                "mode": format!("{:?}", report.mode),
+                "draining": report.draining,
+                "unhealthy_for_seconds": observation.unhealthy_for_seconds,
+                "create_unknown_pending": report.create_unknown_pending,
+                "blocking_identities": identities,
+                "blocking_identities_elided": report.blocking_identities_elided,
+                "seconds_since_last_reconcile": report.seconds_since_last_reconcile,
+                "runbook": "server/docs/operational/stale-admission-occupancy.md",
+            })),
+        )
+    }
+
+    fn reconcile_stale_finding(observation: &BuildAdmissionHealthObservation) -> Option<Finding> {
+        let report = &observation.report;
+        if report.mode == BuildAdmissionMode::Off {
+            return None;
+        }
+        // A pass that has never completed is only meaningful once enough time
+        // has passed that one SHOULD have. Before that, a freshly-elected
+        // leader would report its own startup as a dead reconciler.
+        let age = match report.seconds_since_last_reconcile {
+            Some(age) => age,
+            None if observation.observed_for_seconds >= DEFAULT_RECONCILE_STALE_SECONDS => {
+                observation.observed_for_seconds
+            }
+            None => return None,
+        };
+        if age < DEFAULT_RECONCILE_STALE_SECONDS {
+            return None;
+        }
+        let ever = report.seconds_since_last_reconcile.is_some();
+        let detail = if ever {
+            format!(
+                "the build-admission reconciliation loop has not completed a blocker-free \
+                 pass for {age}s (threshold {DEFAULT_RECONCILE_STALE_SECONDS}s); occupying \
+                 admission rows whose Kubernetes object is gone are no longer being reclaimed"
+            )
+        } else {
+            format!(
+                "the build-admission reconciliation loop has NEVER completed a blocker-free \
+                 pass in {age}s of leadership; occupying admission rows are not being \
+                 reclaimed at all"
+            )
+        };
+        let inputs = json!({
+            "seconds_since_last_reconcile": report.seconds_since_last_reconcile,
+            "observed_for_seconds": observation.observed_for_seconds,
+            "threshold_seconds": DEFAULT_RECONCILE_STALE_SECONDS,
+            "readiness": report.readiness.as_str(),
+        });
+        let outputs = json!({
+            "reason": REASON_RECONCILE_STALE,
+            "severity": FindingSeverity::Error.as_str(),
+            "ever_reconciled": ever,
+        });
+        let snapshot =
+            ResolverSnapshot::new("resolve_build_admission_reconcile_age", inputs, outputs);
+        Some(
+            Finding::new(
+                FindingSeverity::Error,
+                BUILD_ADMISSION_HEALTH_CHECK_NAME,
+                snapshot,
+                detail,
+            )
+            .with_entity_id("reason", REASON_RECONCILE_STALE)
+            .with_evidence(json!({
+                "reason": REASON_RECONCILE_STALE,
+                "seconds_since_last_reconcile": report.seconds_since_last_reconcile,
+                "observed_for_seconds": observation.observed_for_seconds,
+                "threshold_seconds": DEFAULT_RECONCILE_STALE_SECONDS,
+                "ever_reconciled": ever,
+                "readiness": report.readiness.as_str(),
+                "runbook": "server/docs/operational/stale-admission-occupancy.md",
+            })),
+        )
+    }
+}
+
+impl DoctorCheck for BuildAdmissionHealthCheck {
+    fn name(&self) -> &'static str {
+        BUILD_ADMISSION_HEALTH_CHECK_NAME
+    }
+
+    fn description(&self) -> &'static str {
+        "Flags a build-admission controller that has been non-healthy beyond a bounded window, \
+         or a reconciliation loop that has stopped completing passes, naming the admission-journal \
+         rows responsible"
+    }
+
+    fn cadence(&self) -> DoctorCheckCadence {
+        DoctorCheckCadence::Cheap
+    }
+
+    fn run(&self) -> DoctorResult<Vec<Finding>> {
+        let Some(observation) = self.source.snapshot() else {
+            return Ok(Vec::new());
+        };
+        let mut findings = Vec::new();
+        if let Some(finding) = Self::wedged_finding(&observation) {
+            findings.push(finding);
+        }
+        if let Some(finding) = Self::reconcile_stale_finding(&observation) {
+            findings.push(finding);
+        }
+        Ok(findings)
+    }
+}
+
+/// In-memory source for tests.
+#[derive(Clone, Debug, Default)]
+pub struct MemoryBuildAdmissionHealthSource {
+    pub observation: Option<BuildAdmissionHealthObservation>,
+}
+
+impl MemoryBuildAdmissionHealthSource {
+    #[must_use]
+    pub fn new(observation: Option<BuildAdmissionHealthObservation>) -> Self {
+        Self { observation }
+    }
+}
+
+impl BuildAdmissionHealthSource for MemoryBuildAdmissionHealthSource {
+    fn snapshot(&self) -> Option<BuildAdmissionHealthObservation> {
+        self.observation.clone()
+    }
+}
+
+/// Production source over the LEADER's live controller.
+///
+/// The elapsed-unhealthy clock is maintained here rather than on the
+/// controller: the controller's readiness is derived from independent gates
+/// with no notion of "since when", and a latch that only the observer needs
+/// does not belong in the admission path.
+///
+/// Sampling happens on every `snapshot()` — that is, once per cheap doctor tick
+/// — so the reported elapsed time is real observed wall time, never an
+/// extrapolation.
+pub struct ControllerBuildAdmissionHealthSource {
+    controller: Option<Arc<BuildAdmissionController>>,
+    started_at: Instant,
+    /// The readiness label currently latched, and when it was first observed.
+    /// `None` while healthy.
+    unhealthy_since: Mutex<Option<(&'static str, Instant)>>,
+}
+
+impl ControllerBuildAdmissionHealthSource {
+    #[must_use]
+    pub fn new(controller: Option<Arc<BuildAdmissionController>>) -> Self {
+        Self {
+            controller,
+            started_at: SystemClock::new().now_instant(),
+            unhealthy_since: Mutex::new(None),
+        }
+    }
+
+    /// Fold one readiness sample into the elapsed-unhealthy latch.
+    ///
+    /// A CHANGE of reason restarts the clock: "inventory pending for 10s then
+    /// topology pending for 10s" is a startup walking its gates, not admission
+    /// wedged for 20s.
+    fn observe(&self, report: &BuildAdmissionHealthReport, now: Instant) -> i64 {
+        let mut guard = self
+            .unhealthy_since
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if report.readiness.is_healthy() {
+            *guard = None;
+            return 0;
+        }
+        let label = report.readiness.as_str();
+        match guard.as_ref() {
+            Some((latched, since)) if *latched == label => {
+                i64::try_from(now.saturating_duration_since(*since).as_secs()).unwrap_or(i64::MAX)
+            }
+            _ => {
+                *guard = Some((label, now));
+                0
+            }
+        }
+    }
+}
+
+impl BuildAdmissionHealthSource for ControllerBuildAdmissionHealthSource {
+    fn snapshot(&self) -> Option<BuildAdmissionHealthObservation> {
+        let controller = self.controller.as_ref()?;
+        let report = controller.health_report();
+        let now = SystemClock::new().now_instant();
+        let unhealthy_for_seconds = self.observe(&report, now);
+        Some(BuildAdmissionHealthObservation {
+            report,
+            unhealthy_for_seconds,
+            observed_for_seconds: i64::try_from(
+                now.saturating_duration_since(self.started_at).as_secs(),
+            )
+            .unwrap_or(i64::MAX),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build_admission::BuildAdmissionReadiness;
+    use std::time::Duration;
+
+    fn report(readiness: BuildAdmissionReadiness) -> BuildAdmissionHealthReport {
+        BuildAdmissionHealthReport {
+            readiness,
+            mode: BuildAdmissionMode::Enforce,
+            draining: readiness == BuildAdmissionReadiness::ShutdownDraining,
+            create_unknown_pending: u64::from(
+                readiness == BuildAdmissionReadiness::CreateUnknownHealth,
+            ),
+            blocking_identities: if readiness == BuildAdmissionReadiness::CreateUnknownHealth {
+                vec!["warm_build:proj-7:3@djinn-warm-proj-7-3".to_owned()]
+            } else {
+                Vec::new()
+            },
+            blocking_identities_elided: 0,
+            seconds_since_last_reconcile: Some(30),
+        }
+    }
+
+    fn observation(
+        readiness: BuildAdmissionReadiness,
+        unhealthy_for_seconds: i64,
+    ) -> BuildAdmissionHealthObservation {
+        BuildAdmissionHealthObservation {
+            report: report(readiness),
+            unhealthy_for_seconds,
+            observed_for_seconds: unhealthy_for_seconds + 60,
+        }
+    }
+
+    fn run(observation: Option<BuildAdmissionHealthObservation>) -> Vec<Finding> {
+        BuildAdmissionHealthCheck::new(Arc::new(MemoryBuildAdmissionHealthSource::new(observation)))
+            .run()
+            .expect("run")
+    }
+
+    #[test]
+    fn check_is_cheap_and_named() {
+        let check =
+            BuildAdmissionHealthCheck::new(Arc::new(MemoryBuildAdmissionHealthSource::default()));
+        assert_eq!(check.name(), BUILD_ADMISSION_HEALTH_CHECK_NAME);
+        assert_eq!(check.cadence(), DoctorCheckCadence::Cheap);
+    }
+
+    #[test]
+    fn a_healthy_controller_produces_no_finding() {
+        assert!(run(Some(observation(BuildAdmissionReadiness::Healthy, 0))).is_empty());
+    }
+
+    #[test]
+    fn a_process_without_a_controller_produces_no_finding() {
+        assert!(run(None).is_empty());
+    }
+
+    /// Startup walks several non-healthy gates. The window has to clear that,
+    /// or the check would fire on every single boot and be turned off.
+    #[test]
+    fn a_briefly_unhealthy_controller_is_not_yet_a_finding() {
+        assert!(
+            run(Some(observation(
+                BuildAdmissionReadiness::InventoryPending,
+                30
+            )))
+            .is_empty()
+        );
+    }
+
+    /// The core of the outage: the exact readiness reason and the row
+    /// responsible must both reach the operator.
+    #[test]
+    fn a_wedged_controller_reports_the_reason_and_names_the_blocking_row() {
+        let findings = run(Some(observation(
+            BuildAdmissionReadiness::CreateUnknownHealth,
+            600,
+        )));
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.check_name, BUILD_ADMISSION_HEALTH_CHECK_NAME);
+        assert_eq!(finding.severity, FindingSeverity::Warn);
+        assert_eq!(finding.evidence["readiness"], "create_unknown_health");
+        assert_eq!(finding.evidence["reason"], REASON_ADMISSION_WEDGED);
+        assert_eq!(
+            finding.evidence["blocking_identities"][0], "warm_build:proj-7:3@djinn-warm-proj-7-3",
+            "a finding that reports only a COUNT is what cost five hours"
+        );
+        assert!(
+            finding
+                .detail
+                .contains("warm_build:proj-7:3@djinn-warm-proj-7-3"),
+            "the human-readable detail must name the row too: {}",
+            finding.detail
+        );
+        assert!(
+            finding.detail.contains("create_unknown_health"),
+            "the detail must state the exact readiness reason: {}",
+            finding.detail
+        );
+    }
+
+    #[test]
+    fn severity_escalates_with_the_wedge_duration() {
+        assert_eq!(
+            run(Some(observation(
+                BuildAdmissionReadiness::TopologyPending,
+                600
+            )))[0]
+                .severity,
+            FindingSeverity::Warn
+        );
+        assert_eq!(
+            run(Some(observation(
+                BuildAdmissionReadiness::TopologyPending,
+                1000
+            )))[0]
+                .severity,
+            FindingSeverity::Error
+        );
+        assert_eq!(
+            run(Some(observation(
+                BuildAdmissionReadiness::TopologyPending,
+                7200
+            )))[0]
+                .severity,
+            FindingSeverity::Critical
+        );
+    }
+
+    /// `ShutdownDraining` was an absolute latch with no clearing path anywhere.
+    /// If it is ever set outside teardown it denies everything forever, so it
+    /// must be reportable by name.
+    #[test]
+    fn a_stuck_draining_latch_is_reported_by_name() {
+        let findings = run(Some(observation(
+            BuildAdmissionReadiness::ShutdownDraining,
+            1200,
+        )));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].evidence["readiness"], "shutdown_draining");
+        assert_eq!(findings[0].evidence["draining"], true);
+    }
+
+    /// Off never denies, so a non-healthy reason there is not an alarm.
+    #[test]
+    fn off_mode_never_raises_an_alarm() {
+        let mut sample = observation(BuildAdmissionReadiness::InventoryPending, 100_000);
+        sample.report.mode = BuildAdmissionMode::Off;
+        assert!(run(Some(sample)).is_empty());
+    }
+
+    /// The signal the audit called the single most valuable addition: nothing
+    /// anywhere asserted that a reconcile pass had completed recently.
+    #[test]
+    fn a_stale_reconcile_age_is_a_finding_even_while_readiness_is_healthy() {
+        let mut sample = observation(BuildAdmissionReadiness::Healthy, 0);
+        sample.report.seconds_since_last_reconcile = Some(3600);
+        let findings = run(Some(sample));
+        assert_eq!(
+            findings.len(),
+            1,
+            "a dead reconciler must be reported even before it has wedged anything"
+        );
+        assert_eq!(findings[0].evidence["reason"], REASON_RECONCILE_STALE);
+        assert_eq!(findings[0].severity, FindingSeverity::Error);
+        assert_eq!(findings[0].evidence["ever_reconciled"], true);
+    }
+
+    #[test]
+    fn a_fresh_reconcile_age_is_not_a_finding() {
+        let mut sample = observation(BuildAdmissionReadiness::Healthy, 0);
+        sample.report.seconds_since_last_reconcile = Some(60);
+        assert!(run(Some(sample)).is_empty());
+    }
+
+    /// A leader that has never completed a pass is the loudest version of the
+    /// same condition — but only once enough time has passed that one should
+    /// have run, so a freshly-elected leader does not accuse itself.
+    #[test]
+    fn never_having_reconciled_fires_only_after_a_pass_should_have_run() {
+        let mut fresh = observation(BuildAdmissionReadiness::Healthy, 0);
+        fresh.report.seconds_since_last_reconcile = None;
+        fresh.observed_for_seconds = 60;
+        assert!(run(Some(fresh)).is_empty());
+
+        let mut aged = observation(BuildAdmissionReadiness::Healthy, 0);
+        aged.report.seconds_since_last_reconcile = None;
+        aged.observed_for_seconds = 3600;
+        let findings = run(Some(aged));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].evidence["ever_reconciled"], false);
+        assert!(findings[0].detail.contains("NEVER"));
+    }
+
+    /// The elapsed clock must restart when the REASON changes: a startup
+    /// walking inventory → topology is not one wedge of the summed duration.
+    #[test]
+    fn a_changed_readiness_reason_restarts_the_elapsed_clock() {
+        let source = ControllerBuildAdmissionHealthSource::new(None);
+        let start = SystemClock::new().now_instant();
+        let mut inventory = report(BuildAdmissionReadiness::InventoryPending);
+        assert_eq!(source.observe(&inventory, start), 0);
+        assert_eq!(
+            source.observe(&inventory, start + Duration::from_secs(600)),
+            600,
+            "an unchanged reason accumulates"
+        );
+        inventory.readiness = BuildAdmissionReadiness::TopologyPending;
+        assert_eq!(
+            source.observe(&inventory, start + Duration::from_secs(601)),
+            0,
+            "a different reason is a different episode"
+        );
+    }
+
+    #[test]
+    fn becoming_healthy_clears_the_elapsed_clock() {
+        let source = ControllerBuildAdmissionHealthSource::new(None);
+        let start = SystemClock::new().now_instant();
+        let pending = report(BuildAdmissionReadiness::InventoryPending);
+        source.observe(&pending, start);
+        assert_eq!(
+            source.observe(
+                &report(BuildAdmissionReadiness::Healthy),
+                start + Duration::from_secs(60)
+            ),
+            0
+        );
+        assert_eq!(
+            source.observe(&pending, start + Duration::from_secs(61)),
+            0,
+            "a healed-then-degraded controller starts a NEW episode"
+        );
+    }
+
+    /// A source with no controller must yield no observation — and therefore no
+    /// finding — rather than fabricating a healthy one.
+    #[test]
+    fn a_controllerless_source_yields_no_observation() {
+        assert!(
+            ControllerBuildAdmissionHealthSource::new(None)
+                .snapshot()
+                .is_none()
+        );
+    }
+}

--- a/server/crates/djinn-coordinator/src/doctor/mod.rs
+++ b/server/crates/djinn-coordinator/src/doctor/mod.rs
@@ -15,6 +15,7 @@
 
 #![allow(dead_code)]
 
+pub mod build_admission_health;
 pub mod closed_parent_open_children;
 pub mod leader_tick;
 pub mod live_mover;
@@ -29,6 +30,11 @@ use std::sync::Arc;
 
 use djinn_core::doctor::{DoctorCheck, DoctorRegistry};
 
+pub use build_admission_health::{
+    BUILD_ADMISSION_HEALTH_CHECK_NAME, BuildAdmissionHealthCheck, BuildAdmissionHealthObservation,
+    BuildAdmissionHealthSource, ControllerBuildAdmissionHealthSource,
+    MemoryBuildAdmissionHealthSource,
+};
 pub use closed_parent_open_children::{
     CLOSED_PARENT_OPEN_CHILDREN_CHECK_NAME, ClosedParentOpenChildrenCheck,
     ClosedParentOpenChildrenRepairSource, ClosedParentOpenChildrenSource,
@@ -82,6 +88,21 @@ pub fn register_doctor_checks(
         registered.push(previous);
     }
     registered
+}
+
+/// Register the leader-local build-admission health check.
+///
+/// Registered from the same place as [`register_doctor_checks`] — the
+/// coordinator actor's constructor — because that constructor runs only on the
+/// pod that won coordinator leadership, which is the pod whose in-memory
+/// readiness actually decides admission. See the module docs on
+/// [`build_admission_health`] for why that makes the process-local readiness
+/// genuinely observable rather than silently unobservable.
+pub fn register_build_admission_health_check(
+    registry: &DoctorRegistry,
+    source: Arc<dyn BuildAdmissionHealthSource>,
+) -> Option<String> {
+    registry.register(Arc::new(BuildAdmissionHealthCheck::new(source)))
 }
 
 /// Register the shared retrieval source checks independently of refresh success.

--- a/server/crates/djinn-k8s/src/workload_inventory.rs
+++ b/server/crates/djinn-k8s/src/workload_inventory.rs
@@ -1,8 +1,27 @@
 //! Broad, data-only Kubernetes inventory used by coordinator admission recovery.
+//!
+//! ## Why every call here is on a client-side clock
+//!
+//! [`WorkloadInventory::list`] is the first thing a build-admission
+//! reconciliation pass does, and until 2026-07-29 it had no client-side
+//! deadline at all. `kube`'s default client will happily keep a request
+//! outstanding indefinitely when the API server accepts the connection and then
+//! stops answering, so ONE such call parked the whole reconciliation loop
+//! forever while every liveness signal in the process still read healthy — the
+//! board stopped dispatching for five hours and nothing anywhere said why.
+//!
+//! A hung probe is not more informative than a failed one: both mean "the API
+//! server did not answer". Every method below therefore runs under a bounded
+//! budget and maps expiry onto the answer the method already has for "could not
+//! establish this" — `Err` for the LIST, `Uncertain` for the per-object probes.
+//! No timeout can turn absence-of-answer into proof of absence.
 use async_trait::async_trait;
 use k8s_openapi::api::{batch::v1::Job, core::v1::Pod};
 use kube::{Api, api::ListParams};
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::OnceLock;
+use std::time::Duration;
 
 pub const LABEL_ADMISSION_DOMAIN: &str = "djinn.app/admission-domain";
 pub const LABEL_ADMISSION_WORK_ID: &str = "djinn.app/admission-work-id";
@@ -44,6 +63,61 @@ pub enum ObjectPresence {
     Absent,
     /// The probe could not answer. Never treated as proof of anything.
     Uncertain,
+}
+
+/// Environment variable overriding the per-call Kubernetes budget, in seconds.
+pub const CALL_TIMEOUT_ENV: &str = "DJINN_K8S_WORKLOAD_INVENTORY_TIMEOUT_SECS";
+/// Default per-call budget. Comfortably above a healthy namespaced LIST and far
+/// below the reconciliation cadence, so a slow API server costs one pass rather
+/// than every subsequent one.
+const DEFAULT_CALL_TIMEOUT_SECS: u64 = 30;
+/// Floor, so a misconfigured tiny value cannot make every pass expire before a
+/// healthy API server can answer.
+const MIN_CALL_TIMEOUT_SECS: u64 = 5;
+/// Ceiling, so a misconfigured huge value cannot silently restore the unbounded
+/// wait this budget exists to remove.
+const MAX_CALL_TIMEOUT_SECS: u64 = 300;
+
+/// Parse and bound the configured per-call budget. Anything unparseable or out
+/// of range falls back to the default rather than disabling the deadline.
+fn parse_call_timeout(raw: Option<&str>) -> Duration {
+    let secs = raw
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|secs| (MIN_CALL_TIMEOUT_SECS..=MAX_CALL_TIMEOUT_SECS).contains(secs))
+        .unwrap_or(DEFAULT_CALL_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// The process-wide per-call budget, read from the environment exactly once.
+fn call_timeout() -> Duration {
+    static BUDGET: OnceLock<Duration> = OnceLock::new();
+    *BUDGET.get_or_init(|| parse_call_timeout(std::env::var(CALL_TIMEOUT_ENV).ok().as_deref()))
+}
+
+/// Run one Kubernetes call under `budget`, yielding `None` if it expired.
+///
+/// Separate from [`call_timeout`] so tests can drive the deadline directly
+/// instead of mutating process-global environment state.
+pub(crate) async fn with_call_timeout<F>(
+    budget: Duration,
+    op: &'static str,
+    fut: F,
+) -> Option<F::Output>
+where
+    F: Future,
+{
+    match tokio::time::timeout(budget, fut).await {
+        Ok(value) => Some(value),
+        Err(_) => {
+            tracing::error!(
+                op,
+                timeout_secs = budget.as_secs(),
+                "workload inventory Kubernetes call exceeded its client-side budget; \
+                 treating it as unanswered rather than waiting forever"
+            );
+            None
+        }
+    }
 }
 
 #[async_trait]
@@ -105,22 +179,42 @@ impl WorkloadInventory for KubeWorkloadInventory {
         // Child Pods inherit the Job's admission labels. Treating both as
         // independent workloads duplicates task identities and double-counts
         // warm jobs, while the Job is the UID-fenced lifecycle object.
-        let jobs = jobs
-            .list(&ListParams::default())
-            .await
-            .map_err(|e| e.to_string())?;
+        let jobs = with_call_timeout(call_timeout(), "workload_inventory.list", async {
+            jobs.list(&ListParams::default()).await
+        })
+        .await
+        .ok_or_else(|| {
+            format!(
+                "workload inventory LIST exceeded its {}s client-side budget",
+                call_timeout().as_secs()
+            )
+        })?
+        .map_err(|e| e.to_string())?;
         Ok(jobs.items.into_iter().filter_map(job_record).collect())
     }
     async fn get_uid(&self, kind: WorkloadObjectKind, name: &str, uid: &str) -> UidGetResult {
-        let result = match kind {
-            WorkloadObjectKind::Job => Api::<Job>::namespaced(self.client.clone(), &self.namespace)
-                .get_opt(name)
-                .await
-                .map(|v| v.and_then(|o| o.metadata.uid)),
-            WorkloadObjectKind::Pod => Api::<Pod>::namespaced(self.client.clone(), &self.namespace)
-                .get_opt(name)
-                .await
-                .map(|v| v.and_then(|o| o.metadata.uid)),
+        let probe = async {
+            match kind {
+                WorkloadObjectKind::Job => {
+                    Api::<Job>::namespaced(self.client.clone(), &self.namespace)
+                        .get_opt(name)
+                        .await
+                        .map(|v| v.and_then(|o| o.metadata.uid))
+                }
+                WorkloadObjectKind::Pod => {
+                    Api::<Pod>::namespaced(self.client.clone(), &self.namespace)
+                        .get_opt(name)
+                        .await
+                        .map(|v| v.and_then(|o| o.metadata.uid))
+                }
+            }
+        };
+        // An expired probe is indistinguishable from an unanswered one, and
+        // `Uncertain` is exactly the answer that proves nothing.
+        let Some(result) =
+            with_call_timeout(call_timeout(), "workload_inventory.get_uid", probe).await
+        else {
+            return UidGetResult::Uncertain;
         };
         match result {
             Ok(Some(found)) if found == uid => UidGetResult::Present,
@@ -130,15 +224,26 @@ impl WorkloadInventory for KubeWorkloadInventory {
     }
 
     async fn presence(&self, kind: WorkloadObjectKind, name: &str) -> ObjectPresence {
-        let result = match kind {
-            WorkloadObjectKind::Job => Api::<Job>::namespaced(self.client.clone(), &self.namespace)
-                .get_opt(name)
-                .await
-                .map(|v| v.map(|o| o.metadata.uid)),
-            WorkloadObjectKind::Pod => Api::<Pod>::namespaced(self.client.clone(), &self.namespace)
-                .get_opt(name)
-                .await
-                .map(|v| v.map(|o| o.metadata.uid)),
+        let probe = async {
+            match kind {
+                WorkloadObjectKind::Job => {
+                    Api::<Job>::namespaced(self.client.clone(), &self.namespace)
+                        .get_opt(name)
+                        .await
+                        .map(|v| v.map(|o| o.metadata.uid))
+                }
+                WorkloadObjectKind::Pod => {
+                    Api::<Pod>::namespaced(self.client.clone(), &self.namespace)
+                        .get_opt(name)
+                        .await
+                        .map(|v| v.map(|o| o.metadata.uid))
+                }
+            }
+        };
+        let Some(result) =
+            with_call_timeout(call_timeout(), "workload_inventory.presence", probe).await
+        else {
+            return ObjectPresence::Uncertain;
         };
         match result {
             Ok(Some(uid)) => ObjectPresence::Present { uid },
@@ -154,4 +259,59 @@ pub fn has_canonical_warm_signature(r: &WorkloadRecord) -> bool {
         && r.commands
             .iter()
             .any(|c| c.contains(crate::warm_job::WARM_COMMAND_BIN) && c.contains("warm-graph"))
+}
+
+#[cfg(test)]
+mod call_timeout_tests {
+    use super::*;
+
+    /// The property that matters is not "a constant exists" but "a call that
+    /// never answers is cut off". Drive a future that is pending forever and
+    /// assert the helper returns rather than parking the caller.
+    #[tokio::test(start_paused = true)]
+    async fn a_call_that_never_answers_is_cut_off() {
+        let outcome = with_call_timeout(
+            Duration::from_secs(30),
+            "test.hang",
+            std::future::pending::<u8>(),
+        )
+        .await;
+        assert!(
+            outcome.is_none(),
+            "an unanswered Kubernetes call must expire, not park the reconciliation loop forever"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_call_that_answers_within_budget_is_passed_through() {
+        let outcome =
+            with_call_timeout(Duration::from_secs(30), "test.ok", std::future::ready(7u8)).await;
+        assert_eq!(outcome, Some(7), "the budget must not change a live answer");
+    }
+
+    #[test]
+    fn unset_budget_uses_the_default() {
+        assert_eq!(
+            parse_call_timeout(None),
+            Duration::from_secs(DEFAULT_CALL_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn a_valid_budget_is_adopted() {
+        assert_eq!(parse_call_timeout(Some("60")), Duration::from_secs(60));
+        assert_eq!(parse_call_timeout(Some(" 15 ")), Duration::from_secs(15));
+    }
+
+    #[test]
+    fn out_of_range_and_unparseable_budgets_fall_back_to_the_default() {
+        let default = Duration::from_secs(DEFAULT_CALL_TIMEOUT_SECS);
+        for raw in ["0", "1", "301", "99999", "forever", "", "-5"] {
+            assert_eq!(
+                parse_call_timeout(Some(raw)),
+                default,
+                "{raw:?} must fall back to the default rather than remove the deadline"
+            );
+        }
+    }
 }

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -207,6 +207,11 @@ const BUILD_ADMISSION_TRANSITION_OUTCOMES: [&str; 4] =
     ["accepted", "rejected", "reclaimed", "reclaim_fenced"];
 const BUILD_ADMISSION_OCCUPANCY_OVER_CAP: &str = "djinn_build_admission_occupancy_over_cap";
 const BUILD_ADMISSION_STALE_ROWS: &str = "djinn_build_admission_stale_rows";
+/// Seconds since the last blocker-free build-admission reconciliation pass.
+/// `-1` means no pass has ever completed in this process — a louder condition
+/// than a large age, not a quieter one.
+const BUILD_ADMISSION_SECONDS_SINCE_RECONCILE: &str =
+    "djinn_build_admission_seconds_since_reconcile";
 const BUILD_ADMISSION_HANDOFF_WARNING: &str = "djinn_build_admission_handoff_warning";
 const BUILD_ADMISSION_HANDOFF_WARNING_REASONS: [&str; 3] =
     ["unexpected_overlap", "stale_epoch", "epoch_unreadable"];
@@ -1969,6 +1974,13 @@ fn register_metrics() {
          the shape that wedges every admission once the cap is armed."
     );
     metrics::describe_gauge!(
+        BUILD_ADMISSION_SECONDS_SINCE_RECONCILE,
+        "Seconds since the last blocker-free build-admission reconciliation pass; \
+         -1 means no pass has ever completed in this process. A value that keeps \
+         climbing past the configured cadence means the reconciliation loop is \
+         dead or hung, and occupying admission rows are no longer being reclaimed."
+    );
+    metrics::describe_gauge!(
         BUILD_ADMISSION_HANDOFF_WARNING,
         "Current bounded emergency-to-invocation admission handoff warning; one means active."
     );
@@ -3229,6 +3241,17 @@ pub mod build_admission {
         metrics::gauge!(super::BUILD_ADMISSION_JOURNAL_DEGRADED, "effective_mode" => effective_mode, "effective_cap" => cap.clone()).set(f64::from(journal_degraded));
         metrics::gauge!(super::BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH, "effective_mode" => effective_mode, "effective_cap" => cap.clone()).set(f64::from(create_unknown));
         metrics::gauge!(super::BUILD_ADMISSION_OCCUPANCY_OVER_CAP, "effective_mode" => effective_mode, "effective_cap" => cap).set(f64::from(occupancy_over_cap));
+    }
+
+    /// Set how long ago the last blocker-free reconciliation pass completed.
+    ///
+    /// `None` (no pass has ever completed in this process) is exported as `-1`
+    /// rather than omitted: a missing series is indistinguishable from a
+    /// process that never started, which is the exact ambiguity that made the
+    /// dead-reconciler failure mode invisible.
+    pub fn set_seconds_since_reconcile(effective_mode: &'static str, seconds: Option<i64>) {
+        metrics::gauge!(super::BUILD_ADMISSION_SECONDS_SINCE_RECONCILE, "effective_mode" => effective_mode)
+            .set(seconds.unwrap_or(-1) as f64);
     }
 
     /// Set the absolute count of occupying rows whose object was proven absent

--- a/server/src/build_admission_reconcile.rs
+++ b/server/src/build_admission_reconcile.rs
@@ -48,15 +48,44 @@
 //! the pre-existing contract of the reconciler and this loop does not soften
 //! it — it only makes it recoverable. Before this loop a failed inventory at
 //! startup was permanent; now the next tick clears it.
+//!
+//! ## Why the loop is supervised rather than merely spawned
+//!
+//! This loop IS the recovery machinery, so its own failure modes are the ones
+//! that turn a five-minute event into a five-hour one. As originally written it
+//! was a bare `tokio::spawn` with the `JoinHandle` dropped, calling an
+//! unbounded Kubernetes LIST, and logging its exit at `debug!`. All three
+//! failure modes were silent:
+//!
+//! * a panic anywhere in a pass killed the loop permanently, with no log that
+//!   any operator would ever look at and no restart;
+//! * one hung API call parked the pass forever while every process-level
+//!   liveness signal still read healthy;
+//! * an exit — for any reason — produced a single `debug!` line.
+//!
+//! Each pass now runs as its own supervised child task under a bounded budget:
+//! a panic is contained to that pass and reported at `error!`, an overrunning
+//! pass is aborted so the next tick still happens, and any exit of the loop
+//! itself is reported at `warn!`/`error!` and restarted a bounded number of
+//! times. Alongside that, every completed pass advances the durable-ish
+//! "last successful reconcile" stamp on the controller, which
+//! [`crate::server::AppState::publish_build_admission_metrics`] exports and the
+//! `build_admission_health` doctor check reads. Nothing before this asserted
+//! anywhere that a pass had completed within the last N seconds, and that
+//! missing assertion is the whole reason the outage lasted as long as it did.
 
+use std::future::Future;
 use std::time::Duration;
 
 use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
 
 use crate::server::AppState;
 
 /// Environment variable overriding the reconciliation cadence, in seconds.
 pub const INTERVAL_ENV: &str = "DJINN_BUILD_ADMISSION_RECONCILE_INTERVAL_SECS";
+/// Environment variable overriding the per-pass budget, in seconds.
+pub const PASS_TIMEOUT_ENV: &str = "DJINN_BUILD_ADMISSION_RECONCILE_PASS_TIMEOUT_SECS";
 
 /// Default cadence: 120s. Deliberately shorter than the 300s settle window so
 /// that a row becomes reclaimable and is then reclaimed within roughly one
@@ -70,38 +99,183 @@ const MIN_INTERVAL_SECS: u64 = 30;
 /// startup-only behaviour this loop exists to remove.
 const MAX_INTERVAL_SECS: u64 = 60 * 60;
 
+/// Default per-pass budget: 300s. A pass is a bounded number of Kubernetes
+/// reads plus journal writes; anything past five minutes is a hang, not slow
+/// work, and the next tick is more useful than the stuck one.
+const DEFAULT_PASS_TIMEOUT_SECS: u64 = 300;
+const MIN_PASS_TIMEOUT_SECS: u64 = 30;
+const MAX_PASS_TIMEOUT_SECS: u64 = 30 * 60;
+
+/// How many times the supervisor rebuilds the loop after the loop task itself
+/// dies. Bounded so a deterministically-panicking loop cannot spin forever;
+/// exhausting it is reported at `error!` and is a genuine "reconciliation is
+/// gone" condition, which the `build_admission_health` doctor check surfaces
+/// through the reconcile-age signal.
+const MAX_LOOP_RESTARTS: u32 = 8;
+
+/// Why one reconciliation pass stopped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PassOutcome {
+    /// The pass ran to completion. Says nothing about whether reconciliation
+    /// SUCCEEDED — that verdict belongs to the controller's readiness gates —
+    /// only that the loop is alive and making calls.
+    Completed,
+    /// The pass panicked. Contained to the pass; the loop keeps ticking.
+    Panicked,
+    /// The pass exceeded its budget and was aborted.
+    TimedOut,
+}
+
+/// Why the reconciliation loop stopped. Every variant is worth a log line: this
+/// loop stopping means occupying rows stop being reclaimed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LoopExit {
+    /// The process-wide cancellation token fired (normal shutdown).
+    Cancelled,
+}
+
+/// Run one pass as a supervised child task under `budget`.
+///
+/// Spawning rather than `catch_unwind`-ing is deliberate: a `JoinHandle`
+/// reports a panic as data without requiring the pass future to be
+/// `UnwindSafe`, and it gives the timeout something it can actually `abort()`
+/// instead of leaking a stuck future into the loop's own stack forever.
+async fn run_pass<Fut>(budget: Duration, pass: Fut) -> PassOutcome
+where
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let handle = tokio::spawn(pass);
+    let abort = handle.abort_handle();
+    match tokio::time::timeout(budget, handle).await {
+        Ok(Ok(())) => PassOutcome::Completed,
+        Ok(Err(join_error)) if join_error.is_panic() => {
+            tracing::error!(
+                error = %join_error,
+                "build_admission_reconcile pass PANICKED; the loop survives and will \
+                 retry on the next tick, but this pass reclaimed nothing"
+            );
+            PassOutcome::Panicked
+        }
+        // A cancelled (not panicked) join can only come from an abort we did
+        // not issue; treat it as a non-completion rather than a success.
+        Ok(Err(join_error)) => {
+            tracing::error!(
+                error = %join_error,
+                "build_admission_reconcile pass ended without completing"
+            );
+            PassOutcome::Panicked
+        }
+        Err(_) => {
+            abort.abort();
+            tracing::error!(
+                budget_secs = budget.as_secs(),
+                "build_admission_reconcile pass exceeded its budget and was aborted; \
+                 an unbounded Kubernetes call is the usual cause. Reconciliation \
+                 resumes on the next tick rather than stopping here."
+            );
+            PassOutcome::TimedOut
+        }
+    }
+}
+
+/// The reconciliation loop proper, parameterised over the pass so its
+/// supervision properties are testable without an `AppState`.
+///
+/// Returns only when `cancel` fires. Every other way a pass can end — panic,
+/// hang — is absorbed here rather than ending the loop.
+pub(crate) async fn run_loop<F, Fut>(
+    interval: Duration,
+    pass_budget: Duration,
+    cancel: CancellationToken,
+    pass: F,
+) -> LoopExit
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // The first tick fires immediately; consume it. `AppState::initialize` runs
+    // a reconciliation pass on every pod before `become_leader` is even called,
+    // and the leader's own promotion path can run another, so reconciling again
+    // in the same breath would only duplicate API-server traffic during the
+    // leadership transition. This suppression is what makes it safe to spawn
+    // this loop as early as we do — see `become_leader`.
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                return LoopExit::Cancelled;
+            }
+            _ = ticker.tick() => {
+                // Off (no controller) and non-Kubernetes runtimes make this
+                // a cheap no-op inside the call itself; there is no
+                // separate gate here to drift out of sync with that one.
+                let _ = run_pass(pass_budget, pass()).await;
+            }
+        }
+    }
+}
+
 /// Spawn the periodic build-admission reconciliation task. Leader-only
 /// (started from `become_leader`), runs until `state.cancel()` fires.
 pub fn spawn(state: AppState) {
     let interval = parse_interval(std::env::var(INTERVAL_ENV).ok().as_deref());
+    let pass_budget = parse_pass_timeout(std::env::var(PASS_TIMEOUT_ENV).ok().as_deref());
     let cancel = state.cancel().clone();
 
     tokio::spawn(async move {
         tracing::info!(
             ?interval,
+            ?pass_budget,
             "build_admission_reconcile loop starting (leader-only)"
         );
-        let mut ticker = tokio::time::interval(interval);
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        // The first tick fires immediately; consume it. `become_leader` has
-        // just run a reconciliation pass of its own, so reconciling again in
-        // the same breath would only duplicate API-server traffic during the
-        // leadership transition.
-        ticker.tick().await;
-        loop {
-            tokio::select! {
-                _ = cancel.cancelled() => {
-                    tracing::debug!("build_admission_reconcile loop cancelled");
-                    break;
+        // Outer supervision: the loop body already contains per-pass panics, so
+        // reaching this handler means the SUPERVISION code itself died. Rebuild
+        // it rather than leaving the board with no reconciler, and say so at
+        // `error!` — the original code dropped this handle entirely.
+        for restart in 0..=MAX_LOOP_RESTARTS {
+            let loop_state = state.clone();
+            let loop_cancel = cancel.clone();
+            let handle = tokio::spawn(async move {
+                run_loop(interval, pass_budget, loop_cancel, move || {
+                    let state = loop_state.clone();
+                    async move {
+                        state.reconcile_build_admission_inventory().await;
+                        state.publish_build_admission_metrics().await;
+                    }
+                })
+                .await
+            });
+            match handle.await {
+                Ok(LoopExit::Cancelled) => {
+                    // Not an error, but never `debug!`: "reconciliation has
+                    // stopped" is exactly the fact an operator needs when the
+                    // board goes quiet, and a debug line is invisible in
+                    // production.
+                    tracing::warn!(
+                        restarts = restart,
+                        "build_admission_reconcile loop exited on cancellation; occupying \
+                         admission rows are no longer being reclaimed by this process"
+                    );
+                    return;
                 }
-                _ = ticker.tick() => {
-                    // Off (no controller) and non-Kubernetes runtimes make this
-                    // a cheap no-op inside the call itself; there is no
-                    // separate gate here to drift out of sync with that one.
-                    state.reconcile_build_admission_inventory().await;
+                Err(join_error) => {
+                    tracing::error!(
+                        error = %join_error,
+                        restart = restart + 1,
+                        max_restarts = MAX_LOOP_RESTARTS,
+                        "build_admission_reconcile LOOP died; restarting it"
+                    );
                 }
             }
         }
+        tracing::error!(
+            max_restarts = MAX_LOOP_RESTARTS,
+            "build_admission_reconcile loop exhausted its restart budget and is GONE; \
+             occupying admission rows will not be reclaimed until this process restarts. \
+             Run the stale-admission-occupancy runbook."
+        );
     });
 }
 
@@ -116,9 +290,21 @@ fn parse_interval(raw: Option<&str>) -> Duration {
     Duration::from_secs(secs)
 }
 
+/// Parse and bound the configured per-pass budget. Same fallback discipline as
+/// [`parse_interval`]: a typo must not be able to remove the deadline.
+fn parse_pass_timeout(raw: Option<&str>) -> Duration {
+    let secs = raw
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|secs| (MIN_PASS_TIMEOUT_SECS..=MAX_PASS_TIMEOUT_SECS).contains(secs))
+        .unwrap_or(DEFAULT_PASS_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn unset_interval_uses_the_default() {
@@ -148,6 +334,158 @@ mod tests {
                 "{raw:?} must fall back to the default rather than disable the loop"
             );
         }
+    }
+
+    #[test]
+    fn out_of_range_and_unparseable_pass_budgets_fall_back_to_the_default() {
+        let default = Duration::from_secs(DEFAULT_PASS_TIMEOUT_SECS);
+        for raw in ["0", "5", "99999", "forever", "", "-5"] {
+            assert_eq!(
+                parse_pass_timeout(Some(raw)),
+                default,
+                "{raw:?} must fall back to the default rather than remove the pass deadline"
+            );
+        }
+        assert_eq!(parse_pass_timeout(Some("120")), Duration::from_secs(120));
+    }
+
+    /// A pass that panics must not take the loop with it. Before the loop was
+    /// supervised, the very first panic ended reconciliation permanently — no
+    /// log an operator would see, no restart, and the board stayed wedged until
+    /// somebody restarted the process by hand.
+    #[tokio::test(start_paused = true)]
+    async fn a_panicking_pass_does_not_end_the_loop() {
+        let passes = Arc::new(AtomicUsize::new(0));
+        let cancel = CancellationToken::new();
+        let loop_passes = Arc::clone(&passes);
+        let loop_cancel = cancel.clone();
+        let handle = tokio::spawn(async move {
+            run_loop(
+                Duration::from_secs(60),
+                Duration::from_secs(300),
+                loop_cancel,
+                move || {
+                    let passes = Arc::clone(&loop_passes);
+                    async move {
+                        passes.fetch_add(1, Ordering::SeqCst);
+                        panic!("pass exploded");
+                    }
+                },
+            )
+            .await
+        });
+
+        // Three ticks past the suppressed first one.
+        for _ in 0..3 {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::task::yield_now().await;
+        }
+        let observed = passes.load(Ordering::SeqCst);
+        cancel.cancel();
+        assert_eq!(
+            handle.await.expect("the loop task itself must not panic"),
+            LoopExit::Cancelled
+        );
+        assert!(
+            observed >= 3,
+            "every tick after a panicking pass must still run a pass; observed {observed}"
+        );
+    }
+
+    /// A pass that hangs forever must be abandoned, not allowed to park the
+    /// loop. `KubeWorkloadInventory::list` had no client-side deadline at all,
+    /// so exactly one unanswered LIST stopped reconciliation for five hours
+    /// while every process-level health signal still read fine.
+    #[tokio::test(start_paused = true)]
+    async fn a_hanging_pass_is_abandoned_and_the_loop_keeps_ticking() {
+        let started = Arc::new(AtomicUsize::new(0));
+        let cancel = CancellationToken::new();
+        let loop_started = Arc::clone(&started);
+        let loop_cancel = cancel.clone();
+        let handle = tokio::spawn(async move {
+            run_loop(
+                Duration::from_secs(60),
+                Duration::from_secs(120),
+                loop_cancel,
+                move || {
+                    let started = Arc::clone(&loop_started);
+                    async move {
+                        started.fetch_add(1, Ordering::SeqCst);
+                        std::future::pending::<()>().await;
+                    }
+                },
+            )
+            .await
+        });
+
+        // Enough virtual time for the first pass to blow its 120s budget and
+        // for several further ticks to fire.
+        for _ in 0..8 {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::task::yield_now().await;
+        }
+        let observed = started.load(Ordering::SeqCst);
+        cancel.cancel();
+        assert_eq!(
+            handle.await.expect("the loop task itself must not panic"),
+            LoopExit::Cancelled
+        );
+        assert!(
+            observed >= 2,
+            "a hung pass must be aborted so later ticks still run; only {observed} pass(es) started"
+        );
+    }
+
+    /// The pass budget is the thing that turns a hang into a bounded failure.
+    #[tokio::test(start_paused = true)]
+    async fn run_pass_classifies_completion_panic_and_timeout() {
+        assert_eq!(
+            run_pass(Duration::from_secs(60), async {}).await,
+            PassOutcome::Completed
+        );
+        assert_eq!(
+            run_pass(Duration::from_secs(60), async { panic!("boom") }).await,
+            PassOutcome::Panicked
+        );
+        assert_eq!(
+            run_pass(Duration::from_secs(60), std::future::pending::<()>()).await,
+            PassOutcome::TimedOut
+        );
+    }
+
+    /// The loop suppresses its very first tick because a reconciliation pass
+    /// has just run elsewhere. Pin that, because `become_leader` now spawns
+    /// this loop immediately after the topology gate opens and the safety of
+    /// that move rests on this suppression.
+    #[tokio::test(start_paused = true)]
+    async fn the_first_immediate_tick_is_suppressed() {
+        let passes = Arc::new(AtomicUsize::new(0));
+        let cancel = CancellationToken::new();
+        let loop_passes = Arc::clone(&passes);
+        let loop_cancel = cancel.clone();
+        let handle = tokio::spawn(async move {
+            run_loop(
+                Duration::from_secs(60),
+                Duration::from_secs(300),
+                loop_cancel,
+                move || {
+                    let passes = Arc::clone(&loop_passes);
+                    async move {
+                        passes.fetch_add(1, Ordering::SeqCst);
+                    }
+                },
+            )
+            .await
+        });
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        tokio::task::yield_now().await;
+        let observed = passes.load(Ordering::SeqCst);
+        cancel.cancel();
+        let _ = handle.await;
+        assert_eq!(
+            observed, 0,
+            "the immediate first tick must be consumed without running a pass"
+        );
     }
 
     #[test]

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -1185,6 +1185,19 @@ impl AppState {
         self.initialize_build_admission_inventory().await;
     }
 
+    /// Publish the build-admission gauges, including the reconciliation-age
+    /// signal, without running a reconciliation pass.
+    ///
+    /// The reconciliation loop calls this after every tick so the age gauge
+    /// keeps being written even when the pass itself fails: a gauge that stops
+    /// being written is indistinguishable from a process that never started,
+    /// and that ambiguity is exactly what hid the dead reconciler.
+    pub(crate) async fn publish_build_admission_metrics(&self) {
+        if let Some(admission) = self.inner.build_admission.clone() {
+            admission.publish_metrics().await;
+        }
+    }
+
     /// Run the broad Kubernetes build-capable inventory and advance the
     /// Enforce readiness gate.
     ///
@@ -1235,6 +1248,14 @@ impl AppState {
                 .reconcile()
                 .await;
             if report.blockers.is_empty() {
+                // A pass that RAN and a pass that SUCCEEDED are different facts,
+                // and only the second one means occupancy is being reclaimed.
+                // This is the single point that knows the difference, so it is
+                // the one that stamps the "last successful reconcile" signal the
+                // `build_admission_health` doctor check reads. Nothing anywhere
+                // asserted this before, which is why a dead reconciler was
+                // indistinguishable from a working one for five hours.
+                admission.note_reconcile_success();
                 tracing::info!(
                     mode = ?admission.mode(),
                     adopted = report.adopted,
@@ -1265,6 +1286,10 @@ impl AppState {
         match warmer.list_taskrun_jobs().await {
             Ok(jobs) => {
                 admission.mark_inventory_ready();
+                // The non-reconciler path (in-process runtime, or a warmer with
+                // no workload inventory) still proves the inventory, so it is
+                // still a completed pass by the only definition this signal has.
+                admission.note_reconcile_success();
                 admission.publish_metrics().await;
                 tracing::info!(
                     mode = ?admission.mode(),
@@ -2559,6 +2584,36 @@ impl AppState {
         // `TopologyPending` (and their dispatch subsystems never start).
         self.confirm_build_admission_topology().await;
 
+        // Periodic build-admission reconciliation. THE ORDER OF THESE TWO
+        // STATEMENTS IS LOAD-BEARING and this loop is deliberately the very
+        // first thing started after the gate above.
+        //
+        // The line above opens the topology gate, which is the last gate
+        // standing between this process and admitting work for the whole
+        // board. This spawn used to sit ~90 lines lower, behind roughly a dozen
+        // AWAITED initializers (a Zot preflight that can `exit(1)`, a stale
+        // session sweep, a pricing backfill, the coordinator itself). A hang or
+        // panic in ANY of them produced a fully-admitting leader with no
+        // reconciler — silently, forever — and because
+        // `leadership::run_with_leadership` awaits `on_acquire()` inline, the
+        // advisory-lock liveness ping stopped too. Admission open and
+        // reclamation absent is precisely the combination that halts the board.
+        //
+        // Spawning this early is safe because the loop SUPPRESSES ITS OWN FIRST
+        // TICK (see `build_admission_reconcile::run_loop`): `initialize()` runs
+        // a full reconciliation pass on every pod before leadership is even
+        // contested, and `confirm_build_admission_topology` can run another via
+        // the handoff path, so the first real pass is one cadence away either
+        // way. Moving the spawn earlier only shortens the window in which a
+        // pass has just run — it cannot create a duplicate one.
+        //
+        // The startup pass alone cannot reclaim an occupying row that has not
+        // yet settled past the reclaim settle window, and a rolling deploy is
+        // precisely what creates such a row seconds before the successor's only
+        // pass runs. Writes the durable journal, so leader-only for the same
+        // reason as the loops below.
+        crate::build_admission_reconcile::spawn(self.clone());
+
         // Observe-only disk dimension (proposal nquz). Runs after the topology
         // gate because it writes the shared run-dir ledger and inventories the
         // shared cache PVC — leader-only work. It never mutates the volume and
@@ -2637,14 +2692,10 @@ impl AppState {
         );
         crate::mirror_fetcher::spawn(self.clone());
 
-        // Periodic build-admission reconciliation. The startup pass above
-        // cannot reclaim an occupying row that has not yet settled past the
-        // reclaim settle window — and a rolling deploy is precisely what
-        // creates such a row, seconds before the successor's only pass ran.
-        // Left alone, one `CreateUnknown` row from the outgoing pod fails
-        // every admission closed until the next restart. Writes the durable
-        // journal, so leader-only for the same reason as the loops above.
-        crate::build_admission_reconcile::spawn(self.clone());
+        // NOTE: `build_admission_reconcile::spawn` deliberately no longer lives
+        // here. It is now the first statement after the topology gate opens, so
+        // no awaited initializer between the two can leave a fully-admitting
+        // leader with no reconciler. See the comment at that call site.
 
         // Standalone SCIP-index driver (leader-only, same reasoning as
         // mirror_fetcher: it creates cluster objects). The real scheduler is
@@ -5112,6 +5163,94 @@ mod build_admission_config_tests {
         assert_eq!(
             seams.volume_id,
             djinn_coordinator::run_dir_observe::volume_id_from_env()
+        );
+    }
+
+    /// L5. A leader must never be able to reach a fully-admitting state with no
+    /// reconciler.
+    ///
+    /// `confirm_build_admission_topology` opens the LAST gate standing between
+    /// this process and admitting work for the whole board. The reconciler
+    /// spawn used to sit ~90 lines further down, behind roughly a dozen awaited
+    /// initializers — one of which can `std::process::exit(1)` and any of which
+    /// can hang or panic. This pins the ordering at the composition site, which
+    /// is the only place the property is expressible: the two statements are
+    /// both fire-and-forget from the type system's point of view.
+    #[test]
+    fn the_reconciler_is_spawned_immediately_after_the_topology_gate_opens() {
+        let source = include_str!("mod.rs");
+        // Assembled at runtime so these assertions do not match their own
+        // literals inside the file they read.
+        let topology = format!("self.confirm_build_admission_{}().await", "topology");
+        let spawn = format!(
+            "crate::build_admission_reconcile::{}(self.clone())",
+            "spawn"
+        );
+        assert_eq!(
+            source.matches(spawn.as_str()).count(),
+            1,
+            "exactly one production spawn site"
+        );
+
+        let leader = source
+            .find("pub async fn become_leader")
+            .expect("become_leader exists");
+        let gate = source[leader..]
+            .find(topology.as_str())
+            .expect("become_leader opens the topology gate");
+        let spawned = source[leader..]
+            .find(spawn.as_str())
+            .expect("become_leader spawns the reconciler");
+        assert!(
+            spawned > gate,
+            "the reconciler must be spawned AFTER leadership is confirmed"
+        );
+
+        // Nothing may be awaited between the two. An `.await` there is exactly
+        // the hazard: it can hang or panic, and the leader is already admitting.
+        let between = &source[leader + gate + topology.len()..leader + spawned];
+        assert!(
+            !between.contains(".await"),
+            "no awaited initializer may sit between the topology gate opening and \
+             the reconciler spawn; found: {between}"
+        );
+
+        // And it must precede the heavyweight leader initializers it used to
+        // sit behind — including the one that can terminate the process.
+        for later in [
+            "run_zot_retention_preflight",
+            "interrupt_stale_sessions_on_startup",
+            "self.initialize_agents().await",
+        ] {
+            let position = source[leader..]
+                .find(later)
+                .unwrap_or_else(|| panic!("{later} is part of become_leader"));
+            assert!(
+                spawned < position,
+                "the reconciler must be spawned before {later}"
+            );
+        }
+    }
+
+    /// L6. `begin_draining` has no clearing path on the production shutdown
+    /// path by design, so its single caller must genuinely be shutdown. Pins the
+    /// convention that used to be the only thing making the latch safe.
+    #[test]
+    fn draining_is_begun_only_after_the_http_server_has_stopped() {
+        let main_source = include_str!("../../main.rs");
+        let call = format!("begin_build_admission_{}().await", "draining");
+        assert_eq!(
+            main_source.matches(call.as_str()).count(),
+            1,
+            "exactly one production drain caller"
+        );
+        let serve = main_source
+            .find("server::run(router")
+            .expect("main serves HTTP");
+        let drain = main_source.find(call.as_str()).expect("main drains");
+        assert!(
+            drain > serve,
+            "draining may only begin after the HTTP server future has resolved"
         );
     }
 


### PR DESCRIPTION
Companion to #2746. That PR fixes the defect that halted the board for 5 hours on 2026-07-29; this one fixes the reasons the recovery machinery could not heal it, could not be supervised, and could not be seen. The two branches merge cleanly (verified with `git merge-tree`).

Motivating audit finding: **nothing anywhere asserted that a reconciliation pass had completed within the last N seconds.** That single missing signal is what turned a 5-minute event into a 5-hour one.

## Timeouts and supervision (the reconcile loop could die or hang silently)

`build_admission_reconcile::spawn` was a bare `tokio::spawn` with the `JoinHandle` dropped — a panic killed reconciliation permanently, with no log and no restart — and its exit was logged at `debug!` only. `KubeWorkloadInventory` had **no client-side timeout**, so one hung API call parked the loop forever while the process looked healthy.

- `workload_inventory`: `list` / `get_uid` / `presence` now run under a bounded budget (`DJINN_K8S_WORKLOAD_INVENTORY_TIMEOUT_SECS`, default 30s, clamped 5–300). Expiry maps onto each method's existing "could not establish this" answer (`Err` / `Uncertain`) — **never onto proof of absence**, which would license a wrong reclaim.
- `build_admission_reconcile`: each pass is now a supervised child task under `DJINN_..._PASS_TIMEOUT_SECS` (default 300s). Panics are contained and logged at `error!`, overruns are aborted, the loop restarts up to 8× if supervision itself dies, and every exit path logs at `warn!`/`error!`.

## A leader could admit work with no reconciler

`become_leader` opened the topology gate — the last gate between the process and admitting work — and only spawned the reconcile loop about a dozen awaited initializers later. A hang or panic in any of them yielded a fully-admitting leader with nothing reconciling, silently, forever; and because `run_with_leadership` awaits `on_acquire()` inline, the advisory-lock liveness ping stopped too.

The spawn is now the first statement after the gate opens. The loop already suppresses its own first tick because `become_leader` runs a pass of its own, so this is safe. A test pins the ordering against the source itself so it cannot silently regress.

## Gates that could never fall

- **`ShutdownDraining` was an absolute latch** — `begin_draining` set it and *nothing anywhere* cleared it. Added `end_draining()`; `mark_ready()` now clears it, `require_enforcement()` deliberately does not.
- **`over_cap` could not fall on its own**: its downward edge required a durable terminal transition, which a total denial starves of input. `publish_metrics` already computed the correct value every pass and discarded it into telemetry. New `refresh_over_cap_gate()` re-derives the gate — placed **above** the `process_metrics_enabled` early return, because this is admission state, not telemetry. A readable authority moves the gate both ways; an unreadable one leaves it exactly as it was.

## Naming the row, not just counting it

No `build_admission` log line ever named the offending row — only counts. An operator could see that ONE row was wedging the board with no way to learn which. The sibling `build_lease_reclaim` already does this properly (`identity=dispatch:…`, `proof=…`).

`blocking_identity()` now yields `{domain}:{work_id}:{generation}@{object_name}`, captured on the same edge that sets `create_unknown_pending` and dropped on the same edge that decrements it. An edge-triggered `report_readiness_edge()` logs the reason plus the named rows at `error!`, bounded to 16 with an elided count.

## A doctor check for a latched gate

New `build_admission_health`, registered from `CoordinatorActor::new` alongside `stranded_ready`. Fires when the controller has been non-`Healthy` beyond a bounded window, or when the last successful reconcile is too old, and reports the exact readiness reason and the responsible row identities.

**On whether the check can actually observe process-local state** (a real risk of shipping a check that silently always passes): it can, structurally. The registry is built by `CoordinatorActor::new` → `initialize_agents` → `become_leader` only, so the registry containing this check *is* the leader's, and `CoordinatorDeps.build_admission` is the same `Arc` the leader admits through. A standby never registers the check, so it reads as "not registered" rather than as a passing check. No durable signal was needed and none was added. Documented in the module header, including the consequence: `create_unknown_pending` is separately derivable from SQL, but the other readiness variants remain unobservable from a standby.

This reaches operators through `doctor_run` / `doctor_list_findings` and the coordinator's cheap leader tick — deliberately not only through the gauge, since **no metrics stack is deployed on the target cluster** (verified: no Prometheus, no ServiceMonitor CRD, no Grafana).

New gauge `djinn_build_admission_seconds_since_reconcile` (−1 = never), stamped from the two branches that know a pass *succeeded* rather than merely ran.

## Tests

Fail-before verified by reverting each fix in place and running — not asserted. 10 tests failed as expected; 2 (`a_hanging_pass_is_abandoned_and_the_loop_keeps_ticking`, `a_call_that_never_answers_is_cut_off`) **hung forever**, which is precisely the pre-fix behaviour.

Three tests do **not** fail before and are labelled regression pins rather than fix proofs: `require_enforcement_does_not_clear_the_draining_latch`, `the_first_immediate_tick_is_suppressed`, `draining_is_begun_only_after_the_http_server_has_stopped`. No existing test was weakened or deleted.

```
cargo test -p djinn-k8s --lib          → 287 passed
cargo test -p djinn-telemetry          → 5 passed
cargo test -p djinn-server --lib       → 629 passed, 2 ignored
cargo test -p djinn-coordinator --lib doctor::build_admission_health → 14 passed
cargo clippy (4 crates, --lib --tests) → clean
```

`cargo test -p djinn-coordinator --lib` reports 2072 passed / 4 failed. Confirmed pre-existing by stashing and re-running on baseline: the suite stack-overflows without `RUST_MIN_STACK=33554432`, and `session_reaping::*` fails on baseline too via a process-global metrics-registry collision (`unexpected source label in djinn_dispatch_strike_decisions_total`). Two further `wave::tests` failures pass in isolation (120 passed) and are downstream of a `Tokio 1.x context being shutdown` panic — believed the same collision class but **not proven**, so flagged as unverified rather than dismissed. This matches the known process-global flake in this suite; CI uses nextest (process-per-test).

## Reviewer attention

1. `refresh_over_cap_gate` calls `authority.occupancy()` on every `publish_metrics`, including when process metrics are disabled (previously it did not, e.g. in test builds). An extra DB read on a warm path — deliberate, because the gate must not be switchable off by a telemetry flag, but it is a real behaviour change.
2. `mark_ready()` clearing `draining` touches a shared helper used by ~25 existing tests. All pass, but it is broader than `end_draining()` alone.
3. Cancellation now logs at `warn!` — one line per graceful shutdown. Judged worth it: "reconciliation has stopped" matters even when expected.
4. Doctor thresholds are compile-time constants (300/900/1800s wedge, 900s reconcile-stale), unlike the loop cadence which is env-tunable.
5. `MAX_LOOP_RESTARTS = 8`; exhausting it logs `error!` and leaves the process with no reconciler — the reconcile-age finding then fires.

## Open finding — reported, not fixed

`AppState::initialize()` runs the **full mutating** reconciler on **every pod including standbys**, contradicting the single-active-writer rationale documented in `build_admission_reconcile.rs`. Concretely, adoption writes `creator_server_epoch: self.controller.server_epoch()`, so a standby's startup pass re-stamps ownership of live rows to its own epoch — and that field is the very fence that shields a process's in-flight work from reclamation.

Partial mitigation verified: reclamation requires three independent conditions (settle window, absence from the LIST, and a separate direct GET returning authoritative `Absent`), so a standby cannot reclaim a live row. All interleavings of concurrent epoch re-stamping could not be ruled out, and the adoption/reclamation branches belong to #2746, so this is deliberately left alone and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
