### PR TITLE
fix(coordinator): stop convicting every rejecting reviewer of a protocol violation

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/liveness.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/liveness.rs
@@ -132,6 +132,12 @@ impl DbTaskStatus {
     /// `Open` and `InProgress` are NOT settled: a pod that exits while the task
     /// is still queued or still claimed left nothing behind, which is the
     /// genuine inconsistency this detector is for.
+    ///
+    /// Status alone is not the whole test, though. `Open` is ALSO where a
+    /// reviewer's rejection parks a task (`TransitionAction::TaskReviewReject`),
+    /// so [`classify`] additionally consults
+    /// [`LivenessEvidence::handed_off_from_session_held_status`] before
+    /// convicting — see the precedence-3 comment there.
     pub fn is_settled(&self) -> bool {
         matches!(
             self,
@@ -179,6 +185,38 @@ pub struct LivenessEvidence {
     /// (code 0) from nonzero exit. `None` when the pod is still running or
     /// absent.
     pub exit_code: Option<i32>,
+    /// Positive evidence that the task was **handed off** by a live session:
+    /// its most recent recorded status transition moved it OUT of a status that
+    /// only a running session holds (see [`is_session_held_status`]).
+    ///
+    /// A task can sit on a non-settled status (`open` / `in_progress`) for two
+    /// opposite reasons, and the status alone cannot tell them apart:
+    ///
+    /// * `in_task_review → open` — a reviewer explicitly rejected and queued the
+    ///   task for rework. The reviewer completed its protocol exactly as
+    ///   designed; the task is dispatchable and nothing is stranded.
+    /// * `open → in_progress` (and then nothing) — a worker claimed the task and
+    ///   exited without ever handing it on. The task now claims to be in
+    ///   progress with no session behind it: genuinely stranded.
+    ///
+    /// `true` exonerates: some session deliberately moved the task off an
+    /// active status. `false` is the fail-safe default and preserves the
+    /// pre-existing verdict.
+    #[serde(default)]
+    pub handed_off_from_session_held_status: bool,
+}
+
+/// Whether `status` is one that only a LIVE session holds.
+///
+/// These are the statuses whose meaning is "a session is working on this right
+/// now". A transition OUT of one of them is a session's deliberate handoff; a
+/// transition INTO one is a claim, which proves nothing about how the session
+/// ended.
+pub fn is_session_held_status(status: &str) -> bool {
+    matches!(
+        status,
+        "in_progress" | "in_task_review" | "in_lead_intervention"
+    )
 }
 
 // ─── Stable outcome kinds ───────────────────────────────────────────────────
@@ -339,8 +377,9 @@ pub struct ClassificationResult {
 /// 2. **Hard runtime cap exceeded** → `Dead` with `Timeout` outcome (forbids
 ///    extension)
 /// 3. **Protocol violation** → inconsistent clean/nonzero exit on a task that
-///    is positively known to be unsettled (still `open`/`in_progress`) with a
-///    session row positively known to still be running
+///    is positively known to be unsettled (still `open`/`in_progress`), with a
+///    session row positively known to still be running, and with no evidence
+///    that a session deliberately handed the task off to that status
 /// 4. **Dead** → absent/failed pod with no recent activity
 /// 5. **Slow** → activity signal absent/idle, pod running, below hard cap
 /// 6. **Live** → default when other conditions don't match
@@ -401,7 +440,16 @@ pub fn classify(evidence: &LivenessEvidence) -> ClassificationResult {
         .as_ref()
         .is_some_and(|s| !s.is_settled());
 
-    if pod_exited && session_nonterminal && task_unsettled {
+    // A non-settled status is not by itself evidence of abandonment. The task's
+    // own transition record decides: if the last status change moved the task
+    // OUT of a session-held status, a session handed it on deliberately
+    // (`in_task_review → open` is the reviewer-rejection path, which the
+    // supervisor drives on EVERY explicit reject verdict — see
+    // `TransitionAction::TaskReviewReject`). Only a task left sitting where its
+    // session found it — claimed and unmoved — is genuinely stranded.
+    let handed_off = evidence.handed_off_from_session_held_status;
+
+    if pod_exited && session_nonterminal && task_unsettled && !handed_off {
         // Classify the type of protocol violation based on exit code
         let reason = match evidence.exit_code {
             Some(0) => LivenessReason::CleanExitNonterminal,
@@ -520,6 +568,8 @@ mod tests {
             extension_budget_exhausted: false,
             hard_runtime_deadline_exceeded: false,
             exit_code: None,
+
+            handed_off_from_session_held_status: false,
         }
     }
 
@@ -892,6 +942,54 @@ mod tests {
             let result = classify(&crashed);
             assert_eq!(result.verdict, Verdict::ProtocolViolation, "{status:?}");
             assert_eq!(result.outcome, Some(LivenessOutcome::Crash));
+        }
+    }
+
+    /// A non-settled status is ambiguous on its own. The task's own transition
+    /// record disambiguates: a last transition OUT of a session-held status
+    /// means a live session put the task there deliberately (the reviewer
+    /// rejection path, `in_task_review → open`), so the exiting session
+    /// completed its protocol and must NOT be convicted.
+    #[test]
+    fn handoff_off_a_session_held_status_exonerates_an_unsettled_task() {
+        for status in [DbTaskStatus::Open, DbTaskStatus::InProgress] {
+            let mut ev = live_evidence();
+            ev.pod_phase = Some(PodPhase::Succeeded);
+            ev.exit_code = Some(0);
+            ev.db_session_status = Some(DbSessionStatus::Running);
+            ev.db_task_status = Some(status);
+            ev.handed_off_from_session_held_status = true;
+
+            let result = classify(&ev);
+            assert_ne!(
+                result.verdict,
+                Verdict::ProtocolViolation,
+                "{status:?} reached by a deliberate handoff is not a violation"
+            );
+            assert_ne!(result.reason, Some(LivenessReason::CleanExitNonterminal));
+        }
+    }
+
+    /// The statuses that only a live session holds. A transition OUT of one of
+    /// these is a handoff; a transition INTO one is just a claim.
+    #[test]
+    fn session_held_statuses_are_the_active_ones() {
+        for held in ["in_progress", "in_task_review", "in_lead_intervention"] {
+            assert!(is_session_held_status(held), "{held} is session-held");
+        }
+        for not_held in [
+            "open",
+            "needs_task_review",
+            "approved",
+            "pr_draft",
+            "pr_review",
+            "needs_lead_intervention",
+            "closed",
+        ] {
+            assert!(
+                !is_session_held_status(not_held),
+                "{not_held} is not session-held"
+            );
         }
     }
 

--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -2909,6 +2909,15 @@ fn build_liveness_evidence(
     // extension quantum and breaking the "past-lease → kill now" contract.
     let extension_budget_exhausted = claim_ttl_remaining.map(|t| t.is_zero()).unwrap_or(false);
 
+    // ── Handoff evidence ─────────────────────────────────────────────
+    // The task's last recorded transition moved it OUT of a session-held
+    // status, so a live session put it where it is now. See
+    // `LivenessEvidence::handed_off_from_session_held_status`.
+    let handed_off_from_session_held_status = db_state
+        .last_transition_from_status
+        .as_deref()
+        .is_some_and(super::liveness::is_session_held_status);
+
     LivenessEvidence {
         pod_phase: Some(pod_phase),
         activity,
@@ -2918,6 +2927,7 @@ fn build_liveness_evidence(
         extension_budget_exhausted,
         hard_runtime_deadline_exceeded,
         exit_code: None,
+        handed_off_from_session_held_status,
     }
 }
 
@@ -3071,6 +3081,8 @@ mod liveness_foundation_tests {
             session_started_at: Some(ts.clone()),
             task_run_started_at: Some(ts),
             task_run_ended_at: None,
+
+            last_transition_from_status: None,
         }
     }
 
@@ -3209,6 +3221,8 @@ mod liveness_foundation_tests {
             extension_budget_exhausted: false,
             hard_runtime_deadline_exceeded: false,
             exit_code: Some(0),
+
+            handed_off_from_session_held_status: false,
         };
 
         let result = super::super::liveness::classify(&evidence);
@@ -3238,6 +3252,8 @@ mod liveness_foundation_tests {
             extension_budget_exhausted: false,
             hard_runtime_deadline_exceeded: false,
             exit_code: Some(137),
+
+            handed_off_from_session_held_status: false,
         };
 
         let result = super::super::liveness::classify(&evidence);
@@ -3375,6 +3391,8 @@ mod liveness_foundation_tests {
             session_started_at: None,
             task_run_started_at: None,
             task_run_ended_at: None,
+
+            last_transition_from_status: None,
         };
 
         let evidence = build_liveness_evidence(None, &db);
@@ -3433,6 +3451,8 @@ mod liveness_foundation_tests {
             extension_budget_exhausted: true,
             hard_runtime_deadline_exceeded: false,
             exit_code: None,
+
+            handed_off_from_session_held_status: false,
         };
 
         let result = super::super::liveness::classify(&evidence);
@@ -3676,6 +3696,8 @@ mod session_exit_protocol_violation_tests {
             session_started_at: Some(ts.clone()),
             task_run_started_at: Some(ts),
             task_run_ended_at: None,
+
+            last_transition_from_status: None,
         }
     }
 
@@ -3701,6 +3723,8 @@ mod session_exit_protocol_violation_tests {
             session_started_at: Some(ts.clone()),
             task_run_started_at: Some(ts),
             task_run_ended_at: None,
+
+            last_transition_from_status: None,
         }
     }
 
@@ -4039,6 +4063,8 @@ mod restart_amnesia_tests {
             session_started_at: Some(iso(now - TimeDuration::seconds(session_age_secs))),
             task_run_started_at: Some(iso(now - TimeDuration::seconds(task_run_age_secs))),
             task_run_ended_at: None,
+
+            last_transition_from_status: None,
         }
     }
 

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -3899,6 +3899,184 @@ async fn nonzero_exit_is_crash_outcome_distinct_from_clean_violation() {
     assert_eq!(outcome_kind.as_deref(), Some("crash"));
 }
 
+/// A reviewer that REJECTS is not a protocol violator.
+///
+/// `TransitionAction::TaskReviewReject` deliberately lands the task at `open`
+/// (djinn-core `task.rs`), and the supervisor fires it the moment a reviewer
+/// returns an explicit reject verdict. The reviewer process then exits 0 and its
+/// session settles `completed`. Classifying that exit purely on "is the task
+/// status settled?" convicts the reviewer of `clean_exit_nonterminal` for doing
+/// exactly what the protocol asks — the task is queued for rework, not stranded.
+///
+/// The discriminator is the task's own transition record: the last status change
+/// moved it OUT of `in_task_review`, a status only a live session holds. A
+/// session that leaves such a trace handed the task on.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reviewer_reject_exit_is_not_a_protocol_violation() {
+    use djinn_core::models::TransitionAction;
+    use djinn_db::{CreateSessionParams, SessionRepository};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "reviewer-reject-exit").await;
+
+    let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    // Walk the task to the reviewer's own active status.
+    task_repo
+        .set_status(&task.id, "in_task_review")
+        .await
+        .unwrap();
+
+    let run_id = "run-reviewer-reject";
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "reviewer",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+
+    // The reviewer rejects: the supervisor drives the real state-machine
+    // transition, which lands the task at `open` and records the transition.
+    let rejected = task_repo
+        .transition(
+            &task.id,
+            TransitionAction::TaskReviewReject,
+            "supervisor",
+            "system",
+            Some("acceptance criterion 2 is not covered by a test"),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rejected.status, "open",
+        "task_review_reject must land the task at open (rework queue)"
+    );
+
+    let actor = coordinator_actor_for_tests(&db, &tx);
+    let result = actor
+        .classify_session_exit_liveness(
+            &session.id,
+            &task.id,
+            Some(run_id),
+            "completed",
+            "reviewer",
+        )
+        .await
+        .expect("classification must succeed");
+
+    assert_ne!(
+        result.verdict,
+        crate::dispatch::liveness::Verdict::ProtocolViolation,
+        "a reviewer that rejected and handed the task back to the rework queue \
+         must not be classified as a protocol violation"
+    );
+    assert_ne!(
+        result.reason,
+        Some(crate::dispatch::liveness::LivenessReason::CleanExitNonterminal),
+        "reviewer rejection must not be labelled clean_exit_nonterminal"
+    );
+
+    // And nothing may be persisted under the protocol-violation verdict.
+    let liveness_repo = djinn_db::LivenessRepository::new(db.clone());
+    let (verdict, _outcome_kind) = liveness_repo
+        .get_session_liveness_fields(&session.id)
+        .await
+        .unwrap();
+    assert_ne!(
+        verdict.as_deref(),
+        Some("protocol_violation"),
+        "persisted verdict must not be protocol_violation for a rejecting reviewer"
+    );
+}
+
+/// A worker that exits cleanly while its task is still `in_progress` IS a
+/// protocol violation: the task is left claimed by a session that no longer
+/// exists, invisible to dispatch until the recovery scan releases it. This is
+/// the case the detector exists for, and the reviewer-reject exoneration above
+/// must not weaken it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn worker_clean_exit_at_in_progress_is_still_a_protocol_violation() {
+    use djinn_db::{CreateSessionParams, SessionRepository};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "worker-stranded-exit").await;
+
+    let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    // Dispatch claim: `open -> in_progress`. The last recorded status change
+    // moves the task INTO an active status, not out of one.
+    task_repo.set_status(&task.id, "in_progress").await.unwrap();
+
+    let run_id = "run-worker-stranded";
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+
+    let actor = coordinator_actor_for_tests(&db, &tx);
+    let result = actor
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed", "worker")
+        .await
+        .expect("classification must succeed");
+
+    assert_eq!(
+        result.verdict,
+        crate::dispatch::liveness::Verdict::ProtocolViolation,
+        "a worker that exits 0 leaving its task in_progress is still a violation"
+    );
+    assert_eq!(
+        result.reason,
+        Some(crate::dispatch::liveness::LivenessReason::CleanExitNonterminal),
+    );
+}
+
 /// AC 4: Already-terminal race — calling `classify_session_exit_liveness` for
 /// a task that is already closed produces `KillNoop` outcome (not protocol
 /// violation). Terminal state is preserved; only metadata is attached.
@@ -4267,6 +4445,8 @@ fn hard_cap_takes_precedence_over_slow_extension_eligible() {
         extension_budget_exhausted: false,
         hard_runtime_deadline_exceeded: true,
         exit_code: None,
+
+        handed_off_from_session_held_status: false,
     };
 
     let result = classify(&evidence);
@@ -4309,6 +4489,8 @@ fn absent_pod_with_active_activity_is_not_dead() {
         extension_budget_exhausted: false,
         hard_runtime_deadline_exceeded: false,
         exit_code: None,
+
+        handed_off_from_session_held_status: false,
     };
 
     let result = classify(&evidence);
@@ -4340,6 +4522,8 @@ fn running_pod_active_signal_is_live_regardless_of_claim_ttl() {
         extension_budget_exhausted: false,
         hard_runtime_deadline_exceeded: false,
         exit_code: None,
+
+        handed_off_from_session_held_status: false,
     };
 
     let result = classify(&evidence);
@@ -4371,6 +4555,8 @@ fn pending_pod_capacity_crunch_spared_by_classifier() {
         extension_budget_exhausted: false,
         hard_runtime_deadline_exceeded: false,
         exit_code: None,
+
+        handed_off_from_session_held_status: false,
     };
 
     let result = classify(&evidence);
@@ -4404,6 +4590,8 @@ fn pending_pod_past_hard_cap_still_not_dead() {
         extension_budget_exhausted: true,
         hard_runtime_deadline_exceeded: true,
         exit_code: None,
+
+        handed_off_from_session_held_status: false,
     };
 
     // Even with hard_runtime_deadline_exceeded, the classifier applies the
@@ -4418,6 +4606,8 @@ fn pending_pod_past_hard_cap_still_not_dead() {
         extension_budget_exhausted: true,
         hard_runtime_deadline_exceeded: false,
         exit_code: None,
+
+        handed_off_from_session_held_status: false,
     };
     let result = classify(&evidence_no_hard_cap);
     assert_ne!(

--- a/server/crates/djinn-db/src/repositories/liveness.rs
+++ b/server/crates/djinn-db/src/repositories/liveness.rs
@@ -114,6 +114,17 @@ pub struct CurrentLivenessState {
     pub task_run_started_at: Option<String>,
     /// ISO-8601 UTC `ended_at` of the latest task_run (if terminal).
     pub task_run_ended_at: Option<String>,
+    /// `from_status` of the task's MOST RECENT recorded status transition, i.e.
+    /// the status the task was in immediately before it reached
+    /// [`Self::task_status`]. `None` when the task has no recorded transition.
+    ///
+    /// This is the only durable signal that distinguishes a session which
+    /// deliberately handed its task on from one that left the task exactly where
+    /// it found it. A reviewer that rejects moves the task
+    /// `in_task_review → open`; a worker that strands its task moves it
+    /// `open → in_progress` and then leaves it there. Both end on a non-settled
+    /// status, and only this field tells them apart.
+    pub last_transition_from_status: Option<String>,
 }
 
 // ─── Repository ─────────────────────────────────────────────────────────────
@@ -343,6 +354,28 @@ impl LivenessRepository {
             (None, None, None)
         };
 
+        // 6. Load the `from_status` of the task's most recent status transition.
+        //
+        // `TaskRepository::transition` and `set_status` both write an
+        // `activity_log` row whose payload carries `from_status`/`to_status`;
+        // `adoption_handoff` is the one transition that uses a different
+        // `event_type` for the same payload shape. `created_at` is a
+        // millisecond-resolution ISO-8601 string (lexicographic order == time
+        // order); the uuid-v7 `id` breaks ties inside the same millisecond.
+        let last_transition_from_status: Option<String> = sqlx::query_scalar(
+            "SELECT payload->>'from_status'
+                 FROM activity_log
+                 WHERE task_id = $1
+                   AND event_type IN ('status_changed', 'adoption_handoff')
+                   AND payload->>'from_status' IS NOT NULL
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT 1",
+        )
+        .bind(task_id)
+        .fetch_optional(self.db.pool())
+        .await?
+        .flatten();
+
         Ok(CurrentLivenessState {
             task_status,
             task_is_terminal,
@@ -361,6 +394,7 @@ impl LivenessRepository {
             session_started_at,
             task_run_started_at,
             task_run_ended_at,
+            last_transition_from_status,
         })
     }
 


### PR DESCRIPTION
`board_health` reported that **12 of 25** recent sessions ended as `protocol_violation` with `outcome_kind: "success"` and `outcome_reason: "clean_exit_nonterminal"`. Roughly half the fleet's sessions were being convicted of a protocol breach. Most of them had done nothing wrong.

## The mechanism

`dispatch/liveness.rs:404` is the only site that returns `Verdict::ProtocolViolation`. Its predicate was:

```
pod_exited(Succeeded|Failed) && session_nonterminal && task_unsettled
```

where "unsettled" (`:135`) means anything except `Open` and `InProgress`.

But a reviewer that **rejects** hands the task back to the rework queue, and that lands it on `Open`:

- `TransitionAction::TaskReviewReject` / `RejectStale` / `RejectConflict` → `TaskStatus::Open` (`djinn-core/src/models/task.rs:1227, 1240, 1253`)
- the supervisor fires it on every explicit reject verdict (`djinn-agent/src/supervisor_impl/stage.rs:316, 384`)
- the reviewer then exits 0 → session `completed` → classifier sees `open` → convicts

Same shape for `Release` (`in_progress → open`, `task.rs:1300`) and the arbiter park. `is_settled` was already narrowed once by #2634 to stop firing on review/PR/intervention boundaries; the rework queue is the one handoff destination that narrowing missed, because it shares `open` with the genuinely-stranded case.

**The label is shared by unrelated causes** — that is itself the finding. `clean_exit_nonterminal` currently covers at least three disjoint things: reviewer rework handoffs (false), worker releases (false), and workers exiting at `in_progress` (true, and deliberately still convicted after this change).

## The report was also hiding the evidence

`board_health`'s `protocol_violations` section `LEFT JOIN tasks` **live** (`djinn-db/.../board_health.rs:184`), so `task_status` is the status *now*, not at classification time. The evidence-time status sits unexposed in `le.evidence->>'db_task_status'`. That is why several of these read as "closed anyway" — they were `open` when classified and were closed by later work, which makes the report look like it is describing something other than what it convicted.

## The fix

Conviction now additionally requires that the session did **not** hand the task off out of a status it held:

- `djinn-db/src/repositories/liveness.rs` — `CurrentLivenessState.last_transition_from_status`, read from `activity_log` (`event_type IN ('status_changed','adoption_handoff')`, ordered `created_at DESC, id DESC`)
- `dispatch/liveness.rs` — new evidence field `handed_off_from_session_held_status` plus `is_session_held_status()` (`in_progress`, `in_task_review`, `in_lead_intervention`); the predicate at `:452` gains `&& !handed_off`
- `dispatch/session_recovery.rs` — wiring in `build_liveness_evidence`

The discriminator is deliberately **timestamp-free** — it asks whether the last transition was *out of* a session-held status rather than *into* one — so it cannot race with the dispatch claim that happens around session creation.

## Blast radius of the old behaviour: it labelled, it did not cause

Worth stating plainly, because it changes how alarming this is. `classify_session_exit_liveness` step 6 (`session_recovery.rs:2722`) terminalizes an attempt only for `failed`/`interrupted`; a `completed` exit is logged as "evidence only — no attempt accounting" (`:2674-2677`). The only other consumer (`session_recovery.rs:808`) is on the stall path where `pod_phase` is `Running`, so the violation branch is unreachable there. Nothing else in `server/` or `ui/` reads `liveness_verdict` / `liveness_outcome_kind` for gating.

So there was **no** quality strike, no reopen bump, no dispatch backoff, no model-health effect. Task `0n0q`'s reopen loop was caused by the reviewer rejections themselves (`TaskReviewReject` sets `increment_reopen: true`, `task.rs:1228-1229`); the violation verdict merely stood next to it. What was actually lost is the signal — at roughly 50% false positives, real stranded-worker exits were invisible.

## Tests

Proven by running against unmodified code, not asserted. Baseline:

```
thread 'tests::session_reaping::reviewer_reject_exit_is_not_a_protocol_violation' panicked:
assertion `left != right` failed: a reviewer that rejected and handed the task back
to the rework queue must not be classified as a protocol violation
  left: ProtocolViolation
 right: ProtocolViolation
```

Two DB-backed tests plus two pure-classifier tests. One deliberately pins that a worker exiting at `in_progress` is **still** convicted, so the exoneration cannot widen into a blanket amnesty.

```
cargo nextest run -p djinn-coordinator --lib -E 'test(reviewer_reject...) or test(worker_clean_exit...)'
  BEFORE: 1 passed, 1 failed        AFTER: 2 passed
cargo nextest run -p djinn-coordinator --lib   → 2058 passed, 0 skipped
cargo nextest run -p djinn-db                   → 1559 passed, 2 skipped
cargo clippy -p djinn-coordinator -p djinn-db --all-targets → clean
```

## Follow-ups, deliberately not in this PR

1. **`board_health` should expose the evidence-time status** (`le.evidence->>'db_task_status'`) and the session's `agent_type` in `protocol_violations_section` (`board_health.rs:176`). Left out here because it changes the typed `BoardHealthProtocolViolations` in `djinn-control-plane/.../types.rs:991` and risks the tool-schema golden fanout, which must regenerate every derived artifact in one commit.
2. **The `in_task_review` exoneration from #2634 may be too wide.** `stage.rs:322-326` says a no-verdict reviewer intentionally leaves the task at `in_task_review` for the recovery scan to release — that *is* a stranded task, and `is_settled` now excuses it. It reaches the classifier as `failed` rather than `completed`, so it is outside this defect, but it deserves its own look.

The exact split of the 12 between the reviewer-reject class and genuine strandings cannot be determined from the current report, precisely because of follow-up 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
