### PR TITLE
fix(admission): record the real Kubernetes Job name for a task-run going live

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -2100,15 +2100,18 @@ impl BuildAdmissionController {
                 .await
                 .map(|_| ())
                 .map_err(unavailable),
-            WarmAdmissionTransition::Live { uid } => self
-                .journal
-                .mark_live(&UidFencedAdmissionInput {
-                    key: state.key.clone(),
-                    object_uid: uid,
-                })
-                .await
-                .map(|_| ())
-                .map_err(unavailable),
+            WarmAdmissionTransition::Live { uid } => {
+                let object_name = live_object_name(&state.key, &uid);
+                self.journal
+                    .mark_live(&UidFencedAdmissionInput {
+                        key: state.key.clone(),
+                        object_uid: uid,
+                        object_name,
+                    })
+                    .await
+                    .map(|_| ())
+                    .map_err(unavailable)
+            }
             WarmAdmissionTransition::CreateUnknown { .. } => self
                 .journal
                 .mark_create_unknown(&state.key)
@@ -2532,6 +2535,43 @@ fn unavailable(error: impl std::fmt::Display) -> WarmAdmissionError {
 
 fn permit_key(key: &AdmissionJournalKey) -> String {
     admission_generation_key(key)
+}
+
+/// The Kubernetes object name a generation going Live must be judged against,
+/// when its reservation could not have known it.
+///
+/// # Why `task_observation` is the only domain that needs this
+///
+/// A warm or invocation reservation commits to a deterministic object name
+/// BEFORE the POST — `mark_create_started` fences on exactly that name — so its
+/// row already carries the truth and `None` leaves it untouched.
+///
+/// A task-run reservation cannot. The dispatch slot is acquired before the
+/// task-run exists, so the row records the provisional
+/// `task-run-{task_id}-{generation}` while the Job the dispatch goes on to
+/// create is `djinn-taskrun-{task_run_id}`. Nothing ever rewrote it, and the
+/// consequence is not a cosmetic mismatch: it makes every Kubernetes clause the
+/// reconciler evaluates about a task row VACUOUS. The authoritative LIST can
+/// never contain that name, and a GET on it is an authoritative `Ok(None)` —
+/// `NotFound`, the same answer a genuinely deleted Job gives. So the `Live`
+/// branch of `BuildAdmissionReconciler` proved a running task-run's object
+/// absent and retired its row, and `BuildLeaseReclaimer` — for which
+/// `generation_state == Terminal` is the ONE proof that a dispatch lease is
+/// ownerless — then handed that still-running task-run's build slot to another
+/// task.
+///
+/// `uid` is the `task_run_id` here, not a Kubernetes UID: the whole
+/// `task_observation` domain is keyed on it (`live_task_run_build_admission`,
+/// `terminal_task_run_build_admission`, `task_run_permit_for_runtime_id`), and
+/// `taskrun_job_name` is the same derivation `build_lease_reclaim` uses to name
+/// a task-run's Job from it.
+fn live_object_name(key: &AdmissionJournalKey, uid: &str) -> Option<String> {
+    match key.domain {
+        AdmissionDomain::TaskObservation => {
+            (!uid.trim().is_empty()).then(|| djinn_k8s::taskrun_job_name(uid))
+        }
+        AdmissionDomain::WarmBuild | AdmissionDomain::InvocationBuild => None,
+    }
 }
 
 /// Generation-free identity for one work item. Shares the `{domain:?}:{work_id}:`
@@ -3875,6 +3915,7 @@ mod tests {
                     generation: 0,
                 },
                 object_uid: "uid-live".into(),
+                object_name: None,
             })
             .await
             .unwrap();
@@ -4018,6 +4059,7 @@ mod tests {
                         generation: 0,
                     },
                     object_uid: format!("uid-{work}"),
+                    object_name: None,
                 })
                 .await
                 .unwrap();
@@ -4265,6 +4307,7 @@ mod tests {
                         generation: 0,
                     },
                     object_uid: format!("uid-{work}"),
+                    object_name: None,
                 })
                 .await
                 .unwrap();

--- a/server/crates/djinn-coordinator/src/build_admission_inventory.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory.rs
@@ -8,7 +8,7 @@ use djinn_db::{
 use djinn_k8s::{
     LABEL_ADMISSION_DOMAIN, LABEL_ADMISSION_GENERATION, LABEL_ADMISSION_WORK_ID, ObjectPresence,
     UidGetResult, WorkloadInventory, WorkloadObjectKind, WorkloadRecord,
-    has_canonical_warm_signature,
+    has_canonical_warm_signature, job::LABEL_TASK_RUN_ID,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -189,6 +189,51 @@ fn classify(r: &WorkloadRecord) -> Result<Option<ClassifiedWorkload>, String> {
     }
     Ok(None)
 }
+/// The two facts about a listed object that the `Live` branch's task-run
+/// completion proof needs: whether it has finished, and which task-run it
+/// declares itself to be.
+type ListedTaskRun = (bool, Option<String>);
+
+/// Whether the object this Live task-run row recorded exists, declares itself
+/// to be that exact task-run, and has already finished.
+///
+/// This is a POSITIVE identity match, not an absence of contradiction: the
+/// object listed under the row's name must carry
+/// `djinn.app/task-run-id == row.object_uid`. For a `task_observation` row that
+/// uid IS the `task_run_id` (the whole domain is keyed on it — see
+/// `live_task_run_build_admission`), and the Job the dispatch created stamps
+/// that same id as a label. So this is the task-run's own Job saying it is
+/// over, and it plays exactly the role the UID equality plays for warm.
+///
+/// It deliberately proves nothing about anything else. An object that carries
+/// an admission identity of its own has made a claim about which work item it
+/// belongs to; if that claim is not this row's, it is a different work item and
+/// may not speak for this row — which is what keeps a warm Job's deterministic,
+/// REUSED name from letting a predecessor terminalize a live generation.
+///
+/// Without this, a task-run whose Job has finished but has not yet been deleted
+/// by `ttlSecondsAfterFinished` has no exit for a full hour: the identity-keyed
+/// lookup above misses (a task-run Job carries no admission labels, so
+/// `classify` resolves it to the task-RUN id rather than the row's task id),
+/// and the absence proof cannot be made while the object is still listed. That
+/// hour is held capacity whenever the ordinary terminal callback is gone —
+/// which is every in-flight run across a coordinator restart, because the
+/// successor holds no permit binding for the predecessor's generation.
+fn finished_as_its_own_task_run(
+    row: &AdmissionJournalRow,
+    listed: &HashMap<String, ListedTaskRun>,
+) -> bool {
+    if row.key.domain != AdmissionDomain::TaskObservation {
+        return false;
+    }
+    let Some(task_run_id) = row.object_uid.as_deref() else {
+        return false;
+    };
+    listed
+        .get(&row.object_name)
+        .is_some_and(|(terminal, declared)| *terminal && declared.as_deref() == Some(task_run_id))
+}
+
 pub struct BuildAdmissionReconciler {
     controller: Arc<BuildAdmissionController>,
     inventory: Arc<dyn WorkloadInventory>,
@@ -412,6 +457,16 @@ impl BuildAdmissionReconciler {
         // here is never a reclamation candidate, whatever we could or could not
         // make of that object's labels.
         let listed_names: HashSet<String> = records.iter().map(|r| r.name.clone()).collect();
+        // The same listing indexed by name. See `finished_as_its_own_task_run`.
+        let listed_task_runs: HashMap<String, ListedTaskRun> = records
+            .iter()
+            .map(|r| {
+                (
+                    r.name.clone(),
+                    (r.terminal, r.labels.get(LABEL_TASK_RUN_ID).cloned()),
+                )
+            })
+            .collect();
         for r in records {
             match classify(&r) {
                 Ok(Some(c)) => {
@@ -489,7 +544,7 @@ impl BuildAdmissionReconciler {
                 // reconciliation pass reported them as blockers.
                 let completed = by.get(&id).is_some_and(|c| {
                     c.object.terminal && c.object.uid.as_deref() == row.object_uid.as_deref()
-                });
+                }) || finished_as_its_own_task_run(row, &listed_task_runs);
                 // Absence is proven the same way it always was, plus the LIST
                 // fence a pre-Live row already gets: the authoritative listing
                 // holds no object under this name, and a direct GET — which

--- a/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
@@ -338,6 +338,85 @@ async fn uid_and_generation_mismatch_or_uncertain_get_retain_live_occupancy() {
     );
 }
 
+/// The task-run completion proof is a POSITIVE identity match on the task-run
+/// id, and it must never reach a warm row.
+///
+/// A warm Job's name is `deterministic_warm_job_name(project, request)` and IS
+/// reused across generations, which is precisely what the UID fence exists to
+/// guard. A finished object under a warm row's name says nothing about that
+/// row, and neither does a finished object that declares itself to be a
+/// DIFFERENT task-run than the one the row recorded.
+#[tokio::test]
+async fn a_finished_object_only_terminalizes_the_row_whose_identity_it_carries() {
+    let controller = controller(BuildAdmissionMode::Enforce, 4).await;
+
+    // A live warm generation whose deterministic name a finished successor
+    // object now also bears.
+    let warm = AdmissionJournalKey {
+        domain: AdmissionDomain::WarmBuild,
+        work_id: "warm-work".into(),
+        generation: 1,
+    };
+    controller
+        .journal()
+        .adopt_live(&AdoptLiveAdmissionInput {
+            key: warm.clone(),
+            workload_kind: AdmissionWorkloadKind::Warm,
+            creator_server_epoch: "old".into(),
+            object_name: "djinn-warm-project-request".into(),
+            object_uid: "warm-uid-of-generation-1".into(),
+        })
+        .await
+        .unwrap();
+    let mut reused_warm_name = record(
+        "djinn-warm-project-request",
+        Some("warm-uid-of-generation-2"),
+        &[("djinn.app/warm", "true")],
+    );
+    reused_warm_name.terminal = true;
+
+    // A live task-run whose Job name is in the listing, finished, but declaring
+    // a different task-run id.
+    let task = AdmissionJournalKey {
+        domain: AdmissionDomain::TaskObservation,
+        work_id: "task-work".into(),
+        generation: 0,
+    };
+    adopt_live(&controller, task.clone(), "djinn-taskrun-mine", "run-mine").await;
+    let mut impostor = record(
+        "djinn-taskrun-mine",
+        Some("k8s-uid"),
+        &[("djinn.app/task-run-id", "run-someone-else")],
+    );
+    impostor.terminal = true;
+
+    let inventory = Arc::new(FakeInventory::new(vec![reused_warm_name, impostor]));
+    let report = BuildAdmissionReconciler::new(controller.clone(), inventory)
+        .reconcile()
+        .await;
+
+    assert_eq!(
+        report.released, 0,
+        "a finished object may only retire the row whose identity it carries"
+    );
+    let states: Vec<_> = controller
+        .journal()
+        .list_active_rows()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| (row.key, row.state))
+        .collect();
+    assert!(
+        states.contains(&(warm, AdmissionState::Live)),
+        "the live warm generation must survive its name being reused: {states:?}"
+    );
+    assert!(
+        states.contains(&(task, AdmissionState::Live)),
+        "the live task-run must survive another run's Job finishing: {states:?}"
+    );
+}
+
 #[tokio::test]
 async fn authoritative_uid_not_found_releases_and_emits_wakeup() {
     let controller = controller(BuildAdmissionMode::Enforce, 4).await;

--- a/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
@@ -826,6 +826,7 @@ async fn pre_ymx9_generation_history(
             .mark_live(&UidFencedAdmissionInput {
                 key: key.clone(),
                 object_uid: object_uid.clone(),
+                object_name: None,
             })
             .await
             .unwrap();

--- a/server/crates/djinn-coordinator/src/build_lease_dispatch_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_dispatch_reclaim_tests.rs
@@ -449,6 +449,22 @@ async fn a_running_task_run_keeps_its_admission_row_and_its_dispatch_slot() {
         "no Live row may be retired while its object is in the listing"
     );
 
+    // Documented cost of keeping the dispatcher's row: the SAME Job is also
+    // adopted under the identity `classify` gives it — the task-RUN id — so one
+    // running task-run now shows as two LIFECYCLE rows for the life of the run
+    // instead of one. That is a gauge (`djinn_build_slots_in_use`), not
+    // capacity: the cap is compared against `build_leases` alone, asserted just
+    // below, and no gate reads this count. Collapsing the two would mean
+    // stamping the admission identity onto the task-run Job so `adopt_live`
+    // merges into the dispatcher's row instead of inserting its own — which
+    // needs the admission key threaded through the slot-pool seam.
+    assert_eq!(report.adopted, 1);
+    assert_eq!(
+        harness.ledger_rows().await,
+        2,
+        "the dispatcher's row and the adopted row are two identities for one Job"
+    );
+
     // ...and the capacity it bought must still be held, so the lease reclaimer
     // finds no proof of ownerlessness.
     let lease_report = BuildLeaseReclaimer::with_settle_window(

--- a/server/crates/djinn-coordinator/src/build_lease_dispatch_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_dispatch_reclaim_tests.rs
@@ -66,6 +66,58 @@ impl WorkloadInventory for EmptyNamespace {
     }
 }
 
+/// A namespace holding exactly the Jobs it was given, answering `get_uid` and
+/// `presence` from that same set — which is what a live API server does: an
+/// object either exists under a name or it does not, and a name no object bears
+/// is an authoritative `Ok(None)`.
+struct Namespace(Vec<WorkloadRecord>);
+
+#[async_trait]
+impl WorkloadInventory for Namespace {
+    async fn list(&self) -> Result<Vec<WorkloadRecord>, String> {
+        Ok(self.0.clone())
+    }
+    async fn get_uid(&self, _: WorkloadObjectKind, name: &str, uid: &str) -> UidGetResult {
+        match self.0.iter().find(|record| record.name == name) {
+            Some(record) if record.uid.as_deref() == Some(uid) => UidGetResult::Present,
+            Some(_) => UidGetResult::Uncertain,
+            None => UidGetResult::NotFound,
+        }
+    }
+    async fn presence(&self, _: WorkloadObjectKind, name: &str) -> ObjectPresence {
+        match self.0.iter().find(|record| record.name == name) {
+            Some(record) => ObjectPresence::Present {
+                uid: record.uid.clone(),
+            },
+            None => ObjectPresence::Absent,
+        }
+    }
+}
+
+/// The Job a task-run dispatch actually creates, exactly as `build_task_run_job`
+/// renders it: named `djinn-taskrun-{task_run_id}`, labelled with the task-run
+/// id and the worker component, carrying NO admission identity labels
+/// (`stamp_admission_identity` is called from the warm path alone).
+fn task_run_job(task_run_id: &str, terminal: bool) -> WorkloadRecord {
+    WorkloadRecord {
+        kind: WorkloadObjectKind::Job,
+        name: djinn_k8s::taskrun_job_name(task_run_id),
+        uid: Some(format!("k8s-uid-of-{task_run_id}")),
+        labels: [
+            ("djinn.app/task-run-id".to_string(), task_run_id.to_string()),
+            (
+                "djinn.app/component".to_string(),
+                "task-run-worker".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        terminal,
+        images: vec!["reg.example:5000/djinn-project:abc123".into()],
+        commands: vec!["djinn-agent-worker".into()],
+    }
+}
+
 fn lease_key(task_id: &str, generation: i64) -> BuildLeaseKey {
     BuildLeaseKey {
         consumer_kind: BuildLeaseConsumerKind::TaskDispatch,
@@ -302,6 +354,230 @@ async fn a_dispatch_slot_whose_generation_still_occupies_is_never_retired() {
     );
     assert_eq!(report.reclaimed, 0);
     assert_eq!(harness.occupancy().await, 1);
+}
+
+/// One task-run dispatched and then reported live by its worker's session, as
+/// `begin_task_run_build_admission` → `finish_task_run_build_admission` →
+/// `live_task_run_build_admission` do it. Returns the `task_run_id`, which is
+/// the "uid" the whole `task_observation` domain is keyed on.
+async fn dispatch_and_start_task_run(harness: &CapacityHarness, task_id: &str) -> String {
+    dispatch_task_run(harness, task_id).await;
+    let task_run_id = format!("019ea3bd-a305-73e3-806c-run-of-{task_id}");
+    let permit = permitted(&harness.controller, task_id).await;
+    harness
+        .controller
+        .transition(
+            &permit,
+            WarmAdmissionTransition::Live {
+                uid: task_run_id.clone(),
+            },
+        )
+        .await
+        .expect("the session-started callback marks the run live");
+    task_run_id
+}
+
+/// The inverse outage: reconciliation retiring the admission row of a task-run
+/// that is *still running*, and the lease reclaimer then handing its dispatch
+/// slot to another task.
+///
+/// A task-run's admission row is reserved before its Kubernetes object exists,
+/// so it records the provisional name `task-run-{task_id}-{generation}`. The
+/// Job the dispatch goes on to create is named `djinn-taskrun-{task_run_id}`,
+/// and nothing ever rewrote the row to say so. Every Kubernetes clause in the
+/// reconciler's `Live` branch was therefore evaluated against a string no
+/// object in the namespace can ever bear:
+///
+/// * the authoritative LIST never contains it, so the LIST clause always
+///   passed;
+/// * a direct GET on it is an authoritative `Ok(None)` — `NotFound`, the same
+///   answer a genuinely deleted object gives — so the GET clause always passed.
+///
+/// So `absent` was true for a Live row whose task-run was running happily, and
+/// that branch is deliberately generation-agnostic with no epoch and no settle
+/// fence. The row was retired, and because a `task_dispatch` lease is proven
+/// ownerless by exactly one fact — `generation_state == Terminal` — the
+/// falsely-terminal row was then read as proof that the lifecycle the slot was
+/// bought for had ended. The slot went back while the pod ran, and the board
+/// admitted over its cap.
+///
+/// Measured on the unfixed code by this exact test: `released:1 stale:1
+/// adopted:1`, then `ownerless_dispatch:1 reclaimed:1`, occupancy `1 → 0`, and
+/// a second task `Permitted` at `cap 1` with the first still running.
+/// Production, 2026-07-29: `adopted:3, released:2, stale:2` in a single pass
+/// with three task-runs live.
+#[tokio::test]
+async fn a_running_task_run_keeps_its_admission_row_and_its_dispatch_slot() {
+    let harness = harness(1).await;
+    let task_run_id = dispatch_and_start_task_run(&harness, "running-task").await;
+    assert_eq!(
+        harness.occupancy().await,
+        1,
+        "the dispatch attempt must occupy a real build slot"
+    );
+
+    // The namespace holds exactly what the dispatch created: one RUNNING
+    // task-run Job. Reconciliation runs in the same process at the production
+    // settle window — neither fence applies to a `Live` row, which is the
+    // point.
+    let namespace = || Arc::new(Namespace(vec![task_run_job(&task_run_id, false)]));
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&harness.controller),
+        namespace(),
+        crate::build_admission_inventory::DEFAULT_RECLAIM_SETTLE_WINDOW,
+    )
+    .reconcile()
+    .await;
+    assert!(
+        report.blockers.is_empty(),
+        "blockers: {:?}",
+        report.blockers
+    );
+
+    // The side effect first: the lifecycle row of live work must still occupy.
+    assert_eq!(
+        harness
+            .journal
+            .generation_state(AdmissionDomain::TaskObservation, "running-task", 0)
+            .await
+            .unwrap(),
+        Some(AdmissionState::Live),
+        "the task-run is running: nothing about its own Job proves it absent"
+    );
+    assert_eq!(
+        report.released, 0,
+        "no Live row may be retired while its object is in the listing"
+    );
+
+    // ...and the capacity it bought must still be held, so the lease reclaimer
+    // finds no proof of ownerlessness.
+    let lease_report = BuildLeaseReclaimer::with_settle_window(
+        Arc::clone(&harness.leases),
+        Arc::clone(&harness.journal),
+        namespace(),
+        Duration::ZERO,
+    )
+    .reclaim()
+    .await;
+    assert_eq!(
+        harness.occupancy().await,
+        1,
+        "the dispatch slot of a running task-run must never be handed back"
+    );
+    assert_eq!(
+        lease_report.ownerless_dispatch, 0,
+        "a Live generation is not a proof that the lifecycle ended"
+    );
+    assert_eq!(lease_report.reclaimed, 0);
+
+    // The reason it matters: the board must not admit past its cap while the
+    // first task-run is still compiling.
+    assert!(
+        matches!(
+            admit(&harness.controller, "second-task").await,
+            BuildAdmissionDecision::Denied {
+                occupancy: Some(1),
+                cap: 1,
+                cause: DenialCause::AtCapacity
+            }
+        ),
+        "capacity released for running work is an over-admission, not a recovery"
+    );
+}
+
+/// The same absence proof, now non-vacuous in the direction that must still
+/// work: once the task-run's Job is genuinely gone from the namespace, the row
+/// is retired and the slot comes back.
+///
+/// Without this the fix above would collapse into "never reclaim a task row",
+/// which re-creates the stale population #2597 exists to retire.
+#[tokio::test]
+async fn a_task_run_whose_job_really_vanished_is_still_reclaimed() {
+    let harness = harness(1).await;
+    dispatch_and_start_task_run(&harness, "vanished-task").await;
+
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&harness.controller),
+        Arc::new(EmptyNamespace),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+    assert_eq!(
+        harness
+            .journal
+            .generation_state(AdmissionDomain::TaskObservation, "vanished-task", 0)
+            .await
+            .unwrap(),
+        Some(AdmissionState::Terminal),
+        "an empty namespace is a real absence proof for a Live row"
+    );
+    assert_eq!(report.released, 1);
+
+    let lease_report = reclaimer(&harness).reclaim().await;
+    assert_eq!(lease_report.ownerless_dispatch, 1);
+    assert_eq!(
+        harness.occupancy().await,
+        0,
+        "and the orphaned dispatch slot comes back"
+    );
+    assert!(matches!(
+        admit(&harness.controller, "next-task").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+}
+
+/// A task-run whose Job has FINISHED but has not yet been deleted by
+/// `ttlSecondsAfterFinished` releases on the stronger proof — the object exists
+/// and the work is over — rather than waiting up to the full hour of that TTL
+/// for an absence proof to become available.
+///
+/// This is the shape a coordinator restart leaves behind for every in-flight
+/// run: the successor holds no permit binding for the predecessor's generation,
+/// so `terminal_task_run_build_admission` finds no permit and returns without
+/// terminalizing, and the dispatch lease is then waiting on the journal alone.
+#[tokio::test]
+async fn a_finished_but_undeleted_task_run_job_releases_without_waiting_for_the_ttl() {
+    let harness = harness(1).await;
+    let task_run_id = dispatch_and_start_task_run(&harness, "finished-task").await;
+
+    let namespace = || Arc::new(Namespace(vec![task_run_job(&task_run_id, true)]));
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&harness.controller),
+        namespace(),
+        crate::build_admission_inventory::DEFAULT_RECLAIM_SETTLE_WINDOW,
+    )
+    .reconcile()
+    .await;
+    assert!(
+        report.blockers.is_empty(),
+        "blockers: {:?}",
+        report.blockers
+    );
+    assert_eq!(
+        harness
+            .journal
+            .generation_state(AdmissionDomain::TaskObservation, "finished-task", 0)
+            .await
+            .unwrap(),
+        Some(AdmissionState::Terminal),
+        "a finished object is a stronger proof than absence"
+    );
+
+    let lease_report = BuildLeaseReclaimer::with_settle_window(
+        Arc::clone(&harness.leases),
+        Arc::clone(&harness.journal),
+        namespace(),
+        Duration::ZERO,
+    )
+    .reclaim()
+    .await;
+    assert_eq!(lease_report.ownerless_dispatch, 1);
+    assert_eq!(harness.occupancy().await, 0);
+    assert!(matches!(
+        admit(&harness.controller, "next-task").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
 }
 
 /// The second dispatch leak: the FIFO grants a slot to a requester that already

--- a/server/crates/djinn-db/src/repositories/admission_journal.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal.rs
@@ -160,6 +160,21 @@ pub struct CreateStartedInput {
 pub struct UidFencedAdmissionInput {
     pub key: AdmissionJournalKey,
     pub object_uid: String,
+    /// The Kubernetes object name this generation actually created, when the
+    /// reservation could not yet know it.
+    ///
+    /// A warm reservation commits to a deterministic Job name before the POST
+    /// and passes `None` here: its recorded name is already the real one, and
+    /// rewriting it would erase the identity `mark_create_started` fenced.
+    ///
+    /// A task-run reservation cannot. Its slot is acquired before the task-run
+    /// exists, so it records a provisional `task-run-{task_id}-{generation}`
+    /// that no Kubernetes object will ever bear. Left that way, every LIST/GET
+    /// the reconciler makes about the row is a question about a name that
+    /// cannot match — an authoritative `NotFound` that reads as proof of
+    /// deletion while the pod runs. The live callback is the first moment the
+    /// real name is known, so it is the moment the row stops lying.
+    pub object_name: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -362,7 +377,18 @@ impl AdmissionJournalRepository {
         }
         let result = match row.state {
             AdmissionState::CreateInFlight | AdmissionState::CreateUnknown => {
-                update_state(&mut tx, &input.key, "live", Some(&input.object_uid)).await?
+                // `object_name` is finalized on the SAME transition that binds
+                // the UID, and only on the transition INTO Live. An already-Live
+                // row keeps the name it was adopted or marked live under, so a
+                // replayed callback can never rewrite a settled identity out
+                // from under a reclamation that already read it.
+                enter_live(
+                    &mut tx,
+                    &input.key,
+                    &input.object_uid,
+                    input.object_name.as_deref(),
+                )
+                .await?
             }
             AdmissionState::Live => row,
             state => return Err(invalid_state("mark live", state)),
@@ -978,6 +1004,32 @@ async fn update_state(
 ) -> DbResult<AdmissionJournalRow> {
     let row = sqlx::query_as::<_, JournalDbRow>(&format!("UPDATE admission_journal SET state = $1, object_uid = COALESCE($2, object_uid), updated_at = now(), terminal_at = CASE WHEN $3 THEN now() ELSE terminal_at END WHERE domain = $4 AND work_id = $5 AND generation = $6 RETURNING {JOURNAL_COLUMNS}"))
         .bind(state).bind(object_uid).bind(state == "terminal").bind(key.domain.as_str()).bind(&key.work_id).bind(key.generation).fetch_one(&mut **tx).await?;
+    row.try_into()
+}
+
+/// Move one generation into `live`, binding its UID and — when the reservation
+/// could not know it — the Kubernetes object name it actually created.
+///
+/// `COALESCE` on the name so that passing `None` is exactly `update_state`:
+/// a reservation that already committed to a real name keeps it.
+async fn enter_live(
+    tx: &mut Transaction<'_, Postgres>,
+    key: &AdmissionJournalKey,
+    object_uid: &str,
+    object_name: Option<&str>,
+) -> DbResult<AdmissionJournalRow> {
+    let row = sqlx::query_as::<_, JournalDbRow>(&format!(
+        "UPDATE admission_journal SET state = 'live', object_uid = $1, \
+         object_name = COALESCE($2, object_name), updated_at = now() \
+         WHERE domain = $3 AND work_id = $4 AND generation = $5 RETURNING {JOURNAL_COLUMNS}"
+    ))
+    .bind(object_uid)
+    .bind(object_name)
+    .bind(key.domain.as_str())
+    .bind(&key.work_id)
+    .bind(key.generation)
+    .fetch_one(&mut **tx)
+    .await?;
     row.try_into()
 }
 

--- a/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
@@ -33,6 +33,7 @@ fn uid_input(input: &ReserveAdmissionInput, object_uid: &str) -> UidFencedAdmiss
     UidFencedAdmissionInput {
         key: input.key.clone(),
         object_uid: object_uid.into(),
+        object_name: None,
     }
 }
 
@@ -734,5 +735,62 @@ async fn a_terminal_callback_retires_a_create_whose_uid_was_never_observed() {
         .await
         .is_err(),
         "a terminal callback for a different object must not rewrite the row"
+    );
+}
+
+/// The object identity a Live row is judged by must describe a real Kubernetes
+/// object, and it may only be finalized by the transition that binds the UID.
+///
+/// A task-run reservation records a provisional `task-run-{task_id}-{gen}`
+/// because its slot is bought before the task-run exists. Left that way, every
+/// LIST/GET the reconciler makes about the row asks about a name no object can
+/// bear, and the authoritative `NotFound` that comes back reads as proof of
+/// deletion while the pod is running. A warm reservation is the opposite case:
+/// it committed to its real name before the POST and `mark_create_started`
+/// fenced on it, so nothing may overwrite it.
+#[tokio::test]
+async fn mark_live_finalizes_a_provisional_object_name_and_never_rewrites_a_committed_one() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db);
+
+    let task = input(AdmissionDomain::TaskObservation, "provisional", 0);
+    repo.reserve(&task).await.unwrap();
+    repo.mark_create_started(&create_started(&task))
+        .await
+        .unwrap();
+    let live = repo
+        .mark_live(&UidFencedAdmissionInput {
+            key: task.key.clone(),
+            object_uid: "task-run-42".into(),
+            object_name: Some("djinn-taskrun-task-run-42".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(live.state, AdmissionState::Live);
+    assert_eq!(live.object_name, "djinn-taskrun-task-run-42");
+    assert_eq!(live.object_uid.as_deref(), Some("task-run-42"));
+
+    // Replayed on an already-Live row, the callback is a no-op: a settled
+    // identity may never be rewritten out from under a reclamation that has
+    // already read it.
+    let replayed = repo
+        .mark_live(&UidFencedAdmissionInput {
+            key: task.key.clone(),
+            object_uid: "task-run-42".into(),
+            object_name: Some("djinn-taskrun-something-else".into()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(replayed.object_name, "djinn-taskrun-task-run-42");
+
+    let warm = input(AdmissionDomain::WarmBuild, "committed", 0);
+    repo.reserve(&warm).await.unwrap();
+    repo.mark_create_started(&create_started(&warm))
+        .await
+        .unwrap();
+    let warm_live = repo.mark_live(&uid_input(&warm, "k8s-uid")).await.unwrap();
+    assert_eq!(
+        warm_live.object_name, warm.object_name,
+        "a name committed before the POST is the truth already"
     );
 }


### PR DESCRIPTION
Follow-up to #2746, which documented this as a known-adjacent problem and deliberately did not touch it. Investigation confirms it is real — and **fail-open**, which is worse than the "inert" reading in that PR.

## The identity never becomes real

| stage | `object_name` | `object_uid` |
|---|---|---|
| reserve (`task_dispatch.rs:2976`, `refinement_dispatch.rs:1247`) | `task-run-{task_id}-{gen}` | NULL |
| CreateStarted / CreateUnknown | unchanged | NULL |
| **Live** (`live_task_run_build_admission` → `mark_live`) | **unchanged** | `task_run_id` — a djinn id, not a k8s UID |
| the actual Job (`job.rs:242`) | `djinn-taskrun-{task_run_id}` | real k8s UID |

`listed_names` is built from the authoritative LIST, so it holds real Job names and can never contain `task-run-…`. The distinction that could have saved this resolves the wrong way: `KubeWorkloadInventory::get_uid` maps `get_opt` → `Ok(None)` → **`NotFound`**, and `Uncertain` is reserved for the transport/permission and wrong-UID arms. A name no object bears is therefore a clean 404 — an *authoritative absence proof*.

So in the reconciler's `Live` branch, `absent == true` for a row whose pod is running. That branch has no epoch fence and no settle fence.

## Blast radius — measured, not argued

New test against unmodified code, cap 1, one live task-run:

```
released=1  stale=1  adopted=1     # reconciler pass
ownerless=1 reclaimed=1            # BuildLeaseReclaimer pass
occupancy 1 -> 0
second_admit = Permitted { .. }    # at cap 1, while the first run is still running
```

The early release does not cancel out, it **cascades**. `BuildLeaseReclaimer::ownerless_proof` proves a `task_dispatch` lease ownerless by exactly one fact: `generation_state(TaskObservation, task_id, gen) == Terminal`. The falsely-terminal row *is* that fact. The build slot of running work goes back to the pool and the board over-admits.

This also explains why #2746's own-epoch fence is load-bearing: it guards *pre-Live* rows, where these clauses are equally vacuous. The `Live` branch has no such fence, which is why this half is fail-open rather than merely inert.

## The fix

1. `UidFencedAdmissionInput` gains `object_name: Option<String>`; `mark_live` finalizes it via a new `enter_live` (`COALESCE`), **only on the transition into Live** — an already-Live row keeps the identity a reclamation may already have read.
2. `live_object_name` supplies it for `task_observation` **only**. A warm reservation already commits to its real name before the POST and `mark_create_started` fences on it. For a task permit the Live uid *is* the `task_run_id` (the domain is keyed on it), and `taskrun_job_name` is the same derivation `build_lease_reclaim` already uses.
3. `finished_as_its_own_task_run` in the reconciler — required, not gold-plating. With a real name, a finished-but-not-yet-TTL-deleted Job had no exit for a full hour (identity lookup misses, and absence is impossible to prove while the object is still listed), and that hour is held capacity for every in-flight run across a coordinator restart. It is a **positive** identity match (`djinn.app/task-run-id == row.object_uid`), scoped to `task_observation` because a warm Job's deterministic name IS reused across generations. An over-broad version is caught by the pre-existing `uid_and_generation_mismatch_or_uncertain_get_retain_live_occupancy` — which is how the correct shape was found.

**The dispatch hot path and the slot-pool seam are untouched.** `DispatchOutcome::Dispatched` stays a unit variant. Pre-Live rows keep the provisional name because the task-run id genuinely does not exist yet — the population #2746 documented. No partial rename: the identity is finalized at exactly one point, and every reader (LIST, GET, the `reclaim_absent_object` CAS, the completion proof) now agrees.

## Tests

- `a_running_task_run_keeps_its_admission_row_and_its_dispatch_slot` — **failed before, passes after** (`left: Some(Terminal), right: Some(Live)`)
- `a_task_run_whose_job_really_vanished_is_still_reclaimed` — guards that the fix is not "never reclaim a task row"
- `a_finished_but_undeleted_task_run_job_releases_without_waiting_for_the_ttl` — passed before via the vacuous proof, still passes via the real one
- `mark_live_finalizes_a_provisional_object_name_and_never_rewrites_a_committed_one` and `a_finished_object_only_terminalizes_the_row_whose_identity_it_carries` — **mutation-verified**: neutralizing the `COALESCE` and dropping the identity match each fail them

## Known costs

- **Gauge regression, asserted in a test rather than hidden.** One running task-run now shows as **2** lifecycle rows for the life of the run (the dispatcher's plus the adopted one) instead of 1. This affects `djinn_build_slots_in_use` only — `count_task_or_warm_occupancy` has no production caller and `over_cap` reads the slot authority. Collapsing them requires stamping the admission identity on the task-run Job so `adopt_live` merges into the dispatcher's row; that is the slot-pool-seam change, deliberately out of scope here.
- **Rolling deploy:** rows already Live under the old code keep the provisional name and stay falsely reclaimable until they terminalize. Status quo, self-limiting, no migration.

## Verification note

Full local suite (3624 tests, djinn-coordinator + djinn-db) passed before this branch was rebased onto current `main`. After rebasing onto `main` (which now carries #2746 and #2747), the coordinator half re-ran green — 231/231 admission, build-lease and capacity tests. The DB half could not be re-run locally: the shared `djinn_test_template` is stale against migration 160 and three other agents were mid-run against it, so rebuilding it would have broken their runs. CI builds its own template and is the gate for that half.

Not verified against production (no cluster access during the investigation). The 2026-07-29 log line `adopted:3, released:2, stale:2` is consistent with the reproduction, matched by shape only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
