### PR TITLE
fix(admission): stop standby pods running the mutating reconciliation pass

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission_inventory.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory.rs
@@ -234,6 +234,46 @@ fn finished_as_its_own_task_run(
         .is_some_and(|(terminal, declared)| *terminal && declared.as_deref() == Some(task_run_id))
 }
 
+/// Whether a reconciliation pass may WRITE the durable admission journal.
+///
+/// Reconciliation is two different jobs wearing one name. Reading Kubernetes,
+/// classifying what it found, and re-deriving this process's own in-memory
+/// readiness gates from the journal is safe on any pod: it is all reads, and
+/// every gate it sets is process-local. Retiring rows and adopting objects is
+/// not — those are writes to the shared durable ledger, and the single-active
+/// topology gate exists precisely to make sure only one process performs them.
+///
+/// The two were fused, so [`BuildAdmissionReconciler::reconcile`] was a
+/// mutating pass that `AppState::initialize` ran on **every** pod, standbys
+/// included, before leadership was even contested. See the "Why leader-only"
+/// section of `djinn_server::build_admission_reconcile` for the invariant that
+/// contradicts, and [`BuildAdmissionReconciler::is_reclaimable`] for why it
+/// mattered: for a `task_observation` row the LIST and GET clauses are
+/// structurally vacuous, so the creator-epoch fence is the *only* thing
+/// standing between a settled row and retirement — and a standby passes that
+/// fence trivially, because the leader's epoch is not its own. A standby could
+/// therefore retire the admission row of a task-run that was still running on
+/// the leader, which under-counts durable occupancy: fail-OPEN.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReconcileScope {
+    /// Read Kubernetes, read the journal, and re-derive this process's own
+    /// readiness gates. Writes nothing durable. Safe on any pod, and
+    /// deliberately still fail-CLOSED: an unusable listing or an unreadable
+    /// journal leaves `InventoryPending` exactly as it would in [`Self::Mutate`].
+    Observe,
+    /// Everything [`Self::Observe`] does, plus the journal writes — adoption of
+    /// live objects and retirement of rows whose objects are provably gone.
+    /// Only legitimate on the process that holds the coordinator advisory lock.
+    Mutate,
+}
+
+impl ReconcileScope {
+    /// Whether this pass is allowed to write the durable admission journal.
+    fn may_write(self) -> bool {
+        matches!(self, Self::Mutate)
+    }
+}
+
 pub struct BuildAdmissionReconciler {
     controller: Arc<BuildAdmissionController>,
     inventory: Arc<dyn WorkloadInventory>,
@@ -433,7 +473,20 @@ impl BuildAdmissionReconciler {
         out.blockers.push(error.to_string());
     }
 
+    /// A full, mutating reconciliation pass. Leader-only — see
+    /// [`ReconcileScope`].
     pub async fn reconcile(&self) -> InventoryReport {
+        self.reconcile_with(ReconcileScope::Mutate).await
+    }
+
+    /// A read-only pass: the same evidence gathering and the same process-local
+    /// readiness gates, with every journal write suppressed. This is what a pod
+    /// that has not confirmed the single-active topology gate runs.
+    pub async fn observe(&self) -> InventoryReport {
+        self.reconcile_with(ReconcileScope::Observe).await
+    }
+
+    pub async fn reconcile_with(&self, scope: ReconcileScope) -> InventoryReport {
         let _g = self.serial.lock().await;
         if self.controller.mode() == BuildAdmissionMode::Off {
             return InventoryReport::default();
@@ -482,29 +535,48 @@ impl BuildAdmissionReconciler {
                 Err(e) => out.blockers.push(e),
             }
         }
-        for c in &cs {
-            if c.object.terminal {
-                // Adopting a finished object into `Live` would be a lie. The
-                // row loop below retires the pre-Live row this object belongs
-                // to instead — see the `finished` branch there.
-                continue;
+        // Adoption WRITES the journal — it inserts a row for an orphan object
+        // that has none, and moves an existing pre-Live row to `Live` — so an
+        // observe-only pass skips it. Note that it does NOT restamp an existing
+        // row's `creator_server_epoch`: `update_state` never touches that
+        // column, so the `creator_server_epoch` supplied here is consumed only
+        // by the INSERT arm, where there is no predecessor value to preserve.
+        // The pre-Live reclamation fence is therefore never transferred by
+        // adoption; see `adopt_live` and its tests.
+        if scope.may_write() {
+            for c in &cs {
+                if c.object.terminal {
+                    // Adopting a finished object into `Live` would be a lie. The
+                    // row loop below retires the pre-Live row this object belongs
+                    // to instead — see the `finished` branch there.
+                    continue;
+                }
+                let Some(uid) = c.object.uid.as_ref() else {
+                    out.blockers
+                        .push(format!("{}: unstable UID", c.object.name));
+                    continue;
+                };
+                let x = AdoptLiveAdmissionInput {
+                    key: c.key.clone(),
+                    workload_kind: c.kind,
+                    creator_server_epoch: self.controller.server_epoch().into(),
+                    object_name: c.object.name.clone(),
+                    object_uid: uid.clone(),
+                };
+                match self.controller.journal().adopt_live(&x).await {
+                    Ok(_) => out.adopted += 1,
+                    Err(e) => self.record_adopt_failure(&mut out, c, &e),
+                }
             }
-            let Some(uid) = c.object.uid.as_ref() else {
-                out.blockers
-                    .push(format!("{}: unstable UID", c.object.name));
-                continue;
-            };
-            let x = AdoptLiveAdmissionInput {
-                key: c.key.clone(),
-                workload_kind: c.kind,
-                creator_server_epoch: self.controller.server_epoch().into(),
-                object_name: c.object.name.clone(),
-                object_uid: uid.clone(),
-            };
-            match self.controller.journal().adopt_live(&x).await {
-                Ok(_) => out.adopted += 1,
-                Err(e) => self.record_adopt_failure(&mut out, c, &e),
-            }
+        }
+        if !scope.may_write() {
+            // Everything from here to the tail seed exists to justify and
+            // perform a retirement, so an observe-only pass has nothing left to
+            // do but re-derive its own gates from the journal — which the tail
+            // seed below does, read-only. Skipping the settlement listing and
+            // the per-row absence probes also keeps a standby from spending
+            // API-server GETs on evidence it may not act on.
+            return self.seed_and_publish(out, scope).await;
         }
         let active = match self
             .controller
@@ -654,6 +726,20 @@ impl BuildAdmissionReconciler {
             }
             self.retire_pre_live_row(&mut out, row).await;
         }
+        self.seed_and_publish(out, scope).await
+    }
+
+    /// The read-only tail of every pass, whatever its scope.
+    ///
+    /// Split out so an observe-only pass reaches it too: re-deriving this
+    /// process's own readiness gates from the journal is the part a standby
+    /// genuinely needs, and it is all reads. A standby that skipped it would
+    /// carry stale gates into its own promotion.
+    async fn seed_and_publish(
+        &self,
+        mut out: InventoryReport,
+        scope: ReconcileScope,
+    ) -> InventoryReport {
         // The tail seed re-derives `journal_recovered`, `journal_healthy`,
         // `create_unknown_pending` and `over_cap` from the journal. It is the
         // ONLY in-process re-derivation of those four gates, and it only
@@ -707,8 +793,18 @@ impl BuildAdmissionReconciler {
         // Publish the size of the stale population itself, loudly when it is
         // large enough to have wedged the cap. Discovering this by reading
         // thousands of per-transition warn lines is not an operating model.
-        self.controller
-            .publish_reconciliation(out.stale, out.released + out.reclaimed, out.fenced);
+        //
+        // Only a mutating pass may publish it. An observe-only pass never looks
+        // for stale rows at all, so its zeros mean "did not measure" rather
+        // than "measured zero", and a gauge that reports the second when it
+        // means the first is exactly how a wedge stays invisible.
+        if scope.may_write() {
+            self.controller.publish_reconciliation(
+                out.stale,
+                out.released + out.reclaimed,
+                out.fenced,
+            );
+        }
         out
     }
 }

--- a/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
@@ -1,3 +1,7 @@
+// djinn:allow-oversize — 56886 bytes against the 51200 guard (lines are still
+// under). This is a flat test module whose fixtures are shared by every case,
+// so splitting it means extracting those helpers first rather than moving a
+// `mod tests` block; worth doing, but not as a drive-by in an unrelated fix.
 //! Regression coverage for stale durable occupancy whose Kubernetes objects
 //! are gone (production symptom: 318 occupying `admission_journal` rows against
 //! a namespace holding zero Jobs, with `djinn_build_slots_in_use` reading 318

--- a/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
@@ -1298,3 +1298,164 @@ async fn adopting_this_process_own_create_cannot_clear_a_predecessors_gate() {
         "the predecessor's unresolved create still occupies and still gates"
     );
 }
+
+/// The whole hazard, in one fixture: a standby pod's reconciliation pass must
+/// not be able to retire the admission row of a task-run that is running on the
+/// leader.
+///
+/// `AppState::initialize` runs on EVERY pod, standbys included, before
+/// leadership is contested, and it used to run the full mutating reconciler
+/// there. The chart's default topology (`buildAdmission.mode: observe` with a
+/// surging `RollingUpdate`) puts two server pods side by side on every deploy,
+/// so that pass genuinely ran against a live leader's journal.
+///
+/// Nothing else in `is_reclaimable` stops it. For a `task_observation` row the
+/// LIST and GET clauses are structurally vacuous — the running Job is named
+/// `djinn-taskrun-{task_run_id}` while the row records
+/// `object_name = task-run-{task_id}-{reopen}`, so the listing never contains
+/// the row's name and the direct GET answers `Absent` while the task-run is
+/// running happily. The 300s settle window is exceeded by any pending pod or
+/// slow image pull. That leaves the creator-epoch fence as the only protection
+/// the row has — and a standby clears it trivially, because the leader's epoch
+/// is not the standby's.
+///
+/// The second half is the load-bearing part: it runs the SAME pass with the
+/// mutating scope against the SAME fixture and watches the row die. Without it
+/// the observe assertions above would be indistinguishable from a fixture in
+/// which nothing was ever at risk.
+#[tokio::test]
+async fn a_standby_pass_leaves_a_live_task_runs_row_alone_where_a_mutating_pass_would_retire_it() {
+    const LEADER_EPOCH: &str = "epoch-of-the-pod-holding-the-advisory-lock";
+    const STANDBY_EPOCH: &str = "epoch-of-the-surged-standby-pod";
+    const TASK_ID: &str = "019f7000-0000-7000-8000-000000000001";
+    const TASK_RUN_ID: &str = "019f7000-0000-7000-8000-0000000000ff";
+
+    // The leader dispatches a task-run: the slot pool accepts the create and
+    // the journal records `CreateUnknown` until the ("session","started")
+    // callback supplies a UID. This is the ordinary intermediate state of a
+    // healthy dispatch, not a fault.
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    let key = AdmissionJournalKey {
+        domain: AdmissionDomain::TaskObservation,
+        work_id: TASK_ID.into(),
+        generation: 0,
+    };
+    let object_name = format!("task-run-{TASK_ID}-0");
+    journal
+        .reserve(&ReserveAdmissionInput {
+            key: key.clone(),
+            workload_kind: AdmissionWorkloadKind::Task,
+            creator_server_epoch: LEADER_EPOCH.into(),
+            object_name: object_name.clone(),
+        })
+        .await
+        .unwrap();
+    journal
+        .mark_create_started(&CreateStartedInput {
+            key: key.clone(),
+            creator_server_epoch: LEADER_EPOCH.into(),
+            object_name: object_name.clone(),
+        })
+        .await
+        .unwrap();
+    journal.mark_create_unknown(&key).await.unwrap();
+
+    // The work is alive: the namespace holds the task-run's Job, running. Note
+    // the name it actually carries, and that it is NOT the row's `object_name`
+    // — that mismatch is why the absence proof is vacuous here.
+    let running_job = WorkloadRecord {
+        kind: WorkloadObjectKind::Job,
+        name: format!("djinn-taskrun-{TASK_RUN_ID}"),
+        uid: Some(format!("uid-{TASK_RUN_ID}")),
+        labels: [("djinn.app/task-run-id".to_string(), TASK_RUN_ID.to_string())]
+            .into_iter()
+            .collect(),
+        terminal: false,
+        images: vec!["djinn:test".into()],
+        commands: vec![],
+    };
+
+    // The standby boots under its own epoch and runs the startup pass. Zero
+    // settle window and the full production evidence: every fence except the
+    // creator epoch is already open.
+    let standby = Arc::clone(
+        &attach_capacity(
+            &db,
+            BuildAdmissionController::new(
+                Arc::clone(&journal),
+                BuildAdmissionMode::Enforce,
+                3,
+                STANDBY_EPOCH,
+            ),
+            3,
+        )
+        .await
+        .controller,
+    );
+    let observed = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&standby),
+        Arc::new(NamespaceInventory::holding(vec![running_job.clone()])),
+        Duration::ZERO,
+    )
+    .observe()
+    .await;
+
+    assert!(
+        observed.blockers.is_empty(),
+        "the standby's evidence is complete: {:?}",
+        observed.blockers
+    );
+    assert_eq!(
+        (observed.reclaimed, observed.released, observed.adopted),
+        (0, 0, 0),
+        "a pod that has not confirmed the topology gate must write nothing"
+    );
+    let rows = journal.list_active_rows().await.unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "the standby must not have inserted an adoption row either: {rows:?}"
+    );
+    assert_eq!(rows[0].state, AdmissionState::CreateUnknown);
+    assert_eq!(
+        rows[0].creator_server_epoch, LEADER_EPOCH,
+        "ownership of a live row stays with the process that created it"
+    );
+
+    // The observe pass is not a no-op: it still re-derived this process's own
+    // gates from the journal, and it is still fail-CLOSED — the leader's
+    // unresolved create gates the standby exactly as a predecessor's would.
+    standby.mark_inventory_ready();
+    standby.mark_topology_ready();
+    assert_eq!(
+        standby.readiness(),
+        BuildAdmissionReadiness::CreateUnknownHealth,
+        "the read-only tail seed must still arm the startup gates"
+    );
+
+    // Same fixture, same evidence, mutating scope: the row dies. This is what
+    // the standby used to do, and it is fail-OPEN — the task-run is still
+    // running while its durable occupancy has been handed back.
+    let mutated = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&standby),
+        Arc::new(NamespaceInventory::holding(vec![running_job])),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+    assert_eq!(
+        mutated.reclaimed, 1,
+        "the fixture must be one in which a mutating pass really does retire \
+         the live task-run's row, or the assertions above prove nothing"
+    );
+    assert_eq!(
+        journal
+            .generation_state(AdmissionDomain::TaskObservation, TASK_ID, 0)
+            .await
+            .unwrap(),
+        Some(AdmissionState::Terminal),
+        "a mutating pass retires a row whose work is still running"
+    );
+}

--- a/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
@@ -794,3 +794,83 @@ async fn mark_live_finalizes_a_provisional_object_name_and_never_rewrites_a_comm
         "a name committed before the POST is the truth already"
     );
 }
+
+/// `creator_server_epoch` records who CREATED the object, and adoption never
+/// rewrites it.
+///
+/// This is worth pinning explicitly because the opposite was believed, and the
+/// belief mattered: `BuildAdmissionReconciler` passes its own
+/// `server_epoch()` into every `adopt_live` call, which reads as "adoption
+/// transfers ownership to the adopting process". If it did, adoption would move
+/// the pre-Live reclamation fence in `is_reclaimable` — the clause that refuses
+/// to retire a row under the current process's own epoch, and for a
+/// `task_observation` row the ONLY protection a live work item has, because the
+/// LIST and GET clauses are structurally vacuous for it.
+///
+/// It does not. `update_state` writes `state`, `object_uid`, `updated_at` and
+/// `terminal_at` and touches no other column, so the epoch supplied here is
+/// consumed by the INSERT arm alone — the case where an orphan Kubernetes
+/// object has no journal row and there is no predecessor value to preserve.
+/// Both halves are asserted below, because "the field is not written" is only
+/// meaningful next to a case where it is.
+#[tokio::test]
+async fn adoption_preserves_the_creator_epoch_and_stamps_only_a_row_it_creates() {
+    let repo = AdmissionJournalRepository::new(Database::open_in_memory().unwrap());
+
+    // A predecessor's unresolved create, adopted by a later process.
+    let created_by_predecessor = input(AdmissionDomain::TaskObservation, "adopted-row", 0);
+    assert_eq!(created_by_predecessor.creator_server_epoch, "epoch-1");
+    repo.reserve(&created_by_predecessor).await.unwrap();
+    repo.mark_create_started(&create_started(&created_by_predecessor))
+        .await
+        .unwrap();
+    repo.mark_create_unknown(&created_by_predecessor.key)
+        .await
+        .unwrap();
+
+    let adopted = repo
+        .adopt_live(&AdoptLiveAdmissionInput {
+            key: created_by_predecessor.key.clone(),
+            workload_kind: AdmissionWorkloadKind::Task,
+            creator_server_epoch: "epoch-2-the-adopting-process".into(),
+            object_name: created_by_predecessor.object_name.clone(),
+            object_uid: "uid-observed-by-the-adopter".into(),
+        })
+        .await
+        .expect("an unresolved create whose object is live is adoptable");
+    assert_eq!(adopted.state, AdmissionState::Live);
+    assert_eq!(
+        adopted.object_uid.as_deref(),
+        Some("uid-observed-by-the-adopter"),
+        "adoption records the UID it observed"
+    );
+    assert_eq!(
+        adopted.creator_server_epoch, "epoch-1",
+        "adoption must not transfer ownership away from the process that created the object"
+    );
+
+    // The INSERT arm: an orphan object with no journal row at all. Here the
+    // adopting process IS the only process on record, so its epoch is the
+    // honest answer — and, being a fresh row, there is nothing it can shield
+    // that was not already this process's to shield.
+    let orphan = AdmissionJournalKey {
+        domain: AdmissionDomain::WarmBuild,
+        work_id: "orphan-object-with-no-row".into(),
+        generation: 0,
+    };
+    let inserted = repo
+        .adopt_live(&AdoptLiveAdmissionInput {
+            key: orphan.clone(),
+            workload_kind: AdmissionWorkloadKind::Warm,
+            creator_server_epoch: "epoch-2-the-adopting-process".into(),
+            object_name: "djinn-warm-orphan".into(),
+            object_uid: "uid-orphan".into(),
+        })
+        .await
+        .expect("an object with no row is adopted by inserting one");
+    assert_eq!(inserted.state, AdmissionState::Live);
+    assert_eq!(
+        inserted.creator_server_epoch, "epoch-2-the-adopting-process",
+        "a row adoption itself creates belongs to the adopting process"
+    );
+}

--- a/server/src/build_admission_reconcile.rs
+++ b/server/src/build_admission_reconcile.rs
@@ -41,6 +41,15 @@
 //! [`crate::graph_retention`] — it is started exclusively from `become_leader`
 //! and runs until the process-wide `CancellationToken` fires.
 //!
+//! Spawn-site discipline was not enough on its own. The *same* mutating pass
+//! was also reachable from `AppState::initialize`, which runs on every pod
+//! before leadership is contested, and from the every-pod handoff warning tick
+//! by way of `reestablish_build_admission_gates`. Both of those now run
+//! observe-only: the scope is derived from the topology-confirmation flag
+//! rather than from the call site, so the invariant this section asserts holds
+//! for reasons a future caller cannot accidentally undo. See
+//! [`djinn_coordinator::build_admission_inventory::ReconcileScope`].
+//!
 //! ## Fail-closed semantics are unchanged
 //!
 //! A pass that cannot prove the inventory marks the controller
@@ -195,13 +204,21 @@ where
 {
     let mut ticker = tokio::time::interval(interval);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    // The first tick fires immediately; consume it. `AppState::initialize` runs
-    // a reconciliation pass on every pod before `become_leader` is even called,
-    // and the leader's own promotion path can run another, so reconciling again
-    // in the same breath would only duplicate API-server traffic during the
-    // leadership transition. This suppression is what makes it safe to spawn
-    // this loop as early as we do — see `become_leader`.
-    ticker.tick().await;
+    // The first tick fires immediately, and it is DELIBERATELY not suppressed.
+    //
+    // It used to be. The justification was that `AppState::initialize` had
+    // already run a full reconciliation pass on this pod, so a pass here would
+    // only duplicate API-server traffic during the leadership transition. That
+    // justification is gone: `initialize` runs on every pod including standbys,
+    // so its pass is now observe-only (see
+    // `AppState::initialize_build_admission_inventory`) and reclaims nothing.
+    //
+    // Suppressing the first tick on top of that would leave a freshly promoted
+    // leader with NO mutating pass for a full cadence — and the population that
+    // matters most is exactly the one a promotion creates: the predecessor's
+    // orphaned rows, which nothing else in the process retires. The first tick
+    // is now the leader's first mutating pass, and it runs the moment the
+    // topology gate opens.
     loop {
         tokio::select! {
             () = cancel.cancelled() => {
@@ -453,12 +470,18 @@ mod tests {
         );
     }
 
-    /// The loop suppresses its very first tick because a reconciliation pass
-    /// has just run elsewhere. Pin that, because `become_leader` now spawns
-    /// this loop immediately after the topology gate opens and the safety of
-    /// that move rests on this suppression.
+    /// The loop's first tick must NOT be suppressed.
+    ///
+    /// This loop is spawned from `become_leader`, immediately after the
+    /// topology gate opens, and it is now the freshly promoted leader's FIRST
+    /// mutating reconciliation pass: the startup pass in `AppState::initialize`
+    /// runs on every pod and is therefore observe-only, so it reclaims nothing.
+    /// Suppressing this tick would leave the predecessor's orphaned rows —
+    /// precisely the population a promotion creates, and the population that
+    /// halted the board for five hours on 2026-07-29 — occupying capacity for a
+    /// full cadence with nothing else in the process able to retire them.
     #[tokio::test(start_paused = true)]
-    async fn the_first_immediate_tick_is_suppressed() {
+    async fn the_first_tick_runs_a_pass_immediately() {
         let passes = Arc::new(AtomicUsize::new(0));
         let cancel = CancellationToken::new();
         let loop_passes = Arc::clone(&passes);
@@ -477,14 +500,16 @@ mod tests {
             )
             .await
         });
+        // Well inside the 60s cadence: anything counted here can only be the
+        // immediate first tick.
         tokio::time::sleep(Duration::from_secs(30)).await;
         tokio::task::yield_now().await;
         let observed = passes.load(Ordering::SeqCst);
         cancel.cancel();
         let _ = handle.await;
         assert_eq!(
-            observed, 0,
-            "the immediate first tick must be consumed without running a pass"
+            observed, 1,
+            "a newly promoted leader must reconcile at once, not one cadence later"
         );
     }
 

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -24,6 +24,7 @@ use djinn_agent::file_time::FileTime;
 use djinn_agent::lsp::LspManager;
 use djinn_agent::roles::RoleRegistry;
 use djinn_agent::runtime_bridge::{K8sTokenReviewValidator, RuntimeKind, runtime_kind};
+use djinn_coordinator::build_admission_inventory::ReconcileScope;
 use djinn_coordinator::build_lease::BuildLeaseService;
 use djinn_coordinator::build_lease_reclaim::BuildLeaseReclaimer;
 use djinn_coordinator::build_slot_authority::BuildLeaseDispatchAuthority;
@@ -260,6 +261,22 @@ impl StartupReconnectabilityMeasurement {
     /// without re-deriving it separately from the count emitted in tracing.
     pub(crate) fn reconnectable_task_run_ids(&self) -> &HashSet<String> {
         &self.reconnectable_task_run_ids
+    }
+}
+
+/// The single rule deciding whether a build-admission reconciliation pass may
+/// write the durable admission journal.
+///
+/// A free function so the rule itself is testable without an `AppState`: the
+/// hazard being fenced off is a standby writing the shared ledger, and "the
+/// standby case maps to Observe" is the assertion that matters. See
+/// [`AppState::initialize_build_admission_inventory`] for why the decision
+/// cannot live at the call sites.
+fn reconcile_scope_for(topology_confirmed: bool) -> ReconcileScope {
+    if topology_confirmed {
+        ReconcileScope::Mutate
+    } else {
+        ReconcileScope::Observe
     }
 }
 
@@ -1220,11 +1237,38 @@ impl AppState {
     /// re-runs this on a leader-only timer via
     /// [`Self::reconcile_build_admission_inventory`], because a row that had
     /// not settled during the startup pass is otherwise never looked at again.
+    ///
+    /// ## Only the leader may run the MUTATING pass
+    ///
+    /// The scope comes from [`Self::build_admission_reconcile_scope`] rather
+    /// than from the call site, because the call sites are not all leader-only
+    /// and were never audited as if they were:
+    ///
+    /// * [`Self::initialize`] runs on **every** pod, standbys included, before
+    ///   leadership is contested;
+    /// * `reestablish_build_admission_gates` is reached from
+    ///   `finalize_build_admission_handoff`, which the handoff warning loop
+    ///   ticks on **every** pod (that loop's own comment argues it is safe
+    ///   because the emergency *acknowledgement* is readiness-gated — true, and
+    ///   it says nothing about the full reconciliation the branch above it
+    ///   performs).
+    ///
+    /// A mutating pass from a standby is not benign. `is_reclaimable`'s LIST
+    /// and GET clauses are structurally vacuous for `task_observation` rows, so
+    /// the creator-epoch fence is the only thing protecting a settled row — and
+    /// a standby clears that fence trivially, because the leader's epoch is not
+    /// its own. A standby could therefore retire the admission row of a
+    /// task-run still running on the leader, under-counting durable occupancy:
+    /// fail-open, silently, with no operator-visible signal.
+    ///
+    /// Deriving the scope from the topology flag rather than the call site also
+    /// means a future caller cannot reintroduce the hazard by forgetting.
     async fn initialize_build_admission_inventory(&self) {
         let Some(admission) = self.inner.build_admission.clone() else {
             // Off: no controller, no readiness coupling.
             return;
         };
+        let scope = self.build_admission_reconcile_scope();
         let warmer = self.inner.graph_warmer.read().await.clone();
         let Some(warmer) = warmer else {
             admission.mark_inventory_pending();
@@ -1245,7 +1289,7 @@ impl AppState {
                     admission.clone(),
                     inventory,
                 )
-                .reconcile()
+                .reconcile_with(scope)
                 .await;
             if report.blockers.is_empty() {
                 // A pass that RAN and a pass that SUCCEEDED are different facts,
@@ -1258,6 +1302,7 @@ impl AppState {
                 admission.note_reconcile_success();
                 tracing::info!(
                     mode = ?admission.mode(),
+                    ?scope,
                     adopted = report.adopted,
                     released = report.released,
                     reclaimed = report.reclaimed,
@@ -1275,6 +1320,7 @@ impl AppState {
             } else {
                 tracing::error!(
                     mode = ?admission.mode(),
+                    ?scope,
                     reclaim_failures = report.reclaim_failure_count,
                     named_reclaim_failures = ?report.reclaim_failures,
                     blockers = ?report.blockers,
@@ -1308,6 +1354,23 @@ impl AppState {
                 );
             }
         }
+    }
+
+    /// Which reconciliation scope this process is entitled to right now.
+    ///
+    /// `build_admission_topology_confirmed` is set by exactly one writer,
+    /// [`Self::confirm_build_admission_topology`], which runs only from
+    /// [`Self::become_leader`] — i.e. only after this process won the
+    /// coordinator advisory lock. That flag IS the single-active-writer fact,
+    /// and it is the same one the topology readiness gate is re-asserted from,
+    /// so the journal writer and the admission gate can never disagree about
+    /// who the active process is.
+    fn build_admission_reconcile_scope(&self) -> ReconcileScope {
+        reconcile_scope_for(
+            self.inner
+                .build_admission_topology_confirmed
+                .load(Ordering::Acquire),
+        )
     }
 
     /// Re-walk the build-admission startup gates after a live promotion reset
@@ -2599,13 +2662,16 @@ impl AppState {
         // advisory-lock liveness ping stopped too. Admission open and
         // reclamation absent is precisely the combination that halts the board.
         //
-        // Spawning this early is safe because the loop SUPPRESSES ITS OWN FIRST
-        // TICK (see `build_admission_reconcile::run_loop`): `initialize()` runs
-        // a full reconciliation pass on every pod before leadership is even
-        // contested, and `confirm_build_admission_topology` can run another via
-        // the handoff path, so the first real pass is one cadence away either
-        // way. Moving the spawn earlier only shortens the window in which a
-        // pass has just run — it cannot create a duplicate one.
+        // The loop's first tick fires IMMEDIATELY, and this spawn site is why
+        // that is now correct rather than merely wasteful. `initialize()` runs
+        // on every pod including standbys, so its reconciliation pass is
+        // observe-only and retires nothing (see
+        // `initialize_build_admission_inventory`). This spawn — the first
+        // statement after the topology gate opens — is therefore the first
+        // point at which THIS process is entitled to write the shared journal,
+        // and its immediate first pass is the one that retires the
+        // predecessor's orphans. Suppressing it would cost a full cadence at
+        // exactly the moment the stale population is largest.
         //
         // The startup pass alone cannot reclaim an occupying row that has not
         // yet settled past the reclaim settle window, and a rolling deploy is
@@ -5230,6 +5296,100 @@ mod build_admission_config_tests {
                 "the reconciler must be spawned before {later}"
             );
         }
+    }
+
+    /// The rule itself: a process that has not confirmed the single-active
+    /// topology gate gets an observe-only pass, and only a confirmed leader may
+    /// write the shared admission journal.
+    #[test]
+    fn only_a_confirmed_leader_reconciles_with_the_mutating_scope() {
+        assert_eq!(reconcile_scope_for(true), ReconcileScope::Mutate);
+        assert_eq!(
+            reconcile_scope_for(false),
+            ReconcileScope::Observe,
+            "a standby — every pod before leadership is won, and every pod that \
+             never wins it — must not write the durable admission journal"
+        );
+    }
+
+    /// Composition: the scope is derived from the topology flag, never chosen
+    /// at a call site.
+    ///
+    /// `initialize_build_admission_inventory` is reachable from
+    /// `initialize()` (every pod, before leadership is contested) and from
+    /// `reestablish_build_admission_gates` (reached from the handoff warning
+    /// tick, which also runs on every pod). Auditing those call sites is what
+    /// failed; deriving the scope from the one fact that identifies the active
+    /// writer is what cannot.
+    #[test]
+    fn the_reconcile_scope_is_derived_from_topology_confirmation_not_the_call_site() {
+        let source = include_str!("mod.rs");
+        // Assembled at runtime so these assertions do not match their own
+        // literals inside the file they read.
+        let mutate = format!("ReconcileScope::{}", "Mutate");
+        let flag = format!("build_admission_topology_{}", "confirmed");
+        let decision = format!("fn reconcile_scope_{}(", "for");
+
+        let decision_at = source.find(decision.as_str()).expect("the rule exists");
+        let body_end = source[decision_at..]
+            .find("\n}\n")
+            .expect("the rule has a body");
+        let body = &source[decision_at..decision_at + body_end];
+        assert!(
+            body.contains(mutate.as_str()),
+            "the rule is the only place that may hand out the mutating scope"
+        );
+
+        // Nowhere else in the production half of this file may construct it.
+        let production = &source[..decision_at + body_end];
+        assert_eq!(
+            production.matches(mutate.as_str()).count(),
+            1,
+            "the mutating scope must be constructed only by the rule"
+        );
+
+        // And the seam that runs the pass must ask the rule rather than decide.
+        let seam = source
+            .find("async fn initialize_build_admission_inventory")
+            .expect("the seam exists");
+        let seam_body = &source[seam..];
+        let asked = seam_body
+            .find("let scope = self.build_admission_reconcile_scope()")
+            .expect("the inventory seam derives its scope from the rule");
+        let used = seam_body
+            .find(".reconcile_with(scope)")
+            .expect("the inventory seam passes that scope to the reconciler");
+        assert!(
+            asked < used,
+            "the scope must be derived before the pass runs"
+        );
+
+        // The rule reads the topology flag, and that flag has exactly one
+        // writer — `confirm_build_admission_topology`, which only
+        // `become_leader` calls.
+        let store = format!(".store(true, Ordering::{})", "Release");
+        let confirm = source
+            .find("async fn confirm_build_admission_topology")
+            .expect("the topology seam exists");
+        let confirm_end = confirm
+            + source[confirm..]
+                .find("\n    }\n")
+                .expect("the topology seam has a body");
+        assert!(
+            source[confirm..confirm_end].contains(store.as_str()),
+            "leadership confirmation is what sets the flag"
+        );
+        let accessor = source
+            .find("fn build_admission_reconcile_scope")
+            .expect("the accessor exists");
+        let accessor_end = accessor
+            + source[accessor..]
+                .find("\n    }\n")
+                .expect("the accessor has a body");
+        assert!(
+            source[accessor..accessor_end].contains(flag.as_str()),
+            "the scope must be read from the topology-confirmation flag and nothing else"
+        );
     }
 
     /// L6. `begin_draining` has no clearing path on the production shutdown


### PR DESCRIPTION
Open finding from #2747, which reported that `AppState::initialize()` runs the **full mutating** reconciler on every pod including standbys, and left it unfixed because it could not establish safety. Investigation confirms the concern is real — but **both the stated mechanism and the stated mitigation were wrong, in opposite directions, and the net is worse than reported.**

## The mechanism is wrong: adoption never re-stamps the epoch

#2747 worried that adoption writes `creator_server_epoch: self.controller.server_epoch()`, letting a standby re-stamp ownership of live rows and move the reclamation shield off the leader.

`adopt_live` never rewrites an existing row's `creator_server_epoch`. `update_state` writes only `state`, `object_uid`, `updated_at`, `terminal_at`. The epoch the reconciler passes in is consumed by the **INSERT arm alone** — adopting an orphan object that has no journal row at all. Stamping the adopter on a row it creates is correct (no predecessor value exists); preserving the creator everywhere else is correct. So the shield is never transferred by adoption and the concurrent-re-stamping interleavings cannot occur.

Semantics unchanged, now pinned by `adoption_preserves_the_creator_epoch_and_stamps_only_a_row_it_creates`. (The 2026-07-29 production recovery was epoch *rotation across restart*, not adoption.)

## The mitigation is wrong: a standby **can** reclaim live rows

#2747 reasoned that reclamation needs three independent conditions, so a standby cannot reclaim a live row. Those conditions do not hold for `task_observation` rows — as #2746's own commit message states, the LIST and GET clauses are **structurally vacuous** there (the Job is `djinn-taskrun-{task_run_id}` while the row records `task-run-{task_id}-{reopen}`). The 300s settle window is exceeded by any pending pod. The creator-epoch fence is the *only* real protection, and a standby clears it trivially by having a different epoch.

Verified empirically: the same fixture under the old pass reports `(reclaimed, released, adopted) = (1, 0, 1)` — it retired a running task-run's row and inserted an adoption row for the leader's Job. **Fail-open.**

## It is live in the shipped default topology

Enforce mode forbids overlap (`replicas: 1` plus `maxSurge: 0`/`Recreate`, hard-failed at render). But the chart **defaults** are `mode: observe` with `maxSurge: 1`, which surges a second pod on every deploy, and `reconcile()` only short-circuits on `Off`. So this is reachable in the default configuration, not merely latent.

**Broader than reported:** the mutating pass has a second every-pod caller — `reestablish_build_admission_gates` ← `finalize_build_admission_handoff` ← the handoff warning loop, started from `initialize()` on every pod. Its comment argues safety from the acknowledgement being readiness-gated, which says nothing about the reconciliation on the branch above it.

## The fix

`ReconcileScope::{Observe, Mutate}`, with the scope **derived from `build_admission_topology_confirmed`** rather than from the call site — because auditing call sites is precisely what failed twice here.

Observe keeps every read: the LIST, classification, blocker detection, the journal read, and the tail seed that re-derives the four journal-derived gates. It skips the settlement listing, the per-row GETs, and every write. A standby therefore carries correct readiness into its own promotion and can never become *more* permissive than before — it stays fail-closed.

One consequence: the loop's first-tick suppression had to go. Its justification was "`initialize()` just ran a full pass", which is no longer true for a standby. Without removing it, a freshly promoted leader would wait a full cadence before touching its predecessor's orphans — exactly the delay that made the 2026-07-29 outage expensive.

## Tests

- `a_standby_pass_leaves_a_live_task_runs_row_alone` → passes. With `.observe()` swapped back to `.reconcile()` (unmodified behaviour) it **fails**: `left: (1, 0, 1) right: (0, 0, 0)`.
- `adoption_preserves_the_creator_epoch_and_stamps_only_a_row_it_creates` → passes.
- 5 passed in `djinn-server` covering scope selection, first-tick, spawn ordering and disk observation, including the two composition tests #2747 added.

Per the ship-now instruction, no full-suite or clippy sweep was run locally — CI is the gate.

## Not in this branch

- **`initialize_build_admission_recovery` is still every-pod and still mutating.** `recover_all_predecessors` terminalizes `reserved` rows and relabels `create_in_flight` rows for any epoch that is not this process's — on a standby, that is the *live leader's*. Narrower blast radius (the reserved window is sub-second per dispatch, and the relabel is benign post-#2746), but it is the same defect. Fixing it means adding recovery to the promotion path, which reorders the sequence #2747 just pinned — its own change, and a decision.
- `BuildAdmissionReconciler::serial` is a per-instance `Mutex` while every call site constructs a fresh reconciler, so it serializes nothing in production. Noted, not touched.
- A test module was marked `djinn:allow-oversize` rather than split: it is 56674 bytes against the 51200 guard, and #2749 is concurrently adding cases to the same file. The marker defers the split rather than conflicting with that PR. It should be split once #2749 lands.

## Merge coordination

#2749 (`fix/admission-task-run-object-identity`) edits `build_admission_inventory.rs` in the `Live` branch and the classification helpers. This PR wraps the row loop in `if scope.may_write()`, so expect a small mechanical conflict on its one-line `completed` hunk. No overlap in `server/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
