### PR TITLE
fix(slot): retry transient mid-stream provider errors instead of killing the session

### DIFF
--- a/server/crates/djinn-provider/src/provider/client.rs
+++ b/server/crates/djinn-provider/src/provider/client.rs
@@ -840,7 +840,13 @@ impl ApiClient {
 }
 
 /// Calculate exponential backoff delay with jitter for a given attempt (1-based).
-fn backoff_delay_ms(attempt: u32) -> u64 {
+///
+/// Public so retry paths *outside* the HTTP client — notably the reply loop's
+/// bounded restart of a round killed by a transient **mid-stream** provider
+/// error, which the `'retry` loop above cannot reach once the SSE stream is
+/// established on a 200 — use the exact same exponential-with-jitter schedule
+/// instead of inventing a parallel one.
+pub fn backoff_delay_ms(attempt: u32) -> u64 {
     let base = INITIAL_BACKOFF_MS as f64 * BACKOFF_MULTIPLIER.powi(attempt as i32 - 1);
     let capped = base.min(MAX_BACKOFF_MS as f64);
     // Jitter: 0.8x to 1.2x

--- a/server/crates/djinn-slot/src/reply_loop/mod.rs
+++ b/server/crates/djinn-slot/src/reply_loop/mod.rs
@@ -44,3 +44,8 @@ pub use turn::{ReplyLoopContext, run_reply_loop};
 #[cfg(test)]
 #[allow(clippy::await_holding_lock)]
 mod tests;
+
+/// Bounded retry of transient MID-STREAM provider errors (see
+/// `streaming::MAX_STREAM_EVENT_RETRIES`).
+#[cfg(test)]
+mod streaming_retry_tests;

--- a/server/crates/djinn-slot/src/reply_loop/streaming.rs
+++ b/server/crates/djinn-slot/src/reply_loop/streaming.rs
@@ -13,8 +13,9 @@ use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 
 use djinn_core::events::DjinnEventEnvelope;
-use djinn_provider::message::ContentBlock;
-use djinn_provider::provider::{LlmProvider, StreamEvent};
+use djinn_provider::message::{ContentBlock, Conversation};
+use djinn_provider::provider::client::backoff_delay_ms;
+use djinn_provider::provider::{LlmProvider, ProviderError, StreamEvent, ToolChoice};
 
 use super::budget::record_provider_usage;
 use super::error_handling::{
@@ -172,9 +173,18 @@ impl StreamTurnState {
     }
 }
 
+pub(super) type ProviderStream =
+    Pin<Box<dyn futures::Stream<Item = anyhow::Result<StreamEvent>> + Send>>;
+
 pub(super) struct StreamLoopContext<'a> {
     pub provider: &'a dyn LlmProvider,
-    pub stream: Pin<Box<dyn futures::Stream<Item = anyhow::Result<StreamEvent>> + Send>>,
+    pub stream: ProviderStream,
+    /// The exact request inputs that produced [`Self::stream`], so a round
+    /// killed by a *transient* mid-stream provider error can be re-issued
+    /// verbatim. See [`consume_provider_stream`]'s retry branch.
+    pub request_conversation: &'a Conversation,
+    pub request_tools: &'a [serde_json::Value],
+    pub request_tool_choice: Option<ToolChoice>,
     pub tool_metadata: &'a ToolRuntimeMetadataMap,
     pub dispatch: &'a ToolDispatchContext<'a>,
     pub phase_tracker: &'a Arc<Mutex<super::phase::SessionPhaseTracker>>,
@@ -205,11 +215,84 @@ const TOUCH_ACTIVITY_RPC_INTERVAL_SECS: u64 = 30;
 /// Throttle interval for the mid-flight session-row token flush.
 const TOKEN_FLUSH_INTERVAL_SECS: u64 = 30;
 
+/// Additional attempts granted to a round killed by a **transient** mid-stream
+/// provider error (e.g. an OpenAI `server_is_overloaded` SSE `error` event).
+///
+/// The HTTP-level retry in `djinn_provider::provider::client` only covers
+/// request *establishment*: once the provider answers `200 OK` and the SSE
+/// stream is open, its `'retry` loop has already been broken out of, so an
+/// error arriving as a stream *event* had no retry path at all and terminated
+/// the whole agent session on the first occurrence.
+///
+/// Deliberately smaller than the client's `MAX_RETRIES` (3): each attempt here
+/// re-issues a full LLM request, and the surrounding reply loop still has its
+/// own recovery paths above this one.
+pub(super) const MAX_STREAM_EVENT_RETRIES: u32 = 2;
+
+/// Whether the round consumed so far can be safely thrown away and re-issued.
+///
+/// A retry re-sends the identical request, so it is only safe while **nothing
+/// observable has happened yet this round**: no text streamed to the transcript
+/// event bus, no tool call recorded or dispatched (tool execution has real side
+/// effects), no thinking emitted, and no usage folded into the session
+/// counters. `saw_round_event` is the load-bearing flag — it is set on the very
+/// first successfully-decoded event, before any of the per-event handling below
+/// runs — and the remaining checks are explicit belt-and-braces so a future
+/// change to that flag's meaning cannot silently make retries unsafe.
+fn round_is_safely_restartable(state: &StreamTurnState, inflight_tool_futures: usize) -> bool {
+    !state.saw_round_event
+        && state.turn_text.is_empty()
+        && state.turn_thinking.is_empty()
+        && state.turn_tool_calls.is_empty()
+        && state.turn_provider_state.is_empty()
+        && state.turn_unresolved_thinking.is_empty()
+        && state.streaming_dispatched.is_empty()
+        && state.streaming_results.is_empty()
+        && state.turn_tokens_in == 0
+        && state.turn_tokens_out == 0
+        && inflight_tool_futures == 0
+}
+
+/// Delay before re-issuing a round killed by `error`, or `None` when the round
+/// must fail exactly as it does today.
+///
+/// Retryability is decided *solely* by [`ProviderError::retryable`] — the same
+/// predicate the HTTP client and the supervisor's failure classifier use — so
+/// `RateLimit` / `ProviderInternal{5xx}` / `Transport` / `ExhaustedTransport` /
+/// `EmptyCompletion` are retried while `Authentication` / `InvalidRequest` /
+/// `ContextOverflow` / `InvalidOutput` are not. An error with no typed
+/// `ProviderError` source is never retried.
+fn transient_round_restart_delay(
+    error: &anyhow::Error,
+    attempts_used: u32,
+    state: &StreamTurnState,
+    inflight_tool_futures: usize,
+) -> Option<std::time::Duration> {
+    if attempts_used >= MAX_STREAM_EVENT_RETRIES {
+        return None;
+    }
+    if !round_is_safely_restartable(state, inflight_tool_futures) {
+        return None;
+    }
+    let provider_error = error.downcast_ref::<ProviderError>()?;
+    if !provider_error.retryable() {
+        return None;
+    }
+    // Same exponential-with-jitter schedule as the client's request retry,
+    // floored by a server-supplied Retry-After when the provider sent one.
+    let attempt = attempts_used + 1;
+    let delay_ms = backoff_delay_ms(attempt).max(provider_error.retry_after_ms().unwrap_or(0));
+    Some(std::time::Duration::from_millis(delay_ms))
+}
+
 pub(super) async fn consume_provider_stream(
     mut ctx: StreamLoopContext<'_>,
 ) -> anyhow::Result<StreamTurnState> {
     let mut state = StreamTurnState::new();
     let mut streaming_inflight: FuturesUnordered<StreamingFut<'_>> = FuturesUnordered::new();
+    // Attempts already spent restarting this round after a transient
+    // mid-stream provider error (see `MAX_STREAM_EVENT_RETRIES`).
+    let mut stream_event_retries: u32 = 0;
     loop {
         // A concurrent-safe side tool may have temporarily taken phase
         // ownership. Every select iteration waits for the provider again, so
@@ -246,6 +329,71 @@ pub(super) async fn consume_provider_stream(
                         break;
                     }
                     Err(e) => {
+                        // A transient provider failure that arrived as a stream
+                        // *event* (HTTP 200 was already returned, so the client's
+                        // request-establishment retry cannot help) gets a bounded
+                        // restart of the whole round — but only while the round is
+                        // still safely restartable. Otherwise fall through to the
+                        // unchanged terminal path.
+                        if let Some(delay) = transient_round_restart_delay(
+                            &e,
+                            stream_event_retries,
+                            &state,
+                            streaming_inflight.len(),
+                        ) {
+                            stream_event_retries += 1;
+                            tracing::warn!(
+                                task_id = %ctx.task_id,
+                                session_id = %ctx.session_id,
+                                attempt = stream_event_retries,
+                                max_attempts = MAX_STREAM_EVENT_RETRIES,
+                                delay_ms = delay.as_millis() as u64,
+                                error = %e,
+                                "provider stream event failed with a retryable error before any \
+                                 output was emitted; retrying"
+                            );
+                            tokio::select! {
+                                biased;
+                                _ = ctx.cancel.cancelled() => {
+                                    state.interrupted = Some("session cancelled");
+                                    break;
+                                }
+                                _ = ctx.global_cancel.cancelled() => {
+                                    state.interrupted = Some("supervisor shutting down");
+                                    break;
+                                }
+                                _ = tokio::time::sleep(delay) => {}
+                            }
+                            // Re-issue the identical request. Copy the `&'a`
+                            // inputs out first so `ctx.stream` can be reassigned.
+                            let provider = ctx.provider;
+                            let request_conversation = ctx.request_conversation;
+                            let request_tools = ctx.request_tools;
+                            let request_tool_choice = ctx.request_tool_choice;
+                            match provider
+                                .stream(request_conversation, request_tools, request_tool_choice)
+                                .await
+                            {
+                                Ok(restarted) => {
+                                    ctx.stream = restarted;
+                                    // Nothing was emitted (asserted by
+                                    // `round_is_safely_restartable`), so the
+                                    // round starts from a clean slate.
+                                    state = StreamTurnState::new();
+                                    continue;
+                                }
+                                Err(restart_error) => {
+                                    tracing::warn!(
+                                        task_id = %ctx.task_id,
+                                        session_id = %ctx.session_id,
+                                        attempt = stream_event_retries,
+                                        error = %restart_error,
+                                        "retry of the provider stream failed to start; \
+                                         surfacing the original mid-stream error"
+                                    );
+                                }
+                            }
+                        }
                         let diag = runtime_fs_diagnostics(ctx.project_path, ctx.worktree_path);
                         let env_diag = runtime_env_diagnostics(ctx.session_id, ctx.project_path, ctx.worktree_path);
                         let detail = format!(

--- a/server/crates/djinn-slot/src/reply_loop/streaming_retry_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/streaming_retry_tests.rs
@@ -1,0 +1,372 @@
+//! Regression coverage for the bounded retry of **transient mid-stream**
+//! provider errors (`reply_loop::streaming`).
+//!
+//! Before this existed, a single transient upstream overload event destroyed an
+//! entire agent session: `consume_provider_stream` special-cased only
+//! context-length and orphaned-tool-call errors, and every other stream error
+//! fell straight through to `return Err(...)`. The HTTP-level `'retry` loop in
+//! `djinn_provider::provider::client` could not help — it breaks out of the
+//! retry loop the moment the provider answers `200 OK`, so an error arriving as
+//! an SSE *event* has already left that code path behind.
+//!
+//! Every test here asserts a **session-level side effect** (did the session
+//! survive? how many provider requests were actually issued?), never that a
+//! predicate returns `true`.
+
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use djinn_db::SessionRepository;
+use djinn_db::repositories::session::CreateSessionParams;
+use djinn_provider::message::{ContentBlock, Conversation, Message};
+use djinn_provider::provider::{LlmProvider, ProviderError, StreamEvent, ToolChoice};
+use futures::stream;
+use tokio_util::sync::CancellationToken;
+
+use super::streaming::MAX_STREAM_EVENT_RETRIES;
+use super::turn::{ReplyLoopContext, run_reply_loop};
+use crate::test_helpers;
+
+/// The literal upstream payload from the `2gq7` incident:
+/// `{"type":"error","error":{"type":"service_unavailable_error",
+///   "code":"server_is_overloaded","message":"Our servers are currently
+///   overloaded. Please try again later."}}`
+const OVERLOAD_CODE: &str = "server_is_overloaded";
+const OVERLOAD_MESSAGE: &str = "Our servers are currently overloaded. Please try again later.";
+
+/// Build the error the OpenAI Responses adapter produces for that payload:
+/// a typed [`ProviderError`] source carrying the readable message as context.
+///
+/// Deliberately routed through [`ProviderError::from_stream_error`] rather than
+/// naming a variant, so this stays faithful to the production classification
+/// path (and to any future re-classification of the overload code).
+fn overload_stream_error() -> anyhow::Error {
+    anyhow::Error::new(ProviderError::from_stream_error(
+        Some(OVERLOAD_CODE),
+        OVERLOAD_MESSAGE,
+    ))
+    .context(format!("{OVERLOAD_CODE}: {OVERLOAD_MESSAGE}"))
+}
+
+/// A non-retryable failure, used as the negative control.
+fn auth_stream_error() -> anyhow::Error {
+    anyhow::Error::new(ProviderError::from_stream_error(
+        Some("invalid_api_key"),
+        "Incorrect API key provided.",
+    ))
+    .context("invalid_api_key: Incorrect API key provided.")
+}
+
+/// What a single `LlmProvider::stream()` call yields.
+#[derive(Clone)]
+enum TurnScript {
+    /// The stream's very first item is an error — nothing was emitted, so the
+    /// round is safely restartable.
+    ErrorFirst(&'static str),
+    /// A text delta reaches the transcript, *then* the stream errors. Retrying
+    /// here would duplicate downstream output, so it must not be retried.
+    TextThenError(&'static str, &'static str),
+    /// A complete, successful text turn.
+    Text(&'static str),
+}
+
+fn scripted_error(kind: &str) -> anyhow::Error {
+    match kind {
+        "overload" => overload_stream_error(),
+        "auth" => auth_stream_error(),
+        other => panic!("unknown scripted error kind {other}"),
+    }
+}
+
+/// An `LlmProvider` that plays a fixed script of turns and then repeats `tail`
+/// forever, counting how many times `stream()` was actually called.
+///
+/// The call count is the load-bearing assertion: it proves whether a retry did
+/// or did not re-issue the request.
+struct ScriptedStreamProvider {
+    turns: Mutex<VecDeque<TurnScript>>,
+    tail: TurnScript,
+    stream_calls: AtomicUsize,
+}
+
+impl ScriptedStreamProvider {
+    fn new(turns: Vec<TurnScript>, tail: TurnScript) -> Self {
+        Self {
+            turns: Mutex::new(turns.into()),
+            tail,
+            stream_calls: AtomicUsize::new(0),
+        }
+    }
+
+    /// Number of provider requests issued — i.e. `1 + retries actually taken`.
+    fn stream_calls(&self) -> usize {
+        self.stream_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl LlmProvider for ScriptedStreamProvider {
+    fn name(&self) -> &str {
+        "scripted-stream"
+    }
+
+    fn stream<'a>(
+        &'a self,
+        _conversation: &'a Conversation,
+        _tools: &'a [serde_json::Value],
+        _tool_choice: Option<ToolChoice>,
+    ) -> Pin<
+        Box<
+            dyn futures::Future<
+                    Output = anyhow::Result<
+                        Pin<Box<dyn futures::Stream<Item = anyhow::Result<StreamEvent>> + Send>>,
+                    >,
+                > + Send
+                + 'a,
+        >,
+    > {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        let script = {
+            let mut turns = self.turns.lock().expect("scripted turns mutex");
+            turns.pop_front().unwrap_or_else(|| self.tail.clone())
+        };
+        Box::pin(async move {
+            let events: Vec<anyhow::Result<StreamEvent>> = match script {
+                TurnScript::ErrorFirst(kind) => vec![Err(scripted_error(kind))],
+                TurnScript::TextThenError(text, kind) => vec![
+                    Ok(StreamEvent::Delta(ContentBlock::Text {
+                        text: text.to_string(),
+                    })),
+                    Err(scripted_error(kind)),
+                ],
+                TurnScript::Text(text) => vec![
+                    Ok(StreamEvent::Delta(ContentBlock::Text {
+                        text: text.to_string(),
+                    })),
+                    Ok(StreamEvent::Done),
+                ],
+            };
+            Ok(Box::pin(stream::iter(events))
+                as Pin<
+                    Box<dyn futures::Stream<Item = anyhow::Result<StreamEvent>> + Send>,
+                >)
+        })
+    }
+}
+
+/// Minimal reply-loop fixture: a real in-memory DB with the project / epic /
+/// task / task-run / session rows the loop's persistence path requires.
+struct Fixture {
+    slot_ctx: crate::host::SlotContext,
+    project_path: String,
+    task_id: String,
+    session_id: String,
+    cancel: CancellationToken,
+    conversation: Conversation,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let cancel = CancellationToken::new();
+        let db = test_helpers::create_test_db();
+        let slot_ctx = test_helpers::agent_context_from_db(db.clone(), cancel.clone());
+        let project = test_helpers::create_test_project(&db).await;
+        let epic = test_helpers::create_test_epic(&db, &project.id).await;
+        let task = test_helpers::create_test_task(&db, &project.id, &epic.id).await;
+        let task_run_id = uuid::Uuid::now_v7().to_string();
+        djinn_db::repositories::task_run::TaskRunRepository::new(db.clone())
+            .create(djinn_db::repositories::task_run::CreateTaskRunParams {
+                id: &task_run_id,
+                project_id: &project.id,
+                task_id: &task.id,
+                trigger_type: "dispatch",
+                status: Some("running"),
+                workspace_path: Some("/tmp"),
+                mirror_ref: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .expect("create active task run");
+        let session = SessionRepository::new(db.clone(), slot_ctx.event_bus.clone())
+            .create(CreateSessionParams {
+                project_id: &project.id,
+                task_id: Some(&task.id),
+                model: "test/mock-model",
+                agent_type: "worker",
+                metadata_json: None,
+                task_run_id: None,
+                pricing: None,
+                cost_basis: None,
+            })
+            .await
+            .expect("create session");
+        let project_path =
+            djinn_core::paths::project_dir(&project.github_owner, &project.github_repo)
+                .to_string_lossy()
+                .into_owned();
+        let mut conversation = Conversation::new();
+        conversation.push(Message::system("You are a worker."));
+        conversation.push(Message::user("Do the task."));
+        Self {
+            slot_ctx,
+            project_path,
+            task_id: task.id.clone(),
+            session_id: session.id.clone(),
+            cancel,
+            conversation,
+        }
+    }
+
+    async fn run(&mut self, provider: &ScriptedStreamProvider) -> anyhow::Result<()> {
+        let worktree_path = std::path::PathBuf::from("/tmp");
+        let (result, _output, _in, _out, _cr, _cw) = run_reply_loop(
+            ReplyLoopContext {
+                compaction_cs: &super::CompactionCriticalSection::new(),
+                provider,
+                tools: &[],
+                task_id: &self.task_id,
+                task_short_id: "t1",
+                session_id: &self.session_id,
+                project_path: &self.project_path,
+                worktree_path: &worktree_path,
+                role_name: "worker",
+                finalize_tool_names: &["submit_work", "request_planner"],
+                context_window: 100_000,
+                model_id: "test/mock-model",
+                cancel: &self.cancel,
+                global_cancel: &self.cancel,
+                ctx: &self.slot_ctx,
+                active_skill_names: &[],
+                active_mcp_server_names: &[],
+                max_turns_override: None,
+            },
+            &mut self.conversation,
+            false,
+        )
+        .await;
+        result
+    }
+}
+
+/// AC1 — the core assertion. A stream that dies on a transient
+/// `server_is_overloaded` event and then succeeds on the retry produces a
+/// session that **completes successfully**.
+///
+/// Without the retry this returns `Err` on the very first error event and the
+/// second provider request is never issued (`stream_calls == 1`).
+#[tokio::test]
+async fn transient_mid_stream_overload_is_retried_and_the_session_survives() {
+    let provider = ScriptedStreamProvider::new(
+        vec![TurnScript::ErrorFirst("overload")],
+        TurnScript::Text("All done."),
+    );
+    let mut fixture = Fixture::new().await;
+    let result = fixture.run(&provider).await;
+
+    assert!(
+        result.is_ok(),
+        "a transient mid-stream overload must not kill the session; got {:#}",
+        result.unwrap_err()
+    );
+    assert_eq!(
+        provider.stream_calls(),
+        2,
+        "the round must be re-issued exactly once after the transient error"
+    );
+    // The retried round's output really did land in the transcript.
+    let assistant_text: String = fixture
+        .conversation
+        .messages
+        .iter()
+        .filter(|m| m.role == djinn_provider::message::Role::Assistant)
+        .flat_map(|m| m.content.iter().filter_map(ContentBlock::as_text))
+        .collect();
+    assert!(
+        assistant_text.contains("All done."),
+        "the successful retry's assistant turn must be persisted; got {assistant_text:?}"
+    );
+}
+
+/// AC2 — retries are bounded, and the ORIGINAL error survives to the caller
+/// with the same `provider stream event failed: ...` context the coordinator's
+/// classification already relies on.
+#[tokio::test]
+async fn persistent_mid_stream_overload_fails_after_the_retry_cap() {
+    let provider = ScriptedStreamProvider::new(vec![], TurnScript::ErrorFirst("overload"));
+    let mut fixture = Fixture::new().await;
+    let result = fixture.run(&provider).await;
+
+    let err = result.expect_err("a persistently overloaded provider must still fail the session");
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("provider stream event failed"),
+        "the terminal context string must be unchanged; got {rendered}"
+    );
+    assert!(
+        rendered.contains(OVERLOAD_MESSAGE),
+        "the original upstream error must be preserved; got {rendered}"
+    );
+    assert!(
+        err.downcast_ref::<ProviderError>().is_some(),
+        "the typed ProviderError source must survive for downstream classification"
+    );
+    // Absolute lower bound first: this is the assertion that dies if the retry
+    // does nothing. (A purely `MAX_STREAM_EVENT_RETRIES`-relative check would
+    // self-adjust to a no-op fix and stay green.)
+    assert!(
+        provider.stream_calls() > 1,
+        "the transient error must have been retried at least once; got {} request(s)",
+        provider.stream_calls()
+    );
+    // Then the upper bound: bounded, and bounded by exactly the documented cap.
+    assert_eq!(
+        provider.stream_calls(),
+        3,
+        "retries must stop at 1 initial request + MAX_STREAM_EVENT_RETRIES ({MAX_STREAM_EVENT_RETRIES})"
+    );
+}
+
+/// AC3 — negative control. A non-retryable class (`Authentication`) is not
+/// retried: exactly one provider request, immediate failure, as today.
+#[tokio::test]
+async fn non_retryable_mid_stream_error_is_not_retried() {
+    let provider = ScriptedStreamProvider::new(vec![], TurnScript::ErrorFirst("auth"));
+    let mut fixture = Fixture::new().await;
+    let result = fixture.run(&provider).await;
+
+    let err = result.expect_err("an authentication failure must terminate the session");
+    assert!(
+        format!("{err:#}").contains("Incorrect API key provided."),
+        "the original auth error must be preserved; got {err:#}"
+    );
+    assert_eq!(
+        provider.stream_calls(),
+        1,
+        "a non-retryable provider error must never re-issue the request"
+    );
+}
+
+/// AC4 — safety control. Once the round has emitted meaningful downstream
+/// output, the identical transient error is NOT retried: re-issuing would
+/// duplicate the streamed text (and, for tool calls, re-run side effects).
+#[tokio::test]
+async fn transient_error_after_emitted_output_is_not_retried() {
+    let provider = ScriptedStreamProvider::new(
+        vec![],
+        TurnScript::TextThenError("Here is my partial answer. ", "overload"),
+    );
+    let mut fixture = Fixture::new().await;
+    let result = fixture.run(&provider).await;
+
+    let err = result.expect_err("an unsafe-to-retry round must fail as it does today");
+    assert!(
+        format!("{err:#}").contains(OVERLOAD_MESSAGE),
+        "the original error must be preserved; got {err:#}"
+    );
+    assert_eq!(
+        provider.stream_calls(),
+        1,
+        "a round that already streamed output must never be re-issued"
+    );
+}

--- a/server/crates/djinn-slot/src/reply_loop/turn.rs
+++ b/server/crates/djinn-slot/src/reply_loop/turn.rs
@@ -1018,6 +1018,11 @@ pub async fn run_reply_loop(
             let mut stream_state = match consume_provider_stream(StreamLoopContext {
                 provider,
                 stream,
+                // Exact inputs behind `stream`, so a transient mid-stream
+                // provider failure can re-issue the identical request.
+                request_conversation: request_conversation.as_ref(),
+                request_tools: tools,
+                request_tool_choice: tool_choice,
                 tool_metadata: &tool_metadata,
                 dispatch: &dispatch_ctx,
                 phase_tracker: &phase_tracker,
@@ -2600,6 +2605,9 @@ mod tests {
         let state = consume_provider_stream(StreamLoopContext {
             provider: &provider,
             stream,
+            request_conversation: &conversation,
+            request_tools: &[],
+            request_tool_choice: None,
             tool_metadata: &tool_metadata,
             dispatch: &dispatch_ctx,
             phase_tracker: &phase_tracker,
@@ -2706,9 +2714,13 @@ mod tests {
         let mut total_cache_write = 0;
         let mut total_reasoning_out = 0;
 
+        let restart_conversation = Conversation::new();
         let mut state = consume_provider_stream(StreamLoopContext {
             provider: &provider,
             stream,
+            request_conversation: &restart_conversation,
+            request_tools: &[],
+            request_tool_choice: None,
             tool_metadata: &tool_metadata,
             dispatch: &dispatch_ctx,
             phase_tracker: &phase_tracker,


### PR DESCRIPTION
A single transient upstream overload event currently destroys an entire agent
session, because mid-stream provider errors have no retry path at all — the
HTTP-level retry in `djinn-provider/src/provider/client.rs` only covers request
*establishment*.

`consume_provider_stream` (`djinn-slot/src/reply_loop/streaming.rs`) special-cases
exactly two error kinds (`is_context_length_error`, `is_orphaned_tool_call_error`);
everything else falls to `return Err(e.context(detail))` and terminates the
session immediately. The client's `'retry` loop cannot help: it `break 'retry`s
the moment `status.is_success()`, so once the SSE stream is open on HTTP 200 an
error arriving as a stream *event* has already left that code path behind.
`MAX_RETRIES = 3` applies only to establishing the request.

Real incident: task `2gq7` lost 3 consecutive sessions to OpenAI
`server_is_overloaded` events; one died in 2 seconds having consumed 0 input
tokens. The user's local `codex` CLI, on the same ChatGPT Codex subscription,
rides these out fine.

Same class of gap reported upstream in sibling projects:
- https://github.com/anomalyco/opencode/issues/25730 — "Codex server_is_overloaded stream errors are not retried"
- https://github.com/Soju06/codex-lb/issues/565 — "Agent stops after transient upstream overload error instead of retrying"

## The fix

A bounded restart of the round, in the reply loop, before the terminal
`return Err`.

- **Retryability comes only from `ProviderError::retryable()`** — the error is
  downcast the same way `classify_provider_failure` does. No parallel list of
  retryable conditions, and `error.rs` is untouched. `RateLimit` /
  `ProviderInternal{5xx}` / `Transport` / `ExhaustedTransport` /
  `EmptyCompletion` retry; `Authentication` / `InvalidRequest` /
  `ContextOverflow` / `InvalidOutput` do not. An error with no typed
  `ProviderError` source is never retried.
- **Bounded** at `MAX_STREAM_EVENT_RETRIES = 2` additional attempts, using the
  client's own `backoff_delay_ms` (exponential + jitter), now `pub` so the two
  retry paths share one schedule instead of inventing a second. A
  server-supplied `retry_after_ms` is honoured as a floor.
- **Only when safe.** `round_is_safely_restartable` requires that nothing
  observable has happened yet this round: `!saw_round_event` (set on the very
  first successfully-decoded event, before any handling runs) plus explicit
  checks that no text, thinking, provider state, tool call, dispatched or
  completed streaming tool future, and no usage has been recorded. Retrying
  after text has hit the transcript event bus, or after a tool call has
  executed, would duplicate output and side effects — so in that case the
  session fails exactly as it does today.
- **The original error is preserved** when retries are exhausted: it is returned
  with the byte-identical
  `provider stream event failed: display=... debug=...; {diag}; {env_diag}`
  context and its typed `ProviderError` source, so coordinator classification
  and existing diagnostics are unchanged.
- The context-length / orphaned-tool-call compaction branches are untouched.
- Each retry logs at `warn` with attempt number and delay, matching the existing
  `"SSE request failed with retryable status; retrying"` style. Cancellation and
  supervisor shutdown are honoured during the backoff sleep.

## Tests

New file `djinn-slot/src/reply_loop/streaming_retry_tests.rs`, driving the real
`run_reply_loop` against a scripted `LlmProvider` that counts how many requests
were actually issued:

1. `transient_mid_stream_overload_is_retried_and_the_session_survives` — an
   error-then-success stream produces an **`Ok` session** whose retried
   assistant turn is persisted; exactly 2 provider requests.
2. `persistent_mid_stream_overload_fails_after_the_retry_cap` — a persistently
   erroring stream fails after exactly `1 + MAX_STREAM_EVENT_RETRIES` requests,
   with the original upstream message and the unchanged
   `provider stream event failed` context still in the returned error.
3. `non_retryable_mid_stream_error_is_not_retried` — an `Authentication` stream
   error fails immediately after exactly 1 request (no blanket retry).
4. `transient_error_after_emitted_output_is_not_retried` — the same transient
   error, but after a text delta was streamed, is not retried: exactly 1 request.

Tests 1 and 2 fail without the fix (verified by neutralising the retry: the
session dies on the first error event and only 1 request is ever issued);
3 and 4 are controls that must stay green either way.
