### PR TITLE
fix: transient provider faults must not escalate to planner remediation

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -162,6 +162,7 @@ async fn apply_handshake_timeout_failover(
         &task.id,
         djinn_provider::catalog::health::TaskFailureSignal {
             throttle: true,
+            transient: false,
             retry_after_ms: None,
         },
     );
@@ -489,31 +490,43 @@ async fn apply_provider_breaker_feedback(
             .record_success(creator_scope, model_id);
     }
     if let Some(class) = provider_failure_class_for_report(report) {
-        let (is_throttle, retry_after_ms) = match class {
+        let (is_throttle, is_transient, retry_after_ms) = match class {
             djinn_runtime::ProviderFailureClass::Throttle { retry_after_ms } => {
                 app_state
                     .health_tracker
                     .record_stall(creator_scope, model_id, false);
-                (true, retry_after_ms)
+                (true, false, retry_after_ms)
             }
             djinn_runtime::ProviderFailureClass::Failure => {
                 app_state
                     .health_tracker
                     .record_failure(creator_scope, model_id);
-                (false, None)
+                (false, false, None)
+            }
+            // A transient provider-side fault (5xx / transport death) feeds the
+            // SAME gentle consecutive-failure breaker a `Failure` does — model
+            // health and auto-disable behaviour are deliberately unchanged, so a
+            // model that 5xx's on every dispatch still demotes. The ONLY thing
+            // the new class changes is task attribution downstream: the
+            // coordinator must not blame the task for the provider's outage.
+            djinn_runtime::ProviderFailureClass::Transient { retry_after_ms } => {
+                app_state
+                    .health_tracker
+                    .record_failure(creator_scope, model_id);
+                (false, true, retry_after_ms)
             }
             djinn_runtime::ProviderFailureClass::AuthInvalid => {
                 if refresh_oauth_credential_after_401(model_id, app_state).await {
                     app_state
                         .health_tracker
                         .record_stall(creator_scope, model_id, false);
-                    (true, None)
+                    (true, false, None)
                 } else {
                     app_state
                         .health_tracker
                         .record_stall(creator_scope, model_id, true);
                     surface_credential_revocation(app_state, creator_scope, model_id).await;
-                    (true, None)
+                    (true, false, None)
                 }
             }
         };
@@ -521,6 +534,7 @@ async fn apply_provider_breaker_feedback(
             task_id,
             djinn_provider::catalog::health::TaskFailureSignal {
                 throttle: is_throttle,
+                transient: is_transient,
                 retry_after_ms,
             },
         );
@@ -727,6 +741,7 @@ pub(super) async fn dispatch_task_runtime(
             &task.id,
             djinn_provider::catalog::health::TaskFailureSignal {
                 throttle: true,
+                transient: false,
                 retry_after_ms: None,
             },
         );

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -1817,19 +1817,18 @@ mod tests {
             );
         }
 
-        // The exact production shape of the 2gq7 failures: an in-stream
-        // `server_is_overloaded` error event on a 200 response, which
-        // `from_stream_error` maps to a synthetic 500.
-        let overloaded = ProviderError::from_stream_error(
-            Some("server_is_overloaded"),
-            "Our servers are currently overloaded",
-        );
+        // The production shape of 2gq7's second failure: an in-stream
+        // `server_error` event on a 200 response (OpenAI request id
+        // f7bd36f8-6250-455d-8235-738cab51183c), which `from_stream_error` maps
+        // to a synthetic 500.
+        let stream_500 =
+            ProviderError::from_stream_error(Some("server_error"), "An error occurred");
         assert_eq!(
-            classify_provider_failure(&typed(overloaded)),
+            classify_provider_failure(&typed(stream_500)),
             Some(ProviderFailureClass::Transient {
                 retry_after_ms: None
             }),
-            "the in-stream `server_is_overloaded` event that killed 2gq7's sessions is transient",
+            "an in-stream `server_error` event is a transient provider fault",
         );
 
         // …and it survives the context/stream wrapping the production error
@@ -1842,6 +1841,36 @@ mod tests {
             Some(ProviderFailureClass::Transient {
                 retry_after_ms: None
             }),
+        );
+    }
+
+    /// End-to-end for the capacity signal that actually killed `2gq7`'s first
+    /// and third sessions: `server_is_overloaded` from the ChatGPT Codex
+    /// CONSUMER backend. `from_stream_error` classifies it as a `RateLimit`
+    /// (plan capacity shedding, not a broken model), and the wire class must
+    /// therefore be `Throttle` — the host's IMMEDIATE-failover path
+    /// (`record_stall`), so dispatch moves to the user's next model at once
+    /// instead of re-probing a saturated endpoint. Like `Transient`, it is
+    /// exempt from the planner-remediation escalation.
+    #[test]
+    fn overload_stream_event_maps_to_throttle_for_immediate_failover() {
+        let overloaded = ProviderError::from_stream_error(
+            Some("server_is_overloaded"),
+            "Our servers are currently overloaded",
+        );
+        assert_eq!(
+            overloaded,
+            ProviderError::RateLimit {
+                retry_after_ms: None
+            },
+            "an overload code is a throttle, not a provider-internal fault",
+        );
+        assert_eq!(
+            classify_provider_failure(&typed(overloaded)),
+            Some(ProviderFailureClass::Throttle {
+                retry_after_ms: None
+            }),
+            "an overload must fail over immediately, not retry the same saturated model",
         );
     }
 

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -154,14 +154,36 @@ const CODEX_EMPTY_QUOTA_RETRY_AFTER_MS: u64 = 20 * 60 * 1000;
 /// `record_failure` / `record_stall` for the task creator's `(scope, model)`
 /// bucket.
 ///
+/// The class is also the coordinator's ONLY evidence about whom to blame for a
+/// failed session, so the split is not merely a breaker concern: only the
+/// task-attributable class ([`ProviderFailureClass::Failure`]) may arm the
+/// coordinator's third-strike planner-remediation escalation. A provider-side
+/// fault that reproduces independently of the request body must not.
+///
 /// Mapping (mirrors the coordinator's throttle→stall / quiet-failure→failure
 /// intent):
-/// - `Authentication` | `InvalidRequest` | `InvalidOutput` |
-///   `ProviderInternal{5xx}` → [`ProviderFailureClass::Failure`]. These are
-///   "quiet but broken" — a bad/expired credential, a request the provider
-///   keeps rejecting, or a flapping backend. Fed to the gentler
-///   consecutive-failure breaker so a single transient blip doesn't demote the
-///   user's preferred model; only repeats trip it.
+/// - `InvalidRequest` | `InvalidOutput` → [`ProviderFailureClass::Failure`].
+///   The TASK-attributable class: a request this provider keeps rejecting (the
+///   poisoned resume transcript — an assistant `tool_calls` message replayed
+///   without its tool results — 400s identically on every redispatch) or output
+///   we cannot parse. Fed to the gentler consecutive-failure breaker so a
+///   single blip doesn't demote the user's preferred model; only repeats trip
+///   it. Because redispatch genuinely reproduces it, this is the only class
+///   that arms the coordinator's planner-remediation escalation.
+/// - `ProviderInternal{..}` | `Transport` | `ExhaustedTransport` →
+///   [`ProviderFailureClass::Transient`]. A 5xx (`server_error` /
+///   `server_is_overloaded`, including the in-stream `response.failed` form
+///   that `ProviderError::from_stream_error` maps to a synthetic 500) or a hard
+///   network death: the PROVIDER is broken, not the task. Breaker feedback is
+///   deliberately unchanged from `Failure` — the host still calls
+///   `record_failure`, so a model that dies on every dispatch still
+///   auto-disables — but the coordinator spares the two task-blaming counters
+///   (planner-remediation streak, terminal dispatch-failure streak) exactly as
+///   it does for a throttle. Incident (task `2gq7`, 2026-07-29): three
+///   independent OpenAI 500s on three consecutive sessions were folded into
+///   `Failure`, tripped the third-strike escalation, and minted a "Planner
+///   remediation" task asserting a poisoned transcript that never existed.
+/// - `Authentication` → [`ProviderFailureClass::AuthInvalid`] (see below).
 /// - `RateLimit` | `EmptyCompletion` → [`ProviderFailureClass::Throttle`]. A
 ///   throttle/quota signal; fed to the immediate-failover breaker
 ///   (`record_stall`) so dispatch moves to the next model at once with a
@@ -179,13 +201,6 @@ const CODEX_EMPTY_QUOTA_RETRY_AFTER_MS: u64 = 20 * 60 * 1000;
 ///   old `None`) stops a *throttle* from being miscounted as a broken provider
 ///   via `record_failure`, which polluted health stats and escalated the
 ///   auto-disable cooldown for what is merely an account over quota.
-/// - `Transport` → [`ProviderFailureClass::Failure`]. A hard network death
-///   (connection refused / instant timeout / broken stream) that kills the
-///   session with no work done — quiet-but-broken, just like a 5xx. Fed to the
-///   gentle consecutive-failure breaker so a one-off blip is absorbed (a
-///   successful session resets the counter via `record_success`) but a model
-///   that dies on every dispatch finally auto-disables instead of being
-///   re-selected forever (the kimi-for-coding/k2p7 incident).
 /// - `ContextOverflow` → `None`. Excluded by design: handled by reactive
 ///   compaction (the conversation is too big, not a model-health problem).
 ///   Tripping the breaker on it would needlessly demote a healthy model.
@@ -199,9 +214,25 @@ fn classify_provider_failure(err: &anyhow::Error) -> Option<ProviderFailureClass
         // immediately (failover at once) and surfaces the revocation, rather than
         // probing the dead model three times like a "quiet but broken" failure.
         ProviderError::Authentication => Some(ProviderFailureClass::AuthInvalid),
-        ProviderError::InvalidRequest
-        | ProviderError::InvalidOutput
-        | ProviderError::ProviderInternal { .. } => Some(ProviderFailureClass::Failure),
+        // The TASK-attributable class: the provider rejected THIS request (the
+        // poisoned resume transcript) or answered with something we cannot
+        // parse. Redispatch reproduces it identically, so this — and only this
+        // — is what may arm the coordinator's planner-remediation escalation.
+        ProviderError::InvalidRequest | ProviderError::InvalidOutput => {
+            Some(ProviderFailureClass::Failure)
+        }
+        // A provider-side 5xx (`server_error` / `server_is_overloaded`,
+        // including the in-stream `response.failed` form `from_stream_error`
+        // maps to a synthetic 500) is the PROVIDER being broken, not the task:
+        // the same transcript succeeds on the next healthy backend.
+        // `ProviderError::retryable()` has always known this; folding it into
+        // `Failure` threw that knowledge away at the wire boundary and let three
+        // unrelated OpenAI outages look like one reproducible task fault (2gq7).
+        // Breaker feedback is unchanged (the host still calls `record_failure`);
+        // only task attribution differs.
+        ProviderError::ProviderInternal { .. } => Some(ProviderFailureClass::Transient {
+            retry_after_ms: provider_err.retry_after_ms(),
+        }),
         ProviderError::RateLimit { .. } => Some(ProviderFailureClass::Throttle {
             retry_after_ms: provider_err.retry_after_ms(),
         }),
@@ -218,18 +249,21 @@ fn classify_provider_failure(err: &anyhow::Error) -> Option<ProviderFailureClass
             retry_after_ms: Some(CODEX_EMPTY_QUOTA_RETRY_AFTER_MS),
         }),
         // A hard transport failure (connection refused, instant timeout, broken
-        // stream) that kills the session is "quiet but broken" the same way a 5xx
-        // is: the model produced no work and exited fast, invisible to the
-        // coordinator's stall detector. Feed it to the GENTLE consecutive-failure
-        // breaker (`record_failure`), NOT the immediate-failover one — a single
-        // network blip on an otherwise-healthy model must not demote it. The
-        // breaker only trips after the configured run of consecutive failures, and
-        // any successful session calls `record_success` (resets the counter), so a
+        // stream) that kills the session is the same shape as a 5xx: the model
+        // produced no work and exited fast, invisible to the coordinator's stall
+        // detector, and the fault is the network/backend rather than anything
+        // about this task. Feed it to the GENTLE consecutive-failure breaker
+        // (`record_failure`), NOT the immediate-failover one — a single network
+        // blip on an otherwise-healthy model must not demote it. The breaker only
+        // trips after the configured run of consecutive failures, and any
+        // successful session calls `record_success` (resets the counter), so a
         // transient blip is absorbed while a model that dies on EVERY dispatch
         // (the kimi-for-coding/k2p7 incident: instant Transport death, 0 tokens,
         // re-dispatched forever, absent from model_health) finally auto-disables.
         ProviderError::Transport | ProviderError::ExhaustedTransport(_) => {
-            Some(ProviderFailureClass::Failure)
+            Some(ProviderFailureClass::Transient {
+                retry_after_ms: None,
+            })
         }
         // ContextOverflow is handled by reactive compaction (the conversation is
         // too big), not a model-health problem — stays `None` so the breaker
@@ -1749,20 +1783,66 @@ mod tests {
 
     #[test]
     fn quiet_failures_map_to_failure_class() {
-        // Invalid-request / invalid-output / 5xx are "quiet but broken"
-        // → gentle consecutive-failure breaker.
-        for e in [
-            ProviderError::InvalidRequest,
-            ProviderError::InvalidOutput,
-            ProviderError::ProviderInternal { status: 500 },
-            ProviderError::ProviderInternal { status: 503 },
-        ] {
+        // Invalid-request / invalid-output are "quiet but broken" AND
+        // task-attributable (the provider rejected THIS request body, or
+        // answered with something unparseable) → gentle consecutive-failure
+        // breaker, and the only class allowed to arm the coordinator's
+        // planner-remediation escalation.
+        for e in [ProviderError::InvalidRequest, ProviderError::InvalidOutput] {
             assert_eq!(
                 classify_provider_failure(&typed(e.clone())),
                 Some(ProviderFailureClass::Failure),
                 "{e:?} should map to Failure",
             );
         }
+    }
+
+    #[test]
+    fn provider_5xx_maps_to_transient_not_failure() {
+        // Incident (task `2gq7`, 2026-07-29): three independent OpenAI 500s
+        // (`server_is_overloaded` / `server_error`) on three consecutive
+        // sessions were folded into `Failure`, which the coordinator reads as
+        // "the redispatched worker reproduces the same failure each time" and
+        // escalates on the third strike — minting a Planner remediation task
+        // that blamed a poisoned resume transcript that never existed.
+        // `ProviderError::retryable()` already knew a 5xx is transient; the
+        // wire class must now carry that knowledge to the host.
+        for status in [500u16, 502, 503, 529] {
+            assert_eq!(
+                classify_provider_failure(&typed(ProviderError::ProviderInternal { status })),
+                Some(ProviderFailureClass::Transient {
+                    retry_after_ms: None
+                }),
+                "a {status} is the provider's fault, not the task's",
+            );
+        }
+
+        // The exact production shape of the 2gq7 failures: an in-stream
+        // `server_is_overloaded` error event on a 200 response, which
+        // `from_stream_error` maps to a synthetic 500.
+        let overloaded = ProviderError::from_stream_error(
+            Some("server_is_overloaded"),
+            "Our servers are currently overloaded",
+        );
+        assert_eq!(
+            classify_provider_failure(&typed(overloaded)),
+            Some(ProviderFailureClass::Transient {
+                retry_after_ms: None
+            }),
+            "the in-stream `server_is_overloaded` event that killed 2gq7's sessions is transient",
+        );
+
+        // …and it survives the context/stream wrapping the production error
+        // path applies, exactly as the auth/transport cases do.
+        let wrapped = anyhow::Error::new(ProviderError::ProviderInternal { status: 500 })
+            .context("provider API error 500: {\"code\":\"server_error\"}")
+            .context("provider stream event failed: display=...; fs_diag; env_diag");
+        assert_eq!(
+            classify_provider_failure(&wrapped),
+            Some(ProviderFailureClass::Transient {
+                retry_after_ms: None
+            }),
+        );
     }
 
     #[test]
@@ -1985,10 +2065,15 @@ mod tests {
         // stream, 0 tokens) previously classified to `None`, so the per-(scope,
         // model) breaker never tripped and dispatch re-selected the dead model
         // forever (also never surfacing it in model_health). A Transport death
-        // must now feed the GENTLE consecutive-failure breaker (`Failure`).
+        // must feed the GENTLE consecutive-failure breaker — which it still does
+        // as `Transient` (the host maps `Transient` onto the same
+        // `record_failure` call `Failure` uses), while no longer telling the
+        // coordinator that the TASK is at fault.
         assert_eq!(
             classify_provider_failure(&anyhow::Error::new(ProviderError::Transport)),
-            Some(ProviderFailureClass::Failure),
+            Some(ProviderFailureClass::Transient {
+                retry_after_ms: None
+            }),
             "a hard transport death must feed the consecutive-failure breaker",
         );
 
@@ -2003,7 +2088,9 @@ mod tests {
         );
         assert_eq!(
             classify_provider_failure(&from_streaming),
-            Some(ProviderFailureClass::Failure),
+            Some(ProviderFailureClass::Transient {
+                retry_after_ms: None
+            }),
             "a transport error wrapped through the streaming loop must still feed the breaker",
         );
     }

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -619,6 +619,68 @@ impl CoordinatorActor {
             .await
     }
 
+    /// Is the model this task last ran on currently auto-disabled by its own
+    /// health breaker, for the task creator's scope?
+    ///
+    /// The `(scope, model)` breaker trips only after a run of consecutive
+    /// failures on THAT model across every task using it — which makes a tripped
+    /// breaker positive evidence that the failures belong to the model rather
+    /// than to any one task's transcript. Trigger D exists for the opposite
+    /// situation (a task whose own request the provider keeps rejecting), so it
+    /// must stand down while the breaker is blaming the model.
+    ///
+    /// Uses the two pieces of state the coordinator already owns: the
+    /// `HealthTracker` it shares with the slot runners (the same handle
+    /// `is_throttle_cooling` / `is_available` are consulted through on the
+    /// dispatch path) and the task's most recent session for this role, whose
+    /// `model_id` names the model that just failed. Fails OPEN (returns `false`,
+    /// i.e. escalation proceeds) when there is no session yet or the lookup
+    /// errors — this is a backstop over the call-site classification, never the
+    /// primary gate.
+    async fn provider_breaker_blames_model(
+        &self,
+        task: &djinn_core::models::Task,
+        role: &'static str,
+    ) -> bool {
+        let session_repo = djinn_db::SessionRepository::new(
+            self.db.clone(),
+            crate::events::event_bus_for(&self.events_tx),
+        );
+        let model_id = match session_repo.latest_model_for_task_role(&task.id, role).await {
+            Ok(Some(model)) if !model.trim().is_empty() => model,
+            Ok(_) => return false,
+            Err(e) => {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    role,
+                    error = %e,
+                    "CoordinatorActor: provider-failure escalation could not resolve the last \
+                     model for the task; proceeding without the breaker guard"
+                );
+                return false;
+            }
+        };
+        // Same scope the dispatch path keys the breaker on: the task creator
+        // (`tasks.created_by_user_id`), passed as `Some(..)` exactly as
+        // `dispatch_ready_tasks` does, so we read the very bucket the failing
+        // dispatch wrote to.
+        let scope = Some(task.created_by_user_id.as_str());
+        let health = self.health.model_health(scope, &model_id);
+        if health.auto_disabled {
+            tracing::info!(
+                task_id = %task.short_id,
+                role,
+                model_id = %model_id,
+                consecutive_failures = health.consecutive_failures,
+                cooldown_seconds_remaining = health.cooldown_seconds_remaining,
+                "CoordinatorActor: skipping provider-failure planner escalation — the model's \
+                 health breaker is auto-disabled for this scope, so the fault is the model's, \
+                 not the task's"
+            );
+        }
+        health.auto_disabled
+    }
+
     /// Trigger D: consecutive provider-error FAILED sessions without progress.
     ///
     /// A session that dies on a terminal provider/session error — the
@@ -639,13 +701,28 @@ impl CoordinatorActor {
     /// when an intervention was routed (the caller skips the ordinary backoff
     /// ladder for this reappearance); `false` while still below threshold.
     ///
-    /// Callers gate this on a genuine, non-throttle typed provider failure — a
-    /// transient throttle must decay on the cooldown ladder, not escalate.
+    /// Callers gate this on a genuine, TASK-ATTRIBUTABLE typed provider failure
+    /// — neither a throttle nor a transient provider fault (5xx / transport
+    /// death), both of which must decay on the cooldown ladder rather than
+    /// escalate (see [`crate::types::stored_streak_after_failure`]).
+    ///
+    /// Defense in depth: independently of that call-site gate, this refuses to
+    /// escalate while the model the task last ran on is auto-disabled by its own
+    /// health breaker for the task creator's scope. A tripped model-wide breaker
+    /// is direct evidence the fault belongs to the MODEL, not the task — during
+    /// the `2gq7` incident `model_health` already showed
+    /// `openai/gpt-5.6-sol` auto-disabled with 7 consecutive failures while the
+    /// coordinator was minting a planner-remediation task blaming the task's
+    /// transcript. This backstop holds even if a future classification regresses
+    /// or a version-skewed worker reports the coarser old class.
     pub(crate) async fn maybe_escalate_provider_failure_streak(
         &mut self,
         task: &djinn_core::models::Task,
         role: &'static str,
     ) -> bool {
+        if self.provider_breaker_blames_model(task, role).await {
+            return false;
+        }
         let strike_count = {
             let streak = self
                 .provider_failure_streak
@@ -679,11 +756,15 @@ impl CoordinatorActor {
         );
         let intervention_reason = format!(
             "Task failed on {strike_count} consecutive sessions with a terminal \
-             provider/session error and no durable status progress between them (status \
-             `{}`). The redispatched worker reproduces the same failure each time (e.g. a \
-             poisoned resume transcript that the provider rejects, or an unusable \
-             credential), so it is being handed to the Planner to decompose, rescope, or \
-             close rather than redispatched again.",
+             REQUEST-attributable provider error (the provider rejected this task's request \
+             body, or returned output that could not be parsed) and no durable status \
+             progress between them (status `{}`). Transient provider faults — 5xx / \
+             overloaded backends, transport deaths — and throttles are excluded from this \
+             streak and decay on the redispatch cooldown ladder instead, so the failure \
+             above is one the redispatched worker reproduces from the task's own state (for \
+             example a poisoned resume transcript the provider keeps rejecting). It is being \
+             handed to the Planner to decompose, rescope, or close rather than redispatched \
+             again.",
             task.status
         );
 

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -2335,25 +2335,41 @@ impl CoordinatorActor {
                             // reappearance) and the per-(scope,model) breaker still
                             // fails over; only the terminal-close counter is spared.
                             let throttle = provider_failure.is_some_and(|f| f.throttle);
+                            // A transient provider-side fault (5xx
+                            // `server_error` / `server_is_overloaded`, or a hard
+                            // transport death) is the PROVIDER's fault, not the
+                            // task's — the identical transcript succeeds on the
+                            // next healthy backend. It is therefore spared the
+                            // two task-blaming counters exactly as a throttle
+                            // is, while the escalating cooldown and the
+                            // per-(scope,model) breaker failover still apply.
+                            let transient = provider_failure.is_some_and(|f| f.transient);
 
                             // Second-strike Planner escalation for provider-error
-                            // FAILED sessions. A genuine (non-throttle) typed
-                            // provider failure that recurs for the same task is the
-                            // poisoned-transcript-400 / dead-credential / persistent
-                            // server-fault class: redispatch reproduces it
-                            // identically, so riding the backoff ladder toward the
-                            // streak-10 terminal close just burns attempts with
-                            // nobody deciding what to do. The cycling gate (trigger
-                            // B) below excludes provider faults by design, and the
-                            // stall-cancel escalation only covers coordinator stall
-                            // kills — so without this the failure has no Planner
-                            // path. Count consecutive such failures (reset when the
-                            // task's status advances, mirroring the stall streak)
-                            // and hand the task to the Planner on the
-                            // FAILURE_ESCALATION_THRESHOLD-th strike instead of
-                            // another doomed redispatch.
+                            // FAILED sessions. Only a TASK-ATTRIBUTABLE typed
+                            // provider failure qualifies: the poisoned-transcript
+                            // 400 / unparseable-output class, which redispatch
+                            // reproduces identically, so riding the backoff ladder
+                            // toward the streak-10 terminal close just burns
+                            // attempts with nobody deciding what to do. Throttles
+                            // and transient provider faults are excluded — task
+                            // `2gq7` (2026-07-29) failed three sessions on three
+                            // INDEPENDENT OpenAI 500s and the third strike minted a
+                            // "Planner remediation" task whose reason asserted a
+                            // poisoned resume transcript that never existed; the
+                            // model's own health breaker had meanwhile already
+                            // auto-disabled it, which is where that fault belonged.
+                            // The cycling gate (trigger B) below excludes provider
+                            // faults by design, and the stall-cancel escalation only
+                            // covers coordinator stall kills — so without this the
+                            // failure has no Planner path. Count consecutive such
+                            // failures (reset when the task's status advances,
+                            // mirroring the stall streak) and hand the task to the
+                            // Planner on the FAILURE_ESCALATION_THRESHOLD-th strike
+                            // instead of another doomed redispatch.
                             if provider_failure.is_some()
                                 && !throttle
+                                && !transient
                                 && self
                                     .maybe_escalate_provider_failure_streak(&task, role)
                                     .await
@@ -2428,9 +2444,10 @@ impl CoordinatorActor {
                             // After MAX consecutive same-role failures the task is
                             // structurally doomed (e.g. its run can never complete);
                             // fail it terminally instead of looping forever. Skipped
-                            // for throttles (A3): a transient quota window must never
-                            // terminally close the task.
-                            if !throttle && next_streak >= MAX_DISPATCH_FAILURES {
+                            // for throttles (A3) and transient provider faults: a
+                            // quota window or a provider outage must never terminally
+                            // close the task.
+                            if !throttle && !transient && next_streak >= MAX_DISPATCH_FAILURES {
                                 self.terminally_fail_task(
                                     &task,
                                     role,
@@ -2452,9 +2469,15 @@ impl CoordinatorActor {
                             }
 
                             // A3: leave the terminal streak at its current value on a
-                            // throttle (don't persist the advanced `next_streak`).
-                            let stored_streak =
-                                stored_streak_after_failure(current_streak, next_streak, throttle);
+                            // throttle or a transient provider fault (don't persist
+                            // the advanced `next_streak`) — the provider failed, the
+                            // task did not.
+                            let stored_streak = stored_streak_after_failure(
+                                current_streak,
+                                next_streak,
+                                throttle,
+                                transient,
+                            );
                             if stored_streak > 0 {
                                 self.dispatch_failure_streak
                                     .insert(task.id.clone(), stored_streak);
@@ -2499,6 +2522,7 @@ impl CoordinatorActor {
                                 role,
                                 streak = stored_streak,
                                 throttle,
+                                transient,
                                 provider_backoff = provider_failure.is_some(),
                                 cooldown_secs = effective_cooldown.as_secs(),
                                 "CoordinatorActor: repeated task failure — backing off dispatch"

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -1410,6 +1410,7 @@ mod doctor_stranded_ready_e2e;
 mod intervention;
 mod pause_is_not_fault;
 mod proposal_spec_integrity_rollout_contract;
+mod provider_fault_attribution;
 mod session_reaping;
 mod status_and_stuck;
 mod terminal_gate_latest_row;

--- a/server/crates/djinn-coordinator/src/tests/provider_fault_attribution.rs
+++ b/server/crates/djinn-coordinator/src/tests/provider_fault_attribution.rs
@@ -1,0 +1,347 @@
+//! Who gets blamed for a failed session: the task, or the provider?
+//!
+//! Incident (task `2gq7`, 2026-07-29): a planner task failed three consecutive
+//! sessions on `openai/gpt-5.6-sol`, each on an independent OpenAI HTTP 500
+//! (`server_is_overloaded`, `server_error`, `server_is_overloaded` — the last
+//! dying in 2s with `tokens_in=0`, before the first token). The worker folded
+//! all three into `ProviderFailureClass::Failure`, the coordinator counted them
+//! as three strikes of the same reproducible fault, and trigger D minted a
+//! "Planner remediation" task (`oftp`) whose reason asserted *"The redispatched
+//! worker reproduces the same failure each time (e.g. a poisoned resume
+//! transcript that the provider rejects, or an unusable credential)"* — which was
+//! simply untrue. `model_health` meanwhile already showed the model
+//! `auto_disabled` with 7 consecutive failures: the fault was the model's, and
+//! the breaker had already said so.
+//!
+//! These tests drive the REAL dispatch pass (`dispatch_ready_tasks`), not the
+//! classification helper, because the classification label is not the bug — the
+//! bug is what the coordinator DOES with it. Each asserts a durable side effect:
+//! whether a planner-remediation intervention was routed, and whether the
+//! terminal `dispatch_failure_streak` advanced far enough to force-close the
+//! task.
+
+use super::*;
+use djinn_db::ActivityQuery;
+use djinn_provider::catalog::health::TaskFailureSignal;
+
+/// A transient provider-side fault, exactly as the slot supervisor-runner
+/// records it for a `ProviderFailureClass::Transient` report (5xx /
+/// transport death).
+const TRANSIENT: TaskFailureSignal = TaskFailureSignal {
+    throttle: false,
+    transient: true,
+    retry_after_ms: None,
+};
+
+/// A REQUEST-attributable provider failure — `InvalidRequest` / `InvalidOutput`,
+/// i.e. the poisoned-resume-transcript class that redispatch really does
+/// reproduce. This is the control: it must still escalate at the threshold, or
+/// the fix would have merely disabled trigger D wholesale.
+const REQUEST_FAULT: TaskFailureSignal = TaskFailureSignal {
+    throttle: false,
+    transient: false,
+    retry_after_ms: None,
+};
+
+/// Replay `passes` consecutive same-role failed reappearances through the real
+/// dispatch pass, each carrying `signal` on the shared `HealthTracker`
+/// side-channel — the same handoff `apply_provider_breaker_feedback` performs
+/// in production when a task-run reports a typed provider failure.
+///
+/// Between passes we re-seed the `last_dispatched` marker (the pass consumes it)
+/// and drop any cooldown the previous failure applied — wall-clock time is what
+/// expires it in production, and we are modelling three failures spread over
+/// ~11 minutes, as `2gq7`'s were.
+async fn replay_failed_reappearances(
+    actor: &mut CoordinatorActor,
+    task_id: &str,
+    role: &str,
+    signal: TaskFailureSignal,
+    passes: usize,
+) {
+    for _ in 0..passes {
+        actor.last_dispatched.insert(
+            task_id.to_owned(),
+            DispatchMarker {
+                instant: StdInstant::now(),
+                role: role.to_owned(),
+            },
+        );
+        actor.health.note_task_provider_failure(task_id, signal);
+        actor.dispatch_cooldowns.remove(task_id);
+        actor.dispatch_ready_tasks(None).await;
+    }
+}
+
+async fn remediation_blocker_count(repo: &TaskRepository, task_id: &str) -> usize {
+    repo.list_blockers(task_id).await.unwrap().len()
+}
+
+async fn arbiter_dispatched_count(repo: &TaskRepository, task_id: &str) -> usize {
+    repo.query_activity(ActivityQuery {
+        task_id: Some(task_id.to_owned()),
+        event_type: Some("arbiter_dispatched".to_string()),
+        ..ActivityQuery::default()
+    })
+    .await
+    .unwrap()
+    .len()
+}
+
+/// THE regression: three consecutive sessions killed by transient provider
+/// faults must route NO planner-remediation intervention and must NOT advance
+/// the terminal dispatch-failure streak.
+///
+/// Without the fix the third pass crosses `FAILURE_ESCALATION_THRESHOLD`, writes
+/// a `planner_intervention` marker and creates the blocking remediation task —
+/// the `oftp` this test exists to prevent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn three_transient_provider_faults_route_no_planner_remediation() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _project_path) =
+        create_simple_task(&db, &tx, "task", "planner task hit by openai 500s").await;
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let task = repo
+        .set_status(&task.id, "needs_task_review")
+        .await
+        .unwrap();
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    // One more strike than the threshold: the escalation must not fire even
+    // once past the rung that produced `oftp`.
+    let passes = usize::try_from(FAILURE_ESCALATION_THRESHOLD).unwrap() + 1;
+    replay_failed_reappearances(&mut actor, &task.id, "reviewer", TRANSIENT, passes).await;
+
+    assert!(
+        planner_intervention_markers(&repo, &task.id).await.is_empty(),
+        "a run of transient provider faults must never route a planner-remediation \
+         intervention — the provider failed, the task did not"
+    );
+    assert_eq!(
+        remediation_blocker_count(&repo, &task.id).await,
+        0,
+        "no remediation task may be created to block the healthy task"
+    );
+    assert_eq!(
+        arbiter_dispatched_count(&repo, &task.id).await,
+        0,
+        "the arbiter ladder must not be entered either"
+    );
+    assert!(
+        !actor.provider_failure_streak.contains_key(&task.id),
+        "transient faults must not even accumulate a provider-failure strike"
+    );
+
+    // The terminal counter — the one that force-closes a task at
+    // MAX_DISPATCH_FAILURES — must be untouched, and the task must still be
+    // alive and dispatchable.
+    assert!(
+        !actor.dispatch_failure_streak.contains_key(&task.id),
+        "a transient provider fault must not advance the terminal dispatch-failure streak"
+    );
+    let after = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        after.status, "needs_task_review",
+        "the task must stay exactly where it was, awaiting a healthy provider"
+    );
+
+    // …but the task IS still backed off: sparing the counters must not turn
+    // into hammering the provider every tick.
+    assert!(
+        actor.dispatch_cooldowns.contains_key(&task.id),
+        "the escalating redispatch cooldown still applies to a transient fault"
+    );
+}
+
+/// Control for the test above: the REQUEST-attributable class (the poisoned
+/// resume transcript a redispatch genuinely reproduces) must still escalate on
+/// the `FAILURE_ESCALATION_THRESHOLD`-th consecutive strike. If this test and
+/// the one above ever pass for the same reason, trigger D was disabled rather
+/// than corrected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_attributable_provider_failures_still_escalate_at_threshold() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _project_path) =
+        create_simple_task(&db, &tx, "task", "task the provider keeps rejecting").await;
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let task = repo
+        .set_status(&task.id, "needs_task_review")
+        .await
+        .unwrap();
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+
+    // Strikes below the threshold: streak advances, nothing is routed.
+    let below = usize::try_from(FAILURE_ESCALATION_THRESHOLD).unwrap() - 1;
+    replay_failed_reappearances(&mut actor, &task.id, "reviewer", REQUEST_FAULT, below).await;
+    assert_eq!(
+        actor.provider_failure_streak.get(&task.id).map(|s| s.count),
+        Some(FAILURE_ESCALATION_THRESHOLD - 1),
+        "each request-attributable failure advances the provider-failure streak"
+    );
+    assert!(
+        planner_intervention_markers(&repo, &task.id).await.is_empty(),
+        "below the threshold nothing is routed"
+    );
+
+    // The threshold strike escalates.
+    replay_failed_reappearances(&mut actor, &task.id, "reviewer", REQUEST_FAULT, 1).await;
+    assert_eq!(
+        planner_intervention_markers(&repo, &task.id).await.len(),
+        1,
+        "the {FAILURE_ESCALATION_THRESHOLD}th consecutive request-attributable provider failure \
+         must still route a planner-remediation intervention"
+    );
+    assert_eq!(
+        remediation_blocker_count(&repo, &task.id).await,
+        1,
+        "the escalation still creates the remediation task that holds the source task"
+    );
+}
+
+/// The terminal force-close at `MAX_DISPATCH_FAILURES` must also be spared.
+///
+/// A task that already carries a near-terminal streak (from earlier, genuine
+/// failures) and then meets a provider outage must not be closed by that
+/// outage: rehydrate the streak one below the cap, deliver ONE transient fault,
+/// and the task must survive with its streak unchanged.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn transient_provider_fault_cannot_force_close_a_task_at_the_cap() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _project_path) =
+        create_simple_task(&db, &tx, "task", "near-terminal task hit by an outage").await;
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let task = repo
+        .set_status(&task.id, "needs_task_review")
+        .await
+        .unwrap();
+    // Pre-existing planner-intervention marker: keeps trigger B out of the way
+    // so the ONLY thing under test is the terminal-close branch.
+    repo.log_activity(
+        Some(&task.id),
+        "coordinator",
+        "system",
+        PLANNER_INTERVENTION_MARKER,
+        &serde_json::json!({ "reopen_count": task.reopen_count }).to_string(),
+    )
+    .await
+    .unwrap();
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor
+        .dispatch_failure_streak
+        .insert(task.id.clone(), MAX_DISPATCH_FAILURES - 1);
+    replay_failed_reappearances(&mut actor, &task.id, "reviewer", TRANSIENT, 1).await;
+
+    let after = repo.get(&task.id).await.unwrap().unwrap();
+    assert_ne!(
+        after.status, "closed",
+        "a provider outage must never be the strike that terminally closes a task"
+    );
+    assert_eq!(
+        actor.dispatch_failure_streak.get(&task.id).copied(),
+        Some(MAX_DISPATCH_FAILURES - 1),
+        "the terminal streak is left exactly where it was"
+    );
+}
+
+/// Control for the test above, mirroring
+/// `restart_rehydrated_failure_streak_continues_to_terminal_close_threshold`:
+/// the same near-terminal streak plus a REQUEST-attributable failure still ends
+/// in the terminal close. The safety backstop is intact; only the attribution
+/// changed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_attributable_failure_at_the_cap_still_force_closes() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _project_path) =
+        create_simple_task(&db, &tx, "task", "near-terminal undispatchable task").await;
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let task = repo
+        .set_status(&task.id, "needs_task_review")
+        .await
+        .unwrap();
+    repo.log_activity(
+        Some(&task.id),
+        "coordinator",
+        "system",
+        PLANNER_INTERVENTION_MARKER,
+        &serde_json::json!({ "reopen_count": task.reopen_count }).to_string(),
+    )
+    .await
+    .unwrap();
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor
+        .dispatch_failure_streak
+        .insert(task.id.clone(), MAX_DISPATCH_FAILURES - 1);
+    replay_failed_reappearances(&mut actor, &task.id, "reviewer", REQUEST_FAULT, 1).await;
+
+    let after = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        after.status, "closed",
+        "a request-attributable failure at the cap must still close the task terminally"
+    );
+}
+
+/// Defense in depth (E): even if the wire class regressed to the coarse
+/// pre-fix `Failure` — a version-skewed worker, or a future
+/// misclassification — a model whose own health breaker is auto-disabled for
+/// this scope must not have its outage blamed on the task. During `2gq7` the
+/// breaker had already tripped (7 consecutive failures, `auto_disabled`) while
+/// the coordinator was minting a remediation task about the transcript.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auto_disabled_model_breaker_blocks_the_escalation() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _project_path) =
+        create_simple_task(&db, &tx, "task", "task on an auto-disabled model").await;
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let task = repo
+        .set_status(&task.id, "needs_task_review")
+        .await
+        .unwrap();
+
+    // The task's last reviewer session ran on this model.
+    let model_id = "openai/gpt-5.6-sol";
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: model_id,
+            agent_type: "reviewer",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    // Trip the per-(scope, model) breaker for the task creator's scope, as a run
+    // of failures on that model does in production.
+    let scope = Some(task.created_by_user_id.as_str());
+    while !actor.health.model_health(scope, model_id).auto_disabled {
+        actor.health.record_failure(scope, model_id);
+    }
+
+    // Deliver the COARSE pre-fix class: `throttle: false, transient: false` —
+    // indistinguishable from a poisoned transcript at the call-site gate.
+    let passes = usize::try_from(FAILURE_ESCALATION_THRESHOLD).unwrap() + 1;
+    replay_failed_reappearances(&mut actor, &task.id, "reviewer", REQUEST_FAULT, passes).await;
+
+    assert!(
+        planner_intervention_markers(&repo, &task.id).await.is_empty(),
+        "a tripped model-wide breaker is evidence the MODEL is at fault; the task must not be \
+         escalated over it"
+    );
+    assert!(
+        !actor.provider_failure_streak.contains_key(&task.id),
+        "the guard stands the streak down entirely while the breaker blames the model"
+    );
+}

--- a/server/crates/djinn-coordinator/src/tests/provider_fault_attribution.rs
+++ b/server/crates/djinn-coordinator/src/tests/provider_fault_attribution.rs
@@ -21,6 +21,7 @@
 //! task.
 
 use super::*;
+use djinn_core::models::SessionStatus;
 use djinn_db::ActivityQuery;
 use djinn_provider::catalog::health::TaskFailureSignal;
 
@@ -308,7 +309,7 @@ async fn auto_disabled_model_breaker_blocks_the_escalation() {
     // The task's last reviewer session ran on this model.
     let model_id = "openai/gpt-5.6-sol";
     let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
-    session_repo
+    let session = session_repo
         .create(CreateSessionParams {
             project_id: &task.project_id,
             task_id: Some(&task.id),
@@ -319,6 +320,12 @@ async fn auto_disabled_model_breaker_blocks_the_escalation() {
             pricing: None,
             cost_basis: None,
         })
+        .await
+        .unwrap();
+    // Terminate it: a live session would make the task ineligible for dispatch
+    // and the pass would never reach the reappearance branch at all.
+    session_repo
+        .update(&session.id, SessionStatus::Failed, 0, 0, 0, 0, None)
         .await
         .unwrap();
 

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -675,17 +675,29 @@ pub(super) fn dispatch_cooldown_for_failure(streak: u32, had_provider_failure: b
 /// failed reappearance.
 ///
 /// A structural failure advances the streak toward [`MAX_DISPATCH_FAILURES`]
-/// (the task may be undispatchable). A `throttle` (rate-limit) reappearance is a
-/// transient provider fault, not a fault of the task — so it must NOT advance
-/// the terminal counter (else a healthy task whose only problem was a quota blip
-/// gets terminally closed). The task still backs off via the escalating cooldown
-/// and the breaker still fails over; only the terminal-close counter is spared.
+/// (the task may be undispatchable). A PROVIDER-attributable reappearance is
+/// not a fault of the task and must NOT advance the terminal counter (else a
+/// healthy task whose only problem was someone else's outage gets terminally
+/// closed). Two classes qualify:
+///
+/// - `throttle` — a rate-limit / quota window (A3).
+/// - `transient` — a provider-side 5xx (`server_error` /
+///   `server_is_overloaded`) or a hard transport death. Task `2gq7`
+///   (2026-07-29) failed three sessions on three independent OpenAI 500s;
+///   marching those up the terminal ladder walks a perfectly healthy task
+///   toward the force-close at [`MAX_DISPATCH_FAILURES`] for an outage it did
+///   not cause.
+///
+/// In both cases the task still backs off via the escalating cooldown and the
+/// per-`(scope, model)` breaker still fails over; only the terminal-close
+/// counter is spared.
 pub(super) fn stored_streak_after_failure(
     current_streak: u32,
     next_streak: u32,
     throttle: bool,
+    transient: bool,
 ) -> u32 {
-    if throttle {
+    if throttle || transient {
         current_streak
     } else {
         next_streak
@@ -805,12 +817,12 @@ mod cooldown_tests {
         let current = 4;
         let next = 5;
         assert_eq!(
-            stored_streak_after_failure(current, next, false),
+            stored_streak_after_failure(current, next, false, false),
             next,
-            "a non-throttle failure advances the terminal streak"
+            "a non-throttle, non-transient failure advances the terminal streak"
         );
         assert_eq!(
-            stored_streak_after_failure(current, next, true),
+            stored_streak_after_failure(current, next, true, false),
             current,
             "a throttle must NOT advance the terminal streak"
         );
@@ -820,8 +832,29 @@ mod cooldown_tests {
         // (gated on `!throttle && next_streak >= MAX`) never fires.
         let just_below = MAX_DISPATCH_FAILURES - 1;
         assert_eq!(
-            stored_streak_after_failure(just_below, MAX_DISPATCH_FAILURES, true),
+            stored_streak_after_failure(just_below, MAX_DISPATCH_FAILURES, true, false),
             just_below
+        );
+    }
+
+    #[test]
+    fn transient_provider_fault_does_not_advance_terminal_streak() {
+        // A transient provider-side 5xx / transport death is the provider's
+        // fault, not the task's: it is spared the terminal counter exactly as a
+        // throttle is, so an hour of `server_is_overloaded` cannot march a
+        // healthy task toward the force-close at MAX_DISPATCH_FAILURES.
+        let current = 4;
+        let next = 5;
+        assert_eq!(
+            stored_streak_after_failure(current, next, false, true),
+            current,
+            "a transient provider fault must NOT advance the terminal streak"
+        );
+        let just_below = MAX_DISPATCH_FAILURES - 1;
+        assert_eq!(
+            stored_streak_after_failure(just_below, MAX_DISPATCH_FAILURES, false, true),
+            just_below,
+            "a transient fault at the cap boundary keeps the stored streak below MAX"
         );
     }
 

--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -343,9 +343,28 @@ pub struct TaskFailureSignal {
     /// The failure was a rate-limit / quota throttle (not a structural failure).
     /// A3: a throttle reappearance must NOT advance the terminal streak.
     pub throttle: bool,
+    /// The failure was a TRANSIENT provider-side fault — a 5xx
+    /// (`server_error` / `server_is_overloaded`) or a hard transport death
+    /// (`ProviderFailureClass::Transient`).
+    ///
+    /// Like `throttle`, this is a fault of the provider rather than of the task:
+    /// the same transcript redispatched onto a healthy backend succeeds. The
+    /// coordinator therefore spares BOTH task-blaming counters for it — the
+    /// third-strike planner-remediation `provider_failure_streak` and the
+    /// terminal `dispatch_failure_streak` — while the escalating redispatch
+    /// cooldown and the per-`(scope, model)` breaker failover still apply.
+    ///
+    /// Kept as a second flag rather than folding the pair into an enum so the
+    /// change stays additive at every call site; `throttle` and `transient` are
+    /// mutually exclusive in practice (a class maps to at most one of them).
+    /// Incident: task `2gq7`, 2026-07-29 — three independent OpenAI 500s were
+    /// indistinguishable from a reproducible task fault, so the third one minted
+    /// a bogus "Planner remediation" task.
+    pub transient: bool,
     /// Provider-stated reset window (`Retry-After` / rate-limit-reset), if any.
     /// A6: floors the escalating redispatch cooldown so a multi-hour quota
-    /// window isn't probed on the fixed ladder. Only meaningful for throttles.
+    /// window isn't probed on the fixed ladder. Meaningful for throttles and,
+    /// when a provider states one, for transient faults.
     pub retry_after_ms: Option<u64>,
 }
 

--- a/server/crates/djinn-provider/src/catalog/health_tests.rs
+++ b/server/crates/djinn-provider/src/catalog/health_tests.rs
@@ -786,6 +786,7 @@ fn task_failure_signal_is_read_once_and_cleared() {
         "task-1",
         TaskFailureSignal {
             throttle: true,
+            transient: false,
             retry_after_ms: Some(5 * 60 * 60 * 1000),
         },
     );
@@ -810,6 +811,7 @@ fn task_failure_signal_latest_wins_and_is_per_task() {
         "task-a",
         TaskFailureSignal {
             throttle: false,
+            transient: false,
             retry_after_ms: None,
         },
     );
@@ -818,6 +820,7 @@ fn task_failure_signal_latest_wins_and_is_per_task() {
         "task-a",
         TaskFailureSignal {
             throttle: true,
+            transient: false,
             retry_after_ms: Some(1_000),
         },
     );
@@ -825,6 +828,7 @@ fn task_failure_signal_latest_wins_and_is_per_task() {
         "task-b",
         TaskFailureSignal {
             throttle: false,
+            transient: false,
             retry_after_ms: None,
         },
     );

--- a/server/crates/djinn-provider/src/provider/error.rs
+++ b/server/crates/djinn-provider/src/provider/error.rs
@@ -127,8 +127,13 @@ impl ProviderError {
     /// `code` string, fall back to a body scan for context-overflow phrasing,
     /// and default an unrecognised/absent code to a transient provider-internal
     /// failure: the failure was real, so it should feed the breaker as a 5xx
-    /// `Failure` rather than be dropped as an untyped/legacy string error
-    /// (which classifies as `None` and never reaches the breaker).
+    /// rather than be dropped as an untyped/legacy string error (which
+    /// classifies as `None` and never reaches the breaker).
+    ///
+    /// Overload codes (`server_is_overloaded`, `overloaded_error`) are the
+    /// exception to that default: they are classified as
+    /// [`ProviderError::RateLimit`], matching the 529 status path. Capacity
+    /// shedding is a throttle to fail over from, not a backend that is broken.
     pub fn from_stream_error(code: Option<&str>, message: &str) -> Self {
         let code = code.unwrap_or("").to_ascii_lowercase();
         if code.contains("rate_limit") || code.contains("quota") {
@@ -148,6 +153,33 @@ impl ProviderError {
             ProviderError::Authentication
         } else if code.contains("invalid_request") || code.contains("invalid_prompt") {
             ProviderError::InvalidRequest
+        } else if code.contains("overload") {
+            // Capacity shedding, not a provider-internal fault. OpenAI's
+            // `server_is_overloaded` and Anthropic's `overloaded_error` both
+            // match this substring, mirroring how `from_status` already treats
+            // the 529 "overloaded" status as a rate limit rather than a 5xx.
+            //
+            // This matters because of WHERE these arrive from: the `openai`
+            // provider id resolves through `effective_oauth_provider_id` to
+            // `chatgpt_codex`, whose requests go to the ChatGPT CONSUMER
+            // subscription backend (`https://chatgpt.com/backend-api/codex`),
+            // not the OpenAI API. Task `2gq7`'s sessions (94,752 and 35,672
+            // prompt tokens, many concurrent sessions on one consumer plan)
+            // were shed by that backend while the same plan served local
+            // `codex` fine, and `model_health` showed the model succeeding 5
+            // times against 15 failures. That is plan capacity, not a broken
+            // model — so it must feed the immediate-failover throttle path
+            // (`record_stall` → next model at once) rather than back off and
+            // re-probe a saturated endpoint.
+            //
+            // A stream error event carries no `Retry-After`, so no reset window
+            // is known and the ordinary escalating ladder applies. We
+            // deliberately do NOT synthesize one: `CODEX_EMPTY_QUOTA_...` exists
+            // for the empty-200 OVER-QUOTA signature, which is a different
+            // (clock-based) condition from momentary overload.
+            ProviderError::RateLimit {
+                retry_after_ms: None,
+            }
         } else {
             // `server_error`, `internal_error`, an empty code, or any code we
             // don't specifically recognise: treat as a transient provider-side
@@ -470,6 +502,58 @@ mod tests {
         assert!(
             ProviderError::from_stream_error(Some("server_error"), "boom").retryable(),
             "server_error must be retryable"
+        );
+    }
+
+    #[test]
+    fn overload_codes_are_throttles_not_provider_internal() {
+        // An overload code is CAPACITY SHEDDING, not a broken backend. Task
+        // `2gq7`'s sessions died on `server_is_overloaded` from the ChatGPT
+        // Codex CONSUMER backend (`openai` → `chatgpt_codex` →
+        // chatgpt.com/backend-api/codex), while the same subscription served
+        // local `codex` fine and `model_health` showed the model succeeding.
+        // Classifying it as a throttle routes it to the immediate-failover
+        // breaker path instead of re-probing a saturated endpoint.
+        for code in ["server_is_overloaded", "overloaded_error"] {
+            assert_eq!(
+                ProviderError::from_stream_error(Some(code), "Our servers are currently overloaded"),
+                ProviderError::RateLimit {
+                    retry_after_ms: None
+                },
+                "{code} is a capacity throttle",
+            );
+        }
+
+        // No `Retry-After` exists on a stream error event, and we must NOT
+        // synthesize a quota window here — that is the empty-200 over-quota
+        // signature, a different condition.
+        assert!(
+            ProviderError::from_stream_error(Some("server_is_overloaded"), "")
+                .retry_after_ms()
+                .is_none(),
+            "an overload carries no provider-stated reset window"
+        );
+
+        // REGRESSION GUARD: the new arm must not swallow genuine provider
+        // faults. `2gq7`'s second failure was a real `server_error` (OpenAI
+        // request id f7bd36f8-6250-455d-8235-738cab51183c) and must keep
+        // classifying as a 5xx (→ `ProviderFailureClass::Transient`).
+        for code in ["server_error", "internal_error"] {
+            assert_eq!(
+                ProviderError::from_stream_error(Some(code), "An error occurred"),
+                ProviderError::ProviderInternal { status: 500 },
+                "{code} is a provider-internal fault, not a throttle",
+            );
+        }
+
+        // 529 ("overloaded") is already a rate limit on the STATUS path; the
+        // stream-code path now agrees with it.
+        assert_eq!(
+            ProviderError::from_status(529, "overloaded"),
+            ProviderError::RateLimit {
+                retry_after_ms: None
+            },
+            "the status and stream-code paths must classify an overload the same way"
         );
     }
 

--- a/server/crates/djinn-provider/src/provider/format/anthropic/tests/streaming.rs
+++ b/server/crates/djinn-provider/src/provider/format/anthropic/tests/streaming.rs
@@ -403,8 +403,9 @@ async fn test_stream_raw_eof_before_message_stop_yields_error() {
 #[tokio::test]
 async fn test_streamed_overloaded_error_event_surfaces_typed_provider_error() {
     // Anthropic signals overload as a 200 SSE `error` event. It must surface as
-    // a typed retryable `ProviderError::ProviderInternal` (server-side), NOT be
-    // dropped to an "empty turn".
+    // a typed retryable `ProviderError::RateLimit` — capacity shedding, so the
+    // host fails over to the next model at once — and NOT be dropped to an
+    // "empty turn".
     let body = concat!(
         "event: message_start\n",
         "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":7}}}\n\n",
@@ -432,7 +433,12 @@ async fn test_streamed_overloaded_error_event_surfaces_typed_provider_error() {
     let pe = err
         .downcast_ref::<ProviderError>()
         .expect("typed ProviderError must be downcastable from the stream error");
-    assert_eq!(*pe, ProviderError::ProviderInternal { status: 500 });
+    assert_eq!(
+        *pe,
+        ProviderError::RateLimit {
+            retry_after_ms: None
+        }
+    );
     assert!(pe.retryable(), "overloaded_error must be retryable");
     // Human-readable detail rides along as anyhow context.
     let text = err.to_string();
@@ -492,11 +498,33 @@ fn test_classify_anthropic_error_event_rate_limit_carries_retry_after() {
 }
 
 #[test]
-fn test_classify_anthropic_error_event_overloaded_maps_to_internal() {
+fn test_classify_anthropic_error_event_overloaded_maps_to_rate_limit() {
+    // `overloaded_error` is Anthropic's capacity-shedding signal — the same
+    // condition OpenAI reports as `server_is_overloaded`. It is a THROTTLE, not
+    // a broken backend: the host must fail over to the next model immediately
+    // (`record_stall`) rather than re-probe a saturated endpoint. Anthropic also
+    // states 529 (== overloaded) on the status path, which `from_status`
+    // already classifies as a rate limit; the stream-event path now agrees.
     let data = r#"{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}"#;
     let (class, _msg) = classify_anthropic_error_event(data);
-    assert_eq!(class, ProviderError::ProviderInternal { status: 500 });
+    assert_eq!(
+        class,
+        ProviderError::RateLimit {
+            retry_after_ms: None
+        }
+    );
     assert!(class.retryable());
+
+    // And an `error.retry_after` now rides along, because the RateLimit arm is
+    // the one that folds it in.
+    let with_reset = r#"{"type":"error","error":{"type":"overloaded_error","message":"overloaded","retry_after":30}}"#;
+    let (class, _msg) = classify_anthropic_error_event(with_reset);
+    assert_eq!(
+        class,
+        ProviderError::RateLimit {
+            retry_after_ms: Some(30_000)
+        }
+    );
 }
 
 #[tokio::test]

--- a/server/crates/djinn-runtime/src/spec.rs
+++ b/server/crates/djinn-runtime/src/spec.rs
@@ -711,16 +711,30 @@ pub enum ResumeSelectionReason {
 /// (`supervisor_runner.rs`) maps the class back onto `record_failure` /
 /// `record_stall` using the task creator's scope. Only the classes the breaker
 /// actually acts on are represented — failures the breaker deliberately ignores
-/// (ContextOverflow, EmptyCompletion) and untyped/legacy errors carry `None` so
-/// they never trip it. A hard `Transport` death folds into `Failure` (gentle
+/// (ContextOverflow) and untyped/legacy errors carry `None` so they never trip
+/// it. A hard `Transport` death folds into `Transient` (gentle
 /// consecutive-failure breaker) so a model that dies instantly on every dispatch
 /// auto-disables instead of being re-selected forever.
+///
+/// The class is ALSO the coordinator's only evidence about *who* a failed
+/// session should be blamed on, so the split between `Failure` and `Transient`
+/// matters beyond the breaker: `Failure` is the task-attributable class (a
+/// poisoned resume transcript the provider 400s, output we cannot parse) and is
+/// the only one that arms the third-strike planner-remediation escalation;
+/// `Transient` and `Throttle` are provider-attributable and must decay on the
+/// cooldown ladder instead.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProviderFailureClass {
-    /// Auth / persistent-invalid-request / invalid-output / 5xx provider
-    /// internal — a "quiet but broken" failure. Feeds the gentler
+    /// Persistent-invalid-request / invalid-output — a "quiet but broken"
+    /// failure the REQUEST is responsible for (the poisoned resume transcript
+    /// the provider 400s, a body we cannot parse). Feeds the gentler
     /// consecutive-failure breaker (`record_failure`): a one-off may be
     /// transient, so it only demotes the model after it repeats.
+    ///
+    /// This is the task-attributable class, and therefore the ONLY one that
+    /// arms the coordinator's third-strike planner-remediation escalation.
+    /// Provider-side faults that reproduce independently of the request body
+    /// (5xx, transport death) belong to [`Self::Transient`].
     Failure,
     /// Rate-limit / quota (throttle). Feeds the immediate-failover breaker
     /// (`record_stall`), matching the coordinator's throttle→stall intent: a
@@ -749,6 +763,41 @@ pub enum ProviderFailureClass {
     /// owner to reconnect). Added last to preserve the bincode discriminants of
     /// `Failure`/`Throttle` on the worker→host report wire.
     AuthInvalid,
+    /// Transient PROVIDER-side fault — a 5xx (`server_error` /
+    /// `server_is_overloaded`, incl. the in-stream `response.failed` form) or a
+    /// hard network/transport death. The provider is broken, not the task: the
+    /// same transcript redispatched onto a healthy backend succeeds, so this
+    /// class must never be read as evidence that the task itself is
+    /// undispatchable.
+    ///
+    /// Breaker behaviour is deliberately IDENTICAL to [`Self::Failure`]: the
+    /// host feeds it to the gentle consecutive-failure breaker
+    /// (`record_failure`), so model-health/auto-disable is unchanged and a model
+    /// that 5xx's on every dispatch still auto-disables. What changes is
+    /// *task attribution* — the coordinator spares the two task-blaming counters
+    /// (the planner-remediation `provider_failure_streak` and the terminal
+    /// `dispatch_failure_streak`) for this class, exactly as it already does for
+    /// [`Self::Throttle`], while the escalating redispatch cooldown and the
+    /// per-`(scope, model)` failover still apply. Incident (task `2gq7`,
+    /// 2026-07-29): three independent OpenAI 500s across three sessions armed
+    /// the third-strike escalation and minted a "Planner remediation" task whose
+    /// reason asserted a poisoned resume transcript that never existed.
+    ///
+    /// `retry_after_ms` carries a provider-stated reset window when one was
+    /// supplied (rare on a 5xx; `None` otherwise) and floors the redispatch
+    /// cooldown the same way a throttle's does. `#[serde(default)]` keeps the
+    /// field additive over the wire, like `Throttle`'s.
+    ///
+    /// Appended LAST — after `AuthInvalid` — for exactly the reason
+    /// `AuthInvalid` was: the report frame rides a positional,
+    /// non-self-describing bincode wire, so inserting or reordering a variant
+    /// would shift the discriminants of `Failure`/`Throttle`/`AuthInvalid` and
+    /// mis-decode reports from a version-skewed worker mid-deploy. A worker that
+    /// EMITS `Transient` therefore requires a version-matched host.
+    Transient {
+        #[serde(default)]
+        retry_after_ms: Option<u64>,
+    },
 }
 
 /// Terminal outcome of a task-run.
@@ -1317,6 +1366,114 @@ mod tests {
             ),
             other => panic!("unexpected outcome: {other:?}"),
         }
+    }
+
+    #[test]
+    fn failed_outcome_transient_bincode_roundtrip() {
+        // The `Transient` class (provider-side 5xx / transport death) must
+        // survive the worker→host report wire, including its optional
+        // provider-stated reset window.
+        for retry_after_ms in [None, Some(90_000u64)] {
+            let report = TaskRunReport {
+                task_run_id: "run-4".to_string(),
+                outcome: TaskRunOutcome::Failed {
+                    stage: "planner".to_string(),
+                    reason: "server_is_overloaded: Our servers are currently overloaded"
+                        .to_string(),
+                    provider_failure: Some(ProviderFailureClass::Transient { retry_after_ms }),
+                    error_class: None,
+                    hint: None,
+                    body_excerpt: None,
+                },
+                stages_completed: vec![RoleKind::Planner],
+            };
+
+            let bytes = bincode::serialize(&report).expect("serialize");
+            let back: TaskRunReport = bincode::deserialize(&bytes).expect("deserialize");
+
+            match back.outcome {
+                TaskRunOutcome::Failed {
+                    provider_failure, ..
+                } => assert_eq!(
+                    provider_failure,
+                    Some(ProviderFailureClass::Transient { retry_after_ms }),
+                    "the transient class must round-trip verbatim"
+                ),
+                other => panic!("unexpected outcome: {other:?}"),
+            }
+        }
+    }
+
+    /// Wire-compat guard for [`ProviderFailureClass`].
+    ///
+    /// bincode is positional and non-self-describing: an enum is encoded as its
+    /// variant INDEX (u32 LE), so inserting or reordering a variant silently
+    /// re-points every previously-encoded byte sequence at a different variant.
+    /// A version-skewed worker mid-deploy would then have its `Throttle` decoded
+    /// as `AuthInvalid` (or worse). `Transient` was therefore appended LAST,
+    /// after `AuthInvalid`, exactly as `AuthInvalid` was appended after
+    /// `Throttle`.
+    ///
+    /// This pins the pre-existing indices as literal bytes. If someone inserts a
+    /// variant anywhere but the end, these assertions fail rather than shipping
+    /// a mid-deploy mis-decode.
+    #[test]
+    fn provider_failure_class_wire_discriminants_are_append_only() {
+        // Encoded form of each variant, exactly as an older worker emits it.
+        const FAILURE: [u8; 4] = [0, 0, 0, 0];
+        const THROTTLE_NONE: [u8; 5] = [1, 0, 0, 0, 0];
+        const AUTH_INVALID: [u8; 4] = [2, 0, 0, 0];
+        const TRANSIENT_NONE: [u8; 5] = [3, 0, 0, 0, 0];
+
+        assert_eq!(
+            bincode::serialize(&ProviderFailureClass::Failure).unwrap(),
+            FAILURE.to_vec(),
+            "Failure must stay variant index 0"
+        );
+        assert_eq!(
+            bincode::serialize(&ProviderFailureClass::Throttle {
+                retry_after_ms: None
+            })
+            .unwrap(),
+            THROTTLE_NONE.to_vec(),
+            "Throttle must stay variant index 1"
+        );
+        assert_eq!(
+            bincode::serialize(&ProviderFailureClass::AuthInvalid).unwrap(),
+            AUTH_INVALID.to_vec(),
+            "AuthInvalid must stay variant index 2"
+        );
+        assert_eq!(
+            bincode::serialize(&ProviderFailureClass::Transient {
+                retry_after_ms: None
+            })
+            .unwrap(),
+            TRANSIENT_NONE.to_vec(),
+            "Transient is the newest variant and must be appended LAST, at index 3"
+        );
+
+        // And the decode direction: bytes minted by a worker that predates
+        // `Transient` still land on the variant they were written as.
+        assert_eq!(
+            bincode::deserialize::<ProviderFailureClass>(&FAILURE).unwrap(),
+            ProviderFailureClass::Failure
+        );
+        assert_eq!(
+            bincode::deserialize::<ProviderFailureClass>(&THROTTLE_NONE).unwrap(),
+            ProviderFailureClass::Throttle {
+                retry_after_ms: None
+            }
+        );
+        assert_eq!(
+            bincode::deserialize::<ProviderFailureClass>(&AUTH_INVALID).unwrap(),
+            ProviderFailureClass::AuthInvalid
+        );
+        assert_eq!(
+            bincode::deserialize::<ProviderFailureClass>(&TRANSIENT_NONE).unwrap(),
+            ProviderFailureClass::Transient {
+                retry_after_ms: None
+            }
+        );
     }
 
     fn loop_guard_outcome(kind: LoopGuardKind) -> TaskRunOutcome {


### PR DESCRIPTION
## The incident

On 2026-07-29 planner task `2gq7` failed three consecutive sessions on `openai/gpt-5.6-sol`, each on an independent provider HTTP 500:

- 12:48:03 — `server_is_overloaded: Our servers are currently overloaded`
- 12:54:28 — `server_error` (OpenAI request id `f7bd36f8-6250-455d-8235-738cab51183c`)
- 12:59:40 — `server_is_overloaded`, dead in 2s with `tokens_in=0`, before the first token

The coordinator then created a "Planner remediation" task (`oftp`) whose reason asserted:

> *The redispatched worker reproduces the same failure each time (e.g. a poisoned resume transcript that the provider rejects, or an unusable credential)*

That is simply false. These were three unrelated transient outages spread over 11 minutes; nothing about the task was reproducing anything. Meanwhile `model_health` already had the model `auto_disabled` with 7 consecutive failures — the system had correctly identified the model as the faulty party in one place while blaming the task in another.

## Root cause: the taxonomy was too coarse to express the intent

`ProviderError::retryable()` has always known that `ProviderInternal{5xx}` / `Transport` / `ExhaustedTransport` / `RateLimit` are transient. That knowledge was thrown away at the worker→host boundary: `classify_provider_failure` (`supervisor_impl/stage.rs`) folded `InvalidRequest | InvalidOutput | ProviderInternal{..}` — and `Transport` — all into `ProviderFailureClass::Failure`, and the serde enum only had `Failure` / `Throttle` / `AuthInvalid`.

Downstream, `task_dispatch.rs` armed the third-strike planner escalation on `provider_failure.is_some() && !throttle`. A 5xx is `Failure`, not throttle → three strikes → `oftp`. The same conflation fed `stored_streak_after_failure`, which spared only throttles, so a long provider outage also marched a healthy task toward the `MAX_DISPATCH_FAILURES` force-close.

`retry.rs` already documented the correct intent — *"Callers gate this on a genuine, non-throttle typed provider failure — a transient throttle must decay on the cooldown ladder, not escalate"* — the vocabulary just could not say it.

## The fix

**A. `ProviderFailureClass::Transient { retry_after_ms }`**, appended **LAST** in the enum (see wire-compat note below).

**B. Reclassified** in `classify_provider_failure`:
- `ProviderInternal { .. }` → `Transient`
- `Transport` | `ExhaustedTransport(_)` → `Transient`
- `InvalidRequest` | `InvalidOutput` → stay `Failure` — the task-attributable class (the poisoned resume transcript really does 400 identically on every redispatch), and now the **only** thing that arms escalation
- `Authentication` → `AuthInvalid`, `RateLimit`/`EmptyCompletion` → `Throttle`, `ContextOverflow` → `None`: unchanged

**C. Breaker feedback is behaviour-preserving.** `Transient` feeds `record_failure` — the same gentle consecutive-failure breaker `Failure` uses. Model health, auto-disable, and cooldown escalation are byte-for-byte unchanged; a model that 5xx's on every dispatch still demotes. Only *task attribution* moved.

**D. Carried to the coordinator** as an additive `TaskFailureSignal::transient: bool` (the pair is deliberately not refactored into an enum):
- the escalation gate is now `provider_failure.is_some() && !throttle && !transient`
- `stored_streak_after_failure` spares the terminal counter for `transient` exactly as for `throttle`, and the terminal-close branch gains the same `!transient`
- the escalating cooldown ladder, the A6 provider-retry floor, and the per-`(scope, model)` breaker failover **all still apply** to transient faults — only the two task-blaming counters are spared

**E. Breaker-aware backstop.** `maybe_escalate_provider_failure_streak` now stands down entirely when the model the task last ran on is `auto_disabled` for the task creator's scope. It resolves the model via `SessionRepository::latest_model_for_task_role` (already used by the diverse-review path) and reads `HealthTracker::model_health` (the coordinator already holds this handle — same one `is_throttle_cooling` is called through). A tripped model-wide breaker is direct evidence the fault is the model's; during `2gq7` it had already tripped. Fails **open** (escalation proceeds) if there is no session or the lookup errors — it is a backstop over the classification, not the primary gate.

Also fixed: the escalation's reason text, which is what put a false claim in `oftp`. It now states the class it actually fires on and says explicitly that throttles and transient faults are excluded.

## Additional finding: these came through the ChatGPT **Codex consumer** backend, not the OpenAI API

There is no `openai` credential stored. `effective_oauth_provider_id` resolves `openai` → `chatgpt_codex`, and `codex_provider_config` sends requests to `https://chatgpt.com/backend-api/codex` — the ChatGPT **consumer subscription** backend. The same subscription served local `codex` fine at the time, and `model_health` showed the model with 5 successes against 15 failures. So `server_is_overloaded` was not a global OpenAI outage: it was that backend shedding load under djinn's much larger prompts (the failing sessions sent 94,752 and 35,672 tokens) and many concurrent sessions on one consumer plan. **Plan capacity, not a provider-internal fault.**

`from_stream_error` matched only `rate_limit` / `quota`, so `server_is_overloaded` fell through to the `ProviderInternal{500}` catch-all. This PR adds an `overload` substring arm → `ProviderError::RateLimit`:

- one arm covers OpenAI's `server_is_overloaded` and Anthropic's `overloaded_error`
- placed **after** the auth and `invalid_request` checks, before the catch-all, so it cannot swallow them
- `RateLimit` → `ProviderFailureClass::Throttle` → `record_stall` → **immediate failover** to the user's next model, which is the right response to a saturated endpoint (backing off and re-probing it is not)
- no `retry_after_ms` is synthesized — a stream error event carries no reset window, and `CODEX_EMPTY_QUOTA_RETRY_AFTER_MS` belongs to the empty-200 *over-quota* signature, a different (clock-based) condition
- `from_status` already maps 529 → `RateLimit` (consistent with `is_rate_limit_status` in `client.rs`), so the status and stream-code paths now agree
- **regression guard**: `server_error` and `internal_error` still map to `ProviderInternal{500}` → `Transient`. `2gq7`'s second failure was a genuine `server_error` and keeps its classification

Both classes are exempt from escalation, so the escalation fix holds either way; the difference is that an overload now fails over immediately instead of retrying a saturated model.

## Wire compatibility (bincode)

`ProviderFailureClass` rides a **positional, non-self-describing bincode** frame between the worker pod and the host. bincode encodes an enum as its variant index (u32 LE), so inserting or reordering a variant silently re-points every previously-encoded byte sequence at a different variant — a version-skewed worker mid-deploy would have its `Throttle` decoded as `AuthInvalid`. `Transient` is therefore appended **last**, after `AuthInvalid`, which was itself appended last for this reason; the constraint is documented on the variant.

**A new worker emitting `Transient` requires a version-matched host** — the same constraint the enum already carries for `AuthInvalid` and for `Throttle`'s `retry_after_ms` field. `spec.rs` gains a test that pins the literal wire bytes of all four variants in both directions, so a future insertion fails the test instead of shipping a mid-deploy mis-decode.

## Testing

The bar here was *"what stays green if the fixed code did nothing?"* — a `assert_eq!(classify(..), Transient)` label test would pass even if the coordinator still escalated. So the core coverage is a new `tests/provider_fault_attribution.rs` that drives the **real** `dispatch_ready_tasks` pass and asserts durable side effects:

| Test | Asserts |
|---|---|
| `three_transient_provider_faults_route_no_planner_remediation` | 4 consecutive transient failures → **no** `planner_intervention` marker, **no** remediation task blocking the source, **no** `arbiter_dispatched`, no provider-failure strike, terminal streak absent, task still `needs_task_review` — **and** a cooldown IS applied (the ladder still works) |
| `request_attributable_provider_failures_still_escalate_at_threshold` | the control: `InvalidRequest`-class failures still advance the streak and still route the intervention + remediation task on the threshold strike |
| `transient_provider_fault_cannot_force_close_a_task_at_the_cap` | streak rehydrated at `MAX-1` + one transient fault → task **not** closed, streak unchanged |
| `request_attributable_failure_at_the_cap_still_force_closes` | control: same setup with the request-attributable class still closes terminally |
| `auto_disabled_model_breaker_blocks_the_escalation` | feeds the **coarse pre-fix class** on an auto-disabled model → still no escalation (guard E) |

**Verified they fail without the fix**: with the production changes reverted (gate, stored-streak, terminal-close, and guard E) but the tests kept, `three_transient_provider_faults_route_no_planner_remediation`, `transient_provider_fault_cannot_force_close_a_task_at_the_cap` (`left: "closed"`) and `auto_disabled_model_breaker_blocks_the_escalation` all fail; the two controls still pass. Restoring the fix turns all five green.

Also added:
- `spec.rs`: `Transient` bincode round-trip + the append-only discriminant guard
- `types.rs`: `transient_provider_fault_does_not_advance_terminal_streak` (incl. the cap boundary)
- `stage.rs`: 5xx→`Transient` for statuses 500/502/503/529 and through the wrapped-context path; overload stream event → `Throttle` end-to-end (immediate failover); the existing transport tests updated
- `error.rs`: `overload_codes_are_throttles_not_provider_internal` with the `server_error` / `internal_error` regression guard and the 529 status/stream consistency check
- Anthropic's two `overloaded_error` tests updated to the new intent (and `error.retry_after` now rides along, since the `RateLimit` arm is the one that folds it in)

**Gate**: `cargo clippy --workspace --all-targets --features qdrant -- -D warnings` clean; `djinn-provider` (652), `djinn-agent` (1455), `djinn-runtime`, `djinn-supervisor` suites fully green; `check_boundaries.py` and `check-file-size.sh` clean; no golden/schema files derive from these types (verified by search).

The `djinn-coordinator` suite has ~20 pre-existing `SIGABRT` (stack overflow) failures in `rules::tests` / `wave::tests` / `status_and_stuck` on this machine. Verified they reproduce identically on the base commit `15ec485dd` (including in isolation with `--test-threads 1`); the failing set varies run to run and none are related to this diff.

## Deliberately not changed

- `from_stream_error`'s mapping of `server_error` → `ProviderInternal{500}` (per the brief, and now guarded by a test).
- The `Failure`/`Throttle` pair in `TaskFailureSignal` was **not** refactored into an enum — the change is additive.
- Like an existing throttle (A3), a run of *pure* transient faults leaves `dispatch_failure_streak` at its current value, so the ladder does not climb past its first rung for that run. That is exactly the established throttle behaviour and is out of scope here; worth a follow-up only if provider-fault backoff should escalate independently of the terminal counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
