### PR TITLE
fix(coordinator): stop counting pod-Pending time as agent idle time

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -288,6 +288,24 @@ impl CoordinatorActor {
                 }
             };
 
+            // ── Anchor the idle clock to pod-Running ────────────────────────
+            // The slot pool seeds the host ActivityTracker at slot RESERVATION,
+            // before `runtime.prepare` has created the task-run Job. Everything
+            // between that seed and the pod actually running — scheduling on
+            // CPU/memory requests, a DiskPressure taint, an image pull, in-pod
+            // stage init — is infrastructure latency, not an idle agent, yet it
+            // lands in `idle_seconds` verbatim. Left unanchored it silently eats
+            // the 30-minute budget and, past it, terminalizes the attempt
+            // `TimedOut`, feeds the model breaker, and (on the second strike)
+            // tells the Planner to rescope a task whose only problem was that
+            // the cluster was full.
+            //
+            // `sessions.started_at` is the pod-Running witness: that row is
+            // written by the worker from INSIDE the pod (supervisor stage
+            // `session_create`), so it cannot exist before the pod ran. An agent
+            // cannot have been idle longer than its own session has existed.
+            let idle = anchor_idle_to_pod_running(idle, parse_iso_elapsed(&session.started_at));
+
             // Pick the idle clock and threshold. A session with a live
             // ActivityTracker signal falls under the role's full idle budget —
             // covering long quiet stretches (a multi-minute build, a long
@@ -2812,12 +2830,27 @@ impl CoordinatorActor {
 ///
 /// This is a standalone pure helper (no `&self`) so it can be unit-tested
 /// without constructing a full [`CoordinatorActor`].
-fn build_liveness_evidence(
+pub(crate) fn build_liveness_evidence(
     pool_info: Option<&RunningTaskInfo>,
     db_state: &CurrentLivenessState,
 ) -> LivenessEvidence {
     // ── Pod phase ─────────────────────────────────────────────────────
+    // Pool membership alone is NOT pod-Running: a reserved slot exists from the
+    // moment the coordinator hands the task to the pool, which is before
+    // `runtime.prepare` creates the Job. Reporting `Running` there made the
+    // classifier's `Pending` handling unreachable and fed it a phase it could
+    // never contradict. Derive the phase from two independent witnesses that a
+    // Pod actually started:
+    //   * `worker_activity_observed` — the worker completed its startup
+    //     handshake and bridged a real `touch_activity` (or the in-process
+    //     reply loop registered), and
+    //   * an in-pod `sessions` row (`active_session_id`), which the worker
+    //     writes from inside the Pod.
+    // With neither, the Pod is still being scheduled/pulled — `Pending`.
     let pod_phase = match pool_info {
+        Some(info) if !info.worker_activity_observed && db_state.active_session_id.is_none() => {
+            PodPhase::Pending
+        }
         Some(_) => PodPhase::Running,
         None => PodPhase::Absent,
     };
@@ -3034,6 +3067,40 @@ fn resolve_stall_clock(
     }
 }
 
+/// Clamp a pool-reported idle measurement to the age of the session it belongs
+/// to, so time the pod spent NOT running is never counted as agent idle time.
+///
+/// WHY THIS EXISTS: `SlotPool::dispatch` seeds the host `ActivityTracker` the
+/// instant a slot is reserved — before `runtime.prepare` creates the task-run
+/// Job. Until the worker's first `touch_activity` bridges back, `idle_seconds`
+/// is simply "seconds since reservation", which includes every second the Pod
+/// spent `Pending` (unschedulable on its CPU/memory request, held off by a
+/// DiskPressure taint, pulling its image) plus in-pod stage init. The idle-stall
+/// watchdog consumed that number verbatim, so a slow-to-schedule Pod arrived at
+/// its first sweep already past `STALL_TIMEOUT_SECS` and was killed as an
+/// `idle_stall` — blaming the TASK for cluster capacity.
+///
+/// `session_age_secs` comes from `sessions.started_at`, which the worker writes
+/// from INSIDE the Pod (supervisor stage `session_create`). Its existence is
+/// therefore proof the Pod reached `Running`, and its age is an upper bound on
+/// how long the agent could possibly have been idle. Taking the minimum keeps
+/// real stall detection intact — a genuinely hung agent in a Running Pod has a
+/// session that keeps ageing, so it still crosses the threshold on schedule —
+/// while making pre-Running time uncountable.
+///
+/// `None` (unparseable `started_at`) leaves the measurement untouched: absence
+/// of the witness is not evidence, and the caller already logs the parse
+/// failure on the fallback path.
+pub(crate) fn anchor_idle_to_pod_running(
+    measured_idle_secs: u64,
+    session_age_secs: Option<u64>,
+) -> u64 {
+    match session_age_secs {
+        Some(age) => measured_idle_secs.min(age),
+        None => measured_idle_secs,
+    }
+}
+
 fn session_predates_task_status(session_started_at: &str, task_updated_at: &str) -> Option<bool> {
     let session_elapsed = parse_iso_elapsed(session_started_at)?;
     let task_updated_elapsed = parse_iso_elapsed(task_updated_at)?;
@@ -3096,6 +3163,7 @@ mod liveness_foundation_tests {
             duration_seconds: 60,
             idle_seconds: 5,
             activity_tracked: true,
+            worker_activity_observed: true,
             project_id: Some("proj-1".to_owned()),
             token_count: 1000,
             turn_count: 5,

--- a/server/crates/djinn-coordinator/src/refinement_pool_watchdog_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_pool_watchdog_tests.rs
@@ -101,6 +101,7 @@ fn spawn_counting_pool(running: Vec<String>) -> (SlotPoolHandle, Arc<Mutex<PoolC
                             duration_seconds: 0,
                             idle_seconds: 0,
                             activity_tracked: true,
+                            worker_activity_observed: true,
                             project_id: None,
                             token_count: 0,
                             turn_count: 0,

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -1445,3 +1445,8 @@ mod hold_cycle_ceiling;
 
 #[cfg(test)]
 mod incarnation_lease_liveness;
+
+/// Pod-`Pending` time must not be counted as agent idle time by the stall
+/// watchdog (and the negative control that proves the watchdog still works).
+#[cfg(test)]
+mod stall_pod_pending;

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -3347,17 +3347,22 @@ async fn slow_extension_granted_with_evidence_and_claim_extension() {
         })
         .await
         .unwrap();
-    // Keep the session WITHIN its claim window (recent started_at → non-zero
-    // claim TTL → `extension_budget_exhausted == false`), so the classifier
-    // marks it extension-eligible: this is the in-window case that earns the
-    // one coordinator-gated grace extension. The stall itself is driven by the
-    // aged activity tracker below (idle > 30 min), NOT by `started_at`, so the
-    // idle gate still fires. A session past its claim TTL would instead be
-    // egregiously stale and killed on the first tick (see
+    // Keep the session WITHIN its claim window (started_at far short of the
+    // 3-hour HARD_RUNTIME_CAP_SECS → non-zero claim TTL →
+    // `extension_budget_exhausted == false`), so the classifier marks it
+    // extension-eligible: this is the in-window case that earns the one
+    // coordinator-gated grace extension. A session past its claim TTL would
+    // instead be egregiously stale and killed on the first tick (see
     // `slow_extension_budget_exhaustion_falls_through_to_kill` / the stall
     // teardown tests).
+    //
+    // The age must also COVER the aged activity tracker below: the stall sweep
+    // anchors the idle clock to pod-Running (`anchor_idle_to_pod_running`), and
+    // an in-pod `sessions` row two minutes old would prove the pod had only
+    // been running two minutes — making a 35-minute idle reading impossible and
+    // clamping it away. 40 minutes keeps the 35-minute idle honest.
     session_repo
-        .backdate_started_at(&session.id, "2 minutes")
+        .backdate_started_at(&session.id, "40 minutes")
         .await
         .unwrap();
 
@@ -5198,6 +5203,15 @@ async fn stall_timeout_terminalizes_attempt_as_timed_out() {
 
     let attempt_id = seed_pending_attempt(&db, &task.id, "worker").await;
 
+    // Age the session row to match the idle time simulated below. The stall
+    // sweep anchors the idle clock to pod-Running via the in-pod `sessions`
+    // row, so a row created "now" would prove the pod had only just started and
+    // the 2000s of simulated idle would be clamped away as scheduling latency.
+    session_repo
+        .backdate_started_at(&session.id, "40 minutes")
+        .await
+        .unwrap();
+
     // Deterministic clock so we can push monotonic idle time past the 300s
     // first-call cap without sleeping.
     let clock = Arc::new(djinn_core::clock::TestClock::new(
@@ -5918,11 +5932,14 @@ async fn slow_verdict_with_concurrent_terminal_transition_does_not_grant_extensi
         })
         .await
         .unwrap();
-    // Keep the session within its claim window so the Slow verdict (if reached)
-    // would normally be extension-eligible. The stall is driven by aged activity
-    // tracker, not started_at.
+    // Keep the session within its claim window (well short of the 3-hour
+    // HARD_RUNTIME_CAP_SECS) so the Slow verdict (if reached) would normally be
+    // extension-eligible, while still being OLDER than the 35-minute idle the
+    // aged activity tracker reports below — the stall sweep clamps idle to the
+    // session's own age (`anchor_idle_to_pod_running`), so a two-minute-old
+    // session could not be 35 minutes idle.
     session_repo
-        .backdate_started_at(&session.id, "2 minutes")
+        .backdate_started_at(&session.id, "40 minutes")
         .await
         .unwrap();
 

--- a/server/crates/djinn-coordinator/src/tests/stall_pod_pending.rs
+++ b/server/crates/djinn-coordinator/src/tests/stall_pod_pending.rs
@@ -1,0 +1,384 @@
+//! Regression coverage: pod-`Pending` time is not agent idle time.
+//!
+//! `SlotPool::dispatch` seeds the host `ActivityTracker` at slot RESERVATION —
+//! before `runtime.prepare` has created the task-run Job. Until the worker's
+//! first bridged `touch_activity`, `RunningTaskInfo::idle_seconds` is simply
+//! "seconds since reservation", which includes every second the Pod spent
+//! `Pending`: unschedulable on its CPU/memory request, held off by a
+//! DiskPressure taint, or pulling its image. The idle-stall watchdog consumed
+//! that number verbatim, so a slow-to-schedule Pod could arrive at its very
+//! first sweep already past `STALL_TIMEOUT_SECS` and be killed as an
+//! `idle_stall` — terminalizing the attempt `TimedOut`, feeding the model
+//! circuit breaker, and (on the second consecutive occurrence) telling the
+//! Planner to decompose/rescope a task whose only problem was cluster capacity.
+//!
+//! The fix anchors the idle clock to pod-Running: `sessions.started_at` is
+//! written by the worker from INSIDE the Pod, so it cannot predate the Pod
+//! running, and an agent cannot have been idle longer than its own session has
+//! existed.
+//!
+//! These two tests differ in exactly ONE input — the age of the session row —
+//! so the negative control proves the watchdog was not simply disabled.
+
+use super::*;
+use djinn_db::{
+    CreateSessionParams, CreateTaskAttemptParams, SessionRepository, TaskAttemptRepository,
+};
+use djinn_slot::{PoolMessage, PoolStatus, RunningTaskInfo, SlotPoolHandle};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+const STALL_MODEL: &str = "openai/gpt-5.5";
+
+/// Idle the stub pool reports: 35 minutes, comfortably past the 30-minute
+/// `STALL_TIMEOUT_SECS`. This is the reservation-anchored number a Pod that
+/// waited 35 minutes for a node would produce on its first sweep.
+const RESERVATION_ANCHORED_IDLE_SECS: u64 = 35 * 60;
+
+/// Stub pool that reports one running task with a reservation-anchored idle
+/// clock and records every `kill_session` it is asked to perform.
+///
+/// `worker_activity_observed: false` is the load-bearing detail: the tracker
+/// entry backing `idle_seconds` is the pool's own reservation seed, never
+/// moved by a real worker.
+fn spawn_stub_pool(task_id: String) -> (SlotPoolHandle, Arc<Mutex<Vec<String>>>) {
+    let kills: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let kills_task = kills.clone();
+    let (tx, mut rx) = mpsc::channel::<PoolMessage>(64);
+    tokio::spawn(async move {
+        let info = |id: &str| RunningTaskInfo {
+            task_id: id.to_owned(),
+            model_id: STALL_MODEL.to_owned(),
+            slot_id: 0,
+            duration_seconds: RESERVATION_ANCHORED_IDLE_SECS,
+            idle_seconds: RESERVATION_ANCHORED_IDLE_SECS,
+            // The pool seeded the tracker at reservation, so it reports a
+            // "tracked" idle clock…
+            activity_tracked: true,
+            // …but no worker has ever spoken: the Pod may still be Pending.
+            worker_activity_observed: false,
+            project_id: None,
+            token_count: 0,
+            turn_count: 0,
+            no_progress_streak: 0,
+        };
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                PoolMessage::GetSessionForTask {
+                    task_id: asked,
+                    respond_to,
+                } => {
+                    let reply = (asked == task_id).then(|| info(&asked));
+                    let _ = respond_to.send(Ok(reply));
+                }
+                PoolMessage::KillSession {
+                    task_id: asked,
+                    respond_to,
+                } => {
+                    kills_task.lock().expect("kills").push(asked);
+                    let _ = respond_to.send(Ok(()));
+                }
+                PoolMessage::HasSession {
+                    task_id: asked,
+                    respond_to,
+                } => {
+                    let _ = respond_to.send(Ok(asked == task_id));
+                }
+                PoolMessage::GetStatus { respond_to } => {
+                    let _ = respond_to.send(Ok(PoolStatus {
+                        active_slots: 1,
+                        total_slots: 1,
+                        per_model: HashMap::new(),
+                        running_tasks: vec![info(&task_id)],
+                    }));
+                }
+                other => drop(other),
+            }
+        }
+    });
+    (SlotPoolHandle::from_raw_sender(tx), kills)
+}
+
+struct StallFixture {
+    task: djinn_core::models::Task,
+    session_id: String,
+    attempt_id: String,
+    kills: Arc<Mutex<Vec<String>>>,
+    actor: CoordinatorActor,
+}
+
+/// Seed a task + running task_run + running session + pending `worker`
+/// attempt, and point the actor at a stub pool reporting a 35-minute
+/// reservation-anchored idle clock.
+async fn seed_stall_fixture(
+    db: &Database,
+    tx: &broadcast::Sender<DjinnEventEnvelope>,
+    slug: &str,
+) -> StallFixture {
+    let (task, _note) = create_task_with_note(db, tx, slug).await;
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    let run_id = format!("run-{slug}");
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: &run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .unwrap();
+
+    let session = SessionRepository::new(db.clone(), crate::events::event_bus_for(tx))
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: STALL_MODEL,
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(&run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+
+    let attempt_id = uuid::Uuid::now_v7().to_string();
+    TaskAttemptRepository::new(db.clone())
+        .create_or_get_pending(CreateTaskAttemptParams {
+            id: &attempt_id,
+            task_id: &task.id,
+            role: "worker",
+            dispatch_key: &format!("{}:worker:{attempt_id}", task.id),
+            session_id: Some(&session.id),
+            attempt_seq: None,
+            dispatch_owner_incarnation_id: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .unwrap();
+
+    let (pool, kills) = spawn_stub_pool(task.id.clone());
+    let mut actor = coordinator_actor_for_tests(db, tx);
+    actor.pool = pool;
+    // Exhaust the Slow-verdict extension budget up front so both tests measure
+    // the SAME decision — "does this session reach the kill path at all?" —
+    // rather than one of them merely being deferred by a grant. The extension
+    // ladder is orthogonal to the pod-Pending question and is covered
+    // elsewhere.
+    actor.stall_extension_count.insert(
+        session.id.clone(),
+        actor.worker_lifecycle_config.slow_extension.max_extensions,
+    );
+
+    StallFixture {
+        task,
+        session_id: session.id,
+        attempt_id,
+        kills,
+        actor,
+    }
+}
+
+/// Outcome recorded on the seeded attempt, or `None` if it is still pending.
+async fn attempt_outcome(db: &Database, attempt_id: &str, task_id: &str) -> Option<String> {
+    TaskAttemptRepository::new(db.clone())
+        .list_for_task(task_id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|a| a.id == attempt_id)
+        .map(|a| a.outcome.as_str().to_owned())
+}
+
+/// Total consecutive failures the model circuit breaker has been fed for
+/// `STALL_MODEL` across every scope.
+fn breaker_consecutive_failures(actor: &CoordinatorActor) -> u32 {
+    actor
+        .health
+        .all_health()
+        .into_iter()
+        .filter(|h| h.model_id == STALL_MODEL)
+        .map(|h| h.consecutive_failures)
+        .sum()
+}
+
+/// A session whose Pod only just reached `Running` — its in-pod `sessions` row
+/// is seconds old — must NOT be stall-killed just because the pool's
+/// reservation-anchored idle clock already reads 35 minutes. Those 35 minutes
+/// were spent `Pending`, waiting on cluster capacity.
+///
+/// Asserts the three side effects that make this incident expensive, not just
+/// that a field carries a phase: no kill, no `TimedOut` attempt, no breaker
+/// failure. Before the fix all three fired.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pod_pending_time_is_not_counted_as_idle_and_no_stall_kill_fires() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    // The session row is BRAND NEW: the worker wrote it from inside the Pod the
+    // moment the Pod finally got scheduled. Everything before it was Pending.
+    let mut fx = seed_stall_fixture(&db, &tx, "stall-pod-pending").await;
+
+    fx.actor.enforce_session_stall_timeout().await;
+
+    assert!(
+        !fx.actor.stall_killed.contains(&fx.session_id),
+        "a session whose Pod only just started must not be marked stall-killed — \
+         the 35-minute idle clock is pod-Pending time, not agent idle time"
+    );
+    assert!(
+        fx.kills.lock().expect("kills").is_empty(),
+        "no kill_session may be issued for a Pod that just finished scheduling"
+    );
+    assert_eq!(
+        attempt_outcome(&db, &fx.attempt_id, &fx.task.id).await,
+        Some("pending".to_owned()),
+        "the attempt must stay pending — a scheduling delay is not a TimedOut attempt"
+    );
+    assert_eq!(
+        breaker_consecutive_failures(&fx.actor),
+        0,
+        "cluster capacity is not model health: record_failure must not be fed"
+    );
+}
+
+/// Negative control. Same stub pool, same 35-minute reservation-anchored idle
+/// clock, same exhausted extension budget — the ONLY difference is that this
+/// session has genuinely existed for 40 minutes, so its Pod has been `Running`
+/// the whole time and the agent really is hung.
+///
+/// It must still be killed exactly as before: `TimedOut` attempt and a breaker
+/// failure. Without this, "fixing" the Pending case could just mean disabling
+/// the watchdog.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn genuinely_idle_running_pod_is_still_stall_killed() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut fx = seed_stall_fixture(&db, &tx, "stall-running-idle").await;
+    // The single differing input: the Pod has been Running for 40 minutes.
+    SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .backdate_started_at(&fx.session_id, "40 minutes")
+        .await
+        .unwrap();
+
+    fx.actor.enforce_session_stall_timeout().await;
+
+    assert!(
+        fx.actor.stall_killed.contains(&fx.session_id),
+        "a genuinely idle agent in a long-Running Pod must still be stall-killed"
+    );
+    assert_eq!(
+        fx.kills.lock().expect("kills").as_slice(),
+        &[fx.task.id.clone()],
+        "the stall kill must reach the pool"
+    );
+    assert_eq!(
+        attempt_outcome(&db, &fx.attempt_id, &fx.task.id).await,
+        Some("timed_out".to_owned()),
+        "a real idle stall must still terminalize the attempt as TimedOut"
+    );
+    assert!(
+        breaker_consecutive_failures(&fx.actor) >= 1,
+        "a real idle stall must still feed the model circuit breaker"
+    );
+}
+
+/// The pure anchor: pre-pod-Running seconds are uncountable, but a Running
+/// Pod's idle clock passes through untouched, and an unparseable witness is
+/// never treated as evidence.
+#[test]
+fn anchor_clamps_only_when_the_session_is_younger_than_the_idle_clock() {
+    use crate::dispatch::session_recovery::anchor_idle_to_pod_running;
+
+    // Pod waited 35 minutes to schedule; the session is 12 seconds old.
+    assert_eq!(anchor_idle_to_pod_running(2100, Some(12)), 12);
+    // Genuinely idle inside a long-Running Pod — nothing is clamped away.
+    assert_eq!(anchor_idle_to_pod_running(2100, Some(2400)), 2100);
+    // Absence of the witness is not evidence.
+    assert_eq!(anchor_idle_to_pod_running(2100, None), 2100);
+}
+
+/// The liveness classifier's `Pending` handling was unreachable: evidence was
+/// built with `pod_phase = Running` for any task the pool merely had a slot
+/// mapping for, whether or not a Pod had ever started. With a truthful phase a
+/// never-scheduled Pod classifies `Live` (spare it) instead of `Slow` (a
+/// kill-path verdict that burns extension budget and then kills).
+#[test]
+fn unstarted_pod_classifies_live_instead_of_slow() {
+    use crate::dispatch::liveness::{ActivitySignal, PodPhase, Verdict, classify};
+    use crate::dispatch::session_recovery::build_liveness_evidence;
+
+    let mut db_state = unstarted_db_state();
+    let pool_info = RunningTaskInfo {
+        task_id: "task-pending".to_owned(),
+        model_id: STALL_MODEL.to_owned(),
+        slot_id: 0,
+        duration_seconds: RESERVATION_ANCHORED_IDLE_SECS,
+        idle_seconds: RESERVATION_ANCHORED_IDLE_SECS,
+        activity_tracked: true,
+        worker_activity_observed: false,
+        project_id: None,
+        token_count: 0,
+        turn_count: 0,
+        no_progress_streak: 0,
+    };
+
+    let evidence = build_liveness_evidence(Some(&pool_info), &db_state);
+    assert_eq!(evidence.pod_phase, Some(PodPhase::Pending));
+    assert_eq!(evidence.activity, ActivitySignal::Idle);
+    assert_eq!(
+        classify(&evidence).verdict,
+        Verdict::Live,
+        "a Pod that never started must not be classified Slow — Slow is a kill-path \
+         verdict that consumes extension budget and then falls through to the kill"
+    );
+
+    // Once the worker speaks, the same evidence is a Running Pod and the idle
+    // clock is real again: the classifier convicts exactly as before.
+    let mut started = pool_info.clone();
+    started.worker_activity_observed = true;
+    db_state.active_session_id = Some("sess-live".to_owned());
+    let evidence = build_liveness_evidence(Some(&started), &db_state);
+    assert_eq!(evidence.pod_phase, Some(PodPhase::Running));
+    assert_eq!(classify(&evidence).verdict, Verdict::Slow);
+}
+
+/// A `CurrentLivenessState` for a task whose Pod has not started: no in-pod
+/// session row exists yet.
+pub(super) fn unstarted_db_state() -> djinn_db::CurrentLivenessState {
+    djinn_db::CurrentLivenessState {
+        task_status: Some("in_progress".to_owned()),
+        task_is_terminal: false,
+        active_session_id: None,
+        active_session_status: None,
+        latest_task_run_id: Some("run-1".to_owned()),
+        latest_task_run_status: Some("running".to_owned()),
+        session_liveness_verdict: None,
+        session_liveness_outcome_kind: None,
+        session_liveness_outcome_reason: None,
+        session_liveness_evidence: None,
+        task_run_liveness_outcome_kind: None,
+        task_run_liveness_outcome_reason: None,
+        task_run_liveness_evidence: None,
+        task_created_at: None,
+        session_started_at: None,
+        task_run_started_at: None,
+        task_run_ended_at: None,
+        // The task was claimed for this dispatch: `open → in_progress`. That is
+        // the only transition it can have — a task sitting at `in_progress`
+        // with a live task_run has necessarily been claimed, so `None` ("no
+        // recorded transition at all") would describe a state that cannot
+        // occur. `open` is not a session-held status, so
+        // `handed_off_from_session_held_status` stays `false`: nothing has
+        // handed this task on, which is exactly right for a Pod that has not
+        // started yet.
+        last_transition_from_status: Some("open".to_owned()),
+    }
+}

--- a/server/crates/djinn-slot/src/host.rs
+++ b/server/crates/djinn-slot/src/host.rs
@@ -382,6 +382,18 @@ impl SlotContext {
         let last = ts.load(Ordering::Relaxed);
         Some(now.saturating_sub(last))
     }
+    /// The live tracker handle for `task_id`, if any.
+    ///
+    /// Exposed so the slot pool can tell its OWN reservation seed apart from a
+    /// real worker registration: `register_activity` replaces the entry with a
+    /// fresh atomic, so a handle that is no longer pointer-equal to the seeded
+    /// one is itself proof the run reached the reply loop. See
+    /// `RunningTaskInfo::worker_activity_observed`.
+    pub fn activity_handle(&self, task_id: &str) -> Option<Arc<AtomicU64>> {
+        recover_lock(&self.active_tasks, "active_tasks")
+            .get(task_id)
+            .cloned()
+    }
     pub fn register_background_work(&self, task_id: &str) {
         recover_lock(&self.background_work_tasks, "background_work_tasks")
             .insert(task_id.to_string());

--- a/server/crates/djinn-slot/src/pool/actor.rs
+++ b/server/crates/djinn-slot/src/pool/actor.rs
@@ -26,6 +26,19 @@ pub(super) struct SlotPool {
     slot_models: HashMap<usize, String>,
     task_projects: HashMap<String, String>,
     task_started: HashMap<String, Instant>,
+    /// Per-task handle on the host `ActivityTracker` entry the pool SEEDS at
+    /// slot reservation, paired with the seeded timestamp.
+    ///
+    /// The seed is bookkeeping, not liveness: it is written before
+    /// `runtime.prepare` creates the task-run Job, so it exists while the pod
+    /// is still `Pending`. Retaining the `(handle, seed_value)` pair lets
+    /// `session_for_task` / `get_status` report
+    /// [`RunningTaskInfo::worker_activity_observed`] exactly — the atomic's
+    /// value differs from the seed if and only if a real `touch_activity`
+    /// (in-process reply loop, or the worker pod's bridged RPC) has landed.
+    /// Comparing timestamps this way is exact; comparing elapsed seconds would
+    /// race the clock's one-second granularity.
+    task_activity_seed: HashMap<String, (std::sync::Arc<std::sync::atomic::AtomicU64>, u64)>,
     draining_slots: HashSet<usize>,
     retired_slots: HashSet<usize>,
     /// Task IDs whose settlement and mapping release are deferred because the
@@ -73,6 +86,7 @@ impl SlotPool {
             slot_models: HashMap::new(),
             task_projects: HashMap::new(),
             task_started: HashMap::new(),
+            task_activity_seed: HashMap::new(),
             draining_slots: HashSet::new(),
             retired_slots: HashSet::new(),
             pending_teardown_tasks: HashSet::new(),
@@ -239,6 +253,30 @@ impl SlotPool {
             }
         }
     }
+    /// Whether a real worker liveness signal has landed for `task_id` since the
+    /// pool seeded the tracker at slot reservation.
+    ///
+    /// `true` when the seeded atomic has moved (a `touch_activity` landed), or
+    /// when a tracker entry exists that the pool never seeded (the in-process
+    /// reply-loop path registers its own). `false` while the entry is still the
+    /// untouched reservation seed — the window in which the pod may be
+    /// `Pending` and `idle_seconds` is measuring scheduling delay.
+    fn worker_activity_observed(&self, task_id: &str) -> bool {
+        match self.task_activity_seed.get(task_id) {
+            Some((seed_handle, seeded_at)) => match self.ctx.activity_handle(task_id) {
+                // The in-process reply loop calls `register_activity`, which
+                // REPLACES the tracker entry with a fresh atomic. A different
+                // handle is therefore itself proof the run reached the reply
+                // loop.
+                Some(live) if !std::sync::Arc::ptr_eq(&live, seed_handle) => true,
+                // Same entry: a `touch_activity` moved it off the seeded value.
+                Some(live) => live.load(std::sync::atomic::Ordering::Relaxed) != *seeded_at,
+                None => false,
+            },
+            // No seed retained: any tracker entry is a genuine registration.
+            None => self.ctx.idle_seconds(task_id).is_some(),
+        }
+    }
     fn session_for_task(&self, task_id: &str) -> Option<super::types::RunningTaskInfo> {
         let slot_id = self.task_to_slot.get(task_id)?;
         let model_id = self.slot_models.get(slot_id)?.clone();
@@ -276,6 +314,7 @@ impl SlotPool {
             duration_seconds,
             idle_seconds,
             activity_tracked: tracked_idle.is_some(),
+            worker_activity_observed: self.worker_activity_observed(task_id),
             project_id,
             token_count,
             turn_count,
@@ -402,7 +441,18 @@ impl SlotPool {
                     agent_type: String::new(),
                 },
             );
-            self.ctx.register_activity(&task_owned);
+            // Seed the host `ActivityTracker` so a freshly-reserved slot is not
+            // misread as a hung first call. This is bookkeeping, NOT liveness:
+            // it runs before `runtime.prepare` creates the task-run Job, so the
+            // pod behind it may sit `Pending` for minutes (unschedulable
+            // CPU/memory request, DiskPressure taint, image pull). Retain the
+            // seeded handle+value so `worker_activity_observed` can tell that
+            // scheduling window apart from a genuinely idle agent — see
+            // `RunningTaskInfo::worker_activity_observed`.
+            let seed_handle = self.ctx.register_activity(&task_owned);
+            let seeded_at = seed_handle.load(std::sync::atomic::Ordering::Relaxed);
+            self.task_activity_seed
+                .insert(task_owned.clone(), (seed_handle, seeded_at));
             return Ok(());
         }
     }
@@ -455,6 +505,7 @@ impl SlotPool {
                     self.task_to_slot.remove(&task_id);
                     self.task_started.remove(&task_id);
                     self.task_projects.remove(&task_id);
+                    self.task_activity_seed.remove(&task_id);
                     self.ctx.deregister_activity(&task_id);
                 }
                 if self.draining_slots.remove(&slot_id) {
@@ -574,6 +625,7 @@ impl SlotPool {
         self.task_to_slot.remove(task_id);
         self.task_started.remove(task_id);
         self.task_projects.remove(task_id);
+        self.task_activity_seed.remove(task_id);
         self.ctx.deregister_activity(task_id);
         if self.draining_slots.remove(&slot_id) {
             self.retired_slots.insert(slot_id);
@@ -848,6 +900,7 @@ impl SlotPool {
                     duration_seconds,
                     idle_seconds,
                     activity_tracked: tracked_idle.is_some(),
+                    worker_activity_observed: self.worker_activity_observed(task_id),
                     project_id,
                     token_count: 0,
                     turn_count: 0,

--- a/server/crates/djinn-slot/src/pool/types.rs
+++ b/server/crates/djinn-slot/src/pool/types.rs
@@ -75,6 +75,24 @@ pub struct RunningTaskInfo {
     /// Stall detection uses this to tell a genuinely-hung first call (aggressive
     /// cap) from a productive session that merely went quiet (full role budget).
     pub activity_tracked: bool,
+    /// Whether a REAL worker liveness signal has landed for this task — i.e.
+    /// the reply loop (in-process) or the pod's bridged `touch_activity` RPC
+    /// moved the tracker timestamp past the value the pool seeded at slot
+    /// reservation.
+    ///
+    /// This exists because [`Self::activity_tracked`] cannot answer that
+    /// question: the pool seeds the host `ActivityTracker` the moment a slot is
+    /// reserved (so a brand-new dispatch is not misread as a hung first call),
+    /// which is BEFORE `runtime.prepare` has even created the Kubernetes Job.
+    /// Between reservation and the worker's startup handshake the pod may be
+    /// `Pending` — unschedulable on CPU/memory requests, blocked by a
+    /// DiskPressure taint, or pulling its image — and `idle_seconds` is
+    /// measuring that scheduling delay, not an idle agent.
+    ///
+    /// `false` therefore means "`idle_seconds` is time-since-reservation, and
+    /// the pod may never have run"; `true` means the worker has spoken at least
+    /// once, so `idle_seconds` is a genuine idle measurement.
+    pub worker_activity_observed: bool,
     /// Project UUID the task belongs to, tracked in the pool so project-scoped
     /// queries can filter running tasks without depending on a DB session row
     /// (which does not exist during pre-session lifecycle stages).


### PR DESCRIPTION
## The bug

The idle-stall watchdog started its clock at **slot reservation**, not at pod-`Running`.

`SlotPool::dispatch` seeds the host `ActivityTracker` the instant a slot is reserved — which is *before* `runtime.prepare` has even created the task-run Job. Until the worker's first bridged `touch_activity`, `RunningTaskInfo::idle_seconds` is simply "seconds since reservation". That number includes every second the Pod spent `Pending`: unschedulable on its CPU/memory request, held off by a DiskPressure taint, or pulling its image — plus in-pod stage init.

`enforce_session_stall_timeout` consumed that number verbatim against `STALL_TIMEOUT_SECS` (30 min), so **a Pod that waited a long time for capacity could arrive at its very first sweep already over threshold** and be killed as an `idle_stall`.

The consequences all blamed the task for a cluster problem:

- the attempt was terminalized `TimedOut`;
- the model circuit breaker was fed `record_failure` — the model was not at fault;
- on the second consecutive occurrence (`STALL_CANCEL_ESCALATION_THRESHOLD = 2`) a **Planner remediation task was created telling the Planner to decompose / rescope / close a task whose only real problem was that the cluster was full.**

The liveness classifier could not rescue it. `liveness.rs` has correct `Pending` handling, but `build_liveness_evidence` derived `pod_phase` purely from pool membership (`Some(_) => Running`) — and the slot mapping exists from the moment the coordinator hands the task to the pool. The classifier was sound; **the input was a lie**.

This shape has recurred here before (a refinement watchdog counting pod-Pending time and killing tribunals under CPU-request pressure), so the fix is structural rather than a patch at one call site.

## The fix

**Approach (a): suppress the idle clock for pre-`Running` time**, rather than re-anchoring `register_activity` to the pod-Running event.

Re-anchoring (approach (b)) is actively unsafe here: dropping the reservation seed would flip `activity_tracked` to `false` for every fresh dispatch, and `resolve_stall_clock` puts an untracked post-boot session on the **300s** `FIRST_CALL_STALL_SECS` cap. A Pending Pod would then be killed in 5 minutes instead of 30 — strictly worse.

1. **`anchor_idle_to_pod_running`** (`dispatch/session_recovery.rs`) clamps the pool's idle measurement to the age of the session row. `sessions.started_at` is written by the worker from *inside* the Pod (supervisor stage `session_create`), so it cannot predate the Pod running: it is the pod-`Running` witness, and an agent cannot have been idle longer than its own session has existed. Real stall detection is untouched — a genuinely hung agent in a `Running` Pod has a session that keeps ageing and still crosses the threshold on schedule.

2. **Honest `pod_phase`.** `build_liveness_evidence` now derives the phase from two independent witnesses that a Pod actually started — a real worker `touch_activity`, and an in-pod `sessions` row — instead of from bare pool membership. An unstarted Pod now classifies `Live` (spare it) rather than `Slow` (a kill-path verdict that burns extension budget and then falls through to the kill).

3. **`RunningTaskInfo::worker_activity_observed`** (`djinn-slot`) lets the pool's own reservation seed be told apart from a genuine worker signal, by retaining the seeded atomic handle and its value (exact; comparing elapsed seconds would race the clock's one-second granularity).

### Bounded Pending budget: already exists, none added

Per the requirement that a Pod stuck `Pending` must not linger invisibly — it already cannot:

- `bridge_pending_to_bistream`'s **`HANDSHAKE_TIMEOUT = 600s`** (`djinn-k8s/src/runtime.rs:187`) bounds the wait for the Pod to dial back and surfaces `RuntimeError::HandshakeTimeout` → teardown + failover;
- the **pre-session stage-init deadline, 480s** (`PRE_SESSION_DEADLINE_SECS_DEFAULT`, overridable via `DJINN_PRESESSION_DEADLINE_SECS`) bounds the post-handshake, pre-`sessions`-row window.

So no new terminal outcome was introduced. The corollary is that the pre-`Running` window is bounded at roughly 600 + 480 = **~18 minutes**, which is what the unanchored clock was silently deducting from a 30-minute idle budget.

## Testing

New file `djinn-coordinator/src/tests/stall_pod_pending.rs`. The two integration tests differ in **exactly one input** — the age of the session row.

1. `pod_pending_time_is_not_counted_as_idle_and_no_stall_kill_fires` — a Pod that just reached `Running` while the pool reports a 35-minute reservation-anchored idle clock: **no kill_session, attempt stays `pending` (not `timed_out`), breaker `consecutive_failures == 0`.**
2. `genuinely_idle_running_pod_is_still_stall_killed` — negative control, same 35-minute idle clock and same exhausted extension budget, but the session has genuinely existed for 40 minutes: **still killed, attempt `timed_out`, breaker fed.** This is what proves the watchdog was not simply disabled.
3. `anchor_clamps_only_when_the_session_is_younger_than_the_idle_clock` — the pure anchor.
4. `unstarted_pod_classifies_live_instead_of_slow` — asserts the *verdict flips* (`Slow` → `Live`), not that a struct field carries a phase.

Verified by reverting only the two fix hunks: tests 1, 3 and 4 fail, and the negative control (2) still passes — i.e. it is green with or without the fix, exactly as a control should be.

Three existing stall fixtures in `session_reaping.rs` backdated their session row **2 minutes** while simulating 35+ minutes of idle. That fixture was physically impossible under the new invariant, so they now backdate 40 minutes — still far inside the 3-hour `HARD_RUNTIME_CAP_SECS` claim window each of them depends on, so their stated intent is preserved.

## Found but deliberately not changed

- **`apply_handshake_timeout_failover` feeds the model-health breaker for a scheduling delay.** On `HandshakeTimeout` it calls `health_tracker.record_stall(scope, model_id, true)` + `note_task_provider_failure(throttle: true)`, and the operator comment it writes says outright *"image pull, unschedulable, or crash-loop"*. Same class of mistake as the one fixed here, one layer down. It lives in `djinn-agent/src/actors/slot/supervisor_runner.rs` and `djinn-provider/.../health.rs`, both under concurrent edit — left alone rather than opening a conflict.
- **`SlowExtensionConfig::quantum_secs` is decorative.** It is only ever written into the `ClaimExtensionRecord` metadata JSON and a log line; it never gates re-evaluation. `enforce_session_stall_timeout` runs once per `run_tick`, which is on a 30s `STUCK_INTERVAL`, and each Slow grant consumes one of `max_extensions = 3`. A Slow-verdict session therefore buys **~90 seconds**, not the 3 × 600s = 30 minutes the config reads like. Behaviour-preserving to leave; worth its own change.
- The zombie reaper's pool-spare gate (`activity_tracked && idle <= ZOMBIE_HARD_CAP_SECS`) reads the same unanchored idle, but its precondition is `session_age > ZOMBIE_HARD_CAP_SECS`, which makes the clamp provably inert there. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
