### PR TITLE
fix(coordinator): park a tribunal round that died on a transient provider fault

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -503,16 +503,25 @@ async fn apply_provider_breaker_feedback(
                     .record_failure(creator_scope, model_id);
                 (false, false, None)
             }
-            // A transient provider-side fault (5xx / transport death) feeds the
-            // SAME gentle consecutive-failure breaker a `Failure` does — model
-            // health and auto-disable behaviour are deliberately unchanged, so a
-            // model that 5xx's on every dispatch still demotes. The ONLY thing
-            // the new class changes is task attribution downstream: the
+            // A transient provider-side fault (5xx / transport death) is a LOAD
+            // signal about the upstream, not a health signal about the model, so
+            // it gets its own much longer breaker ladder
+            // (`record_transient_failure`, `TRANSIENT_BREAKER_THRESHOLD`) rather
+            // than the three-strike one. The fault stays fully visible in
+            // `model_health` — `consecutive_failures` and `total_failures` move
+            // exactly as a `Failure` would — but a burst of
+            // `server_is_overloaded` no longer auto-disables the user's
+            // preferred model (2026-07-29, task `nr41`: `openai/gpt-5.6-sol`
+            // reached `auto_disabled: true`, 15 consecutive failures and 6
+            // disable-TTL trips, off an OpenAI capacity blip, taking the
+            // tribunal's adversary role down with it). A model whose backend is
+            // actually gone still demotes, just twenty strikes in rather than
+            // three. Task attribution is unchanged from the previous commit: the
             // coordinator must not blame the task for the provider's outage.
             djinn_runtime::ProviderFailureClass::Transient { retry_after_ms } => {
                 app_state
                     .health_tracker
-                    .record_failure(creator_scope, model_id);
+                    .record_transient_failure(creator_scope, model_id);
                 (false, true, retry_after_ms)
             }
             djinn_runtime::ProviderFailureClass::AuthInvalid => {

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -228,8 +228,10 @@ fn classify_provider_failure(err: &anyhow::Error) -> Option<ProviderFailureClass
         // `ProviderError::retryable()` has always known this; folding it into
         // `Failure` threw that knowledge away at the wire boundary and let three
         // unrelated OpenAI outages look like one reproducible task fault (2gq7).
-        // Breaker feedback is unchanged (the host still calls `record_failure`);
-        // only task attribution differs.
+        // The host feeds this class to `record_transient_failure`: still fully
+        // visible in `model_health`, but on a 20-strike ladder instead of the
+        // 3-strike one, so an upstream capacity blip cannot auto-disable the
+        // model while a permanently-dead backend still demotes.
         ProviderError::ProviderInternal { .. } => Some(ProviderFailureClass::Transient {
             retry_after_ms: provider_err.retry_after_ms(),
         }),

--- a/server/crates/djinn-coordinator/src/dispatch/liveness.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/liveness.rs
@@ -276,6 +276,34 @@ pub struct LivenessEvidence {
     /// pre-existing verdict.
     #[serde(default)]
     pub handed_off_from_session_held_status: bool,
+    /// Positive evidence that the run died on a **transient upstream provider
+    /// fault** — a 5xx (`server_is_overloaded` / `server_error`), a 502/503/504,
+    /// or a stream that died mid-flight — rather than on anything this session
+    /// or task did.
+    ///
+    /// This is the signal the exit path used to throw away. A session's terminal
+    /// status has three values (`completed` / `failed` / `interrupted`) and the
+    /// exit path folds them onto two pod phases plus a sentinel exit code, so
+    /// "the worker crashed" and "the worker's provider 500'd" arrive here as the
+    /// identical `(Failed, 1)` pair. The classifier then convicted both of a
+    /// protocol violation with a `Crash` outcome, terminalized the live attempt,
+    /// and let the task be reclaimed and force-closed — which is how a
+    /// three-second OpenAI outage killed refinement round 3 of task `nr41` on
+    /// 2026-07-29.
+    ///
+    /// Distinct from [`Self::handed_off_from_session_held_status`], which
+    /// exonerates by showing the task was moved somewhere DELIBERATELY. This one
+    /// exonerates by naming an external CAUSE. A transient provider fault leaves
+    /// the task exactly where the session found it — there is no handoff to
+    /// find — so neither term subsumes the other.
+    ///
+    /// Carrying it as its own term rather than as another `exit_code` value is
+    /// deliberate: an exit code describes the process, and the process really
+    /// did exit nonzero. What changed is WHO is at fault, and that is a separate
+    /// fact, so it gets a separate field. `false` is the fail-safe default —
+    /// absent evidence preserves the pre-existing verdict exactly.
+    #[serde(default)]
+    pub transient_provider_fault: bool,
 }
 
 /// Whether `status` is one that only a LIVE session holds.
@@ -353,6 +381,12 @@ pub enum LivenessReason {
     /// The claim-extension budget is exhausted — no more slow extensions
     /// available.
     SlowExtensionBudgetExhausted,
+    /// The run ended because its **upstream provider** failed transiently (5xx
+    /// / overloaded / mid-flight stream death), not because the session or the
+    /// task misbehaved. Retryable: the identical work succeeds on the next
+    /// healthy backend, so the attempt must be recorded as environmental rather
+    /// than as a crash or a protocol violation.
+    TransientProviderFault,
     /// No specific reason (e.g. successful completion, live session).
     None,
 }
@@ -364,6 +398,7 @@ impl LivenessReason {
             Self::NonzeroExitNonterminal => "nonzero_exit_nonterminal",
             Self::HardRuntimeExceeded => "hard_runtime_exceeded",
             Self::SlowExtensionBudgetExhausted => "slow_extension_budget_exhausted",
+            Self::TransientProviderFault => "transient_provider_fault",
             Self::None => "none",
         }
     }
@@ -455,6 +490,13 @@ pub struct ClassificationResult {
 /// 4. **Dead** → absent/failed pod with no recent activity
 /// 5. **Slow** → activity signal absent/idle, pod running, below hard cap
 /// 6. **Live** → default when other conditions don't match
+///
+/// One extra rung sits between 2 and 3: a pod that exited on a **transient
+/// upstream provider fault** ([`LivenessEvidence::transient_provider_fault`]) is
+/// never a protocol violation, because nothing about the protocol was violated —
+/// the provider was down. It classifies `Dead` / `DeadReclaimed` with
+/// [`LivenessReason::TransientProviderFault`] so the run is reclaimed and
+/// redispatched instead of convicted and force-closed.
 pub fn classify(evidence: &LivenessEvidence) -> ClassificationResult {
     // ── 1. Terminal task state → noop ────────────────────────────────────
     if evidence
@@ -478,6 +520,44 @@ pub fn classify(evidence: &LivenessEvidence) -> ClassificationResult {
             evidence: evidence.clone(),
             outcome: Some(LivenessOutcome::Timeout),
             reason: Some(LivenessReason::HardRuntimeExceeded),
+            extension_eligible: false,
+        };
+    }
+
+    // ── 2b. Transient upstream provider fault ───────────────────────────
+    // A pod that exited because its PROVIDER failed transiently violated no
+    // protocol: the session did exactly what it was supposed to do until an
+    // upstream 500 / overload / mid-flight stream death took the conversation
+    // away from it. Convicting it here is not a cosmetic mislabel — the
+    // `ProtocolViolation` verdict is what terminalizes the live attempt as a
+    // `Crash`, which in turn lets the task be reclaimed and force-closed
+    // (2026-07-29, task `nr41`, refinement round 3: `server_is_overloaded` →
+    // `protocol_violation` → `Crash` → `dead` → force_closed, all inside one
+    // second).
+    //
+    // This rung outranks the protocol-violation rung rather than being folded
+    // into it because the two answer different questions. Precedence 3 asks "is
+    // the recorded state structurally inconsistent?" and its terms are all
+    // POSITIVE evidence of inconsistency. A transient provider fault is positive
+    // evidence of a CAUSE, and a known cause is precisely what makes the
+    // inconsistency explicable. So it must be consulted first, not appended as
+    // another exoneration term.
+    //
+    // The verdict is `Dead`/`DeadReclaimed`: the pod really is gone and its
+    // resources really must be reclaimed. What differs from a crash is the
+    // reason, and the reason is what downstream reads to decide the attempt is
+    // environmental (no dispatch penalty, no quality strike) and the work is
+    // redispatchable.
+    if matches!(
+        evidence.pod_phase,
+        Some(PodPhase::Succeeded) | Some(PodPhase::Failed)
+    ) && evidence.transient_provider_fault
+    {
+        return ClassificationResult {
+            verdict: Verdict::Dead,
+            evidence: evidence.clone(),
+            outcome: Some(LivenessOutcome::DeadReclaimed),
+            reason: Some(LivenessReason::TransientProviderFault),
             extension_eligible: false,
         };
     }

--- a/server/crates/djinn-coordinator/src/dispatch/liveness_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/liveness_tests.rs
@@ -13,6 +13,7 @@ fn live_evidence() -> LivenessEvidence {
         exit_code: None,
 
         handed_off_from_session_held_status: false,
+        transient_provider_fault: false,
     }
 }
 
@@ -120,6 +121,126 @@ fn nonzero_exit_on_nonterminal_task_is_protocol_violation() {
     assert_eq!(result.verdict, Verdict::ProtocolViolation);
     assert_eq!(result.outcome, Some(LivenessOutcome::Crash));
     assert_eq!(result.reason, Some(LivenessReason::NonzeroExitNonterminal));
+}
+
+/// Production shape of the 2026-07-29 `nr41` failure: refinement round 3's
+/// Adversary died on `reply loop error: provider stream event failed:
+/// display=server_is_overloaded ... provider internal error (status 500)`.
+/// The session was recorded `failed`, which the exit path folds to
+/// `(PodPhase::Failed, exit 1)` on an `in_progress` task — the exact input
+/// that produced `verdict: "protocol_violation", outcome: Some(Crash),
+/// reason: Some(NonzeroExitNonterminal)` and terminalized the live attempt.
+///
+/// With the provider signal preserved, the same input must classify as a
+/// retryable environmental death instead.
+#[test]
+fn transient_provider_fault_is_not_a_protocol_violation() {
+    let mut ev = live_evidence();
+    ev.pod_phase = Some(PodPhase::Failed);
+    ev.exit_code = Some(1);
+    ev.db_task_status = Some(DbTaskStatus::InProgress);
+    ev.db_session_status = Some(DbSessionStatus::Running);
+    ev.transient_provider_fault = true;
+
+    let result = classify(&ev);
+    assert_ne!(
+        result.verdict,
+        Verdict::ProtocolViolation,
+        "an upstream 500 violates no protocol — the session did its part"
+    );
+    assert_ne!(
+        result.outcome,
+        Some(LivenessOutcome::Crash),
+        "the provider crashed, not the run"
+    );
+    assert_ne!(result.reason, Some(LivenessReason::NonzeroExitNonterminal));
+    assert_eq!(result.verdict, Verdict::Dead);
+    assert_eq!(result.outcome, Some(LivenessOutcome::DeadReclaimed));
+    assert_eq!(result.reason, Some(LivenessReason::TransientProviderFault));
+    assert!(!result.extension_eligible);
+}
+
+/// The guard must not be weakened: without the provider signal, the very
+/// same evidence is still convicted. If this ever passes for the wrong
+/// reason — e.g. because the new rung swallowed the branch — the test above
+/// would be meaningless.
+#[test]
+fn genuine_nonzero_crash_without_a_provider_fault_is_still_convicted() {
+    let mut ev = live_evidence();
+    ev.pod_phase = Some(PodPhase::Failed);
+    ev.exit_code = Some(1);
+    ev.db_task_status = Some(DbTaskStatus::InProgress);
+    ev.db_session_status = Some(DbSessionStatus::Running);
+    ev.transient_provider_fault = false;
+
+    let result = classify(&ev);
+    assert_eq!(result.verdict, Verdict::ProtocolViolation);
+    assert_eq!(result.outcome, Some(LivenessOutcome::Crash));
+    assert_eq!(result.reason, Some(LivenessReason::NonzeroExitNonterminal));
+}
+
+/// The new rung is scoped to an EXITED pod. A provider fault noted while the
+/// pod is still running (a mid-session blip the worker recovered from) must
+/// not force a `Dead` verdict on a live session.
+#[test]
+fn transient_provider_fault_does_not_kill_a_still_running_pod() {
+    let mut ev = live_evidence();
+    ev.pod_phase = Some(PodPhase::Running);
+    ev.activity = ActivitySignal::Active;
+    ev.transient_provider_fault = true;
+
+    let result = classify(&ev);
+    assert_eq!(
+        result.verdict,
+        Verdict::Live,
+        "a running, active pod stays live regardless of a past provider blip"
+    );
+}
+
+/// Terminal task state still outranks everything, including the new rung.
+#[test]
+fn terminal_task_wins_over_transient_provider_fault() {
+    let mut ev = live_evidence();
+    ev.pod_phase = Some(PodPhase::Failed);
+    ev.exit_code = Some(1);
+    ev.db_task_status = Some(DbTaskStatus::Closed);
+    ev.transient_provider_fault = true;
+
+    let result = classify(&ev);
+    assert_eq!(result.outcome, Some(LivenessOutcome::KillNoop));
+}
+
+/// The two exoneration terms are independent and must compose. #2748's
+/// handoff evidence answers "was the task moved deliberately?"; this change's
+/// provider evidence answers "did something external kill the run?". A round
+/// that died on an upstream 500 leaves the task exactly where it was, so it
+/// has NO handoff evidence — and must still be exonerated.
+#[test]
+fn transient_provider_fault_exonerates_without_any_handoff_evidence() {
+    let mut ev = live_evidence();
+    ev.pod_phase = Some(PodPhase::Failed);
+    ev.exit_code = Some(1);
+    ev.db_task_status = Some(DbTaskStatus::InProgress);
+    ev.db_session_status = Some(DbSessionStatus::Running);
+    ev.handed_off_from_session_held_status = false;
+    ev.transient_provider_fault = true;
+
+    let result = classify(&ev);
+    assert_eq!(result.reason, Some(LivenessReason::TransientProviderFault));
+
+    // …and the converse still holds: handoff evidence alone, with no provider
+    // fault, keeps taking #2748's path rather than being relabelled.
+    let mut handoff = live_evidence();
+    handoff.pod_phase = Some(PodPhase::Succeeded);
+    handoff.exit_code = Some(0);
+    handoff.db_task_status = Some(DbTaskStatus::Open);
+    handoff.db_session_status = Some(DbSessionStatus::Running);
+    handoff.handed_off_from_session_held_status = true;
+    handoff.transient_provider_fault = false;
+
+    let result = classify(&handoff);
+    assert_ne!(result.verdict, Verdict::ProtocolViolation);
+    assert_ne!(result.reason, Some(LivenessReason::TransientProviderFault));
 }
 
 #[test]
@@ -524,6 +645,9 @@ fn no_verdict_reviewer_exit_is_invisible_to_the_exit_classifier() {
         // Last transition was needs_task_review → in_task_review, i.e. INTO
         // a session-held status: a claim, which proves nothing.
         handed_off_from_session_held_status: false,
+        // The reviewer exited 0 with no provider error at all — this scenario
+        // is about an abandoned post, not an upstream fault.
+        transient_provider_fault: false,
     };
 
     let result = classify(&ev);

--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -2619,6 +2619,23 @@ impl CoordinatorActor {
         // Use Running to represent the state when the pod exited — this
         // is what triggers the protocol-violation classifier path.
         evidence.db_session_status = Some(DbSessionStatus::Running);
+        // ── Recover the signal the status fold discards ─────────────────
+        // `session_status` has three values and the fold above collapses them
+        // onto two pod phases plus a sentinel exit code. Everything about WHY
+        // the run failed is lost there, so a worker whose provider returned
+        // `server_is_overloaded` arrives indistinguishable from a worker that
+        // segfaulted: both are `(Failed, 1)`.
+        //
+        // The reason is not actually unavailable — the slot supervisor-runner
+        // already classified the task-run report and stashed the typed class on
+        // the health tracker's per-task side-channel before the session was
+        // finalized. Peek (never take) that signal: the dispatch-reappearance
+        // path owns it and consumes it for its own cooldown/streak decision, and
+        // stealing it here would silently disable A3/A6 backoff.
+        evidence.transient_provider_fault = self
+            .health
+            .peek_task_provider_failure(task_id)
+            .is_some_and(|signal| signal.transient);
 
         // ── 3. Classify ────────────────────────────────────────────────
         let result = super::liveness::classify(&evidence);
@@ -2722,20 +2739,37 @@ impl CoordinatorActor {
         if matches!(session_status, "failed" | "interrupted")
             && result.outcome != Some(LivenessOutcome::KillNoop)
         {
-            let (attempt_outcome, failure_class, summary) = if session_status == "interrupted" {
-                (
-                    TaskAttemptOutcome::Interrupted,
-                    "environmental_interrupt",
-                    "session interrupted by infrastructure (deploy/rollout/pod-eviction/reap) \
+            let (attempt_outcome, failure_class, summary) =
+                if result.reason == Some(super::liveness::LivenessReason::TransientProviderFault) {
+                    // The run died on the PROVIDER, not on itself. That is the same
+                    // shape of non-event as an infra kill: the task was never
+                    // actually attempted end-to-end, so it earns the environmental
+                    // treatment — terminalize so nothing wedges the respawn guard,
+                    // but contribute no dispatch-failure streak, no quality strike,
+                    // and no reopen_class penalty. Charging it as a `Crashed`
+                    // attempt is what walked task `nr41` toward its force-close on
+                    // 2026-07-29 for a three-second OpenAI outage.
+                    (
+                        TaskAttemptOutcome::Interrupted,
+                        "transient_provider_fault",
+                        "session ended on a transient upstream provider fault (5xx / overload / \
+                     mid-flight stream death) while task nonterminal — environmental \
+                     non-attempt, retry when the provider recovers",
+                    )
+                } else if session_status == "interrupted" {
+                    (
+                        TaskAttemptOutcome::Interrupted,
+                        "environmental_interrupt",
+                        "session interrupted by infrastructure (deploy/rollout/pod-eviction/reap) \
                      while task nonterminal — environmental non-attempt, no dispatch penalty",
-                )
-            } else {
-                (
-                    TaskAttemptOutcome::Crashed,
-                    "session_exit_nonterminal",
-                    "session exited failed while task nonterminal",
-                )
-            };
+                    )
+                } else {
+                    (
+                        TaskAttemptOutcome::Crashed,
+                        "session_exit_nonterminal",
+                        "session exited failed while task nonterminal",
+                    )
+                };
             self.terminalize_recovery_attempt(
                 task_id,
                 role,
@@ -2928,6 +2962,7 @@ fn build_liveness_evidence(
         hard_runtime_deadline_exceeded,
         exit_code: None,
         handed_off_from_session_held_status,
+        transient_provider_fault: false,
     }
 }
 
@@ -3223,6 +3258,7 @@ mod liveness_foundation_tests {
             exit_code: Some(0),
 
             handed_off_from_session_held_status: false,
+            transient_provider_fault: false,
         };
 
         let result = super::super::liveness::classify(&evidence);
@@ -3254,6 +3290,7 @@ mod liveness_foundation_tests {
             exit_code: Some(137),
 
             handed_off_from_session_held_status: false,
+            transient_provider_fault: false,
         };
 
         let result = super::super::liveness::classify(&evidence);
@@ -3453,6 +3490,7 @@ mod liveness_foundation_tests {
             exit_code: None,
 
             handed_off_from_session_held_status: false,
+            transient_provider_fault: false,
         };
 
         let result = super::super::liveness::classify(&evidence);

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -675,6 +675,39 @@ impl CoordinatorActor {
                 return;
             }
 
+            // (c) the session ran, but the PROVIDER died under it. This is a
+            // third case, and reading it as (a) is what broke task `nr41` on
+            // 2026-07-29: an OpenAI `server_is_overloaded` 500 killed the
+            // Adversary ten seconds into round 3, the loop found a session row,
+            // read an empty debate trail, and scored the round as an explicit
+            // dry pass — burning a round, force-closing the task, and leaving
+            // the run with no live work at all.
+            //
+            // A round is only evidence about the proposal if the role got to
+            // form an opinion. When the upstream failed instead, there is no
+            // opinion to record, so the round must be retried rather than
+            // counted. This routes into the SAME bounded retry the never-started
+            // paths use — no new scheduler, and the same
+            // `REFINEMENT_DISPATCH_RETRY_CAP` ceiling so a provider that is down
+            // for good still terminates the loop with an honest reason instead
+            // of looping forever.
+            if self.refinement_round_died_on_transient_provider_fault(&session.task_id) {
+                let over_cap_error = format!(
+                    "role session died on a transient provider fault \
+                     {REFINEMENT_DISPATCH_RETRY_CAP} times (upstream 5xx / overload / \
+                     mid-flight stream death)"
+                );
+                self.retry_or_terminate_unstarted_refinement(
+                    run_id,
+                    &session,
+                    "refinement role session died on a transient provider fault (parked for retry)",
+                    over_cap_error,
+                    false,
+                )
+                .await;
+                return;
+            }
+
             // Session actually ran — clear the dispatch-failure counter and
             // process the outcome, then close the task so finished phase/round
             // tasks don't linger `open` on the board.
@@ -722,6 +755,36 @@ impl CoordinatorActor {
                 true
             }
         }
+    }
+
+    /// Did the just-finished refinement role session die on a **transient
+    /// upstream provider fault** (5xx / `server_is_overloaded` / mid-flight
+    /// stream death) rather than on its own work?
+    ///
+    /// Reads the health tracker's per-task provider-failure side-channel — the
+    /// same typed class the slot supervisor-runner records for every
+    /// `TaskRunOutcome::Failed`, and the same one the ordinary dispatch path
+    /// consults for its A3/A6 backoff. Refinement tasks never travel the
+    /// dispatch-reappearance path (they are force-closed once their round
+    /// resolves), so this reader also owns cleanup: the entry is cleared
+    /// unconditionally, since nothing else will ever collect it for this task id.
+    ///
+    /// Returns `false` when there is no signal at all, which is the fail-safe
+    /// answer: an absent signal means "not a typed provider failure", and the
+    /// round is processed exactly as it was before.
+    fn refinement_round_died_on_transient_provider_fault(&self, task_id: &str) -> bool {
+        let signal = self.health.peek_task_provider_failure(task_id);
+        self.health.clear_task_provider_failure(task_id);
+        let transient = signal.is_some_and(|signal| signal.transient);
+        if transient {
+            tracing::warn!(
+                task_id = %task_id,
+                "Refinement role session died on a transient provider fault — parking the round \
+                 for retry instead of scoring it (an empty debate trail here is the provider's \
+                 silence, not the role's verdict)"
+            );
+        }
+        transient
     }
 
     /// Abandon a dispatched refinement role session that did not execute and
@@ -1132,6 +1195,35 @@ impl CoordinatorActor {
             .await;
             return;
         };
+
+        // ── Step 1b: Provider-health gate ──────────────────────────────────
+        //
+        // Re-dispatching a round straight back into the provider that just
+        // killed it is how a single upstream outage becomes a run of them: the
+        // tribunal burns its `REFINEMENT_DISPATCH_RETRY_CAP` inside a couple of
+        // ticks and terminates for what was a two-minute capacity blip. Gate on
+        // the signal that already tracks exactly this — the per-`(scope, model)`
+        // health breaker — and defer non-terminally while it is cooling.
+        //
+        // Deferral here is free and self-healing: no task row, no spawn budget,
+        // no pool dispatch, and the cooldown expires on its own, so the next
+        // tick re-evaluates. It is deliberately NOT a terminate: a cooling model
+        // is a reason to wait, never a reason to kill the tribunal.
+        let model_health = self.health.model_health(Some(user_id.as_str()), &model_id);
+        if model_health.auto_disabled || model_health.hard_disabled {
+            tracing::info!(
+                proposal_id = %proposal_id,
+                phase = ?phase,
+                user_id = %user_id,
+                model_id = %model_id,
+                consecutive_failures = model_health.consecutive_failures,
+                cooldown_seconds_remaining = model_health.cooldown_seconds_remaining,
+                hard_disabled = model_health.hard_disabled,
+                "Refinement dispatch deferred: the model's health breaker is cooling \
+                 (retryable — no task row, no spawn-budget, no pool dispatch)"
+            );
+            return;
+        }
 
         // ── Step 2: Per-user/model cap admission (check + reserve atomically) ──
         //

--- a/server/crates/djinn-coordinator/src/refinement_pool_watchdog_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_pool_watchdog_tests.rs
@@ -674,3 +674,152 @@ async fn pending_start_timeout_escalates_to_termination_at_retry_cap() {
         Some("agent_failure")
     );
 }
+
+/// (e) A round whose role session actually RAN but died on a transient upstream
+/// provider fault must be parked and retried, not scored and force-closed.
+///
+/// Production, 2026-07-29, task `nr41` (adversary, refinement round 3):
+///
+/// ```text
+/// supervisor dispatch: task-run complete  outcome: Failed {
+///   stage: "refinement",
+///   reason: "reply loop error: provider stream event failed:
+///            display=server_is_overloaded: Our servers are currently overloaded.
+///            Please try again later. ... Caused by: provider internal error (status 500)",
+///   provider_failure: Some(Failure), ... }
+/// ```
+///
+/// Ten seconds after the session started, the slot freed. The loop found a
+/// session row, concluded the Adversary had run, read an empty debate trail,
+/// and scored the round as an explicit dry pass — then force-closed the task.
+/// The round was consumed and the run had no live work left.
+///
+/// An empty debate trail after a provider outage is the provider's silence, not
+/// the Adversary's verdict. Nothing may be inferred from it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn transient_provider_fault_parks_the_round_for_retry_instead_of_scoring_it() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+
+    let task_id = seed_refinement_task_row(&db, &fixture.project_id, &fixture.user_id).await;
+
+    // The role session genuinely started — this is what makes the case
+    // indistinguishable from a completed round without the provider signal.
+    SessionRepository::new(db.clone(), EventBus::noop())
+        .create(CreateSessionParams {
+            project_id: &fixture.project_id,
+            task_id: Some(&task_id),
+            model: TEST_MODEL,
+            agent_type: "adversary",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .expect("materialize the session that the provider then killed");
+
+    // The pool no longer reports the task running: the slot freed when the
+    // task-run reported `Failed`.
+    let (pool, _counts) = spawn_counting_pool(vec![]);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool);
+
+    // The slot supervisor-runner's typed classification of that task-run,
+    // recorded on the health tracker's per-task side-channel exactly as
+    // `apply_provider_breaker_feedback` records it in production.
+    actor.health.note_task_provider_failure(
+        &task_id,
+        djinn_provider::catalog::health::TaskFailureSignal {
+            throttle: false,
+            transient: true,
+            retry_after_ms: None,
+        },
+    );
+
+    seed_running_refinement_dispatched_at(
+        &mut actor,
+        &fixture.proposal_id,
+        &task_id,
+        ago(Duration::from_secs(30)),
+    );
+    let round_before = actor.active_refinements[&fixture.proposal_id].current_round;
+
+    actor.drive_active_refinements().await;
+
+    assert!(
+        actor.active_refinements.contains_key(&fixture.proposal_id),
+        "a transient provider fault is retryable — the tribunal must survive it"
+    );
+    assert!(
+        !actor.refinement_sessions.contains_key(&fixture.proposal_id),
+        "the dead session must be cleared so the SAME phase re-dispatches"
+    );
+    assert_eq!(
+        actor.active_refinements[&fixture.proposal_id].dispatch_failures, 1,
+        "the parked round must count against the bounded retry cap, so a provider \
+         that is down for good still terminates the loop instead of looping forever"
+    );
+    assert_eq!(
+        actor.active_refinements[&fixture.proposal_id].current_round, round_before,
+        "the round must NOT be consumed: the Adversary never formed an opinion, so \
+         there is no pass to score"
+    );
+    assert_eq!(
+        actor.active_refinements[&fixture.proposal_id].stop_reason, None,
+        "parking is not stopping"
+    );
+    assert_eq!(
+        actor.health.peek_task_provider_failure(&task_id),
+        None,
+        "the refinement loop owns cleanup of the side-channel entry for a task it \
+         force-closes, since no dispatch reappearance will ever collect it"
+    );
+}
+
+/// The guard for (e): with no provider signal, the identical situation still
+/// takes the ordinary outcome path. If this regressed, the test above would
+/// pass for the wrong reason — every finished round would look like a park.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_finished_round_without_a_provider_fault_is_still_scored() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+
+    let task_id = seed_refinement_task_row(&db, &fixture.project_id, &fixture.user_id).await;
+    SessionRepository::new(db.clone(), EventBus::noop())
+        .create(CreateSessionParams {
+            project_id: &fixture.project_id,
+            task_id: Some(&task_id),
+            model: TEST_MODEL,
+            agent_type: "adversary",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .expect("materialize a session that ran to completion");
+
+    let (pool, _counts) = spawn_counting_pool(vec![]);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool);
+    // Deliberately NO `note_task_provider_failure` here.
+
+    seed_running_refinement_dispatched_at(
+        &mut actor,
+        &fixture.proposal_id,
+        &task_id,
+        ago(Duration::from_secs(30)),
+    );
+
+    actor.drive_active_refinements().await;
+
+    assert_eq!(
+        actor
+            .active_refinements
+            .get(&fixture.proposal_id)
+            .map(|state| state.dispatch_failures),
+        Some(0),
+        "an ordinary finished round must not be charged to the dispatch-failure cap"
+    );
+}

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -4447,6 +4447,7 @@ fn hard_cap_takes_precedence_over_slow_extension_eligible() {
         exit_code: None,
 
         handed_off_from_session_held_status: false,
+        transient_provider_fault: false,
     };
 
     let result = classify(&evidence);
@@ -4491,6 +4492,7 @@ fn absent_pod_with_active_activity_is_not_dead() {
         exit_code: None,
 
         handed_off_from_session_held_status: false,
+        transient_provider_fault: false,
     };
 
     let result = classify(&evidence);
@@ -4524,6 +4526,7 @@ fn running_pod_active_signal_is_live_regardless_of_claim_ttl() {
         exit_code: None,
 
         handed_off_from_session_held_status: false,
+        transient_provider_fault: false,
     };
 
     let result = classify(&evidence);
@@ -4557,6 +4560,7 @@ fn pending_pod_capacity_crunch_spared_by_classifier() {
         exit_code: None,
 
         handed_off_from_session_held_status: false,
+        transient_provider_fault: false,
     };
 
     let result = classify(&evidence);
@@ -4592,6 +4596,7 @@ fn pending_pod_past_hard_cap_still_not_dead() {
         exit_code: None,
 
         handed_off_from_session_held_status: false,
+        transient_provider_fault: false,
     };
 
     // Even with hard_runtime_deadline_exceeded, the classifier applies the
@@ -4608,6 +4613,7 @@ fn pending_pod_past_hard_cap_still_not_dead() {
         exit_code: None,
 
         handed_off_from_session_held_status: false,
+        transient_provider_fault: false,
     };
     let result = classify(&evidence_no_hard_cap);
     assert_ne!(

--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -1,3 +1,4 @@
+// djinn:allow-oversize — per-(scope, model) breaker state: typed-failure, throttle, stall and transient ladders share one mutex-guarded catalog.
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};

--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -7,6 +7,32 @@ use serde::{Deserialize, Serialize};
 
 /// Number of consecutive failures before circuit breaker trips.
 const CIRCUIT_BREAKER_THRESHOLD: u32 = 3;
+
+/// Number of consecutive **transient upstream** faults
+/// ([`HealthTracker::record_transient_failure`]) before the breaker trips.
+///
+/// Deliberately far above [`CIRCUIT_BREAKER_THRESHOLD`], because a transient
+/// upstream fault is a *load* signal, not a *model-health* signal. A provider
+/// answering `server_is_overloaded` (HTTP 500/502/503/504) or dropping a stream
+/// mid-flight says nothing about whether the model can do the work — the
+/// identical request succeeds minutes later. Counting those on the ordinary
+/// three-strike ladder means an upstream capacity blip demotes the user's
+/// preferred model and, via the escalating cooldown, keeps it demoted long after
+/// the provider recovered.
+///
+/// Incident (2026-07-29, task `nr41`): a run of OpenAI `server_is_overloaded`
+/// 500s pushed `openai/gpt-5.6-sol` to `auto_disabled: true` at 15 consecutive
+/// failures with 6 disable-TTL trips — 30 total failures against 6 successes —
+/// which is the tribunal's own adversary model being disabled for someone else's
+/// outage. At this threshold that run does not trip the breaker at all.
+///
+/// It is still *finite*, and that is deliberate: a model whose backend is
+/// permanently gone (the kimi-for-coding/`k2p7` signature — instant transport
+/// death, zero tokens, re-dispatched forever) must eventually be demoted rather
+/// than re-selected indefinitely. Twenty consecutive transient faults with no
+/// intervening success is no longer "the provider is busy"; it is a dead
+/// endpoint.
+const TRANSIENT_BREAKER_THRESHOLD: u32 = 20;
 /// Initial cooldown after first circuit-breaker trip: 5 seconds.
 const INITIAL_COOLDOWN: Duration = Duration::from_secs(5);
 /// Maximum escalating cooldown: 4 hours.
@@ -217,6 +243,16 @@ struct ModelState {
     /// actually exhaust increment this counter via
     /// `HealthTracker::apply_breaker_check_for`.
     breaker_eligible_consecutive_failures: u32,
+    /// Consecutive TRANSIENT upstream faults (5xx / transport death) with no
+    /// intervening success, counted on their own much longer ladder
+    /// ([`TRANSIENT_BREAKER_THRESHOLD`]) instead of the three-strike one.
+    ///
+    /// Kept separate from `breaker_eligible_consecutive_failures` so that an
+    /// upstream capacity blip cannot demote a healthy model, while a genuinely
+    /// dead endpoint still eventually trips. Reset to 0 by any success, and by
+    /// any genuine (`record_failure`) trip — once the breaker has fired for a
+    /// real fault, this streak is moot. Runtime-only, like the throttle streak.
+    transient_consecutive_failures: u32,
     total_failures: u32,
     total_successes: u32,
     disable_ttl_trips: u32,
@@ -418,6 +454,35 @@ impl HealthTracker {
         self.task_failures.lock().unwrap().remove(task_id)
     }
 
+    /// Read the most recent provider-failure signal for a task **without**
+    /// clearing it.
+    ///
+    /// [`take_task_provider_failure`](Self::take_task_provider_failure) is the
+    /// dispatch-reappearance reader and is deliberately consuming, so exactly
+    /// one redispatch decision can be made per failure. Two other observers need
+    /// the same fact and must not steal it from that reader (nor from each
+    /// other):
+    ///
+    /// * session-exit liveness classification, which must not convict a session
+    ///   of a protocol violation when the provider, not the session, died; and
+    /// * the refinement tribunal loop, which must park and retry a round rather
+    ///   than count it as a completed (dry) round.
+    ///
+    /// Neither owns the signal, so both peek. The refinement loop clears it
+    /// explicitly once it has parked the round, because a refinement task is
+    /// force-closed rather than redispatched and would otherwise leak the entry.
+    pub fn peek_task_provider_failure(&self, task_id: &str) -> Option<TaskFailureSignal> {
+        self.task_failures.lock().unwrap().get(task_id).copied()
+    }
+
+    /// Drop a task's provider-failure signal without reading it. For owners that
+    /// terminate the task themselves (the refinement loop force-closes its round
+    /// tasks), so the side-channel does not accumulate entries for task ids that
+    /// will never reappear on the dispatch path.
+    pub fn clear_task_provider_failure(&self, task_id: &str) {
+        self.task_failures.lock().unwrap().remove(task_id);
+    }
+
     /// Record a failure **observation** — increments the consecutive/total
     /// failure counters for the `(scope, model)` bucket so the candidate's
     /// failure is reflected in health-state diagnostics immediately, but does
@@ -508,6 +573,7 @@ impl HealthTracker {
         let state = map.entry(HealthKey::new(scope, model_id)).or_default();
         state.consecutive_failures = 0;
         state.breaker_eligible_consecutive_failures = 0;
+        state.transient_consecutive_failures = 0;
         state.total_successes += 1;
         // A productive session is proof the model recovered — reset the
         // escalating-cooldown tier and clear the rolling trip window so the next
@@ -564,6 +630,86 @@ impl HealthTracker {
                 trips_in_window = state.trips_in_window(now),
                 hard_disabled,
                 "model circuit-breaker tripped"
+            );
+            if hard_disabled {
+                tracing::error!(
+                    model_id = %key.model_id,
+                    scope = ?key.scope,
+                    trips_in_window = TRIP_RATE_CEILING,
+                    window_hours = TRIP_RATE_WINDOW.as_secs() / 3600,
+                    "model breaker hit trip-rate ceiling — HARD-DISABLED until a human \
+                     re-enables it via model_health(enable)"
+                );
+            }
+        }
+    }
+
+    /// Record a **transient upstream** fault — a provider-side 5xx
+    /// (`server_is_overloaded` / `server_error`, 502/503/504) or a hard
+    /// transport/stream death, i.e. [`crate::catalog::health`]'s view of
+    /// `ProviderFailureClass::Transient`.
+    ///
+    /// Counters move exactly as they do for [`record_failure`] *except* the
+    /// breaker-eligible one: the fault is fully visible in `model_health`
+    /// (`consecutive_failures`, `total_failures`) but is charged to
+    /// `transient_consecutive_failures`, which trips only at
+    /// [`TRANSIENT_BREAKER_THRESHOLD`] instead of [`CIRCUIT_BREAKER_THRESHOLD`].
+    ///
+    /// Why this is not [`record_failure`]: an overloaded upstream is a LOAD
+    /// signal, not a model-health signal. Three of them in a row is an ordinary
+    /// afternoon at a busy provider, and demoting the user's preferred model for
+    /// it — then holding it demoted on the escalating cooldown ladder — is the
+    /// 2026-07-29 `nr41` incident, where `openai/gpt-5.6-sol` reached
+    /// `auto_disabled: true` with 6 disable-TTL trips off a burst of
+    /// `server_is_overloaded` 500s and took the tribunal's adversary role with
+    /// it.
+    ///
+    /// Why this is not [`record_stall`] (the `Throttle` treatment): a stall trips
+    /// the breaker IMMEDIATELY with a five-minute floor. That is right for a
+    /// quota window — which resets on a clock and where instant failover to
+    /// another account/model is the only useful move — but wrong for a load
+    /// blip, where the very next dispatch usually succeeds. Routing overload
+    /// through `Throttle` would still leave the model `auto_disabled`, just for
+    /// a shorter time.
+    ///
+    /// Genuine failure detection is untouched: `Authentication`,
+    /// `InvalidRequest` and `InvalidOutput` continue through
+    /// [`record_failure`]/[`record_stall`] and still trip at three strikes.
+    pub fn record_transient_failure(&self, scope: Option<&str>, model_id: &str) {
+        let now = SystemClock::new().now_instant();
+        let mut map = self.inner.lock().unwrap();
+        let key = HealthKey::new(scope, model_id);
+        let state = map.entry(key.clone()).or_default();
+        state.consecutive_failures += 1;
+        state.transient_consecutive_failures += 1;
+        state.total_failures += 1;
+
+        // If the previous cooldown expired, clear the flag so we can re-trip.
+        if state.auto_disabled && state.is_available(now) {
+            state.auto_disabled = false;
+            state.cooldown_until = None;
+        }
+
+        if !state.auto_disabled
+            && state.transient_consecutive_failures >= TRANSIENT_BREAKER_THRESHOLD
+        {
+            let cooldown = state.compute_cooldown();
+            state.auto_disabled = true;
+            state.cooldown_until = Some(now + cooldown);
+            state.disable_ttl_trips += 1;
+            let hard_disabled = state.register_trip(now);
+            djinn_telemetry::breaker::increment_trip();
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                consecutive_failures = state.consecutive_failures,
+                transient_consecutive_failures = state.transient_consecutive_failures,
+                cooldown_secs = cooldown.as_secs(),
+                disable_ttl_trips = state.disable_ttl_trips,
+                trips_in_window = state.trips_in_window(now),
+                hard_disabled,
+                "model circuit-breaker tripped on a sustained run of TRANSIENT upstream faults \
+                 — this endpoint is not merely busy"
             );
             if hard_disabled {
                 tracing::error!(

--- a/server/crates/djinn-provider/src/catalog/health_tests.rs
+++ b/server/crates/djinn-provider/src/catalog/health_tests.rs
@@ -1088,3 +1088,149 @@ fn apply_breaker_check_for_respects_expired_cooldown() {
         "breaker must re-trip after cooldown expiry + new observation"
     );
 }
+
+// ── Transient upstream faults are a LOAD signal, not a health signal ────────
+
+/// Incident 2026-07-29 (task `nr41`): a burst of OpenAI `server_is_overloaded`
+/// 500s drove `openai/gpt-5.6-sol` to `auto_disabled: true` — 15 consecutive
+/// failures, 6 disable-TTL trips, 30 total failures against 6 successes —
+/// disabling the tribunal's own adversary model for an outage that was not the
+/// model's doing.
+///
+/// A run of transient upstream faults well past the ordinary three-strike
+/// threshold must therefore leave the model available.
+#[test]
+fn repeated_transient_upstream_faults_do_not_auto_disable_a_model() {
+    let ht = HealthTracker::new();
+
+    for _ in 0..(CIRCUIT_BREAKER_THRESHOLD * 4) {
+        ht.record_transient_failure(S, TEST_MODEL);
+    }
+
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        !health.auto_disabled,
+        "an overloaded upstream must not demote the model: {health:?}"
+    );
+    assert!(ht.is_available(S, TEST_MODEL));
+    assert_eq!(
+        health.disable_ttl_trips, 0,
+        "no trips means no escalating-cooldown ratchet either"
+    );
+    // The faults are still fully visible — this is a re-attribution, not a
+    // suppression. An operator reading model_health sees every one of them.
+    assert_eq!(health.consecutive_failures, CIRCUIT_BREAKER_THRESHOLD * 4);
+    assert_eq!(health.total_failures, CIRCUIT_BREAKER_THRESHOLD * 4);
+    assert_eq!(
+        health.breaker_eligible_consecutive_failures, 0,
+        "transient faults must never become breaker-eligible"
+    );
+}
+
+/// The counterpart guard: genuine typed provider failures (auth, invalid
+/// request, unparseable output — everything that routes through
+/// `record_failure`) must still trip at the ordinary threshold. If this ever
+/// fails, the fix above has been over-applied and real breakage stops demoting
+/// models.
+#[test]
+fn repeated_genuine_failures_still_auto_disable_a_model() {
+    let ht = HealthTracker::new();
+
+    for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+        ht.record_failure(S, TEST_MODEL);
+    }
+
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        health.auto_disabled,
+        "genuine failures must still trip the breaker at the ordinary threshold: {health:?}"
+    );
+    assert!(!ht.is_available(S, TEST_MODEL));
+}
+
+/// The transient ladder is longer, not absent. A backend that is permanently
+/// gone (the kimi-for-coding/`k2p7` signature: instant transport death, zero
+/// tokens, re-dispatched forever) must still be demoted eventually rather than
+/// re-selected indefinitely.
+#[test]
+fn a_sustained_run_of_transient_faults_eventually_trips_the_breaker() {
+    let ht = HealthTracker::new();
+
+    for _ in 0..(TRANSIENT_BREAKER_THRESHOLD - 1) {
+        ht.record_transient_failure(S, TEST_MODEL);
+    }
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "one short of the transient threshold is still available"
+    );
+
+    ht.record_transient_failure(S, TEST_MODEL);
+    assert!(
+        !ht.is_available(S, TEST_MODEL),
+        "a dead endpoint still demotes — twenty strikes in, not three"
+    );
+}
+
+/// A success proves the provider recovered, so the transient streak resets and
+/// the next outage starts counting from zero rather than inheriting the last
+/// one's progress toward the threshold.
+#[test]
+fn a_success_resets_the_transient_streak() {
+    let ht = HealthTracker::new();
+
+    for _ in 0..(TRANSIENT_BREAKER_THRESHOLD - 1) {
+        ht.record_transient_failure(S, TEST_MODEL);
+    }
+    ht.record_success(S, TEST_MODEL);
+    for _ in 0..(TRANSIENT_BREAKER_THRESHOLD - 1) {
+        ht.record_transient_failure(S, TEST_MODEL);
+    }
+
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "the streak restarted after the success, so the threshold is not reached"
+    );
+}
+
+/// The per-task side-channel has three readers with different ownership.
+/// `peek` must be non-destructive so the session-exit classifier and the
+/// refinement loop cannot steal the signal the dispatch-reappearance path
+/// consumes for its A3/A6 backoff.
+#[test]
+fn peek_task_provider_failure_does_not_consume_the_signal() {
+    let ht = HealthTracker::new();
+    let signal = TaskFailureSignal {
+        throttle: false,
+        transient: true,
+        retry_after_ms: None,
+    };
+    ht.note_task_provider_failure("task-1", signal);
+
+    assert_eq!(ht.peek_task_provider_failure("task-1"), Some(signal));
+    assert_eq!(
+        ht.peek_task_provider_failure("task-1"),
+        Some(signal),
+        "peek must be repeatable"
+    );
+    assert_eq!(
+        ht.take_task_provider_failure("task-1"),
+        Some(signal),
+        "the owning reader still receives it"
+    );
+    assert_eq!(ht.peek_task_provider_failure("task-1"), None);
+}
+
+#[test]
+fn clear_task_provider_failure_drops_the_signal() {
+    let ht = HealthTracker::new();
+    ht.note_task_provider_failure(
+        "task-2",
+        TaskFailureSignal {
+            throttle: false,
+            transient: true,
+            retry_after_ms: None,
+        },
+    );
+    ht.clear_task_provider_failure("task-2");
+    assert_eq!(ht.peek_task_provider_failure("task-2"), None);
+}

--- a/server/crates/djinn-runtime/src/spec.rs
+++ b/server/crates/djinn-runtime/src/spec.rs
@@ -770,11 +770,21 @@ pub enum ProviderFailureClass {
     /// class must never be read as evidence that the task itself is
     /// undispatchable.
     ///
-    /// Breaker behaviour is deliberately IDENTICAL to [`Self::Failure`]: the
-    /// host feeds it to the gentle consecutive-failure breaker
-    /// (`record_failure`), so model-health/auto-disable is unchanged and a model
-    /// that 5xx's on every dispatch still auto-disables. What changes is
-    /// *task attribution* — the coordinator spares the two task-blaming counters
+    /// Breaker behaviour differs from [`Self::Failure`] in exactly one way: the
+    /// host feeds this class to `record_transient_failure`, whose ladder is
+    /// `TRANSIENT_BREAKER_THRESHOLD` (20) rather than the three-strike
+    /// `CIRCUIT_BREAKER_THRESHOLD`. The fault stays fully visible in
+    /// `model_health` — `consecutive_failures` and `total_failures` move exactly
+    /// as a `Failure` would — but an upstream capacity blip no longer
+    /// auto-disables the model, while a backend that is permanently gone still
+    /// demotes. An overloaded provider is a statement about LOAD, not about
+    /// whether the model can do the work (task `nr41`, 2026-07-29:
+    /// `openai/gpt-5.6-sol` reached `auto_disabled: true` with 15 consecutive
+    /// failures and 6 disable-TTL trips off an OpenAI 500 burst, taking the
+    /// tribunal's own adversary role down with it).
+    ///
+    /// The larger change is *task attribution* — the coordinator spares the two
+    /// task-blaming counters
     /// (the planner-remediation `provider_failure_streak` and the terminal
     /// `dispatch_failure_streak`) for this class, exactly as it already does for
     /// [`Self::Throttle`], while the escalating redispatch cooldown and the


### PR DESCRIPTION
## Symptom

A three-second upstream outage killed a tribunal round outright and force-closed its task, wedging the run and auto-disabling the model it was running on.

Production, 2026-07-29, task `nr41` (`019fae1c-0968-7ae3-8dfc-e9d63c558301`), adversary role, refinement round 3 — the whole thing took **18 seconds**:

```
13:42:33  supervisor dispatch: task-run complete  outcome: Failed {
            stage: "refinement",
            reason: "reply loop error: provider stream event failed:
                     display=server_is_overloaded: Our servers are currently overloaded.
                     Please try again later. ... Caused by: provider internal error (status 500)",
            provider_failure: Some(Failure), error_class: None, hint: None }
13:42:24  classify_session_exit_liveness  verdict: "protocol_violation"
            outcome: Some(Crash)  reason: Some(NonzeroExitNonterminal)
            attempt_accounting: "terminalizes the live attempt"
13:42:40  classify_task_liveness  verdict: "dead"  outcome: Some(DeadReclaimed)
13:42:40  CoordinatorActor: recovered stuck task  nr41  in_progress → open
13:42:41  task closed  close_reason: "force_closed"
```

Net: zero open refinement tasks while `proposal_refinement_status` still reported `active: true, run_state: "active", liveness: "live"`. Collateral: the same burst pushed `openai/gpt-5.6-sol` to `auto_disabled: true` — 15 consecutive failures, 30 total against 6 successes, 6 disable-TTL trips — i.e. transient upstream overload disabling the tribunal's own adversary model.

## Mechanism, per fix

Every defect here is at a **fold site**: a place where a provider-attributable signal existed and was thrown away, not a place where something was misclassified.

### 1. Session-exit liveness convicted the session of a protocol violation

`classify_session_exit_liveness` maps three session statuses onto two pod phases plus a sentinel exit code:

```rust
"completed"              => (PodPhase::Succeeded, Some(0)),
"failed" | "interrupted" => (PodPhase::Failed,    Some(1)),
```

Everything about *why* the run failed dies there, so "the worker segfaulted" and "the worker's provider returned 500" arrive at the classifier as the identical `(Failed, 1)` on an `in_progress` task. The classifier convicted both — `protocol_violation` / `Crash` / `NonzeroExitNonterminal` — and that verdict is what terminalized the live attempt as a `Crash`, which is what let the task be reclaimed and then force-closed.

The reason was never actually unavailable: the slot supervisor-runner had already classified the task-run report and stashed the typed class on the health tracker's per-task side-channel before the session was finalized. This change **peeks** that signal (`HealthTracker::peek_task_provider_failure`, new — the existing reader is deliberately consuming and belongs to the dispatch-reappearance path's A3/A6 backoff, so stealing it would silently disable that) and carries it as `LivenessEvidence::transient_provider_fault`.

A new rung sits **above** the protocol-violation rung — not as another exoneration term inside it, because the two answer different questions. Precedence 3 asks "is the recorded state structurally inconsistent?"; a transient provider fault is positive evidence of a *cause*, and a known cause is what makes the inconsistency explicable. The rung classifies `Dead` / `DeadReclaimed` / `TransientProviderFault` (the pod really is gone and really must be reclaimed; what differs is the reason), and the attempt terminalizes as `Interrupted` with failure class `transient_provider_fault` — the existing environmental non-attempt treatment: no dispatch-failure streak, no quality strike, no `reopen_class` penalty.

### 2. The refinement loop scored a dead round as a dry pass, then force-closed it

The loop told "the role ran and finished" from "the role never started" by whether a session row exists for the task. There is a third case, and reading it as the first is what consumed `nr41`'s round: the session **ran**, and the provider died under it. The loop found the session row, read an empty debate trail, and `explicit_dry = objections.is_empty()` scored it as the Adversary explicitly finding nothing — then force-closed the task.

An empty debate trail after a provider outage is the provider's silence, not the Adversary's verdict; nothing may be inferred from it. The round now routes into the **same bounded retry the never-started paths already use** (`retry_or_terminate_unstarted_refinement`) — no new scheduler, the same `REFINEMENT_DISPATCH_RETRY_CAP` ceiling so a provider that is down for good still terminates the loop with an honest `agent_failure` reason instead of looping forever, and the exact-run/generation CAS fences untouched.

Re-dispatch is gated on the existing breaker: the durable dispatch path now defers non-terminally while the `(scope, model)` health breaker is cooling (no task row, no spawn budget, no pool dispatch — the cooldown expires on its own and the next tick re-evaluates). Without that, the retry walks straight back into the outage and burns the retry cap inside two ticks.

### 3. Transient overload no longer drives the model breaker to auto-disable

`ProviderFailureClass::Transient` fed `record_failure` — the three-strike ladder. An overloaded upstream is a statement about **load**, not about whether the model can do the work.

I did look at `Throttle`, as suggested. It is the right home for the specific `server_is_overloaded` code, and the base branch's newest commit (`38d72c2e7`) already moved it there. It is the wrong home for what remains (`server_error` 500s, 502/503/504, `Transport`/`ExhaustedTransport` deaths): `record_stall` trips the breaker *immediately* with a five-minute floor, which is right for a quota window that resets on a clock and wrong for a blip where the very next dispatch usually succeeds — it would still leave the model `auto_disabled`, just for less time.

So `Transient` now feeds a new `record_transient_failure`: `consecutive_failures` and `total_failures` move exactly as a `Failure` would (this is a re-attribution, not a suppression — every fault stays visible in `model_health`), but the strike is charged to `transient_consecutive_failures` with `TRANSIENT_BREAKER_THRESHOLD = 20` instead of `CIRCUIT_BREAKER_THRESHOLD = 3`. A capacity blip cannot demote a healthy model; a backend that is permanently gone still demotes.

**That finite threshold is deliberate and is the k2p7 protection.** The kimi-for-coding incident (instant transport death, zero tokens, re-dispatched forever) must still eventually demote rather than be re-selected indefinitely — twenty consecutive transient faults with no intervening success is no longer "the provider is busy", it is a dead endpoint. **Reviewer decision point:** this is the one place I traded a documented behaviour (transport deaths demoting at 3 strikes) for the brief's requirement that transient overload not alone auto-disable. If 20 is the wrong number, it is a one-line constant.

Genuine failure detection is untouched: `Authentication`, `InvalidRequest` and `InvalidOutput` still route through `record_failure`/`record_stall` and still trip at three.

## Relationship to work already on main

This started as a stack on #2756 and is now a **standalone change against main**. #2756 squash-merged as `b5fb03ff7`, so this branch was rebased `--onto main`; all 12 conflict hunks were resolved and nothing was dropped as redundant. Where each neighbouring PR stands:

- **#2756 (`b5fb03ff7`, merged)** introduced `ProviderFailureClass::Transient`, `TaskFailureSignal::transient`, the `overload` → `RateLimit` stream-code arm, and the *task-attribution* half of the fix (sparing the planner-remediation streak and the terminal dispatch-failure streak). **None of it is reimplemented here.** This change carries that same signal into the two consumers that still discarded it — session-exit liveness and the refinement loop — and re-homes its breaker treatment.

- **#2755 (`5e991646b`, merged) — checked for subsumption; it does not subsume any of this.** It adds a bounded (2-attempt) restart of the round inside `djinn-slot`'s `consume_provider_stream`, and it is a genuinely good partial mitigation: many transient overloads will now never reach the coordinator at all. But it is bounded, and it only applies "when the round is still safely restartable: nothing streamed to the transcript, no tool call recorded or dispatched, no usage recorded." Once retries are exhausted, or once any meaningful output was emitted, its own commit message is explicit: *"the session fails exactly as before … so coordinator classification is untouched."* That failing-exactly-as-before path is precisely what this PR fixes. The two are complementary layers — #2755 reduces how often the session dies, this reduces the blast radius when it does. There is also zero file overlap: #2755 is entirely `djinn-slot/reply_loop/*` plus `djinn-provider/src/provider/client.rs`; this touches neither.

- **#2748 (`c2e4f71ec`, merged) — the real source of the conflicts, and complementary.** Both add an exoneration signal to `LivenessEvidence`, but they answer different questions and neither subsumes the other: `handed_off_from_session_held_status` exonerates by showing the task was moved somewhere *deliberately*; `transient_provider_fault` exonerates by naming an external *cause*. A round killed by an upstream 500 leaves the task exactly where the session found it, so it has no handoff evidence to find and #2748's term alone would still convict it. Kept as two terms at two rungs: #2748's is an `&& !handed_off` guard *inside* precedence 3; this is a rung *above* it. `transient_provider_fault_exonerates_without_any_handoff_evidence` pins that both directions still work. #2748 also moved `liveness.rs`'s test module to a sibling `liveness_tests.rs`; my four new classifier tests were ported there rather than reinstating the inline module.

- **#2751 (`b04fa75c5`, merged) — same direction, different dispatch path.** It adds a blameless exhaustion path in `task_dispatch.rs` when the breaker is open for *all* candidates on the worker failover chain. The gate added here is on the durable **refinement** dispatch path, which does not go through that chain. They agree in spirit (a provider outage must not be charged to the task) and do not overlap in code. Its suite (`tests::breaker_open_exhaustion`) is green on this branch. As a bonus, re-homing transient faults off the three-strike ladder means the all-candidates-open condition #2751 handles is now reached *less often* in the first place.

- **#2760 (`58b0ee0c0`, merged) and #2759 (`7c9ea8f01`, merged)** touch neither this change's files nor its behaviour — #2759 stays in `refinement_outcome.rs` / `refinement_tools.rs` (deliberately avoided here; this change lives in `refinement_dispatch.rs`), #2760 in `dispatch/retry.rs` / `park_redispatch_bound.rs`. Both suites are green on this branch (`refinement*`: 152 passed; `park_redispatch_bound`: 3 passed).

## Tests

New regression tests, all failing before this change:

| Test | Guards |
| --- | --- |
| `transient_provider_fault_is_not_a_protocol_violation` | the exact production evidence packet classifies `Dead`/`DeadReclaimed`/`TransientProviderFault`, not `ProtocolViolation`/`Crash` |
| `genuine_nonzero_crash_without_a_provider_fault_is_still_convicted` | the guard is not weakened — identical evidence minus the signal is still convicted |
| `transient_provider_fault_does_not_kill_a_still_running_pod` | the rung is scoped to an exited pod |
| `terminal_task_wins_over_transient_provider_fault` | precedence 1 still outranks it |
| `transient_provider_fault_parks_the_round_for_retry_instead_of_scoring_it` | the round parks and re-dispatches; `current_round` is NOT consumed; the run survives; the retry is charged to the cap |
| `a_finished_round_without_a_provider_fault_is_still_scored` | the park branch does not swallow ordinary finished rounds (so the test above cannot pass vacuously) |
| `repeated_transient_upstream_faults_do_not_auto_disable_a_model` | 4× the ordinary threshold of transient faults leaves the model available, with 0 disable-TTL trips, and all faults still visible |
| `repeated_genuine_failures_still_auto_disable_a_model` | genuine failures still trip at three |
| `a_sustained_run_of_transient_faults_eventually_trips_the_breaker` | k2p7 — a dead endpoint still demotes |
| `a_success_resets_the_transient_streak` | outages don't accumulate across recoveries |
| `peek_task_provider_failure_does_not_consume_the_signal` / `clear_task_provider_failure_drops_the_signal` | the three readers of the side-channel don't steal from each other |

Local results after the rebase onto main (`SQLX_OFFLINE=true`, local test-DB template rebuilt for migration 161):

- `djinn-provider --lib catalog::health` — **45 passed, 0 failed**
- `djinn-coordinator --lib dispatch::liveness` — **46 passed, 0 failed**
- `djinn-coordinator --lib refinement_pool_watchdog_tests` — **10 passed, 0 failed**
- `djinn-coordinator --lib tests::session_reaping` — **112 passed, 0 failed**
- `djinn-agent --lib supervisor_impl::stage` — **61 passed, 0 failed**
- Neighbour suites, as interaction checks: `tests::breaker_open_exhaustion` (#2751) **4 passed**, `park_redispatch_bound` (#2760) **3 passed**, `refinement*` (incl. #2759) **152 passed**
- `cargo clippy --all-targets` on `djinn-provider`, `djinn-coordinator`, `djinn-agent`, `djinn-runtime` — clean; `cargo fmt --check` clean on every file this PR touches

Not verified locally, flagged for CI and for the reviewer: the full workspace suite and the DB-backed integration lanes outside the modules above.

## Deliberately not fixed

**A refinement run with no live task still reports `active`/`live`.** I implemented this, then backed it out, and the reason matters.

The wedge comes from `evaluate_refinement_liveness`: the run's `Materialized` intent keeps returning `RefinementLivenessEvidence::MaterializedIntent` after the round's only task was force-closed. Gating that on "the intent's task is terminal" makes the run report `Stale`, which the exact-run reaper already knows how to act on — three lines, and it makes the required test pass.

It also directly reverts a documented invariant with its own prior incident:

> `materialized_intent_with_its_role_task_is_live_even_after_the_task_closes` — "A materialized intent whose correlated role task exists is durable in-flight work: the coordinator still owes it an outcome. That must remain true after the role agent exits and its task closes, which is the exact window in which the admission reaper used to terminalize a run whose adversary had genuinely run (`stop_tag = reaped_phantom`) and mint a fresh generation that repeated the loop."

So the evaluator is *right*: an outstanding materialized intent genuinely is unfinished work the coordinator owes an outcome for. The real defect is that nothing ever re-drives it — `recover_interrupted_refinements` is **startup-only**, and the in-process projection lost its session, so the run sits owed-an-outcome forever with no periodic pass to re-materialize it. That is a separate fix (a periodic re-materialization/reaper pass) and does not belong in a PR about provider faults.

Fix 2 removes the production trigger — the round no longer dies silently — so this cause of the wedge is closed even though the wedge mechanism remains reachable by other means.

**Generation-scoped status counters.** In the same snapshot, after accepting generation 1 and starting generation 2, status still reported `current_round: 5` and `total_entries: 19` (generation-1 numbers) while the live generation-2 task was round 3. The counters aren't scoped to the current generation. Not contained in this change; left as noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
