### PR TITLE
fix(coordinator): stop the park rung redispatching forever on a counter that cannot grow

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/mod.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/mod.rs
@@ -6,6 +6,10 @@ pub(crate) mod cycling_intervention;
 pub(crate) mod lane_resolution_log;
 pub(crate) mod liveness;
 mod outcome;
+/// Cumulative bound on the park rung's `no_attempted_remediation` decline, so a
+/// guard whose counter cannot grow stops redispatching forever. Re-exported
+/// through `crate::types`.
+pub(crate) mod park_redispatch_bound;
 pub(crate) mod post_intervention_lane;
 /// Pre-dispatch respawn guard: consults attempt-history before fresh
 /// spawn/admission and records guard-deferred audit rows.

--- a/server/crates/djinn-coordinator/src/dispatch/park_redispatch_bound.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/park_redispatch_bound.rs
@@ -1,0 +1,219 @@
+//! Cumulative bound on the `no_attempted_remediation` park-rung decline.
+//!
+//! Extracted next to [`super::cycling_intervention`] (and for the same reason:
+//! `crate::types` and `super::retry` both sit at their byte ceilings) so the
+//! bound, its threshold, and the marker accounting it reads live in one place.
+//! `crate::types` re-exports the names, so `use super::*` call sites are
+//! unchanged.
+//!
+//! ## Why this exists (task 6tlg, 2026-07-27/28)
+//!
+//! The attempted-remediation gate on the second-strike park rung
+//! (`super::retry`, the `NON_ATTEMPT_PARK_THRESHOLD` branch) refuses to park
+//! while fewer than [`crate::types::NON_ATTEMPT_PARK_THRESHOLD`] DISTINCT
+//! MODELS have terminated pre-submission, and redispatches with forced model
+//! rotation instead. Two properties of the quantity it measures
+//! (`PostInterventionHistory::non_attempt_models`) make that count unable to
+//! grow for a repeating infrastructure failure:
+//!
+//! 1. Infra outcomes (`crashed` / `timed_out` / `spawn_failed` / `interrupted`,
+//!    per `TaskAttemptOutcome::is_infra`) are deliberately excluded from it — a
+//!    worker session that exits `failed` is booked `crashed`, so it contributes
+//!    nothing.
+//! 2. It is deduplicated by MODEL label, so N identical failures on one model
+//!    count once.
+//!
+//! Task 6tlg rode exactly this: 33 worker sessions all died at ~9m40s on the
+//! same launcher lease error, every one booked `crashed`, and the rung recorded
+//! ten consecutive `park_attempted_remediation_redispatch` markers between
+//! 21:16Z and 06:07Z whose payload read `"non_attempt_count": 1` every single
+//! time — pinned one below a threshold of 2, forever.
+//!
+//! `super::retry`'s own cumulative bound (`MAX_ARBITER_HOLD_CYCLES`, incident
+//! gy53) does not catch this: it reads the arbitration ledger's prospective
+//! hold cycle, and a guard that declines BEFORE any arbitration row is created
+//! never advances that cycle. The bound below is keyed on the durable decline
+//! markers themselves, which the rung writes on every decline, so it advances
+//! precisely when the loop it bounds goes around.
+
+use djinn_core::models::ActivityEntry;
+
+/// How many times the park rung may decline to park via the
+/// `no_attempted_remediation` sub-guard, within one intervention epoch, before
+/// the decline is no longer honored and the rung parks.
+///
+/// Rationale for `3`: the guard exists so a task that has never had a
+/// post-intervention session reach `submit_work` gets real remediation
+/// attempts before a park consumes its strike — with forced model rotation,
+/// three redispatches exhaust a typical creator's model list. Past that the
+/// premise ("rotation has not been tried") is no longer true regardless of what
+/// the model-deduplicated counter reads, and every further decline is another
+/// ~10-minute session with nobody deciding anything.
+pub(crate) const MAX_PARK_REDISPATCH_DECLINES: usize = 3;
+
+/// The `kind` written into a [`crate::types::PARK_REDISPATCH_MARKER`] payload
+/// by the attempted-remediation sub-guard.
+pub(crate) const NO_ATTEMPTED_REMEDIATION_KIND: &str = "no_attempted_remediation";
+
+/// Count the `no_attempted_remediation` declines already recorded for the
+/// CURRENT intervention epoch.
+///
+/// Scoping to `intervention_count` (which the marker payload carries) is what
+/// makes the bound re-arm after a genuine Planner intervention reshapes the
+/// task: a fresh epoch starts from zero declines, exactly like the
+/// reopen-count-keyed planner-intervention marker.
+///
+/// Entries whose payload is missing, unparseable, or carries a different
+/// `kind`/epoch are ignored. That fails OPEN (toward the existing decline
+/// behavior) on payload drift rather than parking a task on evidence that
+/// could not be read.
+pub(crate) fn no_attempted_remediation_declines(
+    entries: &[ActivityEntry],
+    intervention_count: i64,
+) -> usize {
+    entries
+        .iter()
+        .filter(|entry| entry.event_type == crate::types::PARK_REDISPATCH_MARKER)
+        .filter_map(|entry| serde_json::from_str::<serde_json::Value>(&entry.payload).ok())
+        .filter(|payload| {
+            payload["kind"] == NO_ATTEMPTED_REMEDIATION_KIND
+                && payload["intervention_count"].as_i64() == Some(intervention_count)
+        })
+        .count()
+}
+
+/// Should the park rung decline to park because remediation was never actually
+/// attempted?
+///
+/// `true` reproduces the pre-existing behavior (record a decline marker and
+/// redispatch with forced model rotation). `false` lets the rung proceed to the
+/// park it was already about to perform.
+///
+/// The `prior_declines` bound is evaluated LAST so it can only ever REMOVE a
+/// decline, never add one: a task that has submitted post-intervention work, or
+/// whose non-attempt count genuinely reached the threshold, is unaffected.
+pub(crate) fn should_decline_no_attempted_remediation_park(
+    any_submitted: bool,
+    non_attempt_model_count: usize,
+    prior_declines: usize,
+) -> bool {
+    !any_submitted
+        && non_attempt_model_count < crate::types::NON_ATTEMPT_PARK_THRESHOLD
+        && prior_declines < MAX_PARK_REDISPATCH_DECLINES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{NON_ATTEMPT_PARK_THRESHOLD, PARK_REDISPATCH_MARKER};
+
+    fn marker(kind: &str, non_attempt_count: usize, intervention_count: i64) -> ActivityEntry {
+        ActivityEntry {
+            id: String::new(),
+            task_id: None,
+            actor_id: "coordinator".to_owned(),
+            actor_role: "system".to_owned(),
+            event_type: PARK_REDISPATCH_MARKER.to_owned(),
+            payload: serde_json::json!({
+                "kind": kind,
+                "fingerprint": serde_json::Value::Null,
+                "non_attempt_count": non_attempt_count,
+                "intervention_count": intervention_count,
+            })
+            .to_string(),
+            created_at: String::new(),
+        }
+    }
+
+    /// Replay of the exact 6tlg shape: the rung declined ten consecutive times
+    /// between 21:16Z and 06:07Z, every marker's payload reading
+    /// `"non_attempt_count": 1` against a `NON_ATTEMPT_PARK_THRESHOLD` of 2,
+    /// because the model-deduplicated, infra-excluding counter cannot grow when
+    /// every session dies the same infrastructure death. Feed the gate that
+    /// unchanging evidence and it must stop honoring the decline; without the
+    /// bound every one of the ten rounds redispatches and the loop is infinite.
+    ///
+    /// The round count is the OBSERVED incident length, deliberately not derived
+    /// from [`MAX_PARK_REDISPATCH_DECLINES`], so tuning the bound cannot make
+    /// this assertion vacuous.
+    #[test]
+    fn repeated_identical_declines_stop_being_honored() {
+        const OBSERVED_6TLG_DECLINES: usize = 10;
+        const {
+            assert!(
+                MAX_PARK_REDISPATCH_DECLINES < OBSERVED_6TLG_DECLINES,
+                "the bound must trip inside the observed incident, not after it"
+            );
+        }
+
+        let mut recorded: Vec<ActivityEntry> = Vec::new();
+        let mut redispatched = 0usize;
+
+        for _ in 0..OBSERVED_6TLG_DECLINES {
+            // `non_attempt_count` is pinned at 1 every round — the 6tlg payload.
+            if !should_decline_no_attempted_remediation_park(
+                false,
+                1,
+                no_attempted_remediation_declines(&recorded, 2),
+            ) {
+                break;
+            }
+            redispatched += 1;
+            recorded.push(marker(NO_ATTEMPTED_REMEDIATION_KIND, 1, 2));
+        }
+
+        assert_eq!(
+            redispatched, MAX_PARK_REDISPATCH_DECLINES,
+            "the rung must decline exactly {MAX_PARK_REDISPATCH_DECLINES} times and then park; \
+             declining all {OBSERVED_6TLG_DECLINES} observed rounds is the 6tlg wedge"
+        );
+    }
+
+    /// The bound may only remove a decline, never create one. A post-intervention
+    /// submit, or a non-attempt count that genuinely reached the threshold, must
+    /// keep behaving exactly as before regardless of how many declines were
+    /// recorded.
+    #[test]
+    fn bound_never_turns_a_park_into_a_redispatch() {
+        let saturated: Vec<ActivityEntry> = (0..MAX_PARK_REDISPATCH_DECLINES + 5)
+            .map(|_| marker(NO_ATTEMPTED_REMEDIATION_KIND, 1, 0))
+            .collect();
+        let declines = no_attempted_remediation_declines(&saturated, 0);
+
+        assert!(!should_decline_no_attempted_remediation_park(true, 0, 0));
+        assert!(!should_decline_no_attempted_remediation_park(
+            true, 0, declines
+        ));
+        assert!(!should_decline_no_attempted_remediation_park(
+            false,
+            NON_ATTEMPT_PARK_THRESHOLD,
+            0
+        ));
+    }
+
+    /// Declines are scoped to the intervention epoch recorded in the payload, so
+    /// a genuine Planner intervention re-arms the budget. Markers of another
+    /// `kind` (the first-occurrence CI fingerprint guard, which has its own
+    /// novelty bound) and unparseable payloads are not counted.
+    #[test]
+    fn declines_are_scoped_to_the_epoch_and_the_kind() {
+        let entries = vec![
+            marker(NO_ATTEMPTED_REMEDIATION_KIND, 1, 1),
+            marker(NO_ATTEMPTED_REMEDIATION_KIND, 1, 1),
+            marker(NO_ATTEMPTED_REMEDIATION_KIND, 1, 2),
+            marker("first_occurrence_fingerprint", 0, 2),
+            ActivityEntry {
+                payload: "not json".to_owned(),
+                ..marker(NO_ATTEMPTED_REMEDIATION_KIND, 1, 2)
+            },
+            ActivityEntry {
+                event_type: "status_changed".to_owned(),
+                ..marker(NO_ATTEMPTED_REMEDIATION_KIND, 1, 2)
+            },
+        ];
+
+        assert_eq!(no_attempted_remediation_declines(&entries, 1), 2);
+        assert_eq!(no_attempted_remediation_declines(&entries, 2), 1);
+        assert_eq!(no_attempted_remediation_declines(&entries, 3), 0);
+    }
+}

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -1438,13 +1438,31 @@ impl CoordinatorActor {
             // Below the bound, redispatch with forced model rotation instead of
             // consuming the final strike (dispatch-time exclusion in
             // task_dispatch.rs drops the models that just failed).
+            //
+            // Cumulative decline bound (task 6tlg): `non_attempt_models` excludes
+            // infra outcomes (a session that exits `failed` is booked `crashed`)
+            // AND is deduplicated by model, so a task whose every session dies the
+            // same infrastructure death holds this counter at a fixed value below
+            // the threshold indefinitely — 6tlg recorded ten consecutive declines
+            // reading `non_attempt_count: 1` over nine hours. The gy53 hold-cycle
+            // ceiling above cannot catch that: it reads the arbitration ledger's
+            // prospective cycle, which a guard that declines BEFORE creating an
+            // arbitration row never advances. Bound the decline on the durable
+            // markers this rung itself writes, scoped to the current intervention
+            // epoch so a genuine Planner intervention re-arms the budget.
+            let prior_declines = self
+                .no_attempted_remediation_decline_count(&task.id, task.intervention_count)
+                .await;
             if !final_disposition
-                && !history.any_submitted
-                && history.non_attempt_models.len() < NON_ATTEMPT_PARK_THRESHOLD
+                && should_decline_no_attempted_remediation_park(
+                    history.any_submitted,
+                    history.non_attempt_models.len(),
+                    prior_declines,
+                )
             {
                 self.record_park_redispatch_marker(
                     task,
-                    "no_attempted_remediation",
+                    NO_ATTEMPTED_REMEDIATION_KIND,
                     None,
                     history.non_attempt_models.len(),
                 )
@@ -1453,6 +1471,8 @@ impl CoordinatorActor {
                     task_id = %task.short_id,
                     intervention_count = task.intervention_count,
                     non_attempt_models = ?history.non_attempt_models,
+                    prior_declines,
+                    decline_bound = MAX_PARK_REDISPATCH_DECLINES,
                     "uv3p: human-park rung declined to park — no post-intervention session reached submit_work yet; redispatching with forced model rotation instead of parking"
                 );
                 return false;
@@ -2755,6 +2775,35 @@ impl CoordinatorActor {
     /// Has the hold-cycle ceiling already been recorded for this task?
     /// Fail-open (returns `false`) on a query error: a duplicate audit entry is
     /// far cheaper than losing the record entirely.
+    /// How many `no_attempted_remediation` park declines this task already
+    /// recorded in the CURRENT intervention epoch (task 6tlg).
+    ///
+    /// Reads the rung's own durable [`PARK_REDISPATCH_MARKER`] rows, so the
+    /// count advances exactly once per trip around the loop it bounds — unlike
+    /// the model-deduplicated, infra-excluding `non_attempt_models` the decline
+    /// itself measures, which can be pinned below its threshold forever.
+    ///
+    /// A read error returns 0, which fails OPEN toward the pre-existing decline
+    /// behavior: a DB blip must never park a task on evidence nobody read. The
+    /// `limit` sits an order of magnitude above the bound so a task cannot
+    /// escape it by burying its declines under newer markers of another kind.
+    async fn no_attempted_remediation_decline_count(
+        &self,
+        task_id: &str,
+        intervention_count: i64,
+    ) -> usize {
+        self.task_repo()
+            .query_activity(ActivityQuery {
+                task_id: Some(task_id.to_owned()),
+                event_type: Some(PARK_REDISPATCH_MARKER.to_string()),
+                limit: 50,
+                ..ActivityQuery::default()
+            })
+            .await
+            .map(|entries| no_attempted_remediation_declines(&entries, intervention_count))
+            .unwrap_or(0)
+    }
+
     async fn hold_cycle_ceiling_already_recorded(&self, task_id: &str) -> bool {
         self.task_repo()
             .query_activity(ActivityQuery {

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -634,6 +634,22 @@ pub(super) use crate::dispatch::cycling_intervention::{
     PriorSessionDisposition, should_route_cycling_intervention,
 };
 
+/// Threshold companion of the bound above. Referenced by tests and doc links
+/// rather than by non-test dispatch code, so the re-export carries the same
+/// `unused_imports` allowance the sibling test-only re-exports use.
+#[allow(unused_imports)]
+pub(super) use crate::dispatch::park_redispatch_bound::MAX_PARK_REDISPATCH_DECLINES;
+/// The cumulative bound on the park rung's `no_attempted_remediation` decline
+/// lives in [`crate::dispatch::park_redispatch_bound`] next to its only
+/// production caller (task 6tlg: the decline's own counter cannot grow when
+/// every session dies the same infra death, so the rung redispatched ten times
+/// with `non_attempt_count` pinned at 1). Re-exported here so `use types::*`
+/// call sites are unchanged.
+pub(super) use crate::dispatch::park_redispatch_bound::{
+    NO_ATTEMPTED_REMEDIATION_KIND, no_attempted_remediation_declines,
+    should_decline_no_attempted_remediation_park,
+};
+
 /// A task that becomes dispatch-ready again (with no active session) within
 /// this window of its last dispatch is treated as a failed attempt and backed
 /// off. Wide enough to catch SLOW failures — e.g. a worker that runs ~30s and


### PR DESCRIPTION
## Root cause

The second-strike park rung declines to park while fewer than `NON_ATTEMPT_PARK_THRESHOLD` (2) distinct models have terminated pre-submission, redispatching with forced model rotation instead (`retry.rs:1441`). **The quantity it thresholds on cannot grow for a repeating infrastructure failure:**

- A session exiting `failed` while its task is nonterminal is booked `TaskAttemptOutcome::Crashed` (`session_recovery.rs:2722-2738`).
- `Crashed` is `is_infra()` (`task_attempt.rs:118-123`), and `retry.rs:938-949` excludes every infra outcome from `non_attempt_models` outright.
- `retry.rs:957` further deduplicates the survivors **by model label**, so N identical failures on one model count once.

Board task `6tlg` rode exactly this. Thirty-three worker sessions all died at ~9m40s on the same launcher lease error (`lease invocation failed: Launcher(... ControlRejected(State))`), every one booked `crashed`, and the rung recorded **ten consecutive** `park_attempted_remediation_redispatch` markers between 2026-07-27T21:16:23Z and 2026-07-28T06:07:36Z whose payload was byte-identical every time:

```json
{"kind":"no_attempted_remediation","fingerprint":null,"non_attempt_count":1,"intervention_count":2}
```

Pinned one below the threshold, for nine hours — 37 sessions, zero commits, `reopen_count` and `continuation_count` both still `0`.

## Why the existing gy53 ceiling didn't catch it

`retry.rs:1332-1340` documents this exact anti-pattern ("every other guard on this rung declines by RETURNING FALSE ... so a task that declines via a DIFFERENT sub-guard each round never terminates") and installs a cumulative bound meant to be guard-independent. But that bound reads `arbiter_hold_cycle_ceiling_reached` (`retry.rs:2660-2675`) → `resolve_current_hold_cycle` (`task_arbitration.rs:254-266`), a **prospective hold cycle derived from the arbitration ledger**. A guard that declines *before* any arbitration row is created never advances that cycle, so the ceiling is a no-op for this shape.

## The fix

New `dispatch/park_redispatch_bound.rs` (pure gate + counting fn + unit tests, following the `cycling_intervention.rs` precedent — `retry.rs` carries `djinn:allow-oversize`):

- Bounds the decline on **the rung's own durable decline markers**, which advance exactly once per trip around the loop they bound — unlike `non_attempt_models`, which can sit pinned forever.
- **Scoped to the intervention epoch** (`intervention_count` from the marker payload), so a genuine Planner intervention re-arms the budget, mirroring the reopen-count-keyed planner-intervention marker.
- **Fails open on read error** (returns 0 → pre-existing decline behavior): a DB blip must never park a task on evidence nobody read.
- **Evaluated last**, so it can only ever *remove* a decline, never add one. A post-intervention submit, or a non-attempt count that genuinely reached the threshold, is unaffected.
- `MAX_PARK_REDISPATCH_DECLINES = 3`: with forced model rotation, three redispatches exhaust a typical creator's model list; past that the guard's premise ("rotation has not been tried") is false regardless of what the deduplicated counter reads.

The decline's `kind` string is now a shared constant so the writer and the reader cannot drift.

## Verification

**The test was verified to fail without the fix** — I temporarily restored the pre-fix predicate (dropped the `prior_declines` term) and re-ran:

```
assertion `left == right` failed: the rung must decline exactly 3 times and then park;
declining all 10 observed rounds is the 6tlg wedge
  left: 10
 right: 3
```

The test replays the **observed** incident length (10) as a hard-coded constant rather than deriving it from the bound, with a `const` assert that the bound trips inside that window — so retuning the threshold cannot make the assertion vacuous.

Also green: `cargo clippy -p djinn-coordinator --lib --all-targets` (clean), `cargo fmt --check`, and all **74** existing park/intervention tests, including `park_rung_redispatches_when_no_post_intervention_submission` and `park_rung_parks_after_two_non_attempts_with_truthful_reason`.

> [!NOTE]
> `cargo test -p djinn-coordinator --lib` (full parallel run) aborts with a tokio-worker stack overflow. **This is pre-existing and unrelated** — I stashed these changes and reproduced it on a clean baseline. CI uses nextest (process-per-test), which is why it is not seen there.

## Follow-ups not in this PR

- Nothing anywhere counts *"consecutive sessions with no new commit on the task branch"* — no watchdog reads git. The invocation-journal watchdog reads a pod-local timestamp, the stall breaker reads wall-clock idle + token counters + `task.status`, the zombie reaper reads the RPC socket. `task_branch_commits_ahead` already exists but is never called from the recovery path.
- On the proactive-sync conflict path (`supervisor/lib.rs:1428-1440`), `pending_merge_target_sha` is never set, so `enforce_merge_parent` never runs and no `merge_conflict_metadata` is written — 6tlg's workers were handed a stale conflict-file list citing `values.yaml:103-111` when the markers were actually at `133-141`.
- The `is_infra` exclusion is correct for *transient* faults but wrong for deterministic ones (6tlg's repeated identically 33 times); a repeat-count or fingerprint on infra outcomes would let the ladder tell "unlucky once" from "wedged".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
