### PR TITLE
fix(admission): stop a healthy SCIP index fail-closing every dispatch

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission_inventory.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory.rs
@@ -181,6 +181,23 @@ fn classify(r: &WorkloadRecord) -> Result<Option<ClassifiedWorkload>, String> {
     {
         return Ok(None);
     }
+    // SCIP code-graph index Jobs are the same shape of exception as image
+    // builds above, for the same reason. `djinn.io/capacity-reserved` is how
+    // their CPU is accounted (folded into `protected_mcpu` and subtracted from
+    // build capacity by proposal 8ixk); they take NO build lease and carry no
+    // admission identity, so there is nothing here to adopt. Falling through to
+    // the unclassifiable catch-all would keep Enforce fail-closed for the whole
+    // index run — a 4335s budget — during which every worker, reviewer, and
+    // planner dispatch is denied `controller_not_admitting`. Observed in
+    // production 2026-07-29: one healthy rust-analyzer index blocked the board
+    // for its entire duration.
+    if l.get("djinn.app/component")
+        .is_some_and(|value| value == "scip-index")
+        || l.get("djinn.app/scip-index").is_some_and(|v| v == "true")
+        || r.name.starts_with("djinn-scip-")
+    {
+        return Ok(None);
+    }
     if (r.name.starts_with("djinn-") || l.keys().any(|k| k.starts_with("djinn.app/")))
         && !r.terminal
         && !r.images.is_empty()

--- a/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
@@ -484,6 +484,51 @@ async fn image_build_jobs_are_recognised_and_never_block_the_inventory_gate() {
     );
 }
 
+/// A SCIP code-graph index Job shares the namespace with admission workloads.
+/// It takes no build lease and carries no admission identity — its CPU is
+/// accounted through `djinn.io/capacity-reserved` / `protected_mcpu` instead —
+/// so it must never be mistaken for an unclassifiable build workload. In
+/// production on 2026-07-29 one healthy rust-analyzer index marked the gate
+/// pending and kept Enforce fail-closed for its whole 4335s budget, denying
+/// every worker, reviewer, and planner dispatch with `controller_not_admitting`.
+#[tokio::test]
+async fn scip_index_jobs_are_recognised_and_never_block_the_inventory_gate() {
+    // Exactly the labels the real Job carries (djinn-k8s/src/scip_job.rs).
+    let scip_index = record(
+        "djinn-scip-019ea3bd-a305-73e3-806c-4edcc96ebfe2-f13d031f3551",
+        Some("uid-scip-index"),
+        &[
+            ("djinn.app/component", "scip-index"),
+            ("djinn.app/scip-index", "true"),
+            ("djinn.io/capacity-reserved", "true"),
+            (
+                "djinn.app/project-id",
+                "019ea3bd-a305-73e3-806c-4edcc96ebfe2",
+            ),
+        ],
+    );
+    let inventory = Arc::new(FakeInventory::new(vec![
+        scip_index,
+        labeled("real-work", "uid-work", "work", "0"),
+    ]));
+    let controller = controller(BuildAdmissionMode::Enforce, 3).await;
+    let report = BuildAdmissionReconciler::new(controller.clone(), inventory)
+        .reconcile()
+        .await;
+
+    assert!(
+        report.blockers.is_empty(),
+        "a SCIP index must not block the gate: {:?}",
+        report.blockers
+    );
+    assert_eq!(report.adopted, 1, "only the admission workload is adopted");
+    assert_ne!(
+        controller.readiness(),
+        BuildAdmissionReadiness::InventoryPending,
+        "the inventory gate must complete while a code-graph index is running"
+    );
+}
+
 /// A degraded API server answers `Uncertain`, which is not evidence. The row
 /// keeps occupying until a probe can actually answer.
 #[tokio::test]


### PR DESCRIPTION
## What broke

A running code-graph index Job fell through to the unclassifiable catch-all in the build-admission inventory classifier. That marks the inventory gate pending and keeps `Enforce` fail-closed for as long as the object exists.

Observed in production today. The pod was entirely healthy — `ready=True`, `restarts=0`, rust-analyzer at 1200s of a 4335s budget — and yet, every 2 minutes:

```
ERROR build_admission: Kubernetes inventory reconciliation blocked; Enforce remains fail-closed
  blockers: ["djinn-scip-<project>-<hash>: unclassifiable build workload"]
```

with 260 denials in 12 minutes across five tasks and **every** role (worker, reviewer, planner):

```
INFO build admission denied; leaving task queued
  cause="controller_not_admitting" readiness="inventory_pending"
  occupancy="unmeasured" cap=3
```

So an ordinary code-graph re-index blocks all build-requiring dispatch for up to 72 minutes. This is not deploy-specific — it recurs on every re-index. The board looks alive throughout, because refinement/adversary sessions do not go through build admission, which is what makes it easy to misread as "working".

## Why `Ok(None)` is the right classification

A SCIP Job takes no build lease and carries no admission identity. Its CPU is accounted by a different mechanism: `djinn.io/capacity-reserved` folds its request into `protected_mcpu` (proposal 8ixk). `scip_job.rs` says so directly — *"This Job takes no build lease, so without this label its CPU would be accounted by nothing at all."*

There is therefore nothing for the journal to adopt, and it belongs with the image-build exception immediately above it, which exists for precisely this reason and carries the same comment.

## Non-vacuity

The regression test is not decorative. With the classifier arm reverted it fails with the verbatim production blocker string:

```
a SCIP index must not block the gate: ["djinn-scip-…-f13d031f3551: unclassifiable build workload"]
```

`cargo test -p djinn-coordinator build_admission_inventory` → 11 passed, 0 failed.

## Follow-up worth considering separately

The inventory lists Jobs with `ListParams::default()`, so **any** future `djinn-*` Job type that is non-terminal and carries images hits the same catch-all and causes the same total outage. The classifier is fail-closed on unknown Jobs by default, which means each new Job kind is a latent board-wide outage until someone adds an arm here.