### PR TITLE
feat(4q45): deploy-time render preflight and a dispatchable chart default

### DIFF
--- a/deploy/helm/djinn/tests/cgroup-writable-render.sh
+++ b/deploy/helm/djinn/tests/cgroup-writable-render.sh
@@ -4,7 +4,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# DJINN_CHART_DIR lets a caller point the SAME contract at a mutated copy of the
+# chart. deploy/preflight/tests/render-gate.sh uses it to prove this script
+# actually rejects a values.yaml that restores the undispatchable default
+# pairing, rather than merely describing it.
+CHART_DIR="${DJINN_CHART_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 REPO_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 FIXTURES="$SCRIPT_DIR/fixtures/cgroup-writable"
 CONFORMANCE="$REPO_DIR/deploy/node/k3s/djinn-cgroup-writable-conformance.sh"
@@ -32,6 +36,11 @@ helm template cgroup-writable-preparation "$CHART_DIR" --is-upgrade \
   --set cgroupWritable.runtimeClass.enabled=true >"$WORK/preparation.yaml"
 helm template cgroup-writable-activation "$CHART_DIR" --is-upgrade \
   --set cgroupWritable.runtimeClass.enabled=true,cgroupWritable.taskRuns.enabled=true >"$WORK/activation.yaml"
+# The fully armed production pairing: an armed launcher together with the
+# task-run RuntimeClass assignment it cannot dispatch without.
+helm template cgroup-writable-armed "$CHART_DIR" --is-upgrade \
+  --set cgroupLauncher.mode=required \
+  --set cgroupWritable.runtimeClass.enabled=true,cgroupWritable.taskRuns.enabled=true >"$WORK/armed.yaml"
 for invalid in \
   'cgroupWritable.runtimeClass.enabled=not-a-bool' \
   'cgroupWritable.taskRuns.enabled=not-a-bool'; do
@@ -49,7 +58,7 @@ for invalid in \
     exit 1
   fi
 done
-python3 - "$WORK/default.yaml" "$WORK/preparation.yaml" "$WORK/activation.yaml" "$FIXTURES" <<'PY'
+python3 - "$WORK/default.yaml" "$WORK/preparation.yaml" "$WORK/activation.yaml" "$WORK/armed.yaml" "$FIXTURES" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -62,8 +71,10 @@ def documents(text):
 def runtime_classes(text):
     return [doc for doc in documents(text) if '\nkind: RuntimeClass\n' in f'\n{doc}']
 
-base, preparation, activation = (Path(path).read_text(encoding='utf-8') for path in sys.argv[1:4])
-fixtures = Path(sys.argv[4])
+base, preparation, activation, armed = (
+    Path(path).read_text(encoding='utf-8') for path in sys.argv[1:5]
+)
+fixtures = Path(sys.argv[5])
 assert not runtime_classes(base), 'disabled defaults rendered RuntimeClass'
 assert 'runtimeClassName:' not in base, 'disabled defaults assigned RuntimeClass to a PodSpec'
 classes = runtime_classes(preparation)
@@ -79,15 +90,68 @@ assert 'runtimeClassName:' not in preparation, 'preparation must not assign Runt
 assert len(runtime_classes(activation)) == 1, 'activation must retain the RuntimeClass'
 
 
-def server_activation(rendered):
-    marker = 'name: DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED\n              value: '
-    assert marker in rendered, 'server render omitted task-run activation environment'
+def server_env(rendered, name):
+    marker = f'name: {name}\n              value: '
+    assert marker in rendered, f'server render omitted {name}'
     return rendered.split(marker, 1)[1].splitlines()[0].strip().strip('"')
+
+
+def server_activation(rendered):
+    return server_env(rendered, 'DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED')
 
 
 assert server_activation(base) == 'false', 'disabled render armed task-run activation'
 assert server_activation(preparation) == 'false', 'preparation render armed task-run activation'
 assert server_activation(activation) == 'true', 'activation render omitted task-run activation'
+
+
+def assert_dispatchable(rendered, label):
+    """Reject a render djinn-server would refuse to dispatch.
+
+    THIS FILE USED TO CERTIFY THE OPPOSITE. It asserted the default render sets
+    DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED=false and never asked which
+    cgroupLauncher.mode was rendered beside it. Stock values shipped `required`
+    with `false` — the exact pairing `validate_enforcement_render` refuses — so
+    the "correct default render" this test approved was one under which a fresh
+    install creates zero Jobs. That is what took production down on 2026-07-29,
+    with CI green throughout.
+
+    The authoritative gate is `deploy/preflight/render-gate.sh`, which runs the
+    real validator over a real render. This assertion is the hermetic, helm-only
+    half: it keeps the chart-contract lane, which needs no Rust toolchain, from
+    ever reintroducing the pairing.
+    """
+    mode = server_env(rendered, 'DJINN_K8S_CGROUP_LAUNCHER_MODE')
+    enabled = server_activation(rendered)
+    assert not (mode == 'required' and enabled == 'false'), (
+        f'{label}: undispatchable render — cgroupLauncher.mode={mode} paired with '
+        f'cgroupWritable.taskRuns.enabled={enabled} is refused at dispatch as '
+        f'RenderValidationError::MissingDelegatedRuntimeClass, so no Job is ever created'
+    )
+
+
+for label, rendered in (
+    ('chart defaults', base),
+    ('preparation', preparation),
+    ('activation', activation),
+    ('armed', armed),
+):
+    assert_dispatchable(rendered, label)
+
+# Non-vacuity: flip ONLY the launcher mode in the default render and the same
+# check must reject it. Without this, a check that never fires reads identically
+# to one that passes.
+armed_default = base.replace(
+    'name: DJINN_K8S_CGROUP_LAUNCHER_MODE\n              value: "disabled"',
+    'name: DJINN_K8S_CGROUP_LAUNCHER_MODE\n              value: "required"',
+)
+assert armed_default != base, 'default render no longer states the launcher mode this check reads'
+try:
+    assert_dispatchable(armed_default, 'synthetic armed default')
+except AssertionError:
+    pass
+else:
+    raise AssertionError('undispatchable required/false pairing was accepted')
 
 
 def fail(message, contract):

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -92,14 +92,14 @@ buildAdmission:
 # is lifted to the pod's full CPU limit only once it demonstrates it is actually
 # CPU-hungry.
 #
-#   required  (default) — render the cgroup-launcher sidecar. The launcher
+#   required            — render the cgroup-launcher sidecar. The launcher
 #                         establishes its own delegated cgroup v2 root at
 #                         startup, which needs `SYS_ADMIN` plus an AppArmor
 #                         opt-out for the duration of that bootstrap; it drops
 #                         the capability irreversibly out of its bounding set
 #                         before the broker accepts any work, which is the only
 #                         layer under it and is verified at runtime.
-#   disabled            — explicit local/development compatibility: no sidecar,
+#   disabled  (default) — explicit local/development compatibility: no sidecar,
 #                         cgroup leaf, or lease; shell commands run in-process
 #                         at the pod's own quota.
 #
@@ -116,11 +116,37 @@ buildAdmission:
 # Every precondition fails CLOSED: an unusable render is refused at dispatch
 # before a Job is submitted, and a launcher that cannot establish its delegation
 # exits non-zero before binding its socket.
+#
+# WHY THE DEFAULT IS `disabled` — READ BEFORE CHANGING IT
+# -------------------------------------------------------
+# `required` is not a value this chart can default to on its own, because an
+# armed launcher is only half of a pair. `validate_enforcement_render` refuses
+# to dispatch when `cgroupLauncher.mode: required` is paired with
+# `cgroupWritable.taskRuns.enabled: false`, and that pairing was this file's
+# default through v0.7.25: a fresh `helm install` with stock values could not
+# dispatch a single task on any node, and production went down for exactly that
+# reason on 2026-07-29. The two knobs must move together or not at all.
+#
+# Arming is therefore an explicit, three-line act with node prerequisites:
+#
+#   cgroupLauncher:  { mode: required }
+#   cgroupWritable:  { runtimeClass: { enabled: true }, taskRuns: { enabled: true } }
+#
+# and only after the nodes pass
+# `deploy/node/k3s/djinn-cgroup-writable-conformance.sh` and carry
+# `djinn.io/cgroup-writable=true` — otherwise the RuntimeClass assignment
+# leaves task-run Pods unschedulable, which is a slower failure but a failure
+# all the same. Defaulting the OTHER way (arming everything out of the box)
+# would ship precisely that.
+#
+# `deploy/preflight/render-gate.sh` runs the real dispatch validator against a
+# real render; run it against the values you are about to deploy before you
+# deploy them.
 cgroupLauncher:
-  # Production task-runs must use the brokered invocation-leaf path. Set this
-  # explicitly to `disabled` only for local/development environments where the
-  # launcher runtime profile is intentionally unavailable.
-  mode: required
+  # Production task-runs should use the brokered invocation-leaf path, but must
+  # opt in together with `cgroupWritable` above. The stock default is the
+  # prerequisite-free profile that any cluster can actually dispatch.
+  mode: disabled
 
 # -----------------------------------------------------------------------------
 # Writable cgroup preparation rollout
@@ -134,6 +160,11 @@ cgroupLauncher:
 # only makes the class available; it neither changes launcher privileges nor
 # assigns it to task-run Pods. taskRuns may only be enabled together with
 # runtimeClass in the activation release.
+#
+# `taskRuns.enabled` is also the other half of `cgroupLauncher.mode` above:
+# `required` + `taskRuns.enabled: false` is refused at dispatch
+# (`RenderValidationError::MissingDelegatedRuntimeClass`) and produces zero
+# Jobs, which is the outage this default pairing caused on 2026-07-29.
 cgroupWritable:
   runtimeClass:
     enabled: false

--- a/deploy/preflight/render-gate.sh
+++ b/deploy/preflight/render-gate.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Deploy-time preflight: would this chart render, with THESE values, dispatch?
+#
+# WHY THIS EXISTS
+# ---------------
+# v0.7.25 shipped `djinn_k8s::launcher::validate_enforcement_render`, a
+# fail-closed check that runs at dispatch before a Job is submitted. Its
+# rejection condition — `cgroupLauncher.mode: required` paired with
+# `cgroupWritable.taskRuns.enabled: false` — was *the chart's own default
+# pairing*. Every dispatch in production died at `runtime.prepare` with
+# `MissingDelegatedRuntimeClass`, a Job was never created, and a fresh
+# `helm install` with stock values could not have run a single task on any
+# node. Nothing caught it because no test ever ran the real validator against a
+# real render: the chart tests asserted the rendered *values* were the expected
+# ones, which they were.
+#
+# This gate closes exactly that hole and nothing more. It renders the chart the
+# way a deploy would, pulls the `DJINN_K8S_*` environment out of the RENDERED
+# djinn-server container, and runs the crate's OWN validator over it. It is a
+# render-shaped question answered by the dispatch-time code, so it cannot drift
+# from what dispatch will decide.
+#
+# WHAT IT IS NOT
+# --------------
+# It is not a cluster check. It answers "would the server refuse this render at
+# dispatch", not "do the nodes satisfy the runtime prerequisites" — node
+# labels, the containerd handler, and cgroup delegation are the subject of
+# `deploy/node/k3s/djinn-cgroup-writable-conformance.sh`.
+#
+# USAGE
+#   deploy/preflight/render-gate.sh <chart-dir> [helm template args...]
+#
+#   # stock chart defaults
+#   deploy/preflight/render-gate.sh deploy/helm/djinn
+#
+#   # the values a real deployment would apply (production values live in the
+#   # djinn-vps-deploy repo, so an operator points at them from there)
+#   deploy/preflight/render-gate.sh deploy/helm/djinn --values prod-values.yaml
+#
+# Exit status: 0 the render dispatches; non-zero it does not, with the
+# rejecting `RenderValidationError` variant named on stderr.
+#
+# Environment overrides (used by deploy/preflight/tests/render-gate.sh):
+#   HELM            helm executable (default: helm)
+#   RENDER_GATE_BIN path to the `render-gate` binary (default: build it)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HELM="${HELM:-helm}"
+RELEASE_NAME="djinn-render-gate"
+
+die() {
+  printf 'render-gate: %s\n' "$1" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+usage: render-gate.sh <chart-dir> [helm template args...]
+
+Renders the chart, extracts the DJINN_K8S_* environment of the rendered
+djinn-server container, and runs djinn_k8s::launcher::validate_enforcement_render
+over it. Exit 0 when the render would dispatch, non-zero when it would not.
+
+  render-gate.sh deploy/helm/djinn
+  render-gate.sh deploy/helm/djinn --values prod-values.yaml
+  render-gate.sh deploy/helm/djinn --set cgroupLauncher.mode=disabled
+EOF
+}
+
+case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  '')
+    usage >&2
+    die "a chart directory is required"
+    ;;
+esac
+
+CHART_DIR="$1"
+shift
+[ -d "$CHART_DIR" ] || die "chart directory does not exist: $CHART_DIR"
+CHART_DIR="$(cd "$CHART_DIR" && pwd)"
+
+command -v python3 >/dev/null 2>&1 || die "required tool 'python3' is not installed"
+command -v "$HELM" >/dev/null 2>&1 || die "required tool '$HELM' is not installed"
+
+# Locate the validator binary. It is a thin shell over the real
+# `validate_enforcement_render`; building it is the only way to run the actual
+# rule rather than a transcription of it.
+BIN="${RENDER_GATE_BIN:-}"
+if [ -z "$BIN" ]; then
+  BIN="${CARGO_TARGET_DIR:-$REPO_DIR/server/target}/debug/render-gate"
+  if [ ! -x "$BIN" ]; then
+    command -v cargo >/dev/null 2>&1 ||
+      die "render-gate binary missing ($BIN) and cargo is unavailable to build it"
+    cargo build --manifest-path "$REPO_DIR/server/Cargo.toml" \
+      -p djinn-k8s --bin render-gate >&2
+  fi
+fi
+[ -x "$BIN" ] || die "render-gate binary is not executable: $BIN"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The render is the subject under test. Everything below reads THIS file; the
+# `--set`/`--values` arguments are never consulted again, which is what makes
+# the gate honest about templates that ignore, override, or drop a value.
+#
+# `--is-upgrade` is supplied unconditionally, and it is the only argument this
+# gate adds. `.Release.IsInstall` is the chart's SOLE branch on install-vs-
+# upgrade (deployment-server.yaml requires `migration.designatedOperatorSecret`
+# on a fresh install), and that bootstrap secret has nothing to do with whether
+# a render dispatches. Without the flag the stock-defaults question — the one
+# that went unanswered through the 2026-07-29 outage — could not be asked at
+# all. Repeating the flag is harmless if a caller passes it too.
+"$HELM" template "$RELEASE_NAME" "$CHART_DIR" --is-upgrade "$@" >"$WORK/rendered.yaml" ||
+  die "helm template failed for chart $CHART_DIR"
+
+# Reduce the render to the environment the kubelet would hand the djinn-server
+# container: `envFrom` ConfigMap keys first, then explicit `env` entries, with
+# later entries winning — the kubelet's own precedence, so a chart that emits a
+# name twice is judged the way the cluster would resolve it rather than the way
+# a reader might hope.
+python3 - "$WORK/rendered.yaml" >"$WORK/env.nul" <<'PY'
+import sys
+from pathlib import Path
+
+import yaml
+
+PREFIX = 'DJINN_K8S_'
+# Without these two the pairing that caused the outage is unobservable, so an
+# absent name is a gate failure and not a silent fallback to a code default.
+REQUIRED = ('DJINN_K8S_CGROUP_LAUNCHER_MODE', 'DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED')
+
+rendered = Path(sys.argv[1]).read_text(encoding='utf-8')
+documents = [doc for doc in yaml.safe_load_all(rendered) if isinstance(doc, dict)]
+
+
+def fail(message):
+    sys.stderr.write(f'render-gate: {message}\n')
+    raise SystemExit(1)
+
+
+def warn(message):
+    sys.stderr.write(f'render-gate: warning: {message}\n')
+
+
+config_maps = {
+    doc.get('metadata', {}).get('name'): doc.get('data') or {}
+    for doc in documents
+    if doc.get('kind') == 'ConfigMap'
+}
+
+servers = [
+    container
+    for doc in documents
+    if doc.get('kind') == 'Deployment'
+    for container in (doc.get('spec', {}).get('template', {}).get('spec', {}).get('containers')
+                      or [])
+    if container.get('name') == 'djinn-server'
+]
+if len(servers) != 1:
+    fail(f'expected exactly one rendered djinn-server container, found {len(servers)}')
+container = servers[0]
+
+environment = {}
+
+for source in container.get('envFrom') or []:
+    reference = source.get('configMapRef')
+    if not reference:
+        # Secret-sourced env cannot be evaluated from a render at all. Only
+        # complain if it could plausibly carry the names we depend on.
+        warn('ignoring a non-ConfigMap envFrom source; DJINN_K8S_* from it is invisible here')
+        continue
+    name = reference.get('name')
+    if name not in config_maps:
+        warn(f'envFrom ConfigMap {name!r} is not part of this render; its keys are invisible here')
+        continue
+    for key, value in config_maps[name].items():
+        if key.startswith(PREFIX):
+            environment[key] = str(value)
+
+for entry in container.get('env') or []:
+    name = entry.get('name', '')
+    if not name.startswith(PREFIX):
+        continue
+    if 'value' not in entry:
+        fail(f'{name} is rendered via valueFrom; a render gate cannot evaluate it')
+    value = str(entry['value'])
+    if name in environment and environment[name] != value:
+        # The kubelet takes the last one. Say so loudly: a duplicate that
+        # disagrees is how an `extraEnv` override silently re-arms a knob.
+        warn(f'{name} rendered more than once with differing values '
+             f'({environment[name]!r} then {value!r}); the kubelet applies the last, and so does '
+             f'this gate')
+    environment[name] = value
+
+missing = [name for name in REQUIRED if name not in environment]
+if missing:
+    fail('the rendered djinn-server container does not set ' + ', '.join(missing))
+
+out = sys.stdout
+for name, value in sorted(environment.items()):
+    out.write(f'{name}={value}\0')
+PY
+
+pairs=()
+while IFS= read -r -d '' pair; do
+  pairs+=("$pair")
+done <"$WORK/env.nul"
+[ "${#pairs[@]}" -gt 0 ] || die "no DJINN_K8S_* environment was extracted from the render"
+
+# `env -i` is the point: the verdict must depend on the RENDER, never on the
+# DJINN_K8S_* variables that happen to be exported in the operator's shell.
+env -i "${pairs[@]}" "$BIN"

--- a/deploy/preflight/tests/render-gate.sh
+++ b/deploy/preflight/tests/render-gate.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Acceptance contract for deploy/preflight/render-gate.sh.
+#
+# The gate exists because v0.7.25's dispatch validator rejected the chart's own
+# default values, so this suite is organised around two questions the 2026-07-29
+# outage proved nobody was asking:
+#
+#   1. Does the gate reject the pairing that actually caused the outage, accept
+#      the pairings that work, and accept the STOCK chart defaults?
+#   2. Does it read the RENDER, or is it just paraphrasing the `--set` flags it
+#      was handed? A gate that reads flags would have passed the outage render,
+#      because the fatal values were the chart's own defaults, not flags.
+#
+# Question 2 is settled by driving the gate through a stubbed `helm` that emits
+# a fixture manifest regardless of its arguments: known-bad flags with a
+# known-good render must PASS, and known-good flags with a render whose ONLY
+# difference is one env value must FAIL.
+#
+# Usage: bash deploy/preflight/tests/render-gate.sh
+#
+# Overrides (for deliberately mutating the tool to check this suite is not
+# vacuous — see the PR description for the recorded runs):
+#   RENDER_GATE      path to the gate script under test
+#   RENDER_GATE_BIN  path to the render-gate binary the gate should use
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CHART_DIR="$REPO_DIR/deploy/helm/djinn"
+GATE="${RENDER_GATE:-$REPO_DIR/deploy/preflight/render-gate.sh}"
+CHART_CONTRACT="$REPO_DIR/deploy/helm/djinn/tests/cgroup-writable-render.sh"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'FAIL: required test tool %s is not installed\n' "$1" >&2
+    exit 1
+  }
+}
+require_tool helm
+require_tool python3
+require_tool bash
+require_tool cargo
+
+[ -x "$GATE" ] || [ -f "$GATE" ] || {
+  printf 'FAIL: gate script not found: %s\n' "$GATE" >&2
+  exit 1
+}
+
+# Build once here so an individual case never pays for it and a compile error
+# is reported as a compile error rather than as a gate verdict.
+if [ -z "${RENDER_GATE_BIN:-}" ]; then
+  cargo build --manifest-path "$REPO_DIR/server/Cargo.toml" -p djinn-k8s --bin render-gate
+  RENDER_GATE_BIN="${CARGO_TARGET_DIR:-$REPO_DIR/server/target}/debug/render-gate"
+fi
+export RENDER_GATE_BIN
+[ -x "$RENDER_GATE_BIN" ] || {
+  printf 'FAIL: render-gate binary is not executable: %s\n' "$RENDER_GATE_BIN" >&2
+  exit 1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+failures=0
+case_index=0
+
+# Runs the gate and asserts exit status plus, optionally, a required substring
+# of its combined output. Both halves matter: an exit code alone cannot tell a
+# `MissingDelegatedRuntimeClass` rejection apart from a helm crash.
+expect_gate() {
+  local label=$1 want=$2 needle=$3
+  shift 3
+  case_index=$((case_index + 1))
+  local out status
+  set +e
+  out=$("$GATE" "$@" 2>&1)
+  status=$?
+  set -e
+  if [ "$want" = pass ] && [ "$status" -ne 0 ]; then
+    printf 'FAIL [%s]: expected exit 0, got %s\n%s\n' "$label" "$status" "$out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [ "$want" = fail ] && [ "$status" -eq 0 ]; then
+    printf 'FAIL [%s]: expected a non-zero exit, got 0\n%s\n' "$label" "$out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if [ -n "$needle" ] && ! printf '%s' "$out" | grep -qF -- "$needle"; then
+    printf 'FAIL [%s]: output does not mention %s\n%s\n' "$label" "$needle" "$out" >&2
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok [%s]\n' "$label"
+}
+
+# ---------------------------------------------------------------------------
+# 1. The launcher pairing, through the real chart.
+# ---------------------------------------------------------------------------
+expect_gate 'armed launcher without the task-run RuntimeClass is refused' \
+  fail 'MissingDelegatedRuntimeClass' \
+  "$CHART_DIR" --set cgroupLauncher.mode=required --set cgroupWritable.taskRuns.enabled=false
+
+expect_gate 'armed launcher with the task-run RuntimeClass dispatches' \
+  pass 'DISPATCHABLE' \
+  "$CHART_DIR" --set cgroupLauncher.mode=required \
+  --set cgroupWritable.taskRuns.enabled=true --set cgroupWritable.runtimeClass.enabled=true
+
+expect_gate 'disarmed launcher dispatches without the RuntimeClass' \
+  pass 'DISPATCHABLE' \
+  "$CHART_DIR" --set cgroupLauncher.mode=disabled --set cgroupWritable.taskRuns.enabled=false
+
+# The regression that took production down: a stock `helm install` of the chart
+# has to be able to dispatch, with no operator overrides at all.
+expect_gate 'stock chart defaults dispatch' pass 'DISPATCHABLE' "$CHART_DIR"
+
+# ---------------------------------------------------------------------------
+# 2. A chart whose values.yaml restores the fatal default must be rejected by
+#    BOTH the gate and the hermetic chart contract.
+# ---------------------------------------------------------------------------
+ARMED_CHART="$WORK/chart-armed-default"
+cp -R "$CHART_DIR" "$ARMED_CHART"
+python3 - "$ARMED_CHART/values.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+lines = path.read_text(encoding='utf-8').splitlines(keepends=True)
+patched = 0
+for index, line in enumerate(lines):
+    if line.rstrip('\n') == 'cgroupLauncher:':
+        for offset in range(index + 1, len(lines)):
+            stripped = lines[offset].strip()
+            if stripped.startswith('mode:'):
+                assert stripped == 'mode: disabled', f'unexpected default launcher mode: {stripped}'
+                lines[offset] = lines[offset].replace('mode: disabled', 'mode: required')
+                patched += 1
+                break
+        break
+assert patched == 1, 'cgroupLauncher.mode was not found in values.yaml'
+path.write_text(''.join(lines), encoding='utf-8')
+PY
+
+expect_gate 'values.yaml restoring cgroupLauncher.mode=required is refused' \
+  fail 'MissingDelegatedRuntimeClass' "$ARMED_CHART"
+
+case_index=$((case_index + 1))
+set +e
+contract_out=$(DJINN_CHART_DIR="$ARMED_CHART" bash "$CHART_CONTRACT" 2>&1)
+contract_status=$?
+set -e
+if [ "$contract_status" -eq 0 ]; then
+  printf 'FAIL [chart contract rejects the restored fatal default]: expected non-zero, got 0\n%s\n' \
+    "$contract_out" >&2
+  failures=$((failures + 1))
+elif ! printf '%s' "$contract_out" | grep -qF 'undispatchable render'; then
+  printf 'FAIL [chart contract rejects the restored fatal default]: rejected for the wrong reason\n%s\n' \
+    "$contract_out" >&2
+  failures=$((failures + 1))
+else
+  printf 'ok [chart contract rejects the restored fatal default]\n'
+fi
+
+# The same contract must still pass against the unmodified chart, or the check
+# above proves only that something, somewhere, is broken.
+case_index=$((case_index + 1))
+if DJINN_CHART_DIR="$CHART_DIR" bash "$CHART_CONTRACT" >"$WORK/contract-clean.log" 2>&1; then
+  printf 'ok [chart contract passes against the shipped chart]\n'
+else
+  printf 'FAIL [chart contract passes against the shipped chart]\n%s\n' \
+    "$(cat "$WORK/contract-clean.log")" >&2
+  failures=$((failures + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The gate reads the RENDER, not the flags.
+# ---------------------------------------------------------------------------
+# One real, dispatchable render is the base for every fixture below, so each
+# one differs from a genuinely working deployment by exactly the mutation named.
+helm template render-gate-fixture "$CHART_DIR" --is-upgrade \
+  --set cgroupLauncher.mode=required \
+  --set cgroupWritable.runtimeClass.enabled=true \
+  --set cgroupWritable.taskRuns.enabled=true >"$WORK/good.yaml"
+
+# Line-scoped edits of one `- name:`/`value:` env pair. Deliberately not a YAML
+# round-trip: a re-serialised manifest differs from the real render in a hundred
+# incidental ways, and the claim being tested is that ONE value flips the
+# verdict.
+mutate() {
+  python3 - "$1" "$2" "$3" "$4" "${5:-}" <<'PY'
+import sys
+from pathlib import Path
+
+source, destination, operation, name, value = sys.argv[1:6]
+lines = Path(source).read_text(encoding='utf-8').splitlines(keepends=True)
+hits = [i for i, line in enumerate(lines) if line.strip() == f'- name: {name}']
+assert len(hits) == 1, f'expected exactly one {name} env entry, found {len(hits)}'
+index = hits[0]
+assert lines[index + 1].strip().startswith('value:'), f'{name} is not a literal-value env entry'
+indent = lines[index].split('-', 1)[0]
+
+if operation == 'set-value':
+    lines[index + 1] = f'{indent}  value: "{value}"\n'
+elif operation == 'duplicate':
+    lines[index + 2:index + 2] = [f'{indent}- name: {name}\n', f'{indent}  value: "{value}"\n']
+elif operation == 'delete':
+    del lines[index:index + 2]
+else:
+    raise SystemExit(f'unknown operation {operation}')
+
+Path(destination).write_text(''.join(lines), encoding='utf-8')
+PY
+}
+
+# A `helm` that ignores every argument it is given and prints a fixed manifest.
+# Whatever verdict the gate reaches under this stub came from the render.
+stub_helm() {
+  local fixture=$1 path="$WORK/helm-stub-$2"
+  cat >"$path" <<EOF
+#!/usr/bin/env bash
+cat '$fixture'
+EOF
+  chmod +x "$path"
+  printf '%s' "$path"
+}
+
+ACTIVATION_ENV='DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED'
+mutate "$WORK/good.yaml" "$WORK/bad.yaml" set-value "$ACTIVATION_ENV" false
+python3 - "$WORK/good.yaml" "$WORK/bad.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+good, bad = (Path(path).read_text(encoding='utf-8').splitlines() for path in sys.argv[1:3])
+differences = [(a, b) for a, b in zip(good, bad) if a != b]
+assert len(good) == len(bad), 'the fixture changed more than one line'
+assert len(differences) == 1, f'expected exactly one differing line, got {differences}'
+assert 'value:' in differences[0][0], f'the differing line is not an env value: {differences[0]}'
+PY
+
+HELM="$(stub_helm "$WORK/good.yaml" good)" \
+  expect_gate 'a dispatchable render passes despite undispatchable --set flags' \
+  pass 'DISPATCHABLE' \
+  "$CHART_DIR" --set cgroupLauncher.mode=required --set cgroupWritable.taskRuns.enabled=false
+
+HELM="$(stub_helm "$WORK/bad.yaml" bad)" \
+  expect_gate 'one flipped env value in the render fails despite dispatchable --set flags' \
+  fail 'MissingDelegatedRuntimeClass' \
+  "$CHART_DIR" --set cgroupLauncher.mode=required \
+  --set cgroupWritable.taskRuns.enabled=true --set cgroupWritable.runtimeClass.enabled=true
+
+# ---------------------------------------------------------------------------
+# 4. Env extraction: duplicates resolve the way the kubelet resolves them, and
+#    a name the render never sets is an error rather than a code default.
+# ---------------------------------------------------------------------------
+mutate "$WORK/good.yaml" "$WORK/dup-last-false.yaml" duplicate "$ACTIVATION_ENV" false
+mutate "$WORK/bad.yaml" "$WORK/dup-last-true.yaml" duplicate "$ACTIVATION_ENV" true
+mutate "$WORK/good.yaml" "$WORK/no-mode.yaml" delete DJINN_K8S_CGROUP_LAUNCHER_MODE
+
+HELM="$(stub_helm "$WORK/dup-last-false.yaml" duplast-false)" \
+  expect_gate 'a duplicated env name resolves to the LAST entry (true then false)' \
+  fail 'MissingDelegatedRuntimeClass' "$CHART_DIR"
+
+HELM="$(stub_helm "$WORK/dup-last-true.yaml" duplast-true)" \
+  expect_gate 'a duplicated env name resolves to the LAST entry (false then true)' \
+  pass 'DISPATCHABLE' "$CHART_DIR"
+
+HELM="$(stub_helm "$WORK/no-mode.yaml" no-mode)" \
+  expect_gate 'a render that omits the launcher mode is an error, not a default' \
+  fail 'does not set DJINN_K8S_CGROUP_LAUNCHER_MODE' "$CHART_DIR"
+
+# ---------------------------------------------------------------------------
+if [ "$failures" -ne 0 ]; then
+  printf 'FAIL: %s of %s render-gate cases failed\n' "$failures" "$case_index" >&2
+  exit 1
+fi
+printf 'PASS: render preflight contract (%s cases)\n' "$case_index"

--- a/server/crates/djinn-k8s/src/bin/render-gate.rs
+++ b/server/crates/djinn-k8s/src/bin/render-gate.rs
@@ -1,0 +1,62 @@
+//! Deploy-time preflight: would this RENDERED chart be able to dispatch?
+//!
+//! On 2026-07-29 a release shipped a fail-closed dispatch validator
+//! ([`validate_enforcement_render`]) whose rejection condition was *the chart's
+//! own default values*: `cgroupLauncher.mode: required` paired with
+//! `cgroupWritable.taskRuns.enabled: false`. Every dispatch died at
+//! `runtime.prepare` with `MissingDelegatedRuntimeClass` before a Job was ever
+//! submitted, and no repository test noticed, because nothing ran the real
+//! validator against a real render.
+//!
+//! This binary is that missing link, and it is deliberately thin: it rebuilds
+//! the `KubernetesConfig` djinn-server itself builds at startup — via the same
+//! [`KubernetesConfig::from_env`] the server calls, so env-name drift or a
+//! parsing quirk is inherited rather than re-implemented — and hands it to the
+//! REAL `validate_enforcement_render`. There is no second copy of the rule
+//! here; if the crate's rule changes, this gate changes with it.
+//!
+//! The environment it reads is the environment of *the rendered djinn-server
+//! container*, not of whoever ran the deploy: `deploy/preflight/render-gate.sh`
+//! extracts it from `helm template` output and re-execs this binary under
+//! `env -i`, so the only `DJINN_K8S_*` values visible here are the ones the
+//! cluster would give the server pod.
+//!
+//! Exit status is the whole contract: `0` — the render dispatches; `1` — it
+//! does not, and stderr names the rejecting `RenderValidationError` variant.
+
+use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::launcher::validate_enforcement_render;
+use std::process::ExitCode;
+
+#[allow(clippy::print_stdout, clippy::print_stderr)]
+fn main() -> ExitCode {
+    let config = KubernetesConfig::from_env();
+    // Echoed on both paths: a gate that says only "REJECT" leaves an operator
+    // guessing which of the rendered knobs produced the verdict.
+    let summary = format!(
+        "cgroup_launcher_mode={} task_run_cgroup_writable_enabled={} \
+         cgroup_delegation_profile={} volume_ownership_mode={} cpu_limit={}",
+        config.cgroup_launcher_mode.as_str(),
+        config.task_run_cgroup_writable_enabled,
+        config.cgroup_delegation_profile,
+        config.volume_ownership_mode,
+        config.cpu_limit,
+    );
+
+    match validate_enforcement_render(&config) {
+        Ok(()) => {
+            println!("render-gate: DISPATCHABLE {summary}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            // `{error:?}` names the variant (e.g. `MissingDelegatedRuntimeClass`)
+            // and `{error}` carries the operator-facing explanation. Callers —
+            // including deploy/preflight/tests/render-gate.sh — assert on the
+            // variant name, which is stable in a way prose is not.
+            eprintln!("render-gate: UNDISPATCHABLE {summary}");
+            eprintln!("render-gate: RenderValidationError::{error:?}");
+            eprintln!("render-gate: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
## The chart's stock defaults could not dispatch a task

`deploy/helm/djinn/values.yaml` shipped `cgroupLauncher.mode: required` together with
`cgroupWritable.taskRuns.enabled: false`. That is precisely the pairing
`djinn_k8s::launcher::validate_enforcement_render` (added in #2735) refuses:

```
enforcement render validation failed: cgroup launcher mode is 'required',
but task-run RuntimeClass assignment is disabled
```

Every dispatch died at `runtime.prepare` before a Job was ever submitted. A fresh
`helm install` of v0.7.25 with stock values could not have run a single task, on any node.

**And the existing render test certified that fatal default as correct.**
`deploy/helm/djinn/tests/cgroup-writable-render.sh` asserted the default render sets
`DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED=false` — true — and never asked which
`cgroupLauncher.mode` was rendered beside it. Nothing in the repository ever ran the real
validator against a real render, so CI was green through the entire outage.

## What this changes

**1. `deploy/preflight/render-gate.sh` (new) + `server/crates/djinn-k8s/src/bin/render-gate.rs` (new)**

Renders a chart the way a deploy would (`helm template`, same values files and flags),
extracts the `DJINN_K8S_*` environment out of the **rendered** djinn-server container, and
runs the crate's own `validate_enforcement_render` over it. Non-zero exit if the render
would not dispatch, with the rejecting `RenderValidationError` variant named on stderr.

There is no second copy of the rule. The binary calls `KubernetesConfig::from_env()` — the
same constructor djinn-server uses at startup — under `env -i`, so env-name drift or a
parsing quirk is inherited rather than re-implemented, and the operator's own shell cannot
influence the verdict.

```
$ deploy/preflight/render-gate.sh deploy/helm/djinn --set cgroupLauncher.mode=required --set cgroupWritable.taskRuns.enabled=false
render-gate: UNDISPATCHABLE cgroup_launcher_mode=required task_run_cgroup_writable_enabled=false ...
render-gate: RenderValidationError::MissingDelegatedRuntimeClass
```

It is a CLI, so `djinn-vps-deploy` (where the real production values live, in
`group_vars/all/main.yml`) or any operator can point it at real values files:
`render-gate.sh deploy/helm/djinn --values prod-values.yaml`.

**2. `deploy/helm/djinn/values.yaml` — the default is now dispatchable**

`cgroupLauncher.mode` defaults to `disabled`. Arming is an explicit, three-line act with
node prerequisites:

```yaml
cgroupLauncher: { mode: required }
cgroupWritable: { runtimeClass: { enabled: true }, taskRuns: { enabled: true } }
```

Defaulting the other way — arming everything out of the box — would render task-run Pods
assigned to a RuntimeClass whose nodeSelector no stock cluster satisfies, leaving them
Pending forever. That is a slower failure, not a better one.

**3. `deploy/helm/djinn/tests/cgroup-writable-render.sh` — the assertion is inverted**

The test now rejects the `required` + `false` pairing it used to approve, across the
default, preparation, activation and armed renders, with an in-file non-vacuity check that
flips only the launcher mode and requires the new assertion to fire. This is the hermetic
half (helm + python3 only, no Rust toolchain), so the chart-contract lane that CI already
globs cannot reintroduce the pairing.

## Scope note on `release.yml`

The proposal text asked for a gate in `.github/workflows/release.yml` "before the version
bump completes". That was not implemented, deliberately: `release.yml` triggers on an
already-pushed `v*` tag, only builds and publishes images, has no version-bump step, and
never sees production Helm values (a separate repo). A gate there cannot prevent the bump
it claims to prevent. What is promised here is what repository CI can actually enforce —
the stock-chart render assertion in the globbed chart-contract lane — plus an explicit CLI
an operator or another repo can invoke against real values.

`deploy/preflight/tests/render-gate.sh` is not wired into a CI lane because it requires a
cargo build, which the helm-contract lane has no toolchain for. Run it locally or from a
Rust-capable lane.

## Verification

`deploy/preflight/tests/render-gate.sh` — 12 cases, all green. Every case in the task brief
is covered, including "same command, one flipped env value in the render, opposite verdict".

Non-vacuity was demonstrated by two temporary mutations (run manually, not committed as
permanent scaffolding):

- replacing the `validate_enforcement_render` call in `render-gate.rs` with unconditional
  success → **4 of 12 cases fail**;
- stubbing the render step in `render-gate.sh` to emit a fixed known-good environment
  regardless of input → **5 of 12 cases fail**.

Also run: `bash -n` on all three scripts, `rustfmt --edition 2024 --check`,
`cargo clippy -p djinn-k8s --bin render-gate -- -D warnings`, `helm lint` (both value sets),
and the full `scripts/test-helm-chart-contracts.sh` roster (13/15 pass; the two failures are
`incident-observability-contract.sh` and `log-collector-contract.sh`, both `FAIL: vector is
required to execute VRL fixtures` — a missing local tool, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
