### PR TITLE
ci: run the orphaned deploy contract suites

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -273,13 +273,24 @@ jobs:
             scripts/test-tiltfile-config.sh \
             scripts/test-wrap-agent-runtime-image.sh \
             scripts/test-helm-github-app-render.sh \
-            scripts/test-helm-chart-contracts.sh
+            scripts/test-helm-chart-contracts.sh \
+            scripts/test-deploy-contracts.sh
       - name: Test content-addressed warm builds
         run: bash scripts/test-tilt-warm-restart.sh
       - name: Test isolated Tilt configuration
         run: KUBECONFIG=/dev/null sh scripts/test-tiltfile-config.sh
       - name: Test runtime-base self-healing wrapper
         run: bash scripts/test-wrap-agent-runtime-image.sh
+      # deploy/node/k3s/tests/ and deploy/runbooks/tests/ were unreachable from
+      # any workflow until this step existed: scripts/test-helm-chart-contracts.sh
+      # globs only the chart's own tests directory, so four suites had never run
+      # in CI once — including deploy/runbooks/tests/bzpt-production-activation.sh,
+      # which was an acceptance criterion of proposal d308. These need nothing
+      # but bash, which is why they are hosted here rather than on a Rust lane.
+      # The runner globs directories and fails on an empty roster, so a new
+      # suite dropped into either directory runs here with no edit to this file.
+      - name: Test deploy contracts (node, runbooks)
+        run: bash scripts/test-deploy-contracts.sh
       - name: Lint local and default Helm values
         run: |
           helm lint deploy/helm/djinn
@@ -630,11 +641,24 @@ jobs:
       SQLX_OFFLINE: "true"
     steps:
       - uses: actions/checkout@v4
+      # For the deploy render-gate contract at the end of this job. That suite
+      # needs BOTH `helm` and a BUILT `render-gate` binary
+      # (server/crates/djinn-k8s), so it cannot go on local-dev-contracts: that
+      # lane has helm but no Rust, and would pay for a cold toolchain and a cold
+      # djinn-k8s build. Here the `server-test` rust-cache family is already
+      # restored, so the build is incremental. Pinned to the same v3.12.3
+      # local-dev-contracts installs — two lanes rendering the same chart on
+      # different helm majors is a contract that means nothing.
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.12.3
       - run: rustup toolchain install
         working-directory: server
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
+          # NOTE: the `azure/setup-helm@v4` step above this one is for the
+          # deploy render-gate contract at the END of this job, not for clippy.
           # The dedicated `server-quality` family is gone. After #2342 moved
           # server-sqlx-freshness and memory-eval onto server-test, it served
           # exactly one job — this one — while holding ~2.5 GB of a 10 GB
@@ -759,6 +783,17 @@ jobs:
           before='${{ steps.fingerprints-restored.outputs.count }}'
           after=$(ls target/debug/.fingerprint 2>/dev/null | wc -l)
           echo "::notice::clippy-fingerprints restored=${before:-0} after=${after} built=$((after - ${before:-0}))"
+      # deploy/preflight/tests/ had never executed in CI. It is a DEPLOY
+      # contract, not a Rust one, and it is hosted on this lane only because it
+      # must `cargo build -p djinn-k8s --bin render-gate` and shell out to
+      # `helm`: this is the cheapest lane in the file that already has both a
+      # warm Rust cache and (as of the setup-helm step above) helm. Runs last so
+      # a failure here is never confused with a clippy failure, and so it cannot
+      # delay the lint signal. The directory is globbed by the runner, not
+      # enumerated, so a second preflight suite needs no edit here.
+      - name: Test deploy render-gate contract
+        working-directory: ${{ github.workspace }}
+        run: bash scripts/test-deploy-contracts.sh deploy/preflight/tests
   launcher-kernel-boundary:
     name: Launcher Kernel Boundary
     needs: preflight

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -633,7 +633,15 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.clippy == 'true' && github.event_name != 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Raised from 25 when the deploy render-gate contract moved onto this lane.
+    # Measured on run 30479829505: Clippy 3m21s, render-gate 7m42s, job 11m50s
+    # (this lane was ~4m9s before). The render-gate step is slower than its
+    # ~1m local build because `cargo clippy` emits CHECK-mode artifacts for the
+    # workspace crates, so `cargo build -p djinn-k8s` recompiles the whole
+    # djinn-db -> djinn-core -> djinn-k8s chain in build mode; only the
+    # third-party deps come from the restored cache. 25 minutes left too little
+    # margin for a cold-cache run on top of that.
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: server

--- a/scripts/test-deploy-contracts.sh
+++ b/scripts/test-deploy-contracts.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Runs the deploy contract suites that live OUTSIDE deploy/helm/djinn/tests/.
+#
+# scripts/test-helm-chart-contracts.sh globs exactly one directory, so its
+# "drop a script in and CI runs it" guarantee stopped at the chart's own tests.
+# Five suites under deploy/node/k3s/tests/, deploy/runbooks/tests/ and
+# deploy/preflight/tests/ were written, reviewed, merged — and then never
+# executed by CI even once. One of them
+# (deploy/runbooks/tests/bzpt-production-activation.sh) was an acceptance
+# criterion of proposal d308. This runner is the missing half of that
+# guarantee.
+#
+# The directories are globbed, never enumerated: a new contract script dropped
+# into one of them is picked up here (and therefore by CI) with no edit to this
+# file. Any non-zero exit fails the whole run, and every script's output is
+# printed so a CI failure is diagnosable from the first log without a rerun.
+#
+# Usage:
+#   bash scripts/test-deploy-contracts.sh              # the shell-only suites
+#   bash scripts/test-deploy-contracts.sh DIR [DIR...] # explicit directories
+#
+# With no arguments this runs the suites that need nothing but bash and the
+# repository checkout, which is why the local-dev-contracts CI lane can host
+# them. deploy/preflight/tests/ is NOT in that default set: it builds
+# server/crates/djinn-k8s's render-gate binary and shells out to `helm`, so it
+# is passed explicitly by a lane that already has a warm Rust toolchain. It is
+# still a globbed DIRECTORY there, not an enumerated file — same guarantee.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Shell-only by construction. Adding a directory here commits the
+# local-dev-contracts lane to running it with no toolchain beyond bash.
+DEFAULT_DIRS=(
+    deploy/node/k3s/tests
+    deploy/runbooks/tests
+)
+
+if [ "$#" -gt 0 ]; then
+    requested=("$@")
+else
+    requested=("${DEFAULT_DIRS[@]}")
+fi
+
+scripts=()
+for requested_dir in "${requested[@]}"; do
+    # Repo-relative is the intended spelling (that is what CI passes), but an
+    # absolute path must resolve to itself rather than be silently concatenated
+    # onto the repo root into a nonsense path that only fails as "missing".
+    case "$requested_dir" in
+        /*) tests_dir="$requested_dir" ;;
+        *) tests_dir="$REPO_ROOT/$requested_dir" ;;
+    esac
+
+    [ -d "$tests_dir" ] || {
+        printf 'FAIL: deploy contract directory is missing: %s\n' "$tests_dir" >&2
+        exit 1
+    }
+
+    shopt -s nullglob
+    # Non-recursive, matching scripts/test-helm-chart-contracts.sh: a
+    # subdirectory is a deliberate quarantine, not a place to hide work from
+    # the runner. If a suite needs one, give it its own top-level directory.
+    found=("$tests_dir"/*.sh)
+    shopt -u nullglob
+
+    # An empty roster is the exact failure this runner exists to fix. A runner
+    # that reports success because it globbed nothing is worse than no runner:
+    # it manufactures the evidence that the suites ran.
+    if [ "${#found[@]}" -eq 0 ]; then
+        printf 'FAIL: no deploy contract scripts found in %s\n' "$tests_dir" >&2
+        exit 1
+    fi
+
+    scripts+=("${found[@]}")
+done
+
+names=()
+results=()
+failures=0
+capture=$(mktemp)
+trap 'rm -f "$capture"' EXIT
+
+for script in "${scripts[@]}"; do
+    name=${script#"$REPO_ROOT/"}
+    names+=("$name")
+
+    # Honour each script's own shebang rather than assuming bash: these suites
+    # are independent of each other and nothing stops a POSIX sh one landing.
+    case "$(head -n 1 "$script")" in
+        *bash) interpreter=bash ;;
+        *) interpreter=sh ;;
+    esac
+
+    if "$interpreter" "$script" >"$capture" 2>&1; then
+        results+=("PASS")
+        printf '::group::PASS %s\n' "$name"
+        cat "$capture"
+        printf '::endgroup::\n'
+    else
+        status=$?
+        results+=("FAIL(exit $status)")
+        failures=$((failures + 1))
+        # Deliberately not grouped: a failing script's output must be visible
+        # in a collapsed-by-default CI log without expanding anything.
+        printf '\n===== FAIL %s (exit %d) =====\n' "$name" "$status"
+        cat "$capture"
+        printf '===== end %s =====\n\n' "$name"
+    fi
+done
+
+printf '\n=== Deploy contract roster (%d scripts) ===\n' "${#scripts[@]}"
+for index in "${!names[@]}"; do
+    printf '%-14s %s\n' "${results[$index]}" "${names[$index]}"
+done
+
+if [ "$failures" -ne 0 ]; then
+    printf '\nFAIL: %d of %d deploy contract scripts failed\n' \
+        "$failures" "${#scripts[@]}" >&2
+    exit 1
+fi
+
+printf '\n=== All %d deploy contract scripts passed ===\n' "${#scripts[@]}"


### PR DESCRIPTION
## Five deploy contract suites have never executed in CI — not once

`scripts/test-helm-chart-contracts.sh` globs exactly one directory. Its own header promises that the directory is "globbed, never enumerated: a new contract script dropped in [runs automatically]" — and that promise is real, but it stops at `deploy/helm/djinn/tests/`. Every contract suite written anywhere else in `deploy/` is unreachable from any workflow.

```
$ grep -rn "runbooks/tests\|node/k3s/tests\|preflight/tests" .github/workflows/ scripts/
(no output)
```

Orphaned, on `main`, today:

| Suite | Status |
| --- | --- |
| `deploy/node/k3s/tests/containerd-config-version-detection.sh` | never run in CI |
| `deploy/node/k3s/tests/conformance-version-lifecycle.sh` | never run in CI |
| `deploy/runbooks/tests/cgroup-launcher-rearm.sh` | never run in CI |
| `deploy/runbooks/tests/bzpt-production-activation.sh` | **never run in CI — and it was one of proposal d308's acceptance criteria.** It has been dead since d308 landed. The AC was attested against a suite that has executed zero times. |
| `deploy/preflight/tests/render-gate.sh` | never run in CI |

That last row is the whole point. A merged suite that no lane invokes is not coverage; it is the appearance of coverage. All five pass today, so nothing is broken right now — which is exactly the window in which to wire them up, before one of them silently starts failing and nobody finds out.

## What this adds

**`scripts/test-deploy-contracts.sh`** (new) — modelled directly on `scripts/test-helm-chart-contracts.sh`: same per-script `PASS`/`FAIL` roster, same `::group::` framing, same ungrouped output on failure so a red CI log is diagnosable without expanding anything, same non-zero exit on any failure.

Two properties it does not inherit but needs:

- **It globs directories, never files.** `deploy/node/k3s/tests/*.sh` and `deploy/runbooks/tests/*.sh` by default, non-recursive (matching the existing runner's deliberate choice). A new suite dropped into either directory runs with no edit to the runner or the workflow.
- **An empty roster is a hard failure.** A silently empty glob is precisely the failure mode this PR exists to fix; a runner that reports success because it found nothing is worse than no runner, because it manufactures the evidence that the suites ran. Both a missing directory and a present-but-empty one exit 1.

It also takes optional directory arguments, so the preflight directory can be hosted on a different lane while still being **globbed rather than enumerated** — the guarantee holds for all three directories, not just the two that share a lane.

## Lane placement

**`local-dev-contracts`** hosts the four shell-only suites. They need nothing but bash and the checkout. The runner is also added to that lane's existing `bash -n` syntax-check list.

**`server-clippy`** hosts `deploy/preflight/tests/render-gate.sh`, because that suite is not shell-only: it runs `cargo build -p djinn-k8s --bin render-gate` and shells out to `helm template`. `local-dev-contracts` has helm but no Rust, and putting it there would mean installing a cold toolchain and doing a cold `djinn-k8s` build on a lane whose whole design is "no toolchain". `server-clippy` already runs `rustup toolchain install` and restores the `server-test` `Swatinem/rust-cache` family — which, per that lane's own comment, now carries *both* the check-mode and build-mode dependency sets — so the build is incremental there. It gains one `azure/setup-helm@v4` step, pinned to **v3.12.3**, the same version `local-dev-contracts` installs: two lanes rendering the same chart on different helm majors would be a contract that means nothing.

The step runs last in the job so a deploy-contract failure is never confused with a clippy failure and cannot delay the lint signal. Headroom is fine: recent `Server Clippy` runs finish in ~4 minutes against a 25-minute timeout, and the local `render-gate` build measured 1m06s warm.

No routing change is needed. `scripts/ci-changed-scope.mjs` is fail-closed — paths under `deploy/node/` and `deploy/runbooks/` are unclassified, which selects full validation, which selects both lanes.

## Verification

All four shell suites pass through the runner (34 + 31 + 1 + 26 assertions), and `deploy/preflight/tests/render-gate.sh` passes through it as well (12 cases, including the stock-chart-defaults case).

The runner was proven non-vacuous two ways, both restored afterwards:

- **Empty roster fails.** Emptying `deploy/runbooks/tests/` and running the default invocation: `FAIL: no deploy contract scripts found in .../deploy/runbooks/tests`, exit 1. It does not report "2 scripts passed".
- **A broken assertion fails.** Mutating one `expect_eq` in `containerd-config-version-detection.sh` produced exit 1, a `FAIL(exit 1)` roster row naming that exact script, and `FAIL: 1 of 4 deploy contract scripts failed`.

Also: `bash -n` clean on the new script, `actionlint -shellcheck= -pyflakes=` clean on the workflow, and the workflow YAML parses.

Diff is two files: the new runner and `quality-gate.yml`. No suite, no file under `deploy/`, and not `test-helm-chart-contracts.sh` was touched.

> Vercel preview checks are currently rate-limited and will show red. They are not required checks.
