### PR TITLE
fix(4q45): conformance probe cannot run under a node-selected RuntimeClass

### DIFF
--- a/deploy/helm/djinn/README.md
+++ b/deploy/helm/djinn/README.md
@@ -217,6 +217,15 @@ has labeled eligible nodes. That installs `RuntimeClass/djinn-cgroup-writable`
 with its existing handler and node selector, but does not assign it to task-run
 Pods or change launcher privileges.
 
+The same value also installs `RuntimeClass/djinn-cgroup-writable-probe`: the
+same `runc-cgroupwritable` handler with no `scheduling` block. The two always
+appear and disappear together. Node conformance uses the probe class because it
+runs on a node that does not yet carry `djinn.io/cgroup-writable=true`; the
+task-run class's merged `nodeSelector` becomes a NodeAffinity predicate the
+kubelet enforces even for a Pod bound by `spec.nodeName`, so a probe naming it
+could never be admitted, and conformance could never pass. Task-run Pods use
+`djinn-cgroup-writable` only — the probe class is never assigned to them.
+
 `cgroupWritable.taskRuns.enabled=true` requires
 `cgroupWritable.runtimeClass.enabled=true`; Helm rejects the unsafe inverse
 pair. Task-run assignment is reserved for the later activation release.

--- a/deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml
+++ b/deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.cgroupWritable.runtimeClass.enabled }}
+# The task-run class. Its scheduling.nodeSelector is what keeps ordinary
+# task-run Pods off nodes that have not passed node conformance: the
+# RuntimeClass admission controller merges the selector into every Pod that
+# names this class, so an unconformed node is never a candidate.
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
@@ -7,4 +11,30 @@ handler: runc-cgroupwritable
 scheduling:
   nodeSelector:
     djinn.io/cgroup-writable: "true"
+---
+# The conformance-probe class. Same containerd handler, deliberately NO
+# scheduling block.
+#
+# Node conformance runs on a node that does not yet carry
+# djinn.io/cgroup-writable=true — proving the node should become eligible is
+# the whole point of the probe, and the conformance program removes the marker
+# before every risky operation. A probe Pod naming the task-run class above is
+# therefore unrunnable: the merged nodeSelector becomes a NodeAffinity
+# predicate, and `spec.nodeName` does not exempt a Pod from it. nodeName
+# bypasses the scheduler, but the kubelet re-evaluates NodeAffinity at
+# admission and rejects the Pod with
+# `Predicate NodeAffinity failed: node(s) didn't match Pod's node
+# affinity/selector`. That is a deadlock: the marker gates the probe that
+# earns the marker.
+#
+# Splitting handler selection from the scheduling constraint resolves it. This
+# class grants no reach a probe did not already have: it is usable only where
+# the containerd handler exists, and elsewhere the sandbox simply fails to
+# create. It is gated by the same cgroupWritable.runtimeClass.enabled value as
+# the class above so the two always appear and disappear together.
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: djinn-cgroup-writable-probe
+handler: runc-cgroupwritable
 {{- end }}

--- a/deploy/helm/djinn/tests/cgroup-writable-render.sh
+++ b/deploy/helm/djinn/tests/cgroup-writable-render.sh
@@ -71,23 +71,94 @@ def documents(text):
 def runtime_classes(text):
     return [doc for doc in documents(text) if '\nkind: RuntimeClass\n' in f'\n{doc}']
 
+
+TASK_RUN_CLASS = 'djinn-cgroup-writable'
+PROBE_CLASS = 'djinn-cgroup-writable-probe'
+
+
+def runtime_class_named(text, name):
+    """Return the single RuntimeClass document whose metadata.name is `name`.
+
+    The trailing newline matters: 'name: djinn-cgroup-writable' is a prefix of
+    'name: djinn-cgroup-writable-probe', so a substring test would happily
+    hand back the wrong object and certify the wrong scheduling contract.
+    """
+    matches = [doc for doc in runtime_classes(text) if f'\n  name: {name}\n' in f'\n{doc}\n']
+    assert len(matches) == 1, f'expected exactly one RuntimeClass named {name}, got {len(matches)}'
+    return matches[0]
+
+
+def effective(doc):
+    """Drop comment lines so an assertion reads the spec, not the prose.
+
+    The probe class's rationale necessarily mentions the very words its own
+    negative assertions forbid ('nodeSelector', the eligibility marker), and a
+    comment is not a scheduling constraint.
+    """
+    return '\n'.join(line for line in doc.splitlines() if not line.lstrip().startswith('#'))
+
+
 base, preparation, activation, armed = (
     Path(path).read_text(encoding='utf-8') for path in sys.argv[1:5]
 )
 fixtures = Path(sys.argv[5])
-assert not runtime_classes(base), 'disabled defaults rendered RuntimeClass'
+assert not runtime_classes(base), 'disabled defaults rendered a RuntimeClass'
+for absent in (TASK_RUN_CLASS, PROBE_CLASS):
+    assert absent not in base, f'disabled defaults rendered {absent}'
 assert 'runtimeClassName:' not in base, 'disabled defaults assigned RuntimeClass to a PodSpec'
+
+# Enabling the single gate must render BOTH classes: the constrained task-run
+# class and the unconstrained probe class. They exist for opposite reasons and
+# must never be separately switchable — a probe class without its task-run
+# class would be an ungated handler, and a task-run class without its probe
+# class is the deadlock this pair was split to remove (node conformance cannot
+# run on a node that does not yet carry the marker conformance itself earns).
 classes = runtime_classes(preparation)
-assert len(classes) == 1, f'preparation render expected one RuntimeClass, got {len(classes)}'
-manifest = classes[0]
+assert len(classes) == 2, f'preparation render expected two RuntimeClasses, got {len(classes)}'
+
+task_run_class = runtime_class_named(preparation, TASK_RUN_CLASS)
 for exact in (
-    'name: djinn-cgroup-writable',
+    f'name: {TASK_RUN_CLASS}',
     'handler: runc-cgroupwritable',
+    'scheduling:',
+    'nodeSelector:',
     'djinn.io/cgroup-writable: "true"',
 ):
-    assert exact in manifest, f'missing RuntimeClass contract: {exact}'
+    assert exact in effective(task_run_class), f'missing task-run RuntimeClass contract: {exact}'
+
+probe_class = runtime_class_named(preparation, PROBE_CLASS)
+probe_spec = effective(probe_class)
+for exact in (f'name: {PROBE_CLASS}', 'handler: runc-cgroupwritable'):
+    assert exact in probe_spec, f'missing probe RuntimeClass contract: {exact}'
+for forbidden in ('scheduling:', 'nodeSelector:', 'djinn.io/cgroup-writable'):
+    assert forbidden not in probe_spec, (
+        f'probe RuntimeClass carries {forbidden!r}; the RuntimeClass admission controller '
+        'would merge it into the probe Pod as a NodeAffinity predicate, which the kubelet '
+        'rejects on the very unlabeled node conformance exists to evaluate — spec.nodeName '
+        'bypasses the scheduler, not the kubelet admission predicate'
+    )
+
 assert 'runtimeClassName:' not in preparation, 'preparation must not assign RuntimeClass to task-run PodSpecs'
-assert len(runtime_classes(activation)) == 1, 'activation must retain the RuntimeClass'
+assert len(runtime_classes(activation)) == 2, 'activation must retain both RuntimeClasses'
+runtime_class_named(activation, TASK_RUN_CLASS)
+runtime_class_named(activation, PROBE_CLASS)
+assert len(runtime_classes(armed)) == 2, 'armed must retain both RuntimeClasses'
+
+# No chart-rendered PodSpec may ever name the probe class. The probe class is
+# reachable only from the node conformance program.
+for label, rendered in (
+    ('chart defaults', base),
+    ('preparation', preparation),
+    ('activation', activation),
+    ('armed', armed),
+):
+    for line in rendered.splitlines():
+        stripped = line.strip()
+        if stripped.startswith('runtimeClassName:'):
+            assert stripped == f'runtimeClassName: {TASK_RUN_CLASS}', (
+                f'{label}: rendered PodSpec names {stripped!r}; task-run Pods must use the '
+                f'node-selected {TASK_RUN_CLASS} class only'
+            )
 
 
 def server_env(rendered, name):
@@ -183,6 +254,9 @@ def validate_release_contract(contract):
     assert security['readOnlyRootFilesystem'] is True
     assert security['seccompProfile'] == {'type': 'RuntimeDefault'}
     assert caps['drop'] == ['ALL']
+    if pod.get('runtimeClassName') == PROBE_CLASS:
+        fail('task-run PodSpec assigned the conformance probe RuntimeClass, '
+             'which carries no eligibility nodeSelector', contract)
     for volume in pod['volumes']:
         if 'hostPath' in volume and volume['hostPath'].get('path') == '/sys/fs/cgroup':
             fail('enabled task-run PodSpec contains a /sys/fs/cgroup hostPath', contract)
@@ -200,7 +274,7 @@ def validate_release_contract(contract):
 
     if generation != 'privilege-free':
         fail('unknown runtime image generation', contract)
-    if not enabled or pod.get('runtimeClassName') != 'djinn-cgroup-writable':
+    if not enabled or pod.get('runtimeClassName') != TASK_RUN_CLASS:
         fail('privilege-free launcher is not atomically paired with task-run RuntimeClass assignment', contract)
     assert sidecar['imageGeneration'] == 'privilege-free'
     assert sidecar['env']['DJINN_LAUNCHER_CGROUP_ROOT'] == '/sys/fs/cgroup'
@@ -226,6 +300,7 @@ validate_release_contract(rollback_contract)
 for fixture, expected in (
     ('privilege-free-without-runtimeclass.json', 'RuntimeClass assignment'),
     ('enabled-task-run-hostpath.json', '/sys/fs/cgroup hostPath'),
+    ('probe-class-task-run.json', 'conformance probe RuntimeClass'),
 ):
     try:
         validate_release_contract(json.loads((fixtures / fixture).read_text(encoding='utf-8')))
@@ -281,8 +356,18 @@ expected = '''[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-cgro
 assert expected in template.read_text(encoding='utf-8'), 'pinned runtime table changed'
 conformance_text = conformance.read_text(encoding='utf-8')
 assert "RUNTIME_TABLE=" in conformance_text, 'conformance no longer validates live table'
-assert "RUNTIME_CLASS='djinn-cgroup-writable'" in conformance_text
-assert 'runtimeClassName: $RUNTIME_CLASS' in conformance_text
+# The probe must name the unconstrained probe class. Naming the task-run class
+# is the deadlock: its merged nodeSelector becomes a NodeAffinity predicate the
+# kubelet enforces even for a Pod bound by spec.nodeName, so the probe can only
+# run on a node already carrying the marker that only a passing probe earns.
+assert "PROBE_RUNTIME_CLASS='djinn-cgroup-writable-probe'" in conformance_text, \
+    'conformance no longer pins the probe-only RuntimeClass'
+assert 'runtimeClassName: $PROBE_RUNTIME_CLASS' in conformance_text, \
+    'conformance probe manifest no longer uses the probe-only RuntimeClass'
+assert "RUNTIME_CLASS='djinn-cgroup-writable'" not in conformance_text, \
+    'conformance reintroduced the node-selected task-run RuntimeClass'
+# spec.nodeName binding is what makes the probe an observation of ONE node.
+assert 'nodeName: $NODE_NAME' in conformance_text, 'conformance probe is no longer node-bound'
 # This asserts the failure branch of must_deny itself, instead of merely
 # checking for filenames. The fakes below model each named successful write.
 must_deny = re.search(r'must_deny\(\) \{([^\n]+)\}', conformance_text)
@@ -358,7 +443,13 @@ case "\$1" in
     ;;
   apply)
     cat >'$manifest'
-    grep -F 'runtimeClassName: djinn-cgroup-writable' '$manifest' >/dev/null
+    # Exact-match: 'runtimeClassName: djinn-cgroup-writable' is a PREFIX of the
+    # probe class line, so a substring grep cannot tell the two apart.
+    grep -Fx '  runtimeClassName: djinn-cgroup-writable-probe' '$manifest' >/dev/null
+    if grep -Fx '  runtimeClassName: djinn-cgroup-writable' '$manifest' >/dev/null; then
+      printf 'probe used the node-selected task-run RuntimeClass\n' >&2
+      exit 1
+    fi
     grep -F 'nodeName: fixture-node' '$manifest' >/dev/null
     exit 0 ;;
   wait)

--- a/deploy/helm/djinn/tests/fixtures/cgroup-writable/probe-class-task-run.json
+++ b/deploy/helm/djinn/tests/fixtures/cgroup-writable/probe-class-task-run.json
@@ -1,0 +1,29 @@
+{
+  "release": "probe-class-task-run",
+  "server": {
+    "runtimeImageGeneration": "privilege-free",
+    "environment": {
+      "DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED": "true"
+    }
+  },
+  "taskRunPod": {
+    "spec": {
+      "runtimeClassName": "djinn-cgroup-writable-probe",
+      "initContainers": [
+        {
+          "name": "cgroup-launcher",
+          "imageGeneration": "privilege-free",
+          "env": {"DJINN_LAUNCHER_CGROUP_ROOT": "/sys/fs/cgroup"},
+          "volumeMounts": [],
+          "securityContext": {
+            "allowPrivilegeEscalation": false,
+            "readOnlyRootFilesystem": true,
+            "capabilities": {"drop": ["ALL"], "add": ["CHOWN", "SETGID", "SETUID", "SETPCAP"]},
+            "seccompProfile": {"type": "RuntimeDefault"}
+          }
+        }
+      ],
+      "volumes": []
+    }
+  }
+}

--- a/deploy/node/k3s/djinn-cgroup-writable-conformance.sh
+++ b/deploy/node/k3s/djinn-cgroup-writable-conformance.sh
@@ -7,7 +7,18 @@ set -Eeuo pipefail
 
 LABEL='djinn.io/cgroup-writable'
 HANDLER='runc-cgroupwritable'
-RUNTIME_CLASS='djinn-cgroup-writable'
+# The probe names the probe-only RuntimeClass, never the task-run one.
+#
+# Both classes carry the same containerd handler; only the task-run class
+# carries `scheduling.nodeSelector: {djinn.io/cgroup-writable: "true"}`, which
+# the RuntimeClass admission controller merges into every Pod naming it. This
+# program runs with that marker deliberately absent (see ensure_unlabeled), so
+# a probe naming the task-run class is rejected by the kubelet with
+# `Predicate NodeAffinity failed` — `spec.nodeName` bypasses the scheduler but
+# not the kubelet's own admission predicate. Naming the unconstrained probe
+# class keeps handler selection and the eligibility gate separate, which is the
+# only way this program can observe a node that is not yet eligible.
+PROBE_RUNTIME_CLASS='djinn-cgroup-writable-probe'
 # Resolved from the live containerd configuration's own `version` key before
 # anything is written. There is no default: a node whose generation cannot be
 # resolved gets no template and no restart.
@@ -224,7 +235,7 @@ metadata:
     app.kubernetes.io/name: djinn-cgroup-writable-conformance
 spec:
   restartPolicy: Never
-  runtimeClassName: $RUNTIME_CLASS
+  runtimeClassName: $PROBE_RUNTIME_CLASS
   nodeName: $NODE_NAME
   securityContext:
     fsGroup: 1000

--- a/deploy/node/k3s/tests/conformance-version-lifecycle.sh
+++ b/deploy/node/k3s/tests/conformance-version-lifecycle.sh
@@ -29,7 +29,7 @@ expect_eq() {
 }
 
 make_stubs() {
-  local dir=$1 log=$2 post_live=$3 live=$4 exec_status=$5
+  local dir=$1 log=$2 post_live=$3 live=$4 exec_status=$5 manifest=${6:-/dev/null}
   mkdir -p "$dir"
   cat >"$dir/id" <<'EOF'
 #!/usr/bin/env bash
@@ -55,7 +55,7 @@ case "\$1" in
     if [ "\$2" = pod ] && [ "\${*: -2}" = '-o json' ]; then exit 0; fi
     if [ "\$2" = pod ]; then printf '$NODE|$NODE'; exit 0; fi
     ;;
-  apply) cat >/dev/null; exit 0 ;;
+  apply) cat >'$manifest'; exit 0 ;;
   wait) exit 0 ;;
   exec) exit $exec_status ;;
   delete) exit 0 ;;
@@ -67,17 +67,19 @@ EOF
 
 # Every case is described by the live configuration the node starts with, the
 # one k3s renders after a restart, and the template wiring under test.
-CASE_DIR='' STATUS=0 LOG='' LIVE='' DEST=''
+CASE_DIR='' STATUS=0 LOG='' LIVE='' DEST='' MANIFEST=''
 run_case() {
   local name=$1 pre_live=$2 post_live=$3 exec_status=$4
   shift 4
   CASE_DIR="$WORK/$name"
   LOG="$CASE_DIR/log"
   LIVE="$CASE_DIR/live.toml"
+  MANIFEST="$CASE_DIR/manifest.yaml"
   mkdir -p "$CASE_DIR/install"
   : >"$LOG"
+  : >"$MANIFEST"
   cp "$FIXTURES/$pre_live" "$LIVE"
-  make_stubs "$CASE_DIR/bin" "$LOG" "$FIXTURES/$post_live" "$LIVE" "$exec_status"
+  make_stubs "$CASE_DIR/bin" "$LOG" "$FIXTURES/$post_live" "$LIVE" "$exec_status" "$MANIFEST"
   set +e
   env PATH="$CASE_DIR/bin:$PATH" \
     DJINN_KUBECTL=kubectl \
@@ -91,6 +93,34 @@ run_case() {
 }
 
 restarts() { grep -c '^restart ' "$LOG" || true; }
+
+# The applied probe manifest decides whether this program can observe a node
+# that is not yet eligible. `djinn-cgroup-writable` carries
+# `scheduling.nodeSelector: {djinn.io/cgroup-writable: "true"}`, which the
+# RuntimeClass admission controller merges into any Pod naming it; the kubelet
+# then evaluates that as a NodeAffinity predicate and rejects the Pod, even
+# though `spec.nodeName` already bypassed the scheduler. The probe must name
+# the unconstrained `djinn-cgroup-writable-probe` class and stay node-bound.
+# Exact-line matching is required: the task-run class name is a PREFIX of the
+# probe class name.
+assert_probe_manifest() {
+  local name=$1
+  if grep -Fxq '  runtimeClassName: djinn-cgroup-writable-probe' "$MANIFEST"; then
+    ok "$name probe names the unconstrained probe RuntimeClass"
+  else
+    fail "$name probe does not name djinn-cgroup-writable-probe: [$(grep -F 'runtimeClassName' "$MANIFEST" || true)]"
+  fi
+  if grep -Fxq '  runtimeClassName: djinn-cgroup-writable' "$MANIFEST"; then
+    fail "$name probe names the node-selected task-run RuntimeClass, which the kubelet rejects on an unlabeled node"
+  else
+    ok "$name probe avoids the node-selected task-run RuntimeClass"
+  fi
+  if grep -Fxq "  nodeName: $NODE" "$MANIFEST"; then
+    ok "$name probe is bound to the exact node by spec.nodeName"
+  else
+    fail "$name probe is not bound with spec.nodeName"
+  fi
+}
 
 expect_failed() {
   local name=$1
@@ -121,6 +151,7 @@ if grep -Fxq 'label node fixture-node djinn.io/cgroup-writable=true --overwrite'
 else
   fail 'v3 success did not label the node'
 fi
+assert_probe_manifest v3
 
 # ---------------------------------------------------------------------------
 # 2. The version-2 node keeps working, unchanged asset and all.
@@ -139,6 +170,7 @@ if [ -e "$CASE_DIR/install/config-v3.toml.tmpl" ]; then
 else
   ok 'v2 wrote no version-3 template filename'
 fi
+assert_probe_manifest v2
 
 # ---------------------------------------------------------------------------
 # 3. Preflight aborts: zero writes and zero restarts.
@@ -300,6 +332,14 @@ assert_contains 'WORKER_PROBE' "WORKER_PROBE='set -eu"
 assert_contains 'worker denial helper' 'must_deny() { if sh -c "$1"; then'
 assert_contains 'wait_for_probe' 'wait_for_probe() {'
 assert_contains 'verify_node_identity' 'verify_node_identity() {'
+assert_contains 'probe-only RuntimeClass' "PROBE_RUNTIME_CLASS='djinn-cgroup-writable-probe'"
+assert_contains 'probe manifest uses the probe-only class' 'runtimeClassName: $PROBE_RUNTIME_CLASS'
+assert_contains 'probe stays node-bound' 'nodeName: $NODE_NAME'
+case "$conformance_text" in
+  *"RUNTIME_CLASS='djinn-cgroup-writable'"*)
+    fail 'conformance reintroduced the node-selected task-run RuntimeClass for the probe' ;;
+  *) ok 'preserved: probe never names the node-selected task-run RuntimeClass' ;;
+esac
 pass_format_count=$(grep -Fc \
   "printf 'PASS node=%s handler=runc-cgroupwritable cgroup_root=/ writable=true isolated=true worker_denials=true\\n'" \
   "$CONFORMANCE" || true)

--- a/deploy/runbooks/cgroup-launcher-rearm.md
+++ b/deploy/runbooks/cgroup-launcher-rearm.md
@@ -58,11 +58,12 @@ numbered steps, strictly in this order. Do not reorder these steps.
 
 `CGROUP_REARM_STEP: 0 (preparation) — install RuntimeClass, launcher disarmed`
 
-The Step 1 conformance probe Pod sets `runtimeClassName: djinn-cgroup-writable`
-on itself. Kubernetes rejects a Pod that references a `RuntimeClass` object
-that does not yet exist. Therefore the `RuntimeClass` MUST be installed
-**before** conformance runs, via a preparation Helm upgrade that leaves the
-launcher disarmed and leaves task-runs off the delegated cgroup path:
+The Step 1 conformance probe Pod sets
+`runtimeClassName: djinn-cgroup-writable-probe` on itself. Kubernetes rejects
+a Pod that references a `RuntimeClass` object that does not yet exist.
+Therefore the `RuntimeClass` objects MUST be installed **before** conformance
+runs, via a preparation Helm upgrade that leaves the launcher disarmed and
+leaves task-runs off the delegated cgroup path:
 
 ```bash
 helm upgrade djinn deploy/helm/djinn \
@@ -73,17 +74,32 @@ helm upgrade djinn deploy/helm/djinn \
   --set cgroupLauncher.mode=disabled
 ```
 
-After this preparation upgrade: `RuntimeClass/djinn-cgroup-writable` exists
-in the cluster, but no task-run is scheduled onto it
-(`cgroupWritable.taskRuns.enabled: false`) and the launcher is not demanding
-it (`cgroupLauncher.mode` is not `required`). This is the only state in which
-it is safe to run the Step 1 conformance probe.
+After this preparation upgrade both classes exist in the cluster, but no
+task-run is scheduled onto either (`cgroupWritable.taskRuns.enabled: false`)
+and the launcher is not demanding one (`cgroupLauncher.mode` is not
+`required`). This is the only state in which it is safe to run the Step 1
+conformance probe.
+
+The single value renders a pair, and the pair is not redundant:
+
+* `djinn-cgroup-writable` is the **task-run** class. It carries
+  `scheduling.nodeSelector: {djinn.io/cgroup-writable: "true"}`, which the
+  RuntimeClass admission controller merges into every Pod that names it. That
+  selector is what keeps ordinary task-run Pods off unconformed nodes.
+* `djinn-cgroup-writable-probe` is the **conformance-probe** class. Same
+  containerd handler, no `scheduling` block at all. Conformance runs against a
+  node that does *not* yet carry the eligibility marker — earning it is the
+  point — so a probe naming the task-run class would be rejected by the
+  kubelet with `Predicate NodeAffinity failed`. `spec.nodeName` bypasses the
+  scheduler, not the kubelet's own admission predicate. Before the split, that
+  was a deadlock: the marker gated the probe that earns the marker, and
+  conformance could never pass.
 
 ```bash
-kubectl get runtimeclass djinn-cgroup-writable
+kubectl get runtimeclass djinn-cgroup-writable djinn-cgroup-writable-probe
 ```
 
-Do not proceed to Step 1 until this command shows the `RuntimeClass` object.
+Do not proceed to Step 1 until this command shows both `RuntimeClass` objects.
 
 ### Step 1: conformance install and node restart
 
@@ -98,8 +114,8 @@ systemctl restart k3s
 ```
 
 The conformance probe Pod references
-`runtimeClassName: djinn-cgroup-writable`, which now exists because of the
-preparation upgrade above.
+`runtimeClassName: djinn-cgroup-writable-probe`, which now exists because of
+the preparation upgrade above.
 
 After the restart, wait for the probe to complete and inspect its logs for
 the explicit PASS line:


### PR DESCRIPTION
## The production evidence

Node conformance was run against the real production VPS today. It fails:

```
FAIL probe did not become Ready before 180s
```

and the Kubernetes event says exactly why:

```
Warning NodeAffinity  pod/djinn-cgroup-1785351133-19202
  Predicate NodeAffinity failed: node(s) didn't match Pod's node affinity/selector
```

That event disproves the claim the probe was built on — that `spec.nodeName`
binds the probe to one exact kubelet and thereby bypasses RuntimeClass
scheduler selection. `nodeName` bypasses the **scheduler**. The **kubelet**
still evaluates the NodeAffinity predicate at its own admission step and
rejects the Pod.

## The deadlock

1. `RuntimeClass/djinn-cgroup-writable` renders with
   `scheduling.nodeSelector: {djinn.io/cgroup-writable: "true"}`.
2. The RuntimeClass admission controller merges that selector into every Pod
   naming the class — including the conformance probe.
3. `deploy/node/k3s/djinn-cgroup-writable-conformance.sh` is the sole owner of
   that label and deliberately calls `ensure_unlabeled` FIRST, so the node does
   not carry it while the probe runs.
4. The kubelet therefore rejects the probe.

The label gates the probe that earns the label. **Conformance could never have
passed.** That is why no node has ever carried `djinn.io/cgroup-writable=true`.

## The fix

Split the scheduling constraint from the handler selection.
`deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml` now renders a
second, probe-only `RuntimeClass/djinn-cgroup-writable-probe`: same
`handler: runc-cgroupwritable`, no `scheduling` block at all. The conformance
probe names it; task-run Pods keep the constrained `djinn-cgroup-writable`.

This is the right decomposition. The probe's job is to prove one node's
containerd **handler** behaves correctly, bound to that node by `spec.nodeName`.
The `nodeSelector` exists to keep ordinary task-run Pods off unconformed
nodes — a scheduling concern the probe explicitly must not inherit, because the
probe is deciding whether the node should become eligible in the first place.

The probe class grants no new reach: it is usable only where the containerd
handler exists, and elsewhere the sandbox simply fails to create. It is gated
by the **same** `cgroupWritable.runtimeClass.enabled` value as the task-run
class, so the two always appear and disappear together, never independently.

## Invariants preserved

- `djinn-cgroup-writable-conformance.sh` remains the sole mutator of the
  `djinn.io/cgroup-writable` label; the ownership scan still returns only it.
- The PASS line is byte-identical.
- `LAUNCHER_PROBE` / `WORKER_PROBE` assertion strings are unchanged.
- The label is applied only after the probe fully passes; every failure path
  still removes it.
- The version-detection preflight, its zero-write/zero-restart guarantee, and
  the template backup/restore-and-second-restart behaviour are untouched.
- Task-run Pods are never assigned the probe class — now enforced by a new
  rejected fixture, `probe-class-task-run.json`.

## Test changes

`deploy/helm/djinn/tests/cgroup-writable-render.sh` asserts BOTH classes render
when enabled and NEITHER when disabled, that the probe class has no
`scheduling:`/`nodeSelector:` and does not mention the eligibility marker, that
the task-run class still HAS the nodeSelector, and that every rendered
`runtimeClassName:` line names the constrained class.

`deploy/node/k3s/tests/conformance-version-lifecycle.sh` now captures the
applied probe manifest and matches its `runtimeClassName` line **exactly** —
`runtimeClassName: djinn-cgroup-writable` is a strict prefix of
`runtimeClassName: djinn-cgroup-writable-probe`, so a substring grep cannot
tell the two apart and would have certified the broken manifest.

Non-vacuity was demonstrated by reverting only the probe-class line in the
conformance script: both the render contract and the lifecycle contract fail.

Vercel checks are rate-limited and are not required for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
