### PR TITLE
docs(4q45): make the re-arm verification evidence repository-checked

### DIFF
--- a/deploy/runbooks/cgroup-launcher-rearm.md
+++ b/deploy/runbooks/cgroup-launcher-rearm.md
@@ -185,7 +185,9 @@ This is the step that reproduced the 2026-07-29 outage when it was applied
 while `cgroupWritable.taskRuns.enabled` was `false`. Do not run this step
 out of order relative to Step 4.
 
-Resume dispatch only after Step 6 verification below passes:
+Resume dispatch only after Step 6's kernel-evidence rules (1 through 4) hold.
+Step 6's rule 5 then observes live dispatch for an hour after this resume, and
+rule 6 governs abort and rollback throughout:
 
 ```bash
 djinn dispatch resume
@@ -197,11 +199,23 @@ djinn dispatch resume
 
 `CGROUP_REARM_VERIFICATION_REQUIRES_KERNEL_EVIDENCE: a status field or cache-hit flag is not acceptable evidence`
 
+`CGROUP_REARM_VERIFICATION_EVIDENCE_IS_OPERATOR_COLLECTED: the observations below are post-merge operator rollout evidence, collected on the production node by the operator performing the re-arm; no repository check and no CI job observes production state`
+
 Verification MUST use direct kernel evidence from a live, Running task-run
 Pod, not a status field, not a Helm/Kubernetes condition, and not a cached
 "warmed" or "enabled" flag. Reading `cat cpu.max` by itself is also NOT
 acceptable evidence, because it only shows the configured ceiling, not that
-the kernel is enforcing and accounting against it. Required evidence:
+the kernel is enforcing and accounting against it.
+
+The repository check `deploy/runbooks/tests/cgroup-launcher-rearm.sh` asserts
+only that this document contains the six evidence rules below and orders
+them as written. It reads this file and nothing else: it never contacts a
+cluster, never reads a cgroup, and never observes production. A green check
+means the rollout evidence contract is present and correctly ordered — never
+that the evidence was collected. Collecting it is the operator's obligation
+during the rollout, and the change record is where it is attested.
+
+Required evidence, in this order:
 
 1. A Running task-run Pod whose `spec.runtimeClassName` is
    `djinn-cgroup-writable`:
@@ -211,7 +225,11 @@ the kernel is enforcing and accounting against it. Required evidence:
    # expect: Running djinn-cgroup-writable
    ```
 
-2. At birth, the launcher's cgroup leaf reports `cpu.max` of
+2. Exact `cpu.max` expectations, at birth and after the fenced lift.
+
+   `CGROUP_REARM_VERIFY_ORDER_1_CPU_MAX: launcher leaf born at 25000 100000; after a fenced lift exactly 400000 100000`
+
+   At birth, the launcher's cgroup leaf reports `cpu.max` of exactly
    `25000 100000`, and `cpu.stat`'s `nr_throttled` is accumulating (not
    frozen) under load:
 
@@ -222,14 +240,41 @@ the kernel is enforcing and accounting against it. Required evidence:
    # record nr_periods, nr_throttled, throttled_usec
    ```
 
-3. After the fenced lift, `cpu.max` reads exactly `400000 100000`:
+   After the fenced lift, `cpu.max` reads exactly `400000 100000` — that
+   value, not merely "some value higher than birth":
 
    ```bash
    cat /sys/fs/cgroup/<launcher-leaf>/cpu.max
    # expect: 400000 100000
    ```
 
-4. Over a wall-clock window of at least 100 further `nr_periods` after the
+3. Wrong-fence invariant: a lift presented with the wrong fence token is
+   rejected, and the leaf is left clamped.
+
+   `CGROUP_REARM_VERIFY_ORDER_2_WRONG_FENCE: a lift presented with the wrong fence token is rejected and leaves cpu.max clamped at 25000 100000`
+
+   This is the non-vacuity check for the whole step. Without it, a launcher
+   leaf that simply never lifts at all looks identical to a working clamp —
+   both read `25000 100000`, and rule 2's birth reading alone cannot tell
+   them apart. Present a lift carrying a fence token that does not match the
+   leaf's current fence, confirm the lift is refused, and confirm the leaf is
+   still clamped afterwards:
+
+   ```bash
+   # Present a lift whose fence token deliberately does not match the leaf's
+   # current fence; the launcher must refuse it.
+   cat /sys/fs/cgroup/<launcher-leaf>/cpu.max
+   # expect (still clamped, refusal did not widen the leaf): 25000 100000
+   ```
+
+   A wrong-fence lift that is accepted, or that moves `cpu.max` off
+   `25000 100000`, is a FAIL: abort and follow rule 6 below.
+
+4. 100-period sampling rule, read from `cpu.stat` over a wall-clock window.
+
+   `CGROUP_REARM_VERIFY_ORDER_3_HUNDRED_PERIODS: nr_throttled and throttled_usec unchanged across at least 100 further nr_periods, read from cpu.stat over a wall-clock window`
+
+   Over a wall-clock window of at least 100 further `nr_periods` after the
    lift, `cpu.stat`'s `nr_throttled` and `throttled_usec` are UNCHANGED from
    their values immediately after the lift — i.e. read `cpu.stat` at the
    lift, wait, and read it again; `nr_periods` must have advanced by at
@@ -243,13 +288,58 @@ the kernel is enforcing and accounting against it. Required evidence:
    # nr_periods must differ by >= 100; nr_throttled and throttled_usec must be identical
    ```
 
-`cat cpu.max` alone never satisfies this step. Measuring `cpu.stat` across a
-wall-clock window is the only acceptable evidence that the fenced lift is
-real and that the workload is no longer being throttled.
+   `cat cpu.max` alone never satisfies this step. Measuring `cpu.stat` across
+   a wall-clock window is the only acceptable evidence that the fenced lift
+   is real and that the workload is no longer being throttled. A window that
+   advanced fewer than 100 `nr_periods` is not a shorter version of this
+   rule; it is no evidence at all.
 
-Only after all four evidence items are collected and attached to the change
-record may dispatch be resumed (see Step 5) and the re-arm be declared
-complete.
+5. One-hour observation rule: board dispatches remain greater than zero for
+   the hour following the arm.
+
+   `CGROUP_REARM_VERIFY_ORDER_4_ONE_HOUR_DISPATCH: board dispatches remain greater than zero for the hour following the arm`
+
+   The 2026-07-29 outage was a dispatch refusal, not a kernel fault — kernel
+   readings from one Pod cannot detect it. For at least one hour after
+   dispatch is resumed, confirm the board keeps dispatching: task-runs
+   continue to be admitted and started, and the number of dispatches observed
+   across that hour is greater than zero.
+
+   ```bash
+   djinn dispatch pause-status   # expect: not paused
+   # Sample across the full hour; dispatches over the window must be > 0.
+   kubectl get pods -n djinn-taskruns --watch
+   ```
+
+   Zero dispatches across that hour is a FAIL even if every kernel reading
+   above was perfect — that is precisely the shape the outage took.
+
+6. Abort and rollback behavior when any rule above fails.
+
+   `CGROUP_REARM_VERIFY_ORDER_5_ABORT_ROLLBACK: if any rule above fails, roll the launcher back to cgroupLauncher.mode: disabled and do not leave production armed on unproven delegation`
+
+   If any of rules 2 through 5 fails — a wrong `cpu.max` at birth or after
+   the lift, a wrong-fence lift that is not rejected, `nr_throttled` or
+   `throttled_usec` moving across the 100-period window, or zero board
+   dispatches across the hour — abort the re-arm and roll the launcher back:
+
+   ```bash
+   helm upgrade djinn deploy/helm/djinn \
+     --namespace djinn \
+     --reuse-values \
+     --set cgroupLauncher.mode=disabled
+   ```
+
+   Production must never be left armed on unproven delegation. A partially
+   collected evidence set is a failure, not a pass with a caveat: roll back,
+   record which rule failed, and do not re-arm until that rule can be
+   satisfied.
+
+Rules 1 through 4 are collected while dispatch is still paused. Dispatch is
+resumed (see Step 5) only once all four hold; rule 5's one-hour observation
+then runs against live dispatch, and rule 6 applies throughout. The re-arm is
+declared complete only after all six evidence items are collected and
+attached to the change record.
 
 ## Rollback / recovery branch
 
@@ -307,8 +397,15 @@ Do not retry Step 1 conformance until the restore is confirmed complete.
 5. Step 3: `cgroupWritable.runtimeClass.enabled: true` (confirmed).
 6. Step 4: `cgroupWritable.taskRuns.enabled: true`.
 7. Step 5: `cgroupLauncher.mode: required`.
-8. Step 6: verification by kernel evidence (`cpu.max` at birth, at lift, and
-   `cpu.stat` invariance across a wall-clock window), then dispatch resume.
+8. Step 6: verification, whose six evidence rules are ordered as written —
+   the Running task-run Pod, the exact `cpu.max` values at birth and after
+   the fenced lift, the wrong-fence invariant, the 100-period `cpu.stat`
+   sampling window, the one-hour dispatch observation after resume, and the
+   abort/rollback behavior that returns the launcher to disabled.
 
 If Step 1 fails: restore the prior containerd template byte-for-byte (with
 `cmp` confirmation) and restart `k3s` again before any retry.
+
+All of Step 6's observations are operator rollout evidence collected after
+this document merges. The repository check asserts the presence and order of
+the rules only; it makes no claim about production state.

--- a/deploy/runbooks/tests/cgroup-launcher-rearm.sh
+++ b/deploy/runbooks/tests/cgroup-launcher-rearm.sh
@@ -4,6 +4,14 @@
 #
 # This test requires no cluster, no kubectl, no helm, and no credentials. It
 # only reads the runbook markdown and asserts textual/ordering properties.
+#
+# WHAT A PASS HERE DOES AND DOES NOT MEAN. This check asserts that the runbook
+# CONTAINS and ORDERS the re-arm's verification rules. It does not observe
+# production and cannot: it reads one markdown file. A pass means the rollout
+# evidence contract is written down in the required order; it never means a
+# Pod was Running, a cgroup was read, 100 periods elapsed, or the board
+# dispatched for an hour. Those are post-merge operator observations, attested
+# in the change record, and no repository check can stand in for them.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -90,6 +98,31 @@ validate() {
   require_line "$document" 'nr_throttled/throttled_usec invariance over >=100 further nr_periods' \
     'nr_throttled and throttled_usec must be identical' || return 1
 
+  # --- Existence: the five rollout-evidence rules, as an ordered contract. ---
+  # These assert the DOCUMENT states them. Nothing here observes production;
+  # see the header. The markers exist so ordering is checkable without
+  # depending on prose that may legitimately be reworded.
+  require_line "$document" 'verification evidence is declared operator-collected post-merge, not CI-observed' \
+    'CGROUP_REARM_VERIFICATION_EVIDENCE_IS_OPERATOR_COLLECTED:' || return 1
+  require_line "$document" 'rule 1: exact cpu.max expectations (25000 100000 at birth, 400000 100000 after a fenced lift)' \
+    'CGROUP_REARM_VERIFY_ORDER_1_CPU_MAX:' || return 1
+  require_line "$document" 'rule 2: wrong-fence invariant (wrong fence token rejected, cpu.max left clamped)' \
+    'CGROUP_REARM_VERIFY_ORDER_2_WRONG_FENCE:' || return 1
+  require_line "$document" 'rule 3: 100-period cpu.stat sampling rule over a wall-clock window' \
+    'CGROUP_REARM_VERIFY_ORDER_3_HUNDRED_PERIODS:' || return 1
+  require_line "$document" 'rule 4: one-hour observation rule (board dispatches remain > 0 for the hour after the arm)' \
+    'CGROUP_REARM_VERIFY_ORDER_4_ONE_HOUR_DISPATCH:' || return 1
+  require_line "$document" 'rule 5: abort/rollback to cgroupLauncher.mode: disabled on any failure above' \
+    'CGROUP_REARM_VERIFY_ORDER_5_ABORT_ROLLBACK:' || return 1
+  # The preparation step also runs `--set cgroupLauncher.mode=disabled`, so that
+  # flag alone proves nothing about rule 5. Pin the abort instruction itself.
+  require_line "$document" 'rule 5 instructs an abort-and-roll-back on failure' \
+    'abort the re-arm and roll the launcher back' || return 1
+  require_line "$document" 'rule 2 states why the wrong-fence check is the non-vacuity check' \
+    'looks identical to a working clamp' || return 1
+  require_line "$document" 'rule 5 forbids leaving production armed on unproven delegation' \
+    'never be left armed on unproven delegation' || return 1
+
   # --- Ordering: preparation, then steps 0..6 strictly ascending. ---
   require_before "$document" 'step 0 (RuntimeClass install) must precede step 1 (conformance)' \
     'CGROUP_REARM_STEP: 0' 'CGROUP_REARM_STEP: 1 —' || return 1
@@ -103,6 +136,29 @@ validate() {
     'CGROUP_REARM_STEP: 4 —' 'CGROUP_REARM_STEP: 5 —' || return 1
   require_before "$document" 'step 5 must precede step 6' \
     'CGROUP_REARM_STEP: 5 —' 'CGROUP_REARM_STEP: 6 —' || return 1
+
+  # --- Ordering: the five evidence rules, inside the verification step. ---
+  # The rules are a sequence, not a set. cpu.max expectations come first
+  # because everything after them is stated relative to those values; the
+  # wrong-fence invariant must follow them (it is what makes the birth value
+  # non-vacuous); the 100-period window measures the lift the previous rules
+  # established; the one-hour dispatch observation only exists after the arm;
+  # and abort/rollback closes the sequence by covering the failure of any of
+  # them. The whole block must sit after the arm step, never before it.
+  # 'step 5 must precede step 6' above already pins the verification section
+  # after the arm step; it is not repeated here.
+  require_before "$document" 'the evidence rules must sit inside the verification step (step 6)' \
+    'CGROUP_REARM_STEP: 6 —' 'CGROUP_REARM_VERIFY_ORDER_1_CPU_MAX:' || return 1
+  require_before "$document" 'rule 1 (cpu.max expectations) must precede rule 2 (wrong-fence invariant)' \
+    'CGROUP_REARM_VERIFY_ORDER_1_CPU_MAX:' 'CGROUP_REARM_VERIFY_ORDER_2_WRONG_FENCE:' || return 1
+  require_before "$document" 'rule 2 (wrong-fence invariant) must precede rule 3 (100-period sampling)' \
+    'CGROUP_REARM_VERIFY_ORDER_2_WRONG_FENCE:' 'CGROUP_REARM_VERIFY_ORDER_3_HUNDRED_PERIODS:' || return 1
+  require_before "$document" 'rule 3 (100-period sampling) must precede rule 4 (one-hour dispatch observation)' \
+    'CGROUP_REARM_VERIFY_ORDER_3_HUNDRED_PERIODS:' 'CGROUP_REARM_VERIFY_ORDER_4_ONE_HOUR_DISPATCH:' || return 1
+  require_before "$document" 'rule 4 (one-hour dispatch observation) must precede rule 5 (abort/rollback)' \
+    'CGROUP_REARM_VERIFY_ORDER_4_ONE_HOUR_DISPATCH:' 'CGROUP_REARM_VERIFY_ORDER_5_ABORT_ROLLBACK:' || return 1
+  require_before "$document" 'the operator-collected disclaimer must precede the evidence rules it governs' \
+    'CGROUP_REARM_VERIFICATION_EVIDENCE_IS_OPERATOR_COLLECTED:' 'CGROUP_REARM_VERIFY_ORDER_1_CPU_MAX:' || return 1
 
   # --- Ordering: the RuntimeClass must exist before conformance can reference it. ---
   # The preparation step is where runtimeClass.enabled=true is first set; it must
@@ -136,17 +192,20 @@ validate() {
 }
 
 expect_rejected() {
-  local name=$1 document="$WORK/$1.md"
+  local name=$1 document="$WORK/$1.md" diagnostics="$WORK/$1.err"
   shift
   cp "$RUNBOOK" "$document"
   local mutator=$1
   shift
   "$mutator" "$document" "$@"
-  if validate "$document" >/dev/null 2>&1; then
+  if validate "$document" >"$diagnostics" 2>&1; then
     fail "negative fixture '$name' unexpectedly passed"
     return 1
   fi
-  printf 'REJECTED (expected): %s\n' "$name"
+  # Print the rejection reason, not just the fixture name: a fixture that
+  # fails for an unrelated reason is a fixture that proves nothing, and that
+  # is only visible if the assertion that fired is named in the output.
+  printf 'REJECTED (expected): %-44s %s\n' "$name" "$(head -n1 "$diagnostics")"
 }
 
 delete_matching_line() {
@@ -172,6 +231,36 @@ swap_matching_lines() {
     END {
       tmp = lines[a]; lines[a] = lines[b]; lines[b] = tmp
       for (i = 1; i <= NR; i++) print lines[i]
+    }
+  ' "$document" >"$temporary"
+  mv "$temporary" "$document"
+}
+
+# Relocates the whole block [section_start, section_end) so that it begins at
+# the line currently holding destination_pattern, which must appear BEFORE the
+# block. Deletes nothing: it only moves a section, which is exactly the way a
+# reordering regression arrives in a document.
+move_section_before() {
+  local document=$1 section_start=$2 section_end=$3 destination=$4 temporary="$document.tmp"
+  local start_line end_line destination_line
+  start_line=$(first_line "$document" "$section_start")
+  end_line=$(first_line "$document" "$section_end")
+  destination_line=$(first_line "$document" "$destination")
+  if [[ -z "$start_line" || -z "$end_line" || -z "$destination_line" ]]; then
+    fail "move_section_before: pattern not found in $document"
+    return 1
+  fi
+  if [[ "$destination_line" -ge "$start_line" || "$end_line" -le "$start_line" ]]; then
+    fail "move_section_before: destination must precede the block in $document"
+    return 1
+  fi
+  awk -v s="$start_line" -v e="$end_line" -v d="$destination_line" '
+    { lines[NR] = $0 }
+    END {
+      for (i = 1; i < d; i++) print lines[i]
+      for (i = s; i < e; i++) print lines[i]
+      for (i = d; i < s; i++) print lines[i]
+      for (i = e; i <= NR; i++) print lines[i]
     }
   ' "$document" >"$temporary"
   mv "$temporary" "$document"
@@ -210,6 +299,28 @@ expect_rejected verification-lift-cpu-max delete_matching_line '400000 100000'
 expect_rejected verification-throttle-invariance delete_matching_line \
   'nr_throttled and throttled_usec must be identical'
 
+# --- Existence fixtures for the five rollout-evidence rules. Deleting any one
+# rule must fail validation and NAME that rule, so the rules are individually
+# load-bearing rather than collectively satisfied by the section existing.
+expect_rejected verification-operator-collected-disclaimer delete_matching_line \
+  'CGROUP_REARM_VERIFICATION_EVIDENCE_IS_OPERATOR_COLLECTED:'
+expect_rejected verification-rule-1-cpu-max delete_matching_line \
+  'CGROUP_REARM_VERIFY_ORDER_1_CPU_MAX:'
+expect_rejected verification-rule-2-wrong-fence delete_matching_line \
+  'CGROUP_REARM_VERIFY_ORDER_2_WRONG_FENCE:'
+expect_rejected verification-rule-2-non-vacuity-rationale delete_matching_line \
+  'looks identical to a working clamp'
+expect_rejected verification-rule-3-hundred-periods delete_matching_line \
+  'CGROUP_REARM_VERIFY_ORDER_3_HUNDRED_PERIODS:'
+expect_rejected verification-rule-4-one-hour-dispatch delete_matching_line \
+  'CGROUP_REARM_VERIFY_ORDER_4_ONE_HOUR_DISPATCH:'
+expect_rejected verification-rule-5-abort-rollback delete_matching_line \
+  'CGROUP_REARM_VERIFY_ORDER_5_ABORT_ROLLBACK:'
+expect_rejected verification-rule-5-abort-instruction delete_matching_line \
+  'abort the re-arm and roll the launcher back'
+expect_rejected verification-rule-5-unproven-delegation delete_matching_line \
+  'never be left armed on unproven delegation'
+
 # --- Ordering fixtures: swapping step markers must fail validation even
 # though no content is deleted. This is the specific adversary objection:
 # the RuntimeClass must exist (step 0) before conformance can reference it
@@ -223,8 +334,43 @@ expect_rejected reorder-step-5-after-step-6 swap_step_5_and_6
 swap_drain_after_step_1() { swap_matching_lines "$1" 'CGROUP_REARM_DRAIN_REQUIRED:' 'CGROUP_REARM_STEP: 1 —'; }
 expect_rejected reorder-drain-after-restart swap_drain_after_step_1
 
+# The swap above also drags step 1's marker above step 0's, so it is rejected
+# by the step-ordering check before the drain check is ever reached. Relocating
+# only the drain marker leaves every step marker in place, so the drain rule is
+# the sole assertion that can fire.
+relocate_drain_marker_to_end() {
+  local document=$1 marker='CGROUP_REARM_DRAIN_REQUIRED:'
+  local relocated
+  relocated=$(grep -F -- "$marker" "$document" | head -n1)
+  delete_matching_line "$document" "$marker"
+  printf '\n%s\n' "$relocated" >>"$document"
+}
+expect_rejected relocate-drain-after-restart relocate_drain_marker_to_end
+
 swap_pass_after_step_2() { swap_matching_lines "$1" 'CGROUP_REARM_CONFORMANCE_PASS_MARKER:' 'CGROUP_REARM_STEP: 2 —'; }
 expect_rejected reorder-label-before-pass swap_pass_after_step_2
+
+# --- Ordering fixtures for the evidence rules. Nothing is deleted; only the
+# sequence changes. Moving the entire verification section above the arm step
+# is the realistic regression: every rule is still present and a set-based
+# check would still pass, but the document now tells an operator to verify a
+# launcher that has not been armed yet.
+move_verification_before_arm() {
+  move_section_before "$1" \
+    '### Step 6: verification' \
+    '## Rollback / recovery branch' \
+    '### Step 5: arm the launcher'
+}
+expect_rejected reorder-verification-before-arm move_verification_before_arm
+
+swap_rule_1_and_2() { swap_matching_lines "$1" 'CGROUP_REARM_VERIFY_ORDER_1_CPU_MAX:' 'CGROUP_REARM_VERIFY_ORDER_2_WRONG_FENCE:'; }
+expect_rejected reorder-wrong-fence-before-cpu-max swap_rule_1_and_2
+
+swap_rule_3_and_4() { swap_matching_lines "$1" 'CGROUP_REARM_VERIFY_ORDER_3_HUNDRED_PERIODS:' 'CGROUP_REARM_VERIFY_ORDER_4_ONE_HOUR_DISPATCH:'; }
+expect_rejected reorder-one-hour-before-hundred-periods swap_rule_3_and_4
+
+swap_rule_4_and_5() { swap_matching_lines "$1" 'CGROUP_REARM_VERIFY_ORDER_4_ONE_HOUR_DISPATCH:' 'CGROUP_REARM_VERIFY_ORDER_5_ABORT_ROLLBACK:'; }
+expect_rejected reorder-abort-before-one-hour swap_rule_4_and_5
 
 # --- Regression fixture: reintroducing the banned 'label node' substring
 # (e.g. an operator-facing manual mutation command) must fail validation,


### PR DESCRIPTION
A proposal judge rejected an acceptance criterion that tried to make live production observations — a Running Pod, kernel cgroup values, 100 cgroup periods, an hour of board dispatches — into a repository acceptance criterion. Its reasoning: no domain outsider can run one named repository check to establish production state, so that belongs in the runbook as operator rollout evidence, not in CI.

Its narrow correction, quoted:

> remove this item from the acceptance-criteria list and retain the observations as explicitly post-merge operator rollout evidence in the repository-checked runbook. If repository acceptance must cover their presence, extend the preceding named `deploy/runbooks/tests/cgroup-launcher-rearm.sh` check to assert that the runbook contains and orders the exact `cpu.max` expectations, wrong-fence invariant, 100-period sampling rule, one-hour observation rule, and abort/rollback behavior, without claiming CI observed production.

**The runbook now carries the rollout evidence contract, and CI asserts only the document's content and ordering.** The observations remain what they always were — post-merge operator work, attested in the change record — and the repository check makes their *presence and order* impossible to drop silently.

## What Step 6 now states, in order

1. **Exact `cpu.max` expectations** — launcher leaf born at `25000 100000`; after a fenced lift, exactly `400000 100000` (that value, not "higher than birth").
2. **Wrong-fence invariant** — a lift presented with the wrong fence token is rejected and leaves `cpu.max` clamped. This is the non-vacuity rule for the whole step: without it, a leaf that simply never lifts reads identically to a working clamp, since both show `25000 100000`.
3. **100-period sampling rule** — `nr_throttled` and `throttled_usec` unchanged across at least 100 further `nr_periods`, read from `cpu.stat` over a wall-clock window. The runbook states explicitly that `cat cpu.max` alone is not acceptable evidence, and that a window advancing fewer than 100 periods is not a shorter version of the rule but no evidence at all.
4. **One-hour observation rule** — board dispatches remain greater than zero for the hour following the arm. The 2026-07-29 outage was a dispatch refusal, not a kernel fault; no reading from a single Pod can detect it.
5. **Abort/rollback behavior** — on any failure above, roll the launcher back to `cgroupLauncher.mode: disabled` and never leave production armed on unproven delegation.

## What the check does and does not claim

`deploy/runbooks/tests/cgroup-launcher-rearm.sh` reads one markdown file. No cluster, no kubectl, no helm, no credentials. Both the runbook and the test header say plainly that a green check means the evidence contract is present and correctly ordered — **never** that the evidence was collected. A new asserted marker, `CGROUP_REARM_VERIFICATION_EVIDENCE_IS_OPERATOR_COLLECTED`, pins that disclaimer into the document itself, so it cannot be quietly deleted.

## Non-vacuity

Nine new existence fixtures delete exactly one rule each and prove the check names it. Four new ordering fixtures reorder without deleting anything — including `reorder-verification-before-arm`, which relocates the entire Step 6 section above the arm step. That move was verified to preserve every line (sorted content identical, all five rule markers still present), so it fails on ordering alone and not on a deletion side effect.

`expect_rejected` now prints the assertion that fired rather than only the fixture name. A fixture that rejects for an unrelated reason proves nothing, and that is only visible if the firing assertion is named. This immediately surfaced a pre-existing weakness: `reorder-drain-after-restart` fires on the step-0/step-1 ordering check, because swapping the drain marker with step 1's marker also drags step 1 above step 0. That fixture is preserved unchanged, and a companion `relocate-drain-after-restart` was added that moves only the drain marker, so the drain-ordering assertion is now proven non-vacuous. (One residual, left alone as out of scope: `rollback-byte-for-byte` fires on the rollback-marker check, because the `CGROUP_REARM_ROLLBACK` marker line itself contains the phrase `byte-for-byte`.)

## Constraints honored

- Only two files touched: `deploy/runbooks/cgroup-launcher-rearm.md` and `deploy/runbooks/tests/cgroup-launcher-rearm.sh`.
- The literal substring `label node` is still absent from the runbook, and the `regression-label-node-phrase` fixture still rejects. The ownership scan returns only `deploy/node/k3s/djinn-cgroup-writable-conformance.sh`, and `deploy/helm/djinn/tests/cgroup-writable-render.sh` passes.
- Every pre-existing assertion and negative fixture is preserved; the six-step order and the preparation-Helm-upgrade-before-conformance ordering are unchanged.
- `bash scripts/test-deploy-contracts.sh` passes all four suites, so this runs through the CI runner added in #2768.

Vercel checks are rate-limited and red; not required for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
