### PR TITLE
fix(4q45): verify_node_identity compared a Pod status field that does not exist

### DIFF
--- a/deploy/helm/djinn/tests/cgroup-writable-render.sh
+++ b/deploy/helm/djinn/tests/cgroup-writable-render.sh
@@ -431,13 +431,30 @@ printf '%s\n' "\$*" >>'$log'
 case "\$1" in
   label) exit 0 ;;
   get)
-    if [ "\$2" = node ]; then exit 0; fi
-    if [ "\$2" = pod ] && [ "\${*: -2}" = '-o json' ]; then
+    selector=\${*: -1}
+    if [ "\$2" = node ]; then
+      case "\$selector" in
+        # The node's own InternalIP, which the identity check compares the
+        # probe's reported host against. The label read stays empty: this
+        # program removed eligibility before anything else ran.
+        *status.addresses*) printf '%s\n' '10.10.0.7' ;;
+        *) : ;;
+      esac
+      exit 0
+    fi
+    if [ "\$2" = pod ] && [ "\$selector" = json ]; then
       if [ "${case_name}" = sandbox ]; then printf '%s' 'Warning FailedCreatePodSandBox runc-cgroupwritable'; fi
       exit 0
     fi
     if [ "\$2" = pod ]; then
-      if [ "${case_name}" = wrong-node ]; then printf 'fixture-node|other-node'; else printf 'fixture-node|fixture-node'; fi
+      # wrong-node models a probe bound to a different node than the one
+      # requested. Every other case reports the requested binding and a host
+      # that is the requested node's own InternalIP.
+      if [ "${case_name}" = wrong-node ]; then pod_node_name=other-node; else pod_node_name=fixture-node; fi
+      rendered=\${selector#jsonpath=}
+      rendered=\${rendered//\\{.spec.nodeName\\}/\$pod_node_name}
+      rendered=\${rendered//\\{.status.hostIP\\}/10.10.0.7}
+      printf '%s' "\$rendered"
       exit 0
     fi
     ;;

--- a/deploy/node/k3s/djinn-cgroup-writable-conformance.sh
+++ b/deploy/node/k3s/djinn-cgroup-writable-conformance.sh
@@ -271,10 +271,44 @@ wait_for_probe() {
   fi
 }
 
+# Prove the probe actually RAN on the requested node, not merely that it was
+# requested there. PodStatus has no node-name field of any kind — it carries
+# `hostIP`, `hostIPs` and `nominatedNodeName` — so a selector asking status for
+# one renders empty forever and can never equal a node name. The two
+# observations that do exist are the binding this program wrote
+# (`.spec.nodeName`) and the host the admitting kubelet reported
+# (`.status.hostIP`), cross-checked against the Node object's own InternalIP so
+# the kubelet doing the reporting is provably this node's.
 verify_node_identity() {
-  local identity
-  identity=$("$KUBECTL" get pod "$PROBE_NAME" -o 'jsonpath={.spec.nodeName}|{.status.nodeName}')
-  [[ "$identity" == "$NODE_NAME|$NODE_NAME" ]] || die "probe node identity mismatch: $identity"
+  local bound_node host_ip node_internal_ips address observed='' matched=0
+
+  bound_node=$("$KUBECTL" get pod "$PROBE_NAME" -o 'jsonpath={.spec.nodeName}')
+  [[ "$bound_node" == "$NODE_NAME" ]] ||
+    die "probe node identity mismatch: pod spec.nodeName=[$bound_node] requested node=[$NODE_NAME]"
+
+  host_ip=$("$KUBECTL" get pod "$PROBE_NAME" -o 'jsonpath={.status.hostIP}')
+  node_internal_ips=$("$KUBECTL" get node "$NODE_NAME" \
+    -o 'jsonpath={range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}')
+
+  # Fail closed on each side independently. A probe the kubelet never admitted
+  # and a node that publishes no InternalIP both render empty, and empty must
+  # never compare equal to empty: that silent pass is the defect being fixed.
+  [[ -n "$host_ip" ]] ||
+    die "probe node identity mismatch: pod status.hostIP is empty, so no kubelet has reported a host for this probe (requested node=[$NODE_NAME])"
+  [[ -n "$node_internal_ips" ]] ||
+    die "probe node identity mismatch: node=[$NODE_NAME] publishes no InternalIP address (pod status.hostIP=[$host_ip])"
+
+  # A node may publish several InternalIP addresses — a dual-stack node
+  # publishes one per family — while the kubelet writes only the primary into
+  # status.hostIP. Membership of a whole address, never a substring test: an
+  # address is a prefix of longer addresses in the same subnet.
+  while IFS= read -r address; do
+    [[ -n "$address" ]] || continue
+    observed="${observed:+$observed }$address"
+    if [[ "$address" == "$host_ip" ]]; then matched=1; fi
+  done <<<"$node_internal_ips"
+  [[ $matched -eq 1 ]] ||
+    die "probe node identity mismatch: pod status.hostIP=[$host_ip] is not an InternalIP of node=[$NODE_NAME] (node InternalIPs=[$observed])"
 }
 
 # Runs as the root launcher phase of the sole probe process. It proves that the

--- a/deploy/node/k3s/tests/conformance-version-lifecycle.sh
+++ b/deploy/node/k3s/tests/conformance-version-lifecycle.sh
@@ -44,16 +44,46 @@ set -euo pipefail
 printf 'restart %s\n' "\$*" >>'$log'
 cp '$post_live' '$live'
 EOF
+  # The `get` arms render jsonpath selectors the way the real apiserver does.
+  # Crucially, a selector naming a field the Pod API does not have renders
+  # EMPTY rather than a node name, so a comparison against a nonexistent field
+  # fails here for exactly the reason it failed on the production node.
+  # Per-case identity observations come from the environment:
+  #   DJINN_FIXTURE_POD_NODE_NAME       .spec.nodeName on the probe
+  #   DJINN_FIXTURE_POD_HOST_IP         .status.hostIP on the probe
+  #   DJINN_FIXTURE_NODE_INTERNAL_IPS   the node's InternalIP addresses
   cat >"$dir/kubectl" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "\$*" >>'$log'
+selector=\${*: -1}
+pod_node_name=\${DJINN_FIXTURE_POD_NODE_NAME-$NODE}
+pod_host_ip=\${DJINN_FIXTURE_POD_HOST_IP-10.10.0.7}
+node_internal_ips=\${DJINN_FIXTURE_NODE_INTERNAL_IPS-10.10.0.7}
 case "\$1" in
   label) exit 0 ;;
   get)
-    if [ "\$2" = node ]; then exit 0; fi
-    if [ "\$2" = pod ] && [ "\${*: -2}" = '-o json' ]; then exit 0; fi
-    if [ "\$2" = pod ]; then printf '$NODE|$NODE'; exit 0; fi
+    if [ "\$2" = node ]; then
+      case "\$selector" in
+        # A {range} over InternalIP addresses emits one address per line.
+        *status.addresses*)
+          for address in \$node_internal_ips; do printf '%s\n' "\$address"; done ;;
+        # The eligibility label read must render empty: this program removed
+        # the label before anything else, and ensure_unlabeled proves it.
+        *) : ;;
+      esac
+      exit 0
+    fi
+    if [ "\$2" = pod ]; then
+      if [ "\$selector" = json ]; then exit 0; fi
+      rendered=\${selector#jsonpath=}
+      rendered=\${rendered//\\{.spec.nodeName\\}/\$pod_node_name}
+      rendered=\${rendered//\\{.status.hostIP\\}/\$pod_host_ip}
+      # PodStatus has no nodeName field. The apiserver renders it as nothing.
+      rendered=\${rendered//\\{.status.nodeName\\}/}
+      printf '%s' "\$rendered"
+      exit 0
+    fi
     ;;
   apply) cat >'$manifest'; exit 0 ;;
   wait) exit 0 ;;
@@ -152,6 +182,18 @@ else
   fail 'v3 success did not label the node'
 fi
 assert_probe_manifest v3
+# The identity proof must actually be performed on the passing path, otherwise
+# section 6's rejections would be guarding a check nothing ever reaches.
+if grep -Fq 'get pod' "$LOG" && grep -Fq 'jsonpath={.status.hostIP}' "$LOG"; then
+  ok 'v3 success read the host the kubelet reported for the probe'
+else
+  fail 'v3 success never read the probe status.hostIP'
+fi
+if grep -Fq '{range .status.addresses[?(@.type=="InternalIP")]}' "$LOG"; then
+  ok "v3 success cross-checked the node's own InternalIP"
+else
+  fail 'v3 success never read the node InternalIP'
+fi
 
 # ---------------------------------------------------------------------------
 # 2. The version-2 node keeps working, unchanged asset and all.
@@ -273,7 +315,86 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 6. Fixture mode: the success transcript is exact and every failure case,
+# 6. Node identity. The check must prove the probe RAN on the requested node,
+#    not merely that it was requested there. PodStatus has no `nodeName`
+#    field, so the only available cross-check is the admitting kubelet's
+#    reported `.status.hostIP` against the Node object's own InternalIP.
+#    Every empty observation must fail closed: an empty-vs-empty comparison
+#    that passes is precisely the defect these cases exist to forbid.
+# ---------------------------------------------------------------------------
+assert_identity_rejected() {
+  local name=$1
+  shift
+  assert_restored_after_restart "$name"
+  if grep -Fq 'probe node identity mismatch' "$CASE_DIR/stderr"; then
+    ok "$name reports a node identity mismatch"
+  else
+    fail "$name diagnosis: $(cat "$CASE_DIR/stderr")"
+  fi
+  local needle
+  for needle in "$@"; do
+    if grep -Fq "$needle" "$CASE_DIR/stderr"; then
+      ok "$name reports the observed value [$needle]"
+    else
+      fail "$name omitted [$needle] from: $(cat "$CASE_DIR/stderr")"
+    fi
+  done
+  # An unproven host must abort before any cgroup authorization observation.
+  if grep -q '^exec ' "$LOG"; then
+    fail "$name ran the cgroup probe on an unproven host"
+  else
+    ok "$name aborted before the cgroup probe"
+  fi
+}
+
+# The real production node publishes one InternalIP per address family while
+# the kubelet writes only the primary into status.hostIP. Whole-string equality
+# against the node's address list would reject this healthy node outright.
+run_case identity-dual-stack live-v3-vps-preinstall.toml live-v3-vps.toml 0 \
+  DJINN_FIXTURE_NODE_INTERNAL_IPS='10.10.0.7 fd00::7' \
+  DJINN_FIXTURE_POD_HOST_IP=10.10.0.7
+expect_eq 'identity-dual-stack status' 0 "$STATUS"
+expect_eq 'identity-dual-stack stdout' "$PASS_LINE" "$(cat "$CASE_DIR/stdout")"
+
+# The node lookup renders empty: no InternalIP is published at all.
+run_case identity-node-ip-empty live-v3-vps-preinstall.toml live-v3-vps.toml 0 \
+  DJINN_FIXTURE_NODE_INTERNAL_IPS=
+assert_identity_rejected identity-node-ip-empty \
+  'publishes no InternalIP address' 'status.hostIP=[10.10.0.7]'
+
+# The kubelet never reported a host for the probe.
+run_case identity-host-ip-empty live-v3-vps-preinstall.toml live-v3-vps.toml 0 \
+  DJINN_FIXTURE_POD_HOST_IP=
+assert_identity_rejected identity-host-ip-empty \
+  'status.hostIP is empty' 'requested node=[fixture-node]'
+
+# BOTH sides empty. A comparison of one empty rendering against another must
+# never satisfy the check; this is the exact hole `{.status.nodeName}` opened.
+run_case identity-both-empty live-v3-vps-preinstall.toml live-v3-vps.toml 0 \
+  DJINN_FIXTURE_POD_HOST_IP= DJINN_FIXTURE_NODE_INTERNAL_IPS=
+assert_identity_rejected identity-both-empty 'status.hostIP is empty'
+
+# A kubelet on some other host reported this probe.
+run_case identity-foreign-host-ip live-v3-vps-preinstall.toml live-v3-vps.toml 0 \
+  DJINN_FIXTURE_POD_HOST_IP=10.10.0.9
+assert_identity_rejected identity-foreign-host-ip \
+  'status.hostIP=[10.10.0.9]' 'node InternalIPs=[10.10.0.7]'
+
+# Address membership is compared whole. A substring test would accept this,
+# because 10.10.0.7 is a substring of the node's only address 10.10.0.71.
+run_case identity-substring-near-miss live-v3-vps-preinstall.toml live-v3-vps.toml 0 \
+  DJINN_FIXTURE_POD_HOST_IP=10.10.0.7 DJINN_FIXTURE_NODE_INTERNAL_IPS=10.10.0.71
+assert_identity_rejected identity-substring-near-miss \
+  'status.hostIP=[10.10.0.7]' 'node InternalIPs=[10.10.0.71]'
+
+# The binding half still has to hold on its own.
+run_case identity-bound-elsewhere live-v3-vps-preinstall.toml live-v3-vps.toml 0 \
+  DJINN_FIXTURE_POD_NODE_NAME=other-node
+assert_identity_rejected identity-bound-elsewhere \
+  'spec.nodeName=[other-node]' 'requested node=[fixture-node]'
+
+# ---------------------------------------------------------------------------
+# 7. Fixture mode: the success transcript is exact and every failure case,
 #    including the new version-mismatch case, removes eligibility only.
 # ---------------------------------------------------------------------------
 run_fixture_case() {
@@ -316,7 +437,7 @@ run_fixture_case handler-removed
 run_fixture_case version-mismatch
 
 # ---------------------------------------------------------------------------
-# 7. Load-bearing text a reviewer will diff, and sole ownership of the label.
+# 8. Load-bearing text a reviewer will diff, and sole ownership of the label.
 # ---------------------------------------------------------------------------
 conformance_text=$(cat "$CONFORMANCE")
 assert_contains() {
@@ -332,6 +453,18 @@ assert_contains 'WORKER_PROBE' "WORKER_PROBE='set -eu"
 assert_contains 'worker denial helper' 'must_deny() { if sh -c "$1"; then'
 assert_contains 'wait_for_probe' 'wait_for_probe() {'
 assert_contains 'verify_node_identity' 'verify_node_identity() {'
+# Both halves of the identity proof, by the fields that actually exist.
+assert_contains 'identity reads the probe binding' 'jsonpath={.spec.nodeName}'
+assert_contains 'identity reads the reported host' 'jsonpath={.status.hostIP}'
+assert_contains 'identity cross-checks the node InternalIP' \
+  '{range .status.addresses[?(@.type=="InternalIP")]}'
+# The regression guard for this whole change: PodStatus has no nodeName field,
+# so any selector naming one renders empty and can never prove a thing.
+case "$conformance_text" in
+  *'.status.nodeName'*)
+    fail 'conformance reads .status.nodeName, a field the Pod API does not have' ;;
+  *) ok 'preserved: conformance never reads the nonexistent .status.nodeName' ;;
+esac
 assert_contains 'probe-only RuntimeClass' "PROBE_RUNTIME_CLASS='djinn-cgroup-writable-probe'"
 assert_contains 'probe manifest uses the probe-only class' 'runtimeClassName: $PROBE_RUNTIME_CLASS'
 assert_contains 'probe stays node-bound' 'nodeName: $NODE_NAME'
@@ -348,7 +481,7 @@ owners=$(grep -rl 'label node' "$NODE_DIR" --include='*.sh' | grep -v "$SCRIPT_D
 expect_eq 'sole label owner under deploy/node' "$CONFORMANCE" "$owners"
 
 # ---------------------------------------------------------------------------
-# 8. Non-vacuity: the pre-change script restarts k3s on the very fixture the
+# 9. Non-vacuity: the pre-change script restarts k3s on the very fixture the
 #    preflight now refuses. Skipped once the baseline ref carries the preflight.
 # ---------------------------------------------------------------------------
 baseline_ref=${DJINN_CONFORMANCE_BASELINE_REF:-origin/main}


### PR DESCRIPTION
## The production failure

After #2770 fixed the probe RuntimeClass the probe now reaches Ready — real progress. It fails at the very next step:

```
FAIL probe node identity mismatch: vmi3355738|
EXIT=1
```

This is the **second never-exercised check found in this one script**. Like the RuntimeClass bug in #2770, `verify_node_identity` had never run to completion before today, because the probe never reached Ready — so a comparison that can never succeed sat in the script undetected.

## Live-cluster proof that `.status.nodeName` does not exist

`verify_node_identity` did:

```bash
identity=$("$KUBECTL" get pod "$PROBE_NAME" -o 'jsonpath={.spec.nodeName}|{.status.nodeName}')
[[ "$identity" == "$NODE_NAME|$NODE_NAME" ]] || die "probe node identity mismatch: $identity"
```

`.spec.nodeName` resolves. `.status.nodeName` **is not a field of the Kubernetes Pod API**, so it always renders empty and the right-hand side can never be matched. Verified on the live VPS k3s node (server `v1.35.5+k3s1`):

```
spec.nodeName   = [vmi3355738]
status.nodeName = []
status.hostIP   = [13.140.147.151]
```

`kubectl explain pod.status --recursive | grep -i nodename` returns exactly one line — `nominatedNodeName`. There is no `nodeName` under `status`. `kubectl explain pod.status.hostIP` confirms `hostIP` exists and is populated by the kubelet.

## The fix

The intent — prove the probe actually **ran** on the exact node requested, not merely that it was requested there — is preserved using fields that exist:

1. `.spec.nodeName` must equal the requested `$NODE_NAME` (the binding this program wrote).
2. The probe's `.status.hostIP` — written by the kubelet that actually admitted the Pod — is cross-checked against the Node object's own InternalIP addresses.

**Both sides fail closed.** An absent kubelet report and a node with no InternalIP each render empty, and empty is never allowed to compare equal to empty. That was precisely the defect, and it is the single most important property of the change.

### A third latent bug avoided: the production node is dual-stack

The obvious implementation — compare `hostIP` to the output of `jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}'` — would itself have been dead on arrival on this node:

```
$ kubectl get node vmi3355738 -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}'
13.140.147.151 2a02:c207:2335:5738::1
```

The node publishes one InternalIP per address family, while the kubelet writes only the primary into `status.hostIP`. A whole-string equality would have rejected this healthy node outright. So membership of a **whole address** is compared instead — and per-address equality rather than a substring test, since an address can be a prefix of another in the same subnet (`10.10.0.7` vs `10.10.0.71`).

The new logic was run verbatim against the live production node and pod:

```
IDENTITY OK bound_node=vmi3355738 host_ip=13.140.147.151 node_internal_ips=[13.140.147.151 2a02:c207:2335:5738::1]
```

Failure messages keep the `die "probe node identity mismatch: ..."` style and name both observed values, e.g.:

```
FAIL probe node identity mismatch: pod status.hostIP=[10.10.0.9] is not an InternalIP of node=[fixture-node] (node InternalIPs=[10.10.0.7])
```

## Per-expression jsonpath audit

Every `jsonpath=` in `deploy/node/k3s/djinn-cgroup-writable-conformance.sh` was checked against the live cluster API. The script contains exactly two (plus one `-o json`); one was broken.

| Expression | Object | Verdict | Evidence |
| --- | --- | --- | --- |
| `{.metadata.labels.djinn\.io/cgroup-writable}` (`ensure_unlabeled`) | Node | **Correct, unchanged** | `metadata.labels` is `map[string]string` on every object. Queried live: renders `[]` on the currently-unlabeled node, which is the emptiness `ensure_unlabeled` requires. Semantics untouched. |
| `{.spec.nodeName}\|{.status.nodeName}` (`verify_node_identity`) | Pod | **BROKEN — fixed** | `PodStatus` has no `nodeName`; `kubectl explain pod.status --recursive` yields only `nominatedNodeName`. Live pod renders `[]`. Was dead on arrival. |
| `-o json` (`wait_for_probe`) | Pod | **Correct, unchanged** | Not a jsonpath; whole-object serialization greped for `FailedCreatePodSandBox\|runc-cgroupwritable`. No field reference to be wrong. |
| `{.status.hostIP}` (new) | Pod | **Verified present** | `kubectl explain pod.status.hostIP` → `FIELD: hostIP <string>`, "holds the IP address of the host to which the pod is assigned". Live pod renders `13.140.147.151`. |
| `{range .status.addresses[?(@.type=="InternalIP")]}{.address}{"\n"}{end}` (new) | Node | **Verified present** | `kubectl explain node.status.addresses` → `<[]NodeAddress>` with required `address` and `type`, type "one of Hostname, ExternalIP or InternalIP". Live node renders both InternalIPs, one per line. |

Neighbouring files were swept for the same class of defect; no further nonexistent-field references were found:

- `deploy/runbooks/cgroup-launcher-rearm.md:153` — `{.metadata.labels.djinn\.io/cgroup-writable}` on a Node: correct.
- `deploy/runbooks/cgroup-launcher-rearm.md:240` — `{.status.phase} {.spec.runtimeClassName}` on a Pod: both exist (`PodStatus.phase`, `PodSpec.runtimeClassName`).
- `scripts/kind/setup-kind.sh:103` — `{.spec.clusterIP}` on a Service: exists.
- `scripts/taskrun-backstop-preflight.sh:108` — `{..namespace}` against `kubectl config view`, a kubeconfig document, not the Pod API: correct.

## Tests

`deploy/node/k3s/tests/conformance-version-lifecycle.sh` gains seven identity cases. Its kubectl stub now **renders jsonpath selectors the way the apiserver does** — a selector naming a field the Pod API lacks renders empty — so the pre-fix comparison fails in the harness for exactly the reason it failed in production, reproducing the `probe node identity mismatch: fixture-node|` shape verbatim.

| Case | Fixture | Expectation |
| --- | --- | --- |
| `identity-dual-stack` | node publishes `10.10.0.7 fd00::7`, hostIP `10.10.0.7` | PASS (models the real node) |
| `identity-node-ip-empty` | node InternalIP lookup returns EMPTY | FAIL |
| `identity-host-ip-empty` | hostIP EMPTY | FAIL |
| `identity-both-empty` | **both EMPTY** | FAIL — the hole is closed |
| `identity-foreign-host-ip` | hostIP `10.10.0.9`, node `10.10.0.7` | FAIL |
| `identity-substring-near-miss` | hostIP `10.10.0.7`, node `10.10.0.71` | FAIL |
| `identity-bound-elsewhere` | `spec.nodeName` = `other-node` | FAIL |

Each failing case additionally asserts the template was restored with a second restart, that the eligibility label was never applied, that both observed values appear in the diagnosis, and that the cgroup probe **never ran on an unproven host**. The passing path asserts both identity reads actually happen, so the rejections are not guarding a check nothing reaches. A source-level guard now fails the suite if `.status.nodeName` reappears anywhere in the script, comments included.

### Non-vacuity 1 — restore the old comparison, new tests fail

With `{.spec.nodeName}|{.status.nodeName}` put back, the suite reports **27 failures**, including the production shape:

```
FAIL: identity-node-ip-empty omitted [publishes no InternalIP address] from: FAIL probe node identity mismatch: fixture-node|
FAIL: v3 success status: expected [0], got [1]
FAIL: conformance reads .status.nodeName, a field the Pod API does not have
FAIL: 27 conformance version lifecycle assertion(s)
```

### Non-vacuity 2 — the empty-vs-empty proof

With the real fields but the fail-closed guards removed (plain equality, no `-n` checks), `identity-both-empty` **passes and arms the node**:

```
FAIL: identity-both-empty: unexpectedly succeeded
FAIL: identity-both-empty: applied the eligibility label
FAIL: identity-both-empty: left the unproven template installed
FAIL: identity-both-empty ran the cgroup probe on an unproven host
FAIL: identity-dual-stack status: expected [0], got [1]
```

That is the hole being fixed: empty-vs-empty certifies a node nothing was ever observed on. The last line also shows the naive whole-string equality rejecting the real dual-stack production node, which is why membership is compared.

### Non-vacuity 3 — the helm `wrong-node` case is genuinely driven by this check

Neutralising that fixture (reporting the requested binding instead of `other-node`) makes the helm contract fail with `FAIL: wrong-node unexpectedly succeeded`, then it was restored.

## Verification

All green on the final tree:

- `bash -n` on all three touched scripts → 0
- `bash deploy/node/k3s/tests/conformance-version-lifecycle.sh` → PASS
- `bash deploy/node/k3s/tests/containerd-config-version-detection.sh` → PASS
- `bash deploy/helm/djinn/tests/cgroup-writable-render.sh` → PASS
- `bash deploy/runbooks/tests/cgroup-launcher-rearm.sh` → PASS
- `bash scripts/test-deploy-contracts.sh` → all 4 deploy contract scripts passed

## Preserved

`LAUNCHER_PROBE` and `WORKER_PROBE` byte-for-byte, the exact PASS line, `PROBE_RUNTIME_CLASS='djinn-cgroup-writable-probe'`, the `spec.nodeName` binding in the probe manifest, sole ownership of `djinn.io/cgroup-writable`, the zero-write/zero-restart version-detection preflight, and the backup/restore-and-second-restart path. The conformance-script diff is confined to `verify_node_identity`. No new occurrence of the CI-scanned `label node` substring.

`deploy/helm/djinn/tests/cgroup-writable-render.sh` is touched for one reason only: its kubectl stub answered *any* pod jsonpath with the combined `fixture-node|fixture-node` string, so it had to learn the same per-selector rendering or every case would break. Its `wrong-node` semantics are unchanged, as demonstrated above.

Vercel checks are rate-limited and red; not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
