### PR TITLE
fix(4q45): probe leaked root's group 0 into the worker identity

### DIFF
--- a/deploy/node/k3s/djinn-cgroup-writable-conformance.sh
+++ b/deploy/node/k3s/djinn-cgroup-writable-conformance.sh
@@ -415,13 +415,39 @@ render_manifest | "$KUBECTL" apply -f - >/dev/null
 wait_for_probe
 verify_node_identity
 # A single exec process performs both phases so the retained launcher leaf and
-# all worker checks necessarily use one private cgroup namespace/root. fsGroup
-# supplies supplementary group 1000; setpriv preserves that sole group, changes
-# uid/gid, enables no-new-privileges, clears every capability set, and execs the
-# worker checks without any path back to launcher authority.
+# all worker checks necessarily use one private cgroup namespace/root. setpriv
+# changes uid/gid, replaces the supplementary group set outright, enables
+# no-new-privileges, clears every capability set, and execs the worker checks
+# without any path back to launcher authority.
+#
+# The supplementary set is stated explicitly, never inherited. The launcher
+# phase runs as `runAsUser: 0`, so its own supplementary set is `0 1000` — group
+# 0 from root plus the pod's fsGroup. `--keep-groups` therefore carried root's
+# group 0 across the transition and the worker identity became `0 1000`, which
+# is an identity no rendered worker ever has: worker_security_context() in
+# server/crates/djinn-k8s/src/launcher.rs pins the worker container to
+# runAsUser/runAsGroup 1000 with runAsNonRoot, and the pod securityContext there
+# supplies fsGroup 1000, so a real worker's supplementary set is exactly `1000`
+# (asserted in server/crates/djinn-k8s/src/job.rs). `--groups` sets that set by
+# setgroups(2) rather than preserving it, and setpriv rejects it alongside
+# --keep-groups/--clear-groups/--init-groups, so it cannot append: whatever the
+# launcher held, the worker holds exactly 1000. Verified against the setpriv in
+# $PROBE_IMAGE (util-linux 2.39.3, Ubuntu 24.04), not assumed.
 COMBINED_PROBE="$LAUNCHER_PROBE
-exec setpriv --reuid=1000 --regid=1000 --keep-groups --nnp --inh-caps=-all --ambient-caps=-all --bounding-set=-all /bin/sh -ceu \"\$1\""
-"$KUBECTL" exec "$PROBE_NAME" -c conformance -- /bin/sh -ceu "$COMBINED_PROBE" probe "$WORKER_PROBE" >/dev/null || die 'launcher/worker cgroup conformance failed'
+exec setpriv --reuid=1000 --regid=1000 --groups=1000 --nnp --inh-caps=-all --ambient-caps=-all --bounding-set=-all /bin/sh -ceux \"\$1\""
+# Both phases run under `sh -ceux`, and everything the probe emits on either
+# stream is captured rather than discarded. On success the capture is dropped so
+# stdout stays exactly the PASS line; on failure the whole xtrace goes to stderr
+# so the failing assertion names itself. A `>/dev/null` here is what kept three
+# earlier defects in this program invisible: the operator saw only
+# "conformance failed" and had to re-run the exec by hand to learn which
+# assertion had never passed.
+probe_transcript=''
+if ! probe_transcript=$("$KUBECTL" exec "$PROBE_NAME" -c conformance -- \
+  /bin/sh -ceux "$COMBINED_PROBE" probe "$WORKER_PROBE" 2>&1); then
+  printf '%s\n' "$probe_transcript" >&2
+  die 'launcher/worker cgroup conformance failed'
+fi
 
 "$KUBECTL" label node "$NODE_NAME" "$LABEL=true" --overwrite >/dev/null
 printf 'PASS node=%s handler=runc-cgroupwritable cgroup_root=/ writable=true isolated=true worker_denials=true\n' "$NODE_NAME"

--- a/deploy/node/k3s/tests/conformance-version-lifecycle.sh
+++ b/deploy/node/k3s/tests/conformance-version-lifecycle.sh
@@ -87,7 +87,15 @@ case "\$1" in
     ;;
   apply) cat >'$manifest'; exit 0 ;;
   wait) exit 0 ;;
-  exec) exit $exec_status ;;
+  # The probe emits on BOTH streams, exactly as \`sh -ceux\` does: assertions on
+  # stdout, the xtrace on stderr. A passing run must forward neither, so the
+  # PASS line stays the whole of stdout; a failing run must forward both, or the
+  # operator is told only that conformance failed and has to re-run the exec by
+  # hand to learn which assertion never passed.
+  exec)
+    printf '%s\n' 'probe-emitted-on-stdout'
+    printf '%s\n' 'probe-xtrace: + [ 0 1000 = 1000 ]' >&2
+    exit $exec_status ;;
   delete) exit 0 ;;
 esac
 exit 0
@@ -193,6 +201,19 @@ if grep -Fq '{range .status.addresses[?(@.type=="InternalIP")]}' "$LOG"; then
   ok "v3 success cross-checked the node's own InternalIP"
 else
   fail 'v3 success never read the node InternalIP'
+fi
+# The PASS-line contract: a successful run forwards nothing the probe wrote on
+# either stream, so capturing the transcript for the failure path cannot change
+# what an operator or an automation parses out of a passing run.
+if grep -Fq 'probe-emitted-on-stdout' "$CASE_DIR/stdout" || grep -Fq 'probe-xtrace' "$CASE_DIR/stdout"; then
+  fail "v3 success leaked probe output onto stdout: $(cat "$CASE_DIR/stdout")"
+else
+  ok 'v3 success keeps the PASS line as the whole of stdout'
+fi
+if [ -s "$CASE_DIR/stderr" ]; then
+  fail "v3 success wrote to stderr: $(cat "$CASE_DIR/stderr")"
+else
+  ok 'v3 success forwards no probe transcript on stderr either'
 fi
 
 # ---------------------------------------------------------------------------
@@ -307,6 +328,22 @@ fi
 run_case probe-failure live-v3-vps-preinstall.toml live-v3-vps.toml 1
 assert_restored_after_restart probe-failure
 if grep -q '^delete pod ' "$LOG"; then ok 'probe-failure deleted the probe'; else fail 'probe-failure left the probe'; fi
+# A failing probe must name the assertion that failed. Suppressing the exec with
+# `>/dev/null` is why three defects in this program stayed invisible: the
+# operator saw only the summary line and had to re-run the exec by hand under
+# `set -x` to find the assertion that had never once passed.
+for stream_marker in 'probe-xtrace: + [ 0 1000 = 1000 ]' 'probe-emitted-on-stdout'; do
+  if grep -Fq "$stream_marker" "$CASE_DIR/stderr"; then
+    ok "probe-failure surfaced the probe transcript [$stream_marker]"
+  else
+    fail "probe-failure suppressed [$stream_marker]: $(cat "$CASE_DIR/stderr")"
+  fi
+done
+if grep -Fq 'launcher/worker cgroup conformance failed' "$CASE_DIR/stderr"; then
+  ok 'probe-failure still reports the summary diagnosis'
+else
+  fail "probe-failure lost its summary diagnosis: $(cat "$CASE_DIR/stderr")"
+fi
 unlabels=$(grep -Fc 'label node fixture-node djinn.io/cgroup-writable- --overwrite' "$LOG" || true)
 if [ "$unlabels" -ge 2 ]; then
   ok 'probe-failure removed eligibility again in cleanup'
@@ -394,7 +431,103 @@ assert_identity_rejected identity-bound-elsewhere \
   'spec.nodeName=[other-node]' 'requested node=[fixture-node]'
 
 # ---------------------------------------------------------------------------
-# 7. Fixture mode: the success transcript is exact and every failure case,
+# 7. Worker identity: the supplementary group SET. The launcher phase runs as
+#    `runAsUser: 0`, so its own supplementary set is `0 1000` — root's group 0
+#    plus the pod's fsGroup. No rendered task-run worker ever has that set:
+#    worker_security_context() in server/crates/djinn-k8s/src/launcher.rs pins
+#    the worker container to runAsUser/runAsGroup 1000 with runAsNonRoot and the
+#    pod securityContext there to fsGroup 1000 (asserted in
+#    server/crates/djinn-k8s/src/job.rs), so a real worker's supplementary set
+#    is exactly `1000` and nothing else. The probe must
+#    therefore STATE the worker group set, never inherit the launcher's, and the
+#    assertion must reject the inherited shape rather than tolerate it.
+# ---------------------------------------------------------------------------
+setpriv_line=$(grep -F 'exec setpriv ' "$CONFORMANCE" || true)
+if [ -z "$setpriv_line" ]; then
+  fail 'no setpriv launcher-to-worker transition found in the conformance script'
+fi
+case "$setpriv_line" in
+  *--groups=1000*)
+    ok 'worker transition states the supplementary group set explicitly' ;;
+  *)
+    fail "worker transition does not set --groups=1000: [$setpriv_line]" ;;
+esac
+# setpriv rejects --groups alongside --keep-groups/--clear-groups/--init-groups,
+# so this is not merely redundant with the assertion above: --keep-groups is the
+# defect, and it is the one shape that would silently reintroduce group 0.
+case "$setpriv_line" in
+  *--keep-groups*)
+    fail "worker transition uses --keep-groups, which carries the launcher's group 0 into the worker identity: [$setpriv_line]" ;;
+  *)
+    ok 'worker transition never inherits the launcher supplementary groups' ;;
+esac
+
+# The assertion itself, executed. The line is lifted verbatim out of
+# WORKER_PROBE (un-escaping the '\'' sequences bash uses to embed a single quote
+# inside a single-quoted literal) and pointed at a fixture status file, so these
+# cases exercise the same expression the worker phase runs on the node — it
+# cannot drift from the script without this section noticing.
+groups_assertion=$(grep -F '/^Groups:/' "$CONFORMANCE" || true)
+if [ -z "$groups_assertion" ]; then
+  fail 'WORKER_PROBE carries no Groups: assertion at all'
+else
+  embedded_quote="'\\''"
+  bare_quote="'"
+  groups_assertion=${groups_assertion//"$embedded_quote"/"$bare_quote"}
+  assert_groups_fixture() {
+    local name=$1 status_line=$2 expect=$3 fixture snippet observed
+    fixture="$WORK/status-$name"
+    # Shaped exactly like the kernel's /proc/<pid>/status rendering: a tab after
+    # the key, a space after every GID including the last.
+    printf 'Name:\tsh\nUid:\t1000\t1000\t1000\t1000\nGid:\t1000\t1000\t1000\t1000\n%s\nNoNewPrivs:\t1\n' \
+      "$status_line" >"$fixture"
+    snippet=${groups_assertion//\/proc\/self\/status/$fixture}
+    set +e
+    sh -eu -c "$snippet" >/dev/null 2>&1
+    observed=$?
+    set -e
+    if [ "$expect" = pass ] && [ "$observed" -eq 0 ]; then
+      ok "worker Groups assertion accepts the rendered worker set [$status_line]"
+    elif [ "$expect" = fail ] && [ "$observed" -ne 0 ]; then
+      ok "worker Groups assertion rejects [$status_line]"
+    else
+      fail "worker Groups assertion on [$status_line]: expected to $expect, exit=$observed"
+    fi
+  }
+  # The set a rendered worker actually has, trailing space included.
+  assert_groups_fixture rendered-worker "$(printf 'Groups:\t1000 ')" pass
+  # What --keep-groups produced on the production node: root's group 0 leaked
+  # through the transition and the worker ran with `0 1000`. This must FAIL.
+  # Relaxing it would make the probe certify a worker identity production never
+  # has, which is the entire class of defect this program exists to exclude.
+  assert_groups_fixture leaked-root-group "$(printf 'Groups:\t0 1000 ')" fail
+  # Neither may a bare root group, a reordering, nor an empty set pass.
+  assert_groups_fixture only-root-group "$(printf 'Groups:\t0 ')" fail
+  assert_groups_fixture reordered-with-root "$(printf 'Groups:\t1000 0 ')" fail
+  assert_groups_fixture empty-group-set "$(printf 'Groups:\t')" fail
+fi
+
+# The load-bearing property of --groups is that it REPLACES the set by
+# setgroups(2) and cannot append to it. setpriv enforces that by refusing
+# --groups alongside --keep-groups at all, which is observable without any
+# privilege. The diagnostic wording differs between util-linux releases, so only
+# the refusal is asserted.
+if command -v setpriv >/dev/null 2>&1; then
+  set +e
+  setpriv_exclusivity=$(setpriv --groups=1000 --keep-groups /bin/true 2>&1)
+  setpriv_exclusivity_status=$?
+  set -e
+  if [ "$setpriv_exclusivity_status" -ne 0 ] && [ -n "$setpriv_exclusivity" ]; then
+    ok "setpriv refuses --groups alongside --keep-groups, so --groups cannot append [$setpriv_exclusivity]"
+  else
+    fail "setpriv accepted --groups with --keep-groups (exit=$setpriv_exclusivity_status): --groups may not be replacing the set"
+  fi
+else
+  printf 'SKIP setpriv group-flag exclusivity: setpriv is not installed\n'
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Fixture mode: the success transcript is exact and every failure case,
 #    including the new version-mismatch case, removes eligibility only.
 # ---------------------------------------------------------------------------
 run_fixture_case() {
@@ -437,7 +570,7 @@ run_fixture_case handler-removed
 run_fixture_case version-mismatch
 
 # ---------------------------------------------------------------------------
-# 8. Load-bearing text a reviewer will diff, and sole ownership of the label.
+# 9. Load-bearing text a reviewer will diff, and sole ownership of the label.
 # ---------------------------------------------------------------------------
 conformance_text=$(cat "$CONFORMANCE")
 assert_contains() {
@@ -465,6 +598,15 @@ case "$conformance_text" in
     fail 'conformance reads .status.nodeName, a field the Pod API does not have' ;;
   *) ok 'preserved: conformance never reads the nonexistent .status.nodeName' ;;
 esac
+# The probe transcript must stay captured. Discarding the exec is what hid the
+# three preceding defects in this program from every operator who ran it.
+case "$conformance_text" in
+  *'"$WORKER_PROBE" >/dev/null'*)
+    fail 'conformance discards the probe transcript again' ;;
+  *) ok 'preserved: the probe transcript is captured, not discarded' ;;
+esac
+assert_contains 'probe transcript reaches stderr on failure' "printf '%s\\n' \"\$probe_transcript\" >&2"
+assert_contains 'both probe phases run under xtrace' '/bin/sh -ceux'
 assert_contains 'probe-only RuntimeClass' "PROBE_RUNTIME_CLASS='djinn-cgroup-writable-probe'"
 assert_contains 'probe manifest uses the probe-only class' 'runtimeClassName: $PROBE_RUNTIME_CLASS'
 assert_contains 'probe stays node-bound' 'nodeName: $NODE_NAME'
@@ -481,8 +623,8 @@ owners=$(grep -rl 'label node' "$NODE_DIR" --include='*.sh' | grep -v "$SCRIPT_D
 expect_eq 'sole label owner under deploy/node' "$CONFORMANCE" "$owners"
 
 # ---------------------------------------------------------------------------
-# 9. Non-vacuity: the pre-change script restarts k3s on the very fixture the
-#    preflight now refuses. Skipped once the baseline ref carries the preflight.
+# 10. Non-vacuity: the pre-change script restarts k3s on the very fixture the
+#     preflight now refuses. Skipped once the baseline carries the preflight.
 # ---------------------------------------------------------------------------
 baseline_ref=${DJINN_CONFORMANCE_BASELINE_REF:-origin/main}
 baseline_path='deploy/node/k3s/djinn-cgroup-writable-conformance.sh'


### PR DESCRIPTION
## The traced assertion

Run on the real production VPS (`vmi3355738`). The conformance script now gets all
the way to the kernel probes — version detection, template install, k3s restart,
live-table validation, probe Ready, and node identity all pass — and then fails.
The script suppressed the probe with `>/dev/null`, so the identical `kubectl exec`
was re-run with `set -eux`. The exact failing assertion:

```
+ awk /^Groups:/ { $1=""; sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, ""); print } /proc/self/status
+ [ 0 1000 = 1000 ]
command terminated with exit code 1
```

The worker phase observed supplementary groups `0 1000`; `WORKER_PROBE` asserts
exactly `1000`.

## The assertion is right; the setpriv invocation was wrong

Live task-run Pod, read off production:

```
pod securityContext:    {"fsGroup": 1000, "fsGroupChangePolicy": "OnRootMismatch"}
worker securityContext: {"runAsUser": 1000, "runAsGroup": 1000, "runAsNonRoot": true,
                         "allowPrivilegeEscalation": false, "capabilities": {"drop": ["ALL"]},
                         "seccompProfile": {"type": "RuntimeDefault"}}
```

`worker_security_context()` in `server/crates/djinn-k8s/src/launcher.rs` renders
that, and `server/crates/djinn-k8s/src/job.rs` asserts `run_as_user == Some(1000)`,
`run_as_group == Some(1000)`, `fs_group == Some(1000)`. **A real worker never runs
as root, so its supplementary set is exactly `[1000]`.** The assertion encodes
production correctly.

The probe did not. Phase 1 runs as `runAsUser: 0`, so root's supplementary set
contains group 0 alongside the pod's `fsGroup: 1000`, and the transition used
`--keep-groups`, which preserves the *current* set. Group 0 leaked from the root
launcher phase into the worker phase, and the probe was certifying a worker
identity production never has.

`--keep-groups` → `--groups=1000`. `--groups` sets the set by `setgroups(2)`
rather than preserving it, and setpriv refuses it alongside
`--keep-groups`/`--clear-groups`/`--init-groups`, so it cannot append. Verified
against the setpriv actually in the probe image
(`ubuntu@sha256:4fbb8e6a...`, util-linux 2.39.3, Ubuntu 24.04), not assumed:

```
$ docker run --rm --group-add 1000 $PROBE_IMAGE sh -c 'setpriv --groups=1000 --keep-groups /bin/true'
setpriv: mutually exclusive arguments: --clear-groups --keep-groups --init-groups --groups
```

Before / after, in that image, with the launcher's real group set:

```
--keep-groups : Uid: 1000 …  Gid: 1000 …  Groups: 0 1000     <- production failure
--groups=1000 : Uid: 1000 …  Gid: 1000 …  Groups: 1000       <- rendered worker
```

The `Groups:` assertion is untouched. Relaxing it to tolerate group 0 would have
made the probe certify an identity production never has, which is the whole class
of bug being eliminated.

## This is the fourth never-exercised check found in this script

Each of the three preceding defects was a check that had never once run on
hardware, and each was hidden by the same thing: the probe exec was
`>/dev/null`, so an operator saw only `FAIL launcher/worker cgroup conformance
failed` and had to re-run the exec by hand to learn which assertion failed.

That is fixed here too. Both phases now run under `sh -ceux` and the transcript
is captured rather than discarded:

* **on success** the capture is dropped, so stdout stays exactly the PASS line —
  the PASS-line contract is untouched, and a new test asserts nothing leaks onto
  either stream;
* **on failure** the whole xtrace goes to stderr, so the failing assertion names
  itself.

`LAUNCHER_PROBE`, `WORKER_PROBE` and every `must_deny` are byte-identical; the
xtrace comes from the outer `sh` flags, not from editing the probe bodies.

## Denial results: no withdrawal criterion triggered

This fix makes the worker denial assertions reachable for the first time, so they
were run on the production node — with **no k3s restart, no template write and no
label change**, because that node's live containerd already carries
`cgroup_writable = true` and both RuntimeClasses. **All 11 `must_deny`
assertions denied**, every one with `Permission denied`: `mkdir` a worker leaf,
`mkdir` under the launcher leaf, write root `cpu.max`, write root `cgroup.procs`
(own pid and a literal), write root `cgroup.kill`, write the launcher leaf's
`cpu.max`/`cgroup.procs`/`cgroup.kill`, and `rmdir` the launcher leaf. The
capability sets (`CapBnd`/`CapEff`/`CapPrm` all zero), `NoNewPrivs: 1`,
`Seccomp: 2` and AppArmor (`cri-containerd.apparmor.d (enforce)`) all passed.

## Tests

`deploy/node/k3s/tests/conformance-version-lifecycle.sh` gains a group-set
fidelity section:

* the setpriv invocation must state `--groups=1000`, and must never carry
  `--keep-groups`;
* the `Groups:` assertion is lifted verbatim out of `WORKER_PROBE` (un-escaping
  the embedded quotes) and executed against fixture `/proc/self/status` files, so
  it cannot drift from the script: `Groups:\t1000 ` passes, and `Groups:\t0 1000 `
  — **the exact shape `--keep-groups` produced on the node** — fails, as do
  `Groups:\t0 `, `Groups:\t1000 0 ` and the empty set;
* setpriv's own refusal of `--groups` with `--keep-groups` is asserted rather
  than assumed (skipped where setpriv is absent);
* the probe stub now emits on both streams, so one case proves the transcript
  reaches stderr on failure and another proves neither stream leaks on success.

Non-vacuity: restoring `--keep-groups` fails the new section with the group-0
shape named in the diagnosis.

```
FAIL: worker transition does not set --groups=1000: [exec setpriv --reuid=1000 --regid=1000 --keep-groups --nnp …]
FAIL: worker transition uses --keep-groups, which carries the launcher's group 0 into the worker identity: [exec setpriv --reuid=1000 --regid=1000 --keep-groups --nnp …]
FAIL: 2 conformance version lifecycle assertion(s)
```

All green with the fix in place: `conformance-version-lifecycle.sh`,
`containerd-config-version-detection.sh`, `deploy/helm/djinn/tests/cgroup-writable-render.sh`,
`deploy/runbooks/tests/cgroup-launcher-rearm.sh`, `scripts/test-deploy-contracts.sh`
(4/4).

Preserved unchanged: the PASS line, `PROBE_RUNTIME_CLASS='djinn-cgroup-writable-probe'`,
the `spec.nodeName` binding, #2779's identity check including dual-stack
InternalIP membership and the empty-value fail-closed guards, sole ownership of
`djinn.io/cgroup-writable`, the zero-write/zero-restart version preflight, and
backup/restore-and-second-restart.

## Follow-up: a fifth never-exercised defect (not fixed here)

Exercising the denials surfaced one more check that has never run, and it is out
of scope for this change because fixing it requires editing `LAUNCHER_PROBE`.
`WORKER_PROBE` reads the launcher leaf's `cpu.max` under `set -eu`:

```
+ cat /sys/fs/cgroup/.djinn-launcher-leaf/cpu.max
cat: /sys/fs/cgroup/.djinn-launcher-leaf/cpu.max: No such file or directory
+ launcher_cpu_max=
command terminated with exit code 1
```

That file cannot exist. Kernel evidence from the node:

```
root cgroup.controllers      = cpuset cpu io memory hugetlb pids rdma misc
root cgroup.subtree_control = []
root has cpu.max            = yes
leaf cgroup.controllers     = []
leaf has cpu.max            = no
```

`LAUNCHER_PROBE` creates the leaf without writing `+cpu` into the root's
`cgroup.subtree_control`, so the leaf gets only core interface files. Two
consequences: the hard `cat` aborts the worker phase before the final five
denials, and the `must_deny` on the launcher leaf's `cpu.max` is vacuous even if
the read were tolerated — writing to a nonexistent file fails for the wrong
reason. The five denials past that point were confirmed to deny by running an
investigation-only variant that tolerated *only* that read, leaving every
`must_deny` byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
