### PR TITLE
fix(coordinator): make durable refinement dispatch honour the operator gates

### DIFF
--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -120,6 +120,38 @@ fn refinement_phase_for_intent(
     }
 }
 
+/// Why the administrative / terminal gates forbid **new** durable refinement
+/// dispatch on this tick.
+///
+/// The durable intent ledger is the only dispatch path for a run with a
+/// `run_id`, so it must honour the same operator controls
+/// `dispatch_next_refinement_phase` already honours — otherwise
+/// `dispatch_pause` and `proposal_stop_build --freeze` stop epic work while the
+/// tribunal keeps spawning adversary/advocate/judge sessions. Derivation is
+/// shared with the legacy path (`derive_proposal_evidence_lifecycle`), so this
+/// is gate parity, not a second policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DurableDispatchBlock {
+    /// Administrative dispatch pause (global or project) or
+    /// `proposals.build_frozen`.
+    PausedOrFrozen,
+    /// The proposal reached a terminal status (`TERMINAL_PROPOSAL_STATUSES`).
+    Terminal,
+    /// The proposal row could not be read, so no gate state is known. Fail
+    /// closed, exactly as the legacy path does.
+    ProposalUnreadable,
+}
+
+impl DurableDispatchBlock {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::PausedOrFrozen => "paused_or_frozen",
+            Self::Terminal => "terminal",
+            Self::ProposalUnreadable => "proposal_unreadable",
+        }
+    }
+}
+
 /// Shared readiness/feedback context injected into every tribunal role task.
 pub(super) struct RefinementRoleContext {
     /// Rendered current-head DoR failures and `SpecLintResultV1` summary, plus
@@ -216,6 +248,17 @@ impl CoordinatorActor {
                     continue;
                 }
             };
+            if intents.is_empty() {
+                continue;
+            }
+            // Operator-control parity with the legacy phase dispatcher, read
+            // once per run rather than once per intent. Consulted only at the
+            // points that would create or enqueue role work — never before the
+            // recovery arm below, which merely re-registers an already-running
+            // role so its outcome is still processed while the gate holds.
+            let dispatch_block = self
+                .durable_refinement_dispatch_block(&run.proposal_id)
+                .await;
             for intent in intents {
                 if matches!(
                     intent.state,
@@ -247,6 +290,26 @@ impl CoordinatorActor {
                                     },
                                 )
                                 .await;
+                                continue;
+                            }
+                            // The role never ran, so this arm would push the
+                            // materialized task through the pool again. Gated:
+                            // leave the intent `materialized` with its task
+                            // intact — nothing is consumed, terminalized, or
+                            // abandoned, and a `materialized` intent is durable
+                            // liveness evidence, so the run cannot be reaped
+                            // while it waits. The same retry enqueues it once
+                            // the gate clears.
+                            if let Some(block) = dispatch_block {
+                                tracing::info!(
+                                    run_id = %run.run_id,
+                                    proposal_id = %run.proposal_id,
+                                    intent_id = %intent.intent_id,
+                                    gate = block.as_str(),
+                                    "durable refinement enqueue skipped by an administrative gate; \
+                                     the materialized intent keeps its task and re-enqueues when \
+                                     the gate clears"
+                                );
                                 continue;
                             }
                             let Some(owner) = proposal.refinement_owner_user_id.as_deref() else {
@@ -310,6 +373,31 @@ impl CoordinatorActor {
                     }
                     continue;
                 }
+                // Gated, and this intent is still `pending`: do not even take
+                // the lease. A `pending` intent is permanent durable liveness
+                // evidence (`evaluate_refinement_liveness`), so leaving it
+                // untouched survives any pause length and any coordinator
+                // restart, and the next ungated tick claims it normally.
+                // Claiming it here would instead convert it to `claimed`, whose
+                // only liveness evidence is an unexpired lease — a coordinator
+                // that died mid-pause would then leave the run reapable as
+                // `reaped_phantom`.
+                if let Some(block) = dispatch_block
+                    && matches!(
+                        intent.state,
+                        djinn_core::refinement_liveness::RefinementIntentState::Pending
+                    )
+                {
+                    tracing::info!(
+                        run_id = %run.run_id,
+                        proposal_id = %run.proposal_id,
+                        intent_id = %intent.intent_id,
+                        gate = block.as_str(),
+                        "durable refinement dispatch skipped by an administrative gate; the pending \
+                         intent is left unleased and dispatches when the gate clears"
+                    );
+                    continue;
+                }
                 let owner = format!("coordinator:{}", self.coordinator_incarnation_id);
                 let Some(lease) = (match proposal_repo
                     .claim_refinement_intent(ClaimRefinementIntentRequest {
@@ -333,6 +421,25 @@ impl CoordinatorActor {
                 }) else {
                     continue;
                 };
+
+                // Gated, and this intent was already `claimed` before the gate
+                // engaged. The claim above is a *renewal*, which is the only
+                // thing that keeps a `claimed` intent's liveness evidence fresh
+                // (see `claim_refinement_intent`), so it must keep happening
+                // while the gate holds; only task creation and pool enqueue
+                // stop. Nothing is consumed — the lease is retained and the
+                // next ungated tick materializes this same intent.
+                if let Some(block) = dispatch_block {
+                    tracing::info!(
+                        run_id = %run.run_id,
+                        proposal_id = %run.proposal_id,
+                        intent_id = %lease.intent_id,
+                        gate = block.as_str(),
+                        "durable refinement dispatch skipped by an administrative gate; the claimed \
+                         intent keeps a renewed lease and dispatches when the gate clears"
+                    );
+                    continue;
+                }
 
                 // Resolve owner/model/admission before task creation. A denied
                 // attempt keeps the lease/intention retryable without creating
@@ -464,6 +571,71 @@ impl CoordinatorActor {
                     }
                 }
             }
+        }
+    }
+
+    /// Whether the operator-facing gates permit **new** durable refinement
+    /// dispatch for this proposal on this tick.
+    ///
+    /// Parity with the three gates `dispatch_next_refinement_phase` honours:
+    /// the administrative dispatch pause, `proposals.build_frozen`, and a
+    /// terminal proposal status. All three are read through the same
+    /// [`EvidenceLifecycleState`] derivation the legacy path uses, so there is
+    /// one definition of "paused/frozen/terminal" for both dispatch paths.
+    ///
+    /// Fail-closed on an unreadable proposal, mirroring the legacy path's
+    /// "could not load proposal for evidence lifecycle check (fail-closed)"
+    /// arm: without the proposal row the gate state is unknown, and the durable
+    /// path must not spawn a tribunal role on a proposal it cannot see. (The
+    /// pause-state read *inside* `refinement_dispatch_paused` keeps its own
+    /// legacy fail-open behaviour — this helper deliberately does not change it,
+    /// so both paths agree.)
+    ///
+    /// Returns `None` when dispatch may proceed.
+    async fn durable_refinement_dispatch_block(
+        &self,
+        proposal_id: &str,
+    ) -> Option<DurableDispatchBlock> {
+        let Some(proposal) = self.load_proposal_for_lifecycle(proposal_id).await else {
+            tracing::warn!(
+                proposal_id = %proposal_id,
+                "Durable refinement dispatch skipped: could not load proposal for evidence \
+                 lifecycle check (fail-closed)"
+            );
+            return Some(DurableDispatchBlock::ProposalUnreadable);
+        };
+        match self.derive_proposal_evidence_lifecycle(&proposal).await {
+            EvidenceLifecycleState::PausedOrFrozen => {
+                tracing::info!(
+                    proposal_id = %proposal_id,
+                    lifecycle_state = "paused_or_frozen",
+                    build_frozen = proposal.build_frozen,
+                    "Durable refinement dispatch skipped: proposal is paused or build-frozen \
+                     (persisted state gate)"
+                );
+                Some(DurableDispatchBlock::PausedOrFrozen)
+            }
+            EvidenceLifecycleState::Terminal => {
+                tracing::info!(
+                    proposal_id = %proposal_id,
+                    lifecycle_state = "terminal",
+                    proposal_status = %proposal.status,
+                    "Durable refinement dispatch skipped: proposal in terminal status \
+                     (persisted state gate)"
+                );
+                Some(DurableDispatchBlock::Terminal)
+            }
+            // The evidence-cycle states are deliberately NOT gated here. The
+            // durable ledger parks an evidence demand as a run-level
+            // `RefinementParkKind::AwaitingEvidence` (which removes the run
+            // from `load_active_refinement_runs`), so it owns that pause
+            // already; layering the derived evidence states on top would be a
+            // new policy for durable runs rather than the operator-control
+            // parity this gate is for.
+            EvidenceLifecycleState::Active
+            | EvidenceLifecycleState::EvidenceReady
+            | EvidenceLifecycleState::AwaitingEvidence
+            | EvidenceLifecycleState::EvidenceFailed => None,
         }
     }
 
@@ -1512,3 +1684,7 @@ mod refinement_durable_dispatch_tests;
 #[cfg(test)]
 #[path = "refinement_durable_handoff_tests.rs"]
 mod refinement_durable_handoff_tests;
+
+#[cfg(test)]
+#[path = "refinement_durable_gate_tests.rs"]
+mod refinement_durable_gate_tests;

--- a/server/crates/djinn-coordinator/src/refinement_durable_dispatch_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_durable_dispatch_tests.rs
@@ -81,7 +81,11 @@ async fn wait_until_pool_releases(pool: &djinn_slot::SlotPoolHandle, task_id: &s
     panic!("observing pool did not release {task_id}");
 }
 
-async fn admit_run(repo: &ProposalRepository, proposal_id: &str, key: &str) -> (String, i32) {
+pub(crate) async fn admit_run(
+    repo: &ProposalRepository,
+    proposal_id: &str,
+    key: &str,
+) -> (String, i32) {
     match repo
         .admit_refinement_run(AdmitRefinementRunRequest {
             proposal_id: proposal_id.into(),
@@ -103,7 +107,11 @@ async fn admit_run(repo: &ProposalRepository, proposal_id: &str, key: &str) -> (
     }
 }
 
-async fn only_intent(repo: &ProposalRepository, run_id: &str, generation: i32) -> String {
+pub(crate) async fn only_intent(
+    repo: &ProposalRepository,
+    run_id: &str,
+    generation: i32,
+) -> String {
     let intents = repo
         .load_dispatchable_refinement_intents(run_id, generation)
         .await

--- a/server/crates/djinn-coordinator/src/refinement_durable_gate_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_durable_gate_tests.rs
@@ -1,0 +1,380 @@
+//! Operator-control parity for the durable refinement dispatch path.
+//!
+//! `dispatch_next_refinement_phase` honours three operator gates — the
+//! administrative dispatch pause, `proposals.build_frozen`
+//! (`proposal_stop_build --freeze`), and a terminal proposal status — but it is
+//! unreachable for a run with a `run_id`: `drive_one_refinement` early-returns
+//! for durable runs because the leased intent ledger is their only dispatch
+//! path. These tests lock the gates onto that ledger, and lock the two
+//! properties that make gating safe:
+//!
+//!   * a gated tick creates NO role task and enqueues NOTHING, and
+//!   * the durable intent is not consumed, leased away, terminalized, or
+//!     parked — the very next ungated tick dispatches the same intent.
+
+use djinn_core::{
+    events::{DjinnEventEnvelope, EventBus},
+    refinement_liveness::{RefinementIntentState, RefinementRunState},
+};
+use djinn_db::{
+    DispatchPauseTarget, LoadRefinementRunSnapshotRequest, ProposalRepository, TaskRepository,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+use super::refinement_cap_tests::{self, TEST_MODEL};
+use super::refinement_durable_dispatch_tests::{admit_run, only_intent};
+use crate::actor::CoordinatorActor;
+
+const HEARTBEAT_GRACE_MILLIS: i64 = 60_000;
+
+type ObservedDispatches = tokio::sync::mpsc::UnboundedReceiver<(String, String)>;
+
+/// A pool whose runner only records `(task_id, model_id)`, so a dispatch that
+/// reaches a slot is observable without running a real agent session.
+fn spawn_observing_pool(
+    db: &djinn_db::Database,
+) -> (djinn_slot::SlotPoolHandle, ObservedDispatches) {
+    let cancel = CancellationToken::new();
+    let (observed_tx, observed_rx) = tokio::sync::mpsc::unbounded_channel();
+    let pool = djinn_slot::SlotPoolHandle::spawn_with_factory(
+        crate::test_helpers::agent_context_from_db(db.clone(), cancel.clone()),
+        cancel,
+        djinn_slot::SlotPoolConfig {
+            models: vec![djinn_slot::ModelSlotConfig {
+                model_id: TEST_MODEL.to_owned(),
+                max_slots: 1,
+                roles: ["advocate", "adversary", "judge", "worker"]
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect(),
+            }],
+            role_priorities: HashMap::new(),
+        },
+        Arc::new(move |slot_id, model_id, event_tx, app_state, cancel| {
+            let observed_tx = observed_tx.clone();
+            let runner: djinn_slot::TestLifecycleRunner =
+                Arc::new(move |task_id, _, model_id, _, _, _, _| {
+                    let observed_tx = observed_tx.clone();
+                    Box::pin(async move {
+                        observed_tx
+                            .send((task_id, model_id))
+                            .expect("record gated-path dispatch");
+                        Ok(())
+                    })
+                });
+            djinn_slot::SlotHandle::spawn_with_test_runner(
+                slot_id, model_id, event_tx, app_state, cancel, runner,
+            )
+        }),
+    );
+    (pool, observed_rx)
+}
+
+/// One durable run plus everything needed to assert against it.
+struct DurableGateCase {
+    db: djinn_db::Database,
+    repo: ProposalRepository,
+    fixture: refinement_cap_tests::RefinementFixture,
+    run_id: String,
+    generation: i32,
+    intent_id: String,
+}
+
+/// Seed a durable run plus the disposable run-keyed projection a live tribunal
+/// has.
+async fn durable_gate_fixture(
+    db: &djinn_db::Database,
+    events_tx: &tokio::sync::broadcast::Sender<DjinnEventEnvelope>,
+    idempotency_key: &str,
+) -> (CoordinatorActor, ObservedDispatches, DurableGateCase) {
+    let fixture = refinement_cap_tests::seed_refinement_fixture(db).await;
+    let (pool, observed) = spawn_observing_pool(db);
+    let mut actor = refinement_cap_tests::build_refinement_actor(db, events_tx, pool);
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    let (run_id, generation) = admit_run(&repo, &fixture.proposal_id, idempotency_key).await;
+    let intent_id = only_intent(&repo, &run_id, generation).await;
+    let projection =
+        super::super::refinement::RefinementLoopState::new(fixture.proposal_id.clone(), 0)
+            .with_run_identity(run_id.clone(), generation)
+            .with_attributed_user(Some(fixture.user_id.clone()));
+    actor.active_refinements.insert(run_id.clone(), projection);
+    (
+        actor,
+        observed,
+        DurableGateCase {
+            db: db.clone(),
+            repo,
+            fixture,
+            run_id,
+            generation,
+            intent_id,
+        },
+    )
+}
+
+impl DurableGateCase {
+    async fn dispatchable_intents(&self) -> Vec<djinn_db::RefinementPendingIntent> {
+        self.repo
+            .load_dispatchable_refinement_intents(&self.run_id, self.generation)
+            .await
+            .expect("read dispatchable intents")
+    }
+
+    async fn role_task_id(&self) -> Option<String> {
+        TaskRepository::new(self.db.clone(), EventBus::noop())
+            .find_by_refinement_intent_id(&self.intent_id)
+            .await
+            .expect("read role task for intent")
+            .map(|task| task.id)
+    }
+
+    /// A gated tick must create no role task, enqueue nothing, and leave the
+    /// durable intent exactly as dispatchable as it was.
+    async fn assert_gated_and_work_preserved(
+        &self,
+        actor: &CoordinatorActor,
+        observed: &mut ObservedDispatches,
+        gate: &str,
+    ) {
+        assert!(
+            self.role_task_id().await.is_none(),
+            "{gate}: a gated durable tick must not create a tribunal role task"
+        );
+        assert!(
+            observed.try_recv().is_err(),
+            "{gate}: a gated durable tick must not enqueue anything into the pool"
+        );
+        assert!(
+            actor.refinement_sessions.is_empty(),
+            "{gate}: a gated durable tick must not manufacture an outcome projection"
+        );
+
+        // The intent is not consumed: still dispatchable, still `pending`, still
+        // unleased, so the next ungated tick claims it normally.
+        let intents = self.dispatchable_intents().await;
+        assert_eq!(
+            intents.len(),
+            1,
+            "{gate}: the gated intent must survive the tick"
+        );
+        assert_eq!(
+            intents[0].state,
+            RefinementIntentState::Pending,
+            "{gate}: a gated tick must leave the intent pending, never claimed or terminal"
+        );
+        assert_eq!(
+            intents[0].intent_id, self.intent_id,
+            "{gate}: the surviving intent must be the same intent"
+        );
+        assert!(
+            intents[0].claimed_by.is_none(),
+            "{gate}: a gated tick must not hold a lease on the intent"
+        );
+
+        // The run itself is untouched: not terminalized, not parked.
+        let snapshot = self
+            .repo
+            .load_refinement_run_snapshot(LoadRefinementRunSnapshotRequest {
+                run_id: self.run_id.clone(),
+                heartbeat_grace_millis: HEARTBEAT_GRACE_MILLIS,
+            })
+            .await
+            .expect("read exact run after gated tick")
+            .expect("gated run still exists");
+        assert_eq!(
+            snapshot.snapshot.run.state,
+            RefinementRunState::Active,
+            "{gate}: gating must not terminalize the run"
+        );
+        assert_eq!(
+            snapshot.snapshot.run.terminal_reason, None,
+            "{gate}: gating must not record a stop reason"
+        );
+        assert!(
+            snapshot.snapshot.park.is_none(),
+            "{gate}: gating must not park the run"
+        );
+    }
+
+    /// Once the gate clears, the same preserved intent dispatches.
+    async fn assert_dispatches_after_gate_clears(
+        &self,
+        actor: &mut CoordinatorActor,
+        observed: &mut ObservedDispatches,
+        gate: &str,
+    ) {
+        actor.drive_active_refinements().await;
+
+        let task_id = self.role_task_id().await.unwrap_or_else(|| {
+            panic!("{gate}: the preserved intent must dispatch once the gate clears")
+        });
+        let (dispatched_task_id, dispatched_model_id) =
+            tokio::time::timeout(Duration::from_secs(5), observed.recv())
+                .await
+                .unwrap_or_else(|_| panic!("{gate}: ungated dispatch must reach the pool"))
+                .unwrap_or_else(|| panic!("{gate}: ungated dispatch observation"));
+        assert_eq!(dispatched_task_id, task_id);
+        assert_eq!(dispatched_model_id, TEST_MODEL);
+        assert_eq!(
+            self.dispatchable_intents().await[0].state,
+            RefinementIntentState::Materialized,
+            "{gate}: the ungated tick must materialize the same intent"
+        );
+    }
+}
+
+// ── Gate 1: administrative dispatch pause ───────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dispatch_pause_stops_durable_refinement_and_preserves_the_intent() {
+    let db = crate::test_helpers::create_test_db();
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let (mut actor, mut observed, case) =
+        durable_gate_fixture(&db, &events_tx, "durable-gate-pause").await;
+
+    djinn_db::DispatchPauseRepository::new(db.clone(), crate::events::event_bus_for(&events_tx))
+        .pause(
+            DispatchPauseTarget::Global,
+            djinn_core::models::DispatchPause {
+                paused_by: "durable-gate-test".to_owned(),
+                paused_at: ::time::OffsetDateTime::now_utc()
+                    .format(&::time::format_description::well_known::Rfc3339)
+                    .expect("format pause timestamp"),
+                reason: "operator halted dispatch".to_owned(),
+                expires_at: None,
+            },
+        )
+        .await
+        .expect("pause dispatch globally");
+
+    actor.drive_active_refinements().await;
+    case.assert_gated_and_work_preserved(&actor, &mut observed, "dispatch_pause")
+        .await;
+
+    djinn_db::DispatchPauseRepository::new(db.clone(), crate::events::event_bus_for(&events_tx))
+        .resume(DispatchPauseTarget::Global)
+        .await
+        .expect("resume dispatch");
+    case.assert_dispatches_after_gate_clears(&mut actor, &mut observed, "dispatch_pause")
+        .await;
+}
+
+// ── Gate 2: proposal build freeze (`proposal_stop_build --freeze`) ──────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn build_freeze_stops_durable_refinement_and_preserves_the_intent() {
+    let db = crate::test_helpers::create_test_db();
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let (mut actor, mut observed, case) =
+        durable_gate_fixture(&db, &events_tx, "durable-gate-freeze").await;
+
+    case.repo
+        .set_frozen(&case.fixture.proposal_id, true)
+        .await
+        .expect("freeze the proposal build");
+
+    actor.drive_active_refinements().await;
+    case.assert_gated_and_work_preserved(&actor, &mut observed, "build_frozen")
+        .await;
+
+    case.repo
+        .set_frozen(&case.fixture.proposal_id, false)
+        .await
+        .expect("unfreeze the proposal build");
+    case.assert_dispatches_after_gate_clears(&mut actor, &mut observed, "build_frozen")
+        .await;
+}
+
+// ── Gate 3: terminal proposal status ────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn terminal_proposal_status_stops_durable_refinement_and_preserves_the_intent() {
+    let db = crate::test_helpers::create_test_db();
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let (mut actor, mut observed, case) =
+        durable_gate_fixture(&db, &events_tx, "durable-gate-terminal").await;
+
+    case.repo
+        .set_status(&case.fixture.proposal_id, "rejected")
+        .await
+        .expect("move the proposal to a terminal status");
+
+    actor.drive_active_refinements().await;
+    case.assert_gated_and_work_preserved(&actor, &mut observed, "terminal_status")
+        .await;
+
+    // Restoring a non-terminal status is not a supported operator flow; it is
+    // only proof that the terminal gate SKIPPED rather than consumed the intent.
+    case.repo
+        .set_status(&case.fixture.proposal_id, "building")
+        .await
+        .expect("restore a non-terminal status");
+    case.assert_dispatches_after_gate_clears(&mut actor, &mut observed, "terminal_status")
+        .await;
+}
+
+// ── The gate must not block outcome recovery for a role that already ran ────
+
+/// A gate stops NEW dispatch; it must not orphan a role session that is already
+/// running. The recovery arm (materialized intent + an observed agent session)
+/// still re-registers the in-flight projection while the gate holds, so the
+/// round's outcome is processed instead of being stranded.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_gate_does_not_strand_a_role_session_that_already_started() {
+    let db = crate::test_helpers::create_test_db();
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let (mut actor, mut observed, case) =
+        durable_gate_fixture(&db, &events_tx, "durable-gate-recovery").await;
+
+    // Dispatch the round while ungated, then drop the disposable projection as a
+    // coordinator restart would.
+    actor.drive_active_refinements().await;
+    let task_id = case
+        .role_task_id()
+        .await
+        .expect("ungated tick dispatches the round");
+    let _ = tokio::time::timeout(Duration::from_secs(5), observed.recv())
+        .await
+        .expect("ungated dispatch reaches the pool");
+    actor.refinement_sessions.clear();
+
+    // The role's agent session exists, so the round is genuinely in flight.
+    djinn_db::SessionRepository::new(db.clone(), EventBus::noop())
+        .create(djinn_db::CreateSessionParams {
+            project_id: &case.fixture.project_id,
+            task_id: Some(&task_id),
+            model: TEST_MODEL,
+            agent_type: "adversary",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .expect("materialize the running role session");
+
+    case.repo
+        .set_frozen(&case.fixture.proposal_id, true)
+        .await
+        .expect("freeze the proposal build mid-round");
+
+    actor.drive_active_refinements().await;
+
+    assert!(
+        actor.refinement_sessions.contains_key(&case.run_id),
+        "a gate must not strand an already-running role: the in-flight projection \
+         has to be re-registered so its outcome is still processed"
+    );
+    assert!(
+        observed.try_recv().is_err(),
+        "the already-running role must not be re-enqueued while the gate holds"
+    );
+    assert_eq!(
+        case.dispatchable_intents().await[0].state,
+        RefinementIntentState::Materialized,
+        "the gated tick must leave the materialized intent and its task intact"
+    );
+}


### PR DESCRIPTION
## The defect

`refinement_dispatch.rs:730-732` early-returns from `drive_one_refinement` whenever `state.run_id` is non-empty:

```rust
// Durable runs are dispatched exclusively by the leased intent ledger.
if !state.run_id.is_empty() {
    return;
}
```

That makes `dispatch_next_refinement_phase` — and therefore all three of its gates — **unreachable for every durable run**:

* `refinement_dispatch_paused()` (the administrative `dispatch_pause`),
* `EvidenceLifecycleState::PausedOrFrozen` (`proposals.build_frozen`, i.e. `proposal_stop_build --freeze`) and `::Terminal` (`TERMINAL_PROPOSAL_STATUSES`),
* the fail-closed proposal load.

`drive_durable_refinement_intents` — the only dispatch path for a run with a `run_id` — consulted **none** of them. It leased intents, called `create_refinement_task_with_context_and_correlation`, and called `pool.dispatch(...)` unconditionally. `grep` for `pool.dispatch` in the coordinator confirms exactly three refinement dispatch sites: two durable and ungated, one legacy and gated.

## Real consequence, observed today

Proposal `v342` had its build aborted via `proposal_stop_build --abort` and was then set `superseded`, yet its durable refinement run (generation 2, round 3) **kept spawning adversary/advocate/judge sessions into the same worker pool**. Neither `dispatch_pause` nor `proposal_stop_build --freeze` could stop it. The only exits were a human `proposal_refinement_resolve` from an `awaiting_review` park, or exhausting the 16-spawn `max_total_spawns` cap.

## The fix

Gate parity, not new policy. The durable path now reads the gate through the **same** `load_proposal_for_lifecycle` + `derive_proposal_evidence_lifecycle` derivation the legacy arm uses, and emits the same structured log fields (`lifecycle_state`, `build_frozen`, `proposal_status`, plus `gate`, `run_id`, `intent_id`) so a skipped dispatch is diagnosable rather than silent. The gate is read **once per run per tick**, not once per intent.

Evidence-cycle states are deliberately *not* gated: the durable ledger already owns that pause via a run-level `RefinementParkKind::AwaitingEvidence`, which drops the run out of `load_active_refinement_runs`.

### The claim-renewal subtlety — the non-obvious part

Not dispatching is **not** automatically free. Per `claim_refinement_intent`'s own doc (`djinn-db/src/repositories/refinement_run_lifecycle.rs:629-641`):

> An unexpired claim is the only liveness evidence an intent has between `claimed` and `materialized`, and the durable poll is the only thing that can refresh it.

So a naive "gate → skip the tick" would let an existing claim lapse, at which point the run matches no evidence class in `evaluate_refinement_liveness` and `reap_and_admit` **terminalizes it as `reaped_phantom`**. Gating must not terminalize work, so there are three consult points rather than one:

| Intent state | Behaviour when gated | Why |
| --- | --- | --- |
| `pending` | Skip **before** the claim — never lease it | `pending` is *permanent* durable liveness evidence, so it survives any pause length and any coordinator restart |
| `claimed` | Let the claim run as a **renewal**, then skip only task creation and enqueue | Stopping the renewal is exactly what hands the run to the `reaped_phantom` reaper |
| `materialized` | Skip the pool re-enqueue; keep the intent and its task | `materialized` is also permanent liveness evidence |

The materialized gate is placed **after** the `role_ran` recovery arm, so a gate can never strand an already-running role session and leave its outcome unprocessed.

## Deliberately NOT changed

* `refinement_dispatch_paused`'s internal **fail-open** on a pause-state read error (`refinement_outcome.rs:1080-1087` returns `false` → "proceeding") stays as-is. Tightening it would make the durable path *stricter* than the legacy path — new policy, not a fix. The proposal-load arm does fail **closed** (`ProposalUnreadable`), mirroring the legacy behaviour exactly; that arm is behaviour-preserving anyway, since both pre-existing durable branches already `continue`d on `Ok(None) | Err(_)`.
* `revision_admission.rs` (whether editing a `building` proposal should auto-admit a run is an open policy decision), `refinement.rs` caps, and `rules.rs` — all untouched.

## Test evidence

New: `server/crates/djinn-coordinator/src/refinement_durable_gate_tests.rs`.

Reverting `refinement_dispatch.rs` to `HEAD` (keeping only the `mod` declaration) fails 3 of 4 with the defect's exact signature:

```
running 4 tests
test ...::a_gate_does_not_strand_a_role_session_that_already_started ... ok
test ...::build_freeze_stops_durable_refinement_and_preserves_the_intent ... FAILED
test ...::dispatch_pause_stops_durable_refinement_and_preserves_the_intent ... FAILED
test ...::terminal_proposal_status_stops_durable_refinement_and_preserves_the_intent ... FAILED

panicked at refinement_durable_gate_tests.rs:121:5:
  build_frozen: a gated durable tick must not create a tribunal role task
  dispatch_pause: a gated durable tick must not create a tribunal role task
  terminal_status: a gated durable tick must not create a tribunal role task

test result: FAILED. 1 passed; 3 failed
```

With the fix, `4 passed`. Each gate test also asserts the intent **survives unchanged** — exactly one intent, still `pending`, `claimed_by: None`, run still `Active`, no `terminal_reason`, no park — and then that the *same* intent dispatches to the pool and reaches `materialized` on the next tick once the gate clears.

`cargo test -p djinn-coordinator --lib refinement` → **156 passed, 0 failed** (covers every neighbouring durable/cap/recovery/wake/handoff/watchdog suite). Clippy `--all-targets` and `cargo fmt --check` clean, re-verified after rebasing onto current `origin/main`.

**Explicitly:** `a_gate_does_not_strand_a_role_session_that_already_started` **passes with and without the change**. It is *not* a defect proof — it guards the design choice of placing the materialized gate after the `role_ran` recovery arm against a future regression. Please do not read it as evidence for the bug.

## Known gaps

* **No live-system verification.** The live `v342` run was not touched, and no real `dispatch_pause` was exercised against a running tribunal.
* **The `ProposalUnreadable` arm has no test.** Forcing that failure needs either DB fault injection the harness lacks, or deleting the proposal row (which cascades the run and intents away). The arm is behaviour-preserving, so the risk is low — but it is a gap.

## Cost

One extra gate read per active durable run per ~30s tick. `build_evidence_lifecycle_snapshot` reads the proposal, the dispatch-pause state, the proposal targets, and `revisions(proposal_id)` — that last one grows with revision count. The legacy path already paid this per dispatch attempt, so it is not a new class of cost, but it is new load on the durable path.

## Unrelated pre-existing failure

`cargo test -p djinn-coordinator --lib` (full parallel run) aborts with a **tokio-worker stack overflow**. This is pre-existing and unrelated: it still reproduces with `-- --skip refinement_durable_gate_tests`, at the same point. Targeted filters were used throughout. Please don't misattribute it to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
