### PR TITLE
ci: cut PR-lane wall clock and stop the cache budget bleeding

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -26,7 +26,23 @@ on:
       keep:
         description: Newest entries to retain per rust cache family
         type: string
-        default: '2'
+        # 2 -> 1. Keeping a second entry per family protected nothing: rust-cache
+        # restores by key PREFIX and GitHub returns the newest match, so the
+        # older entry is never read under any circumstance — including the one it
+        # looks like insurance against, a corrupt newest entry (the warm job sets
+        # `cache-on-failure: true`, so a partial deposit is saved and still wins
+        # the prefix match). This script's own header already says only the
+        # newest entry per family is ever read.
+        #
+        # It was not free: measured 2026-07-30, the second copies were 1.67 GB
+        # (server-test) and 0.78 GB (server-aarch64-check) = 2.45 GB of a 10 GB
+        # repo cap that was sitting at 10.49 GB and actively evicting the live
+        # entries CI restores on every run.
+        #
+        # Safe because each family has exactly one writer, on main, in a
+        # push/dispatch-only job (`ci-cache-policy.test.mjs` enforces this), and
+        # an in-flight save is not visible to restores until it completes.
+        default: '1'
 
 # The token needs `actions: write` to delete a cache. Everything else stays
 # read-only: this workflow must never be able to touch repository contents.
@@ -56,17 +72,35 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |-
+          # Both defaults must agree. `inputs.keep` is empty on the SCHEDULED
+          # run (inputs exist only for workflow_dispatch), so this fallback —
+          # not the `default:` above — is what governs the daily prune. They
+          # were 2 and 2; see the input's comment for why 1.
           node scripts/prune-actions-caches.mjs \
-            --keep '${{ inputs.keep || '2' }}' \
+            --keep '${{ inputs.keep || '1' }}' \
             ${{ inputs.dry_run && '--dry-run' || '' }}
+      # This step failed on every scheduled run from at least 2026-07-28 until
+      # 2026-07-30 with:
+      #
+      #   the `--slurp` option is not supported with `--jq` or `--template`
+      #
+      # A newer `gh` on the runner image began rejecting that flag combination.
+      # The prune itself was unaffected and kept working (run 30429331029
+      # reclaimed 2.46 GB before dying here), so the only symptom was a red
+      # workflow and — worse — the budget notice this step exists to emit never
+      # reaching anyone while the repo sat over its cap.
+      #
+      # Rewritten onto the dedicated cache-usage endpoint rather than re-fixing
+      # the flags: it returns both figures in ONE unpaginated response, so there
+      # is no `--paginate`, no `--slurp`, and nothing left for that
+      # incompatibility to apply to.
       - name: Report remaining budget
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |-
-          total=$(gh api "/repos/${{ github.repository }}/actions/caches?per_page=100" --paginate --slurp \
-            --jq '[.[].actions_caches[].size_in_bytes] | add // 0')
-          count=$(gh api "/repos/${{ github.repository }}/actions/caches?per_page=100" --paginate --slurp \
-            --jq '[.[].actions_caches[]] | length')
+          usage=$(gh api "/repos/${{ github.repository }}/actions/cache/usage")
+          total=$(printf '%s' "$usage" | jq -r '.active_caches_size_in_bytes // 0')
+          count=$(printf '%s' "$usage" | jq -r '.active_caches_count // 0')
           gb=$(awk "BEGIN { printf \"%.2f\", ${total}/1073741824 }")
           echo "::notice::cache-budget ${gb} GB across ${count} entries (repo cap 10 GB, LRU eviction)"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -633,14 +633,13 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.clippy == 'true' && github.event_name != 'push'
     runs-on: ubuntu-latest
-    # Raised from 25 when the deploy render-gate contract moved onto this lane.
-    # Measured on run 30479829505: Clippy 3m21s, render-gate 7m42s, job 11m50s
-    # (this lane was ~4m9s before). The render-gate step is slower than its
-    # ~1m local build because `cargo clippy` emits CHECK-mode artifacts for the
-    # workspace crates, so `cargo build -p djinn-k8s` recompiles the whole
-    # djinn-db -> djinn-core -> djinn-k8s chain in build mode; only the
-    # third-party deps come from the restored cache. 25 minutes left too little
-    # margin for a cold-cache run on top of that.
+    # 25 was raised to 35 while the deploy render-gate contract shared this
+    # lane. That contract now lives in `deploy-render-gate` below, so this job
+    # is back to lint-only: measured 4m9s before the contract arrived, 11m50s
+    # with it (Clippy 3m21s + render-gate 7m42s on run 30479829505), and the
+    # split returns it to ~4m. 35 is retained deliberately — the margin is for
+    # a COLD-cache clippy run, which is a property of this step, not of the
+    # contract that moved out.
     timeout-minutes: 35
     defaults:
       run:
@@ -649,24 +648,11 @@ jobs:
       SQLX_OFFLINE: "true"
     steps:
       - uses: actions/checkout@v4
-      # For the deploy render-gate contract at the end of this job. That suite
-      # needs BOTH `helm` and a BUILT `render-gate` binary
-      # (server/crates/djinn-k8s), so it cannot go on local-dev-contracts: that
-      # lane has helm but no Rust, and would pay for a cold toolchain and a cold
-      # djinn-k8s build. Here the `server-test` rust-cache family is already
-      # restored, so the build is incremental. Pinned to the same v3.12.3
-      # local-dev-contracts installs — two lanes rendering the same chart on
-      # different helm majors is a contract that means nothing.
-      - uses: azure/setup-helm@v4
-        with:
-          version: v3.12.3
       - run: rustup toolchain install
         working-directory: server
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
-          # NOTE: the `azure/setup-helm@v4` step above this one is for the
-          # deploy render-gate contract at the END of this job, not for clippy.
           # The dedicated `server-quality` family is gone. After #2342 moved
           # server-sqlx-freshness and memory-eval onto server-test, it served
           # exactly one job — this one — while holding ~2.5 GB of a 10 GB
@@ -791,16 +777,85 @@ jobs:
           before='${{ steps.fingerprints-restored.outputs.count }}'
           after=$(ls target/debug/.fingerprint 2>/dev/null | wc -l)
           echo "::notice::clippy-fingerprints restored=${before:-0} after=${after} built=$((after - ${before:-0}))"
-      # deploy/preflight/tests/ had never executed in CI. It is a DEPLOY
-      # contract, not a Rust one, and it is hosted on this lane only because it
-      # must `cargo build -p djinn-k8s --bin render-gate` and shell out to
-      # `helm`: this is the cheapest lane in the file that already has both a
-      # warm Rust cache and (as of the setup-helm step above) helm. Runs last so
-      # a failure here is never confused with a clippy failure, and so it cannot
-      # delay the lint signal. The directory is globbed by the runner, not
-      # enumerated, so a second preflight suite needs no edit here.
+  # deploy/preflight/tests/ is a DEPLOY contract, not a Rust one, but it must
+  # `cargo build -p djinn-k8s --bin render-gate` and shell out to `helm`, so it
+  # cannot go on local-dev-contracts: that lane has helm but no Rust, and would
+  # pay for a cold toolchain and a cold djinn-k8s build.
+  #
+  # It lived as the LAST STEP of `server-clippy` until this job existed, which
+  # made it a serial tail on the second-longest lane in the file: measured
+  # 7m42s of render-gate behind 3m21s of clippy for an 11m50s job (run
+  # 30479829505), against a ~12m30s `server-test` critical path. Two
+  # independent gates were queued behind one runner for no reason — clippy's
+  # lint signal was delayed by a Helm contract, and the Helm contract could not
+  # start until the lint finished.
+  #
+  # Splitting them is not free: this lane re-pays checkout and a rust-cache
+  # restore (~45s together). It wins anyway because the 7m42s was never
+  # clippy's fault. The old comment blamed it on `cargo clippy` emitting
+  # CHECK-mode artifacts, but that is not the mechanism: check-mode `.rmeta`
+  # and build-mode `.rlib` units coexist in target/ under different `-C
+  # metadata` and neither displaces the other. The real cost is that
+  # `actions/checkout` restamps every workspace source mtime, so cargo
+  # fingerprints the whole djinn-db -> djinn-core -> djinn-k8s chain as dirty
+  # and rebuilds it in build mode on ANY lane — see the `cache-workspace-crates`
+  # note on `cache-warm-x86_64-test`. That cost is unchanged by this split; what
+  # the split removes is paying it in series behind clippy.
+  #
+  # The `server-test` family is restored here for the same reason clippy uses
+  # it: `cache-warm-x86_64-test` deposits both the codegen and the check-mode
+  # dependency layers into that one entry, so the third-party half of the
+  # djinn-k8s chain comes from cache. Restore-only (`save-if: false`) —
+  # `ci-cache-policy.test.mjs` enforces single-writer ownership per family.
+  #
+  # The runner globs deploy/preflight/tests/, so a second suite dropped in
+  # there runs here with no edit to this file.
+  deploy-render-gate:
+    name: Deploy Render Gate
+    needs: preflight
+    # Same routing as `server-clippy` on purpose: this contract's inputs are
+    # the chart and the djinn-k8s binary, and every path that can change either
+    # lands in the router's `rustCore` lane or fails closed into `unknown`
+    # (deploy/** is not a narrow lane, so it selects full validation). Gating
+    # it on its own router output would be a new, weaker guard for the same
+    # set of files.
+    if: needs.preflight.outputs.clippy == 'true' && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    # Measured 7m42s as a clippy step with a warm cache. 20 leaves margin for a
+    # cold-cache djinn-k8s chain without hiding a hang.
+    timeout-minutes: 20
+    env:
+      SQLX_OFFLINE: "true"
+    steps:
+      - uses: actions/checkout@v4
+      # Pinned to the same v3.12.3 local-dev-contracts installs — two lanes
+      # rendering the same chart on different helm majors is a contract that
+      # means nothing.
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.12.3
+      - run: rustup toolchain install
+        working-directory: server
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: server
+          shared-key: server-test
+          cache-on-failure: true
+          cache-all-crates: true
+          save-if: false
+        id: rust-cache
+      - name: Log cache family and restore status
+        run: |-
+          echo "cache-family=server-test"
+          echo "shared-key=server-test"
+          echo "runner-os=${{ runner.os }}"
+          echo "rustc=$(rustc --version || echo 'unknown')"
+          echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
+          echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
+      - name: Runner disk headroom preflight
+        # Body/thresholds: CI_RUNNER_DISK_PREFLIGHT at the top of this file.
+        run: bash -c "$CI_RUNNER_DISK_PREFLIGHT"
       - name: Test deploy render-gate contract
-        working-directory: ${{ github.workspace }}
         run: bash scripts/test-deploy-contracts.sh deploy/preflight/tests
   launcher-kernel-boundary:
     name: Launcher Kernel Boundary
@@ -2096,6 +2151,7 @@ jobs:
       - ci-contracts
       - server-guards
       - server-clippy
+      - deploy-render-gate
       - server-aarch64-check
       - nextest-plan
       - server-test
@@ -2118,6 +2174,8 @@ jobs:
                || needs.preflight.outputs.capability == 'true'
                || needs.preflight.outputs.boundaries == 'true') }}:${{ needs.server-guards.result }}
           CLIPPY: ${{ needs.preflight.outputs.clippy }}:${{ needs.server-clippy.result }}
+          # Routed by the same output as clippy — see the job's own comment.
+          RENDER_GATE: ${{ needs.preflight.outputs.clippy }}:${{ needs.deploy-render-gate.result }}
           AARCH64: ${{ needs.preflight.outputs.aarch64 }}:${{ needs.server-aarch64-check.result }}
           SERVER_TEST_PLAN: ${{ needs.preflight.outputs.serverTest }}:${{ needs.nextest-plan.result }}
           SERVER_TEST_SHARDS: ${{ needs.preflight.outputs.serverTest }}:${{ needs.server-test.result }}
@@ -2137,7 +2195,8 @@ jobs:
             if [ "$selected" = false ] && [ "$result" = skipped ]; then return; fi
             echo "lane $lane selected=$selected result=$result"; return 1
           }
-          check server-guards "$GUARDS"; check clippy "$CLIPPY"; check aarch64 "$AARCH64"
+          check server-guards "$GUARDS"; check clippy "$CLIPPY"
+          check deploy-render-gate "$RENDER_GATE"; check aarch64 "$AARCH64"
           check server-test-plan "$SERVER_TEST_PLAN"; check server-test-shards "$SERVER_TEST_SHARDS"; check server-test-timing "$SERVER_TEST_TIMING"
           check sqlx-freshness "$SQLX"; check memory-eval "$MEMORY"
           check local-dev-contracts "$TILT_CONTRACTS"; check qa-smoke "$QA_SMOKE"; check ui "$UI"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,36 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=djinn-image-builder
-          cache-to: type=gha,scope=djinn-image-builder,mode=max
+          # NO `type=gha` cache here (or on any build step in this workflow).
+          # It cannot work: GitHub scopes a cache entry to the ref that wrote
+          # it, and a run may read only its own ref or the default branch. This
+          # workflow triggers on TAGS, so every release wrote a cache that no
+          # later release could ever read.
+          #
+          # Measured 2026-07-30 — each tag's 44 blob entries were created and
+          # last-accessed entirely inside that tag's own run:
+          #
+          #   v0.7.25  run 15:45-16:11  created 15:45-15:48  last read 15:50
+          #   v0.7.26  run 18:20-18:46  created 18:21-18:22  last read 18:25
+          #   v0.7.27  run 19:36-20:02  created 19:37-19:39  last read 19:41
+          #
+          # v0.7.26's run never touched v0.7.25's entries. Cost of that
+          # write-only ballast: 0.92 GB per release, ~3 releases/day, against a
+          # 10 GB repo cap that was at 10.49 GB and evicting the `server-test`
+          # family every CI lane restores. That eviction is the reason to remove
+          # this, not the wasted bytes.
+          #
+          # Nothing is lost. Where a job builds the same image twice
+          # (`runtime-base` below), the second build reuses the first's layers
+          # from the buildx BUILDER's own local cache — the builder persists for
+          # the job's lifetime, so intra-run reuse never depended on an exported
+          # cache. Single-build jobs like this one got nothing from it at all.
+          #
+          # Real cross-release reuse needs a ref-independent backend
+          # (`type=registry,ref=...:buildcache` on GHCR, which this workflow
+          # already authenticates to). That is a release-SPEED change with its
+          # own export cost to measure on a production path, deliberately not
+          # bundled into a PR-lane latency change.
 
   buildkitd:
     name: djinn-buildkitd
@@ -129,8 +157,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=djinn-buildkitd
-          cache-to: type=gha,scope=djinn-buildkitd,mode=max
+          # No `type=gha` cache — see the image-builder job above for why it was
+          # provably write-only on a tag-triggered workflow.
 
   runtime-base:
     name: djinn-agent-runtime-base
@@ -166,8 +194,13 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: djinn-agent-runtime-base:validation
-          cache-from: type=gha,scope=djinn-agent-runtime-base
-          cache-to: type=gha,scope=djinn-agent-runtime-base,mode=max
+          # No `type=gha` cache — see the image-builder job for why it was
+          # provably write-only. This job builds runtime-base TWICE (here for
+          # validation, then again to publish below). That second build still
+          # reuses this one's layers: both steps drive the same
+          # docker/setup-buildx-action builder, which keeps its local cache for
+          # the job's lifetime. The exported cache was never what made the
+          # publish step fast.
       - name: Build representative generated Rust image
         uses: docker/build-push-action@v6
         with:
@@ -206,8 +239,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=djinn-agent-runtime-base
-          cache-to: type=gha,scope=djinn-agent-runtime-base,mode=max
+          # No `type=gha` cache. This build's inputs are byte-identical to the
+          # validation build above, so every layer is already in the shared
+          # builder's local cache and this step is a re-tag-and-push.
 
   # ── UI build (parallel with the worker cargo build) ───────────────────
   ui-dist:

--- a/scripts/ci-nextest-plan.mjs
+++ b/scripts/ci-nextest-plan.mjs
@@ -14,7 +14,31 @@ export const PROOF_VERSION = 'ci-nextest-plan/v1';
 export const FALLBACK_DURATION_SECONDS = 30;
 export const DEFAULT_MAX_AGE_DAYS = 7;
 export const PR_DEFAULT_SHARDS = 2;
-export const PR_MAX_SHARDS = 4;
+// 4 -> 8. The PR lane's critical path is one `server-test` shard, and only the
+// TEST-RUN half of that job scales with shard count: measured on run
+// 30498632438, a shard was 1m36s setup + 5m54s `Build test binaries` + 4m00s
+// run. The build is the same `--workspace --all-targets` compile in every
+// shard and does not shrink when the shard's test list does, so doubling shards
+// halves ~4m and leaves ~7m30s untouched. At 8 the run half is ~2m and the
+// fixed half dominates; going wider buys progressively less for a full extra
+// runner each time, which is why this stops at 8 rather than 16.
+//
+// The exact-once proof is shard-count agnostic (`planTests` distributes over
+// `shardCount` and `validateExactOnce` checks the partition), so this is a
+// balancing knob, not a coverage one. The suite is 11 633 discovered tests
+// against 8 shards and `planTests` assigns each test to the least-loaded shard,
+// so no shard can come out empty here. Do not read the workflow's
+// `active=false` guard as empty-shard handling: that path fires only for a
+// matrix shardIndex >= the plan's shardCount, which the dynamic matrix (built
+// from `.shards[]`) never produces. A shard row with an empty test list would
+// get `not (binary_id(/./))` and still run — unreachable at this ratio, but it
+// is not the guard's job to catch it.
+//
+// This is deliberately NOT applied to the merge queue below. A queue entry that
+// fails ejects and invalidates the entries speculatively stacked behind it
+// (maximumEntriesToBuild=5, mergingStrategy=HEADGREEN), so the queue's cost
+// function is throughput under contention, not latency of one entry.
+export const PR_MAX_SHARDS = 8;
 export const WIDE_DEFAULT_SHARDS = 4;
 export const COLD_START_SHARDS = 4;
 export const PR_WIDEN_TEST_THRESHOLD = 200;

--- a/scripts/ci-nextest-plan.test.mjs
+++ b/scripts/ci-nextest-plan.test.mjs
@@ -484,7 +484,7 @@ describe('planTests', () => {
     assert.equal(plan.coldStart, false);
   });
 
-  it('widens PR to four shards at the test-count threshold with fresh timing', () => {
+  it('widens PR to the max shard count at the test-count threshold with fresh timing', () => {
     const testCases = {};
     for (let i = 0; i < PR_WIDEN_TEST_THRESHOLD; i++) {
       testCases[`t_${i}`] = testCase();
@@ -497,7 +497,7 @@ describe('planTests', () => {
     assert.equal(plan.coldStart, false);
   });
 
-  it('widens PR to four shards at the duration threshold with fresh timing', () => {
+  it('widens PR to the max shard count at the duration threshold with fresh timing', () => {
     const testCases = {};
     const target = Math.ceil(PR_WIDEN_DURATION_THRESHOLD_SECONDS / 100) + 1;
     for (let i = 0; i < target; i++) {
@@ -511,7 +511,7 @@ describe('planTests', () => {
     assert.equal(plan.coldStart, false);
   });
 
-  it('keeps merge-group and full-validation wide at four shards', () => {
+  it('keeps merge-group and full-validation at the wide default shard count', () => {
     const tests = parseDiscovery(JSON.stringify(SUMMARY_ONE));
     const timings = timingMap(tests, 10);
     const mg = planTests({ tests, timings, profile: 'merge-group' });


### PR DESCRIPTION
## Why

The PR lane and the merge-queue lane run an **identical job set** — every guard in `quality-gate.yml` is `github.event_name != 'push'` — and both sit at a p50 of **14.1 min** (n=65 PR / n=98 merge_group successful runs). The queue is authoritative, so the PR lane's only job is to predict churn cheaply. Its latency is what's worth attacking.

Measured critical path, run [30498632438](https://github.com/djinnos/djinn/actions/runs/30498632438) (typical PR):

| Segment | Time | % |
|---|---|---|
| queue + `preflight` | 0:27 | 3% |
| shard setup (container, checkout, cache restore 38s, migrations 35s) | 1:36 | 11% |
| **`Build test binaries`** (`--workspace --all-targets`) | **5:54** | **42%** |
| **`Run planner-selected shard tests`** (2909 of 11 633) | **4:00** | **28%** |
| upload + `Quality Gate` rollup | 1:10 | 8% |

## What changed

### 1. Split the deploy render-gate contract off `Server Clippy`

`Server Clippy` was 11m50s — the second-longest lane — of which **only 3m21s was clippy**. The other 7m42s was `Test deploy render-gate contract`, a Helm/shell suite running as a serial tail. Two independent gates were queued behind one runner: clippy's lint signal was delayed by a Helm contract, and the contract couldn't start until the lint finished.

Now `deploy-render-gate`, routed by the same `preflight.outputs.clippy` output and wired **fail-closed** into the `quality-gate` rollup (`needs` + a `check` line). Clippy returns to ~4m; the contract runs in parallel at ~8.5m, inside the server-test critical path.

The split does **not** make the 7m42s cheaper, and the old comment misattributed it. It blamed `cargo clippy` emitting check-mode artifacts, but check-mode `.rmeta` and build-mode `.rlib` units coexist under different `-C metadata` and neither displaces the other. The real cause is that `actions/checkout` restamps every workspace source mtime, so cargo rebuilds the `djinn-db → djinn-core → djinn-k8s` chain in build mode on *any* lane. What the split removes is paying it in series.

### 2. `PR_MAX_SHARDS` 4 → 8

Only the test-**run** half of a shard scales with shard count; the 5m54s build is the same `--workspace` compile in every shard and doesn't shrink when the shard's test list does. Doubling shards halves ~4m and leaves ~7m30s untouched. Stops at 8 because the fixed half then dominates — 16 would buy progressively less for a full extra runner each time.

Merge-queue stays at `WIDE_DEFAULT_SHARDS = 4` deliberately: a failing queue entry ejects and invalidates the entries speculatively stacked behind it (`maximumEntriesToBuild=5`, `mergingStrategy=HEADGREEN`), so the queue's cost function is throughput under contention, not latency of one entry.

The exact-once proof is shard-count agnostic, so this is a balancing knob, not a coverage one. 48/48 planner tests pass.

### 3. Drop `type=gha` buildkit cache from `release.yml`

It could never work. GitHub scopes a cache entry to the ref that wrote it, and a run may read only its own ref or the default branch — and this workflow triggers on **tags**. Verified: each tag's 44 blob entries were created *and* last-read entirely inside that tag's own run.

| Tag | Release run | Blobs created | Last read |
|---|---|---|---|
| v0.7.25 | 15:45 → 16:11 | 15:45–15:48 | **15:50** |
| v0.7.26 | 18:20 → 18:46 | 18:21–18:22 | **18:25** |
| v0.7.27 | 19:36 → 20:02 | 19:37–19:39 | **19:41** |

v0.7.26's run never touched v0.7.25's blobs. That was 0.92 GB written per release, ~3 releases/day, **evicting the `server-test` family that every CI lane restores** — the eviction is the reason to remove it, not the wasted bytes.

Nothing is lost. `runtime-base` builds the same image twice, and the second build reuses the first's layers from the buildx **builder's** local cache (it persists for the job's lifetime); intra-run reuse never depended on an exported cache. Single-build jobs got nothing from it at all.

Real cross-release reuse needs a ref-independent backend (`type=registry,ref=…:buildcache` on GHCR, which this workflow already authenticates to). That's a release-**speed** change with its own export cost to measure on a production path — deliberately not bundled here.

### 4. `cache-prune`: fix the budget report, `--keep` 2 → 1

The report step had failed on **every scheduled run since at least 2026-07-28**:

```
the `--slurp` option is not supported with `--jq` or `--template`
```

A newer `gh` on the runner image began rejecting that combination. The prune itself was unaffected and kept working (run 30429331029 reclaimed 2.46 GB before dying here), so the only symptoms were a red workflow and — worse — the budget notice this step exists to emit never reaching anyone while the repo sat at **10.49 GB against a 10 GB cap**. Rewritten onto the unpaginated `/actions/cache/usage` endpoint, so there is no `--paginate` and no `--slurp` left for the incompatibility to apply to.

`--keep 2` protected nothing: rust-cache restores by key **prefix** and GitHub returns the newest match, so the older entry is never read — including in the case it looks like insurance against, a corrupt newest entry (`cache-on-failure: true` means a partial deposit is saved and still wins the prefix match). The script's own header already says only the newest entry per family is ever read. That was 1.67 GB + 0.78 GB = **2.45 GB of pure ballast**. Safe because each family has exactly one writer, on main, in a push/dispatch-only job — enforced by `ci-cache-policy.test.mjs`.

Note both defaults had to move: `inputs.keep` is empty on the scheduled run, so the `|| '1'` fallback, not `default:`, governs the daily prune.

## How to measure

Baseline (before this PR), from the last 100 completed runs of each event:

| Metric | Baseline |
|---|---|
| PR-lane wall clock | **p50 14.1 / p75 14.4 / p90 16.1 min** (n=65) |
| merge_group wall clock | p50 14.1 / p75 15.1 / p90 17.2 min (n=98) |
| `Server Clippy` | 11m50s (clippy 3m21s + render-gate 7m42s) |
| `Server Test` shard | 12–13m (setup 1m36s + build 5m54s + run 4m00s) |
| Actions cache | 10.49 GB / 154 entries, over a 10 GB cap, evicting |

Reproduce after merge:

```bash
# per-run wall clock distribution
gh api "repos/djinnos/djinn/actions/workflows/quality-gate.yml/runs?event=pull_request&per_page=100&status=completed" \
  -q '.workflow_runs[] | select(.conclusion=="success") | "\(.run_started_at) \(.updated_at)"'

# per-job and per-step timings for one run
gh api repos/djinnos/djinn/actions/runs/<id>/jobs \
  -q '.jobs[] | "\(.name)\t\((((.completedAt|fromdate)-(.startedAt|fromdate))/60)|floor)m"'

# cache budget
gh api repos/djinnos/djinn/actions/cache/usage
```

Expected: PR-lane p50 ≈ **11.3 min** (−20%), `Server Clippy` ≈ 4m, cache settling ≈ 5.3 GB once the prune runs and no new tag-scoped blobs are written.

## What was measured and rejected

- **Crate-scoped test selection.** Reverse-dependency closure over the last 48 server-touching commits retains a **median 70%** of test time, ≥90% for 22 of 48, and **never below 50%**. `djinn-db` is in ~40% of PRs and pulls in 18 of 32 packages. Best case ~1.2 min off 14, against forfeited signal — of 100 failing PR runs, 66 failed on a test shard and **45 were caught by nothing else**.
- **Crate-scoped clippy.** Only 3m21s to begin with, and narrowing the package set changes the resolver-2 feature union, hands shared deps a different `-C metadata`, and misses the ~1900 cached units — the trap already documented at `quality-gate.yml:768-784` and measured in #2349.
- **`cache-workspace-crates`.** Measured in #2349: cache 1267 → 2283 MB, shard build time unmoved.
- **sccache.** The config comment's objection (forbids incremental) is scoped to the platform pods; CI already pins `CARGO_INCREMENTAL: 0`. But it's still the wrong tool: it does not cache **linking**, and the workspace ships **175 test binaries** against 41 crate compiles. A `cargo build --timings` run is needed to get the compile/link split before investing.
- **mold / lld.** mold needs a network install that has broken CI before. `rust-lld` ships with the toolchain, but the stable flag is unavailable on the pinned channel (`-C link-self-contained=+linker` requires `-Z unstable-options` on 1.97.1).

## Verification

- `actionlint -shellcheck= -pyflakes=` clean on all workflows
- All 9 locally-runnable `ci-contracts` suites pass, including `ci-cache-policy` (single-writer ownership for the new lane) and `ci-release-image-validation` (release step ordering preserved)
- `ci-nextest-plan.test.mjs` 48/48
- Rollup verified structurally: `deploy-render-gate` in `needs`, in `env`, and in a `check` line
