### PR TITLE
fix(supervisor): don't book transient planner-session deaths as completed review closes

### DIFF
--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -535,6 +535,169 @@ where
     }
 }
 
+/// Routing decision for [`apply_planner_failed_close`] — the
+/// `StageOutcome::Failed` arm's planner-review close backstop.
+///
+/// Pure helper (no I/O, no async) mirroring [`PlannerEscalateRoute`] so unit
+/// tests can branch on the rule without driving the transition closure.
+#[derive(Debug, PartialEq, Eq)]
+enum PlannerFailedRoute {
+    /// Not the Planner + `issue_type == "review"` leg — the Failed arm's
+    /// close backstop does not apply; no transition is fired here.
+    NotApplicable,
+    /// The run was cancelled (stall-kill / preempt) — fire NO transition so
+    /// the task stays in its current state for redispatch. Mirrors the
+    /// Escalate arm's cancel gate ([`PlannerEscalateRoute::Cancelled`]).
+    Cancelled,
+    /// The stage died on a transient provider-side fault (5xx overload /
+    /// transport death) or a throttle. The provider failed, the planner never
+    /// adjudicated anything — closing here would book a false "completed"
+    /// close. Fire NO transition: the coordinator's execution-state orphan
+    /// reconciler releases the task back to `open`, and the same-role
+    /// reappearance machinery applies the escalating provider-protection
+    /// cooldown ladder (see `dispatch_cooldown_for_failure`), so leaving it
+    /// open does NOT reintroduce the ~30s tight re-dispatch loop this arm
+    /// was added to prevent.
+    LeaveOpenTransient,
+    /// The task carries the `human-review-hold` label — a human-only
+    /// terminal hold that must NEVER be auto-closed by an agent decision
+    /// (`planner_terminal_close_action` returned `None`). No transition.
+    HoldNoClose,
+    /// Genuinely-terminal planner failure (no provider fault, or a
+    /// deterministic one): close the review task so the coordinator's
+    /// ready-task sweep stops re-dispatching it, with a
+    /// `"planner session failed:"`-prefixed reason so the persisted record
+    /// is distinguishable from a planner-adjudicated completion.
+    CloseWithFailureReason,
+}
+
+/// Compute the routing branch for the planner-review close backstop in the
+/// `StageOutcome::Failed` arm of the supervisor loop.
+///
+/// Incident (2026-07-30): four "Planner remediation" review tasks whose
+/// planner sessions died ~11s in on a transient OpenAI `server_is_overloaded`
+/// error were each closed with `close_reason="completed"` despite the planner
+/// having produced nothing — the old arm closed unconditionally, ignoring
+/// `provider_failure`, the cancel token, and the `human-review-hold` guard.
+fn route_planner_failed(
+    role_kind: RoleKind,
+    task: &Task,
+    provider_failure: Option<djinn_runtime::ProviderFailureClass>,
+    cancel_is_cancelled: bool,
+) -> PlannerFailedRoute {
+    if role_kind != RoleKind::Planner || task.issue_type != "review" {
+        return PlannerFailedRoute::NotApplicable;
+    }
+    if cancel_is_cancelled {
+        return PlannerFailedRoute::Cancelled;
+    }
+    if matches!(
+        provider_failure,
+        Some(
+            djinn_runtime::ProviderFailureClass::Transient { .. }
+                | djinn_runtime::ProviderFailureClass::Throttle { .. }
+        )
+    ) {
+        return PlannerFailedRoute::LeaveOpenTransient;
+    }
+    // Defense in depth: the same guard the PlannerExecute / PlannerClose
+    // terminal paths use — a `human-review-hold` task is never auto-closed.
+    match planner_terminal_close_action(task) {
+        Some(_) => PlannerFailedRoute::CloseWithFailureReason,
+        None => PlannerFailedRoute::HoldNoClose,
+    }
+}
+
+/// Apply the planner-review close backstop for a `StageOutcome::Failed`
+/// stage. Encapsulates the routing decision AND the `transition_task` call
+/// (like [`apply_planner_escalate_route`]) so unit tests can assert both the
+/// chosen route and the exact set of transition invocations with a recording
+/// closure. Returns the route taken; the caller's run outcome is unchanged
+/// (the arm still surfaces `TaskRunOutcome::Failed` so the host breaker sees
+/// the provider-failure class).
+#[allow(clippy::too_many_arguments)]
+async fn apply_planner_failed_close<F, Fut>(
+    role_kind: RoleKind,
+    task: &Task,
+    task_id: &str,
+    task_run_id: &str,
+    reason: &str,
+    provider_failure: Option<djinn_runtime::ProviderFailureClass>,
+    cancel_is_cancelled: bool,
+    transition: F,
+) -> PlannerFailedRoute
+where
+    F: FnOnce(String, String, Option<String>) -> Fut,
+    Fut: std::future::Future<Output = Result<(), String>>,
+{
+    let route = route_planner_failed(role_kind, task, provider_failure, cancel_is_cancelled);
+    match route {
+        PlannerFailedRoute::NotApplicable => {}
+        PlannerFailedRoute::Cancelled => {
+            tracing::debug!(
+                task_run_id = %task_run_id,
+                task_id = %task_id,
+                issue_type = %task.issue_type,
+                "supervisor: run cancelled — skipping planner-Failed close transition",
+            );
+        }
+        PlannerFailedRoute::LeaveOpenTransient => {
+            tracing::warn!(
+                task_run_id = %task_run_id,
+                task_id = %task_id,
+                issue_type = %task.issue_type,
+                provider_failure = ?provider_failure,
+                reason = %reason,
+                "supervisor: planner review stage died on a transient provider fault — \
+                 NOT closing the task (a close here would book a false \"completed\"); \
+                 leaving it for redispatch under the coordinator's provider cooldown ladder",
+            );
+        }
+        PlannerFailedRoute::HoldNoClose => {
+            tracing::warn!(
+                task_run_id = %task_run_id,
+                task_id = %task_id,
+                issue_type = %task.issue_type,
+                "supervisor: planner stage failed on a human-review-hold task — \
+                 NOT auto-closing; the hold is human-only",
+            );
+        }
+        PlannerFailedRoute::CloseWithFailureReason => {
+            // Prefix the durable reason (activity log + run outcome surface)
+            // so the closed row is grep-ably distinct from a genuine
+            // planner-adjudicated completion — mirrors the
+            // "planner escalated:" convention of the Escalate arm. The
+            // `close` transition still writes `close_reason="completed"`
+            // (that value is hardcoded in `TransitionAction::Close`); the
+            // reason marker is the honest-labeling surface for this PR.
+            let surfaced_reason = format!("planner session failed: {reason}");
+            info!(
+                task_run_id = %task_run_id,
+                task_id = %task_id,
+                issue_type = %task.issue_type,
+                surfaced_reason = %surfaced_reason,
+                "supervisor: planner review stage failed terminally — closing the \
+                 task so the ready sweep stops re-dispatching it",
+            );
+            if let Err(e) = transition(
+                task_id.to_string(),
+                "close".to_string(),
+                Some(surfaced_reason),
+            )
+            .await
+            {
+                tracing::warn!(
+                    task_run_id = %task_run_id,
+                    task_id = %task_id,
+                    error = %e,
+                    "supervisor: planner-Failed close transition skipped"
+                );
+            }
+        }
+    }
+    route
+}
+
 // ── TaskRunSupervisor ────────────────────────────────────────────────────────
 
 /// Outcome of [`prepare_resume_workspace`] — what the supervisor's
@@ -2619,32 +2782,45 @@ impl TaskRunSupervisor {
                         reason,
                         provider_failure,
                     } => {
-                        // Planner review tasks (issue_type=review) must close
-                        // even on Failed — the LLM sometimes finishes without
-                        // calling submit_grooming (StageOutcome::Failed via
-                        // "finalized via unexpected tool", or no finalize at
-                        // all), and the task otherwise stays `open` and the
-                        // coordinator re-dispatches it every ~30s in a tight
-                        // loop. Observed on n6k8 "Planner board
-                        // health review" after k4my had the same pattern.
-                        if role_kind == RoleKind::Planner
-                            && task.issue_type == "review"
-                            && let Err(e) = self
-                                .services
-                                .transition_task(
-                                    spec.task_id.clone(),
-                                    "close".into(),
-                                    Some(reason.clone()),
-                                )
-                                .await
-                        {
-                            tracing::warn!(
-                                task_run_id = %run_id,
-                                task_id = %spec.task_id,
-                                error = %e,
-                                "supervisor: planner-Failed close transition skipped"
-                            );
-                        }
+                        // Planner review tasks (issue_type=review) that fail
+                        // TERMINALLY must still close — the LLM sometimes
+                        // finishes without calling submit_grooming
+                        // (StageOutcome::Failed via "finalized via unexpected
+                        // tool", or no finalize at all), and the task
+                        // otherwise stays `open` and the coordinator
+                        // re-dispatches it every ~30s in a tight loop.
+                        // Observed on n6k8 "Planner board health review" after
+                        // k4my had the same pattern.
+                        //
+                        // But NOT unconditionally (incident 2026-07-30: four
+                        // planner-remediation reviews whose sessions died ~11s
+                        // in on a transient OpenAI `server_is_overloaded`
+                        // were closed as "completed" with zero planner
+                        // output). `apply_planner_failed_close` gates the
+                        // close on: not cancelled, not a transient/throttle
+                        // provider fault (those are left open for redispatch
+                        // under the coordinator's provider cooldown ladder —
+                        // no tight loop), and not a `human-review-hold` task
+                        // (`planner_terminal_close_action`, the same guard the
+                        // PlannerExecute / PlannerClose paths use). A close
+                        // that does happen carries a "planner session failed:"
+                        // reason marker so it is distinguishable from a
+                        // planner-adjudicated completion.
+                        apply_planner_failed_close(
+                            role_kind,
+                            &task,
+                            &spec.task_id,
+                            &run_id,
+                            &reason,
+                            provider_failure,
+                            self.services.cancel().is_cancelled(),
+                            |task_id, action, close_reason| async move {
+                                self.services
+                                    .transition_task(task_id, action, close_reason)
+                                    .await
+                            },
+                        )
+                        .await;
                         // Arbiter session termination accounting: distinguish
                         // provider/infra failures from sessions that ran and
                         // ended without a valid decision.  Infra failures
@@ -3236,6 +3412,12 @@ mod tests {
         /// Counts `execute_stage` invocations so a test can assert the stage was
         /// (or was not) run.
         execute_stage_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        /// Role the scripted stage expects to be driven with (Worker for the
+        /// worker-flow tests, Planner for the Planning-flow tests).
+        expected_role: RoleKind,
+        /// Records every `transition_task` call so tests can assert exactly
+        /// which board transitions a run requested (and which it must NOT).
+        transitions: std::sync::Arc<std::sync::Mutex<Vec<TransitionCall>>>,
     }
 
     #[async_trait]
@@ -3259,7 +3441,7 @@ mod tests {
         ) -> Result<StageOutcome, StageError> {
             self.execute_stage_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            assert_eq!(role_kind, RoleKind::Worker);
+            assert_eq!(role_kind, self.expected_role);
             Ok(self.outcome.clone())
         }
 
@@ -3386,10 +3568,18 @@ mod tests {
 
         async fn transition_task(
             &self,
-            _task_id: String,
+            task_id: String,
             action: String,
-            _reason: Option<String>,
+            reason: Option<String>,
         ) -> Result<(), String> {
+            self.transitions
+                .lock()
+                .expect("transitions mutex poisoned")
+                .push(TransitionCall {
+                    task_id,
+                    action: action.clone(),
+                    reason,
+                });
             if self.fail_start_transition && action == "start" {
                 return Err("task has unresolved blockers".into());
             }
@@ -3466,6 +3656,8 @@ mod tests {
             updated_statuses: updated_statuses.clone(),
             fail_start_transition: true,
             execute_stage_calls: execute_stage_calls.clone(),
+            expected_role: RoleKind::Worker,
+            transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -3538,6 +3730,8 @@ mod tests {
             updated_statuses: updated_statuses.clone(),
             fail_start_transition: true,
             execute_stage_calls: execute_stage_calls.clone(),
+            expected_role: RoleKind::Worker,
+            transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -3700,6 +3894,8 @@ mod tests {
             updated_statuses: std::sync::Arc::clone(&updated_statuses),
             fail_start_transition: false,
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            expected_role: RoleKind::Worker,
+            transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -3777,6 +3973,8 @@ mod tests {
             updated_statuses: std::sync::Arc::clone(&updated_statuses),
             fail_start_transition: false,
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            expected_role: RoleKind::Worker,
+            transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let provider_supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), provider_services);
         let provider_spec = TaskRunSpec {
@@ -3880,6 +4078,8 @@ mod tests {
             updated_statuses: std::sync::Arc::clone(&updated_statuses),
             fail_start_transition: false,
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            expected_role: RoleKind::Worker,
+            transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -3948,6 +4148,8 @@ mod tests {
             updated_statuses: std::sync::Arc::clone(&updated_statuses),
             fail_start_transition: false,
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            expected_role: RoleKind::Worker,
+            transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let summary_supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), summary_services);
         let summary_spec = TaskRunSpec {
@@ -4141,6 +4343,480 @@ mod tests {
         task.issue_type = "task".into();
         task.labels = "[]".into();
         assert_eq!(planner_terminal_close_action(&task), None);
+    }
+
+    // ── StageOutcome::Failed planner-review close backstop ───────────────
+    //
+    // Incident regression (2026-07-30): four "Planner remediation" review
+    // tasks whose planner sessions died ~11s in on a transient OpenAI
+    // `server_is_overloaded` provider error were each closed with
+    // `close_reason="completed"` — the Failed arm closed unconditionally,
+    // ignoring `provider_failure`, the cancel token, and the
+    // `human-review-hold` guard. These tests pin the gated behavior.
+
+    fn planner_remediation_review_task(task_id: &str) -> Task {
+        let mut task = fixture_task(task_id, "p1");
+        task.issue_type = "review".into();
+        task.labels = r#"["planner-remediation"]"#.into();
+        task
+    }
+
+    /// Pure routing: a transient provider fault (and a throttle) must NOT
+    /// close the review task — the provider failed, not the planner.
+    #[test]
+    fn route_planner_failed_transient_leaves_task_open() {
+        let task = planner_remediation_review_task("t-transient");
+        for pf in [
+            djinn_runtime::ProviderFailureClass::Transient {
+                retry_after_ms: None,
+            },
+            djinn_runtime::ProviderFailureClass::Transient {
+                retry_after_ms: Some(30_000),
+            },
+            djinn_runtime::ProviderFailureClass::Throttle {
+                retry_after_ms: None,
+            },
+        ] {
+            assert_eq!(
+                route_planner_failed(RoleKind::Planner, &task, Some(pf), false),
+                PlannerFailedRoute::LeaveOpenTransient,
+                "a {pf:?} planner-review failure must leave the task open, not close it"
+            );
+        }
+    }
+
+    /// Pure routing: non-transient failures (untyped, task-attributable
+    /// `Failure`, deterministic `AuthInvalid`) still terminalize via close —
+    /// the tight-loop backstop is preserved — but through the marked-reason
+    /// close path.
+    #[test]
+    fn route_planner_failed_non_transient_closes_with_marked_reason() {
+        let task = planner_remediation_review_task("t-terminal");
+        for pf in [
+            None,
+            Some(djinn_runtime::ProviderFailureClass::Failure),
+            Some(djinn_runtime::ProviderFailureClass::AuthInvalid),
+        ] {
+            assert_eq!(
+                route_planner_failed(RoleKind::Planner, &task, pf, false),
+                PlannerFailedRoute::CloseWithFailureReason,
+                "a non-transient ({pf:?}) planner-review failure must still close the task"
+            );
+        }
+    }
+
+    /// Pure routing: the cancel gate fires before any close decision
+    /// (mirrors the Escalate arm) — a stall-kill / preempt must not park
+    /// the task.
+    #[test]
+    fn route_planner_failed_cancelled_fires_no_transition() {
+        let task = planner_remediation_review_task("t-cancel");
+        assert_eq!(
+            route_planner_failed(RoleKind::Planner, &task, None, true),
+            PlannerFailedRoute::Cancelled,
+        );
+        // Cancel wins even over a transient fault (both are no-transition).
+        assert_eq!(
+            route_planner_failed(
+                RoleKind::Planner,
+                &task,
+                Some(djinn_runtime::ProviderFailureClass::Transient {
+                    retry_after_ms: None
+                }),
+                true
+            ),
+            PlannerFailedRoute::Cancelled,
+        );
+    }
+
+    /// Pure routing: a `human-review-hold` review task is never auto-closed
+    /// by the Failed arm — the same `planner_terminal_close_action` guard
+    /// the PlannerExecute / PlannerClose paths use.
+    #[test]
+    fn route_planner_failed_human_review_hold_is_never_closed() {
+        let mut task = planner_remediation_review_task("t-hold");
+        task.labels = r#"["planner-remediation","human-review-hold"]"#.into();
+        assert_eq!(
+            route_planner_failed(RoleKind::Planner, &task, None, false),
+            PlannerFailedRoute::HoldNoClose,
+            "a human-review-hold review task must never be auto-closed by the Failed arm"
+        );
+    }
+
+    /// Pure routing: the backstop stays narrow — non-planner roles and
+    /// non-review issue types are untouched by the Failed arm.
+    #[test]
+    fn route_planner_failed_scope_stays_narrow() {
+        let mut task = planner_remediation_review_task("t-scope");
+        assert_eq!(
+            route_planner_failed(RoleKind::Worker, &task, None, false),
+            PlannerFailedRoute::NotApplicable,
+        );
+        task.issue_type = "task".into();
+        assert_eq!(
+            route_planner_failed(RoleKind::Planner, &task, None, false),
+            PlannerFailedRoute::NotApplicable,
+        );
+    }
+
+    /// Headline incident regression: the exact 2026-07-30 shape — planner +
+    /// review + `server_is_overloaded` transient — must fire NO transition
+    /// at all (previously it fired a plain `close` that booked
+    /// `close_reason="completed"`).
+    #[tokio::test]
+    async fn planner_failed_transient_provider_fault_does_not_close_task() {
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<TransitionCall>::new()));
+        let calls_for_closure = std::sync::Arc::clone(&calls);
+        let task = planner_remediation_review_task("remediation-1");
+
+        let route = apply_planner_failed_close(
+            RoleKind::Planner,
+            &task,
+            "remediation-1",
+            "run-1",
+            "reply loop error: provider stream event failed: display=server_is_overloaded",
+            Some(djinn_runtime::ProviderFailureClass::Transient {
+                retry_after_ms: None,
+            }),
+            false,
+            move |task_id, action, reason| {
+                let calls = std::sync::Arc::clone(&calls_for_closure);
+                async move {
+                    calls
+                        .lock()
+                        .expect("calls mutex poisoned")
+                        .push(TransitionCall {
+                            task_id,
+                            action,
+                            reason,
+                        });
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(route, PlannerFailedRoute::LeaveOpenTransient);
+        let calls = calls.lock().expect("calls mutex poisoned");
+        assert!(
+            calls.is_empty(),
+            "a transient provider fault must not fire ANY transition (was: plain close \
+             booking close_reason=completed), got {calls:?}"
+        );
+    }
+
+    /// Non-transient failures still close, but the durable reason must be
+    /// marked as a planner session failure — distinguishable from a genuine
+    /// planner-adjudicated completion.
+    #[tokio::test]
+    async fn planner_failed_non_transient_closes_with_marked_reason() {
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<TransitionCall>::new()));
+        let calls_for_closure = std::sync::Arc::clone(&calls);
+        let task = planner_remediation_review_task("remediation-2");
+
+        let route = apply_planner_failed_close(
+            RoleKind::Planner,
+            &task,
+            "remediation-2",
+            "run-2",
+            "finalized via unexpected tool",
+            None,
+            false,
+            move |task_id, action, reason| {
+                let calls = std::sync::Arc::clone(&calls_for_closure);
+                async move {
+                    calls
+                        .lock()
+                        .expect("calls mutex poisoned")
+                        .push(TransitionCall {
+                            task_id,
+                            action,
+                            reason,
+                        });
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(route, PlannerFailedRoute::CloseWithFailureReason);
+        let calls = calls.lock().expect("calls mutex poisoned");
+        assert_eq!(
+            calls.len(),
+            1,
+            "a terminal planner-review failure must fire exactly one close, got {calls:?}"
+        );
+        assert_eq!(calls[0].action, "close");
+        assert_eq!(calls[0].task_id, "remediation-2");
+        let reason = calls[0]
+            .reason
+            .as_ref()
+            .expect("planner-Failed close must carry a durable reason");
+        assert!(
+            reason.starts_with("planner session failed: "),
+            "close reason must carry the failure marker prefix, got {reason:?}"
+        );
+        assert!(
+            reason.contains("finalized via unexpected tool"),
+            "close reason must preserve the original failure reason, got {reason:?}"
+        );
+    }
+
+    /// A `human-review-hold` review task must not be auto-closed by the
+    /// Failed arm even on a genuinely-terminal failure.
+    #[tokio::test]
+    async fn planner_failed_human_review_hold_fires_no_transition() {
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<TransitionCall>::new()));
+        let calls_for_closure = std::sync::Arc::clone(&calls);
+        let mut task = planner_remediation_review_task("remediation-3");
+        task.labels = r#"["planner-remediation","human-review-hold"]"#.into();
+
+        let route = apply_planner_failed_close(
+            RoleKind::Planner,
+            &task,
+            "remediation-3",
+            "run-3",
+            "planner produced no grooming decision",
+            None,
+            false,
+            move |task_id, action, reason| {
+                let calls = std::sync::Arc::clone(&calls_for_closure);
+                async move {
+                    calls
+                        .lock()
+                        .expect("calls mutex poisoned")
+                        .push(TransitionCall {
+                            task_id,
+                            action,
+                            reason,
+                        });
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(route, PlannerFailedRoute::HoldNoClose);
+        assert!(
+            calls.lock().expect("calls mutex poisoned").is_empty(),
+            "a human-review-hold task must never be auto-closed by the Failed arm"
+        );
+    }
+
+    /// A cancelled run fires no transition (consistent with the Escalate
+    /// arm's cancel gate) — the task stays in its current state for a clean
+    /// redispatch.
+    #[tokio::test]
+    async fn planner_failed_cancelled_run_fires_no_transition() {
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::<TransitionCall>::new()));
+        let calls_for_closure = std::sync::Arc::clone(&calls);
+        let task = planner_remediation_review_task("remediation-4");
+
+        let route = apply_planner_failed_close(
+            RoleKind::Planner,
+            &task,
+            "remediation-4",
+            "run-4",
+            "planner produced no grooming decision",
+            None,
+            true,
+            move |task_id, action, reason| {
+                let calls = std::sync::Arc::clone(&calls_for_closure);
+                async move {
+                    calls
+                        .lock()
+                        .expect("calls mutex poisoned")
+                        .push(TransitionCall {
+                            task_id,
+                            action,
+                            reason,
+                        });
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(route, PlannerFailedRoute::Cancelled);
+        assert!(
+            calls.lock().expect("calls mutex poisoned").is_empty(),
+            "a cancelled planner-review run must not fire the close transition"
+        );
+    }
+
+    /// Full-run integration regression: drive a `Planning` flow over a
+    /// planner-remediation review task whose stage dies exactly like the
+    /// 2026-07-30 incident (transient `server_is_overloaded`), and assert
+    /// the supervisor requests NO `close` transition while still surfacing
+    /// `TaskRunOutcome::Failed` with the provider class for the host
+    /// breaker.
+    #[tokio::test]
+    async fn planning_run_transient_provider_failure_leaves_review_task_open() {
+        let root = tempfile::tempdir_in(std::env::current_dir().expect("current dir"))
+            .expect("temp test root");
+        let source_dir = root.path().join("source");
+        make_source_repo(&source_dir);
+
+        let project_id = "project-planner-transient";
+        let task_id = "task-planner-transient";
+        let mirror = Arc::new(MirrorManager::new(root.path().join("mirrors")));
+        mirror
+            .ensure_mirror(project_id, &format!("file://{}", source_dir.display()))
+            .await
+            .expect("install fixture mirror");
+
+        let mut task = planner_remediation_review_task(task_id);
+        task.project_id = project_id.into();
+        let transitions = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let services: Arc<dyn SupervisorServices> = Arc::new(ScriptedLoopGuardServices {
+            cancel: CancellationToken::new(),
+            task,
+            outcome: StageOutcome::Failed {
+                reason: "reply loop error: provider stream event failed: \
+                         display=server_is_overloaded"
+                    .into(),
+                provider_failure: Some(djinn_runtime::ProviderFailureClass::Transient {
+                    retry_after_ms: None,
+                }),
+            },
+            updated_statuses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            fail_start_transition: false,
+            execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            expected_role: RoleKind::Planner,
+            transitions: transitions.clone(),
+        });
+        let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
+        let spec = TaskRunSpec {
+            task_run_id: "run-planner-transient".into(),
+            task_attempt_id: None,
+            task_id: task_id.into(),
+            project_id: project_id.into(),
+            trigger: TaskRunTrigger::NewTask,
+            base_branch: "main".into(),
+            task_branch: "djinn/planner-transient".into(),
+            flow: SupervisorFlow::Planning,
+            model_id_per_role: Default::default(),
+            read_source_project_ids: Vec::new(),
+            knowledge_injection: djinn_core::models::KnowledgeInjectionConfig::default(),
+            github_owner: None,
+            github_install_token: None,
+            commit_author_name: None,
+            commit_author_email: None,
+            resume_lifecycle_metadata: None,
+            is_evidence_spike: false,
+        };
+
+        let report = supervisor.run(spec).await.expect("supervisor run");
+
+        // The run outcome must stay `Failed` and carry the provider class so
+        // the host breaker sees the transient fault.
+        match &report.outcome {
+            TaskRunOutcome::Failed {
+                provider_failure, ..
+            } => {
+                assert!(
+                    matches!(
+                        provider_failure,
+                        Some(djinn_runtime::ProviderFailureClass::Transient { .. })
+                    ),
+                    "run outcome must carry the transient provider class, got {provider_failure:?}"
+                );
+            }
+            other => panic!("expected TaskRunOutcome::Failed, got {other:?}"),
+        }
+
+        let transitions = transitions.lock().expect("transitions mutex poisoned");
+        assert!(
+            !transitions.iter().any(|t| t.action == "close"),
+            "a transient provider failure must NOT close the review task (it would book \
+             close_reason=completed with zero planner output), got {transitions:?}"
+        );
+        // The pre-stage claim is the only transition a transient-failed
+        // planning run should request.
+        assert_eq!(
+            transitions
+                .iter()
+                .map(|t| t.action.as_str())
+                .collect::<Vec<_>>(),
+            vec!["start"],
+            "only the pre-stage start claim should fire"
+        );
+    }
+
+    /// Full-run integration: a NON-transient planner failure on a review
+    /// task still terminalizes it (the n6k8/k4my tight-loop backstop), with
+    /// the marked reason.
+    #[tokio::test]
+    async fn planning_run_terminal_failure_still_closes_review_task_with_marker() {
+        let root = tempfile::tempdir_in(std::env::current_dir().expect("current dir"))
+            .expect("temp test root");
+        let source_dir = root.path().join("source");
+        make_source_repo(&source_dir);
+
+        let project_id = "project-planner-terminal";
+        let task_id = "task-planner-terminal";
+        let mirror = Arc::new(MirrorManager::new(root.path().join("mirrors")));
+        mirror
+            .ensure_mirror(project_id, &format!("file://{}", source_dir.display()))
+            .await
+            .expect("install fixture mirror");
+
+        let mut task = planner_remediation_review_task(task_id);
+        task.project_id = project_id.into();
+        let transitions = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let services: Arc<dyn SupervisorServices> = Arc::new(ScriptedLoopGuardServices {
+            cancel: CancellationToken::new(),
+            task,
+            outcome: StageOutcome::Failed {
+                reason: "finalized via unexpected tool".into(),
+                provider_failure: None,
+            },
+            updated_statuses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            fail_start_transition: false,
+            execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            expected_role: RoleKind::Planner,
+            transitions: transitions.clone(),
+        });
+        let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
+        let spec = TaskRunSpec {
+            task_run_id: "run-planner-terminal".into(),
+            task_attempt_id: None,
+            task_id: task_id.into(),
+            project_id: project_id.into(),
+            trigger: TaskRunTrigger::NewTask,
+            base_branch: "main".into(),
+            task_branch: "djinn/planner-terminal".into(),
+            flow: SupervisorFlow::Planning,
+            model_id_per_role: Default::default(),
+            read_source_project_ids: Vec::new(),
+            knowledge_injection: djinn_core::models::KnowledgeInjectionConfig::default(),
+            github_owner: None,
+            github_install_token: None,
+            commit_author_name: None,
+            commit_author_email: None,
+            resume_lifecycle_metadata: None,
+            is_evidence_spike: false,
+        };
+
+        let _report = supervisor.run(spec).await.expect("supervisor run");
+
+        let transitions = transitions.lock().expect("transitions mutex poisoned");
+        let closes: Vec<_> = transitions.iter().filter(|t| t.action == "close").collect();
+        assert_eq!(
+            closes.len(),
+            1,
+            "a terminal planner failure must still close the review task exactly once, \
+             got {transitions:?}"
+        );
+        let reason = closes[0]
+            .reason
+            .as_ref()
+            .expect("terminal close must carry a reason");
+        assert!(
+            reason.starts_with("planner session failed: ")
+                && reason.contains("finalized via unexpected tool"),
+            "close reason must be marked as a planner session failure, got {reason:?}"
+        );
     }
 
     /// The headline regression test for `ep1i`: planner + `planning`


### PR DESCRIPTION
## Incident

Overnight 2026-07-30, four "Planner remediation" tasks (`issue_type="review"`, label `planner-remediation`) minted by the coordinator's escalation ladder each had their planner session die ~11s in on a transient OpenAI `server_is_overloaded` provider error (0 tokens out, session status `failed`). Each task was then closed with `close_reason="completed"` as if the planner had adjudicated it.

## Traced chain

1. `djinn-agent/src/supervisor_impl/stage.rs` — the reply-loop error becomes `StageOutcome::Failed { reason, provider_failure: Some(ProviderFailureClass::Transient { .. }) }`.
2. `djinn-supervisor/src/lib.rs` `StageOutcome::Failed` arm — for `Planner + issue_type=="review"` it fired a plain `"close"` transition **unconditionally**: `provider_failure` was ignored, there was no cancel gate, and it bypassed `planner_terminal_close_action` (the human-review-hold guard both adjudicated planner paths use).
3. `TransitionAction::Close` hardcodes `close_reason = "completed"` — so a provider 5xx death was indistinguishable from a genuine planner completion.
4. Because `releases_source_on_close` is false for the planner-remediation label, these free deaths never advanced `planner_escalation_count` — the ladder could re-mint remediations forever without progressing.

The original unconditional close existed for a real reason (n6k8/k4my): a planner that finishes without calling `submit_grooming` leaves the review task `open` and the ready sweep re-dispatches it every ~30s. That backstop is preserved for genuinely-terminal failures.

## What changed

The Failed arm now routes through `route_planner_failed` / `apply_planner_failed_close` (pure route + transition-applying wrapper, mirroring the Escalate arm's `apply_planner_escalate_route`):

- **Transient / Throttle provider fault → no transition.** The task is left for redispatch. This does **not** reintroduce the ~30s tight loop: the run still leaves the task `in_progress`; the coordinator's execution-state orphan reconciler releases it back to `open` once the session is gone, and the same-role reappearance machinery in `dispatch/task_dispatch.rs` applies the escalating provider-protection cooldown ladder (`dispatch_cooldown_for_failure` with provider backoff + the retry-after floor). Transient/throttle classes are already deliberately exempt from the two task-blaming counters there, and from the streak-MAX terminal close — matching how every other role's transient failure is treated.
- **Cancel gate** — a cancelled run fires no transition (consistent with the Escalate arm), leaving the task for clean redispatch.
- **human-review-hold guard** — the close decision goes through `planner_terminal_close_action`, so the Failed arm can no longer auto-close a `human-review-hold` task.
- **Honest labeling** — a close that does happen (untyped failure, task-attributable `Failure`, deterministic `AuthInvalid`) carries a `"planner session failed: <reason>"` prefixed transition reason (mirroring the `"planner escalated:"` convention), durably visible in the activity log and the run outcome.
- The run outcome remains `TaskRunOutcome::Failed` carrying the provider class in all routes, so the host breaker side-channel is unchanged.

### close_reason decision

`close_reason` is left as-is (the `close` transition hardcodes `"completed"` in `djinn-core/src/models/task.rs`). Introducing a distinct close_reason for this path would require a new `TransitionAction` (the free-form reason string only reaches the activity log) and an audit of all `close_reason` consumers (`rules.rs` natural-completion filter, the merged pseudo-status in task_list, reentrance guards, force-close terminalization) — too invasive for this fix. The `"planner session failed:"` reason marker is the honest-labeling surface for this PR. Note the transient case no longer closes at all, so the incident shape can no longer book `completed`.

### Deferred

- **Escalation accounting for died-before-adjudication remediations** (`planner_escalation_count` never advances because `releases_source_on_close` is false for the label): touches ladder semantics in `djinn-coordinator/src/dispatch/retry.rs` / `roles.rs` and deserves its own PR. With this fix, transient deaths no longer close the remediation at all, so the ladder no longer records phantom "completed" remediations.
- A distinct non-"completed" `close_reason` value for failure-path closes (see above).
- No changes to `djinn-slot/src/reply_loop/` — the streaming-retry deepening is owned by a sibling PR.

## Tests

New coverage (there was none for this branch; the supervisor fixture task hardcoded `issue_type: "task"`):

- Pure-route: transient/throttle → leave open; `None`/`Failure`/`AuthInvalid` → close-with-marker; cancelled → no transition; human-review-hold → never closed; non-planner / non-review → untouched.
- Recording-closure apply tests for all four behaviors, including the exact incident reason string.
- Two full-run `SupervisorFlow::Planning` regressions over a `planner-remediation` review task: transient `server_is_overloaded` fires no `close` (only the pre-stage `start` claim) while the run outcome still carries the Transient class for the breaker; a non-transient failure still closes exactly once with the `"planner session failed:"` marker.

Evidence:
- `cargo test -p djinn-supervisor -- --test-threads=1`: **189 passed; 0 failed** (default-thread run shows 6 failures in global-metrics tests that fail identically on the untouched base commit — pre-existing parallel-run flake; CI runs nextest with per-test processes).
- `cargo clippy -p djinn-supervisor --all-targets`: clean, no warnings.
- `cargo check -p djinn-agent -p djinn-coordinator`: clean (crates untouched, link-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
