### PR TITLE
fix(slot): give throttle-class mid-stream errors minutes of retry patience, not seconds

### DIFF
--- a/server/crates/djinn-provider/src/provider/error.rs
+++ b/server/crates/djinn-provider/src/provider/error.rs
@@ -71,6 +71,23 @@ impl ProviderError {
         }
     }
 
+    /// Whether this failure is a **throttle** — the provider shedding load
+    /// (rate limit / quota / overload) rather than malfunctioning.
+    ///
+    /// Every throttle signal is folded into [`ProviderError::RateLimit`] at
+    /// classification time ([`from_status`](Self::from_status) maps
+    /// 408/425/429/529 there; [`from_stream_error`](Self::from_stream_error)
+    /// maps `rate_limit`/`quota`/`overload` codes there), so the variant is the
+    /// single throttle marker. Callers use this to pick retry *patience*
+    /// separately from retry *eligibility* ([`retryable`](Self::retryable)):
+    /// a throttle episode routinely lasts minutes and clears on its own, so it
+    /// is worth waiting out with a deep schedule, while a genuine provider
+    /// fault that persists across a few quick retries usually will not clear
+    /// just by asking again.
+    pub fn is_throttle(&self) -> bool {
+        matches!(self, ProviderError::RateLimit { .. })
+    }
+
     /// Server-supplied Retry-After in milliseconds, if this is a RateLimit
     /// that carried one.
     pub fn retry_after_ms(&self) -> Option<u64> {
@@ -583,6 +600,39 @@ mod tests {
         assert!(!ProviderError::InvalidRequest.retryable());
         assert!(!ProviderError::ContextOverflow.retryable());
         assert!(!ProviderError::InvalidOutput.retryable());
+    }
+
+    #[test]
+    fn throttle_classification_tracks_the_rate_limit_variant() {
+        // `is_throttle` picks the retry PATIENCE (deep wait-it-out schedule vs
+        // shallow), so it must agree exactly with where the classifiers put
+        // capacity shedding: the RateLimit variant, and nothing else.
+        assert!(
+            ProviderError::from_stream_error(Some("server_is_overloaded"), "overloaded")
+                .is_throttle(),
+            "an overload stream code is capacity shedding and must get throttle patience"
+        );
+        assert!(ProviderError::from_status(429, "").is_throttle());
+        assert!(ProviderError::from_status(529, "overloaded").is_throttle());
+        assert!(
+            ProviderError::RateLimit {
+                retry_after_ms: Some(1000)
+            }
+            .is_throttle()
+        );
+
+        // Retryable-but-not-throttle classes keep the shallow budget: a fault
+        // is not a queue you can wait out.
+        for err in [
+            ProviderError::from_stream_error(Some("server_error"), "An error occurred"),
+            ProviderError::Transport,
+            ProviderError::EmptyCompletion,
+            ProviderError::ProviderInternal { status: 503 },
+        ] {
+            assert!(err.retryable(), "{err:?} must stay retryable");
+            assert!(!err.is_throttle(), "{err:?} is a fault, not a throttle");
+        }
+        assert!(!ProviderError::Authentication.is_throttle());
     }
 
     #[test]

--- a/server/crates/djinn-slot/src/reply_loop/mod.rs
+++ b/server/crates/djinn-slot/src/reply_loop/mod.rs
@@ -45,7 +45,8 @@ pub use turn::{ReplyLoopContext, run_reply_loop};
 #[allow(clippy::await_holding_lock)]
 mod tests;
 
-/// Bounded retry of transient MID-STREAM provider errors (see
-/// `streaming::MAX_STREAM_EVENT_RETRIES`).
+/// Bounded, error-class-aware retry of transient MID-STREAM provider errors
+/// (see `streaming::MAX_STREAM_EVENT_RETRIES` and
+/// `streaming::MAX_THROTTLE_STREAM_EVENT_RETRIES`).
 #[cfg(test)]
 mod streaming_retry_tests;

--- a/server/crates/djinn-slot/src/reply_loop/streaming.rs
+++ b/server/crates/djinn-slot/src/reply_loop/streaming.rs
@@ -344,27 +344,38 @@ fn transient_round_restart_delay(
 ///
 /// Returns the unix timestamp used, so the per-event path can reuse it for
 /// its token-flush throttle.
-async fn touch_stream_activity(ctx: &StreamLoopContext<'_>) -> u64 {
-    let now = ctx
-        .ctx
+///
+/// Deliberately takes the individual fields rather than `&StreamLoopContext`:
+/// a `&StreamLoopContext` held across the `touch_activity_rpc` await would
+/// require the whole struct to be `Sync`, and it is not — it owns the
+/// `Pin<Box<dyn Stream + Send>>` provider stream (`Send` but not `Sync`) —
+/// which would strip `Send` from `consume_provider_stream`'s future and break
+/// `djinn-agent`'s `execute_stage`, whose spawned future must be `Send`.
+/// Callers copy these (`Sync`) references out of the context first.
+async fn touch_stream_activity(
+    slot_ctx: &crate::host::SlotContext,
+    task_id: &str,
+    activity_ts: &AtomicU64,
+    last_rpc_touch: &AtomicU64,
+) -> u64 {
+    let now = slot_ctx
         .clock
         .now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    ctx.activity_ts.store(now, Ordering::Relaxed);
+    activity_ts.store(now, Ordering::Relaxed);
     // Bridge to the host's ActivityTracker.
-    let last = ctx.last_rpc_touch.load(Ordering::Relaxed);
+    let last = last_rpc_touch.load(Ordering::Relaxed);
     if now.saturating_sub(last) >= TOUCH_ACTIVITY_RPC_INTERVAL_SECS {
-        ctx.last_rpc_touch.store(now, Ordering::Relaxed);
-        if let Err(e) = ctx
-            .ctx
+        last_rpc_touch.store(now, Ordering::Relaxed);
+        if let Err(e) = slot_ctx
             .callbacks
-            .touch_activity_rpc(ctx.task_id.to_string())
+            .touch_activity_rpc(task_id.to_string())
             .await
         {
             tracing::warn!(
-                task_id = %ctx.task_id,
+                task_id = %task_id,
                 error = %e,
                 "reply_loop::streaming: touch_activity RPC failed; \
                  host stall poller may see stale idle for this turn"
@@ -445,7 +456,13 @@ pub(super) async fn consume_provider_stream(
                             // refresh the liveness clocks so the coordinator's
                             // stall poller keeps counting this session as live
                             // across a multi-minute throttle wait.
-                            touch_stream_activity(&ctx).await;
+                            touch_stream_activity(
+                                ctx.ctx,
+                                ctx.task_id,
+                                ctx.activity_ts,
+                                ctx.last_rpc_touch,
+                            )
+                            .await;
                             tokio::select! {
                                 biased;
                                 _ = ctx.cancel.cancelled() => {
@@ -497,7 +514,13 @@ pub(super) async fn consume_provider_stream(
                     }
                 };
                 state.saw_round_event = true;
-                let now = touch_stream_activity(&ctx).await;
+                let now = touch_stream_activity(
+                    ctx.ctx,
+                    ctx.task_id,
+                    ctx.activity_ts,
+                    ctx.last_rpc_touch,
+                )
+                .await;
                 match evt {
                     StreamEvent::Delta(ContentBlock::Text { text }) => {
                         ctx.ctx.event_bus.send(DjinnEventEnvelope::session_message(

--- a/server/crates/djinn-slot/src/reply_loop/streaming.rs
+++ b/server/crates/djinn-slot/src/reply_loop/streaming.rs
@@ -226,8 +226,32 @@ const TOKEN_FLUSH_INTERVAL_SECS: u64 = 30;
 ///
 /// Deliberately smaller than the client's `MAX_RETRIES` (3): each attempt here
 /// re-issues a full LLM request, and the surrounding reply loop still has its
-/// own recovery paths above this one.
+/// own recovery paths above this one. This shallow budget applies to
+/// retryable **fault** classes (transport, provider-internal 5xx, empty
+/// completion); throttle-class failures get the deeper
+/// [`MAX_THROTTLE_STREAM_EVENT_RETRIES`] instead.
 pub(super) const MAX_STREAM_EVENT_RETRIES: u32 = 2;
+
+/// Additional attempts granted when the mid-stream failure is a **throttle**
+/// ([`ProviderError::is_throttle`]: rate limit / quota / overload).
+///
+/// The shallow budget above adds up to ~3 seconds of total patience (1s + 2s
+/// backoff), which is the wrong order of magnitude for capacity shedding:
+/// real overload episodes last minutes. The overnight `server_is_overloaded`
+/// incident killed planner sessions ~11 seconds after start — all three
+/// requests burned inside a single burst that the retry was nominally
+/// "handling". Ten attempts on the shared `backoff_delay_ms` schedule
+/// (1, 2, 4, 8, 16, then 30s at the cap ≈ 3 minutes of waiting in total)
+/// actually reaches the client's 30-second backoff ceiling and spans a
+/// realistic episode, while staying far below the coordinator's 30-minute
+/// session-stall budget.
+///
+/// A deep wait is only safe because the waits stay cancellation-responsive
+/// (every sleep sits in a `tokio::select!` with both cancel tokens) and
+/// because each retry iteration refreshes the activity clocks (see
+/// [`touch_stream_activity`]) so the coordinator's stall poller cannot
+/// mistake a deliberate backoff for a hung first call.
+pub(super) const MAX_THROTTLE_STREAM_EVENT_RETRIES: u32 = 10;
 
 /// Whether the round consumed so far can be safely thrown away and re-issued.
 ///
@@ -253,8 +277,9 @@ fn round_is_safely_restartable(state: &StreamTurnState, inflight_tool_futures: u
         && inflight_tool_futures == 0
 }
 
-/// Delay before re-issuing a round killed by `error`, or `None` when the round
-/// must fail exactly as it does today.
+/// Delay before re-issuing a round killed by `error` plus the class-dependent
+/// attempt budget (surfaced for logging), or `None` when the round must fail
+/// exactly as it does today.
 ///
 /// Retryability is decided *solely* by [`ProviderError::retryable`] — the same
 /// predicate the HTTP client and the supervisor's failure classifier use — so
@@ -262,15 +287,22 @@ fn round_is_safely_restartable(state: &StreamTurnState, inflight_tool_futures: u
 /// `EmptyCompletion` are retried while `Authentication` / `InvalidRequest` /
 /// `ContextOverflow` / `InvalidOutput` are not. An error with no typed
 /// `ProviderError` source is never retried.
+///
+/// *Patience* is decided separately, by [`ProviderError::is_throttle`]:
+/// throttle-class failures (capacity shedding that routinely lasts minutes)
+/// get [`MAX_THROTTLE_STREAM_EVENT_RETRIES`] attempts so the schedule can
+/// wait an episode out, while every other retryable class keeps the shallow
+/// [`MAX_STREAM_EVENT_RETRIES`]. Both budgets are compared against the
+/// round's single shared attempt counter, so an error that changes class
+/// mid-episode can never enlarge the patience already spent: a transport
+/// fault arriving after three throttle waits is already over the shallow
+/// budget and fails immediately.
 fn transient_round_restart_delay(
     error: &anyhow::Error,
     attempts_used: u32,
     state: &StreamTurnState,
     inflight_tool_futures: usize,
-) -> Option<std::time::Duration> {
-    if attempts_used >= MAX_STREAM_EVENT_RETRIES {
-        return None;
-    }
+) -> Option<(std::time::Duration, u32)> {
     if !round_is_safely_restartable(state, inflight_tool_futures) {
         return None;
     }
@@ -278,11 +310,68 @@ fn transient_round_restart_delay(
     if !provider_error.retryable() {
         return None;
     }
-    // Same exponential-with-jitter schedule as the client's request retry,
+    let budget = if provider_error.is_throttle() {
+        MAX_THROTTLE_STREAM_EVENT_RETRIES
+    } else {
+        MAX_STREAM_EVENT_RETRIES
+    };
+    if attempts_used >= budget {
+        return None;
+    }
+    // Same exponential-with-jitter schedule as the client's request retry
+    // (which the throttle budget is deep enough to ride up to its 30s cap),
     // floored by a server-supplied Retry-After when the provider sent one.
     let attempt = attempts_used + 1;
     let delay_ms = backoff_delay_ms(attempt).max(provider_error.retry_after_ms().unwrap_or(0));
-    Some(std::time::Duration::from_millis(delay_ms))
+    Some((std::time::Duration::from_millis(delay_ms), budget))
+}
+
+/// Refresh the liveness clocks: store the in-process activity timestamp and
+/// bridge it to the host's `ActivityTracker` via the (throttled)
+/// `touch_activity` RPC.
+///
+/// Called on every decoded stream event, and — deliberately — before each
+/// mid-stream retry wait. The host-side tracker entry is *upserted* by the
+/// first touch, and its presence doubles as the stall poller's "past the
+/// first LLM call" signal (see `AgentContext::touch_activity`): without a
+/// touch, a session whose FIRST round lands inside an overload burst would
+/// sit under the poller's aggressive first-call stall cap (300s) while
+/// waiting out the multi-minute throttle schedule, and the coordinator would
+/// kill it mid-backoff — a retry budget the watchdog undercuts is worthless.
+/// Each retry iteration waits at most 30s (the `backoff_delay_ms` cap), so
+/// touching once per iteration keeps observed idle within roughly one
+/// [`TOUCH_ACTIVITY_RPC_INTERVAL_SECS`] interval.
+///
+/// Returns the unix timestamp used, so the per-event path can reuse it for
+/// its token-flush throttle.
+async fn touch_stream_activity(ctx: &StreamLoopContext<'_>) -> u64 {
+    let now = ctx
+        .ctx
+        .clock
+        .now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    ctx.activity_ts.store(now, Ordering::Relaxed);
+    // Bridge to the host's ActivityTracker.
+    let last = ctx.last_rpc_touch.load(Ordering::Relaxed);
+    if now.saturating_sub(last) >= TOUCH_ACTIVITY_RPC_INTERVAL_SECS {
+        ctx.last_rpc_touch.store(now, Ordering::Relaxed);
+        if let Err(e) = ctx
+            .ctx
+            .callbacks
+            .touch_activity_rpc(ctx.task_id.to_string())
+            .await
+        {
+            tracing::warn!(
+                task_id = %ctx.task_id,
+                error = %e,
+                "reply_loop::streaming: touch_activity RPC failed; \
+                 host stall poller may see stale idle for this turn"
+            );
+        }
+    }
+    now
 }
 
 pub(super) async fn consume_provider_stream(
@@ -335,7 +424,7 @@ pub(super) async fn consume_provider_stream(
                         // restart of the whole round — but only while the round is
                         // still safely restartable. Otherwise fall through to the
                         // unchanged terminal path.
-                        if let Some(delay) = transient_round_restart_delay(
+                        if let Some((delay, max_attempts)) = transient_round_restart_delay(
                             &e,
                             stream_event_retries,
                             &state,
@@ -346,12 +435,17 @@ pub(super) async fn consume_provider_stream(
                                 task_id = %ctx.task_id,
                                 session_id = %ctx.session_id,
                                 attempt = stream_event_retries,
-                                max_attempts = MAX_STREAM_EVENT_RETRIES,
+                                max_attempts,
                                 delay_ms = delay.as_millis() as u64,
                                 error = %e,
                                 "provider stream event failed with a retryable error before any \
                                  output was emitted; retrying"
                             );
+                            // A deliberate backoff is activity, not idleness:
+                            // refresh the liveness clocks so the coordinator's
+                            // stall poller keeps counting this session as live
+                            // across a multi-minute throttle wait.
+                            touch_stream_activity(&ctx).await;
                             tokio::select! {
                                 biased;
                                 _ = ctx.cancel.cancelled() => {
@@ -403,24 +497,7 @@ pub(super) async fn consume_provider_stream(
                     }
                 };
                 state.saw_round_event = true;
-                let now = ctx.ctx.clock.now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0);
-                ctx.activity_ts.store(now, Ordering::Relaxed);
-                // Bridge to the host's ActivityTracker.
-                let last = ctx.last_rpc_touch.load(Ordering::Relaxed);
-                if now.saturating_sub(last) >= TOUCH_ACTIVITY_RPC_INTERVAL_SECS {
-                    ctx.last_rpc_touch.store(now, Ordering::Relaxed);
-                    if let Err(e) = ctx.ctx.callbacks.touch_activity_rpc(ctx.task_id.to_string()).await {
-                        tracing::warn!(
-                            task_id = %ctx.task_id,
-                            error = %e,
-                            "reply_loop::streaming: touch_activity RPC failed; \
-                             host stall poller may see stale idle for this turn"
-                        );
-                    }
-                }
+                let now = touch_stream_activity(&ctx).await;
                 match evt {
                     StreamEvent::Delta(ContentBlock::Text { text }) => {
                         ctx.ctx.event_bus.send(DjinnEventEnvelope::session_message(

--- a/server/crates/djinn-slot/src/reply_loop/streaming_retry_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/streaming_retry_tests.rs
@@ -9,9 +9,18 @@
 //! retry loop the moment the provider answers `200 OK`, so an error arriving as
 //! an SSE *event* has already left that code path behind.
 //!
+//! The retry budget is **error-class-aware**: throttle-class failures
+//! ([`ProviderError::is_throttle`] — rate limit / quota / overload) get the
+//! deep `MAX_THROTTLE_STREAM_EVENT_RETRIES` schedule (~3 minutes of patience,
+//! reaching the 30s backoff cap), because capacity-shedding episodes last
+//! minutes; every other retryable class keeps the shallow
+//! `MAX_STREAM_EVENT_RETRIES`. The 2026-07-30 incident behind the split:
+//! overnight `server_is_overloaded` bursts killed planner sessions ~11 seconds
+//! after start — the shallow retry burned all three requests inside one burst.
+//!
 //! Every test here asserts a **session-level side effect** (did the session
-//! survive? how many provider requests were actually issued?), never that a
-//! predicate returns `true`.
+//! survive? how many provider requests were actually issued? how long did it
+//! really wait?), never that a predicate returns `true`.
 
 use std::collections::VecDeque;
 use std::pin::Pin;
@@ -25,7 +34,7 @@ use djinn_provider::provider::{LlmProvider, ProviderError, StreamEvent, ToolChoi
 use futures::stream;
 use tokio_util::sync::CancellationToken;
 
-use super::streaming::MAX_STREAM_EVENT_RETRIES;
+use super::streaming::{MAX_STREAM_EVENT_RETRIES, MAX_THROTTLE_STREAM_EVENT_RETRIES};
 use super::turn::{ReplyLoopContext, run_reply_loop};
 use crate::test_helpers;
 
@@ -59,6 +68,30 @@ fn auth_stream_error() -> anyhow::Error {
     .context("invalid_api_key: Incorrect API key provided.")
 }
 
+/// A retryable **fault** (provider-internal 5xx) — retried, but only on the
+/// shallow budget: a fault is not a queue you can wait out.
+fn server_fault_stream_error() -> anyhow::Error {
+    anyhow::Error::new(ProviderError::from_stream_error(
+        Some("server_error"),
+        "An error occurred.",
+    ))
+    .context("server_error: An error occurred.")
+}
+
+/// Server-supplied Retry-After used by the flooring scenario. Two minutes:
+/// far above every backoff step (including the 30s cap), so a wait of this
+/// length is only explicable by the floor being honored.
+const RETRY_AFTER_FLOOR_MS: u64 = 120_000;
+
+/// A throttle carrying an explicit server-supplied Retry-After, which must
+/// floor the backoff delay.
+fn floored_throttle_stream_error() -> anyhow::Error {
+    anyhow::Error::new(ProviderError::RateLimit {
+        retry_after_ms: Some(RETRY_AFTER_FLOOR_MS),
+    })
+    .context("rate_limit_exceeded: Retry-After supplied.")
+}
+
 /// What a single `LlmProvider::stream()` call yields.
 #[derive(Clone)]
 enum TurnScript {
@@ -76,6 +109,8 @@ fn scripted_error(kind: &str) -> anyhow::Error {
     match kind {
         "overload" => overload_stream_error(),
         "auth" => auth_stream_error(),
+        "server_fault" => server_fault_stream_error(),
+        "floored_throttle" => floored_throttle_stream_error(),
         other => panic!("unknown scripted error kind {other}"),
     }
 }
@@ -249,6 +284,108 @@ impl Fixture {
     }
 }
 
+/// Drive `consume_provider_stream` directly with `provider` under a paused
+/// tokio clock, returning the stream-consumer result plus the **virtual**
+/// time the retry schedule spent waiting.
+///
+/// The reply-loop fixture above cannot host the deep-budget scenarios: its
+/// persistence path performs real Postgres I/O between turns, and under a
+/// paused clock sqlx's pool-acquire timeout auto-advances past real TCP I/O
+/// and fires spuriously (see the `provider_phase_scripted_reply_loop_scenarios`
+/// note in `reply_loop/tests.rs`). `consume_provider_stream` itself performs
+/// no DB I/O — the test `SlotContext`'s host callbacks are no-ops — so the
+/// clock is paused only around the drive (DB/pool setup stays under real
+/// time), letting a ~3-minute backoff schedule run instantly while
+/// `tokio::time::Instant` still measures exactly how long the session would
+/// really have waited.
+async fn drive_stream_directly(
+    provider: &ScriptedStreamProvider,
+) -> (
+    anyhow::Result<super::streaming::StreamTurnState>,
+    std::time::Duration,
+) {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+
+    use super::streaming::{StreamLoopContext, consume_provider_stream};
+
+    // DB + context setup under REAL time: pool establishment is TCP I/O.
+    let db = test_helpers::create_test_db();
+    db.ensure_initialized().await.expect("db init");
+    let slot_ctx = test_helpers::agent_context_from_db(db, CancellationToken::new());
+    let cancel = CancellationToken::new();
+    let global_cancel = CancellationToken::new();
+    let tool_metadata = super::tool_dispatch::tool_runtime_metadata(&[]);
+    let conversation = Conversation::new();
+    let dispatcher = slot_ctx
+        .tool_dispatcher
+        .as_deref()
+        .expect("test SlotContext has a tool dispatcher");
+    let phase_tracker = Arc::new(Mutex::new(super::phase::SessionPhaseTracker::new(
+        &slot_ctx, "worker",
+    )));
+    let dispatch_ctx = super::tool_dispatch::ToolDispatchContext {
+        ctx: &slot_ctx,
+        task_id: "task",
+        worktree_path: std::path::Path::new("/tmp"),
+        role_name: "worker",
+        tool_metadata: &tool_metadata,
+        tool_dispatcher: dispatcher,
+        otel_session: None,
+        phase_tracker: None,
+        cancel: &cancel,
+    };
+    let activity_ts = Arc::new(AtomicU64::new(0));
+    let last_rpc_touch = Arc::new(AtomicU64::new(0));
+    let last_token_flush = Arc::new(AtomicU64::new(0));
+    let mut current_context_tokens = 0u32;
+    let mut total_tokens_in = 0u32;
+    let mut total_tokens_out = 0u32;
+    let mut total_cache_read = 0u32;
+    let mut total_cache_write = 0u32;
+    let mut total_reasoning_out = 0u32;
+
+    tokio::time::pause();
+    let started = tokio::time::Instant::now();
+    let stream = provider
+        .stream(&conversation, &[], None)
+        .await
+        .expect("initial stream");
+    let result = consume_provider_stream(StreamLoopContext {
+        provider,
+        stream,
+        request_conversation: &conversation,
+        request_tools: &[],
+        request_tool_choice: None,
+        tool_metadata: &tool_metadata,
+        dispatch: &dispatch_ctx,
+        phase_tracker: &phase_tracker,
+        task_id: "task",
+        session_id: "session",
+        role_name: "worker",
+        project_path: "/tmp",
+        worktree_path: std::path::Path::new("/tmp"),
+        context_window: 100_000,
+        ctx: &slot_ctx,
+        cancel: &cancel,
+        global_cancel: &global_cancel,
+        activity_ts: &activity_ts,
+        last_rpc_touch: &last_rpc_touch,
+        last_token_flush: &last_token_flush,
+        compaction_attempts: 0,
+        current_context_tokens: &mut current_context_tokens,
+        total_tokens_in: &mut total_tokens_in,
+        total_tokens_out: &mut total_tokens_out,
+        total_cache_read: &mut total_cache_read,
+        total_cache_write: &mut total_cache_write,
+        total_reasoning_out: &mut total_reasoning_out,
+    })
+    .await;
+    let waited = started.elapsed();
+    tokio::time::resume();
+    (result, waited)
+}
+
 /// AC1 — the core assertion. A stream that dies on a transient
 /// `server_is_overloaded` event and then succeeds on the retry produces a
 /// session that **completes successfully**.
@@ -288,16 +425,73 @@ async fn transient_mid_stream_overload_is_retried_and_the_session_survives() {
     );
 }
 
-/// AC2 — retries are bounded, and the ORIGINAL error survives to the caller
-/// with the same `provider stream event failed: ...` context the coordinator's
-/// classification already relies on.
+/// AC2a — a throttle deeper than the old shallow cap still recovers the
+/// session, end to end. Three consecutive `server_is_overloaded` events would
+/// have exhausted the pre-class-aware budget (1 initial + 2 retries) and
+/// killed the session; the throttle schedule rides them out and the fourth
+/// request's output lands in the transcript.
+///
+/// Kept at the reply-loop level (real clock) so the assertion covers the full
+/// session-level side effect; three 1s/2s/4s waits keep the real sleep budget
+/// comparable to the suite's existing backoff tests.
 #[tokio::test]
-async fn persistent_mid_stream_overload_fails_after_the_retry_cap() {
-    let provider = ScriptedStreamProvider::new(vec![], TurnScript::ErrorFirst("overload"));
+async fn overload_deeper_than_the_shallow_cap_still_recovers_the_session() {
+    let provider = ScriptedStreamProvider::new(
+        vec![
+            TurnScript::ErrorFirst("overload"),
+            TurnScript::ErrorFirst("overload"),
+            TurnScript::ErrorFirst("overload"),
+        ],
+        TurnScript::Text("All done."),
+    );
     let mut fixture = Fixture::new().await;
     let result = fixture.run(&provider).await;
 
-    let err = result.expect_err("a persistently overloaded provider must still fail the session");
+    assert!(
+        result.is_ok(),
+        "an overload burst outlasting the shallow budget must not kill the session; got {:#}",
+        result.unwrap_err()
+    );
+    assert_eq!(
+        provider.stream_calls(),
+        4,
+        "the round must be re-issued once per overload event — one attempt past \
+         the shallow cap of {} total requests",
+        1 + MAX_STREAM_EVENT_RETRIES
+    );
+    let assistant_text: String = fixture
+        .conversation
+        .messages
+        .iter()
+        .filter(|m| m.role == djinn_provider::message::Role::Assistant)
+        .flat_map(|m| m.content.iter().filter_map(ContentBlock::as_text))
+        .collect();
+    assert!(
+        assistant_text.contains("All done."),
+        "the successful deep retry's assistant turn must be persisted; got {assistant_text:?}"
+    );
+}
+
+/// AC2b — the deep throttle budget is still **bounded**: a provider that sheds
+/// load forever exhausts all `MAX_THROTTLE_STREAM_EVENT_RETRIES` attempts over
+/// roughly three minutes of (virtual) waiting, then surfaces the ORIGINAL
+/// error with the same `provider stream event failed: ...` context the
+/// coordinator's classification already relies on.
+///
+/// The elapsed-time bounds are load-bearing in both directions: the lower
+/// bound proves the schedule actually reaches the 30s backoff cap (patience on
+/// the order of minutes, not the old ~3 seconds), and the upper bound proves
+/// the patience cannot silently grow into the coordinator's 30-minute stall
+/// budget.
+#[tokio::test]
+async fn persistent_throttle_exhausts_the_deep_budget_after_minutes_of_patience() {
+    let provider = ScriptedStreamProvider::new(vec![], TurnScript::ErrorFirst("overload"));
+    let (result, waited) = drive_stream_directly(&provider).await;
+
+    // `StreamTurnState` has no `Debug` impl, so `expect_err` cannot be used.
+    let Err(err) = result else {
+        panic!("a persistently overloaded provider must still fail the round");
+    };
     let rendered = format!("{err:#}");
     assert!(
         rendered.contains("provider stream event failed"),
@@ -311,19 +505,90 @@ async fn persistent_mid_stream_overload_fails_after_the_retry_cap() {
         err.downcast_ref::<ProviderError>().is_some(),
         "the typed ProviderError source must survive for downstream classification"
     );
+    assert_eq!(
+        provider.stream_calls() as u32,
+        1 + MAX_THROTTLE_STREAM_EVENT_RETRIES,
+        "retries must stop at 1 initial request + MAX_THROTTLE_STREAM_EVENT_RETRIES"
+    );
+    // Base schedule 1+2+4+8+16+30·5 = 181s; jitter is 0.8x–1.2x per step.
+    assert!(
+        waited >= std::time::Duration::from_secs(140),
+        "the deep schedule must wait minutes (reaching the 30s cap), not seconds; waited {waited:?}"
+    );
+    assert!(
+        waited <= std::time::Duration::from_secs(230),
+        "total patience must stay bounded around ~3 minutes; waited {waited:?}"
+    );
+}
+
+/// AC2c — negative control for the class split. A retryable **fault**
+/// (`server_error` → `ProviderInternal`) keeps the shallow budget: exactly
+/// 1 initial + MAX_STREAM_EVENT_RETRIES requests, then the session fails with
+/// the original error, exactly as before the throttle deepening.
+#[tokio::test]
+async fn persistent_non_throttle_fault_keeps_the_shallow_retry_cap() {
+    let provider = ScriptedStreamProvider::new(vec![], TurnScript::ErrorFirst("server_fault"));
+    let mut fixture = Fixture::new().await;
+    let result = fixture.run(&provider).await;
+
+    let err = result.expect_err("a persistent provider fault must still fail the session");
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("provider stream event failed"),
+        "the terminal context string must be unchanged; got {rendered}"
+    );
+    assert!(
+        rendered.contains("An error occurred."),
+        "the original upstream error must be preserved; got {rendered}"
+    );
     // Absolute lower bound first: this is the assertion that dies if the retry
     // does nothing. (A purely `MAX_STREAM_EVENT_RETRIES`-relative check would
     // self-adjust to a no-op fix and stay green.)
     assert!(
         provider.stream_calls() > 1,
-        "the transient error must have been retried at least once; got {} request(s)",
+        "the transient fault must have been retried at least once; got {} request(s)",
         provider.stream_calls()
     );
-    // Then the upper bound: bounded, and bounded by exactly the documented cap.
+    // Then the upper bound: bounded by exactly the SHALLOW cap — the deep
+    // throttle budget must not leak onto fault classes.
+    assert_eq!(
+        provider.stream_calls() as u32,
+        1 + MAX_STREAM_EVENT_RETRIES,
+        "fault-class retries must stop at 1 initial request + MAX_STREAM_EVENT_RETRIES"
+    );
+}
+
+/// AC2d — a server-supplied Retry-After floors the backoff. The first
+/// attempt's backoff step is ~1s, so a wait of two minutes before the single
+/// successful re-issue is only explicable by the floor being honored; the
+/// tight upper bound proves the floor replaced (rather than stacked onto) the
+/// schedule.
+#[tokio::test]
+async fn retry_after_floors_the_backoff_delay() {
+    let provider = ScriptedStreamProvider::new(
+        vec![TurnScript::ErrorFirst("floored_throttle")],
+        TurnScript::Text("All done."),
+    );
+    let (result, waited) = drive_stream_directly(&provider).await;
+
+    let state = result.expect("the floored throttle must be retried and succeed");
+    assert_eq!(
+        state.turn_text, "All done.",
+        "the retried round's output must be observed by the stream consumer"
+    );
     assert_eq!(
         provider.stream_calls(),
-        3,
-        "retries must stop at 1 initial request + MAX_STREAM_EVENT_RETRIES ({MAX_STREAM_EVENT_RETRIES})"
+        2,
+        "exactly one re-issue after the floored wait"
+    );
+    let floor = std::time::Duration::from_millis(RETRY_AFTER_FLOOR_MS);
+    assert!(
+        waited >= floor,
+        "the wait must honor the server-supplied Retry-After floor of {floor:?}; waited {waited:?}"
+    );
+    assert!(
+        waited <= floor + std::time::Duration::from_secs(5),
+        "the wait must be the floor itself, not the floor plus extra schedule; waited {waited:?}"
     );
 }
 


### PR DESCRIPTION
## Incident

Overnight, OpenAI `server_is_overloaded` errors killed planner sessions ~11 seconds after start, despite the mid-stream retry that landed in #2755. The retry worked exactly as designed but was too shallow: `MAX_STREAM_EVENT_RETRIES = 2` on the `backoff_delay_ms` schedule (1s, 2s — the 30s cap is never reached with two attempts) adds up to ~3 seconds of total patience, while real overload episodes last minutes. Sessions burned all three requests inside a single burst and died.

## What changed

**Error-class-aware retry patience in `reply_loop/streaming.rs`:**

- New `ProviderError::is_throttle()` (djinn-provider) names the classification 38d72c2e7 already established: every rate-limit / quota / overload signal folds into the `RateLimit` variant. Patience is now decided by class, separately from eligibility (`retryable()`).
- **Throttle class** (rate limit / quota / overload): `MAX_THROTTLE_STREAM_EVENT_RETRIES = 10` attempts on the shared backoff schedule — 1, 2, 4, 8, 16, then 30s at the cap, ≈ 3 minutes of total waiting. The schedule now actually reaches the 30s ceiling and spans a realistic overload episode. Server-supplied `Retry-After` still floors each delay.
- **Every other retryable class** (transport, provider-internal 5xx, empty completion) keeps the shallow budget of 2 — a fault is not a queue you can wait out. Both budgets compare against the round's single shared attempt counter, so a mid-episode class change can never enlarge patience already spent.
- The `round_is_safely_restartable` gate is untouched: nothing is retried once the round emitted anything observable. Every backoff sleep stays inside the biased `tokio::select!` with both cancel tokens, so long waits remain cancellation-responsive.

**Watchdog interaction (verified, and fixed as part of this change):** the coordinator stall poller (`session_recovery.rs`) gives sessions with no tracked activity an aggressive 300s first-call budget (`FIRST_CALL_STALL_SECS`), and the "has activity" signal is the presence of an upserted `ActivityTracker` entry, created by the first `touch_activity` RPC. A session whose FIRST round lands inside an overload burst would previously accrue no touch at all during a ~3-minute backoff and could be killed mid-wait (backoff sleeps plus per-attempt request time approach the 300s cap). The retry wait path now refreshes the activity clocks each iteration via a new `touch_stream_activity` helper (shared with the per-event path, which previously inlined the same logic). Since per-iteration delays cap at 30s, observed idle stays around the 30s touch interval — far under both the 300s first-call cap and the 30-minute stall budget.

**Deliberately NOT changed** (follow-up candidates):
- The HTTP request-establishment retry in `djinn-provider/src/provider/client.rs` (`MAX_RETRIES = 3`). Establishment failures surface as the first stream item and funnel into this same class-aware mid-stream path (which re-issues the whole request), so the session path is already covered; deepening the client loop itself would multiply patience for every caller of the client (side queries, extraction, judges), which is a bigger behavioural change than this incident needs.
- The rare adapter path where a restart's `provider.stream()` call itself returns `Err` still surfaces the original error immediately (production adapters defer establishment errors into the stream, so this branch is effectively cold).

## Test evidence

`streaming_retry_tests.rs` now covers: (a) a 3-burst overload recovering end-to-end past the old cap (4 requests, transcript persisted), (b) deep-budget exhaustion — bounded stop at exactly 11 requests after 140–230s of measured (virtual) waiting, original error + typed source preserved, (c) a persistent non-throttle `server_error` still capped at exactly 3 requests, (d) `Retry-After` flooring the delay (120s floor honored, not stacked), plus the unchanged non-retryable and emitted-output-gate negative controls. Deep-schedule tests drive `consume_provider_stream` directly under a paused tokio clock (the reply-loop fixture does real Postgres I/O, which sqlx's pool-acquire timeout breaks under a paused clock — same constraint documented in `reply_loop/tests.rs`).

- `cargo nextest run -p djinn-slot`: **560 passed, 0 failed**
- `cargo nextest run -p djinn-provider`: **659 passed, 0 failed**
- `cargo clippy -p djinn-slot -p djinn-provider --all-targets`: **0 warnings**
- Plain single-process `cargo test -p djinn-slot --lib` shows the known pre-existing process-global telemetry/env collision flakes (5 failures on unmodified main as well); nextest (what CI runs) is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)