### PR TITLE
ci: repair the nextest timing restore, which had never once succeeded

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1135,14 +1135,51 @@ jobs:
               rm -f "$page_response" "$page_candidates"
               break
             fi
-            jq -r '.artifacts[] | select(.workflow_run.conclusion == "success") | .id' "$page_response" > "$page_candidates"
+            # Emit `<artifact-id> <run-id>` pairs. The producing run's
+            # conclusion is resolved per candidate below and NOT filtered here:
+            # the artifacts endpoint's `workflow_run` object carries only
+            # {id, repository_id, head_repository_id, head_branch, head_sha} —
+            # there is no `conclusion` field on it. Selecting candidates by that
+            # missing field — which this loop did until 2026-07-30 — therefore
+            # matched NOTHING on every run: the candidate list came out empty,
+            # the bounded search ran to exhaustion, and the planner cold-started
+            # every single time. (ci-nextest-plan.test.mjs now fails if the
+            # filter comes back; that is why the expression is described here
+            # rather than quoted.) Verified 2026-07-30 on
+            # runs 30493437428, 30497097480, 30498632438 and 30499367637 — all
+            # four logged "No compatible prior timing artifact found".
+            #
+            # That silently made COLD_START_SHARDS the only shard count the PR
+            # lane ever used, so PR_DEFAULT_SHARDS, PR_MAX_SHARDS and both
+            # PR_WIDEN_* thresholds were dead code, and shard balancing was
+            # always equal-test-count rather than equal-duration.
+            #
+            # `expired` artifacts are dropped here because their download
+            # returns 410 and would burn a candidate slot.
+            jq -r '.artifacts[] | select(.expired != true) | "\(.id) \(.workflow_run.id)"' "$page_response" > "$page_candidates"
             artifact_count="$(jq '.artifacts | length' "$page_response")"
             rm -f "$page_response"
             if [ "$artifact_count" -eq 0 ]; then
               rm -f "$page_candidates"
               break
             fi
-            while IFS= read -r artifact_id && [ -n "$artifact_id" ]; do
+            while IFS=' ' read -r artifact_id run_id && [ -n "$artifact_id" ]; do
+              # Resolve the producing run's conclusion on the runs endpoint,
+              # which does expose it. Bounded: the loop breaks on the first
+              # compatible artifact, so this is normally one extra call. A
+              # non-success run's timings would still be SAFE to use (the
+              # planner's contract lets timing influence balancing only, never
+              # selection) but they are skewed — tests after an early failure
+              # never ran — so prefer a successful run and fall through to an
+              # older one.
+              set +e
+              run_conclusion="$(gh api "repos/${{ github.repository }}/actions/runs/$run_id" \
+                --jq '.conclusion' 2>> nextest-timing/restore.log)"
+              set -e
+              if [ "$run_conclusion" != success ]; then
+                echo "::notice::Timing artifact $artifact_id came from run $run_id (conclusion=${run_conclusion:-unknown}); trying next older candidate."
+                continue
+              fi
               rm -f nextest-timing/timing.zip nextest-timing/timing.json
               set +e
               gh api "repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip" > nextest-timing/timing.zip 2>> nextest-timing/restore.log
@@ -1161,11 +1198,30 @@ jobs:
                 continue
               fi
               # Apply the planner's seven-day freshness policy before acceptance.
+              #
+              # The fractional-second strip is load-bearing, not defensive.
+              # `fromdateiso8601` is strptime("%Y-%m-%dT%H:%M:%SZ") and does NOT
+              # accept a fractional part, but this artifact's `generated_at` is
+              # written by `new Date().toISOString()` (see the timing publish
+              # step below), which always emits milliseconds:
+              #
+              #   date "2026-07-30T11:45:20.077Z" does not match format ...
+              #
+              # jq then EXITS NON-ZERO, `2>&1` swallowed the message, and the
+              # candidate was rejected as "malformed or incompatible" — so this
+              # gate rejected 100% of artifacts, including ones it had just
+              # confirmed were the right version and shape. Stacked with the
+              # artifacts-endpoint filter bug above, the restore had two
+              # independent reasons never to succeed.
+              #
+              # Fixed at the READER on purpose. Emitting second precision from
+              # the writer instead would leave every artifact already inside the
+              # seven-day window unreadable, i.e. a week with no balancing.
               if ! jq -e '
                 .version == "ci-nextest-timing/v1" and
                 (.tests | type) == "object" and
                 (.generated_at | type) == "string" and
-                ((.generated_at | fromdateiso8601) as $generated |
+                ((.generated_at | sub("\\.[0-9]+(?=Z$)"; "") | fromdateiso8601) as $generated |
                   $generated <= now and (now - $generated) <= (7 * 24 * 60 * 60))
               ' nextest-timing/timing.json > /dev/null 2>&1; then
                 echo "::notice::Timing artifact $artifact_id is malformed or incompatible; trying next older candidate."

--- a/scripts/ci-nextest-plan.test.mjs
+++ b/scripts/ci-nextest-plan.test.mjs
@@ -861,5 +861,42 @@ describe('workflow static checks', () => {
     // Also reject any --filter-expr line that uses command substitution to read a file.
     assert.ok(!/--filter-expr\s+["']?\$\(cat\s/.test(source), 'workflow must not use command substitution to feed --filter-expr');
   });
+
+  // Regression guard for a silent, total loss of timing-fed balancing.
+  //
+  // The timing-restore loop used to select candidates with
+  // `select(.workflow_run.conclusion == "success")` against
+  // /actions/artifacts. That endpoint's `workflow_run` object has no
+  // `conclusion` field, so the filter matched nothing on every run: the planner
+  // cold-started always, COLD_START_SHARDS became the only shard count the PR
+  // lane could reach, and PR_DEFAULT_SHARDS / PR_MAX_SHARDS / both PR_WIDEN_*
+  // thresholds were unreachable. Nothing failed — the cold-start fallback is
+  // deliberately safe — so the only visible symptom was a shard count that
+  // happened to equal COLD_START_SHARDS.
+  //
+  // These assertions are about the SIDE EFFECT (which endpoint supplies the
+  // conclusion), not about the notice text, because the notices printed
+  // correctly the whole time it was broken.
+  it('resolves the timing artifact run conclusion on an endpoint that returns it', () => {
+    const source = readFileSync(WORKFLOW, 'utf8');
+    const artifactQuery = /actions\/artifacts\?name=nextest-timing[^\n]*/.exec(source);
+    assert.ok(artifactQuery, 'workflow must query the nextest-timing artifact list');
+
+    assert.ok(
+      !/select\(\s*\.workflow_run\.conclusion/.test(source),
+      'the /actions/artifacts response has no workflow_run.conclusion field; '
+      + 'filtering on it selects nothing and silently forces cold-start balancing',
+    );
+    assert.match(
+      source,
+      /actions\/runs\/\$run_id"?\s*\\?\s*\n?\s*--jq '\.conclusion'/,
+      'the producing run conclusion must come from /actions/runs/<id>, which does return it',
+    );
+    assert.match(
+      source,
+      /if \[ "\$run_conclusion" != success \]; then/,
+      'a candidate from a non-successful run must be skipped in favour of an older one',
+    );
+  });
 });
 


### PR DESCRIPTION
## The bug

The nextest shard planner's timing restore has **never once succeeded**. Every PR and every merge-queue run has cold-started, silently, since the loop was written.

Found while verifying #2799: that PR raised `PR_MAX_SHARDS` 4 → 8, and its own CI run ([30538880312](https://github.com/djinnos/djinn/actions/runs/30538880312)) still ran **4 shards**. `pickShardCount` short-circuits on `timings.size === 0` before it ever looks at the profile, so the change was inert.

Confirmed across four unrelated runs — 30493437428, 30497097480, 30498632438, 30499367637 — all four logged `No compatible prior timing artifact found`.

Two independent bugs, stacked. Each alone is sufficient to force a cold start, so fixing either one by itself changes nothing.

### 1. The candidate filter could never match

The loop selected candidates by `.workflow_run.conclusion` on `/actions/artifacts`. That endpoint's `workflow_run` object contains only:

```json
{ "id": …, "repository_id": …, "head_repository_id": …, "head_branch": …, "head_sha": … }
```

There is no `conclusion` field. The filter produced an empty candidate list on every run, the bounded five-page search ran to exhaustion, and the planner fell through to cold start.

Now emits `<artifact-id> <run-id>` pairs and resolves the conclusion on `/actions/runs/<id>`, which does return it. Bounded to ~1 extra API call — the loop breaks on the first compatible artifact. Expired artifacts are dropped so a 410 cannot burn a candidate slot.

### 2. The freshness gate rejected 100% of artifacts, with the error swallowed

`fromdateiso8601` is `strptime("%Y-%m-%dT%H:%M:%SZ")` and does not accept a fractional part. But `generated_at` is written by `new Date().toISOString()`, which always emits milliseconds:

```
jq: error: date "2026-07-30T11:45:20.077Z" does not match format "%Y-%m-%dT%H:%M:%SZ"
```

jq exited non-zero, `2>&1` hid the message, and the candidate was reported as *"malformed or incompatible"* — after the very same expression had already confirmed its version and shape.

Fixed at the **reader**, not the writer: emitting second precision instead would leave every artifact already inside the seven-day window unreadable, i.e. a week with no balancing at all.

## What this was costing

Nothing failed — the cold-start fallback is deliberately safe — which is exactly why it survived. The costs were invisible:

- `COLD_START_SHARDS` was the only shard count the PR lane could reach, so **`PR_DEFAULT_SHARDS`, `PR_MAX_SHARDS`, `PR_WIDEN_TEST_THRESHOLD` and `PR_WIDEN_DURATION_THRESHOLD_SECONDS` were all unreachable code**.
- Shard balancing was always equal-**test-count**, never equal-**duration**. Measured after the fix, this turns out **not** to matter here: shard run-steps went 278/304/321/305s (cold) → 304/290/317/288s (duration-balanced), i.e. max-over-mean 6.3% → 5.7%. The suite's per-test durations are near-uniform (~0.11s across every package in the timing artifact), so count-balancing and duration-balancing coincide. An earlier revision of this description claimed the 12.5–13.3m job spread came from count-balancing — that was wrong; the spread is build-step variance, not test distribution. The real value of this fix is making `PR_MAX_SHARDS` reachable at all.
- The entire timing publish/restore apparatus — the 7-day freshness policy, the bounded five-page search, the planner-compatibility parser — was dead weight.

## Verification

Verified against the real artifacts rather than by re-running CI, since a green run is exactly what this bug produces. Same discovery (11 647 tests, run 30538880312), same profile:

| | shardCount | coldStart | exactOnce | assigned |
|---|---|---|---|---|
| before | 4 | **true** | true | — |
| after (this PR alone) | 4 | **false** | true | 11 647 |
| after (with #2799's `PR_MAX_SHARDS=8`) | **8** | false | true | 11 647 |

With both, the 8 shards come out at ~1456 tests / **151s estimated each** — evenly duration-balanced.

Also checked the fixed gate still rejects what it should: a `generated_at` outside the 7-day window is refused, and a timestamp with no fractional part still parses.

## Interaction with #2799

Independent and composable, in either merge order:

- **This PR alone** → `coldStart=false`, 4 shards, duration-balanced (an improvement on its own: it also affects the **merge queue**, which cold-starts today too).
- **#2799 alone** → still 4 shards; `PR_MAX_SHARDS=8` sits inert.
- **Both** → 8 shards on the PR lane, merge queue stays at `WIDE_DEFAULT_SHARDS=4` by design.

Note this changes merge-queue behaviour too — the authoritative lane gets duration-balanced shards for the first time. That is why it is a separate PR rather than a tail commit on #2799.

## Regression test

`ci-nextest-plan.test.mjs` gains a guard asserting the **side effect** — which endpoint supplies the conclusion — rather than any log text, because the notices printed correctly the entire time this was broken. No log assertion could have caught it.

It works: the test immediately failed against my own explanatory comment in this change, which quoted the forbidden expression verbatim. The comment now describes it instead.
