### PR TITLE
fix(ci): provision 8 server-test shards so half the suite stops being skipped

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -52,6 +52,12 @@ env:
   # what a healthy hosted runner has free after the reclaim set below, so a
   # healthy runner never trips it — a preflight that false-fails is worse than
   # no preflight.
+  # Number of rows in `server-test`'s static matrix. Asserted against the plan
+  # inside every shard, so a plan wider than the matrix fails loudly instead of
+  # silently dropping the tail shards' tests. Must equal the row count of that
+  # matrix AND be >= the planner's widest shard count; `ci-nextest-plan.test.mjs`
+  # enforces both.
+  CI_SERVER_TEST_MATRIX_WIDTH: "8"
   CI_RUNNER_DISK_MIN_GB: "14"
   # Warn band. Free space between MIN and WARN still completes the build but is
   # already abnormal for a hosted runner, so annotate it: the run summary is
@@ -1362,6 +1368,25 @@ jobs:
     timeout-minutes: 40
     strategy:
       fail-fast: false
+      # WIDTH INVARIANT: this list must have at least as many rows as the
+      # WIDEST plan the planner can emit, i.e. max(PR_MAX_SHARDS,
+      # WIDE_DEFAULT_SHARDS, COLD_START_SHARDS) in scripts/ci-nextest-plan.mjs.
+      # `CI_SERVER_TEST_MATRIX_WIDTH` at the top of this file must equal this
+      # row count, and `ci-nextest-plan.test.mjs` fails if either side drifts.
+      #
+      # Why it is load-bearing: because the surplus direction is SAFE and the
+      # deficit direction is SILENT. A plan narrower than the matrix no-ops its
+      # extra indices. A plan WIDER than the matrix has no job for the tail
+      # indices, so those tests simply never run — and nothing notices. The
+      # exact-once proof is a property of the PLAN's partition, not of what
+      # executed, so it still passes; the surviving shards all succeed; and the
+      # gate goes green.
+      #
+      # This happened. #2799 raised PR_MAX_SHARDS 4 -> 8 against this list
+      # while it still had four rows, and once #2803 made the planner reach
+      # PR_MAX_SHARDS at all, run 30544309199 planned eight shards of ~1458
+      # tests and ran four of them: 5834 of 11666 tests (50%) were assigned to
+      # shardIndex 4-7, which had no jobs. The run was green.
       matrix:
         include:
           - shard: shard-1
@@ -1372,6 +1397,14 @@ jobs:
             shardIndex: 2
           - shard: shard-4
             shardIndex: 3
+          - shard: shard-5
+            shardIndex: 4
+          - shard: shard-6
+            shardIndex: 5
+          - shard: shard-7
+            shardIndex: 6
+          - shard: shard-8
+            shardIndex: 7
     defaults:
       run:
         working-directory: server
@@ -1598,6 +1631,16 @@ jobs:
           set -euo pipefail
           matched=$(jq -r --argjson idx "$SHARD_INDEX" '[.shards[] | select(.shardIndex == $idx)] | length' nextest-plan/matrix.json)
           shard_count=$(jq -r '.shardCount' nextest-plan/matrix.json)
+          # WIDTH GUARD — fail closed when the plan is WIDER than the static
+          # matrix. Every running shard trips this, because no job can detect
+          # its own absence: the shards that would cover indices >= the matrix
+          # width are precisely the ones that were never created. Without this,
+          # a plan of 8 against a matrix of 4 runs half the suite and reports
+          # success (run 30544309199: 5834 of 11666 tests never executed).
+          if [ "$shard_count" -gt "$CI_SERVER_TEST_MATRIX_WIDTH" ]; then
+            echo "::error title=Shard matrix too narrow::Plan selected $shard_count shard(s) but server-test's static matrix provisions only $CI_SERVER_TEST_MATRIX_WIDTH. Tests on shardIndex $CI_SERVER_TEST_MATRIX_WIDTH..$((shard_count - 1)) would NEVER RUN and the gate would still pass. Add matrix rows (and raise CI_SERVER_TEST_MATRIX_WIDTH) or lower the planner's shard count."
+            exit 1
+          fi
           if [ "$matched" -eq 0 ]; then
             if [ "$SHARD_INDEX" -ge "$shard_count" ]; then
               # The matrix provisions the planner's maximum width; this plan

--- a/scripts/ci-nextest-plan.test.mjs
+++ b/scripts/ci-nextest-plan.test.mjs
@@ -877,6 +877,64 @@ describe('workflow static checks', () => {
   // These assertions are about the SIDE EFFECT (which endpoint supplies the
   // conclusion), not about the notice text, because the notices printed
   // correctly the whole time it was broken.
+  // The invariant whose violation silently halved the test suite.
+  //
+  // `server-test`'s matrix is STATIC (the shards deliberately do not
+  // `needs: nextest-plan`, so they can build concurrently with the planner's
+  // discovery). A plan NARROWER than the matrix is safe — surplus indices
+  // no-op. A plan WIDER than the matrix is silent data loss: the tail indices
+  // have no jobs, so their tests never run, and nothing fails. The exact-once
+  // proof does not catch it because it validates the plan's partition, not what
+  // executed.
+  //
+  // #2799 raised PR_MAX_SHARDS 4 -> 8 while the matrix still had four rows.
+  // Once #2803 let the planner reach PR_MAX_SHARDS, run 30544309199 planned
+  // eight shards of ~1458 tests and ran four: 5834 of 11666 tests (50%) never
+  // executed, and the run was GREEN.
+  it('provisions a server-test matrix at least as wide as the widest possible plan', () => {
+    const source = readFileSync(WORKFLOW, 'utf8');
+
+    const serverTest = /^ {2}server-test:$/m.exec(source);
+    assert.ok(serverTest, 'server-test job must exist');
+    const afterJob = source.slice(serverTest.index);
+    const nextJob = /\n {2}[a-z0-9-]+:\n/.exec(afterJob.slice(1));
+    const jobBlock = nextJob ? afterJob.slice(0, nextJob.index + 1) : afterJob;
+
+    const rows = [...jobBlock.matchAll(/^ {10}- shard: shard-(\d+)$/gm)].map((m) => Number(m[1]));
+    const indices = [...jobBlock.matchAll(/^ {12}shardIndex: (\d+)$/gm)].map((m) => Number(m[1]));
+    assert.ok(rows.length > 0, 'server-test must declare an explicit shard matrix');
+    assert.equal(rows.length, indices.length, 'every matrix row needs a shardIndex');
+    assert.deepEqual(
+      indices,
+      indices.map((_, i) => i),
+      'shardIndex values must be a dense 0-based range, since the planner assigns by index',
+    );
+
+    const widest = Math.max(PR_MAX_SHARDS, WIDE_DEFAULT_SHARDS, COLD_START_SHARDS);
+    assert.ok(
+      indices.length >= widest,
+      `server-test's static matrix has ${indices.length} rows but the planner can emit up to `
+      + `${widest} shards (max of PR_MAX_SHARDS=${PR_MAX_SHARDS}, `
+      + `WIDE_DEFAULT_SHARDS=${WIDE_DEFAULT_SHARDS}, COLD_START_SHARDS=${COLD_START_SHARDS}). `
+      + 'Tests on the unprovisioned tail indices would never run and CI would still pass.',
+    );
+
+    // The runtime guard reads this env var; if it drifts from the real row
+    // count the guard either misfires or stops firing.
+    const declared = /^ {2}CI_SERVER_TEST_MATRIX_WIDTH: "(\d+)"$/m.exec(source);
+    assert.ok(declared, 'CI_SERVER_TEST_MATRIX_WIDTH must be declared at workflow level');
+    assert.equal(
+      Number(declared[1]),
+      indices.length,
+      'CI_SERVER_TEST_MATRIX_WIDTH must equal the number of server-test matrix rows',
+    );
+    assert.match(
+      jobBlock,
+      /if \[ "\$shard_count" -gt "\$CI_SERVER_TEST_MATRIX_WIDTH" \]; then/,
+      'every shard must fail closed when the plan is wider than the provisioned matrix',
+    );
+  });
+
   it('resolves the timing artifact run conclusion on an endpoint that returns it', () => {
     const source = readFileSync(WORKFLOW, 'utf8');
     const artifactQuery = /actions\/artifacts\?name=nextest-timing[^\n]*/.exec(source);


### PR DESCRIPTION
## Severity

**Since #2803 merged (12:23Z), every PR-lane run has executed half its tests and reported green.**

`server-test`'s matrix is static — the shards deliberately do not `needs: nextest-plan`, so they can build concurrently with the planner's discovery — and it had **four** rows. #2799 raised `PR_MAX_SHARDS` 4 → 8 without widening it. That was inert until #2803 repaired the timing restore and let the planner actually reach `PR_MAX_SHARDS`. From then on:

```
run 30544309199 (pull_request, 12:51Z)
  plan shardCount=8, 11666 tests, exactOnce=true
  jobs created:  shardIndex 0,1,2,3
  shardIndex 4-7: 5834 of 11666 tests (50%)  ->  NEVER RAN
  run conclusion: success
```

## Why it was silent

Every safeguard was pointed the other way:

- The **exact-once proof** validates the *plan's* partition, not what executed — so it passed.
- The four provisioned shards each resolved their row and passed normally.
- **No job can detect its own absence.** The shards that would have covered indices 4–7 are exactly the ones that were never created.
- The existing surplus-index guard handles plan **narrower** than matrix. The deficit direction had no check.

The workflow even documented the invariant it depended on — *"the matrix is statically provisioned at the planner's maximum width … PR\_MAX\_SHARDS … are all 4"* — and that comment silently stopped being true when the constant changed.

## The fix

Widening the matrix alone would leave the same trap armed for whoever next edits a shard constant, so:

1. **Matrix → 8 rows** (shardIndex 0–7).
2. **Fail-closed runtime guard.** Every shard asserts `plan.shardCount <= CI_SERVER_TEST_MATRIX_WIDTH` and fails loudly if the plan is wider. Checked in the shards that *do* exist, precisely because the missing ones cannot check anything.
3. **Contract test.** Asserts matrix width ≥ `max(PR_MAX_SHARDS, WIDE_DEFAULT_SHARDS, COLD_START_SHARDS)`, that shardIndex values form a dense 0-based range, that `CI_SERVER_TEST_MATRIX_WIDTH` equals the real row count, and that the runtime guard is present.

## Verified non-vacuous

Reverting the matrix to four rows makes the new test fail:

```
✖ provisions a server-test matrix at least as wide as the widest possible plan
  AssertionError: server-test's static matrix has 4 rows but the planner can emit
  up to 8 shards (max of PR_MAX_SHARDS=8, WIDE_DEFAULT_SHARDS=4, COLD_START_SHARDS=4).
  Tests on the unprovisioned tail indices would never run and CI would still pass.
```

Restoring it: 50/50 pass. `actionlint` clean; all other contract suites pass.

## Affected runs

Only `pull_request` runs started after 12:23:16Z: 30544309199 and 30544818057 (#2805). Both need a rerun after this lands — their green is not trustworthy. Merge-queue runs were never affected (`WIDE_DEFAULT_SHARDS` stayed at 4).