### PR TITLE
fix(memory-eval): stop a unit test from rewriting the committed baseline

### DIFF
--- a/server/crates/djinn-memory-eval/README.md
+++ b/server/crates/djinn-memory-eval/README.md
@@ -264,6 +264,62 @@ cargo run -p djinn-memory-eval -- refresh-baseline
 cargo test -p djinn-memory-eval
 ```
 
+## `refresh-baseline` is the only writer of `baselines/phase1.json`
+
+**Running the test suite must never modify a tracked file.** After
+`cargo test -p djinn-memory-eval` (or `cargo test --workspace`),
+`git status --porcelain server/crates/djinn-memory-eval/` must be empty.
+
+The committed goldens — `baselines/phase1.json` and `fixtures/*.jsonl` —
+have exactly two sanctioned writers, both invoked deliberately by a human:
+
+```bash
+# the baseline
+cargo run -p djinn-memory-eval -- run              # writes target/memory-eval/ only
+cargo run -p djinn-memory-eval -- compare          # review the delta first
+cargo run -p djinn-memory-eval -- refresh-baseline # writes baselines/phase1.json
+
+# the fixtures
+python3 scripts/generate_fixtures.py               # then re-run the two commands above
+```
+
+This is enforced, not merely documented: `report::write_baseline` and the
+`test_helpers` fixture writers call
+[`fixtures::reject_tracked_golden_write`](src/fixtures.rs), which hard-fails
+when the target directory is this crate's own source tree **and** `cfg!(test)`
+is set. The crate is a single `[[bin]]` target, so that condition is true
+exactly under the test harness and false in the shipped binary —
+`refresh-baseline` is unaffected. Tests that need to exercise these writers
+must point them at a `tempfile::tempdir()`.
+
+**Why the guard exists.** A test called `refresh_baseline_with_committed_
+fixtures` used to regenerate the baseline in-place so reviewers "could see"
+the signal-comparison proof cases. It re-implemented `cmd_run`'s report
+assembly and got it wrong in two ways: it passed an empty note-age map and
+omitted bad-case records from the age-bucket computation (collapsing
+`age_bucket_recall` to `["under7d"]`), and it stamped a fabricated
+`metadata.refresh_commit`. Because `cargo test` wrote the file in the working
+tree, a later `git add -A` committed the degraded baseline — that is exactly
+what shipped on PR #2805 (`af35429`) and was caught only by the separate
+`Memory Eval Phase 1` lane. A stripped baseline fails nothing locally: the
+ranking-regression suite still passes while measuring less.
+
+Two tests replace it, both asserting side effects rather than labels:
+
+- `run::tests::a_test_cannot_write_the_tracked_baseline` performs the exact
+  offending call and asserts the file's **bytes are unchanged** afterwards.
+- `commands::tests::committed_baseline_and_fixtures_pass_the_shipped_gate`
+  runs `validate-fixtures` against the committed artifacts under
+  `cargo test`, so a stripped baseline fails in the unit-test lane instead of
+  only in the separate CI job.
+
+The second is a *coverage* check, not a byte-for-byte golden, and
+deliberately so: `cmd_run` derives age buckets from `SystemClock::now()`, so
+the bucket set drifts as fixtures age on the calendar. A strict-equality
+golden would rot on a date boundary. The invariant `validate-fixtures`
+depends on is time-safe — notes only get older, so `over_decay_threshold`
+only ever grows.
+
 ## Implementation roadmap
 
 | module                       | task  | status         |

--- a/server/crates/djinn-memory-eval/src/commands/mod.rs
+++ b/server/crates/djinn-memory-eval/src/commands/mod.rs
@@ -762,6 +762,33 @@ mod tests {
     use crate::fixtures::*;
     use test_helpers::*;
 
+    // ── Committed artifacts satisfy the shipped gate ─────────────────────
+
+    /// The committed fixtures + baseline must pass the very gate the
+    /// `Memory Eval Phase 1` CI lane runs.
+    ///
+    /// This is the inverted form of the old `refresh_baseline_with_committed_
+    /// fixtures` test: instead of *rewriting* `baselines/phase1.json` to
+    /// whatever a test run produced, verify the committed file satisfies every
+    /// invariant `validate-fixtures` enforces — including the
+    /// `over_decay_threshold` age-bucket entry that PR #2805 stripped.
+    ///
+    /// Deliberately NOT a byte-for-byte golden comparison against a fresh run.
+    /// `cmd_run` derives age buckets from `SystemClock::now()`, so the bucket
+    /// *set* migrates as the fixtures age on the calendar (the committed
+    /// baseline was refreshed when several notes were `under7d`; those same
+    /// notes are `days7to30` weeks later). A strict-equality golden would rot
+    /// on a date boundary with nobody touching the code. What
+    /// `validate-fixtures` actually depends on is time-invariant, because
+    /// notes only ever get older and so `over_decay_threshold` only ever
+    /// grows — that is what this asserts.
+    #[test]
+    fn committed_baseline_and_fixtures_pass_the_shipped_gate() {
+        let crate_root = tracked_crate_root();
+        cmd_validate_fixtures(crate_root)
+            .expect("committed fixtures + baseline must pass `validate-fixtures`");
+    }
+
     // ── AC: Low query count ──────────────────────────────────────────────
 
     #[test]

--- a/server/crates/djinn-memory-eval/src/commands/test_helpers.rs
+++ b/server/crates/djinn-memory-eval/src/commands/test_helpers.rs
@@ -8,7 +8,12 @@ use crate::report::{self, BaselineMetadata, Phase1Baseline};
 use crate::run;
 
 /// Write a Phase1Fixtures to a temp directory structure on disk.
+///
+/// Panics if `crate_root` is this crate's own source tree — the committed
+/// `fixtures/*.jsonl` are tracked goldens regenerated only by
+/// `scripts/generate_fixtures.py`.
 pub fn write_fixtures_to_disk(crate_root: &std::path::Path, fixtures: &Phase1Fixtures) {
+    reject_tracked_golden_write(crate_root, FixturePaths::FIXTURES_DIR).unwrap();
     let fixtures_dir = crate_root.join(FixturePaths::FIXTURES_DIR);
     std::fs::create_dir_all(&fixtures_dir).unwrap();
     std::fs::write(
@@ -29,7 +34,11 @@ pub fn write_fixtures_to_disk(crate_root: &std::path::Path, fixtures: &Phase1Fix
 }
 
 /// Write a Phase1Baseline to a temp directory on disk.
+///
+/// Panics if `crate_root` is this crate's own source tree — see
+/// [`reject_tracked_golden_write`].
 pub fn write_baseline_to_disk(crate_root: &std::path::Path, baseline: &Phase1Baseline) {
+    reject_tracked_golden_write(crate_root, FixturePaths::PHASE1_BASELINE).unwrap();
     let baselines_dir = crate_root.join(FixturePaths::BASELINES_DIR);
     std::fs::create_dir_all(&baselines_dir).unwrap();
     let json = serde_json::to_string_pretty(baseline).unwrap();

--- a/server/crates/djinn-memory-eval/src/fixtures.rs
+++ b/server/crates/djinn-memory-eval/src/fixtures.rs
@@ -394,6 +394,59 @@ impl FixturePaths {
     }
 }
 
+// ── Tracked-golden write guard ──────────────────────────────────────────────
+
+/// This crate's own source directory — the tree holding the **tracked**
+/// `fixtures/` and `baselines/` goldens.
+pub fn tracked_crate_root() -> &'static std::path::Path {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Fail-closed guard against a **test** writing this crate's tracked goldens.
+///
+/// `baselines/phase1.json` and `fixtures/*.jsonl` are committed goldens. Their
+/// only sanctioned writer is a deliberate `refresh-baseline` (or
+/// `scripts/generate_fixtures.py`) invoked by a human — see the crate README.
+/// When a test writes them instead, `cargo test` silently mutates the working
+/// tree and the next `git add` commits whatever that run happened to produce.
+///
+/// That is not hypothetical. A test named `refresh_baseline_with_committed_
+/// fixtures` did exactly this until PR #2807: on PR #2805 it shipped a baseline
+/// whose `age_bucket_recall` had collapsed to `["under7d"]` (the test passed an
+/// empty note-age map and skipped bad-case records) carrying a fabricated
+/// `refresh_commit`, and only the separate `Memory Eval Phase 1` lane caught it.
+///
+/// This crate is a single `[[bin]]` target, so `cfg!(test)` is true exactly
+/// when the test harness is running and false in the shipped binary. The guard
+/// therefore blocks tests without touching `refresh-baseline`. Tests that
+/// legitimately exercise these writers must point them at a
+/// `tempfile::tempdir()`.
+pub fn reject_tracked_golden_write(
+    target_root: &std::path::Path,
+    artifact: &str,
+) -> anyhow::Result<()> {
+    if !cfg!(test) {
+        return Ok(());
+    }
+    let tracked = tracked_crate_root();
+    let is_tracked_tree = match (target_root.canonicalize(), tracked.canonicalize()) {
+        (Ok(target), Ok(known)) => target == known,
+        _ => target_root == tracked,
+    };
+    if !is_tracked_tree {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "refusing to write the tracked golden `{artifact}` inside {} from a \
+         test: that mutates the working tree and a later `git add` commits it \
+         (see PR #2805). Point the write at a `tempfile::tempdir()`, or \
+         regenerate the committed baseline deliberately with \
+         `cargo run -p djinn-memory-eval -- run` followed by \
+         `cargo run -p djinn-memory-eval -- refresh-baseline`.",
+        tracked.display(),
+    )
+}
+
 // ── Aggregate Phase 1 fixture set ───────────────────────────────────────────
 
 /// The full Phase 1 fixture set. This is the in-memory representation after

--- a/server/crates/djinn-memory-eval/src/report.rs
+++ b/server/crates/djinn-memory-eval/src/report.rs
@@ -292,7 +292,16 @@ pub fn load_baseline(crate_root: &Path) -> Result<Phase1Baseline> {
 }
 
 /// Write a Phase 1 baseline to disk.
+///
+/// Refuses to write this crate's own tracked `baselines/phase1.json` when
+/// running under the test harness — see
+/// [`crate::fixtures::reject_tracked_golden_write`]. The sanctioned writer is
+/// `cmd_refresh_baseline`, reached from the shipped binary.
 pub fn write_baseline(crate_root: &Path, baseline: &Phase1Baseline) -> Result<()> {
+    crate::fixtures::reject_tracked_golden_write(
+        crate_root,
+        crate::fixtures::FixturePaths::PHASE1_BASELINE,
+    )?;
     let dir = crate_root.join("baselines");
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("creating baselines dir {}", dir.display()))?;

--- a/server/crates/djinn-memory-eval/src/run.rs
+++ b/server/crates/djinn-memory-eval/src/run.rs
@@ -948,15 +948,20 @@ mod tests {
         );
     }
 
-    /// Run the committed fixtures through the pipeline and write the baseline
-    /// with signal_comparisons. This test overwrites `baselines/phase1.json`
-    /// so reviewers can see graph/entity and task-affinity proof cases.
-    #[allow(clippy::print_stderr)]
+    /// Verification (NOT a refresh): the committed fixtures must still drive
+    /// both required signal-proof families through the real pipeline.
+    ///
+    /// This test used to *write* `baselines/phase1.json` from inside the test
+    /// harness, which made `cargo test` mutate a tracked file. See
+    /// [`crate::fixtures::reject_tracked_golden_write`] for why that was
+    /// removed and PR #2805 for what it cost. The committed baseline is
+    /// regenerated only by `run` + `refresh-baseline`; this test just proves
+    /// the fixtures still produce the coverage that baseline claims.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn refresh_baseline_with_committed_fixtures() {
-        let crate_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    async fn committed_fixtures_produce_both_signal_proof_families() {
+        let crate_root = crate::fixtures::tracked_crate_root();
         let fixtures =
-            crate::loader::load_fixtures_from_disk(&crate_root).expect("load committed fixtures");
+            crate::loader::load_fixtures_from_disk(crate_root).expect("load committed fixtures");
 
         let output = execute_run_with_fixtures(&fixtures)
             .await
@@ -967,117 +972,77 @@ mod tests {
             "committed fixtures must produce signal comparisons"
         );
 
-        let graph_count = output
+        // Same predicate the `validate-fixtures` gate applies to the committed
+        // baseline: at least one graph/entity and one task-affinity comparison
+        // that actually changed rank.
+        let graph_changed = output
             .signal_comparisons
             .iter()
-            .filter(|c| c.signal == "graph")
+            .filter(|c| c.signal == "graph" && c.rank_changed)
             .count();
-        let ta_count = output
+        let ta_changed = output
             .signal_comparisons
             .iter()
-            .filter(|c| c.signal == "task_affinity")
+            .filter(|c| c.signal == "task_affinity" && c.rank_changed)
             .count();
         assert!(
-            graph_count > 0,
-            "must have graph signal comparisons from committed fixtures"
+            graph_changed > 0,
+            "committed fixtures must yield a graph/entity rank-change proof case: {:?}",
+            output.signal_comparisons
         );
         assert!(
-            ta_count > 0,
-            "must have task-affinity signal comparisons from committed fixtures"
+            ta_changed > 0,
+            "committed fixtures must yield a task-affinity rank-change proof case: {:?}",
+            output.signal_comparisons
         );
 
-        // Build query result records
-        let all_records: Vec<&QueryRankRecord> = output
-            .query_records
-            .iter()
-            .chain(output.bad_case_records.iter())
-            .collect();
+        // The run path enforces the same invariant; keep them in lockstep.
+        assert_signal_effects(&output)
+            .expect("committed fixtures must satisfy assert_signal_effects");
+    }
 
-        let query_result_records: Vec<crate::metrics::QueryResultRecord> = all_records
-            .iter()
-            .map(|r| crate::metrics::QueryResultRecord {
-                query_id: r.query_id.clone(),
-                query_text: r.query_text.clone(),
-                expected_permalinks: r.expected_permalinks.clone(),
-                result_permalinks: r.result_permalinks.clone(),
-                best_rank: r.relevant_ranks.iter().filter_map(|rank| *rank).min(),
-                relevant_ranks: r.relevant_ranks.clone(),
-                is_bad_case: r.is_bad_case,
-                bad_case_type: r.bad_case_type.clone(),
-                note_ages_days: vec![],
-            })
-            .collect();
+    /// Regression guard for the #2805 vector, asserting the SIDE EFFECT.
+    ///
+    /// Performs the exact operation the deleted `refresh_baseline_with_
+    /// committed_fixtures` test performed — `write_baseline` against the
+    /// crate's own root — and asserts the tracked file's bytes are unchanged
+    /// afterwards. Delete the guard in `reject_tracked_golden_write` and this
+    /// test fails on the byte comparison, not on the error message.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_test_cannot_write_the_tracked_baseline() {
+        let crate_root = crate::fixtures::tracked_crate_root();
+        let baseline_path = crate_root.join(crate::fixtures::FixturePaths::PHASE1_BASELINE);
 
-        // Compute metrics
-        let all_query_metrics = crate::metrics::compute_suite_metrics(&output.query_records);
-        let bad_case_metrics = crate::metrics::compute_suite_metrics(&output.bad_case_records);
+        let before = std::fs::read(&baseline_path).expect("read committed baseline");
+        let committed = crate::report::load_baseline(crate_root).expect("load committed baseline");
 
-        let mut suite_metrics = std::collections::HashMap::new();
-        suite_metrics.insert("all_queries".to_string(), all_query_metrics.clone());
-        if !output.bad_case_records.is_empty() {
-            suite_metrics.insert("bad_cases".to_string(), bad_case_metrics.clone());
-        }
+        // A baseline that is *valid* but not what is committed: if the write
+        // went through, the bytes below would differ and the assert would fire.
+        let mut mutated = committed.clone();
+        mutated.age_bucket_recall.clear();
+        mutated.metadata.refresh_commit = "aabbccdd00112233445566778899aabbccddeeff".to_string();
 
-        let agg_suites: Vec<(&str, &crate::metrics::SuiteMetrics)> =
-            suite_metrics.iter().map(|(k, v)| (k.as_str(), v)).collect();
-        let aggregate_metrics = crate::metrics::compute_aggregate_metrics(&agg_suites);
+        let result = crate::report::write_baseline(crate_root, &mutated);
 
-        let age_bucket_recall = crate::metrics::compute_age_bucket_recall(
-            &output.query_records,
-            &std::collections::HashMap::new(),
-        );
-        let directional = crate::metrics::directional_metrics(&output.query_records);
-
-        // Build report
-        let fixture_hashes = fixtures.manifest.as_ref().map(|m| m.file_hashes.clone());
-        let report = crate::report::Phase1Report {
-            suite_metrics,
-            aggregate_metrics,
-            age_bucket_recall,
-            directional,
-            query_records: query_result_records,
-            signal_comparisons: output.signal_comparisons.clone(),
-            compare_result: None,
-            threshold_policy_version: crate::metrics::THRESHOLD_POLICY_VERSION.to_string(),
-            fixture_hashes,
-        };
-
-        // Build and write baseline
-        let refresh_commit = "aabbccdd00112233445566778899aabbccddeeff".to_string();
-        let baseline = crate::report::build_baseline(
-            &report,
-            report.fixture_hashes.clone(),
-            refresh_commit,
-            1752115200,
-        );
-
+        let after = std::fs::read(&baseline_path).expect("re-read committed baseline");
+        // Deliberately `assert!` on the comparison rather than `assert_eq!` on
+        // the buffers: this file is ~90 KB and a failing `assert_eq!` dumps
+        // both copies as byte arrays into the CI log.
         assert!(
-            !baseline.signal_comparisons.is_empty(),
-            "baseline must contain signal_comparisons"
+            before == after,
+            "a test mutated the tracked baseline at {} ({} bytes -> {} bytes); \
+             `cargo test` must never dirty the working tree (see PR #2805)",
+            baseline_path.display(),
+            before.len(),
+            after.len(),
         );
 
-        crate::report::write_baseline(&crate_root, &baseline).expect("write baseline");
-
-        let reloaded = crate::report::load_baseline(&crate_root).expect("reload baseline");
+        let err = result.expect_err("write_baseline must refuse the tracked crate root");
+        let err = format!("{err:#}");
         assert!(
-            !reloaded.signal_comparisons.is_empty(),
-            "reloaded baseline must contain signal_comparisons"
+            err.contains("refresh-baseline"),
+            "the refusal must point at the sanctioned writer: {err}"
         );
-
-        eprintln!(
-            "=== Baseline refreshed with {} signal comparisons ===",
-            reloaded.signal_comparisons.len()
-        );
-        for sc in &reloaded.signal_comparisons {
-            eprintln!(
-                "  query={}, signal={}, with={:?}, without={:?}, changed={}",
-                sc.query_id,
-                sc.signal,
-                sc.rank_with_signal,
-                sc.rank_without_signal,
-                sc.rank_changed
-            );
-        }
     }
 
     // ── assert_signal_effects focused tests ──────────────────────────────


### PR DESCRIPTION
## The bug

`run::tests::refresh_baseline_with_committed_fixtures` called
`report::write_baseline` against `env!("CARGO_MANIFEST_DIR")`. Every
`cargo test --workspace` therefore rewrote the tracked
`server/crates/djinn-memory-eval/baselines/phase1.json` in the working tree,
and the next `git add -A` committed it.

That shipped on #2805 (`af3542928c6ff404908356f89e3bdb9df76b20bb`), where CI run
30545460857 failed in `Memory Eval Phase 1` → `Validate fixtures`:

```
Error: fixtures include an over-decay-threshold bad case but baseline age_bucket_recall
is missing the 'over_decay_threshold' bucket. Re-run `run` then `refresh-baseline`.
```

**The test was not writing "whatever the run produced."** It re-implemented
`cmd_run`'s report assembly and got it wrong in two ways:

| | `cmd_run` (the real path) | the test |
|---|---|---|
| `age_bucket_recall` input | `query_records` **+** `bad_case_records`, real note ages from `SystemClock` | `query_records` only, `&HashMap::new()` for ages → every note bucketed as age 0 |
| `refresh_commit` | `djinn_git::head_commit_sha()` | hard-coded `aabbccdd0011…`, long enough to satisfy `validate_refresh_commit` |

So a `cargo test` run reduced `age_bucket_recall` from
`["under7d","days30to90","over_decay_threshold"]` to `["under7d"]` and destroyed
the baseline's commit provenance. A stripped baseline fails nothing locally —
the ranking-regression suite still passes while measuring less.

## Chosen option and why

**Option 1 (invert the test into a verification), but as a coverage check, not a
byte-for-byte golden.** Plus a fail-closed guard so the vector cannot come back.

Concretely:

1. **`fixtures::reject_tracked_golden_write`** — fail-closes when a write targets
   this crate's own source tree **and** `cfg!(test)` is set. The crate is a single
   `[[bin]]` target, so that condition is true exactly under the test harness and
   false in the shipped binary. Wired into `report::write_baseline` and both
   `commands::test_helpers` writers (`fixtures/*.jsonl` are tracked goldens too —
   all their current callers use `tempdir()`, but nothing had stopped them).
2. **The offending test becomes `committed_fixtures_produce_both_signal_proof_families`** —
   keeps every real assertion, drops ~80 lines of divergent report assembly and
   the write.
3. **`commands::tests::committed_baseline_and_fixtures_pass_the_shipped_gate`** —
   runs `cmd_validate_fixtures` against the committed artifacts under
   `cargo test`, so a stripped baseline now fails in the unit-test lane instead
   of only in the separate CI job. This is the "verification" half of option 1.
4. **README** documents the invariant and the sanctioned refresh workflow.

`validate-fixtures` is untouched. `refresh-baseline` remains the only writer and
is verified working below.

## What I rejected, and why

**A strict-equality golden against a fresh run — rejected, and the prior that it
would work is wrong.** I measured it. The deterministic parts really are
byte-stable: today's `run` reproduces the committed `aggregate_metrics`,
`suite_metrics` and all 29 `signal_comparisons` exactly. But
`age_bucket_recall` is **not** time-invariant. `cmd_run` derives note ages from
`SystemClock::now()`, so the bucket *set* migrates as fixtures age on the
calendar:

```
COMMITTED baseline (refreshed 2026-07-10): ['days30to90', 'over_decay_threshold', 'under7d']
REAL run today       (2026-07-30):         ['days30to90', 'days7to30',           'over_decay_threshold']
```

Seven corpus notes carry `last_accessed=2026-07-08`. They were `under7d` when the
baseline was refreshed; 22 days later they are `days7to30`. **A strict-equality
golden would fail today**, with nobody having touched the code — exactly the
rotting lane we were warned off. What `validate-fixtures` actually depends on is
time-safe, because notes only ever get older and so `over_decay_threshold` only
ever grows. That is what the new test asserts.

**Redirect the write to `target/memory-eval/` — rejected.** It fixes the symptom
and leaves the divergent, wrong report assembly in place, still producing a
misleading artifact and still permitting the next test to aim at the crate root.

**`#[ignore]` — rejected.** Silently drops the one check that the *committed*
fixtures still produce both signal-proof families, and leaves the loaded gun on
the table.

## Verification (all run, real output)

**1. `cargo test -p djinn-memory-eval`** (`SQLX_OFFLINE=true`, local Postgres :5433):

```
test result: ok. 174 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.19s
```

**2. THE KEY ONE — after that test command:**

```
$ git status --porcelain server/crates/djinn-memory-eval/baselines/
<no output — EMPTY>
```

Before this PR, the same command after the same test run printed:

```
 M server/crates/djinn-memory-eval/baselines/phase1.json
```

**3. `validate-fixtures`** (prebuilt binary, not `cargo run`, per the build-dir
lock hazard):

```
INFO required coverage types present over_decay=true graph_entity=true task_affinity=true
INFO baseline validated baseline_commit=abbba5bf12aab66d6febc1dd81d0260f8a2766be suites=2 policy=phase1-v1 signal_comparisons=29
INFO signal comparison rank-change summary graph_rank_changes=6 task_affinity_rank_changes=8
INFO === All validations passed ===
```

**4. `cargo clippy -p djinn-memory-eval --all-targets -- -D warnings`** — clean.
`cargo fmt --check` clean.

**5. `git diff origin/main -- server/crates/djinn-memory-eval/baselines/phase1.json`** — empty.

**6. `refresh-baseline` still works** (the guard must not break the sanctioned
writer):

```
INFO === Refresh Baseline ===
INFO refresh commit commit=92b9f092d3baa6027fbff7087921fef609fd6018
INFO baseline refreshed path=.../baselines/phase1.json
```

It wrote the file with a real HEAD SHA. Reverted afterwards so this PR does not
touch the baseline.

## Non-vacuity proof for the regression test

`run::tests::a_test_cannot_write_the_tracked_baseline` performs the exact #2805
operation — `write_baseline` against the crate root — and asserts the file's
**bytes are unchanged** afterwards.

Disabling the guard (`if !cfg!(test)` → `if true`) and running only that test:

```
test run::tests::a_test_cannot_write_the_tracked_baseline ... FAILED

thread 'run::tests::a_test_cannot_write_the_tracked_baseline' panicked at crates/djinn-memory-eval/src/run.rs:1027:9:
assertion `left == right` failed: a test mutated the tracked baseline at
.../server/crates/djinn-memory-eval/baselines/phase1.json;
`cargo test` must never dirty the working tree (see PR #2805)
```

It fails on the **byte comparison**, not on the error message — so it is
asserting the side effect, not the label. With the guard restored it passes, and
`git status` on `baselines/` is empty. (That failure dumped ~125 KB of byte
arrays into the log, so the final version uses `assert!(before == after, …)`
with a length summary rather than `assert_eq!` on the buffers.)

## Notes for the reviewer

- The README already told people to use "explicitly fake hex strings (e.g.
  `aabbccdd0011…`)" in test baseline helpers. The offending test followed that
  advice — which is precisely why `validate_refresh_commit` did not catch the
  corrupted provenance. The guard closes that gap by preventing the write at all.
- `Memory Eval Phase 1` invokes the binary (`validate-fixtures`, `run`,
  `compare`), never `cargo test -p djinn-memory-eval`, so the crate's unit tests
  reach CI through the `server-test` shards. Both paths are exercised above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
