### PR TITLE
fix(ci): plan the full matrix width so surplus shards stop paying for a build

### DIFF
--- a/scripts/ci-nextest-plan.mjs
+++ b/scripts/ci-nextest-plan.mjs
@@ -39,8 +39,36 @@ export const PR_DEFAULT_SHARDS = 2;
 // (maximumEntriesToBuild=5, mergingStrategy=HEADGREEN), so the queue's cost
 // function is throughput under contention, not latency of one entry.
 export const PR_MAX_SHARDS = 8;
-export const WIDE_DEFAULT_SHARDS = 4;
-export const COLD_START_SHARDS = 4;
+// Both 4 -> 8, to match the matrix width. NOT a latency change in intent — a
+// COST fix, and it reverses the reasoning recorded above.
+//
+// `server-test`'s matrix is STATIC at `CI_SERVER_TEST_MATRIX_WIDTH` (8) rows,
+// because the shards must start before the planner has decided anything. A
+// plan NARROWER than the matrix does not save those runners: the surplus jobs
+// are still created and still execute steps 1-14, which includes the
+// unconditional ~6m `Build test binaries`. They only discover they are surplus
+// at step 16, after the plan artifact downloads. Measured step order on
+// 2026-07-30 — only `Run planner-selected shard tests` carries the
+// `steps.shard.outputs.active` guard; the build does not, and cannot, because
+// it deliberately runs concurrently with the planner's discovery.
+//
+// So a narrow plan against a wide matrix costs ~7.5m of runner time per
+// surplus shard and buys nothing. At WIDE_DEFAULT_SHARDS=4 against 8 rows that
+// was 4 idle jobs x ~7.5m = ~30 runner-min per merge-queue run, ~46 queue runs
+// a day.
+//
+// This supersedes the "the queue optimizes throughput, not latency, so keep it
+// at 4" note on PR_MAX_SHARDS above. That was true when the matrix was also 4.
+// Once the matrix is 8 the runners are committed either way, so planning 8 is
+// both CHEAPER (no build-then-idle jobs) and faster. If these are ever lowered,
+// lower the matrix and CI_SERVER_TEST_MATRIX_WIDTH in the same commit, or the
+// waste comes straight back.
+//
+// PR_DEFAULT_SHARDS is left at 2 and is unreachable in practice: the widen
+// check is `tests.length >= PR_WIDEN_TEST_THRESHOLD` (200) and the suite is
+// ~11.6k tests, so the PR lane always takes PR_MAX_SHARDS.
+export const WIDE_DEFAULT_SHARDS = 8;
+export const COLD_START_SHARDS = 8;
 export const PR_WIDEN_TEST_THRESHOLD = 200;
 export const PR_WIDEN_DURATION_THRESHOLD_SECONDS = 600;
 export const MAX_ARG_STRLEN = 131072;

--- a/scripts/ci-nextest-plan.test.mjs
+++ b/scripts/ci-nextest-plan.test.mjs
@@ -790,23 +790,36 @@ describe('nextest.toml compatibility', () => {
 });
 
 describe('consumer boundary: file-backed filter transport', () => {
-  it('produces a matrix row filter larger than the Linux single-argument ceiling', () => {
-    // Synthesize enough tests that the planner emits a filter exceeding
-    // Linux's MAX_ARG_STRLEN. This mirrors the PR #1988 failure mode.
-    const binaryCount = 260;
-    const testsPerBinary = 50;
+  // Synthesize enough tests that the planner emits a per-shard filter
+  // exceeding Linux's MAX_ARG_STRLEN, mirroring the PR #1988 failure mode.
+  //
+  // SIZED PER SHARD, not absolutely. The filter these tests need to overflow is
+  // ONE shard's, so the corpus must grow with the shard count or the boundary
+  // stops being exercised. This was hard-coded at 260 binaries when
+  // PR_MAX_SHARDS was 4; raising it to 8 halved each shard's filter to 70737
+  // bytes and both assertions here failed — the transport bug they guard was
+  // still real, the fixture had just stopped reaching it. 65 binaries per shard
+  // reproduces the original ~3250-tests-per-shard density at any width.
+  const BINARIES_PER_SHARD = 65;
+  const TESTS_PER_BINARY = 50;
+
+  function oversizedFilterPlan() {
     const suites = {};
-    for (let b = 0; b < binaryCount; b += 1) {
+    for (let b = 0; b < BINARIES_PER_SHARD * PR_MAX_SHARDS; b += 1) {
       const binaryId = `pkg${b}::bin`;
       const testCases = {};
-      for (let t = 0; t < testsPerBinary; t += 1) {
+      for (let t = 0; t < TESTS_PER_BINARY; t += 1) {
         testCases[`test_${t}_name_with_some_length`] = testCase();
       }
       suites[binaryId] = suite(`pkg${b}`, 'bin', testCases, { binaryId });
     }
     const summary = makeSummary({ 'rust-suites': suites });
     const tests = parseDiscovery(JSON.stringify(summary));
-    const plan = planTests({ tests, timings: new Map(), profile: 'pull-request' });
+    return planTests({ tests, timings: new Map(), profile: 'pull-request' });
+  }
+
+  it('produces a matrix row filter larger than the Linux single-argument ceiling', () => {
+    const plan = oversizedFilterPlan();
     validateExactOnce(plan);
 
     const largestFilter = plan.matrix
@@ -818,20 +831,7 @@ describe('consumer boundary: file-backed filter transport', () => {
   it('materializes the oversized filter through a generated nextest config', async () => {
     const dir = await makeTempDir();
     try {
-      const binaryCount = 260;
-      const testsPerBinary = 50;
-      const suites = {};
-      for (let b = 0; b < binaryCount; b += 1) {
-        const binaryId = `pkg${b}::bin`;
-        const testCases = {};
-        for (let t = 0; t < testsPerBinary; t += 1) {
-          testCases[`test_${t}_name_with_some_length`] = testCase();
-        }
-        suites[binaryId] = suite(`pkg${b}`, 'bin', testCases, { binaryId });
-      }
-      const summary = makeSummary({ 'rust-suites': suites });
-      const tests = parseDiscovery(JSON.stringify(summary));
-      const plan = planTests({ tests, timings: new Map(), profile: 'pull-request' });
+      const plan = oversizedFilterPlan();
 
       const row = plan.matrix[0];
       assert.ok(Buffer.byteLength(row.filter, 'utf8') > MAX_ARG_STRLEN);


### PR DESCRIPTION
## The cost regression

Widening `server-test`'s static matrix to 8 in #2806 fixed a coverage hole and introduced a cost one. **A surplus shard is not free.**

The matrix is static — the shards must start before the planner has decided anything — so a plan *narrower* than the matrix still creates every job. Verified step order and guards:

```
14. Build test binaries ...     if=(none)     ← ~6m, unconditional
15. Wait for and download plan  if=(none)
16. Resolve and validate shard  if=(none)     ← discovers "surplus" only here
18. Run planner-selected tests  if=steps.shard.outputs.active == 'true'
```

The build **cannot** be gated on `active`: running it concurrently with the planner's discovery is the entire reason the shards do not `needs: nextest-plan`.

So with `WIDE_DEFAULT_SHARDS=4` against 8 matrix rows, every merge-queue run created four jobs that each spent **~7.5m** (setup + full workspace build) to discover they had nothing to do — **~30 wasted runner-minutes per queue run**, at ~46 queue runs/day.

## The fix

`WIDE_DEFAULT_SHARDS` and `COLD_START_SHARDS` both 4 → 8, matching `CI_SERVER_TEST_MATRIX_WIDTH`.

This **supersedes** the reasoning I recorded on `PR_MAX_SHARDS` in #2799 — *"the queue optimizes throughput, not latency, so keep it at 4."* That was true when the matrix was also 4. Once the matrix is 8 the runners are committed either way, so planning 8 is **both cheaper** (no build-then-idle jobs) **and faster** for the queue.

Every reachable profile now uses the full width:

| profile | shardCount | coldStart |
|---|---|---|
| pull-request | 8 | false |
| merge-group | 8 | false |
| full-validation | 8 | false |
| any (no timing) | 8 | true |

`PR_DEFAULT_SHARDS` stays at 2 and is unreachable: the widen check is `tests.length >= 200` and the suite is ~11.6k tests.

## Test fallout, fixed properly

The file-backed filter transport tests synthesize a corpus big enough that **one shard's** filter exceeds Linux `MAX_ARG_STRLEN` (the PR #1988 failure mode). They sized it *absolutely* — 260 binaries — against a 4-wide plan. At 8 shards each filter halved to **70737 bytes** and both assertions failed:

```
AssertionError: expected filter > 131072, got 70737
```

The transport bug they guard was still real; the fixture had stopped reaching it. Now sized **per shard** (`65 * PR_MAX_SHARDS` binaries), reproducing the original ~3250-tests-per-shard density at any width — so it cannot rot again the next time a shard constant moves.

## Verification

- `ci-nextest-plan.test.mjs` 50/50, with both boundary tests confirmed still exercising the ceiling (not passing vacuously)
- `actionlint` clean; all other contract suites pass
- Matrix-width contract test from #2806 still holds (8 rows ≥ max(8, 8, 8))