### PR TITLE
feat(kueue): S1 arm-gated opt-in across all four Job renderers (jxbt)

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -17,6 +17,25 @@
     {{- fail "buildAdmission.mode=enforce requires server.strategy.type=Recreate or non-overlapping RollingUpdate" -}}
   {{- end -}}
 {{- end -}}
+{{- /*
+Kueue arming invariants. Rendered from this template because it is the one that
+always renders, so both checks fire regardless of `--show-only`.
+*/ -}}
+{{- if .Values.kueue.armed -}}
+  {{- if not .Values.kueue.enabled -}}
+    {{- fail "kueue.armed=true requires kueue.enabled=true: armed implies enabled. Arming stamps suspend: true and a kueue.x-k8s.io/queue-name onto every build Job, but kueue.enabled=false renders no ClusterQueue or LocalQueue for them to be admitted into, so every build Job would hang forever." -}}
+  {{- end -}}
+  {{- /*
+  Mirror of the renderer assertion at server/crates/djinn-k8s/src/job.rs:242.
+  That line is an `assert!` — a coordinator PANIC, not a graceful fail-close —
+  so arming Kueue on top of it stacks two fail-closed gates and wedges ALL
+  dispatch. Surfacing the collision at `helm template` beats discovering it as a
+  crash loop in production (v0.7.25, and again on 2026-07-30).
+  */ -}}
+  {{- if and (eq .Values.cgroupLauncher.mode "required") (not .Values.cgroupWritable.taskRuns.enabled) -}}
+    {{- fail "kueue.armed=true with cgroupLauncher.mode=required requires cgroupWritable.taskRuns.enabled=true (required cgroup launcher requires runtimeClassName: djinn-cgroup-writable). The task-run renderer asserts this at djinn-k8s/src/job.rs:242 and panics the coordinator otherwise; arming Kueue on top of it wedges all dispatch. Enable cgroupWritable.taskRuns (and cgroupWritable.runtimeClass), or set cgroupLauncher.mode=disabled." -}}
+  {{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -402,6 +421,21 @@ spec:
             # atomic activation upgrade.
             - name: DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED
               value: {{ .Values.cgroupWritable.taskRuns.enabled | quote }}
+            # Kueue arming. This is the SAME value that labels the Namespace
+            # `djinn.io/kueue-managed` in templates/namespace.yaml, and the two
+            # must never be driven apart: a Job created `suspend: true` in an
+            # unlabelled namespace is never captured by Kueue, so nothing ever
+            # unsuspends it and the build hangs forever.
+            - name: DJINN_KUEUE_ARMED
+              value: {{ .Values.kueue.armed | quote }}
+            # LocalQueue name prefix, so an armed Job's
+            # `kueue.x-k8s.io/queue-name` resolves to a LocalQueue that this
+            # release actually rendered (kueue-topology.yaml names them
+            # `<djinn.fullname>-task-run` / `-warm` / `-scip`). A hard-coded
+            # prefix would silently name a non-existent queue on any release
+            # whose fullname is not `djinn`.
+            - name: DJINN_KUEUE_LOCAL_QUEUE_PREFIX
+              value: {{ include "djinn.fullname" . | quote }}
             - name: DJINN_K8S_MIRROR_PVC
               value: {{ include "djinn.pvcName.mirrors" . | quote }}
             - name: DJINN_K8S_CACHE_PVC

--- a/deploy/helm/djinn/templates/kueue-topology.yaml
+++ b/deploy/helm/djinn/templates/kueue-topology.yaml
@@ -19,9 +19,12 @@ deploy/kueue/README.md). If you set it true without that, `helm install` stops
 with a plain "no matches for kind ResourceFlavor" from the API server — a
 diagnosable error, not a chart that quietly ships less than you asked for.
 
-This topology is INERT either way: no Djinn Job carries a queue name and no
-namespace is Kueue-managed, so nothing is ever admitted through these queues.
-Arming them belongs to the Kueue cutover epic 4c9q.
+This topology is INERT until `kueue.armed` is ALSO true. `kueue.enabled` renders
+the queues; `kueue.armed` labels the Namespace and stamps `suspend` +
+`kueue.x-k8s.io/queue-name` onto build Jobs. Keeping them separate is what makes
+"Kueue installed, topology rendered, nothing captured" representable — the exact
+state `deploy/kueue/zero-capture-gate.sh` verifies. `armed` implies `enabled`;
+`deployment-server.yaml` fails the render on the other combination.
 */ -}}
 {{- if .Values.kueue.enabled -}}
 {{- $kueue := .Values.kueue -}}
@@ -46,7 +49,12 @@ metadata:
   labels:
     {{- include "djinn.labels" . | nindent 4 }}
 spec:
-  queueingStrategy: StrictFIFO
+  # BestEffortFIFO, not StrictFIFO. Three kinds (task-run, warm, SCIP) share a
+  # queue whose default nominal quota is 3 pods, and a warm Pod is long-lived
+  # (measured 5442s end to end). Under StrictFIFO one head-of-line Workload that
+  # cannot fit blocks every smaller Workload behind it; BestEffortFIFO lets the
+  # rest through. Fairness across kinds is not a goal here — throughput is.
+  queueingStrategy: BestEffortFIFO
   resourceGroups:
     - coveredResources: ["pods"]
       flavors:
@@ -69,6 +77,26 @@ apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
 metadata:
   name: {{ include "djinn.fullname" . }}-warm
+  namespace: {{ include "djinn.namespace" . }}
+  labels:
+    {{- include "djinn.labels" . | nindent 4 }}
+spec:
+  clusterQueue: {{ $clusterQueueName }}
+---
+{{- /*
+SCIP joins Kueue. rust-analyzer indexing is genuinely CPU-heavy — the measured
+SCIP phase of a production warm was 3644s — so leaving it outside the quota
+would make the ClusterQueue under-count the very load it exists to bound.
+
+Image build deliberately gets NO LocalQueue. It is an upstream dependency of a
+task-run, so sharing this ClusterQueue admits a priority-inversion deadlock: a
+task-run holds a slot waiting on its project image while that image build is
+queued behind it. Adding a `-build` queue here re-introduces that.
+*/ -}}
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: {{ include "djinn.fullname" . }}-scip
   namespace: {{ include "djinn.namespace" . }}
   labels:
     {{- include "djinn.labels" . | nindent 4 }}

--- a/deploy/helm/djinn/templates/namespace.yaml
+++ b/deploy/helm/djinn/templates/namespace.yaml
@@ -5,4 +5,12 @@ metadata:
   name: {{ include "djinn.namespace" . }}
   labels:
     {{- include "djinn.labels" . | nindent 4 }}
+    {{- if .Values.kueue.armed }}
+    # Kueue captures Jobs ONLY in a namespace carrying this label. It is driven
+    # by the same value (`kueue.armed`) that makes the renderers create Jobs
+    # `suspend: true`, and it must stay that way: a suspended Job in an
+    # unlabelled namespace is never captured, so nothing ever unsuspends it and
+    # every build Job hangs forever. Never split these onto two flags.
+    djinn.io/kueue-managed: "true"
+    {{- end }}
 {{- end -}}

--- a/deploy/helm/djinn/tests/kueue-build-object-labels.sh
+++ b/deploy/helm/djinn/tests/kueue-build-object-labels.sh
@@ -27,9 +27,16 @@ require_tool python3
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
+# Rendered at BOTH arming states. Control-plane workloads must stay out of Kueue
+# build-object admission forever, including after the cutover arms build Jobs —
+# a shared label helper that leaked into the server Deployment would be caught
+# only by the armed render.
 helm template kueue-build-object-test "$CHART_DIR" --is-upgrade >"$WORK/rendered.yaml"
+helm template kueue-build-object-test "$CHART_DIR" --is-upgrade \
+    --set kueue.enabled=true --set kueue.armed=true >"$WORK/rendered-armed.yaml"
 
-python3 - "$WORK/rendered.yaml" <<'PY'
+for manifest in "$WORK/rendered.yaml" "$WORK/rendered-armed.yaml"; do
+python3 - "$manifest" <<'PY'
 import sys
 import yaml
 
@@ -79,5 +86,6 @@ assert labelled_pod_templates([negative_fixture]) == ["negative-labelled-fixture
     "scanner must reject the explicit reserved-label fixture"
 )
 PY
+done
 
 echo "=== Kueue build-object label render contract passed ==="

--- a/deploy/helm/djinn/tests/kueue-topology-render.sh
+++ b/deploy/helm/djinn/tests/kueue-topology-render.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
-# Structural Helm render contract for the inert Kueue prerequisite topology.
+# Structural Helm render contract for the Kueue topology and its arming switch.
+#
+# TWO FLAGS, NOT ONE:
+#   kueue.enabled — renders the ResourceFlavor/ClusterQueue/LocalQueue topology.
+#   kueue.armed   — labels the Namespace djinn.io/kueue-managed AND sets
+#                   DJINN_KUEUE_ARMED on djinn-server, which is what makes the
+#                   Job renderers emit `suspend: true` + a queue-name label.
+#
+# The pair exists so "Kueue installed, topology rendered, nothing captured" stays
+# representable — the state deploy/kueue/zero-capture-gate.sh verifies. Collapsing
+# them would make it unrepresentable and leave that gate with nothing to check.
+#
 # Usage: bash deploy/helm/djinn/tests/kueue-topology-render.sh
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CHART_DIR/../../.." && pwd)"
 
 require_tool() {
     command -v "$1" >/dev/null 2>&1 || {
@@ -24,6 +36,14 @@ render() {
     helm template kueue-topology-test "$CHART_DIR" --is-upgrade "$@" >"$output"
 }
 
+# Same render, with helm's stderr folded into the output file. Rejection cases
+# grep the diagnostic, and `fail` messages arrive on stderr.
+render_capture() {
+    local output=$1
+    shift
+    helm template kueue-topology-test "$CHART_DIR" --is-upgrade "$@" >"$output" 2>&1
+}
+
 # The topology is `kueue.x-k8s.io/v1beta1`, so it only renders when the operator
 # has declared the Kueue prerequisite installed. Everything below that asserts
 # topology shape therefore has to opt in explicitly.
@@ -33,13 +53,16 @@ render_enabled() {
     render "$output" --set kueue.enabled=true "$@"
 }
 
+# `expected_managed` is yes/no: whether the Namespace must carry
+# djinn.io/kueue-managed=true. It is the arming half of the contract, asserted in
+# BOTH directions so neither branch can rot into a tautology.
 assert_topology() {
-    local manifest=$1 expected_pods=$2
-    python3 - "$manifest" "$expected_pods" <<'PY'
+    local manifest=$1 expected_pods=$2 expected_managed=$3
+    python3 - "$manifest" "$expected_pods" "$expected_managed" <<'PY'
 import sys
 import yaml
 
-manifest, expected_pods = sys.argv[1:]
+manifest, expected_pods, expected_managed = sys.argv[1:]
 docs = [doc for doc in yaml.safe_load_all(open(manifest, encoding="utf-8")) if doc]
 
 def named(kind):
@@ -54,7 +77,11 @@ queues = named("ClusterQueue")
 assert len(queues) == 1, f"expected one ClusterQueue, got {len(queues)}"
 queue = queues[0]
 spec = queue["spec"]
-assert spec.get("queueingStrategy") == "StrictFIFO", "ClusterQueue must use StrictFIFO"
+# BestEffortFIFO, not StrictFIFO: three kinds share a 3-slot queue, so one
+# head-of-line Workload that cannot fit would block everything behind it.
+assert spec.get("queueingStrategy") == "BestEffortFIFO", (
+    f"ClusterQueue must use BestEffortFIFO, got {spec.get('queueingStrategy')}"
+)
 groups = spec.get("resourceGroups")
 assert isinstance(groups, list) and len(groups) == 1, "ClusterQueue must have one resource group"
 group = groups[0]
@@ -69,15 +96,36 @@ assert quota.get("name") == "pods", "sole nominal quota must be pods"
 assert quota.get("nominalQuota") == int(expected_pods), "pods quota must render buildPods verbatim"
 assert "cpu" not in str(spec).lower() and "memory" not in str(spec).lower(), "CPU/memory quota is forbidden"
 
+# Exactly three LocalQueues. SCIP joins Kueue because rust-analyzer indexing is
+# CPU-heavy and excluding it under-counts the load the quota exists to bound.
+# Image build stays out on purpose: it is an UPSTREAM DEPENDENCY of a task-run,
+# so a shared ClusterQueue admits a priority-inversion deadlock. A fourth queue
+# here is a regression, not an addition.
 local_queues = named("LocalQueue")
-assert len(local_queues) == 2, f"expected task-run and warm LocalQueues, got {len(local_queues)}"
+assert len(local_queues) == 3, f"expected task-run, warm and scip LocalQueues, got {len(local_queues)}"
 local_names = {local["metadata"]["name"] for local in local_queues}
-assert local_names == {"kueue-topology-test-djinn-task-run", "kueue-topology-test-djinn-warm"}
+assert local_names == {
+    "kueue-topology-test-djinn-task-run",
+    "kueue-topology-test-djinn-warm",
+    "kueue-topology-test-djinn-scip",
+}, f"unexpected LocalQueue set: {sorted(local_names)}"
 assert all(local.get("spec", {}).get("clusterQueue") == queue["metadata"]["name"] for local in local_queues)
 
 namespaces = named("Namespace")
 assert len(namespaces) == 1, f"expected one Namespace, got {len(namespaces)}"
-assert "djinn.io/kueue-managed" not in namespaces[0].get("metadata", {}).get("labels", {}), "Namespace must remain unlabelled for Kueue"
+labels = namespaces[0].get("metadata", {}).get("labels", {})
+managed = labels.get("djinn.io/kueue-managed")
+if expected_managed == "yes":
+    # Kueue captures Jobs ONLY in a labelled namespace. Without this label the
+    # `suspend: true` the same flag turns on is never undone, and every build
+    # Job hangs forever.
+    assert managed == "true", (
+        f"kueue.armed=true must label the Namespace djinn.io/kueue-managed=true, got {managed!r}"
+    )
+else:
+    assert "djinn.io/kueue-managed" not in labels, (
+        "Namespace must remain unlabelled for Kueue unless kueue.armed=true"
+    )
 
 roles = named("Role")
 assert len(roles) >= 1, "expected namespaced controller Role"
@@ -106,12 +154,29 @@ server = next(container for container in containers if container["name"] == "dji
 values = {entry["name"]: entry.get("value") for entry in server["env"]}
 assert values["DJINN_BUILD_ADMISSION_MODE"] == "observe", "buildAdmission mode changed"
 assert values["DJINN_MAX_BUILD_TASKRUNS"] == "3", "buildAdmission cap changed"
+# The renderer half of the arming contract. It must move with the namespace
+# label, never independently: they are two halves of one capture decision.
+expected_armed = "true" if expected_managed == "yes" else "false"
+assert values["DJINN_KUEUE_ARMED"] == expected_armed, (
+    f"DJINN_KUEUE_ARMED must be {expected_armed}, got {values.get('DJINN_KUEUE_ARMED')!r}"
+)
+# An armed Job's queue-name label has to resolve to a LocalQueue this release
+# actually rendered, or it is never admitted.
+assert values["DJINN_KUEUE_LOCAL_QUEUE_PREFIX"] == "kueue-topology-test-djinn", (
+    f"queue prefix must match the rendered LocalQueue names, got {values.get('DJINN_KUEUE_LOCAL_QUEUE_PREFIX')!r}"
+)
 PY
 }
 
-echo "=== valid Kueue topology (kueue.enabled=true) ==="
+echo "=== zero-capture-representable state: enabled=true, armed=false ==="
+# This is the configuration deploy/kueue/zero-capture-gate.sh exists to verify:
+# the whole topology present, the Namespace still unlabelled, nothing captured.
 render_enabled "$WORK/valid.yaml" --set kueue.buildPods=7
-assert_topology "$WORK/valid.yaml" 7
+assert_topology "$WORK/valid.yaml" 7 no
+
+echo "=== armed state: enabled=true, armed=true ==="
+render_enabled "$WORK/armed.yaml" --set kueue.buildPods=7 --set kueue.armed=true
+assert_topology "$WORK/armed.yaml" 7 yes
 
 echo "=== chart default omits the topology entirely ==="
 # Regression guard for the defect this flag fixes: the topology used to render
@@ -153,6 +218,83 @@ grep -q 'kueue.x-k8s.io/v1beta1' "$WORK/disabled.yaml" && {
     exit 1
 }
 
+# ---------------------------------------------------------------------------
+# The topology flag alone arms nothing.
+# ---------------------------------------------------------------------------
+assert_disarmed_server() {
+    local manifest=$1 label=$2
+    python3 - "$manifest" "$label" <<'PY'
+import sys
+import yaml
+
+manifest, label = sys.argv[1:]
+docs = [doc for doc in yaml.safe_load_all(open(manifest, encoding="utf-8")) if doc]
+
+namespaces = [doc for doc in docs if doc.get("kind") == "Namespace"]
+assert len(namespaces) == 1, f"{label}: expected one Namespace, got {len(namespaces)}"
+labels = namespaces[0].get("metadata", {}).get("labels", {})
+assert "djinn.io/kueue-managed" not in labels, (
+    f"{label}: the topology flag must not label the Namespace"
+)
+
+server = next(
+    container
+    for doc in docs
+    if doc.get("kind") == "Deployment"
+    and doc.get("metadata", {}).get("name", "").endswith("-server")
+    for container in doc["spec"]["template"]["spec"]["containers"]
+    if container["name"] == "djinn-server"
+)
+values = {entry["name"]: entry.get("value") for entry in server["env"]}
+assert values["DJINN_KUEUE_ARMED"] == "false", (
+    f"{label}: the topology flag must not arm the renderers, got "
+    f"{values.get('DJINN_KUEUE_ARMED')!r}"
+)
+PY
+}
+
+echo "=== kueue.enabled alone arms nothing, at BOTH of its values ==="
+assert_disarmed_server "$WORK/default.yaml" "kueue.enabled=false"
+assert_disarmed_server "$WORK/valid.yaml" "kueue.enabled=true"
+
+# ---------------------------------------------------------------------------
+# armed implies enabled
+# ---------------------------------------------------------------------------
+echo "=== armed=true with enabled=false is rejected by name ==="
+if render_capture "$WORK/armed-without-enabled.out" --set kueue.armed=true; then
+    echo "FAIL: kueue.armed=true with kueue.enabled=false rendered successfully" >&2
+    exit 1
+fi
+# The invariant must be NAMED, not merely violated by some unrelated error.
+grep -q 'kueue.armed=true requires kueue.enabled=true' "$WORK/armed-without-enabled.out" || {
+    echo "FAIL: the armed-implies-enabled rejection did not name the invariant:" >&2
+    cat "$WORK/armed-without-enabled.out" >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# RuntimeClass stacking: mirror of the renderer assert at job.rs:242.
+# ---------------------------------------------------------------------------
+echo "=== armed=true with a required cgroup launcher and no RuntimeClass is rejected ==="
+RUNTIME_CLASS_VALUES=(
+    --set kueue.enabled=true
+    --set-string cgroupLauncher.mode=required
+    --set cgroupWritable.taskRuns.enabled=false
+)
+if render_capture "$WORK/armed-runtimeclass.out" "${RUNTIME_CLASS_VALUES[@]}" --set kueue.armed=true; then
+    echo "FAIL: arming Kueue over an unsatisfiable cgroup launcher rendered successfully" >&2
+    exit 1
+fi
+grep -q 'required cgroup launcher requires runtimeClassName: djinn-cgroup-writable' "$WORK/armed-runtimeclass.out" || {
+    echo "FAIL: the RuntimeClass rejection did not mirror the job.rs:242 assertion:" >&2
+    cat "$WORK/armed-runtimeclass.out" >&2
+    exit 1
+}
+# Non-vacuity: the SAME values with armed=false must render, so the failure above
+# cannot be an unrelated chart error that would reject either way.
+render "$WORK/disarmed-runtimeclass.yaml" "${RUNTIME_CLASS_VALUES[@]}" --set kueue.armed=false
+assert_topology "$WORK/disarmed-runtimeclass.yaml" 3 no
+
 expect_rejected() {
     local name=$1
     shift
@@ -173,6 +315,12 @@ if render "$WORK/enabled-string.out" --set-string kueue.enabled=yes 2>&1; then
     exit 1
 fi
 
+echo "=== invalid kueue.armed ==="
+if render "$WORK/armed-string.out" --set-string kueue.armed=yes 2>&1; then
+    echo "FAIL: a non-boolean kueue.armed rendered successfully" >&2
+    exit 1
+fi
+
 echo "=== missing kueue.enabled ==="
 cp -R "$CHART_DIR" "$WORK/chart-without-enabled"
 python3 - "$WORK/chart-without-enabled/values.yaml" <<'PY'
@@ -187,6 +335,23 @@ with open(path, "w", encoding="utf-8") as output:
 PY
 if helm template kueue-topology-test "$WORK/chart-without-enabled" --is-upgrade >"$WORK/missing-enabled.out" 2>&1; then
     echo "FAIL: missing kueue.enabled rendered successfully" >&2
+    exit 1
+fi
+
+echo "=== missing kueue.armed ==="
+cp -R "$CHART_DIR" "$WORK/chart-without-armed"
+python3 - "$WORK/chart-without-armed/values.yaml" <<'PY'
+import sys
+import yaml
+
+path = sys.argv[1]
+values = yaml.safe_load(open(path, encoding="utf-8"))
+values["kueue"].pop("armed")
+with open(path, "w", encoding="utf-8") as output:
+    yaml.safe_dump(values, output, sort_keys=False)
+PY
+if helm template kueue-topology-test "$WORK/chart-without-armed" --is-upgrade >"$WORK/missing-armed.out" 2>&1; then
+    echo "FAIL: missing kueue.armed rendered successfully" >&2
     exit 1
 fi
 
@@ -206,5 +371,101 @@ if helm template kueue-topology-test "$WORK/chart-without-kueue" --is-upgrade >"
     echo "FAIL: missing kueue.buildPods rendered successfully" >&2
     exit 1
 fi
+
+echo "=== kueue.armed ships false ==="
+python3 - "$CHART_DIR/values.yaml" <<'PY'
+import sys
+import yaml
+
+values = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+assert values["kueue"]["armed"] is False, (
+    f"kueue.armed must ship false, got {values['kueue']['armed']!r}"
+)
+assert values["kueue"]["enabled"] is False, (
+    f"kueue.enabled must ship false, got {values['kueue']['enabled']!r}"
+)
+PY
+
+# ---------------------------------------------------------------------------
+# The zero-capture gate must actually discriminate.
+# ---------------------------------------------------------------------------
+# deploy/kueue/zero-capture-gate.sh is a live-cluster gate. Run the REAL script
+# here with a fake kubectl whose namespace answer is derived from a REAL render
+# of this chart, so "the gate passes" and "the gate fails" are decided by the
+# chart, not by a hand-written fixture. Without this, arming could silently
+# change the Namespace label while the gate kept reporting inert.
+GATE="$REPO_ROOT/deploy/kueue/zero-capture-gate.sh"
+if [ ! -f "$GATE" ]; then
+    echo "FAIL: zero-capture gate is missing: $GATE" >&2
+    exit 1
+fi
+
+GATE_BIN="$WORK/gate-bin"
+mkdir -p "$GATE_BIN"
+cat >"$GATE_BIN/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+args=" $* "
+if [[ "$args" == *' get namespace djinn '* ]]; then
+    cat "$FAKE_NAMESPACE_LABEL"
+elif [[ "$args" == *' get pods '* ]]; then
+    printf 'Running'
+fi
+EOF
+cat >"$GATE_BIN/helm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$GATE_BIN/kubectl" "$GATE_BIN/helm"
+
+run_gate_against_render() {
+    local name=$1 expectation=$2
+    shift 2
+    local dir="$WORK/gate-$name"
+    mkdir -p "$dir"
+    helm template djinn-inert-kueue-gate "$CHART_DIR" --is-upgrade "$@" >"$dir/render.yaml"
+    python3 - "$dir/render.yaml" >"$dir/namespace-label.txt" <<'PY'
+import sys
+import yaml
+
+docs = [doc for doc in yaml.safe_load_all(open(sys.argv[1], encoding="utf-8")) if doc]
+namespaces = [doc for doc in docs if doc.get("kind") == "Namespace"]
+assert len(namespaces) == 1, f"expected one Namespace, got {len(namespaces)}"
+label = namespaces[0].get("metadata", {}).get("labels", {}).get("djinn.io/kueue-managed", "")
+sys.stdout.write(str(label))
+PY
+    set +e
+    FAKE_NAMESPACE_LABEL="$dir/namespace-label.txt" \
+    KUBECTL="$GATE_BIN/kubectl" \
+    HELM="$GATE_BIN/helm" \
+    KUEUE_GATE_POLL_SECONDS=0 \
+        bash "$GATE" \
+            --context fake-disposable \
+            --designated-operator-secret fake-designated-operator \
+            --timeout-seconds 1 >"$dir/out" 2>&1
+    local status=$?
+    set -e
+    if [ "$expectation" = pass ] && [ "$status" -ne 0 ]; then
+        echo "FAIL: zero-capture gate rejected the $name render" >&2
+        cat "$dir/out" >&2
+        exit 1
+    fi
+    if [ "$expectation" = fail ] && [ "$status" -eq 0 ]; then
+        echo "FAIL: zero-capture gate accepted the $name render; it does not detect the armed state" >&2
+        cat "$dir/out" >&2
+        exit 1
+    fi
+}
+
+echo "=== zero-capture gate passes against the default render ==="
+run_gate_against_render default pass
+
+echo "=== zero-capture gate FAILS against an armed render ==="
+run_gate_against_render armed fail --set kueue.enabled=true --set kueue.armed=true
+grep -q 'djinn.io/kueue-managed=true' "$WORK/gate-armed/out" || {
+    echo "FAIL: the armed gate run failed for some other reason than capture:" >&2
+    cat "$WORK/gate-armed/out" >&2
+    exit 1
+}
 
 echo "=== All Kueue topology Helm render tests passed ==="

--- a/deploy/helm/djinn/values.schema.json
+++ b/deploy/helm/djinn/values.schema.json
@@ -41,10 +41,11 @@
     "kueue": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["enabled", "buildPods"],
+      "required": ["enabled", "buildPods", "armed"],
       "properties": {
         "enabled": { "type": "boolean" },
-        "buildPods": { "type": "integer", "minimum": 1 }
+        "buildPods": { "type": "integer", "minimum": 1 },
+        "armed": { "type": "boolean" }
       }
     },
     "logCollector": {

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -102,9 +102,37 @@ kueue:
   # value on a Kueue-less cluster fails the install loudly instead.
   #
   # Enabling it does NOT arm anything: no Job carries a queue name and no
-  # namespace is Kueue-managed. Arming belongs to cutover epic 4c9q.
+  # namespace is Kueue-managed. Arming is the separate `armed` flag below.
   enabled: false
   buildPods: 3
+
+  # Arm Kueue admission for build Jobs (cutover epic 4c9q, slice S1).
+  #
+  # This single value drives BOTH halves of the capture contract, and they can
+  # never be split onto separate flags:
+  #   1. the `djinn.io/kueue-managed` label on the Namespace
+  #      (templates/namespace.yaml) — Kueue captures Jobs ONLY in a namespace
+  #      carrying it;
+  #   2. `DJINN_KUEUE_ARMED` on djinn-server, which makes the task-run, warm and
+  #      standalone-SCIP renderers create their Jobs `suspend: true` with a
+  #      `kueue.x-k8s.io/queue-name` label.
+  #
+  # `suspend: true` is NOT inert. A suspended Job in an UNLABELLED namespace is
+  # never captured, so nothing ever unsuspends it and every build Job hangs
+  # forever. That is why both halves hang off this one value.
+  #
+  # INVARIANT: armed implies enabled. `armed: true` with `enabled: false` fails
+  # the render — arming with no ClusterQueue to admit into is the same hang.
+  #
+  # Related prerequisite that the chart cannot check for you: if you manage the
+  # namespace externally (`namespace.create: false`), the chart renders no
+  # Namespace object and therefore cannot apply the label. Label it yourself
+  # BEFORE arming, or every build Job hangs.
+  #
+  # Image builds stay deliberately unarmed at every value of this flag: an image
+  # build is an upstream dependency of a task-run, so sharing one ClusterQueue
+  # creates a priority-inversion deadlock.
+  armed: false
 
 # -----------------------------------------------------------------------------
 # Per-invocation CPU lease (cgroup launcher)

--- a/server/crates/djinn-image-controller/tests/unit.rs
+++ b/server/crates/djinn-image-controller/tests/unit.rs
@@ -95,37 +95,92 @@ fn build_job_labels_and_envs_match_plan() {
     );
 }
 
+/// An image build is an UPSTREAM DEPENDENCY of a task-run, so it must stay out
+/// of the shared ClusterQueue: a task-run holding a slot while the image build
+/// it is waiting on is queued behind it is a priority-inversion deadlock the
+/// current ledger cannot produce. Kueue cutover S1 therefore arms task-run, warm
+/// and SCIP only.
+///
+/// Parameterized over every combination of the two chart flags (`kueue.enabled`
+/// / `kueue.armed`, reaching this process only as `DJINN_KUEUE_*` env vars,
+/// since `ImageControllerConfig` deliberately has no Kueue field). Asserting the
+/// one default combination would pass even if `build_job.rs` started calling the
+/// shared `djinn_k8s` label helper.
 #[test]
 fn image_build_job_does_not_opt_into_kueue_build_object_admission() {
     const KUEUE_BUILD_OBJECT_LABEL: &str = "djinn.io/kueue-build-object";
+    const KUEUE_QUEUE_NAME_LABEL: &str = "kueue.x-k8s.io/queue-name";
+    const ARMED: &str = "DJINN_KUEUE_ARMED";
+    const ENABLED: &str = "DJINN_KUEUE_ENABLED";
 
-    let config = ImageControllerConfig::for_testing();
+    let restore_armed = std::env::var(ARMED).ok();
+    let restore_enabled = std::env::var(ENABLED).ok();
+
     let context = test_build_context();
-    let job = build_image_build_job(
-        &config,
-        &BuildSubject::project("proj-kueue-contract"),
-        "1a2b3c4d5e6f",
-        "registry.example/djinn-project-proj-kueue-contract:1a2b3c4d5e6f",
-        &context,
-    );
+    for enabled in ["false", "true"] {
+        for armed in ["false", "true"] {
+            // SAFETY: single-threaded within this test; no other test in this
+            // binary reads DJINN_KUEUE_*, and the pre-existing values are
+            // restored below.
+            unsafe {
+                std::env::set_var(ENABLED, enabled);
+                std::env::set_var(ARMED, armed);
+            }
 
-    assert!(
-        !job.metadata
-            .labels
-            .as_ref()
-            .and_then(|labels| labels.get(KUEUE_BUILD_OBJECT_LABEL))
-            .is_some_and(|value| value == "true"),
-        "image-build Job metadata must remain outside Kueue build-object admission",
-    );
-    assert!(
-        !job.spec
-            .as_ref()
-            .and_then(|spec| spec.template.metadata.as_ref())
-            .and_then(|metadata| metadata.labels.as_ref())
-            .and_then(|labels| labels.get(KUEUE_BUILD_OBJECT_LABEL))
-            .is_some_and(|value| value == "true"),
-        "image-build Pod-template metadata must remain outside Kueue build-object admission",
-    );
+            // `from_env`, not `for_testing`: a config constructor that ignored
+            // the environment would make the parameterization vacuous.
+            let config = ImageControllerConfig::from_env();
+            let job = build_image_build_job(
+                &config,
+                &BuildSubject::project("proj-kueue-contract"),
+                "1a2b3c4d5e6f",
+                "registry.example/djinn-project-proj-kueue-contract:1a2b3c4d5e6f",
+                &context,
+            );
+            let flags = format!("kueue.enabled={enabled} kueue.armed={armed}");
+
+            for (location, labels) in [
+                ("Job metadata", job.metadata.labels.as_ref()),
+                (
+                    "Pod-template metadata",
+                    job.spec
+                        .as_ref()
+                        .and_then(|spec| spec.template.metadata.as_ref())
+                        .and_then(|metadata| metadata.labels.as_ref()),
+                ),
+            ] {
+                let labels: &BTreeMap<String, String> =
+                    labels.expect("image-build Job renders labels at both locations");
+                assert!(
+                    !labels.contains_key(KUEUE_BUILD_OBJECT_LABEL),
+                    "image-build {location} must remain outside Kueue build-object admission at {flags}",
+                );
+                assert!(
+                    !labels.contains_key(KUEUE_QUEUE_NAME_LABEL),
+                    "image-build {location} must name no LocalQueue at {flags}",
+                );
+            }
+
+            // A suspended Job that no ClusterQueue will ever admit hangs forever.
+            assert_eq!(
+                job.spec.as_ref().and_then(|spec| spec.suspend),
+                None,
+                "image-build Job must never be created suspended at {flags}",
+            );
+        }
+    }
+
+    // SAFETY: see above; restores the ambient environment for the rest of the run.
+    unsafe {
+        match restore_armed {
+            Some(value) => std::env::set_var(ARMED, value),
+            None => std::env::remove_var(ARMED),
+        }
+        match restore_enabled {
+            Some(value) => std::env::set_var(ENABLED, value),
+            None => std::env::remove_var(ENABLED),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -323,6 +323,122 @@ pub struct KubernetesConfig {
     /// Activates the kubelet-delegated cgroup RuntimeClass for new task-run Pods.
     #[serde(default)]
     pub task_run_cgroup_writable_enabled: bool,
+    /// Opts task-run, warm and standalone-SCIP Jobs into Kueue admission.
+    ///
+    /// When true the renderers stamp `suspend: true`, the
+    /// `kueue.x-k8s.io/queue-name` LocalQueue selector and the
+    /// `djinn.io/kueue-build-object` marker onto BOTH the Job metadata and the
+    /// Pod template, so Kueue's Job webhook and Pod webhook both see them.
+    ///
+    /// DANGER: `suspend: true` is not inert. Kueue only captures Jobs in a
+    /// namespace labelled `djinn.io/kueue-managed`, so a suspended Job in an
+    /// unlabelled namespace is never admitted and hangs forever. The Helm chart
+    /// drives this field and that namespace label from the SAME value
+    /// (`kueue.armed`) for exactly that reason — never plumb them apart.
+    ///
+    /// Overridable via `DJINN_KUEUE_ARMED`; defaults to false.
+    #[serde(default)]
+    pub kueue_armed: bool,
+    /// Name prefix of the per-kind LocalQueues rendered by
+    /// `deploy/helm/djinn/templates/kueue-topology.yaml`.
+    ///
+    /// The chart names them `<djinn.fullname>-task-run` / `-warm` / `-scip`, and
+    /// `djinn.fullname` depends on the Helm release name — so the value cannot be
+    /// hard-coded here without risking a `queue-name` that resolves to no
+    /// LocalQueue, which (once armed) means the Job is never admitted.
+    ///
+    /// Overridable via `DJINN_KUEUE_LOCAL_QUEUE_PREFIX`. Only read when
+    /// [`Self::kueue_armed`] is true.
+    #[serde(default = "default_kueue_local_queue_prefix")]
+    pub kueue_local_queue_prefix: String,
+}
+
+fn default_kueue_local_queue_prefix() -> String {
+    "djinn".into()
+}
+
+/// Kueue's LocalQueue selector. Kueue's Job webhook reads it from the Job, and
+/// its Pod webhook reads it from the Pod — hence both label locations.
+pub const LABEL_KUEUE_QUEUE_NAME: &str = "kueue.x-k8s.io/queue-name";
+
+/// Djinn's own marker for "this object is admitted through Kueue". Used by the
+/// chart contracts and by `tests/kueue_build_object_labels.rs` to tell an armed
+/// build object apart from a control-plane workload.
+pub const LABEL_KUEUE_BUILD_OBJECT: &str = "djinn.io/kueue-build-object";
+
+/// The Job kinds that participate in Kueue admission.
+///
+/// There is deliberately NO image-build variant. An image build is an upstream
+/// dependency of a task-run, so sharing one ClusterQueue would let a task-run
+/// hold slots while waiting for the image build queued behind it — a
+/// priority inversion the current ledger cannot produce. Keeping the variant
+/// absent makes that mistake a compile error rather than a review catch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KueueQueueKind {
+    /// Per-task-run worker Job.
+    TaskRun,
+    /// Graph-warm Job.
+    Warm,
+    /// Standalone SCIP index Job.
+    Scip,
+}
+
+impl KueueQueueKind {
+    /// Suffix of the LocalQueue this kind is admitted through. Must match the
+    /// LocalQueue names in `deploy/helm/djinn/templates/kueue-topology.yaml`.
+    #[must_use]
+    pub const fn local_queue_suffix(self) -> &'static str {
+        match self {
+            Self::TaskRun => "task-run",
+            Self::Warm => "warm",
+            Self::Scip => "scip",
+        }
+    }
+}
+
+impl KubernetesConfig {
+    /// Name of the LocalQueue `kind` is admitted through.
+    #[must_use]
+    pub fn kueue_local_queue_name(&self, kind: KueueQueueKind) -> String {
+        format!(
+            "{}-{}",
+            self.kueue_local_queue_prefix,
+            kind.local_queue_suffix()
+        )
+    }
+
+    /// `JobSpec::suspend` for a build Job of `kind`.
+    ///
+    /// `None` when disarmed so the rendered Job is byte-identical to the
+    /// pre-cutover shape — an explicit `Some(false)` would serialize a
+    /// `suspend: false` key that was never there before.
+    #[must_use]
+    pub fn kueue_job_suspend(&self) -> Option<bool> {
+        self.kueue_armed.then_some(true)
+    }
+
+    /// Stamp the Kueue admission labels for `kind` into `labels` when armed, and
+    /// do nothing at all when disarmed.
+    ///
+    /// Call this from each renderer's `job_labels()` — the single map that is
+    /// cloned into BOTH `Job.metadata.labels` and
+    /// `Job.spec.template.metadata.labels`. Stamping after the fact (the
+    /// `stamp_admission_identity` pattern in `graph_warmer_identity.rs`) reaches
+    /// only the Job metadata and silently misses Kueue's Pod webhook.
+    pub fn apply_kueue_build_object_labels(
+        &self,
+        kind: KueueQueueKind,
+        labels: &mut BTreeMap<String, String>,
+    ) {
+        if !self.kueue_armed {
+            return;
+        }
+        labels.insert(LABEL_KUEUE_BUILD_OBJECT.to_string(), "true".to_string());
+        labels.insert(
+            LABEL_KUEUE_QUEUE_NAME.to_string(),
+            self.kueue_local_queue_name(kind),
+        );
+    }
 }
 
 impl KubernetesConfig {
@@ -398,6 +514,11 @@ impl KubernetesConfig {
             // Production task-runs require the launcher and use fresh invocation leaves.
             cgroup_launcher_mode: CgroupLauncherMode::Required,
             task_run_cgroup_writable_enabled: true,
+            // Kueue arming is OFF until the cutover epic 4c9q flips it. See the
+            // field doc: arming without the `djinn.io/kueue-managed` namespace
+            // label hangs every build Job.
+            kueue_armed: false,
+            kueue_local_queue_prefix: default_kueue_local_queue_prefix(),
             // Unbounded by default: per-project build_resources overrides are
             // gated only by request <= limit until an operator configures the
             // per-kind DJINN_K8S_{TASK,WARM}_{CPU,MEMORY}_{MIN,MAX} envs.
@@ -452,6 +573,8 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_CGROUP_DELEGATION_PROFILE` | `cgroup_delegation_profile` | `cgroup-v2-cpu-only` |
     /// | `DJINN_K8S_VOLUME_OWNERSHIP_MODE` | `volume_ownership_mode` | `fsgroup-on-root-mismatch` |
     /// | `DJINN_K8S_CGROUP_LAUNCHER_MODE` | `cgroup_launcher_mode` | `required` |
+    /// | `DJINN_KUEUE_ARMED` | `kueue_armed` | `false` — the Kueue arming switch |
+    /// | `DJINN_KUEUE_LOCAL_QUEUE_PREFIX` | `kueue_local_queue_prefix` | `djinn` |
     ///
     /// `DJINN_DATABASE_URL` is read from djinn-server's own environment (the
     /// Helm chart projects it via `envFrom: configMap djinn-config`) and
@@ -673,6 +796,22 @@ impl KubernetesConfig {
                     tracing::warn!(value = %v, %error, "DJINN_K8S_TASK_RUN_CGROUP_WRITABLE_ENABLED is not a boolean — keeping disabled")
                 }
             }
+        }
+        // Kueue arming. Deliberately NOT `DJINN_K8S_*`-prefixed: it is one half
+        // of a chart-level contract with the `djinn.io/kueue-managed` namespace
+        // label, both driven by `kueue.armed` in values.yaml.
+        if let Ok(v) = std::env::var("DJINN_KUEUE_ARMED") {
+            match v.parse::<bool>() {
+                Ok(armed) => cfg.kueue_armed = armed,
+                Err(error) => {
+                    tracing::warn!(value = %v, %error, "DJINN_KUEUE_ARMED is not a boolean — keeping Kueue disarmed")
+                }
+            }
+        }
+        if let Ok(v) = std::env::var("DJINN_KUEUE_LOCAL_QUEUE_PREFIX")
+            && !v.is_empty()
+        {
+            cfg.kueue_local_queue_prefix = v;
         }
         // Per-project build_resources hard bounds (per Pod kind, per resource).
         // Unset leaves the axis unbounded. Empty strings are ignored so an

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -242,7 +242,7 @@ pub fn build_task_run_job(
         "required cgroup launcher requires runtimeClassName: djinn-cgroup-writable"
     );
     let task_run_id_str = task_run_id.to_string();
-    let labels = job_labels(&task_run_id_str);
+    let labels = job_labels(config, &task_run_id_str);
     let job_name = format!("djinn-taskrun-{task_run_id}");
     let role_class = RoleResourceClass::for_role(role);
 
@@ -623,6 +623,10 @@ pub fn build_task_run_job(
         spec: Some(JobSpec {
             template,
             backoff_limit: Some(0),
+            // Kueue create-then-admit: armed Jobs are created suspended and
+            // unsuspended by Kueue once the ClusterQueue admits their Workload.
+            // `None` when disarmed — see `KubernetesConfig::kueue_job_suspend`.
+            suspend: config.kueue_job_suspend(),
             // Static failed-job safety net. The coordinator may delete known
             // successes earlier, but this must never become a configurable
             // short retention policy for unknown or failed outcomes.
@@ -701,13 +705,17 @@ pub fn build_task_run_job_with_read_sources(
     job
 }
 
-fn job_labels(task_run_id: &str) -> BTreeMap<String, String> {
+fn job_labels(config: &KubernetesConfig, task_run_id: &str) -> BTreeMap<String, String> {
     let mut labels = BTreeMap::new();
     labels.insert(LABEL_TASK_RUN_ID.to_string(), task_run_id.to_string());
     labels.insert(
         LABEL_COMPONENT.to_string(),
         COMPONENT_TASK_RUN_WORKER.to_string(),
     );
+    // Stamped HERE, in the one map the caller clones into both the Job metadata
+    // and the Pod template, so Kueue's Job webhook and Pod webhook both see it.
+    // No-op unless `config.kueue_armed`.
+    config.apply_kueue_build_object_labels(crate::config::KueueQueueKind::TaskRun, &mut labels);
     labels
 }
 

--- a/server/crates/djinn-k8s/src/scip_job.rs
+++ b/server/crates/djinn-k8s/src/scip_job.rs
@@ -193,15 +193,21 @@ pub fn scip_index_job_name(project_id: &str, revision: &str) -> String {
 }
 
 /// Labels every SCIP-index resource carries.
-fn job_labels(project_id: &str) -> BTreeMap<String, String> {
-    BTreeMap::from([
+fn job_labels(config: &KubernetesConfig, project_id: &str) -> BTreeMap<String, String> {
+    let mut labels = BTreeMap::from([
         (LABEL_COMPONENT.into(), COMPONENT_SCIP_INDEX.into()),
         (LABEL_SCIP_INDEX.into(), "true".into()),
         (LABEL_PROJECT_ID.into(), sanitize_id(project_id)),
         // 8ixk: this Job takes no build lease, so this label is the ONLY thing
         // that makes its CPU visible to the capacity derivation.
         (LABEL_CAPACITY_RESERVED.into(), "true".into()),
-    ])
+    ]);
+    // SCIP joins Kueue: rust-analyzer indexing is genuinely CPU-heavy, so
+    // excluding it would make the ClusterQueue under-count the very load the
+    // quota exists to bound. Stamped into the one map cloned into both the Job
+    // metadata and the Pod template. No-op unless `config.kueue_armed`.
+    config.apply_kueue_build_object_labels(crate::config::KueueQueueKind::Scip, &mut labels);
+    labels
 }
 
 fn env_var(name: &str, value: &str) -> EnvVar {
@@ -231,7 +237,7 @@ pub fn build_scip_index_job(
 ) -> Job {
     let sanitized_project = sanitize_id(project_id);
     let job_name = scip_index_job_name(project_id, revision);
-    let labels = job_labels(project_id);
+    let labels = job_labels(config, project_id);
     let annotations =
         BTreeMap::from([(ANNOTATION_SCIP_REVISION.to_string(), revision.to_string())]);
 
@@ -435,6 +441,9 @@ exec {bin} scip-index "{project_id}"
                 spec: Some(pod_spec),
             },
             backoff_limit: Some(0),
+            // Kueue create-then-admit; `None` when disarmed. See
+            // `KubernetesConfig::kueue_job_suspend`.
+            suspend: config.kueue_job_suspend(),
             // Retained deliberately longer than the index interval: the
             // retained succeeded-Job inventory IS the change-detection ledger
             // read by [`crate::scip_schedule`]. See

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -115,7 +115,7 @@ pub fn build_warm_job(
     let suffix = Uuid::now_v7();
     let sanitized_project = sanitize_id(project_id);
     let job_name = format!("djinn-warm-{}-{}", sanitized_project, short_uuid(&suffix));
-    let labels = job_labels(project_id);
+    let labels = job_labels(config, project_id);
 
     let project_root = format!("{WORKSPACE_MOUNT_DIR}/{sanitized_project}");
     let mirror_path = format!("{MIRROR_MOUNT_DIR}/{project_id}.git");
@@ -391,6 +391,9 @@ exec {bin} warm-graph "{project_id}"
         spec: Some(JobSpec {
             template,
             backoff_limit: Some(0),
+            // Kueue create-then-admit; `None` when disarmed. See
+            // `KubernetesConfig::kueue_job_suspend`.
+            suspend: config.kueue_job_suspend(),
             ttl_seconds_after_finished: Some(config.warm_job_ttl_seconds),
             // Deadline margin: this ONE deadline covers both halves of the warm
             // Pod's work — `warm_cargo_target_base`'s single default-features
@@ -527,11 +530,16 @@ done"#,
     }
 }
 
-fn job_labels(project_id: &str) -> BTreeMap<String, String> {
+fn job_labels(config: &KubernetesConfig, project_id: &str) -> BTreeMap<String, String> {
     let mut labels = BTreeMap::new();
     labels.insert(LABEL_COMPONENT.into(), COMPONENT_GRAPH_WARM.into());
     labels.insert(LABEL_WARM.into(), "true".into());
     labels.insert(LABEL_PROJECT_ID.into(), sanitize_id(project_id));
+    // Stamped HERE rather than post-render. `stamp_admission_identity`
+    // (`graph_warmer_identity.rs:108`) mutates ONLY `job.metadata.labels`;
+    // following that pattern would leave the Pod template unlabelled and Kueue's
+    // Pod webhook blind. This map is cloned into both locations.
+    config.apply_kueue_build_object_labels(crate::config::KueueQueueKind::Warm, &mut labels);
     labels
 }
 

--- a/server/crates/djinn-k8s/tests/kueue_build_object_labels.rs
+++ b/server/crates/djinn-k8s/tests/kueue_build_object_labels.rs
@@ -1,10 +1,19 @@
-//! Regression contract for the inert Kueue prerequisite release.
+//! Arming contract for the Kueue cutover (epic 4c9q, slice S1).
 //!
-//! These are the real current Job renderers, not copied label maps.  The later
-//! Kueue cutover owns opting build objects in, so this release must not render
-//! `djinn.io/kueue-build-object=true` on either the Job or its Pod template.
+//! These are the real current Job renderers, not copied label maps.
+//!
+//! Two halves:
+//!
+//! * `kueue_armed = false` (the shipped default) must reproduce the
+//!   pre-cutover Job byte-for-byte: no `suspend`, no `kueue.x-k8s.io/queue-name`
+//!   and no `djinn.io/kueue-build-object`, anywhere in the serialized object.
+//! * `kueue_armed = true` must stamp all three onto BOTH `/metadata/labels` and
+//!   `/spec/template/metadata/labels` — Kueue runs a Job webhook that reads the
+//!   first and a Pod webhook that reads the second, and a post-render stamp that
+//!   touches only the Job metadata (the `stamp_admission_identity` pattern in
+//!   `graph_warmer_identity.rs:108`) silently satisfies half of that.
 
-use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::config::{KubernetesConfig, LABEL_KUEUE_BUILD_OBJECT, LABEL_KUEUE_QUEUE_NAME};
 use djinn_k8s::job::build_task_run_job;
 use djinn_k8s::{build_scip_index_job, build_warm_job};
 use k8s_openapi::api::batch::v1::Job;
@@ -38,11 +47,68 @@ fn assert_not_a_kueue_build_object(name: &str, job: &Job) {
     );
 }
 
-#[test]
-fn current_job_builders_do_not_opt_into_kueue_build_object_admission() {
+// ---------------------------------------------------------------------------
+// Whole-document sweep
+// ---------------------------------------------------------------------------
+
+/// Every JSON path in `value` whose key or string value mentions Kueue, plus
+/// `suspend` wherever it appears.
+///
+/// Deliberately broader than [`reserved_label_locations`]: the disarmed
+/// renderers must be byte-identical to the pre-cutover shape, so ANY new
+/// Kueue-flavoured key, annotation, selector or `suspend` field is a
+/// violation — not just the two label maps Kueue's webhooks read.
+fn kueue_traces(value: &Value, path: &str, found: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                let child_path = format!("{path}/{key}");
+                if key == "suspend" || key.contains("kueue") {
+                    found.push(format!("{child_path} = {child}"));
+                }
+                kueue_traces(child, &child_path, found);
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                kueue_traces(child, &format!("{path}/{index}"), found);
+            }
+        }
+        Value::String(text) if text.contains("kueue") => {
+            found.push(format!("{path} = {text}"));
+        }
+        _ => {}
+    }
+}
+
+fn kueue_surface(job: &Job) -> Vec<String> {
+    let rendered = serde_json::to_value(job).expect("Job serializes");
+    let mut found = Vec::new();
+    kueue_traces(&rendered, "", &mut found);
+    found.sort();
+    found
+}
+
+fn disarmed_config() -> KubernetesConfig {
     let config = KubernetesConfig::for_testing();
-    let task_run = build_task_run_job(
-        &config,
+    assert!(
+        !config.kueue_armed,
+        "kueue_armed must default to false; the disarmed half of this contract is vacuous otherwise"
+    );
+    config
+}
+
+fn armed_config() -> KubernetesConfig {
+    KubernetesConfig {
+        kueue_armed: true,
+        kueue_local_queue_prefix: "release-djinn".into(),
+        ..KubernetesConfig::for_testing()
+    }
+}
+
+fn task_run_job(config: &KubernetesConfig) -> Job {
+    build_task_run_job(
+        config,
         &Uuid::nil(),
         "project-id",
         "task-run-secret",
@@ -51,25 +117,182 @@ fn current_job_builders_do_not_opt_into_kueue_build_object_admission() {
         None,
         false,
         None,
-    );
-    let warm = build_warm_job(
-        &config,
+    )
+}
+
+fn warm_job(config: &KubernetesConfig) -> Job {
+    build_warm_job(
+        config,
         "project-id",
         "registry.example/project:current",
         None,
-    );
-    let scip = build_scip_index_job(
-        &config,
+    )
+}
+
+fn scip_job(config: &KubernetesConfig) -> Job {
+    build_scip_index_job(
+        config,
         "project-id",
         "registry.example/project:current",
         "deadbeef1234567890",
         None,
-    );
-
-    assert_not_a_kueue_build_object("task-run Job", &task_run);
-    assert_not_a_kueue_build_object("warm Job", &warm);
-    assert_not_a_kueue_build_object("standalone SCIP Job", &scip);
+    )
 }
+
+// ---------------------------------------------------------------------------
+// Disarmed (the shipped default)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn current_job_builders_do_not_opt_into_kueue_build_object_admission() {
+    let config = disarmed_config();
+
+    assert_not_a_kueue_build_object("task-run Job", &task_run_job(&config));
+    assert_not_a_kueue_build_object("warm Job", &warm_job(&config));
+    assert_not_a_kueue_build_object("standalone SCIP Job", &scip_job(&config));
+}
+
+#[test]
+fn disarmed_renderers_carry_no_suspend_and_no_kueue_surface_at_all() {
+    let config = disarmed_config();
+
+    for (name, job) in [
+        ("task-run Job", task_run_job(&config)),
+        ("warm Job", warm_job(&config)),
+        ("standalone SCIP Job", scip_job(&config)),
+    ] {
+        assert_eq!(
+            kueue_surface(&job),
+            Vec::<String>::new(),
+            "{name} must be byte-identical to the pre-cutover shape when disarmed",
+        );
+    }
+}
+
+/// Non-vacuity for [`kueue_surface`]: a neutered sweep that always returned an
+/// empty vector would pass the test above forever.
+#[test]
+fn kueue_surface_sweep_finds_the_armed_shape() {
+    let armed = kueue_surface(&task_run_job(&armed_config()));
+
+    assert!(
+        armed.iter().any(|entry| entry == "/spec/suspend = true"),
+        "sweep must observe the armed suspend field, got {armed:?}",
+    );
+    assert!(
+        armed
+            .iter()
+            .filter(|entry| entry.contains(LABEL_KUEUE_QUEUE_NAME))
+            .count()
+            >= 2,
+        "sweep must observe the queue-name label at both label locations, got {armed:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Armed
+// ---------------------------------------------------------------------------
+
+/// Assert the Kueue opt-in at BOTH label locations explicitly, by JSON pointer.
+///
+/// Asserting only `job.metadata.labels` would pass against a post-render stamp
+/// that misses Kueue's Pod webhook, which is the precise defect this checks for.
+fn assert_kueue_labels_at_both_locations(name: &str, job: &Job, expected_queue: &str) {
+    let rendered = serde_json::to_value(job).expect("Job serializes");
+    for pointer in ["/metadata/labels", "/spec/template/metadata/labels"] {
+        let labels = rendered
+            .pointer(pointer)
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| panic!("{name} has no labels at {pointer}"));
+        assert_eq!(
+            labels.get(LABEL_KUEUE_BUILD_OBJECT).and_then(Value::as_str),
+            Some("true"),
+            "{name} must carry the build-object label at {pointer}",
+        );
+        assert_eq!(
+            labels.get(LABEL_KUEUE_QUEUE_NAME).and_then(Value::as_str),
+            Some(expected_queue),
+            "{name} must target its own LocalQueue at {pointer}",
+        );
+    }
+    assert_eq!(
+        rendered.pointer("/spec/suspend"),
+        Some(&Value::Bool(true)),
+        "{name} must be created suspended so Kueue owns the admission decision",
+    );
+}
+
+#[test]
+fn armed_renderers_opt_into_kueue_at_both_label_locations() {
+    let config = armed_config();
+
+    assert_kueue_labels_at_both_locations(
+        "task-run Job",
+        &task_run_job(&config),
+        "release-djinn-task-run",
+    );
+    assert_kueue_labels_at_both_locations("warm Job", &warm_job(&config), "release-djinn-warm");
+    assert_kueue_labels_at_both_locations(
+        "standalone SCIP Job",
+        &scip_job(&config),
+        "release-djinn-scip",
+    );
+}
+
+/// The three kinds must land in three DIFFERENT LocalQueues. A helper that
+/// returned one constant queue name would satisfy every per-kind assertion
+/// above if each were read in isolation.
+#[test]
+fn armed_renderers_use_three_distinct_local_queues() {
+    let config = armed_config();
+
+    let queue_of = |job: &Job| {
+        job.metadata
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.get(LABEL_KUEUE_QUEUE_NAME))
+            .cloned()
+            .expect("armed Job carries a queue-name label")
+    };
+
+    let queues = [
+        queue_of(&task_run_job(&config)),
+        queue_of(&warm_job(&config)),
+        queue_of(&scip_job(&config)),
+    ];
+    let unique: std::collections::BTreeSet<_> = queues.iter().collect();
+    assert_eq!(
+        unique.len(),
+        3,
+        "task-run, warm and SCIP must use distinct LocalQueues, got {queues:?}",
+    );
+}
+
+/// The queue name must follow the chart's `<djinn.fullname>-<kind>` LocalQueue
+/// naming, or an armed Job names a LocalQueue that does not exist and is never
+/// admitted — i.e. hangs forever.
+#[test]
+fn local_queue_prefix_is_configurable_and_not_hard_coded() {
+    let config = KubernetesConfig {
+        kueue_armed: true,
+        kueue_local_queue_prefix: "some-other-release".into(),
+        ..KubernetesConfig::for_testing()
+    };
+
+    assert_eq!(
+        task_run_job(&config)
+            .metadata
+            .labels
+            .expect("labels")
+            .get(LABEL_KUEUE_QUEUE_NAME)
+            .map(String::as_str),
+        Some("some-other-release-task-run"),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scanner self-test — retained verbatim from the inert-release contract.
+// ---------------------------------------------------------------------------
 
 #[test]
 fn label_scanner_rejects_explicit_job_and_pod_template_fixtures() {


### PR DESCRIPTION
Implements board task `jxbt` — **Kueue cutover S1: arm-gated opt-in across all four Job renderers** (epic `4c9q`, proposal `9oga`).

Ships with `kueue.armed=false`. **Nothing is armed in production by this slice.**

## Two flags, not one

| flag | default | drives |
|---|---|---|
| `kueue.enabled` (existing) | `false` | the ResourceFlavor / ClusterQueue / LocalQueue topology. **Semantics unchanged.** |
| `kueue.armed` (**new**) | `false` | the `djinn.io/kueue-managed` Namespace label **and** `suspend: true` + `kueue.x-k8s.io/queue-name` + `djinn.io/kueue-build-object` on task-run, warm and standalone-SCIP Jobs, via `DJINN_KUEUE_ARMED` → `KubernetesConfig::kueue_armed`. |

`suspend: true` is **not** inert. Kueue captures Jobs only in a namespace carrying `djinn.io/kueue-managed`, so a suspended Job in an unlabelled namespace is never captured, nothing ever unsuspends it, and every build Job hangs forever. Both halves therefore hang off one value and can never ship on independent code paths.

**Invariant: armed implies enabled.** `armed=true, enabled=false` fails the render with a message naming the invariant.

Keeping them separate preserves the state epic `w177` exists to provide — Kueue installed, topology rendered, nothing captured — which is exactly what `deploy/kueue/zero-capture-gate.sh` verifies. Collapsing them would make that state unrepresentable.

## Renderers

The Kueue labels are stamped **inside each `job_labels()`** — the one map cloned into both `Job.metadata.labels` and `Job.spec.template.metadata.labels` — so Kueue's Job webhook and Pod webhook are covered by construction. A post-render stamp (the `stamp_admission_identity` pattern at `graph_warmer_identity.rs:108`) would reach only the Job metadata.

## Queue topology

- Adds a **`-scip` LocalQueue**: rust-analyzer indexing is CPU-heavy, and excluding it would under-count the very load the quota exists to bound.
- **Image build stays deliberately unlabelled** at every combination of the two flags. It is an upstream dependency of a task-run, so a shared ClusterQueue admits a priority-inversion deadlock (task-run holds slots waiting on its image; the image build is queued behind it).
- `queueingStrategy` flips **StrictFIFO → BestEffortFIFO**: three kinds in a 3-slot queue makes head-of-line blocking likely.

## RuntimeClass stacking

`djinn-k8s/src/job.rs:242` is an `assert!` — a coordinator **panic**, not a graceful fail-close. Arming Kueue on top of a required cgroup launcher without `cgroupWritable.taskRuns.enabled` stacks two fail-closed gates and wedges all dispatch (v0.7.25, and again on 2026-07-30). `deployment-server.yaml` now mirrors that assertion as a Helm-render-time `fail()`, so the collision surfaces at `helm template`.

## Acceptance criteria and their non-vacuity proofs

1. **Disarmed renderers are byte-identical to `origin/main`, at both values of `kueue.enabled`.** `disarmed_renderers_carry_no_suspend_and_no_kueue_surface_at_all` runs a recursive sweep over the whole serialized Job for any key/value mentioning `kueue` plus any `suspend` field, on all three djinn-k8s renderers — strictly broader than the two label pointers. *Non-vacuity:* `kueue_surface_sweep_finds_the_armed_shape` proves the sweep finds `/spec/suspend = true` and ≥2 queue-name hits on an armed Job, and `label_scanner_rejects_explicit_job_and_pod_template_fixtures` is **retained verbatim**. The `kueue.enabled` half is asserted in the chart contract (`assert_disarmed_server` on both the default and `kueue.enabled=true` renders: Namespace unlabelled **and** `DJINN_KUEUE_ARMED=false`).
2. **Armed renderers carry `suspend: true` + build-object label at BOTH label locations plus a kind-appropriate queue-name.** `assert_kueue_labels_at_both_locations` asserts the JSON pointers `/metadata/labels` **and** `/spec/template/metadata/labels` explicitly, per kind. *Non-vacuity:* asserting only `job.metadata.labels` would pass against the `stamp_admission_identity` pattern; the Pod-template pointer is what rejects it. `armed_renderers_use_three_distinct_local_queues` additionally rejects a helper returning one constant queue name.
3. **`armed=true, enabled=false` fails naming the invariant; `enabled=true, armed=false` renders the full topology with an unlabelled Namespace.** The rejection is grepped for the literal string `kueue.armed=true requires kueue.enabled=true`, so an unrelated render error cannot satisfy it. *Non-vacuity:* the zero-capture-representable state is asserted positively in the same script — full topology present **and** `djinn.io/kueue-managed` absent.
4. **Image build carries neither label at either location at every flag combination.** `unit.rs`'s retained gate now loops over all four combinations of `DJINN_KUEUE_ENABLED` × `DJINN_KUEUE_ARMED`, building through `ImageControllerConfig::from_env()` (not `for_testing()`, which would ignore the environment and make the parameterization vacuous), and also asserts `spec.suspend` stays `None`. *Non-vacuity:* `KueueQueueKind` has no image-build variant, so a shared helper leaking into `build_job.rs` cannot even name a queue — and if it stamped the label anyway, all four iterations fail.
5. **Namespace label IFF `kueue.armed`; exactly three LocalQueues, BestEffortFIFO.** `assert_topology` takes an `expected_managed` yes/no argument and is called in **both** directions (`armed=false` → label absent, `armed=true` → label `"true"`), so neither branch can rot into a tautology. LocalQueue set equality is asserted (`== {task-run, warm, scip}`), so a fourth queue is a failure, not an addition.
6. **`--set kueue.armed=true` fails when the cgroup launcher requires an unenabled RuntimeClass.** Asserted with the `expect_rejected` idiom and grepped for the literal renderer message `required cgroup launcher requires runtimeClassName: djinn-cgroup-writable`. *Non-vacuity:* the **same values** with `kueue.armed=false` are then rendered and passed through the full `assert_topology`, so the failure cannot be an unrelated chart error that would reject either way.
7. **`kueue.armed` ships false, and the zero-capture gate discriminates.** The contract runs the **real** `deploy/kueue/zero-capture-gate.sh` with a fake `kubectl` whose namespace answer is extracted from a **real `helm template`** of this chart. Default render → gate **passes**; `--set kueue.enabled=true --set kueue.armed=true` → gate **fails**, and the failure output is grepped for `djinn.io/kueue-managed=true` so it cannot pass for an unrelated reason. Plus a direct assertion that `values.yaml` ships `kueue.armed: false`.

## Beyond the letter of the ACs

- `DJINN_KUEUE_LOCAL_QUEUE_PREFIX` is rendered from `djinn.fullname`. A hard-coded prefix would emit a `queue-name` naming a non-existent LocalQueue on any release whose fullname is not `djinn` — once armed, that is the same hang the task warns about.
- `kueue-build-object-labels.sh` (the control-plane gate the task says to leave inverted) is **not** inverted; it now additionally runs its unchanged scanner against an **armed** render, so a shared label helper leaking into the server Deployment is caught.
- `values.yaml` documents the one prerequisite the chart cannot check: with `namespace.create: false` the chart renders no Namespace and therefore cannot apply the label. This is deliberately documentation rather than a `fail()` — an operator who manages the namespace externally has no escape hatch from a hard failure.

## Verification

- `cargo test -p djinn-k8s -p djinn-image-controller` — all green (90 + 287 + 4 + …).
- `cargo clippy -p djinn-k8s -p djinn-image-controller --all-targets -- -D warnings` — clean.
- `cargo check --workspace --all-targets` — clean.
- `scripts/test-helm-chart-contracts.sh` — 15/17 pass. The 2 failures (`incident-observability-contract.sh`, `log-collector-contract.sh`) are the pre-existing `FAIL: vector is required to execute VRL fixtures` baseline, confirmed identical on `origin/main` and unrelated to this change.
- No sqlx query changes, so no `make sqlx-prepare` was needed.

Do **not** merge or enqueue — S2 (`37yq`) lands on the same renderer files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
