### PR TITLE
fix(kueue): gate arming on a namespace the label can actually reach (xbrl)

### DIFF
--- a/deploy/helm/djinn/templates/namespace.yaml
+++ b/deploy/helm/djinn/templates/namespace.yaml
@@ -1,3 +1,22 @@
+{{- /*
+Arming requires a namespace this chart can actually label.
+
+This gate lives OUTSIDE the `namespace.create` conditional on purpose: it has to
+fire in exactly the case where this template renders nothing at all. Helm
+executes every template regardless of whether it produces output, so a `fail`
+here still aborts the render (and still fires under `--show-only`, which filters
+AFTER rendering).
+
+The sibling arming invariants — armed implies enabled, and the RuntimeClass
+stacking check — live in templates/deployment-server.yaml. This one lives here
+because it is a fact about the Namespace object this template does or does not
+render.
+*/ -}}
+{{- if and .Values.kueue.armed (not .Values.namespace.create) -}}
+  {{- if not .Values.kueue.namespaceLabelledExternally -}}
+    {{- fail "kueue.armed=true with namespace.create=false cannot label the namespace: the chart renders no Namespace object, so it cannot apply djinn.io/kueue-managed, and Kueue captures Jobs ONLY in a namespace carrying that label. Arming anyway stamps `suspend: true` onto every task-run, warm and standalone-SCIP Job in a namespace nothing is watching, so nothing ever unsuspends them and every build Job hangs forever. Either set namespace.create=true, or label the namespace yourself (`kubectl label namespace <ns> djinn.io/kueue-managed=true`) and set kueue.namespaceLabelledExternally=true to acknowledge it. That acknowledgement is an unverified claim at render time; djinn-server re-checks it against the live namespace at startup and disarms itself if the label is missing." -}}
+  {{- end -}}
+{{- end -}}
 {{- if .Values.namespace.create -}}
 apiVersion: v1
 kind: Namespace

--- a/deploy/helm/djinn/templates/role-controller.yaml
+++ b/deploy/helm/djinn/templates/role-controller.yaml
@@ -41,3 +41,19 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch"]
+  # The Kueue arming preflight reads THIS namespace back at startup to confirm
+  # it really carries `djinn.io/kueue-managed` before any renderer stamps
+  # `suspend: true` onto a build Job
+  # (server/crates/djinn-k8s/src/kueue_preflight.rs).
+  #
+  # Namespaces are cluster-scoped, but the apiserver derives the request's
+  # namespace attribute from the object name for `GET /api/v1/namespaces/<name>`,
+  # so this NAMESPACED rule authorizes reading this namespace and nothing else.
+  # Verified against a real apiserver (kind, k8s v1.34): with only this rule, GET
+  # of the own namespace returns 200 while GET of another namespace and LIST
+  # namespaces both return 403. That is why the preflight needs no ClusterRole,
+  # and TokenReview (role-tokenreview.yaml) remains the server's only
+  # cluster-wide permission.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]

--- a/deploy/helm/djinn/tests/kueue-topology-render.sh
+++ b/deploy/helm/djinn/tests/kueue-topology-render.sh
@@ -253,6 +253,35 @@ assert values["DJINN_KUEUE_ARMED"] == "false", (
 PY
 }
 
+# Same assertion for an externally-managed namespace, where there is no
+# Namespace object to check at all.
+assert_disarmed_server_no_namespace() {
+    local manifest=$1 label=$2
+    python3 - "$manifest" "$label" <<'PY'
+import sys
+import yaml
+
+manifest, label = sys.argv[1:]
+docs = [doc for doc in yaml.safe_load_all(open(manifest, encoding="utf-8")) if doc]
+
+assert not [doc for doc in docs if doc.get("kind") == "Namespace"], (
+    f"{label}: namespace.create=false must render no Namespace object"
+)
+server = next(
+    container
+    for doc in docs
+    if doc.get("kind") == "Deployment"
+    and doc.get("metadata", {}).get("name", "").endswith("-server")
+    for container in doc["spec"]["template"]["spec"]["containers"]
+    if container["name"] == "djinn-server"
+)
+values = {entry["name"]: entry.get("value") for entry in server["env"]}
+assert values["DJINN_KUEUE_ARMED"] == "false", (
+    f"{label}: expected a disarmed server, got {values.get('DJINN_KUEUE_ARMED')!r}"
+)
+PY
+}
+
 echo "=== kueue.enabled alone arms nothing, at BOTH of its values ==="
 assert_disarmed_server "$WORK/default.yaml" "kueue.enabled=false"
 assert_disarmed_server "$WORK/valid.yaml" "kueue.enabled=true"
@@ -294,6 +323,141 @@ grep -q 'required cgroup launcher requires runtimeClassName: djinn-cgroup-writab
 # cannot be an unrelated chart error that would reject either way.
 render "$WORK/disarmed-runtimeclass.yaml" "${RUNTIME_CLASS_VALUES[@]}" --set kueue.armed=false
 assert_topology "$WORK/disarmed-runtimeclass.yaml" 3 no
+
+# ---------------------------------------------------------------------------
+# Arming requires a namespace the chart can actually label.
+#
+# `namespace.create: false` renders no Namespace object, so the chart CANNOT
+# apply djinn.io/kueue-managed while still setting DJINN_KUEUE_ARMED. Every
+# build Job would render `suspend: true` into a namespace Kueue does not manage,
+# nothing would capture them, and nothing would ever unsuspend them. That is the
+# exact failure the one-flag design exists to prevent, reachable through a values
+# combination the chart used to accept in silence.
+# ---------------------------------------------------------------------------
+echo "=== armed=true with namespace.create=false is rejected by name ==="
+if render_capture "$WORK/armed-external-ns.out" \
+    --set kueue.enabled=true --set kueue.armed=true --set namespace.create=false; then
+    echo "FAIL: kueue.armed=true with namespace.create=false rendered successfully" >&2
+    exit 1
+fi
+# The hazard must be NAMED, not merely violated by some unrelated render error.
+grep -q 'kueue.armed=true with namespace.create=false cannot label the namespace' \
+    "$WORK/armed-external-ns.out" || {
+    echo "FAIL: the unlabelled-namespace rejection did not name the hazard:" >&2
+    cat "$WORK/armed-external-ns.out" >&2
+    exit 1
+}
+grep -q 'djinn.io/kueue-managed' "$WORK/armed-external-ns.out" || {
+    echo "FAIL: the rejection did not name the label Kueue actually requires:" >&2
+    cat "$WORK/armed-external-ns.out" >&2
+    exit 1
+}
+# The gate lives in templates/namespace.yaml, i.e. in the template that renders
+# NOTHING in this configuration. Prove it still fires when helm is asked for one
+# unrelated template, because `--show-only` filters after rendering.
+if helm template kueue-topology-test "$CHART_DIR" --is-upgrade \
+    --set kueue.enabled=true --set kueue.armed=true --set namespace.create=false \
+    --show-only templates/deployment-server.yaml >"$WORK/armed-external-ns-showonly.out" 2>&1; then
+    echo "FAIL: the unlabelled-namespace gate did not fire under --show-only" >&2
+    exit 1
+fi
+grep -q 'kueue.armed=true with namespace.create=false cannot label the namespace' \
+    "$WORK/armed-external-ns-showonly.out" || {
+    echo "FAIL: --show-only skipped the gate in templates/namespace.yaml:" >&2
+    cat "$WORK/armed-external-ns-showonly.out" >&2
+    exit 1
+}
+
+echo "=== namespace.create=false alone still renders; only ARMING is gated ==="
+# Non-vacuity: an externally-managed namespace is a supported configuration and
+# must keep rendering. Without this the rejection above could be an unrelated
+# namespace.create=false breakage.
+render "$WORK/external-ns-disarmed.yaml" --set kueue.enabled=true --set namespace.create=false
+assert_disarmed_server_no_namespace "$WORK/external-ns-disarmed.yaml" "namespace.create=false, armed=false"
+
+echo "=== the acknowledgement reopens the escape hatch ==="
+# The gate must not be an unconditional fail: an operator who HAS labelled their
+# externally-managed namespace can still arm.
+render "$WORK/external-ns-acked.yaml" \
+    --set kueue.enabled=true --set kueue.armed=true --set namespace.create=false \
+    --set kueue.namespaceLabelledExternally=true
+python3 - "$WORK/external-ns-acked.yaml" <<'PY'
+import sys
+import yaml
+
+docs = [doc for doc in yaml.safe_load_all(open(sys.argv[1], encoding="utf-8")) if doc]
+
+# No Namespace object: that is the whole premise of this configuration.
+assert not [doc for doc in docs if doc.get("kind") == "Namespace"], (
+    "namespace.create=false must still render no Namespace object"
+)
+# The topology must be there for the armed Jobs to be admitted into.
+local_queues = [doc for doc in docs if doc.get("kind") == "LocalQueue"]
+assert len(local_queues) == 3, f"expected three LocalQueues, got {len(local_queues)}"
+
+server = next(
+    container
+    for doc in docs
+    if doc.get("kind") == "Deployment"
+    and doc.get("metadata", {}).get("name", "").endswith("-server")
+    for container in doc["spec"]["template"]["spec"]["containers"]
+    if container["name"] == "djinn-server"
+)
+values = {entry["name"]: entry.get("value") for entry in server["env"]}
+# The escape hatch must produce a genuinely ARMED render — otherwise the
+# acknowledgement would be a no-op that only silenced the gate.
+assert values["DJINN_KUEUE_ARMED"] == "true", (
+    "the acknowledgement must still arm the renderers, got "
+    f"{values.get('DJINN_KUEUE_ARMED')!r}"
+)
+assert values["DJINN_KUEUE_LOCAL_QUEUE_PREFIX"] == "kueue-topology-test-djinn", (
+    f"queue prefix must match the rendered LocalQueues, got {values.get('DJINN_KUEUE_LOCAL_QUEUE_PREFIX')!r}"
+)
+PY
+
+echo "=== the acknowledgement does NOT arm anything on its own ==="
+# It is an acknowledgement, not a second arming switch.
+render "$WORK/ack-without-armed.yaml" \
+    --set kueue.enabled=true --set kueue.namespaceLabelledExternally=true
+assert_topology "$WORK/ack-without-armed.yaml" 3 no
+
+echo "=== the acknowledgement is inert when the chart owns the namespace ==="
+# namespace.create=true is unaffected by the new value in either direction.
+render "$WORK/ack-with-owned-ns.yaml" \
+    --set kueue.enabled=true --set kueue.armed=true --set kueue.namespaceLabelledExternally=true
+assert_topology "$WORK/ack-with-owned-ns.yaml" 3 yes
+
+echo "=== the preflight's namespace RBAC is granted ==="
+# The render-time acknowledgement is an unverified claim; djinn-server re-checks
+# it at startup by GETting its own Namespace. That read needs a namespaced `get`
+# on `namespaces` — without it the preflight can only report "unverifiable" and
+# disarms, silently costing the deployment its Kueue quota.
+python3 - "$WORK/armed.yaml" <<'PY'
+import sys
+import yaml
+
+docs = [doc for doc in yaml.safe_load_all(open(sys.argv[1], encoding="utf-8")) if doc]
+rules = [
+    rule
+    for doc in docs
+    if doc.get("kind") == "Role"
+    for rule in doc.get("rules", [])
+    if rule.get("apiGroups") == [""] and "namespaces" in rule.get("resources", [])
+]
+assert len(rules) == 1, f"expected exactly one namespaces RBAC rule, got {rules}"
+# Read-only, and namespaced: the apiserver scopes `get namespaces` in a Role to
+# the Role's own namespace, so this grants reading THIS namespace and nothing
+# else. Any write verb, or a ClusterRole, would be a real privilege escalation.
+assert rules[0].get("verbs") == ["get"], (
+    f"the preflight's namespace read must stay get-only, got {rules[0].get('verbs')}"
+)
+assert not [
+    doc for doc in docs
+    if doc.get("kind") == "ClusterRole"
+    for rule in doc.get("rules", [])
+    if "namespaces" in rule.get("resources", [])
+], "reading the namespace must NOT require a ClusterRole"
+PY
 
 expect_rejected() {
     local name=$1
@@ -355,6 +519,29 @@ if helm template kueue-topology-test "$WORK/chart-without-armed" --is-upgrade >"
     exit 1
 fi
 
+echo "=== invalid kueue.namespaceLabelledExternally ==="
+if render "$WORK/ack-string.out" --set-string kueue.namespaceLabelledExternally=yes 2>&1; then
+    echo "FAIL: a non-boolean kueue.namespaceLabelledExternally rendered successfully" >&2
+    exit 1
+fi
+
+echo "=== missing kueue.namespaceLabelledExternally ==="
+cp -R "$CHART_DIR" "$WORK/chart-without-ack"
+python3 - "$WORK/chart-without-ack/values.yaml" <<'PY'
+import sys
+import yaml
+
+path = sys.argv[1]
+values = yaml.safe_load(open(path, encoding="utf-8"))
+values["kueue"].pop("namespaceLabelledExternally")
+with open(path, "w", encoding="utf-8") as output:
+    yaml.safe_dump(values, output, sort_keys=False)
+PY
+if helm template kueue-topology-test "$WORK/chart-without-ack" --is-upgrade >"$WORK/missing-ack.out" 2>&1; then
+    echo "FAIL: missing kueue.namespaceLabelledExternally rendered successfully" >&2
+    exit 1
+fi
+
 echo "=== missing kueue.buildPods ==="
 cp -R "$CHART_DIR" "$WORK/chart-without-kueue"
 python3 - "$WORK/chart-without-kueue/values.yaml" <<'PY'
@@ -383,6 +570,12 @@ assert values["kueue"]["armed"] is False, (
 )
 assert values["kueue"]["enabled"] is False, (
     f"kueue.enabled must ship false, got {values['kueue']['enabled']!r}"
+)
+# The escape hatch is opt-in too. Shipping it true would pre-acknowledge a claim
+# no operator ever made, which is exactly the silence this gate replaced.
+assert values["kueue"]["namespaceLabelledExternally"] is False, (
+    "kueue.namespaceLabelledExternally must ship false, got "
+    f"{values['kueue']['namespaceLabelledExternally']!r}"
 )
 PY
 

--- a/deploy/helm/djinn/values.schema.json
+++ b/deploy/helm/djinn/values.schema.json
@@ -41,11 +41,12 @@
     "kueue": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["enabled", "buildPods", "armed"],
+      "required": ["enabled", "buildPods", "armed", "namespaceLabelledExternally"],
       "properties": {
         "enabled": { "type": "boolean" },
         "buildPods": { "type": "integer", "minimum": 1 },
-        "armed": { "type": "boolean" }
+        "armed": { "type": "boolean" },
+        "namespaceLabelledExternally": { "type": "boolean" }
       }
     },
     "logCollector": {

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -124,15 +124,41 @@ kueue:
   # INVARIANT: armed implies enabled. `armed: true` with `enabled: false` fails
   # the render — arming with no ClusterQueue to admit into is the same hang.
   #
-  # Related prerequisite that the chart cannot check for you: if you manage the
-  # namespace externally (`namespace.create: false`), the chart renders no
-  # Namespace object and therefore cannot apply the label. Label it yourself
-  # BEFORE arming, or every build Job hangs.
+  # INVARIANT: armed requires a namespace this chart can label. With
+  # `namespace.create: false` the chart renders no Namespace object and
+  # therefore CANNOT apply `djinn.io/kueue-managed`, so that combination fails
+  # the render unless you acknowledge you have labelled it yourself — see
+  # `namespaceLabelledExternally` below.
   #
   # Image builds stay deliberately unarmed at every value of this flag: an image
   # build is an upstream dependency of a task-run, so sharing one ClusterQueue
   # creates a priority-inversion deadlock.
   armed: false
+
+  # Operator acknowledgement that an EXTERNALLY MANAGED namespace already
+  # carries `djinn.io/kueue-managed=true`.
+  #
+  # Only consulted when `armed: true` AND `namespace.create: false`. In that
+  # combination the chart renders no Namespace object, so it cannot apply the
+  # label Kueue requires in order to capture anything — while still setting
+  # `DJINN_KUEUE_ARMED`, which makes every task-run, warm and standalone-SCIP
+  # Job render `suspend: true`. Nothing captures those Jobs, so nothing
+  # unsuspends them, and every build hangs forever. The chart therefore REFUSES
+  # that combination outright unless you set this true.
+  #
+  # Before setting it:
+  #     kubectl label namespace <ns> djinn.io/kueue-managed=true
+  #
+  # This value is an unverified CLAIM at render time — Helm cannot see cluster
+  # state. The claim is checked for real at djinn-server startup: the server
+  # GETs its own namespace and, when the label is absent, DISARMS itself and
+  # logs the reason rather than rendering Jobs that would hang (see
+  # `server/crates/djinn-k8s/src/kueue_preflight.rs`). This flag buys you an
+  # install; it does not buy you capture.
+  #
+  # Leave false when `namespace.create: true` — the chart applies the label
+  # itself and the acknowledgement is inert.
+  namespaceLabelledExternally: false
 
 # -----------------------------------------------------------------------------
 # Per-invocation CPU lease (cgroup launcher)

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -441,9 +441,49 @@ impl KubernetesConfig {
     }
 }
 
+/// Latch set by the startup Kueue preflight when it refuses to arm.
+///
+/// Deliberately process-global. `KubernetesConfig` is rebuilt by
+/// [`KubernetesConfig::from_env`] at each construction site — the graph warmer at
+/// startup, the slot supervisor at every dispatch — and no single instance is
+/// retained for the process, so mutating one struct would leave the others armed.
+/// The latch is the only place a refusal reaches all of them without threading a
+/// new parameter through every renderer.
+///
+/// One-way by construction: it can only ever move `armed` from true to false, so
+/// a stuck latch degrades to the pre-cutover behaviour (unsuspended Jobs, no
+/// Kueue quota) and can never arm anything.
+static KUEUE_DISARMED_BY_PREFLIGHT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Latch a startup refusal to arm Kueue. Every subsequent
+/// [`KubernetesConfig::from_env`] renders disarmed regardless of
+/// `DJINN_KUEUE_ARMED`.
+///
+/// Call this from the startup preflight only — see [`crate::kueue_preflight`].
+/// It must run before the first renderer builds its config; in djinn-server that
+/// is `AppState::initialize_graph_warmer`.
+pub fn disarm_kueue_globally() {
+    KUEUE_DISARMED_BY_PREFLIGHT.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Whether the startup preflight refused to arm Kueue.
+#[must_use]
+pub fn kueue_disarmed_by_preflight() -> bool {
+    KUEUE_DISARMED_BY_PREFLIGHT.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Clear the latch. Test-only: the latch is one-way in production.
+#[cfg(test)]
+fn rearm_kueue_latch_for_test() {
+    KUEUE_DISARMED_BY_PREFLIGHT.store(false, std::sync::atomic::Ordering::SeqCst);
+}
+
 impl KubernetesConfig {
     /// Minimal default used by unit tests; production deployments load
-    /// from the djinn-server config file.
+    /// their Kubernetes settings from the `DJINN_*` environment projected by
+    /// `deploy/helm/djinn/templates/deployment-server.yaml` via
+    /// [`KubernetesConfig::from_env`].
     pub fn for_testing() -> Self {
         Self {
             namespace: "djinn".into(),
@@ -808,6 +848,13 @@ impl KubernetesConfig {
                 }
             }
         }
+        // Honor a startup preflight refusal. `KubernetesConfig` is not held on
+        // AppState — every renderer rebuilds it from the environment at dispatch
+        // time — so the latch, not a mutated struct, is what makes the refusal
+        // reach all of them.
+        if cfg.kueue_armed && kueue_disarmed_by_preflight() {
+            cfg.kueue_armed = false;
+        }
         if let Ok(v) = std::env::var("DJINN_KUEUE_LOCAL_QUEUE_PREFIX")
             && !v.is_empty()
         {
@@ -834,6 +881,58 @@ mod tests {
     use super::*;
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// The startup preflight's refusal has to reach `from_env()`, because that
+    /// is where every renderer gets its config — including the slot supervisor,
+    /// which rebuilds one per dispatch long after startup.
+    ///
+    /// Mutation check: delete the `kueue_disarmed_by_preflight()` branch in
+    /// `from_env` and this test fails on the first assertion.
+    #[test]
+    fn a_preflight_refusal_disarms_every_later_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("DJINN_KUEUE_ARMED").ok();
+        // SAFETY: serialized against sibling tests via ENV_LOCK.
+        unsafe {
+            std::env::set_var("DJINN_KUEUE_ARMED", "true");
+        }
+        rearm_kueue_latch_for_test();
+
+        // Precondition: the env alone does arm, so the assertion below is about
+        // the latch and not about a var that was never read.
+        assert!(
+            KubernetesConfig::from_env().kueue_armed,
+            "DJINN_KUEUE_ARMED=true must arm before the preflight refuses"
+        );
+
+        disarm_kueue_globally();
+        let cfg = KubernetesConfig::from_env();
+        assert!(
+            !cfg.kueue_armed,
+            "a preflight refusal must disarm despite DJINN_KUEUE_ARMED=true"
+        );
+        // The refusal has to reach the rendered Job shape, not just the flag.
+        assert_eq!(
+            cfg.kueue_job_suspend(),
+            None,
+            "a disarmed config must not render `suspend: true`"
+        );
+        let mut labels = BTreeMap::new();
+        cfg.apply_kueue_build_object_labels(KueueQueueKind::TaskRun, &mut labels);
+        assert!(
+            labels.is_empty(),
+            "a disarmed config must not stamp a queue-name label: {labels:?}"
+        );
+
+        rearm_kueue_latch_for_test();
+        // SAFETY: serialized against sibling tests via ENV_LOCK.
+        unsafe {
+            match saved {
+                Some(value) => std::env::set_var("DJINN_KUEUE_ARMED", value),
+                None => std::env::remove_var("DJINN_KUEUE_ARMED"),
+            }
+        }
+    }
 
     /// `from_env()` honors the env vars it documents.  This is a sanity
     /// check on the env-var names (regressions would silently fall back to

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -441,44 +441,6 @@ impl KubernetesConfig {
     }
 }
 
-/// Latch set by the startup Kueue preflight when it refuses to arm.
-///
-/// Deliberately process-global. `KubernetesConfig` is rebuilt by
-/// [`KubernetesConfig::from_env`] at each construction site — the graph warmer at
-/// startup, the slot supervisor at every dispatch — and no single instance is
-/// retained for the process, so mutating one struct would leave the others armed.
-/// The latch is the only place a refusal reaches all of them without threading a
-/// new parameter through every renderer.
-///
-/// One-way by construction: it can only ever move `armed` from true to false, so
-/// a stuck latch degrades to the pre-cutover behaviour (unsuspended Jobs, no
-/// Kueue quota) and can never arm anything.
-static KUEUE_DISARMED_BY_PREFLIGHT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-/// Latch a startup refusal to arm Kueue. Every subsequent
-/// [`KubernetesConfig::from_env`] renders disarmed regardless of
-/// `DJINN_KUEUE_ARMED`.
-///
-/// Call this from the startup preflight only — see [`crate::kueue_preflight`].
-/// It must run before the first renderer builds its config; in djinn-server that
-/// is `AppState::initialize_graph_warmer`.
-pub fn disarm_kueue_globally() {
-    KUEUE_DISARMED_BY_PREFLIGHT.store(true, std::sync::atomic::Ordering::SeqCst);
-}
-
-/// Whether the startup preflight refused to arm Kueue.
-#[must_use]
-pub fn kueue_disarmed_by_preflight() -> bool {
-    KUEUE_DISARMED_BY_PREFLIGHT.load(std::sync::atomic::Ordering::SeqCst)
-}
-
-/// Clear the latch. Test-only: the latch is one-way in production.
-#[cfg(test)]
-fn rearm_kueue_latch_for_test() {
-    KUEUE_DISARMED_BY_PREFLIGHT.store(false, std::sync::atomic::Ordering::SeqCst);
-}
-
 impl KubernetesConfig {
     /// Minimal default used by unit tests; production deployments load
     /// their Kubernetes settings from the `DJINN_*` environment projected by
@@ -851,8 +813,8 @@ impl KubernetesConfig {
         // Honor a startup preflight refusal. `KubernetesConfig` is not held on
         // AppState — every renderer rebuilds it from the environment at dispatch
         // time — so the latch, not a mutated struct, is what makes the refusal
-        // reach all of them.
-        if cfg.kueue_armed && kueue_disarmed_by_preflight() {
+        // reach all of them. See `crate::kueue_preflight`.
+        if cfg.kueue_armed && crate::kueue_preflight::kueue_disarmed_by_preflight() {
             cfg.kueue_armed = false;
         }
         if let Ok(v) = std::env::var("DJINN_KUEUE_LOCAL_QUEUE_PREFIX")
@@ -877,67 +839,14 @@ impl KubernetesConfig {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    /// The startup preflight's refusal has to reach `from_env()`, because that
-    /// is where every renderer gets its config — including the slot supervisor,
-    /// which rebuilds one per dispatch long after startup.
-    ///
-    /// Mutation check: delete the `kueue_disarmed_by_preflight()` branch in
-    /// `from_env` and this test fails on the first assertion.
-    #[test]
-    fn a_preflight_refusal_disarms_every_later_from_env() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let saved = std::env::var("DJINN_KUEUE_ARMED").ok();
-        // SAFETY: serialized against sibling tests via ENV_LOCK.
-        unsafe {
-            std::env::set_var("DJINN_KUEUE_ARMED", "true");
-        }
-        rearm_kueue_latch_for_test();
-
-        // Observe everything BEFORE asserting anything: a panic here would skip
-        // the restore below, leave DJINN_KUEUE_ARMED set and the latch tripped
-        // for the rest of the process, and poison ENV_LOCK for every sibling
-        // test — turning one real failure into a cascade of misleading ones.
-        let armed_before = KubernetesConfig::from_env().kueue_armed;
-        disarm_kueue_globally();
-        let cfg = KubernetesConfig::from_env();
-        let mut labels = BTreeMap::new();
-        cfg.apply_kueue_build_object_labels(KueueQueueKind::TaskRun, &mut labels);
-
-        rearm_kueue_latch_for_test();
-        // SAFETY: serialized against sibling tests via ENV_LOCK.
-        unsafe {
-            match saved {
-                Some(value) => std::env::set_var("DJINN_KUEUE_ARMED", value),
-                None => std::env::remove_var("DJINN_KUEUE_ARMED"),
-            }
-        }
-
-        // Precondition: the env alone does arm, so the assertion below is about
-        // the latch and not about a var that was never read.
-        assert!(
-            armed_before,
-            "DJINN_KUEUE_ARMED=true must arm before the preflight refuses"
-        );
-        assert!(
-            !cfg.kueue_armed,
-            "a preflight refusal must disarm despite DJINN_KUEUE_ARMED=true"
-        );
-        // The refusal has to reach the rendered Job shape, not just the flag.
-        assert_eq!(
-            cfg.kueue_job_suspend(),
-            None,
-            "a disarmed config must not render `suspend: true`"
-        );
-        assert!(
-            labels.is_empty(),
-            "a disarmed config must not stamp a queue-name label: {labels:?}"
-        );
-    }
+    /// Serializes every test that mutates process env around `from_env()`.
+    /// `pub(crate)` because `kueue_preflight`'s latch test drives `from_env()`
+    /// too and has to take the SAME lock — a second mutex would serialize
+    /// nothing.
+    pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// `from_env()` honors the env vars it documents.  This is a sanity
     /// check on the env-var names (regressions would silently fall back to

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -898,15 +898,31 @@ mod tests {
         }
         rearm_kueue_latch_for_test();
 
+        // Observe everything BEFORE asserting anything: a panic here would skip
+        // the restore below, leave DJINN_KUEUE_ARMED set and the latch tripped
+        // for the rest of the process, and poison ENV_LOCK for every sibling
+        // test — turning one real failure into a cascade of misleading ones.
+        let armed_before = KubernetesConfig::from_env().kueue_armed;
+        disarm_kueue_globally();
+        let cfg = KubernetesConfig::from_env();
+        let mut labels = BTreeMap::new();
+        cfg.apply_kueue_build_object_labels(KueueQueueKind::TaskRun, &mut labels);
+
+        rearm_kueue_latch_for_test();
+        // SAFETY: serialized against sibling tests via ENV_LOCK.
+        unsafe {
+            match saved {
+                Some(value) => std::env::set_var("DJINN_KUEUE_ARMED", value),
+                None => std::env::remove_var("DJINN_KUEUE_ARMED"),
+            }
+        }
+
         // Precondition: the env alone does arm, so the assertion below is about
         // the latch and not about a var that was never read.
         assert!(
-            KubernetesConfig::from_env().kueue_armed,
+            armed_before,
             "DJINN_KUEUE_ARMED=true must arm before the preflight refuses"
         );
-
-        disarm_kueue_globally();
-        let cfg = KubernetesConfig::from_env();
         assert!(
             !cfg.kueue_armed,
             "a preflight refusal must disarm despite DJINN_KUEUE_ARMED=true"
@@ -917,21 +933,10 @@ mod tests {
             None,
             "a disarmed config must not render `suspend: true`"
         );
-        let mut labels = BTreeMap::new();
-        cfg.apply_kueue_build_object_labels(KueueQueueKind::TaskRun, &mut labels);
         assert!(
             labels.is_empty(),
             "a disarmed config must not stamp a queue-name label: {labels:?}"
         );
-
-        rearm_kueue_latch_for_test();
-        // SAFETY: serialized against sibling tests via ENV_LOCK.
-        unsafe {
-            match saved {
-                Some(value) => std::env::set_var("DJINN_KUEUE_ARMED", value),
-                None => std::env::remove_var("DJINN_KUEUE_ARMED"),
-            }
-        }
     }
 
     /// `from_env()` honors the env vars it documents.  This is a sanity

--- a/server/crates/djinn-k8s/src/kueue_preflight.rs
+++ b/server/crates/djinn-k8s/src/kueue_preflight.rs
@@ -1,0 +1,345 @@
+//! Startup verification that the namespace djinn-server runs in is actually
+//! Kueue-managed before anything is allowed to render an armed Job.
+//!
+//! # Why this exists
+//!
+//! `kueue.armed` drives two halves of one contract: the
+//! `djinn.io/kueue-managed` label on the Namespace, and `DJINN_KUEUE_ARMED` on
+//! djinn-server, which makes the task-run, warm and standalone-SCIP renderers
+//! emit `suspend: true` plus a `kueue.x-k8s.io/queue-name` label. Kueue captures
+//! Jobs ONLY in a labelled namespace, so an armed Job in an unlabelled namespace
+//! is never captured, never unsuspended, and hangs forever — every build, until
+//! someone notices.
+//!
+//! The chart keeps the halves together, but it cannot label a namespace it does
+//! not render: with `namespace.create=false` there is no Namespace object.
+//! `deploy/helm/djinn/templates/namespace.yaml` refuses that combination unless
+//! the operator sets `kueue.namespaceLabelledExternally=true`. That value is an
+//! unverified CLAIM — Helm cannot see cluster state, so an operator who sets it
+//! and is wrong reaches the identical hang.
+//!
+//! This module closes that hole with the one check Helm cannot do: at startup
+//! the server GETs its own Namespace and reads the label back off the live
+//! object.
+//!
+//! # Arm only on positive proof
+//!
+//! [`decide`] arms only when the label is confirmed present. Every other outcome
+//! — label absent, label present with an unexpected value, RBAC forbidden,
+//! apiserver unreachable — disarms. That asymmetry is deliberate:
+//!
+//! * disarmed-when-it-should-be-armed costs quota enforcement; Jobs still render
+//!   (unsuspended) and still run. It is the pre-cutover status quo.
+//! * armed-when-it-should-be-disarmed hangs every build Job forever.
+//!
+//! The failure modes are not symmetric, so the tie-break is not either.
+//!
+//! Refusal disarms rather than aborting the process for the same reason: a
+//! crash-looping server is a total outage, which is no better than the hang it
+//! was trying to prevent.
+//!
+//! # RBAC
+//!
+//! Namespaces are cluster-scoped, but the apiserver derives the request's
+//! namespace attribute from the object name for `GET
+//! /api/v1/namespaces/<name>`, so a NAMESPACED `Role` granting `get` on
+//! `namespaces` authorizes a ServiceAccount to read its own namespace and
+//! nothing else. Verified against a real apiserver (kind, k8s v1.34): with only
+//! that Role, GET of the own namespace returns 200 while GET of another
+//! namespace and LIST namespaces both return 403.
+//!
+//! That is what `deploy/helm/djinn/templates/role-controller.yaml` grants, which
+//! is why this check does not need — and must not acquire — the cluster-wide
+//! permission that `role-tokenreview.yaml` documents as the server's only one.
+//!
+//! # Re-proving the live half
+//!
+//! [`decide`] and [`classify_labels`] are pure and covered by unit tests, but
+//! "the restricted Role is sufficient" and "kube-rs reads the label back" need
+//! an apiserver. Both were verified against kind (k8s v1.34) by minting a
+//! kubeconfig for a ServiceAccount holding ONLY the rule above and calling
+//! [`observe_namespace`]:
+//!
+//! | namespace state              | observed                             |
+//! |------------------------------|--------------------------------------|
+//! | no label                     | `Unmanaged { observed: None }`       |
+//! | `djinn.io/kueue-managed=false` | `Unmanaged { observed: Some("false") }` |
+//! | `djinn.io/kueue-managed=true`  | `Managed`                            |
+//! | label `=true`, RoleBinding deleted | `Unverifiable { .. 403 Forbidden }` |
+//!
+//! The last row is the one that matters most: losing the read permission must
+//! never be mistaken for a confirmed label. It disarms.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use k8s_openapi::api::core::v1::Namespace;
+use kube::api::Api;
+
+/// Namespace label Kueue requires in order to capture Jobs in that namespace.
+///
+/// Applied by `deploy/helm/djinn/templates/namespace.yaml` when `kueue.armed` is
+/// true, or by the operator's own tooling when `namespace.create` is false.
+pub const LABEL_KUEUE_MANAGED: &str = "djinn.io/kueue-managed";
+
+/// What the live Namespace object says about Kueue management.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamespaceKueueStatus {
+    /// `djinn.io/kueue-managed=true` is present on the live object.
+    Managed,
+    /// The label is absent, or present with a value other than `true`. Arming
+    /// into this namespace hangs every build Job.
+    Unmanaged {
+        /// The observed label value, if the key was present at all.
+        observed: Option<String>,
+    },
+    /// The namespace could not be read, so nothing is known either way.
+    Unverifiable {
+        /// Human-readable cause, surfaced in the disarm log line.
+        reason: String,
+    },
+}
+
+/// What the server should do with the requested arming state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KueuePreflightOutcome {
+    /// Arming was never requested; no namespace read was performed.
+    NotRequested,
+    /// Arming was requested and the namespace label was confirmed. Stay armed.
+    Armed,
+    /// Arming was requested but not proven. Disarm and log `reason`.
+    Disarmed {
+        /// Operator-facing explanation of why arming was refused.
+        reason: String,
+    },
+}
+
+impl KueuePreflightOutcome {
+    /// Whether the renderers may keep stamping Kueue admission onto build Jobs.
+    #[must_use]
+    pub fn armed(&self) -> bool {
+        matches!(self, Self::Armed)
+    }
+}
+
+/// Classify a Namespace's labels.
+///
+/// Split out from the API call so the decision table is testable without a
+/// cluster.
+#[must_use]
+pub fn classify_labels(labels: Option<&BTreeMap<String, String>>) -> NamespaceKueueStatus {
+    let observed = labels
+        .and_then(|labels| labels.get(LABEL_KUEUE_MANAGED))
+        .cloned();
+    match observed.as_deref() {
+        Some("true") => NamespaceKueueStatus::Managed,
+        _ => NamespaceKueueStatus::Unmanaged { observed },
+    }
+}
+
+/// The whole decision table: requested arming plus observed namespace state in,
+/// final arming state out.
+///
+/// Pure, so the "arm only on positive proof" rule can be asserted directly
+/// rather than inferred from log output.
+#[must_use]
+pub fn decide(requested_armed: bool, status: &NamespaceKueueStatus) -> KueuePreflightOutcome {
+    if !requested_armed {
+        return KueuePreflightOutcome::NotRequested;
+    }
+    match status {
+        NamespaceKueueStatus::Managed => KueuePreflightOutcome::Armed,
+        NamespaceKueueStatus::Unmanaged { observed } => KueuePreflightOutcome::Disarmed {
+            reason: format!(
+                "namespace is not labelled {LABEL_KUEUE_MANAGED}=true (observed: {observed:?}), \
+                 so Kueue would never capture the suspended build Jobs arming creates"
+            ),
+        },
+        NamespaceKueueStatus::Unverifiable { reason } => KueuePreflightOutcome::Disarmed {
+            reason: format!(
+                "could not read the namespace to confirm {LABEL_KUEUE_MANAGED}=true ({reason}); \
+                 arming is only safe on positive proof"
+            ),
+        },
+    }
+}
+
+/// Number of namespace reads attempted before giving up.
+///
+/// A single transient apiserver error at boot must not cost the deployment its
+/// quota enforcement until the next restart, but the retry budget stays small:
+/// a genuinely absent label is not going to appear.
+const READ_ATTEMPTS: u32 = 3;
+/// Backoff between namespace read attempts.
+const READ_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Read `namespace` and classify its Kueue-management label, retrying transient
+/// failures a bounded number of times.
+pub async fn observe_namespace(client: &kube::Client, namespace: &str) -> NamespaceKueueStatus {
+    let api: Api<Namespace> = Api::all(client.clone());
+    let mut last_error = String::new();
+    for attempt in 1..=READ_ATTEMPTS {
+        match api.get(namespace).await {
+            Ok(object) => return classify_labels(object.metadata.labels.as_ref()),
+            Err(error) => {
+                last_error = error.to_string();
+                tracing::debug!(
+                    namespace,
+                    attempt,
+                    error = %last_error,
+                    "kueue preflight: namespace read failed"
+                );
+                if attempt < READ_ATTEMPTS {
+                    tokio::time::sleep(READ_BACKOFF).await;
+                }
+            }
+        }
+    }
+    NamespaceKueueStatus::Unverifiable {
+        reason: format!("{READ_ATTEMPTS} namespace GETs failed, last error: {last_error}"),
+    }
+}
+
+/// Run the preflight end to end and log the outcome.
+///
+/// Returns the outcome so the caller can latch it; see
+/// [`crate::config::disarm_kueue_globally`].
+pub async fn run(
+    client: &kube::Client,
+    namespace: &str,
+    requested_armed: bool,
+) -> KueuePreflightOutcome {
+    if !requested_armed {
+        return KueuePreflightOutcome::NotRequested;
+    }
+    let status = observe_namespace(client, namespace).await;
+    let outcome = decide(requested_armed, &status);
+    match &outcome {
+        KueuePreflightOutcome::Armed => tracing::info!(
+            namespace,
+            label = LABEL_KUEUE_MANAGED,
+            "kueue preflight: namespace is Kueue-managed, arming confirmed"
+        ),
+        KueuePreflightOutcome::Disarmed { reason } => tracing::error!(
+            namespace,
+            reason = %reason,
+            "kueue preflight: REFUSING to arm Kueue — build Jobs will render unsuspended \
+             (no Kueue quota) instead of hanging forever. Label the namespace with \
+             `kubectl label namespace <ns> djinn.io/kueue-managed=true` and restart, or set \
+             kueue.armed=false."
+        ),
+        // Unreachable: `requested_armed` was checked above.
+        KueuePreflightOutcome::NotRequested => {}
+    }
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn managed_only_when_the_label_reads_true() {
+        assert_eq!(
+            classify_labels(Some(&labels(&[(LABEL_KUEUE_MANAGED, "true")]))),
+            NamespaceKueueStatus::Managed
+        );
+        // A namespace that merely has SOME labels is not managed. Guards against
+        // a classifier that keys off label presence rather than this key.
+        assert_eq!(
+            classify_labels(Some(&labels(&[("app.kubernetes.io/name", "djinn")]))),
+            NamespaceKueueStatus::Unmanaged { observed: None }
+        );
+        assert_eq!(
+            classify_labels(None),
+            NamespaceKueueStatus::Unmanaged { observed: None }
+        );
+    }
+
+    #[test]
+    fn a_non_true_label_value_is_not_management() {
+        // `kubectl label ns x djinn.io/kueue-managed=false` is not "close
+        // enough": Kueue reads the value, and so must this.
+        for value in ["false", "True", "1", "yes", ""] {
+            assert_eq!(
+                classify_labels(Some(&labels(&[(LABEL_KUEUE_MANAGED, value)]))),
+                NamespaceKueueStatus::Unmanaged {
+                    observed: Some(value.to_string())
+                },
+                "value {value:?} must not count as Kueue management"
+            );
+        }
+    }
+
+    #[test]
+    fn disarmed_state_is_never_touched_by_the_preflight() {
+        // The preflight must not be able to ARM something the operator did not
+        // ask to arm, whatever the namespace says.
+        for status in [
+            NamespaceKueueStatus::Managed,
+            NamespaceKueueStatus::Unmanaged { observed: None },
+            NamespaceKueueStatus::Unverifiable {
+                reason: "boom".into(),
+            },
+        ] {
+            assert_eq!(decide(false, &status), KueuePreflightOutcome::NotRequested);
+            assert!(!decide(false, &status).armed());
+        }
+    }
+
+    #[test]
+    fn arming_survives_only_a_confirmed_label() {
+        assert_eq!(
+            decide(true, &NamespaceKueueStatus::Managed),
+            KueuePreflightOutcome::Armed
+        );
+        assert!(decide(true, &NamespaceKueueStatus::Managed).armed());
+    }
+
+    #[test]
+    fn an_unlabelled_namespace_disarms_and_says_why() {
+        // This is the exact configuration the task exists to close: an operator
+        // claimed `kueue.namespaceLabelledExternally=true` and was wrong.
+        let outcome = decide(true, &NamespaceKueueStatus::Unmanaged { observed: None });
+        assert!(
+            !outcome.armed(),
+            "an unlabelled namespace must not stay armed"
+        );
+        let KueuePreflightOutcome::Disarmed { reason } = outcome else {
+            panic!("expected a disarm");
+        };
+        assert!(
+            reason.contains(LABEL_KUEUE_MANAGED),
+            "the disarm reason must name the missing label: {reason}"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_namespace_disarms_rather_than_assuming() {
+        // RBAC stripped, apiserver down, whatever: no proof is not proof.
+        let outcome = decide(
+            true,
+            &NamespaceKueueStatus::Unverifiable {
+                reason: "forbidden".into(),
+            },
+        );
+        assert!(
+            !outcome.armed(),
+            "an unverifiable namespace must not stay armed"
+        );
+        let KueuePreflightOutcome::Disarmed { reason } = outcome else {
+            panic!("expected a disarm");
+        };
+        assert!(
+            reason.contains("forbidden"),
+            "the disarm reason must carry the underlying cause: {reason}"
+        );
+    }
+}

--- a/server/crates/djinn-k8s/src/kueue_preflight.rs
+++ b/server/crates/djinn-k8s/src/kueue_preflight.rs
@@ -38,6 +38,17 @@
 //! crash-looping server is a total outage, which is no better than the hang it
 //! was trying to prevent.
 //!
+//! # What this does NOT cover
+//!
+//! The check runs once, at startup. If the label is stripped from a live,
+//! already-armed deployment, this process stays armed until it restarts. That is
+//! a deliberate limit rather than an oversight: by then Kueue has already
+//! captured the in-flight Workloads, and re-checking on a timer could not
+//! unsuspend the Jobs it would belatedly disapprove of — it would only add a way
+//! for a transient apiserver blip to disarm a healthy cluster mid-flight. The
+//! window this closes is the one that actually produces the hang: arming a
+//! deployment into a namespace that was never labelled in the first place.
+//!
 //! # RBAC
 //!
 //! Namespaces are cluster-scoped, but the apiserver derives the request's
@@ -81,6 +92,44 @@ use kube::api::Api;
 /// Applied by `deploy/helm/djinn/templates/namespace.yaml` when `kueue.armed` is
 /// true, or by the operator's own tooling when `namespace.create` is false.
 pub const LABEL_KUEUE_MANAGED: &str = "djinn.io/kueue-managed";
+
+/// Latch set when this preflight refuses to arm.
+///
+/// Deliberately process-global. [`crate::KubernetesConfig`] is rebuilt by
+/// `from_env()` at each construction site — the graph warmer at startup, the
+/// slot supervisor at every dispatch — and no single instance is retained for
+/// the process, so mutating one struct would leave the others armed. The latch
+/// is the only place a refusal reaches all of them without threading a new
+/// parameter through every renderer.
+///
+/// One-way by construction: it can only ever move `armed` from true to false, so
+/// a stuck latch degrades to the pre-cutover behaviour (unsuspended Jobs, no
+/// Kueue quota) and can never arm anything.
+static KUEUE_DISARMED_BY_PREFLIGHT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Latch a refusal to arm Kueue. Every subsequent `KubernetesConfig::from_env`
+/// renders disarmed regardless of `DJINN_KUEUE_ARMED`.
+///
+/// Call this from the startup preflight only. It must run before the first
+/// renderer builds its config; in djinn-server that is
+/// `AppState::run_kueue_arming_preflight`, ordered ahead of
+/// `initialize_graph_warmer`.
+pub fn disarm_kueue_globally() {
+    KUEUE_DISARMED_BY_PREFLIGHT.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Whether the startup preflight refused to arm Kueue.
+#[must_use]
+pub fn kueue_disarmed_by_preflight() -> bool {
+    KUEUE_DISARMED_BY_PREFLIGHT.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Clear the latch. Test-only: the latch is one-way in production.
+#[cfg(test)]
+fn rearm_kueue_latch_for_test() {
+    KUEUE_DISARMED_BY_PREFLIGHT.store(false, std::sync::atomic::Ordering::SeqCst);
+}
 
 /// What the live Namespace object says about Kueue management.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -237,6 +286,67 @@ pub async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::KubernetesConfig;
+    use crate::config::KueueQueueKind;
+    use crate::config::tests::ENV_LOCK;
+
+    /// The refusal has to reach `KubernetesConfig::from_env()`, because that is
+    /// where every renderer gets its config — including the slot supervisor,
+    /// which rebuilds one per dispatch long after startup. A refusal that only
+    /// mutated the startup config would leave every dispatched Job armed.
+    ///
+    /// Mutation check: delete the `kueue_disarmed_by_preflight()` branch in
+    /// `config::from_env` and this test fails.
+    #[test]
+    fn a_preflight_refusal_disarms_every_later_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var("DJINN_KUEUE_ARMED").ok();
+        // SAFETY: serialized against sibling tests via ENV_LOCK.
+        unsafe {
+            std::env::set_var("DJINN_KUEUE_ARMED", "true");
+        }
+        rearm_kueue_latch_for_test();
+
+        // Observe everything BEFORE asserting anything: a panic here would skip
+        // the restore below, leave DJINN_KUEUE_ARMED set and the latch tripped
+        // for the rest of the process, and poison ENV_LOCK for every sibling
+        // test — turning one real failure into a cascade of misleading ones.
+        let armed_before = KubernetesConfig::from_env().kueue_armed;
+        disarm_kueue_globally();
+        let cfg = KubernetesConfig::from_env();
+        let mut stamped = BTreeMap::new();
+        cfg.apply_kueue_build_object_labels(KueueQueueKind::TaskRun, &mut stamped);
+
+        rearm_kueue_latch_for_test();
+        // SAFETY: serialized against sibling tests via ENV_LOCK.
+        unsafe {
+            match saved {
+                Some(value) => std::env::set_var("DJINN_KUEUE_ARMED", value),
+                None => std::env::remove_var("DJINN_KUEUE_ARMED"),
+            }
+        }
+
+        // Precondition: the env alone does arm, so the assertion below is about
+        // the latch and not about a var that was never read.
+        assert!(
+            armed_before,
+            "DJINN_KUEUE_ARMED=true must arm before the preflight refuses"
+        );
+        assert!(
+            !cfg.kueue_armed,
+            "a preflight refusal must disarm despite DJINN_KUEUE_ARMED=true"
+        );
+        // The refusal has to reach the rendered Job shape, not just the flag.
+        assert_eq!(
+            cfg.kueue_job_suspend(),
+            None,
+            "a disarmed config must not render `suspend: true`"
+        );
+        assert!(
+            stamped.is_empty(),
+            "a disarmed config must not stamp a queue-name label: {stamped:?}"
+        );
+    }
 
     fn labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
         pairs

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -14,6 +14,7 @@ pub mod graph_warmer_identity;
 pub mod infra_death_log_tail;
 pub mod invocation_journal;
 pub mod job;
+pub mod kueue_preflight;
 pub mod label_value;
 pub mod launcher;
 pub mod launcher_child_fs;
@@ -32,7 +33,7 @@ pub use build_resources::{
     ResolveError, ResourceBounds, apply_resolved_resources, resolve_task_run_resources,
     resolve_warm_resources,
 };
-pub use config::KubernetesConfig;
+pub use config::{KubernetesConfig, disarm_kueue_globally, kueue_disarmed_by_preflight};
 pub use env_config::{
     ENV_CONFIG_KEY, ENV_CONFIG_MOUNT_DIR, ENV_CONFIG_MOUNT_FILE, VOLUME_ENV_CONFIG,
     build_env_config_config_map, env_config_config_map_name, env_config_volume,
@@ -52,6 +53,11 @@ pub use graph_warmer_candidates::{
     WarmInventoryObservation, WarmObjectLifecycle,
 };
 pub use graph_warmer_identity::{LeasedWarmJobIdentity, deterministic_warm_job_name, warm_work_id};
+pub use kueue_preflight::{
+    KueuePreflightOutcome, LABEL_KUEUE_MANAGED, NamespaceKueueStatus,
+    classify_labels as classify_kueue_namespace_labels, decide as decide_kueue_preflight,
+    observe_namespace as observe_kueue_namespace, run as run_kueue_preflight,
+};
 pub use runtime::{KubernetesRuntime, taskrun_job_name};
 pub use scip_job::{
     ANNOTATION_SCIP_REVISION, COMPONENT_SCIP_INDEX, LABEL_CAPACITY_RESERVED, LABEL_SCIP_INDEX,

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -33,7 +33,7 @@ pub use build_resources::{
     ResolveError, ResourceBounds, apply_resolved_resources, resolve_task_run_resources,
     resolve_warm_resources,
 };
-pub use config::{KubernetesConfig, disarm_kueue_globally, kueue_disarmed_by_preflight};
+pub use config::KubernetesConfig;
 pub use env_config::{
     ENV_CONFIG_KEY, ENV_CONFIG_MOUNT_DIR, ENV_CONFIG_MOUNT_FILE, VOLUME_ENV_CONFIG,
     build_env_config_config_map, env_config_config_map_name, env_config_volume,
@@ -56,6 +56,7 @@ pub use graph_warmer_identity::{LeasedWarmJobIdentity, deterministic_warm_job_na
 pub use kueue_preflight::{
     KueuePreflightOutcome, LABEL_KUEUE_MANAGED, NamespaceKueueStatus,
     classify_labels as classify_kueue_namespace_labels, decide as decide_kueue_preflight,
+    disarm_kueue_globally, kueue_disarmed_by_preflight,
     observe_namespace as observe_kueue_namespace, run as run_kueue_preflight,
 };
 pub use runtime::{KubernetesRuntime, taskrun_job_name};

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -1704,6 +1704,53 @@ impl AppState {
     ///   [`djinn_k8s::KubeClient`] can be constructed → [`K8sGraphWarmer`].
     /// * Otherwise (explicit `DJINN_RUNTIME=test`, local dev without a
     ///   cluster) → in-process warmer via [`build_in_process_graph_warmer`].
+    /// Verify, against the live cluster, that this pod's namespace is actually
+    /// Kueue-managed before any renderer is allowed to arm.
+    ///
+    /// `kueue.armed` in the chart drives both the `djinn.io/kueue-managed`
+    /// Namespace label and `DJINN_KUEUE_ARMED` here, so the two normally cannot
+    /// diverge. They can in exactly one configuration: `namespace.create=false`
+    /// renders no Namespace object, so the chart cannot apply the label, and the
+    /// operator asserts it exists via `kueue.namespaceLabelledExternally`. That
+    /// assertion is unverifiable at render time — this is where it is checked.
+    /// An armed Job in an unlabelled namespace is never captured, never
+    /// unsuspended, and hangs forever.
+    ///
+    /// Refusal disarms (via [`djinn_k8s::disarm_kueue_globally`]) rather than
+    /// aborting the boot: unsuspended Jobs with no Kueue quota is the
+    /// pre-cutover status quo, whereas a crash-looping server is a total outage.
+    async fn run_kueue_arming_preflight(&self) {
+        let config = KubernetesConfig::from_env();
+        if !config.kueue_armed {
+            return;
+        }
+        if !matches!(runtime_kind(), RuntimeKind::Kubernetes) {
+            tracing::warn!(
+                "kueue preflight: DJINN_KUEUE_ARMED is set but the runtime is not Kubernetes; \
+                 disarming"
+            );
+            djinn_k8s::disarm_kueue_globally();
+            return;
+        }
+        let client = match djinn_k8s::try_default_client().await {
+            Ok(client) => client,
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    "kueue preflight: no Kubernetes client, cannot confirm the namespace is \
+                     Kueue-managed; disarming"
+                );
+                djinn_k8s::disarm_kueue_globally();
+                return;
+            }
+        };
+        let outcome =
+            djinn_k8s::run_kueue_preflight(&client, &config.namespace, config.kueue_armed).await;
+        if !outcome.armed() {
+            djinn_k8s::disarm_kueue_globally();
+        }
+    }
+
     async fn initialize_graph_warmer(&self) {
         {
             let existing = self.inner.graph_warmer.read().await;
@@ -2794,6 +2841,11 @@ impl AppState {
         self.initialize_build_pod_permit_prerequisites().await;
         self.initialize_build_admission_recovery().await;
         self.initialize_build_admission_deferred_recovery().await;
+
+        // Kueue arming preflight. MUST precede `initialize_graph_warmer`: that
+        // is the first `KubernetesConfig::from_env()` whose result is retained,
+        // and a refusal only reaches a config built AFTER the latch is set.
+        self.run_kueue_arming_preflight().await;
 
         // Phase 3 PR 8: pick the canonical-graph warmer impl (K8s or
         // in-process) and cache it. This is just a cached handle (the actual

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -1696,14 +1696,6 @@ impl AppState {
         }
     }
 
-    /// Pick the best available [`GraphWarmerService`] implementation and
-    /// cache it on [`AppState`]. Idempotent.
-    ///
-    /// Policy:
-    /// * If `DJINN_RUNTIME=kubernetes` (or unset — default) AND a
-    ///   [`djinn_k8s::KubeClient`] can be constructed → [`K8sGraphWarmer`].
-    /// * Otherwise (explicit `DJINN_RUNTIME=test`, local dev without a
-    ///   cluster) → in-process warmer via [`build_in_process_graph_warmer`].
     /// Verify, against the live cluster, that this pod's namespace is actually
     /// Kueue-managed before any renderer is allowed to arm.
     ///
@@ -1751,6 +1743,14 @@ impl AppState {
         }
     }
 
+    /// Pick the best available [`GraphWarmerService`] implementation and
+    /// cache it on [`AppState`]. Idempotent.
+    ///
+    /// Policy:
+    /// * If `DJINN_RUNTIME=kubernetes` (or unset — default) AND a
+    ///   [`djinn_k8s::KubeClient`] can be constructed → [`K8sGraphWarmer`].
+    /// * Otherwise (explicit `DJINN_RUNTIME=test`, local dev without a
+    ///   cluster) → in-process warmer via [`build_in_process_graph_warmer`].
     async fn initialize_graph_warmer(&self) {
         {
             let existing = self.inner.graph_warmer.read().await;


### PR DESCRIPTION
Closes the `namespace.create=false` arming gap that jxbt (#2812) opened. Task `xbrl`, epic `4c9q`, proposal `9oga`. **Prerequisite of the arming step** — this must land before Kueue is armed on any cluster.

## The gap

S1 made `kueue.armed` drive BOTH halves of the capture contract — the `djinn.io/kueue-managed` Namespace label AND `suspend: true` + queue-name on task-run/warm/SCIP Jobs — precisely so they can never diverge. One values combination split them anyway:

With `namespace.create: false` the chart renders no Namespace object, so it **cannot** apply the label, while still setting `DJINN_KUEUE_ARMED`. Every build Job renders suspended into a namespace Kueue does not manage. Nothing captures them, nothing unsuspends them, **every build hangs forever** — the exact failure the one-flag design exists to prevent, reachable in silence. S1 documented it in `values.yaml`; a comment is not a gate.

## Render-time gate

`templates/namespace.yaml` now fails `kueue.armed=true` + `namespace.create=false`, naming the hazard, **unless** the operator sets the new `kueue.namespaceLabelledExternally=true`. That keeps the escape hatch open for externally-managed namespaces — which have no other way out of a hard failure — while making the dangerous combination unreachable by accident.

The gate sits **outside** the `namespace.create` conditional on purpose: it has to fire in exactly the case where that template renders nothing. Helm executes every template regardless of output and `--show-only` filters *after* rendering, so the `fail` still aborts — asserted explicitly in the contract.

## Startup check — implemented

The task asked whether the server can verify the label at startup and refuse to arm when it is absent. **It can, and this PR does it.** The acknowledgement above is an unverified claim; an operator who sets it and is wrong reaches the identical hang.

`AppState::run_kueue_arming_preflight` runs before the first retained `KubernetesConfig::from_env()`, GETs its own Namespace, and arms **only** on a confirmed `djinn.io/kueue-managed=true`. Label absent, label set to something else, RBAC forbidden, apiserver unreachable (3 attempts, 500ms apart) — all disarm.

**Arm only on positive proof.** The failure modes are not symmetric, so the tie-break is not either:

| outcome | cost |
|---|---|
| disarmed when it should be armed | loses Kueue quota; Jobs still render (unsuspended) and still run — the pre-cutover status quo |
| armed when it should be disarmed | every build Job hangs forever |

Refusal **disarms rather than aborting the boot**, for the same reason: a crash-looping server is a total outage, no better than the hang it was preventing.

**Known limit, deliberate:** the check runs once at boot. Stripping the label from a live armed deployment is not detected until restart. Re-checking on a timer could not unsuspend the Jobs it would belatedly disapprove of — Kueue has already captured them — and would add a way for a transient apiserver blip to disarm a healthy cluster mid-flight. The window this closes is the one that actually produces the hang: arming into a namespace that was never labelled.

`KubernetesConfig` is not retained anywhere — the graph warmer builds one at startup, the slot supervisor rebuilds one per dispatch — so the refusal is a process-global latch consulted by `from_env()` rather than a mutated struct. It is one-way by construction: it can only move `armed` true → false, so a stuck latch degrades to pre-cutover behaviour and can never arm anything. This also kept the change out of the six renderer files owned by the parallel `37yq`. The latch lives in `kueue_preflight.rs` next to the check that sets it, not in `config.rs`, which keeps that file under the 51200-byte `Server Guards` cap without an `allow-oversize` marker.

### RBAC: no new cluster-wide permission

Namespaces are cluster-scoped, but the apiserver derives the request's namespace attribute from the object name for `GET /api/v1/namespaces/<name>`, so a **namespaced** `Role` granting `get` on `namespaces` is sufficient. Verified against a real apiserver (kind, k8s v1.34) rather than assumed — with only that rule:

```
GET own namespace      -> HTTP 200
GET kube-system        -> HTTP 403
LIST namespaces        -> HTTP 403
```

TokenReview therefore remains djinn-server's only cluster-wide permission, as `role-tokenreview.yaml` documents.

### Live end-to-end verification

Against that same cluster, authenticating as a ServiceAccount holding **only** the chart's rule:

| namespace state | `observe_namespace` returned |
|---|---|
| no label | `Unmanaged { observed: None }` |
| `djinn.io/kueue-managed=false` | `Unmanaged { observed: Some("false") }` |
| `djinn.io/kueue-managed=true` | `Managed` |
| label `=true`, RoleBinding deleted | `Unverifiable { .. 403 Forbidden }` |

The last row matters most: losing the read permission is **not** mistaken for a confirmed label — it disarms. (Run manually; the live test is not committed because it needs a `rustls` dev-dep and a hakari regeneration for a cluster-only test. The reproduction is recorded in the module docs.)

## Non-vacuity

Every acceptance criterion was proven by mutation — break the thing, watch the test go red. All 14 mutations were caught, each by the intended assertion:

| # | mutation | caught by |
|---|---|---|
| H1 | `namespace.yaml` reverted to the jxbt version (clean gate removal) | `FAIL: kueue.armed=true with namespace.create=false rendered successfully` |
| H2 | gate fires but with a generic message | `FAIL: the unlabelled-namespace rejection did not name the hazard` |
| H3 | gate always fails (escape hatch closed) | `the acknowledgement reopens the escape hatch` |
| H4 | ack doubles as a second arming switch | `Namespace must remain unlabelled for Kueue unless kueue.armed=true` |
| H5 | ack silently stops arming (a no-op that only quiets the gate) | `the acknowledgement must still arm the renderers, got 'false'` |
| H6 | preflight's namespace RBAC dropped | `expected exactly one namespaces RBAC rule, got []` |
| H7 | namespace RBAC widened to `patch` | `the preflight's namespace read must stay get-only` |
| H8 | ack dropped from the schema entirely | schema rejection on the first render |
| H9 | ack present in schema but not `required` | `FAIL: missing kueue.namespaceLabelledExternally rendered successfully` |
| H10 | ack ships pre-acknowledged (`true`) | `FAIL: kueue.armed=true with namespace.create=false rendered successfully` |
| R1 | `from_env` ignores the preflight latch | `a_preflight_refusal_disarms_every_later_from_env` |
| R2 | unverifiable namespace arms | `an_unreadable_namespace_disarms_rather_than_assuming` |
| R3 | unlabelled namespace arms | `an_unlabelled_namespace_disarms_and_says_why` |
| R4 | any label value counts as managed | `a_non_true_label_value_is_not_management` |

R1 is the one that matters structurally: it proves the refusal reaches the config the **slot supervisor rebuilds per dispatch**, not just the one built at startup.

## Nothing is armed

`kueue.armed` and `kueue.namespaceLabelledExternally` both ship `false`. The default render is unchanged: no namespace is labelled, no Job is suspended, and the `armed=true, namespace.create=true` path renders exactly as it did before.

## Verification

- `deploy/helm/djinn/tests/kueue-topology-render.sh` — pass (+193 lines of new contract)
- `scripts/test-helm-chart-contracts.sh` — 15/17, same as the pre-existing baseline on `main` (`incident-observability` and `log-collector` fail locally only because `vector` is not installed; both pass in CI)
- `cargo test -p djinn-k8s --all-targets` — 294 + 31 pass, 0 fail
- `cargo test -p djinn-image-controller` — 94 pass
- `cargo clippy -p djinn-k8s -p djinn-server --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
