### PR TITLE
fix(ci): raw-SQL guard silently skipped compiled non-.rs source (.inc)

### DIFF
--- a/scripts/check-raw-sql-boundary.sh
+++ b/scripts/check-raw-sql-boundary.sh
@@ -7,6 +7,22 @@
 # This guard fails when changed Rust files outside approved boundaries
 # introduce raw sqlx query calls (sqlx::query, sqlx::query!, etc.).
 #
+# Classification is DEFAULT-DENY. "Rust source" is not the same thing as
+# "path ending in .rs": `.inc` files under server/ are `include!`d into a
+# module and compiled verbatim, and nothing stops the next novel extension
+# from appearing. So every changed path under the server source tree is
+# sorted into exactly one of three buckets:
+#
+#   compiled      — inspected for raw sqlx usage (.rs, .inc).
+#   inert         — data/config/docs that are never compiled into a crate;
+#                   skipped silently (.sql, .toml, .json, .md, .snap, ...).
+#   unclassified  — anything else. Inspected ANYWAY and announced with a
+#                   ::warning::, so a novel extension is a visible skip
+#                   rather than an invisible one. Silently dropping a
+#                   compiled file is the failure mode this guard exists to
+#                   prevent; add the extension to one of the two lists
+#                   below to clear the warning.
+#
 # Usage:
 #   BASE_SHA=<sha> ./scripts/check-raw-sql-boundary.sh
 #   ./scripts/check-raw-sql-boundary.sh                      # uses locally available origin/main
@@ -89,23 +105,16 @@ esac
 
 # ── Scope / filter helpers ─────────────────────────────────────────────
 
-# is_in_scope_rs_file returns 0 if the path is a Rust source file we should
-# inspect. Generated paths and the djinn-db crate are excluded.
-is_in_scope_rs_file() {
+# is_in_scope_path returns 0 if the path lives in the territory this guard
+# polices, regardless of extension. Extension-based classification happens
+# separately in classify_path so that an unrecognised extension inside the
+# territory is loud instead of silently dropped.
+is_in_scope_path() {
     path=$1
-
-    # Must be a .rs file.
-    case "$path" in
-        *.rs)
-            ;;
-        *)
-            return 1
-            ;;
-    esac
 
     # Must be under the server source tree.
     case "$path" in
-        server/crates/*.rs|server/src/*.rs)
+        server/crates/*|server/src/*)
             ;;
         *)
             return 1
@@ -128,6 +137,40 @@ is_in_scope_rs_file() {
     esac
 
     return 0
+}
+
+# classify_path prints exactly one of: compiled | inert | unclassified.
+#
+# Callers must have already established that the path is in scope. Keeping
+# the two lists adjacent makes it obvious that anything matching neither
+# falls through to `unclassified` — which is inspected and reported, never
+# skipped.
+classify_path() {
+    path=$1
+
+    # Compiled into a crate. `.inc` files are pulled in with include!() and
+    # are ordinary Rust source as far as rustc is concerned.
+    case "$path" in
+        *.rs|*.inc)
+            echo compiled
+            return 0
+            ;;
+    esac
+
+    # Never compiled into a crate: fixtures, snapshots, schemas, docs,
+    # scripts, and binary blobs that happen to live under server/.
+    case "$path" in
+        *.sql|*.toml|*.json|*.jsonl|*.md|*.mdx|*.yaml|*.yml|*.snap|*.txt \
+        |*.lock|*.csv|*.tsv|*.html|*.css|*.ts|*.tsx|*.js|*.mjs|*.cjs \
+        |*.py|*.sh|*.proto|*.graphql|*.patch|*.diff|*.env|*.png|*.jpg \
+        |*.jpeg|*.gif|*.ico|*.svg|*.webp|*.gz|*.zip|*.tar|*.bin|*.wasm \
+        |*.gitattributes|*.gitignore|*.dockerignore|*Dockerfile)
+            echo inert
+            return 0
+            ;;
+    esac
+
+    echo unclassified
 }
 
 # ── Grep patterns ──────────────────────────────────────────────────────
@@ -160,6 +203,7 @@ SQL_PATTERN='(sqlx::query[!(]|sqlx::query_as[!(]|sqlx::query_scalar[!(]|(^|[^a-z
 check_files() {
     violations=0
     checked=0
+    unclassified=0
 
     while IFS= read -r file || [ -n "$file" ]; do
         [ -n "$file" ] || continue
@@ -168,9 +212,23 @@ check_files() {
             ./*) file=${file#./} ;;
         esac
 
-        is_in_scope_rs_file "$file" || continue
+        is_in_scope_path "$file" || continue
         # Skip deleted / nonexistent files.
         [ -f "$file" ] || continue
+
+        kind=$(classify_path "$file")
+        case "$kind" in
+            inert)
+                continue
+                ;;
+            unclassified)
+                # Fail loud, not silent: we do not know whether this file is
+                # compiled, so we inspect it and say so.
+                unclassified=$((unclassified + 1))
+                printf '::warning::check-raw-sql-boundary: unrecognised extension under the server source tree; inspecting it as if it were compiled Rust: %s\n' "$file" >&2
+                printf '  Add this extension to the compiled or inert list in scripts/check-raw-sql-boundary.sh to silence this warning.\n' >&2
+                ;;
+        esac
 
         checked=$((checked + 1))
 
@@ -198,6 +256,11 @@ check_files() {
         exit 1
     fi
 
+    if [ "$unclassified" -gt 0 ]; then
+        echo "OK: checked $checked compiled source file(s) outside djinn-db ($unclassified with an unrecognised extension, inspected anyway); no raw-sqlx boundary violations."
+        exit 0
+    fi
+
     echo "OK: checked $checked Rust source file(s) outside djinn-db; no raw-sqlx boundary violations."
     exit 0
 }
@@ -207,10 +270,16 @@ check_files() {
 get_changed_files_from_diff() {
     echo "Checking raw-sqlx boundary against base $BASE_SHA ..."
 
-    # Diff to find changed (Added, Modified, Copied) Rust files. We only care
-    # about files that are present in the working tree (so Deleted/Renamed-from
-    # are naturally skipped by subsequent [ -f ] checks).
-    git diff --name-only --diff-filter=ACMR "$BASE_SHA...HEAD" -- '*.rs' || true
+    # Diff to find changed (Added, Modified, Copied, Renamed) files under the
+    # server source tree. We only care about files that are present in the
+    # working tree (so Deleted/Renamed-from are naturally skipped by subsequent
+    # [ -f ] checks).
+    #
+    # The pathspec deliberately does NOT filter by extension. Extension
+    # filtering lives in exactly one place — classify_path — because a second
+    # copy of the rule here is a copy that can silently disagree with it. That
+    # is precisely how `.inc` files went uninspected.
+    git diff --name-only --diff-filter=ACMR "$BASE_SHA...HEAD" -- server/crates server/src || true
 }
 
 resolve_base_sha() {

--- a/scripts/test-check-raw-sql-boundary.sh
+++ b/scripts/test-check-raw-sql-boundary.sh
@@ -311,6 +311,119 @@ assert_output_contains "T9 reports query! macro violation" \
     "::error::Raw sqlx query usage detected outside djinn-db: $QUERY_MACRO_PATH" \
     "$LOG_DIR/t9_query_macro.log.out"
 
+# ── T20: .inc files are compiled source and MUST be inspected ─────────
+#
+# Regression test for the hole this suite did not have: `.inc` files are
+# include!()d into a .rs module and compiled verbatim, but the guard's
+# candidate filter only accepted `*.rs`, so a real violation in
+# graph_tools/tests_coverage.inc sat in the tree with a green gate.
+FIXTURE_INC="$REPO_ROOT/$FIXTURE_BASE/src/tests_seed.inc"
+cat > "$FIXTURE_INC" <<'FIXTURE'
+    async fn seed(db: &Database) {
+        sqlx::query("INSERT INTO projects (id, name) VALUES ($1,$2)")
+            .bind("p1")
+            .bind("p1")
+            .execute(db.pool())
+            .await
+            .expect("seed project");
+    }
+FIXTURE
+
+INC_PATH="$FIXTURE_BASE/src/tests_seed.inc"
+set +e
+run_guard t20_inc_violation "$INC_PATH"
+t20_actual=$?
+set -e
+assert_exit "T20 sqlx::query in a .inc file exits non-zero" 1 "$t20_actual" "$LOG_DIR/t20_inc_violation.log.out"
+assert_output_contains "T20 reports the violating .inc file" \
+    "::error::Raw sqlx query usage detected outside djinn-db: $INC_PATH" \
+    "$LOG_DIR/t20_inc_violation.log.out"
+assert_output_lacks "T20 does not warn about .inc as unrecognised" \
+    "unrecognised extension" "$LOG_DIR/t20_inc_violation.log.out"
+
+# ── T21: a clean .inc file passes and is counted as checked ───────────
+FIXTURE_INC_CLEAN="$REPO_ROOT/$FIXTURE_BASE/src/tests_clean.inc"
+cat > "$FIXTURE_INC_CLEAN" <<'FIXTURE'
+    async fn seed(db: &Database) {
+        ProjectRepository::new(db.clone(), EventBus::noop())
+            .create_with_id("p1", "p1", "test", "p1")
+            .await
+            .expect("seed project");
+    }
+FIXTURE
+
+INC_CLEAN_PATH="$FIXTURE_BASE/src/tests_clean.inc"
+set +e
+run_guard t21_inc_clean "$INC_CLEAN_PATH"
+t21_actual=$?
+set -e
+assert_exit "T21 clean .inc file exits 0" 0 "$t21_actual" "$LOG_DIR/t21_inc_clean.log.out"
+assert_output_contains "T21 counts the .inc file as checked" \
+    "checked 1 Rust source file(s)" "$LOG_DIR/t21_inc_clean.log.out"
+
+# ── T22: an unrecognised extension is LOUD, not silently skipped ──────
+#
+# The defect was never `.inc` specifically — it was that a file the guard
+# declines to classify vanishes without a trace. An unknown extension under
+# the server source tree must be announced AND inspected, so a novel
+# compiled extension can never pass quietly.
+FIXTURE_UNKNOWN="$REPO_ROOT/$FIXTURE_BASE/src/generated_queries.rs2"
+cat > "$FIXTURE_UNKNOWN" <<'FIXTURE'
+pub async fn fetch(pool: &sqlx::PgPool) {
+    sqlx::query("SELECT 1").execute(pool).await.unwrap();
+}
+FIXTURE
+
+UNKNOWN_PATH="$FIXTURE_BASE/src/generated_queries.rs2"
+set +e
+run_guard t22_unknown_ext "$UNKNOWN_PATH"
+t22_actual=$?
+set -e
+assert_exit "T22 unrecognised extension with a violation exits non-zero" 1 "$t22_actual" "$LOG_DIR/t22_unknown_ext.log.out"
+assert_output_contains "T22 warns about the unrecognised extension" \
+    "::warning::check-raw-sql-boundary: unrecognised extension under the server source tree; inspecting it as if it were compiled Rust: $UNKNOWN_PATH" \
+    "$LOG_DIR/t22_unknown_ext.log.out"
+assert_output_contains "T22 still reports the violation" \
+    "::error::Raw sqlx query usage detected outside djinn-db: $UNKNOWN_PATH" \
+    "$LOG_DIR/t22_unknown_ext.log.out"
+
+# ── T23: a clean unrecognised extension warns but does not fail ───────
+FIXTURE_UNKNOWN_CLEAN="$REPO_ROOT/$FIXTURE_BASE/src/notes.rs2"
+cat > "$FIXTURE_UNKNOWN_CLEAN" <<'FIXTURE'
+pub const GREETING: &str = "hello";
+FIXTURE
+
+UNKNOWN_CLEAN_PATH="$FIXTURE_BASE/src/notes.rs2"
+set +e
+run_guard t23_unknown_clean "$UNKNOWN_CLEAN_PATH"
+t23_actual=$?
+set -e
+assert_exit "T23 clean unrecognised extension exits 0" 0 "$t23_actual" "$LOG_DIR/t23_unknown_clean.log.out"
+assert_output_contains "T23 still warns about the unrecognised extension" \
+    "unrecognised extension" "$LOG_DIR/t23_unknown_clean.log.out"
+assert_output_contains "T23 summary names the unclassified count" \
+    "1 with an unrecognised extension, inspected anyway" \
+    "$LOG_DIR/t23_unknown_clean.log.out"
+
+# ── T24: inert data files under server/ are skipped silently ──────────
+#
+# The loud-unclassified rule must not turn every fixture into noise. A .sql
+# fixture living under server/crates is data, not compiled source.
+FIXTURE_SQL="$REPO_ROOT/$FIXTURE_BASE/fixtures/seed.sql"
+mkdir -p -- "$(dirname -- "$FIXTURE_SQL")"
+cat > "$FIXTURE_SQL" <<'FIXTURE'
+INSERT INTO projects (id, name) VALUES ('p1', 'p1');
+FIXTURE
+
+SQL_FIXTURE_PATH="$FIXTURE_BASE/fixtures/seed.sql"
+set +e
+run_guard t24_inert "$SQL_FIXTURE_PATH"
+t24_actual=$?
+set -e
+assert_exit "T24 inert .sql fixture exits 0" 0 "$t24_actual" "$LOG_DIR/t24_inert.log.out"
+assert_output_lacks "T24 does not warn about inert data files" \
+    "unrecognised extension" "$LOG_DIR/t24_inert.log.out"
+
 # ── T10: mixed files — violation + clean + djinn-db ───────────────────
 set +e
 run_guard t10_mixed "$VIOLATION_PATH" "$CLEAN_PATH" "$DJINNDB_PATH"

--- a/server/crates/djinn-control-plane/src/tools/graph_tools/tests_coverage.inc
+++ b/server/crates/djinn-control-plane/src/tools/graph_tools/tests_coverage.inc
@@ -8,8 +8,8 @@
 //   * the `impact_check` verdict (escalated to `needs_spike`, naming `server`).
 
 use djinn_db::{
-    COVERAGE_STATUS_INDEXED, COVERAGE_STATUS_TIMED_OUT, ProjectWorkspaceCoverageRepository,
-    ProjectWorkspaceCoverageUpsert,
+    COVERAGE_STATUS_INDEXED, COVERAGE_STATUS_TIMED_OUT, ProjectRepository,
+    ProjectWorkspaceCoverageRepository, ProjectWorkspaceCoverageUpsert,
 };
 
 const COVERAGE_PROJECT: &str = "proj-coverage";
@@ -17,12 +17,8 @@ const COVERAGE_PROJECT: &str = "proj-coverage";
 /// Seed the two-workspace coverage fixture into `db` (project row + coverage
 /// rows). `server` (rust) timed out; `ui` (typescript) indexed.
 async fn seed_coverage_fixture(db: &Database) {
-    sqlx::query("INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1,$2,$3,$4)")
-        .bind(COVERAGE_PROJECT)
-        .bind(COVERAGE_PROJECT)
-        .bind("test")
-        .bind("coverage-repo")
-        .execute(db.pool())
+    ProjectRepository::new(db.clone(), EventBus::noop())
+        .create_with_id(COVERAGE_PROJECT, COVERAGE_PROJECT, "test", "coverage-repo")
         .await
         .expect("seed project");
 
@@ -163,12 +159,8 @@ async fn coverage_advisory_absent_when_clean() {
     let db = Database::open_in_memory().expect("db");
     db.ensure_initialized().await.expect("init");
     // Seed only an indexed workspace — no gap.
-    sqlx::query("INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1,$2,$3,$4)")
-        .bind("proj-clean")
-        .bind("proj-clean")
-        .bind("test")
-        .bind("clean-repo")
-        .execute(db.pool())
+    ProjectRepository::new(db.clone(), EventBus::noop())
+        .create_with_id("proj-clean", "proj-clean", "test", "clean-repo")
         .await
         .expect("seed project");
     ProjectWorkspaceCoverageRepository::new(db.clone())
@@ -274,12 +266,8 @@ async fn impact_check_ignores_unrelated_workspace_gap() {
     let db = Database::open_in_memory().expect("db");
     db.ensure_initialized().await.expect("init");
     // `server` indexed cleanly; only `ui` (typescript) is a gap.
-    sqlx::query("INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1,$2,$3,$4)")
-        .bind("proj-unrelated")
-        .bind("proj-unrelated")
-        .bind("test")
-        .bind("unrelated-repo")
-        .execute(db.pool())
+    ProjectRepository::new(db.clone(), EventBus::noop())
+        .create_with_id("proj-unrelated", "proj-unrelated", "test", "unrelated-repo")
         .await
         .expect("seed project");
     ProjectWorkspaceCoverageRepository::new(db.clone())


### PR DESCRIPTION
## The bug

`scripts/check-raw-sql-boundary.sh` filtered candidates with a `*.rs)` case arm and diffed with a `-- '*.rs'` pathspec. Anything not ending in `.rs` was dropped — not reported, not counted, just gone.

`server/crates/djinn-control-plane/src/tools/graph_tools/tests_coverage.inc` is `include!`d into `graph_tools/tests.rs`, so rustc compiles it as ordinary source. Because it ends in `.inc`, the guard inspected **zero bytes** of it. Three `sqlx::query(` calls — a hard failure in any `.rs` file — have been sitting in the tree with a green gate.

## Before / after

Same file, same (unmodified) content. Only the guard differs.

**Before** — guard on `main`, violations present:

```
$ printf '%s\n' server/crates/djinn-control-plane/src/tools/graph_tools/tests_coverage.inc \
    | sh scripts/check-raw-sql-boundary.sh --files-from-stdin
Checked 0 Rust source file(s) outside djinn-db; no raw-sqlx boundary violations.
EXIT=0
```

"Checked 0" is the whole bug in one line: the file was handed to the guard and the guard looked at nothing.

**After** — fixed guard, same unmodified violating file:

```
$ printf '%s\n' server/crates/djinn-control-plane/src/tools/graph_tools/tests_coverage.inc \
    | sh scripts/check-raw-sql-boundary.sh --files-from-stdin
::error::Raw sqlx query usage detected outside djinn-db: server/crates/djinn-control-plane/src/tools/graph_tools/tests_coverage.inc
  20:    sqlx::query("INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1,$2,$3,$4)")
  166:    sqlx::query("INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1,$2,$3,$4)")
  277:    sqlx::query("INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1,$2,$3,$4)")


::error::Found 1 file(s) with raw sqlx query usage outside server/crates/djinn-db/. All direct sqlx query calls must go through the djinn-db repository layer.
EXIT=1
```

**After the call sites are fixed** — full guard, default diff mode against `origin/main`:

```
$ sh scripts/check-raw-sql-boundary.sh
Checking raw-sqlx boundary against base 8f5221dcd...
OK: checked 1 Rust source file(s) outside djinn-db; no raw-sqlx boundary violations.
EXIT=0
```

## Design: loud beats allowlisted

`.inc` was today's instance; **silent skipping** was the defect. Adding `.inc` to the accepted-extension list fixes one case and leaves the mechanism that hid it fully intact — the next novel extension disappears exactly the same way.

So classification is now **default-deny**. Every changed path under the server source tree lands in exactly one of three buckets:

| bucket | extensions | behaviour |
| --- | --- | --- |
| `compiled` | `.rs`, `.inc` | inspected |
| `inert` | `.sql`, `.toml`, `.json`, `.md`, `.snap`, images, archives, … | skipped silently |
| `unclassified` | everything else | **inspected anyway**, announced with a `::warning::` |

An unrecognised extension under `server/` therefore cannot pass quietly: if it contains raw sqlx the build fails, and if it doesn't, the run still names the file and asks for it to be classified. A novel compiled extension is now a visible skip that still gets scanned, rather than an invisible one that doesn't. It also avoids failing the build over a genuinely inert new fixture type, which a hard-fail-on-unknown rule would have done.

The diff-mode pathspec is widened to `-- server/crates server/src` and no longer filters by extension either. Extension rules now live in exactly one place (`classify_path`), because a second copy of the rule in the pathspec is a copy that can silently disagree with the first — and that disagreement is precisely how `.inc` went uninspected.

## The three violations

Brought into compliance with `ProjectRepository::create_with_id`, whose doc comment names this exact use — *"Tests that need a stable, well-known id use this instead of `Self::create`'s generated UUID"* — and which is how the rest of the codebase seeds fixture projects (`djinn-graph/src/canonical_graph.rs`, `djinn-agent/src/environment.rs`, `server/src/server/chat/tests/adversarial.rs`, …). The file already imported `ProjectWorkspaceCoverageRepository` from `djinn_db` for its other seeding, so this just makes the project row consistent with the coverage rows beside it.

No suppression added, no rule weakened.

## Verification

- `sh scripts/test-check-raw-sql-boundary.sh` — **42 passed, 0 failed**. New cases T20–T24: a violating `.inc` fails; a clean `.inc` is counted as checked; an unknown extension warns *and* is still scanned (asserted both with and without a violation present); inert `.sql` fixtures stay quiet. T20 also asserts `.inc` does **not** trip the unclassified warning, so the two lists can't silently swap.
- `SQLX_OFFLINE=true cargo clippy -p djinn-control-plane --all-targets -- -D warnings` — clean.
- `cargo test -p djinn-control-plane --lib graph_tools::tests` — 183 passed, 0 failed. The four tests touching the edited seeds (`coverage_op_surfaces_the_gap`, `coverage_advisory_attaches_to_dead_symbols`, `coverage_advisory_absent_when_clean`, `impact_check_ignores_unrelated_workspace_gap`) all pass.

## Sibling guards share the same hole — not fixed here

Reported, deliberately out of scope for this PR:

- **`scripts/check-file-size.sh`** — same `server/crates/*.rs|server/src/*.rs)` arm (line ~89) *and* `-name '*.rs'` in its `--all` `find` (line ~179). This one has **live violations today**: with `MAX_LINES=1500`, three `.inc` files are already over the limit and invisible to it — `graph_tools/tests_part1.inc` (2087), `graph_tools/tests_registry_dispatch.inc` (1774), `graph_tools/tests_part3.inc` (1600).
- **`scripts/check-git-boundary.sh`**, **`check-http-boundary.sh`**, **`check-k8s-boundary.sh`** — all three delegate to `scripts/check-capability-boundaries.sh`, so they share *one* instance of the hole: `is_in_scope_file` has the identical `*.rs)` + `server/crates/*.rs` arms (lines ~294 and ~304) and the identical `-- '*.rs'` diff pathspec (line ~476). I grepped every `.inc` file for the git, http, and k8s patterns and found **no** live violations — the exposure is structural, not yet realised.

## Heads-up for the parallel `include!` → `mod` conversion

Beyond the three fixed here, **29 more raw-sqlx violations sit in five other `.inc` files**, all invisible for the same reason:

```
refinement_tools/tests_part9.inc  20
refinement_tools/tests_part4.inc   3
refinement_tools/tests_part3.inc   2
refinement_tools/tests_part6.inc   2
refinement_tools/tests_part1.inc   1
refinement_tools/tests_part5.inc   1
```

This guard is diff-scoped, so they stay dormant until someone touches those files — but a PR that renames every `.inc` to `.rs` touches all of them at once (`--diff-filter=ACMR` includes renames) and will fail this gate on all 29. Worth resolving in that PR or a precursor.
