### PR TITLE
test(control-plane): route refinement_tools fixtures through djinn-db (unblocks #2815)

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part1.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part1.inc
@@ -273,23 +273,17 @@
         link_proposal_to_project(&db, &repo, &proposal.id).await;
         // `proposals.refinement_owner_user_id` is FK-constrained to `users`, so
         // durable owner attribution can only be observed against a real row.
-        sqlx::query("INSERT INTO users (id, github_id, github_login) VALUES ($1, $2, $3)")
-            .bind("durable-owner-019f")
-            .bind(919_019_019i64)
-            .bind("durable-owner-019f")
-            .execute(db.pool())
-            .await
-            .unwrap();
+        let owner_user_id = create_test_user(&db, "durable-owner-019f").await;
         for _ in 0..2 {
             let response = server.dispatch_tool("proposal_refinement_start", serde_json::json!({
-                "proposal_id": proposal.id, "owner_user_id": "durable-owner-019f",
+                "proposal_id": proposal.id, "owner_user_id": owner_user_id,
                 "request_id": "start-request-019f"
             })).await.unwrap();
             assert_eq!(response["error"], "accepted; dispatch pending");
         }
         assert_eq!(
             repo.get(&proposal.id).await.unwrap().unwrap().refinement_owner_user_id.as_deref(),
-            Some("durable-owner-019f")
+            Some(owner_user_id.as_str())
         );
         assert_eq!(repo.load_refinement_run_aggregates(&proposal.id, 60_000).await.unwrap().len(), 1);
         assert_eq!(repo.revisions(&proposal.id).await.unwrap().iter()

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part3.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part3.inc
@@ -17,33 +17,30 @@
     async fn every_admission_source_leaves_the_run_durably_attributed() {
         let (server, db) = test_server().await;
         let repo = ProposalRepository::new(db.clone(), EventBus::noop());
-        let proposal = repo
-            .create(ProposalCreateInput {
-                title: "Attribution on demand",
-                body: "body",
-                acceptance_criteria: Some("[]"),
-                status: None,
-                body_format: None,
+        // `refinement_owner_user_id` is FK-constrained to `users`, so the
+        // author fallback can only be observed against a real row.
+        // `ProposalRepository::create` stamps `author_user_id` from the ambient
+        // auth context, which is the only way the column is ever written.
+        let author_user_id = create_test_user(&db, "attribution-author-019f").await;
+        let proposal = djinn_core::auth_context::SESSION_USER_ID
+            .scope(Some(author_user_id.clone()), async {
+                repo.create(ProposalCreateInput {
+                    title: "Attribution on demand",
+                    body: "body",
+                    acceptance_criteria: Some("[]"),
+                    status: None,
+                    body_format: None,
+                })
+                .await
             })
             .await
             .unwrap();
+        assert_eq!(
+            proposal.author_user_id.as_deref(),
+            Some(author_user_id.as_str()),
+            "the attribution fallback under test reads the proposal author"
+        );
         link_proposal_to_project(&db, &repo, &proposal.id).await;
-
-        // `refinement_owner_user_id` is FK-constrained to `users`, so the
-        // author fallback can only be observed against a real row.
-        sqlx::query("INSERT INTO users (id, github_id, github_login) VALUES ($1, $2, $3)")
-            .bind("attribution-author-019f")
-            .bind(919_067_201i64)
-            .bind("attribution-author-019f")
-            .execute(db.pool())
-            .await
-            .unwrap();
-        sqlx::query("UPDATE proposals SET author_user_id = $2 WHERE id = $1")
-            .bind(&proposal.id)
-            .bind("attribution-author-019f")
-            .execute(db.pool())
-            .await
-            .unwrap();
 
         // A demanded round carries no explicit owner. It must still attribute
         // the run from the proposal author.
@@ -66,7 +63,7 @@
                 .unwrap()
                 .refinement_owner_user_id
                 .as_deref(),
-            Some("attribution-author-019f"),
+            Some(author_user_id.as_str()),
             "a demanded round must attribute the run it admits"
         );
 
@@ -93,7 +90,7 @@
                 .unwrap()
                 .refinement_owner_user_id
                 .as_deref(),
-            Some("attribution-author-019f"),
+            Some(author_user_id.as_str()),
             "an implicit start must never clear a run's durable owner"
         );
     }

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part4.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part4.inc
@@ -3,53 +3,65 @@
 
     use djinn_core::models::{EvidenceFindings, NeedsEvidenceClaim};
 
-    /// Helper: insert a project row and return its id.
+    /// Helper: create a project row and return its id.
     async fn insert_project(db: &Database, name: &str) -> String {
         let id = uuid::Uuid::now_v7().to_string();
-        sqlx::query(
-            "INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1, $2, $3, $4)",
-        )
-        .bind(&id)
-        .bind(name)
-        .bind(name)
-        .bind(format!("repo-{}", &id.replace('-', "")[..31]))
-        .execute(db.pool())
-        .await
-        .unwrap();
+        djinn_db::ProjectRepository::new(db.clone(), EventBus::noop())
+            .create_with_id(
+                &id,
+                name,
+                name,
+                &format!("repo-{}", &id.replace('-', "")[..31]),
+            )
+            .await
+            .unwrap();
         id
     }
 
-    /// Helper: insert an epic row and return its id.
-    async fn insert_epic(db: &Database, project_id: &str, short_id: &str) -> String {
-        let id = uuid::Uuid::now_v7().to_string();
-        sqlx::query(
-            "INSERT INTO epics (id, project_id, short_id, title, description, emoji, color, status, owner, memory_refs, auto_breakdown) VALUES ($1, $2, $3, 'T', '', '', '', 'open', '', '[]'::jsonb, true)",
-        )
-        .bind(&id)
-        .bind(project_id)
-        .bind(short_id)
-        .execute(db.pool())
-        .await
-        .unwrap();
-        id
+    /// Helper: create an epic row and return its id. The short id is
+    /// repository-generated; these fixtures only need a valid FK target.
+    async fn insert_epic(db: &Database, project_id: &str) -> String {
+        djinn_db::EpicRepository::new(db.clone(), EventBus::noop())
+            .create_for_project(
+                project_id,
+                djinn_db::EpicCreateInput {
+                    title: "T",
+                    description: "",
+                    emoji: "",
+                    color: "",
+                    owner: "",
+                    memory_refs: None,
+                    status: None,
+                    auto_breakdown: None,
+                    originating_adr_id: None,
+                    blocked_by: None,
+                },
+            )
+            .await
+            .unwrap()
+            .id
     }
 
-    /// Helper: insert a task row and return its id.
-    async fn insert_task(db: &Database, project_id: &str, epic_id: &str, short_id: &str) -> String {
-        let id = uuid::Uuid::now_v7().to_string();
-        let creator_id = create_test_user(db, &format!("spike-creator-{id}")).await;
-        sqlx::query(
-            "INSERT INTO tasks (id, project_id, short_id, epic_id, title, description, design, issue_type, priority, owner, status, continuation_count, labels, acceptance_criteria, memory_refs, created_by_user_id) VALUES ($1, $2, $3, $4, 'T', '', '', 'task', 0, '', 'open', 0, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, $5)",
-        )
-        .bind(&id)
-        .bind(project_id)
-        .bind(short_id)
-        .bind(epic_id)
-        .bind(creator_id)
-        .execute(db.pool())
-        .await
-        .unwrap();
-        id
+    /// Helper: create a task row and return its id. The short id and the
+    /// creator are repository-generated; these fixtures only need a valid FK
+    /// target for `linked_spike_task_id`.
+    async fn insert_task(db: &Database, project_id: &str, epic_id: &str) -> String {
+        djinn_db::TaskRepository::new(db.clone(), EventBus::noop())
+            .create_fixture_in_project(
+                project_id,
+                Some(epic_id),
+                "T",
+                "",
+                "",
+                "task",
+                0,
+                "",
+                Some("open"),
+                None,
+            )
+            .await
+            .unwrap()
+            .id
     }
 
     /// Helper: create a proposal, start refinement, set a structured
@@ -75,8 +87,8 @@
 
         // Create a real task to satisfy the FK constraint on linked_spike_task_id.
         let proj = insert_project(&db, "svc-test").await;
-        let epic = insert_epic(&db, &proj, "sp01").await;
-        let spike_id = insert_task(&db, &proj, &epic, "spike-01").await;
+        let epic = insert_epic(&db, &proj).await;
+        let spike_id = insert_task(&db, &proj, &epic).await;
 
         let claim = NeedsEvidenceClaim {
             question: "Is module X load-bearing?".to_owned(),
@@ -148,8 +160,8 @@
 
         // Create a real task to satisfy the FK constraint.
         let proj = insert_project(&db, "svc-legacy").await;
-        let epic = insert_epic(&db, &proj, "lg01").await;
-        let spike_id = insert_task(&db, &proj, &epic, "spike-lg").await;
+        let epic = insert_epic(&db, &proj).await;
+        let spike_id = insert_task(&db, &proj, &epic).await;
 
         // Use the legacy plain-string setter.
         repo.set_needs_evidence_spike(&p.id, &spike_id, "X is load-bearing")

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part5.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part5.inc
@@ -43,17 +43,17 @@
         proposal_id: &str,
     ) -> String {
         let project_id = uuid::Uuid::now_v7().to_string();
-        sqlx::query(
-            "INSERT INTO projects (id, name, github_owner, github_repo) \
-             VALUES ($1, $2, $3, $4)",
-        )
-        .bind(&project_id)
-        .bind(format!("test-project-{project_id}"))
-        .bind("test-owner")
-        .bind(format!("test-repo-{project_id}"))
-        .execute(db.pool())
-        .await
-        .unwrap();
+        // `create_with_id` rather than `create`: the `test-owner/test-repo-<id>`
+        // coordinates are how callers address this project through `board_health`.
+        djinn_db::ProjectRepository::new(db.clone(), EventBus::noop())
+            .create_with_id(
+                &project_id,
+                &format!("test-project-{project_id}"),
+                "test-owner",
+                &format!("test-repo-{project_id}"),
+            )
+            .await
+            .unwrap();
 
         repo.add_target(proposal_id, &project_id, "primary")
             .await

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part6.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part6.inc
@@ -131,12 +131,9 @@
         let (server, db, p, user_id, _judge_task_id) =
             setup_demand_test().await;
 
-        // Count tasks before via direct SQL.
-        let before_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM tasks")
-                .fetch_one(db.pool())
-                .await
-                .unwrap();
+        // Count every task row, not just this project's: a spike created and
+        // then stranded outside the fixture project must still be visible.
+        let before_count = djinn_db::test_support::task_row_count_for_test(&db).await;
 
         // Use a stale round to force rejection.
         let mut params = valid_demand_params(&p.id);
@@ -154,11 +151,7 @@
         assert!(!resp.get("accepted").and_then(|v| v.as_bool()).unwrap_or(true));
 
         // Count tasks after.
-        let after_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM tasks")
-                .fetch_one(db.pool())
-                .await
-                .unwrap();
+        let after_count = djinn_db::test_support::task_row_count_for_test(&db).await;
 
         assert_eq!(
             before_count, after_count,

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part8.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part8.inc
@@ -93,8 +93,8 @@
             .unwrap();
 
         let proj = insert_project(&db, "svc-legacy-new").await;
-        let epic = insert_epic(&db, &proj, "lg02").await;
-        let spike_id = insert_task(&db, &proj, &epic, "spike-lg2").await;
+        let epic = insert_epic(&db, &proj).await;
+        let spike_id = insert_task(&db, &proj, &epic).await;
 
         repo.set_needs_evidence_spike(&p.id, &spike_id, "X is load-bearing")
             .await

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part9.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part9.inc
@@ -17,8 +17,10 @@
             },
         )
         .await;
-        sqlx::query("UPDATE tasks SET refinement_run_id = $1 WHERE id = $2")
-            .bind(run_id).bind(&task_id).execute(db.pool()).await.unwrap();
+        // Deliberately partial: run id only, no intent identity. That is the
+        // durable shape that makes the task itself the liveness evidence.
+        djinn_db::test_support::correlate_task_to_refinement_run_for_test(db, &task_id, run_id)
+            .await;
         (project_id, task_id)
     }
 
@@ -41,8 +43,10 @@
                 task_id: Some(task_id),
             },
         ).await;
-        sqlx::query("UPDATE sessions SET status = 'running' WHERE id = $1")
-            .bind(&session_id).execute(db.pool()).await.unwrap();
+        djinn_db::SessionRepository::new(db.clone(), EventBus::noop())
+            .set_running(&session_id)
+            .await
+            .unwrap();
         session_id
     }
 
@@ -205,8 +209,11 @@
                 Fixture::Handoff => {}
                 Fixture::Heartbeat => {
                     djinn_db::test_support::make_refinement_run_phantom_for_test(&db, &run_id).await;
-                    sqlx::query("UPDATE refinement_runs SET heartbeat_at = to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') WHERE id = $1")
-                        .bind(&run_id).execute(db.pool()).await.unwrap();
+                    // The only durable heartbeat writer: it stamps
+                    // `transaction_timestamp()` on the exact generation.
+                    repo.record_refinement_durable_progress(
+                        &run_id, generation, djinn_db::RefinementDurableProgress::DebateAppend,
+                    ).await.unwrap();
                 }
                 Fixture::ExpiredClaim => {
                     assert!(repo.claim_refinement_intent(djinn_db::ClaimRefinementIntentRequest {
@@ -284,14 +291,15 @@
             title: "Exact evidence status", body: "body", acceptance_criteria: Some("[]"),
             status: Some("draft"), body_format: None,
         }).await.unwrap();
-        let run_id = match repo.reap_and_admit(djinn_db::AdmitRefinementRunRequest {
+        let (run_id, intent_id, generation) = match repo.reap_and_admit(djinn_db::AdmitRefinementRunRequest {
             proposal_id: proposal.id.clone(), idempotency_key: "status-evidence".into(),
             source: djinn_db::RefinementAdmissionSource::Demand { demand_id: "status-evidence".into() },
             heartbeat_grace_millis: 60_000,
         }).await.unwrap() {
-            djinn_db::RefinementAdmissionOutcome::Admitted { run_id, .. } => run_id,
+            djinn_db::RefinementAdmissionOutcome::Admitted { run_id, intent_id, generation, .. } => (run_id, intent_id, generation),
             _ => unreachable!(),
         };
+        let owner = "status-evidence-fixture".to_owned();
         let pending = build_refinement_status(&repo, &proposal.id).await.unwrap();
         assert_eq!(pending.run_id.as_deref(), Some(run_id.as_str()));
         assert_eq!(pending.run_state.as_deref(), Some("active"));
@@ -299,24 +307,36 @@
         assert_eq!(pending.liveness_evidence.as_deref(), Some("pending_intent"));
         assert!(pending.active);
 
-        sqlx::query("UPDATE refinement_dispatch_intents SET state = 'claimed', claimed_by = 'test', claimed_at = '2000-01-01T00:00:00.000Z', claim_expires_at = '2999-01-01T00:00:00.000Z' WHERE run_id = $1")
-            .bind(&run_id).execute(db.pool()).await.unwrap();
+        let lease = repo.claim_refinement_intent(djinn_db::ClaimRefinementIntentRequest {
+            run_id: run_id.clone(), intent_id: intent_id.clone(), generation,
+            owner: owner.clone(), lease_millis: 60_000,
+        }).await.unwrap().unwrap();
         let claimed = build_refinement_status(&repo, &proposal.id).await.unwrap();
         assert_eq!(claimed.run_id.as_deref(), Some(run_id.as_str()));
         assert_eq!(claimed.liveness.as_deref(), Some("live"));
         assert_eq!(claimed.liveness_evidence.as_deref(), Some("claimed_intent"));
         assert!(claimed.active);
 
-        sqlx::query("UPDATE refinement_dispatch_intents SET state = 'materialized', claimed_by = NULL, claimed_at = NULL, claim_expires_at = NULL WHERE run_id = $1")
-            .bind(&run_id).execute(db.pool()).await.unwrap();
-        sqlx::query("UPDATE refinement_runs SET heartbeat_at = '2000-01-01T00:00:00.000Z' WHERE id = $1")
-            .bind(&run_id).execute(db.pool()).await.unwrap();
+        // Materialization is only reachable through the repository once the
+        // task already carries the exact correlation, so the task is seeded
+        // and correlated before the acknowledgement rather than after it.
         let (project_id, task_id) = seed_status_task(&db, &run_id, "open").await;
+        djinn_db::TaskRepository::new(db.clone(), EventBus::noop())
+            .set_refinement_correlation(&task_id, Some(&djinn_core::models::TaskRefinementCorrelation::new(
+                run_id.clone(), intent_id.clone(), i64::from(generation), i64::from(lease.round), lease.phase, lease.role,
+            ).unwrap())).await.unwrap();
+        assert!(repo.acknowledge_refinement_task_materialization(djinn_db::AcknowledgeRefinementTaskMaterializationRequest {
+            run_id: run_id.clone(), intent_id: intent_id.clone(), generation,
+            task_id: task_id.clone(), owner: owner.clone(),
+        }).await.unwrap());
+        // Acknowledgement advances the heartbeat once; age it back out of grace
+        // so no fresh-heartbeat fallback can stand in for the intent below.
+        djinn_db::test_support::elapse_refinement_run_wall_clock_for_test(&db, &run_id, 3_600).await;
+        let task_repo = djinn_db::TaskRepository::new(db.clone(), EventBus::noop());
         // A materialized exact-run intent precedes all task, session, and
         // heartbeat fallbacks in the shared evaluator.
         for task_status in ["open", "queued", "in_progress", "pool_paused"] {
-            sqlx::query("UPDATE tasks SET status = $1 WHERE id = $2")
-                .bind(task_status).bind(&task_id).execute(db.pool()).await.unwrap();
+            task_repo.set_status(&task_id, task_status).await.unwrap();
             let status = build_refinement_status(&repo, &proposal.id).await.unwrap();
             assert_eq!(status.run_id.as_deref(), Some(run_id.as_str()));
             assert_eq!(status.liveness.as_deref(), Some("live"));
@@ -324,18 +344,19 @@
             assert!(status.active);
         }
 
-        sqlx::query("UPDATE tasks SET status = 'closed' WHERE id = $1")
-            .bind(&task_id).execute(db.pool()).await.unwrap();
+        task_repo.set_status(&task_id, "closed").await.unwrap();
         let session_id = seed_live_status_session(&db, &project_id, &task_id).await;
         let session = build_refinement_status(&repo, &proposal.id).await.unwrap();
         assert_eq!(session.run_id.as_deref(), Some(run_id.as_str()));
         assert_eq!(session.liveness.as_deref(), Some("live"));
         assert_eq!(session.liveness_evidence.as_deref(), Some("materialized_intent"));
         assert!(session.active);
-        sqlx::query("UPDATE sessions SET status = 'completed' WHERE id = $1")
-            .bind(&session_id).execute(db.pool()).await.unwrap();
-        sqlx::query("UPDATE refinement_runs SET heartbeat_at = to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') WHERE id = $1")
-            .bind(&run_id).execute(db.pool()).await.unwrap();
+        djinn_db::SessionRepository::new(db.clone(), EventBus::noop())
+            .update(&session_id, djinn_core::models::SessionStatus::Completed, 0, 0, 0, 0, None)
+            .await.unwrap();
+        repo.record_refinement_durable_progress(
+            &run_id, generation, djinn_db::RefinementDurableProgress::DebateAppend,
+        ).await.unwrap();
         let heartbeat = build_refinement_status(&repo, &proposal.id).await.unwrap();
         assert_eq!(heartbeat.run_id.as_deref(), Some(run_id.as_str()));
         assert_eq!(heartbeat.liveness.as_deref(), Some("live"));
@@ -379,12 +400,12 @@
             title: "Exact status snapshot", body: "body", acceptance_criteria: Some("[]"),
             status: Some("draft"), body_format: None,
         }).await.unwrap();
-        let run_id = match repo.reap_and_admit(djinn_db::AdmitRefinementRunRequest {
+        let (run_id, intent_id, generation) = match repo.reap_and_admit(djinn_db::AdmitRefinementRunRequest {
             proposal_id: proposal.id.clone(), idempotency_key: "exact-status-fixture".into(),
             source: djinn_db::RefinementAdmissionSource::Demand { demand_id: "exact-status-fixture".into() },
             heartbeat_grace_millis: 60_000,
         }).await.unwrap() {
-            djinn_db::RefinementAdmissionOutcome::Admitted { run_id, .. } => run_id,
+            djinn_db::RefinementAdmissionOutcome::Admitted { run_id, intent_id, generation, .. } => (run_id, intent_id, generation),
             djinn_db::RefinementAdmissionOutcome::Existing { .. } => unreachable!(),
         };
 
@@ -393,11 +414,13 @@
         assert_eq!(live.liveness_evidence.as_deref(), Some("pending_intent"));
 
         // Status must evaluate the durable expired lease rather than treating
-        // every claimed intent as live.
-        sqlx::query("UPDATE refinement_dispatch_intents SET state = 'claimed', claimed_by = 'test', claimed_at = '2000-01-01T00:00:00.000Z', claim_expires_at = '2000-01-01T00:00:01.000Z' WHERE run_id = $1")
-            .bind(&run_id).execute(db.pool()).await.unwrap();
-        sqlx::query("UPDATE refinement_runs SET heartbeat_at = '2000-01-01T00:00:00.000Z' WHERE id = $1")
-            .bind(&run_id).execute(db.pool()).await.unwrap();
+        // every claimed intent as live. Rewinding the run's wall clock expires
+        // the real lease and ages the heartbeat out of grace together.
+        assert!(repo.claim_refinement_intent(djinn_db::ClaimRefinementIntentRequest {
+            run_id: run_id.clone(), intent_id, generation,
+            owner: "exact-status-fixture".into(), lease_millis: 60_000,
+        }).await.unwrap().is_some());
+        djinn_db::test_support::elapse_refinement_run_wall_clock_for_test(&db, &run_id, 3_600).await;
         let expired_claim = build_refinement_status(&repo, &proposal.id).await.unwrap();
         assert_eq!(expired_claim.liveness.as_deref(), Some("stale"));
 
@@ -413,21 +436,38 @@
         );
         assert_eq!(before, after, "status must not mutate a stale phantom");
 
-        sqlx::query("UPDATE refinement_runs SET state = 'parked', park_kind = 'awaiting_review', parked_at = '2026-01-01T00:00:00.000Z' WHERE id = $1")
-            .bind(&run_id).execute(db.pool()).await.unwrap();
+        // The park transition stamps a fresh heartbeat; age it straight back
+        // out of grace so the park itself stays the only live evidence.
+        assert!(repo.park_refinement_run(djinn_db::ParkRefinementRunRequest {
+            run_id: run_id.clone(), generation,
+            kind: djinn_core::refinement_liveness::RefinementParkKind::AwaitingReview,
+        }).await.unwrap());
+        djinn_db::test_support::elapse_refinement_run_wall_clock_for_test(&db, &run_id, 3_600).await;
         let parked = build_refinement_status(&repo, &proposal.id).await.unwrap();
         assert_eq!(parked.run_state.as_deref(), Some("parked"));
         assert_eq!(parked.liveness_evidence.as_deref(), Some("awaiting_review_park"));
         assert!(parked.awaiting_review);
 
-        sqlx::query("UPDATE refinement_runs SET park_kind = 'awaiting_evidence' WHERE id = $1")
-            .bind(&run_id).execute(db.pool()).await.unwrap();
+        // `park_refinement_run` fences on `state = 'running'`, so an already
+        // parked run has no repository path to the other park kind.
+        djinn_db::test_support::force_refinement_run_park_kind_for_test(
+            &db, &run_id, djinn_core::refinement_liveness::RefinementParkKind::AwaitingEvidence,
+        ).await;
         let awaiting_evidence = build_refinement_status(&repo, &proposal.id).await.unwrap();
         assert_eq!(awaiting_evidence.liveness_evidence.as_deref(), Some("awaiting_evidence_park"));
         assert!(!awaiting_evidence.awaiting_review);
 
-        sqlx::query(r#"UPDATE refinement_runs SET state = 'terminal', parked_at = NULL, park_kind = NULL, terminal_at = '2026-01-01T00:00:00.000Z', stop_tag = 'operator_stop', stop_context = '{"actor": "test", "reason": null}'::jsonb WHERE id = $1"#)
-            .bind(&run_id).execute(db.pool()).await.unwrap();
+        // A forced terminal keeps the run row the only evidence: the
+        // repository transition would also append a `refinement_stop`
+        // revision, which `build_refinement_status` reads as a display-only
+        // stop-reason fallback.
+        djinn_db::test_support::force_refinement_run_terminal_for_test(
+            &db, &run_id,
+            &djinn_core::refinement_liveness::RefinementStopReason::OperatorStop {
+                actor: "test".into(), reason: None,
+            },
+            "2026-01-01T00:00:00.000Z",
+        ).await;
         let terminal = build_refinement_status(&repo, &proposal.id).await.unwrap();
         assert_eq!(terminal.run_state.as_deref(), Some("terminal"));
         assert_eq!(terminal.liveness.as_deref(), Some("terminal"));
@@ -453,8 +493,18 @@
         };
         let (project_id, prior_task) = seed_status_task(&db, &first, "closed").await;
         let prior_session = seed_live_status_session(&db, &project_id, &prior_task).await;
-        sqlx::query(r#"UPDATE refinement_runs SET state = 'terminal', terminal_at = '2026-01-01T00:00:00.000Z', stop_tag = 'operator_stop', stop_context = '{"actor": "test", "reason": null}'::jsonb WHERE id = $1"#)
-            .bind(&first).execute(db.pool()).await.unwrap();
+        // Forced, not `terminal_refinement_run`: that transition also appends a
+        // `refinement_stop` revision, and `build_refinement_status` falls back
+        // to the latest such revision for `stop_reason` whenever the current
+        // run has no terminal reason — which is exactly the leak this test
+        // asserts does not happen.
+        djinn_db::test_support::force_refinement_run_terminal_for_test(
+            &db, &first,
+            &djinn_core::refinement_liveness::RefinementStopReason::OperatorStop {
+                actor: "test".into(), reason: None,
+            },
+            "2026-01-01T00:00:00.000Z",
+        ).await;
         let second = match repo.reap_and_admit(admit("current-run")).await.unwrap() {
             djinn_db::RefinementAdmissionOutcome::Admitted { run_id, .. } => run_id,
             _ => unreachable!(),
@@ -464,7 +514,11 @@
         assert_eq!(status.run_id.as_deref(), Some(second.as_str()));
         assert_eq!(status.liveness.as_deref(), Some("stale"));
         assert!(!status.active);
-        assert_eq!(sqlx::query_scalar::<_, String>("SELECT status FROM sessions WHERE id = $1").bind(&prior_session).fetch_one(db.pool()).await.unwrap(), "running");
+        assert_eq!(
+            djinn_db::SessionRepository::new(db.clone(), EventBus::noop())
+                .get(&prior_session).await.unwrap().unwrap().status,
+            "running",
+        );
         assert_ne!(status.stop_reason.as_deref(), Some("operator_stop"));
     }
 
@@ -638,9 +692,12 @@
                     let task_id = djinn_db::test_support::seed_task_row(&db, djinn_db::test_support::UsageTestTaskSeed {
                         project_id: &project_id, status: "closed", close_reason: None, total_reopen_count: 0,
                     }).await;
-                    sqlx::query("UPDATE tasks SET refinement_run_id = $1, refinement_intent_id = $2, refinement_generation = $3, refinement_round = $4, refinement_phase = 'adversary_attack', refinement_role = 'adversary' WHERE id = $5")
-                        .bind(&run_id).bind(&intent_id).bind(generation).bind(lease.round).bind(&task_id)
-                        .execute(db.pool()).await.unwrap();
+                    djinn_db::TaskRepository::new(db.clone(), EventBus::noop())
+                        .set_refinement_correlation(&task_id, Some(&djinn_core::models::TaskRefinementCorrelation::new(
+                            run_id.clone(), intent_id.clone(), i64::from(generation), i64::from(lease.round),
+                            djinn_core::refinement_liveness::RefinementPhase::AdversaryAttack,
+                            djinn_core::refinement_liveness::RefinementRole::Adversary,
+                        ).unwrap())).await.unwrap();
                     assert!(repo.acknowledge_refinement_task_materialization(djinn_db::AcknowledgeRefinementTaskMaterializationRequest {
                         run_id: run_id.clone(), intent_id: intent_id.clone(), generation, task_id: task_id.clone(), owner,
                     }).await.unwrap());
@@ -651,13 +708,16 @@
                     let task_id = djinn_db::test_support::seed_task_row(&db, djinn_db::test_support::UsageTestTaskSeed {
                         project_id: &project_id, status: "queued", close_reason: None, total_reopen_count: 0,
                     }).await;
-                    sqlx::query("UPDATE tasks SET refinement_run_id = $1, refinement_intent_id = $2, refinement_generation = $3, refinement_round = 1, refinement_phase = 'adversary_attack', refinement_role = 'adversary' WHERE id = $4")
-                        .bind(&run_id).bind(&intent_id).bind(generation).bind(&task_id)
-                        .execute(db.pool()).await.unwrap();
+                    djinn_db::TaskRepository::new(db.clone(), EventBus::noop())
+                        .set_refinement_correlation(&task_id, Some(&djinn_core::models::TaskRefinementCorrelation::new(
+                            run_id.clone(), intent_id.clone(), i64::from(generation), 1,
+                            djinn_core::refinement_liveness::RefinementPhase::AdversaryAttack,
+                            djinn_core::refinement_liveness::RefinementRole::Adversary,
+                        ).unwrap())).await.unwrap();
                     // The completed source intent and old heartbeat leave the queued task as the sole evidence.
-                    // Terminal intent rows require their terminal timestamp under the durable schema.
-                    sqlx::query("UPDATE refinement_dispatch_intents SET state = 'completed', terminal_at = to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'), updated_at = to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') WHERE id = $1")
-                        .bind(&intent_id).execute(db.pool()).await.unwrap();
+                    // `complete_refinement_intent` would persist a successor in the same transaction, and a
+                    // pending successor intent outranks the queued task in the shared evaluator.
+                    djinn_db::test_support::complete_refinement_intent_without_successor_for_test(&db, &intent_id).await;
                     djinn_db::test_support::elapse_refinement_run_wall_clock_for_test(&db, &run_id, 3_600).await;
                 }
             }
@@ -709,15 +769,25 @@
             };
             let (prior_project, prior_task) = seed_status_task(&db, &prior, "closed").await;
             let _prior_session = seed_live_status_session(&db, &prior_project, &prior_task).await;
+            // Terminalized out of band on purpose: `terminal_refinement_run`
+            // would also append a `refinement_stop` revision, and the assertion
+            // below counts exactly those revisions to prove the tool handler
+            // emitted no spurious stop. A fixture-written audit row would be
+            // indistinguishable from the defect.
+            //
             // `RefinementStopReason` is adjacently tagged (`tag`/`context`), and
             // `OperatorStop` is a struct variant — a row carrying the tag with a
             // null `stop_context` cannot be deserialized and fails every later
-            // snapshot read with `invalid stop reason "operator_stop"`. Write the
-            // context the tag requires.
-            sqlx::query("UPDATE refinement_runs SET state = 'terminal', terminal_at = '2000-01-01T00:00:00.000Z', stop_tag = 'operator_stop', stop_context = $2 WHERE id = $1")
-                .bind(&prior)
-                .bind(serde_json::json!({ "actor": "operator", "reason": "prior run stopped by hand" }))
-                .execute(db.pool()).await.unwrap();
+            // snapshot read with `invalid stop reason "operator_stop"`. The
+            // helper derives the context the tag requires from the reason.
+            djinn_db::test_support::force_refinement_run_terminal_for_test(
+                &db, &prior,
+                &djinn_core::refinement_liveness::RefinementStopReason::OperatorStop {
+                    actor: "operator".into(),
+                    reason: Some("prior run stopped by hand".into()),
+                },
+                "2000-01-01T00:00:00.000Z",
+            ).await;
             let phantom = match repo.reap_and_admit(admission(format!("{name}-phantom"))).await.unwrap() {
                 djinn_db::RefinementAdmissionOutcome::Admitted { run_id, .. } => run_id,
                 _ => unreachable!(),

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -27,11 +27,14 @@ pub mod test_support {
         apply_all_migrations_to_fresh_database, backdate_coordinator_incarnation_lease,
         backdate_task_attempt_created_at, backdate_task_updated_at,
         build_multi_project_housekeeping_fixture, close_task_at,
-        corrupt_credential_encrypted_value, corrupt_refinement_task_role_for_test,
-        delete_proposal_lint_result_for_revision_for_test, delete_proposal_lint_results_for_test,
-        delete_session_row, drop_table_cascade_for_test, drop_table_for_test,
-        elapse_refinement_run_wall_clock_for_test, ensure_doctor_findings_schema, event_bus_for,
-        insert_pending_attempt_with_raw_owner, make_coordinator_incarnation_error_after_first_read,
+        complete_refinement_intent_without_successor_for_test,
+        correlate_task_to_refinement_run_for_test, corrupt_credential_encrypted_value,
+        corrupt_refinement_task_role_for_test, delete_proposal_lint_result_for_revision_for_test,
+        delete_proposal_lint_results_for_test, delete_session_row, drop_table_cascade_for_test,
+        drop_table_for_test, elapse_refinement_run_wall_clock_for_test,
+        ensure_doctor_findings_schema, event_bus_for, force_refinement_run_park_kind_for_test,
+        force_refinement_run_terminal_for_test, insert_pending_attempt_with_raw_owner,
+        make_coordinator_incarnation_error_after_first_read,
         make_coordinator_incarnation_vanish_after_first_read, make_project,
         make_refinement_run_phantom_for_test, nullify_note_confidence_for_test,
         override_debate_trail_body_metadata, proposal_lint_revision_id_for_test,
@@ -42,7 +45,7 @@ pub mod test_support {
         rename_note_confidence_column_for_test, replace_legacy_proposal_head_for_test,
         seed_board_health_mismatch_candidate, seed_chat_session_row, seed_project,
         seed_readiness_detail_projection_for_test, seed_session_row, seed_session_row_with_id,
-        seed_task_row, structured_evidence_handoff_counts_for_test,
+        seed_task_row, structured_evidence_handoff_counts_for_test, task_row_count_for_test,
     };
 }
 

--- a/server/crates/djinn-db/src/repositories/test_support.rs
+++ b/server/crates/djinn-db/src/repositories/test_support.rs
@@ -187,6 +187,153 @@ pub async fn refinement_run_audit_for_test(
     }
 }
 
+/// Count every row in `tasks`, across all projects and statuses.
+///
+/// No repository read is equivalent: every `TaskRepository` list is scoped to a
+/// project, an epic, or a status set, so a task row created and then stranded
+/// outside the fixture's project would not appear in any of them. The tests that
+/// use this assert that a *rejected* tool call left the whole table unchanged,
+/// which is precisely a claim about rows no scoped read can see.
+///
+/// **Not for production use.** Panics on SQL errors.
+pub async fn task_row_count_for_test(db: &Database) -> i64 {
+    db.ensure_initialized().await.unwrap();
+    sqlx::query_scalar("SELECT COUNT(*) FROM tasks")
+        .fetch_one(db.pool())
+        .await
+        .expect("failed to count task rows")
+}
+
+/// Correlate a task to a refinement run by run id ALONE, leaving
+/// `refinement_intent_id`, `refinement_generation`, `refinement_round`,
+/// `refinement_phase`, and `refinement_role` null.
+///
+/// [`crate::repositories::task::TaskRepository::set_refinement_correlation`]
+/// only writes a complete [`djinn_core::models::TaskRefinementCorrelation`], and
+/// [`ProposalRepository::acknowledge_refinement_task_materialization`] refuses a
+/// task that is not fully correlated. Neither can express the partially
+/// correlated row this fixture needs: the liveness snapshot selects task
+/// evidence on `refinement_run_id` alone, so a run-correlated task with no
+/// intent identity is exactly the durable shape that distinguishes task
+/// evidence from intent evidence.
+///
+/// **Not for production use.** Panics on SQL errors.
+pub async fn correlate_task_to_refinement_run_for_test(db: &Database, task_id: &str, run_id: &str) {
+    db.ensure_initialized().await.unwrap();
+    sqlx::query("UPDATE tasks SET refinement_run_id = $1 WHERE id = $2")
+        .bind(run_id)
+        .bind(task_id)
+        .execute(db.pool())
+        .await
+        .expect("failed to correlate task to refinement run");
+}
+
+/// Replace the `park_kind` of a run that is ALREADY parked.
+///
+/// [`ProposalRepository::park_refinement_run`] carries `AND state = 'running'`
+/// and [`ProposalRepository::park_refinement_run_from_intent`] consumes a live
+/// source intent, so neither can re-park a run that is already parked, and
+/// there is no un-park transition. Status tests that must observe both park
+/// kinds project from the same exact run have no repository path to the second
+/// one.
+///
+/// `parked_at` is left untouched so the run keeps the timestamp its original
+/// park wrote.
+///
+/// **Not for production use.** Panics on SQL errors.
+pub async fn force_refinement_run_park_kind_for_test(
+    db: &Database,
+    run_id: &str,
+    kind: djinn_core::refinement_liveness::RefinementParkKind,
+) {
+    db.ensure_initialized().await.unwrap();
+    let kind = match kind {
+        djinn_core::refinement_liveness::RefinementParkKind::AwaitingReview => "awaiting_review",
+        djinn_core::refinement_liveness::RefinementParkKind::AwaitingEvidence => {
+            "awaiting_evidence"
+        }
+    };
+    sqlx::query("UPDATE refinement_runs SET park_kind = $2 WHERE id = $1 AND state = 'parked'")
+        .bind(run_id)
+        .bind(kind)
+        .execute(db.pool())
+        .await
+        .expect("failed to force refinement run park kind");
+}
+
+/// Terminalize a run row out of band: no `proposal_revisions` audit append, no
+/// heartbeat refresh, and no generation fence.
+///
+/// [`ProposalRepository::terminal_refinement_run`] additionally appends a
+/// `refinement_stop` revision in the same transaction and stamps
+/// `heartbeat_at`. Both are observable, and the tests that use this helper
+/// observe them:
+///
+/// * one counts `refinement_stop` revisions to prove a tool handler emitted no
+///   spurious stop — a fixture-written audit row would be indistinguishable
+///   from the defect;
+/// * one asserts that a *prior* terminal run's stop reason does not leak into
+///   the current run's status, and `build_refinement_status` falls back to the
+///   latest `refinement_stop` revision when the exact run has no terminal
+///   reason — so a fixture-written audit row would make the regression
+///   undetectable.
+///
+/// `terminal_at` is caller-supplied because these fixtures model historic rows.
+///
+/// **Not for production use.** Panics on SQL errors.
+pub async fn force_refinement_run_terminal_for_test(
+    db: &Database,
+    run_id: &str,
+    reason: &djinn_core::refinement_liveness::RefinementStopReason,
+    terminal_at: &str,
+) {
+    db.ensure_initialized().await.unwrap();
+    let context = serde_json::to_value(reason)
+        .expect("failed to serialize refinement stop reason")
+        .get("context")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    sqlx::query(
+        "UPDATE refinement_runs \
+         SET state = 'terminal', parked_at = NULL, park_kind = NULL, \
+             terminal_at = $2, stop_tag = $3, stop_context = $4 \
+         WHERE id = $1",
+    )
+    .bind(run_id)
+    .bind(terminal_at)
+    .bind(reason.tag())
+    .bind(&context)
+    .execute(db.pool())
+    .await
+    .expect("failed to force refinement run terminal");
+}
+
+/// Complete a dispatch intent WITHOUT persisting its successor.
+///
+/// [`ProposalRepository::complete_refinement_intent`] always inserts exactly one
+/// next-phase intent in the same transaction — that atomicity is the point of
+/// the production method. A fixture that needs the completed intent to be the
+/// run's last intent (so that some other durable row is the sole remaining
+/// liveness evidence) cannot use it: the successor lands `pending`, and a
+/// pending intent outranks every task, session, and heartbeat fallback in the
+/// shared evaluator.
+///
+/// **Not for production use.** Panics on SQL errors.
+pub async fn complete_refinement_intent_without_successor_for_test(db: &Database, intent_id: &str) {
+    db.ensure_initialized().await.unwrap();
+    sqlx::query(
+        "UPDATE refinement_dispatch_intents \
+         SET state = 'completed', claimed_by = NULL, claimed_at = NULL, claim_expires_at = NULL, \
+             terminal_at = to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'), \
+             updated_at = to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') \
+         WHERE id = $1",
+    )
+    .bind(intent_id)
+    .execute(db.pool())
+    .await
+    .expect("failed to complete refinement intent without successor");
+}
+
 /// Corrupt a task role to model malformed legacy correlation evidence.
 pub async fn corrupt_refinement_task_role_for_test(db: &Database, task_id: &str, role: &str) {
     db.ensure_initialized().await.unwrap();


### PR DESCRIPTION
Converts the **30 raw `sqlx::query*` call sites** in
`server/crates/djinn-control-plane/src/tools/refinement_tools/*.inc` to go
through the djinn-db repository layer.

**This unblocks #2815.** That PR migrates `include!` → real `mod`s, which renames
these files and thereby pulls all 30 sites into the diff the raw-SQL guard
inspects. #2815 can rebase straight on top of this. No `include!` line was
touched, no file was renamed or converted, and
`graph_tools/tests_coverage.inc` (owned by #2814) is untouched.

---

## Guard: before and after

#2814 (which teaches `scripts/check-raw-sql-boundary.sh` to classify `.inc` as
compiled source) has **not** merged yet, so the guard on `main` still skips
these files silently. Both runs below use **#2814's version of the script**,
fetched from `refs/pull/2814/head`, invoked with `--files-from-stdin` on the
affected files.

**Before** (`EXIT=1`):

```
::error::Raw sqlx query usage detected outside djinn-db: .../tests_part1.inc
  276:        sqlx::query("INSERT INTO users (id, github_id, github_login) VALUES ($1, $2, $3)")

::error::Raw sqlx query usage detected outside djinn-db: .../tests_part3.inc
  34:        sqlx::query("INSERT INTO users (id, github_id, github_login) VALUES ($1, $2, $3)")
  41:        sqlx::query("UPDATE proposals SET author_user_id = $2 WHERE id = $1")

::error::Raw sqlx query usage detected outside djinn-db: .../tests_part4.inc
  9:        sqlx::query(
  25:        sqlx::query(
  41:        sqlx::query(

::error::Raw sqlx query usage detected outside djinn-db: .../tests_part5.inc
  46:        sqlx::query(

::error::Raw sqlx query usage detected outside djinn-db: .../tests_part6.inc
  136:            sqlx::query_scalar("SELECT COUNT(*) FROM tasks")
  158:            sqlx::query_scalar("SELECT COUNT(*) FROM tasks")

::error::Raw sqlx query usage detected outside djinn-db: .../tests_part9.inc
  20, 44, 208, 302, 310, 312, 318, 327, 335, 337, 397, 399, 416, 423, 429,
  456, 467, 641, 654, 659, 717   (21 hits)

::error::Found 6 file(s) with raw sqlx query usage outside server/crates/djinn-db/.
EXIT=1
```

(1 + 2 + 3 + 1 + 2 + 21 = 30.)

**After** (`EXIT=0`) — `tests_part8.inc` is included because this PR also touches
it (call-site signature update):

```
OK: checked 7 Rust source file(s) outside djinn-db; no raw-sqlx boundary violations.
EXIT=0
```

`grep -n 'sqlx::query\|db.pool()' .../refinement_tools/*.inc` now returns nothing.

---

## Test count: unchanged

```
cargo nextest list -p djinn-control-plane --all-targets | wc -l
before: 1121
after:  1121
```

`cargo test -p djinn-control-plane`:

```
test result: ok. 905 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok.   7 passed; 0 failed; ...
test result: ok.   6 passed; 0 failed; ...
```

`tests/doctor_closed_parent_tools.rs` fails a **different random subset** on each
parallel run and is green at `--test-threads=1`:

```
running 5 tests
test closed_parent_open_children_db_dry_run_is_read_only ... ok
test closed_parent_open_children_db_repair_applies_safe_disposition ... ok
test closed_parent_open_children_repair_cascades_internal_blocker ... ok
test closed_parent_open_children_repair_skips_external_open_dependent ... ok
test closed_parent_open_children_repair_skips_stale_snapshot ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

That file is not in this diff — it is the documented pre-existing parallelism
flake, not a regression from this change.

Also clean:

* `cargo clippy -p djinn-control-plane --all-targets -- -D warnings`
* `cargo clippy -p djinn-db --all-targets --features test-support -- -D warnings`
* `cargo fmt --check -p djinn-db -p djinn-control-plane`

---

## Sites that mapped onto existing API (24)

| Was | Now |
| --- | --- |
| `INSERT INTO projects` (×2 helpers) | `ProjectRepository::create_with_id` |
| `INSERT INTO epics` | `EpicRepository::create_for_project` |
| `INSERT INTO tasks` | `TaskRepository::create_fixture_in_project` |
| `INSERT INTO users` (×2) | the existing `create_test_user` fixture (`UserRepository::upsert_from_github`) |
| `UPDATE proposals SET author_user_id` | create the proposal inside `SESSION_USER_ID.scope(..)` — `ProposalRepository::create` stamps the column from the ambient auth context, which is the only writer of it |
| `UPDATE tasks SET status` (×2) | `TaskRepository::set_status` (already documented "raw status update … only used for tests and admin tooling") |
| `UPDATE tasks SET refinement_* ` full correlation (×2) | `TaskRepository::set_refinement_correlation` |
| `UPDATE sessions SET status='running'` | `SessionRepository::set_running` (byte-identical statement) |
| `UPDATE sessions SET status='completed'` | `SessionRepository::update(.., Completed, 0,0,0,0, None)` |
| `SELECT status FROM sessions` | `SessionRepository::get` |
| `UPDATE …intents SET state='claimed'` (×2) | `ProposalRepository::claim_refinement_intent` |
| `UPDATE …intents SET state='materialized'` | `ProposalRepository::acknowledge_refinement_task_materialization` |
| `UPDATE refinement_runs SET state='parked'` | `ProposalRepository::park_refinement_run` |
| `UPDATE refinement_runs SET heartbeat_at = now()` (×2) | `ProposalRepository::record_refinement_durable_progress` (the only durable heartbeat writer) |
| `UPDATE refinement_runs SET heartbeat_at = '2000-…'` (×2) | the existing `elapse_refinement_run_wall_clock_for_test` |

---

## New `djinn-db` `test_support` API (5)

All five are `#[cfg(any(test, feature = "test-support"))]` via the existing
`pub mod test_support` gate, named `*_for_test`, and carry a doc comment naming
the production method that cannot be used and why. No suppressions, no change to
the boundary rule.

1. **`task_row_count_for_test(db) -> i64`**
   Every `TaskRepository` list is scoped to a project, an epic, or a status set.
   The two `rejection_does_not_create_tasks` assertions are specifically a claim
   that a rejected demand created **no** task row *anywhere* — including one
   stranded outside the fixture's project, which no scoped read can see.

2. **`correlate_task_to_refinement_run_for_test(db, task_id, run_id)`**
   Writes `refinement_run_id` **alone**. `set_refinement_correlation` only writes
   a complete `TaskRefinementCorrelation`, and
   `acknowledge_refinement_task_materialization` rejects a partially correlated
   task. The liveness snapshot selects task evidence on `refinement_run_id`
   alone, so a run-correlated task with no intent identity is exactly the durable
   shape that distinguishes task evidence from intent evidence.

3. **`force_refinement_run_park_kind_for_test(db, run_id, kind)`**
   `park_refinement_run` carries `AND state = 'running'`;
   `park_refinement_run_from_intent` consumes a live source intent; there is no
   un-park transition. A run that is already parked therefore has **no**
   repository path to the other park kind, which
   `exact_run_status_is_read_only_for_phantom_parked_and_terminal_runs` must
   observe on the same exact run. `parked_at` is left untouched.

4. **`force_refinement_run_terminal_for_test(db, run_id, reason, terminal_at)`**
   Terminalizes the run row only — no `proposal_revisions` audit append, no
   heartbeat refresh, no generation fence. See the two behavioural notes below;
   this one is load-bearing, not cosmetic.

5. **`complete_refinement_intent_without_successor_for_test(db, intent_id)`**
   `complete_refinement_intent` always inserts exactly one next-phase intent in
   the same transaction — that atomicity is the point of the production method.
   The `QueuedOpenRoleTask` fixture needs the completed intent to be the run's
   *last* intent so the queued task is the sole remaining evidence; a `pending`
   successor outranks every task, session, and heartbeat fallback in the shared
   evaluator, so the assertion would have started reporting `pending_intent`.

---

## Behavioural notes — why three terminalizations are forced, not repository calls

`ProposalRepository::terminal_refinement_run` does **two** things the raw SQL did
not: it appends a `refinement_stop` row to `proposal_revisions`, and it stamps
`heartbeat_at`. Both are observable here.

* **`cross_surface_phantom_reads_are_pure_and_admission_reaps_once`** asserts
  `revisions.filter(event_kind == "refinement_stop").count() == 1` with the
  message *"no handler-error stop"*. The single expected row comes from the
  phantom reap. A fixture-written audit row would make the count 2 and would be
  indistinguishable from the defect the assertion exists to catch.

* **`exact_status_uses_latest_generation_not_prior_run_evidence`** asserts
  `status.stop_reason != Some("operator_stop")` for the *current* run.
  `build_refinement_status` computes `stop_reason` as
  `exact-run terminal reason  .or(legacy_stop_reason)`, where `legacy_stop_reason`
  is read from the **latest `refinement_stop` revision**. Terminalizing the prior
  run through the repository would have written exactly that revision and made
  the assertion pass — or rather, made the regression it guards undetectable.
  This is the leak the test exists to catch.

* The third site (`exact_run_status_is_read_only_…`) uses the same helper for
  consistency; it terminalizes an already-parked, phantom run whose generation
  fence and heartbeat the fixture deliberately controls.

`park_refinement_run` and `acknowledge_refinement_task_materialization` similarly
advance the heartbeat, so each call site that previously left a stale heartbeat
now follows with `elapse_refinement_run_wall_clock_for_test(.., 3_600)` to
restore the exact durable property under test (no fresh-heartbeat fallback
standing in for the evidence being asserted).

### Tests whose observed fixture shape changed (1)

**`exact_status_observes_repository_intent_task_session_and_heartbeat_evidence`.**
Reaching the `materialized` intent state through
`acknowledge_refinement_task_materialization` requires the task to already carry
the exact correlation, so the task is now seeded and correlated **before** the
acknowledgement rather than after it, and it is **fully** correlated
(`intent_id`/`generation`/`round`/`phase`/`role`) instead of run-id-only.

What the test asserts is unchanged: a materialized exact-run intent still
outranks every task status in `["open","queued","in_progress","pool_paused"]`, a
running session, and a fresh heartbeat. The task remains a live evidence
candidate under full correlation — the sibling `QueuedOpenRoleTask` fixture in
the same file proves a fully correlated queued task does project as
`queued_task` — so the precedence being asserted is still genuinely exercised.
No other test's meaning changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
