### PR TITLE
fix(kueue): disable DRA feature gates so djinn-prereqs installs below k8s 1.34

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -18,9 +18,12 @@ Phase 2 installs Djinn on top of Kubernetes via three charts:
 - `kubectl` >= 1.29
 - `helm` >= 3.14
 - Only if you set `kueue.enabled: true` on the `djinn` chart: the
-  `djinn-prereqs` release, and a cluster at **Kubernetes >= 1.29** (a Kueue 0.19
+  `djinn-prereqs` release, and a cluster at **Kubernetes >= 1.30** (a Kueue 0.19
   requirement that the upstream chart does not declare, so Helm will not check
-  it). Without it the `djinn` chart still installs — the queue topology is off
+  it; 1.29 rejects its CRDs, and the floor is 1.30 rather than 1.34 only
+  because Djinn's values disable the DRA feature gates — see
+  [deploy/kueue/README.md](../kueue/README.md#minimum-kubernetes-is-130-and-only-because-dra-is-disabled)).
+  Without it the `djinn` chart still installs — the queue topology is off
   by default.
 - A Kubernetes cluster. For production deploys, ensure a StorageClass that
   satisfies `ReadWriteMany` is available (the `mirrors` and `cache` PVCs

--- a/deploy/helm/djinn-prereqs/README.md
+++ b/deploy/helm/djinn-prereqs/README.md
@@ -11,9 +11,26 @@ helm install djinn-prereqs deploy/helm/djinn-prereqs \
   --namespace kueue-system --create-namespace --wait
 ```
 
-Requires **Kubernetes >= 1.29** (a Kueue 0.19 requirement). The upstream
-`Chart.yaml` declares no `kubeVersion`, so Helm will *not* stop you on an older
-cluster — check `kubectl version` yourself.
+Requires **Kubernetes >= 1.30**, measured by installing this chart rather than
+read off a release note. The upstream `Chart.yaml` declares no `kubeVersion`,
+so Helm will *not* stop you on an older cluster — check `kubectl version`
+yourself.
+
+| Cluster | Result |
+| --- | --- |
+| 1.29.14 | **fails** — Kueue 0.19's CRDs use `spec.versions[].selectableFields`, which does not exist before 1.30, so the `workloads.kueue.x-k8s.io` apply is rejected |
+| 1.30.13 | installs, controller Ready |
+| 1.31.0 (the `scripts/kind/setup-kind.sh` pin) | installs, controller Ready |
+| k3s 1.35.5 (production VPS) | above the floor |
+
+The floor is 1.30 **only because `values.yaml` disables Kueue's DRA feature
+gates**. Kueue 0.19 ships `KueueDRAIntegration` on, which makes the manager
+index `resource.k8s.io/v1` ResourceSlices — an API group that is GA only in
+Kubernetes **1.34**. Left at the upstream default the controller exits with
+`could not setup ResourceSlice indexer`, `helm --wait` never returns, and you
+are left with Established CRDs and registered webhooks behind a dead
+controller. Do not remove those gates without moving this number to 1.34;
+`tests/feature-gates.sh` fails if you try.
 
 ## What this release does and does not do
 

--- a/deploy/helm/djinn-prereqs/tests/check-dra-gates.py
+++ b/deploy/helm/djinn-prereqs/tests/check-dra-gates.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Assert the two facts about djinn-prereqs that a fake kubectl cannot see.
+
+Both were found by the FIRST real-cluster install of this chart (task srdw,
+2026-07-30). Everything before that had been proven against `helm template`
+output and fake-kubectl fixtures only, which is precisely why both survived to
+production readiness.
+
+CHECK 1 — Dynamic Resource Allocation is switched OFF.
+------------------------------------------------------
+Kueue 0.19.0 ships `KueueDRAIntegration` ENABLED. With it on, the manager
+builds a ResourceSlice indexer against `resource.k8s.io/v1` unconditionally.
+That API group is GA only in Kubernetes 1.34, so on anything older the process
+exits at startup:
+
+    "msg":"Unable to setup indexes","error":"could not setup ResourceSlice
+     indexer: no matches for kind \\"ResourceSlice\\" in version
+     \\"resource.k8s.io/v1\\""
+
+The Deployment then CrashLoopBackOffs, `helm --wait` never returns, and the
+release is left with all 11 CRDs Established and BOTH webhook configurations
+registered behind a dead controller. Reproduced on a disposable kind cluster at
+1.31.0 — the repo's own pin in scripts/kind/setup-kind.sh.
+
+All THREE gates must be off. `KueueDRAIntegrationExtendedResource` and
+`KueueDRAIntegrationPartitionableDevices` default to enabled and each declares
+a hard dependency on the parent gate, so disabling only the parent makes the
+manager reject its own flags ("conflicting feature gates detected"). A checker
+that only looked for `KueueDRAIntegration=false` would pass a render that
+cannot start.
+
+This check fails if any of the three is missing from the rendered
+`--feature-gates` flag or is set to anything but `false`, so an upstream
+default cannot silently restore the 1.34 floor on a chart bump.
+
+CHECK 2 — the disabled-framework webhooks are REGISTERED, with Ignore.
+----------------------------------------------------------------------
+values.yaml used to claim that dropping pod/deployment/statefulset from
+`integrations.frameworks` "deletes mpod/vpod, mdeployment/vdeployment and
+mstatefulset/vstatefulset from the rendered MutatingWebhookConfiguration and
+ValidatingWebhookConfiguration outright". That is false, and it was the text an
+operator read as the scoping policy. Disproven by `helm template` AND by the
+live cluster: all six ARE registered. The upstream template branch
+(`templates/webhook/manifests.yaml`) is a failurePolicy switch, not a
+registration guard:
+
+    {{- if has "pod" ... }} failurePolicy: Fail {{- else }}
+    failurePolicy: Ignore {{- end }}
+
+So this check asserts what is actually true and load-bearing: those six
+webhooks are PRESENT and carry `failurePolicy: Ignore`. `Ignore` is the real
+availability guarantee — a Kueue webhook whose handler the manager never
+enabled is skipped rather than fatal. Asserting presence (not absence) is what
+stops the prose from drifting back to the comfortable-but-wrong version.
+
+`mjob`/`vjob` are deliberately excluded: batch/job is the framework Djinn will
+use at cutover, so `Fail` there is correct and the positive namespace fence is
+what keeps it safe. That fence is checked by
+deploy/kueue/tests/check-webhook-selectors.py, not here.
+
+Usage: check-dra-gates.py <rendered-manifest.yaml>
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("FAIL: PyYAML is required by this checker.", file=sys.stderr)
+    raise SystemExit(2)
+
+# Every gate that must be OFF. The two children are not decoration: each
+# declares `requires KueueDRAIntegration to be enabled`, so leaving either on
+# while the parent is off is a startup-fatal flag conflict, not a no-op.
+REQUIRED_DISABLED_GATES = (
+    "KueueDRAIntegration",
+    "KueueDRAIntegrationExtendedResource",
+    "KueueDRAIntegrationPartitionableDevices",
+)
+
+GATE_FLAG = "--feature-gates="
+
+# Webhook name prefixes that must be registered with failurePolicy: Ignore,
+# split by the configuration kind they belong to.
+IGNORE_MUTATING = ("mpod", "mdeployment", "mstatefulset")
+IGNORE_VALIDATING = ("vpod", "vdeployment", "vstatefulset")
+
+
+def load_docs(path: Path) -> list[dict]:
+    with path.open(encoding="utf-8") as handle:
+        return [doc for doc in yaml.safe_load_all(handle) if isinstance(doc, dict)]
+
+
+def manager_args(docs: list[dict]) -> list[str]:
+    """Return the args of the Kueue controller-manager container.
+
+    Selected by the `/manager` command rather than by a name match, so a
+    release-name or label change cannot make this checker quietly find nothing
+    and report success.
+    """
+    for doc in docs:
+        if doc.get("kind") != "Deployment":
+            continue
+        spec = doc.get("spec", {}).get("template", {}).get("spec", {})
+        for container in spec.get("containers", []) or []:
+            if "/manager" in (container.get("command") or []):
+                return list(container.get("args") or [])
+    return []
+
+
+def check_gates(docs: list[dict]) -> list[str]:
+    failures: list[str] = []
+    args = manager_args(docs)
+    if not args:
+        return ["no container running /manager was rendered; the checker had nothing to assert on"]
+
+    flags = [a for a in args if a.startswith(GATE_FLAG)]
+    if not flags:
+        return [
+            "the controller-manager renders no --feature-gates flag. Kueue 0.19 defaults "
+            "KueueDRAIntegration to ENABLED, so this install requires Kubernetes >= 1.34 "
+            "and CrashLoopBackOffs below it. Restore kueue.controllerManager.featureGates "
+            "in values.yaml."
+        ]
+    if len(flags) > 1:
+        failures.append(f"expected exactly one --feature-gates flag, got {len(flags)}: {flags}")
+
+    parsed: dict[str, str] = {}
+    for flag in flags:
+        for pair in flag[len(GATE_FLAG):].split(","):
+            pair = pair.strip()
+            if not pair:
+                continue
+            name, _, value = pair.partition("=")
+            parsed[name.strip()] = value.strip()
+
+    for gate in REQUIRED_DISABLED_GATES:
+        actual = parsed.get(gate)
+        if actual is None:
+            failures.append(
+                f"feature gate {gate} is not disabled in the rendered --feature-gates flag "
+                f"(saw: {sorted(parsed)}). Kueue 0.19 defaults it ON, which forces a "
+                f"Kubernetes 1.34 floor."
+            )
+        elif actual != "false":
+            failures.append(
+                f"feature gate {gate} is set to {actual!r}; it must be 'false'. Enabling DRA "
+                f"integration makes the manager index resource.k8s.io/v1 ResourceSlices, which "
+                f"exist only on Kubernetes >= 1.34."
+            )
+    return failures
+
+
+def check_ignore_webhooks(docs: list[dict]) -> list[str]:
+    failures: list[str] = []
+    for kind, expected in (
+        ("MutatingWebhookConfiguration", IGNORE_MUTATING),
+        ("ValidatingWebhookConfiguration", IGNORE_VALIDATING),
+    ):
+        found: dict[str, str | None] = {}
+        for doc in docs:
+            if doc.get("kind") != kind:
+                continue
+            for hook in doc.get("webhooks") or []:
+                name = hook.get("name", "")
+                found[name.split(".")[0]] = hook.get("failurePolicy")
+
+        for short in expected:
+            if short not in found:
+                failures.append(
+                    f"{short} is ABSENT from the rendered {kind}. It must be PRESENT: the "
+                    f"upstream chart renders it unconditionally and uses integrations.frameworks "
+                    f"only to switch failurePolicy. If this ever legitimately changes, fix the "
+                    f"scoping note in values.yaml in the same commit."
+                )
+                continue
+            policy = found[short]
+            if policy != "Ignore":
+                failures.append(
+                    f"{short} in the rendered {kind} has failurePolicy={policy!r}, expected "
+                    f"'Ignore'. 'Fail' means its framework was re-added to "
+                    f"integrations.frameworks, pointing a fail-closed admission webhook at core "
+                    f"Kubernetes CREATE."
+                )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, help="rendered djinn-prereqs manifest")
+    args = parser.parse_args()
+
+    if not args.manifest.is_file():
+        print(f"FAIL: rendered manifest not found: {args.manifest}", file=sys.stderr)
+        return 2
+
+    docs = load_docs(args.manifest)
+    if not docs:
+        print(f"FAIL: {args.manifest} contains no Kubernetes objects", file=sys.stderr)
+        return 2
+
+    failures = check_gates(docs) + check_ignore_webhooks(docs)
+    for failure in failures:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+
+    print(
+        "OK: DRA feature gates disabled "
+        f"({', '.join(REQUIRED_DISABLED_GATES)}) and "
+        f"{', '.join(IGNORE_MUTATING + IGNORE_VALIDATING)} registered with failurePolicy Ignore."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/helm/djinn-prereqs/tests/feature-gates.sh
+++ b/deploy/helm/djinn-prereqs/tests/feature-gates.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Contract for the two facts a rendering-only proof kept missing (task srdw).
+#
+#   1. Kueue's DRA integration is disabled, so djinn-prereqs installs below
+#      Kubernetes 1.34. Left at the upstream default it CrashLoopBackOffs with
+#      "could not setup ResourceSlice indexer".
+#   2. mpod/vpod, mdeployment/vdeployment and mstatefulset/vstatefulset ARE
+#      registered, with failurePolicy: Ignore. values.yaml used to claim the
+#      framework list deleted them outright; it does not.
+#
+# Every negative case is a REAL helm render of this same pinned subchart with
+# the property deliberately broken — never a hand-written fixture. A fixture
+# can drift into agreeing with a checker that no longer means anything; a
+# broken render cannot.
+#
+# What this canNOT prove, and why the cluster evidence lives in the task rather
+# than here: a render cannot tell you the manager starts. `helm template` was
+# green for the entire life of the 1.34-floor defect. The gate assertion below
+# is a REGRESSION fence on a fact established on real clusters (fails at 1.29,
+# installs and reaches Ready at 1.30.13 and 1.31.0), not a substitute for it.
+#
+# Needs `helm` and python3 with PyYAML. A missing tool FAILS here, never skips.
+#
+# Usage: bash deploy/helm/djinn-prereqs/tests/feature-gates.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECKER="$SCRIPT_DIR/check-dra-gates.py"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || fail "required tool '$1' is not installed"
+}
+
+require_tool helm
+require_tool python3
+python3 -c 'import yaml' 2>/dev/null || fail "python3 PyYAML is required by this suite"
+[ -f "$CHECKER" ] || fail "checker is missing: $CHECKER"
+
+render() {
+    # $1 = output file, rest = extra helm args
+    local out="$1"
+    shift
+    helm template djinn-prereqs "$CHART" "$@" >"$out" 2>"$out.err" \
+        || fail "helm template failed ($*): $(cat "$out.err")"
+}
+
+echo "=== 1/5 default render satisfies the contract ==="
+render "$WORK/default.yaml"
+python3 "$CHECKER" "$WORK/default.yaml" || fail "the shipped values.yaml does not satisfy its own contract"
+
+echo "=== 2/5 render carries the exact three-gate flag ==="
+# Asserted on the flag text as well as through the checker: the parser could in
+# principle accept a shape the manager rejects, and this defect was originally
+# missed by trusting a render.
+EXPECTED_FLAG='--feature-gates=KueueDRAIntegration=false,KueueDRAIntegrationExtendedResource=false,KueueDRAIntegrationPartitionableDevices=false'
+grep -Fq -- "$EXPECTED_FLAG" "$WORK/default.yaml" \
+    || fail "rendered manager args do not contain the expected flag: $EXPECTED_FLAG"
+
+echo "=== 3/5 NEGATIVE: dropping the gates is caught ==="
+# This is the upstream default. It renders perfectly and cannot start below
+# Kubernetes 1.34.
+render "$WORK/no-gates.yaml" --set-json 'kueue.controllerManager.featureGates=[]'
+if grep -Fq -- '--feature-gates' "$WORK/no-gates.yaml"; then
+    fail "the negative render still emits --feature-gates; the negative case proves nothing"
+fi
+if python3 "$CHECKER" "$WORK/no-gates.yaml" >/dev/null 2>&1; then
+    fail "checker PASSED a render with no feature gates — it would not catch an upstream default"
+fi
+
+echo "=== 4/5 NEGATIVE: flipping KueueDRAIntegration back on is caught ==="
+# --set-json with the whole list, not --set on an index: helm's indexed --set
+# REPLACES the list element rather than merging into it, which silently renders
+# `--feature-gates=%!s(<nil>)=true` and would make this negative case vacuous.
+render "$WORK/dra-on.yaml" --set-json 'kueue.controllerManager.featureGates=[{"name":"KueueDRAIntegration","enabled":true},{"name":"KueueDRAIntegrationExtendedResource","enabled":false},{"name":"KueueDRAIntegrationPartitionableDevices","enabled":false}]'
+grep -Fq -- '--feature-gates=KueueDRAIntegration=true' "$WORK/dra-on.yaml" \
+    || fail "the negative render did not actually enable KueueDRAIntegration"
+if python3 "$CHECKER" "$WORK/dra-on.yaml" >/dev/null 2>&1; then
+    fail "checker PASSED a render with KueueDRAIntegration enabled"
+fi
+
+echo "=== 5/5 NEGATIVE: re-adding 'pod' flips mpod/vpod to Fail and is caught ==="
+# A real render with the scoping broken: "pod" put back into
+# integrations.frameworks. The webhooks do not appear or disappear — their
+# failurePolicy flips from Ignore to Fail, which is exactly the behaviour the
+# old values.yaml prose denied.
+python3 - "$CHART/values.yaml" "$WORK/pod-readded.values.yaml" <<'PY'
+import sys
+
+src, dst = sys.argv[1], sys.argv[2]
+lines = open(src, encoding="utf-8").read().splitlines(keepends=True)
+out, injected = [], False
+for line in lines:
+    out.append(line)
+    if not injected and line.strip() == '- "batch/job"':
+        out.append(line.replace('"batch/job"', '"pod"'))
+        injected = True
+if not injected:
+    raise SystemExit('FAIL: could not find the "batch/job" framework entry to inject after')
+open(dst, "w", encoding="utf-8").writelines(out)
+PY
+render "$WORK/pod-readded.yaml" --values "$WORK/pod-readded.values.yaml"
+if python3 "$CHECKER" "$WORK/pod-readded.yaml" >/dev/null 2>&1; then
+    fail "checker PASSED a render with 'pod' re-added to integrations.frameworks"
+fi
+# Prove the negative render broke what we think it broke: mpod is still
+# REGISTERED (not deleted) and is now fail-closed.
+python3 - "$WORK/pod-readded.yaml" <<'PY'
+import sys
+
+import yaml
+
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1], encoding="utf-8")) if isinstance(d, dict)]
+hooks = {
+    h["name"].split(".")[0]: h.get("failurePolicy")
+    for d in docs
+    if d.get("kind") == "MutatingWebhookConfiguration"
+    for h in d.get("webhooks") or []
+}
+if "mpod" not in hooks:
+    raise SystemExit("FAIL: mpod vanished from the render; the negative case is not what it claims")
+if hooks["mpod"] != "Fail":
+    raise SystemExit(f"FAIL: expected mpod failurePolicy Fail with 'pod' enabled, got {hooks['mpod']!r}")
+print("OK: re-adding 'pod' keeps mpod registered and flips it Ignore -> Fail")
+PY
+
+echo
+echo "PASS: djinn-prereqs feature-gate and webhook-registration contract"

--- a/deploy/helm/djinn-prereqs/values.yaml
+++ b/deploy/helm/djinn-prereqs/values.yaml
@@ -17,6 +17,52 @@ kueue:
   enabled: true
 
   # -------------------------------------------------------------------------
+  # Kubernetes floor: Dynamic Resource Allocation must be switched OFF
+  # -------------------------------------------------------------------------
+  # Kueue 0.19.0 ships KueueDRAIntegration ENABLED by default, and the manager
+  # builds a ResourceSlice indexer against `resource.k8s.io/v1` unconditionally
+  # when it is on. That API group is GA only in Kubernetes **1.34**; on anything
+  # older `setupIndexes` fails and the process exits:
+  #
+  #   "msg":"Unable to setup indexes","error":"could not setup ResourceSlice
+  #    indexer: no matches for kind \"ResourceSlice\" in version
+  #    \"resource.k8s.io/v1\""
+  #
+  # That is fatal, not degraded: the Deployment CrashLoopBackOffs, `helm --wait`
+  # never returns, and the release is left with all 11 CRDs Established and both
+  # webhook configurations registered behind a dead controller. Verified on a
+  # disposable kind cluster at 1.31.0 — the pin in scripts/kind/setup-kind.sh,
+  # i.e. the canonical local dev cluster, which could not install this chart at
+  # all until this override existed.
+  #
+  # Djinn does not use dynamic resource allocation: no ResourceClaim, no
+  # DeviceClass, no ResourceSlice, no `resourceClaims` in any PodSpec this
+  # repository renders. Turning the integration off costs nothing and restores
+  # a sub-1.34 floor.
+  #
+  # All THREE gates are required. KueueDRAIntegrationExtendedResource and
+  # KueueDRAIntegrationPartitionableDevices default to enabled and each declares
+  # a hard dependency on the parent; disabling only KueueDRAIntegration makes
+  # the manager reject its own flags at startup:
+  #
+  #   "msg":"conflicting feature gates detected","error":"featureGates: Invalid
+  #    value: \"KueueDRAIntegrationExtendedResource\":
+  #    KueueDRAIntegrationExtendedResource requires KueueDRAIntegration to be
+  #    enabled"
+  #
+  # Contract: deploy/helm/djinn-prereqs/tests/feature-gates.sh renders THIS
+  # chart and fails if any of the three is removed or flipped back on, so an
+  # upstream default cannot silently restore the 1.34 floor on a version bump.
+  controllerManager:
+    featureGates:
+      - name: KueueDRAIntegration
+        enabled: false
+      - name: KueueDRAIntegrationExtendedResource
+        enabled: false
+      - name: KueueDRAIntegrationPartitionableDevices
+        enabled: false
+
+  # -------------------------------------------------------------------------
   # Djinn scoping policy
   # -------------------------------------------------------------------------
   # The upstream chart exposes both knobs only through this one opaque string,
@@ -32,13 +78,33 @@ kueue:
   #      applies that label, which is what makes this release inert.
   #
   #   2. `integrations.frameworks` drops "pod", "deployment" and "statefulset".
-  #      Those three are the only entries the upstream chart gates a webhook
-  #      registration on (`{{- if has "pod" ... }}` and friends in
-  #      templates/webhook/manifests.yaml), and they are the only ones that
-  #      intercept CREATE on core Kubernetes types. Removing them deletes
-  #      mpod/vpod, mdeployment/vdeployment and mstatefulset/vstatefulset from
-  #      the rendered MutatingWebhookConfiguration and
-  #      ValidatingWebhookConfiguration outright.
+  #      Those three are the only entries that intercept CREATE on core
+  #      Kubernetes types, and the only ones the upstream chart branches on in
+  #      templates/webhook/manifests.yaml.
+  #
+  #      Read the branch carefully, because it is counter-intuitive and this
+  #      comment used to get it wrong. It is
+  #      `{{- if has "pod" ... }} failurePolicy: Fail {{- else }}
+  #      failurePolicy: Ignore {{- end }}` — a policy switch, NOT a
+  #      registration guard. mpod/vpod, mdeployment/vdeployment and
+  #      mstatefulset/vstatefulset are rendered UNCONDITIONALLY and ARE present
+  #      in the MutatingWebhookConfiguration and ValidatingWebhookConfiguration
+  #      on a live cluster. There is no values hook that removes them. Dropping
+  #      the frameworks flips those six from `failurePolicy: Fail` to
+  #      `failurePolicy: Ignore`, and that is the entire render-visible effect.
+  #
+  #      `Ignore` is what carries the guarantee: the manager does not enable
+  #      the handlers, and an unreachable or handler-less Kueue webhook is
+  #      SKIPPED by the API server instead of blocking CREATE. Combined with
+  #      edit 1's positive namespace fence — which those same webhooks also
+  #      carry — nothing in an unlabelled namespace is intercepted. Do not read
+  #      the shorter framework list as "core Pod CREATE is not intercepted at
+  #      all"; read it as "it is intercepted by a fenced, fail-open webhook".
+  #
+  #      Contract: deploy/helm/djinn-prereqs/tests/feature-gates.sh asserts all
+  #      six webhooks are PRESENT with failurePolicy Ignore, so this text cannot
+  #      drift from the render again. deploy/kueue/tests/check-webhook-selectors.py
+  #      has always described this correctly.
   #
   #      Everything else in the list is left EXACTLY as upstream ships it. The
   #      remaining frameworks are CRD-scoped (ray.io, kubeflow.org, jobset,
@@ -117,8 +183,11 @@ kueue:
         - "workload.codeflare.dev/appwrapper"
       #  - "sparkoperator.k8s.io/sparkapplication"
       # DJINN EDIT 2 of 2: upstream 0.19.0 ships "pod", "deployment" and
-      # "statefulset" ENABLED here. All three are removed so Kueue registers no
-      # admission webhook on core Pod/Deployment/StatefulSet CREATE.
+      # "statefulset" ENABLED here. All three are removed so the manager enables
+      # no handler for core Pod/Deployment/StatefulSet, and the chart renders
+      # mpod/vpod, mdeployment/vdeployment and mstatefulset/vstatefulset with
+      # failurePolicy: Ignore. The webhooks themselves are still registered —
+      # see the note above; there is no values hook that unregisters them.
         - "leaderworkerset.x-k8s.io/leaderworkerset"
       #  externalFrameworks:
       #  - "Foo.v1.example.com"

--- a/deploy/kueue/README.md
+++ b/deploy/kueue/README.md
@@ -21,7 +21,7 @@ cutover epic **4c9q**.
 | Pin recorded in | `deploy/helm/djinn-prereqs/Chart.yaml` + `Chart.lock` |
 | Chart digest | `sha256:2fbaa5b15b54c1149185d7f399c573838c630c10eb35b363763cbbd3327e4333` |
 | Vendored dependency | `deploy/helm/djinn-prereqs/charts/kueue-0.19.0.tgz` |
-| Minimum Kubernetes | **1.29** (Kueue 0.19 requirement; the chart does **not** declare `kubeVersion`, so Helm will not enforce it) |
+| Minimum Kubernetes | **1.30**, and only because Djinn disables Kueue's DRA feature gates — see [Minimum Kubernetes](#minimum-kubernetes-is-130-and-only-because-dra-is-disabled). The chart does **not** declare `kubeVersion`, so Helm will not enforce it |
 
 ### There is no fork any more
 
@@ -37,8 +37,52 @@ It was forced, not opportunistic. Kueue **never published a `0.10.0` chart** —
 the OCI repository goes `0.9.5`, `0.10.3`, `0.11.0` … `0.19.0`. The old pin was
 taken from a GitHub release *asset*, which has no chart equivalent, so "pin the
 same version as a chart" was not an available option. `0.19.0` is the latest
-published chart. Kueue 0.19 requires Kubernetes >= 1.29; the production VPS
-(k3s v1.35.5) and the local kind cluster (1.31.0) both clear it.
+published chart.
+
+### Minimum Kubernetes is 1.30, and only because DRA is disabled
+
+This number was **measured by installing the chart**, not read off a release
+note — the previously documented 1.29 was neither.
+
+Kueue 0.19.0 ships the `KueueDRAIntegration` feature gate **enabled**. With it
+on, the controller-manager builds a ResourceSlice indexer against
+`resource.k8s.io/v1`, and that API group is GA only in Kubernetes **1.34**. On
+anything older the process exits at startup:
+
+```
+"msg":"Unable to setup indexes",
+"error":"could not setup ResourceSlice indexer: no matches for kind
+ \"ResourceSlice\" in version \"resource.k8s.io/v1\""
+```
+
+That is fatal, not degraded. `helm --wait` never returns, the Deployment
+CrashLoopBackOffs, and the release is left with all 11 CRDs Established and
+**both** webhook configurations registered with CA bundles injected, backed by
+a dead controller. Harmless today only because `mjob`/`vjob` are fenced to a
+label nothing applies — a fragile place to be.
+
+Djinn uses no dynamic resource allocation, so `values.yaml` turns the
+integration off (all three gates: the two child gates declare a hard dependency
+on the parent and the manager rejects its own flags if only the parent is
+disabled). That is what restores a sub-1.34 floor.
+
+The floor that remains is **1.30**, set by the CRDs rather than the manager:
+Kueue 0.19's `workloads.kueue.x-k8s.io` uses
+`spec.versions[].selectableFields`, a field that does not exist in the
+CustomResourceDefinition schema before 1.30, so the apply is rejected outright
+on 1.29.
+
+| Cluster | `helm install ... --wait` |
+| --- | --- |
+| kind 1.29.14 | **fails** — `.spec.versions[1].selectableFields: field not declared in schema` |
+| kind 1.30.13 | succeeds, controller Ready |
+| kind 1.31.0 (`scripts/kind/setup-kind.sh` pin) | succeeds, controller Ready |
+| VPS k3s v1.35.5 | above the floor |
+
+Both the production VPS and the local kind cluster clear 1.30. Re-enabling DRA
+would move this floor to 1.34 and take the local kind cluster below it;
+`deploy/helm/djinn-prereqs/tests/feature-gates.sh` fails the build if the gates
+are removed or flipped back on.
 
 ### Offline / hermetic story
 

--- a/deploy/runbooks/kueue-inert-release-zero-capture.md
+++ b/deploy/runbooks/kueue-inert-release-zero-capture.md
@@ -53,8 +53,10 @@ timeout for that fixture's Pod to become `Running`, and requires
 The prerequisite arrives as a **pinned upstream chart**, not a byte-vendored
 manifest: `deploy/kueue/vendor/kueue-v0.10.0.yaml` was retired, and the gate
 now fails if any static Kueue manifest is applied instead. The target cluster
-must be **Kubernetes >= 1.29** (Kueue 0.19); the upstream chart declares no
-`kubeVersion`, so nothing enforces this for you.
+must be **Kubernetes >= 1.30** (measured, not quoted: 1.29 rejects Kueue 0.19's
+CRDs, and the floor is 1.30 rather than 1.34 only because Djinn's values
+disable the DRA feature gates — see `deploy/kueue/README.md`); the upstream
+chart declares no `kubeVersion`, so nothing enforces this for you.
 
 Note the reduced fence, in full, before recording a pass: the per-object
 `djinn.io/kueue-build-object` selector no longer exists, because the upstream

--- a/docs/deploy/kubernetes.md
+++ b/docs/deploy/kubernetes.md
@@ -35,7 +35,7 @@ bits. Nothing in the chart is AWS-specific.
   managed node images, set them via node group launch-template user data or a
   privileged DaemonSet.
 - **Optional: Kueue**, if you want the Djinn queue topology
-  (`kueue.enabled: true`). Kubernetes **>= 1.29** required. See
+  (`kueue.enabled: true`). Kubernetes **>= 1.30** required. See
   [the prerequisite release](#cluster-prerequisite-releases) below.
 
 ### Cluster prerequisite releases
@@ -59,8 +59,14 @@ helm upgrade --install djinn-prereqs deploy/helm/djinn-prereqs \
 ```
 
 That pins Kueue `0.19.0` (`oci://registry.k8s.io/kueue/charts/kueue`) and
-requires **Kubernetes >= 1.29**. The upstream `Chart.yaml` declares no
+requires **Kubernetes >= 1.30** — verified by installing on 1.30.13 and 1.31.0,
+and by 1.29.14 rejecting the CRDs. The upstream `Chart.yaml` declares no
 `kubeVersion`, so Helm will not enforce it — check `kubectl version` first.
+
+The floor is 1.30 only because Djinn's values disable Kueue's DRA feature
+gates. Kueue 0.19 ships `KueueDRAIntegration` on, which needs
+`resource.k8s.io/v1` (GA in Kubernetes 1.34) and CrashLoopBackOffs below it.
+See [deploy/kueue/README.md](../../deploy/kueue/README.md#minimum-kubernetes-is-130-and-only-because-dra-is-disabled).
 
 The release is **inert**: Djinn's values set a *positive*
 `managedJobsNamespaceSelector` matching only namespaces labelled

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -226,8 +226,12 @@ does not own. Only needed if you want the Kueue queue topology
 (`kueue.enabled: true` in your values below); the chart installs fine without
 it, and the topology is inert either way.
 
-Requires **Kubernetes >= 1.29** — `k3s --version`. The upstream chart declares
-no `kubeVersion`, so Helm will not check this for you.
+Requires **Kubernetes >= 1.30** — `k3s --version`. The upstream chart declares
+no `kubeVersion`, so Helm will not check this for you. The production VPS runs
+k3s v1.35.5 and is well clear. That floor holds only because Djinn's values
+disable Kueue's DRA feature gates; with them at the upstream default the
+requirement is 1.34. See
+[deploy/kueue/README.md](../../deploy/kueue/README.md#minimum-kubernetes-is-130-and-only-because-dra-is-disabled).
 
 ```bash
 helm install djinn-prereqs deploy/helm/djinn-prereqs \

--- a/scripts/test-deploy-contracts.sh
+++ b/scripts/test-deploy-contracts.sh
@@ -40,7 +40,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # hosting lane already installs both (it runs `helm lint` and the chart
 # contracts in the same job), and the suite FAILS rather than skips if either
 # tool is missing.
+#
+# deploy/helm/djinn-prereqs/tests has the same needs as deploy/kueue/tests and
+# for the same reason: it renders the wrapper chart. It lives next to the chart
+# rather than under deploy/kueue/tests because it asserts chart VALUES (the
+# Kueue feature gates that set the Kubernetes floor), not the cutover scoping.
 DEFAULT_DIRS=(
+    deploy/helm/djinn-prereqs/tests
     deploy/kueue/tests
     deploy/node/k3s/tests
     deploy/runbooks/tests


### PR DESCRIPTION
Fixes djinn board task `srdw` (epic `w177`, proposal `9oga`).

## The defect

`deploy/helm/djinn-prereqs` **could not install on the repo's own kind pin**
(`scripts/kind/setup-kind.sh:14`, k8s 1.31.0) — i.e. the canonical local dev
cluster the Tiltfile drives.

Kueue 0.19.0 ships `KueueDRAIntegration` **enabled**. With it on, the
controller-manager builds a ResourceSlice indexer against `resource.k8s.io/v1`
unconditionally. That API group is GA only in Kubernetes **1.34**, so below it
the process exits at startup:

```
"msg":"Unable to setup indexes",
"error":"could not setup ResourceSlice indexer: no matches for kind
 \"ResourceSlice\" in version \"resource.k8s.io/v1\""
```

Fatal, not degraded: `helm --wait` never returns, the Deployment
CrashLoopBackOffs, and the release is left with all 11 CRDs Established and
**both** webhook configurations registered with CA bundles injected, backed by
a dead controller.

This was invisible to `helm template` and to every fake-`kubectl` fixture,
which is exactly why it survived to production readiness. It took the first
real-cluster install to surface.

## The fix

Djinn uses no dynamic resource allocation, so `values.yaml` turns the
integration off. This is the preferred path from the task: it genuinely
restores a sub-1.34 floor rather than forcing a kind bump on every developer
(which would also have been **inert** for anyone with an existing cluster,
since `setup-kind.sh:53-55` skips creation when the cluster already exists).

**All three gates are required** — the task description called for one. The
other two default to enabled and each declares a hard dependency on the parent,
so disabling only `KueueDRAIntegration` makes the manager reject its own flags:

```
"msg":"conflicting feature gates detected","error":"featureGates: Invalid value:
 \"KueueDRAIntegrationExtendedResource\": KueueDRAIntegrationExtendedResource
 requires KueueDRAIntegration to be enabled"
```

## Acceptance evidence — real disposable kind clusters

Isolated `CLUSTER_NAME`/`REG_NAME`/`REG_PORT`, every call pinned to
`--context kind-djinn-srdw-*`. Both clusters and the registry have been
deleted.

| Cluster | `helm install djinn-prereqs --wait` |
| --- | --- |
| **1.31.0, before** | **FAILED** — `Deployment ... not ready. status: InProgress, message: Available: 0/1`, `context deadline exceeded` at the 5m deadline; pod `0/1 CrashLoopBackOff 5`; release `failed`. Fatal log verbatim as above. |
| **1.31.0, after** | **deployed in 11s**, `djinn-prereqs-kueue-controller-manager 1/1 1 1` |
| **1.30.13** | **deployed in 42s**, controller `1/1 Running` |
| **1.29.14** | **rejected** — `.spec.versions[1].selectableFields: field not declared in schema` on `workloads.kueue.x-k8s.io` |

Rendered manager args on both successful installs:

```
["--config=/controller_manager_config.yaml","--zap-log-level=2",
 "--feature-gates=KueueDRAIntegration=false,KueueDRAIntegrationExtendedResource=false,KueueDRAIntegrationPartitionableDevices=false"]
```

### The corrected floor is 1.30, not 1.29

Disabling DRA takes the manager's requirement off 1.34, but a second floor
remains that nobody had measured: Kueue 0.19's CRDs use
`spec.versions[].selectableFields`, which does not exist in the
CustomResourceDefinition schema before **1.30**. So 1.29 was never a real floor
either — it was quoted, not tested.

Corrected in **eight** places (the task listed seven; `deploy/helm/README.md:21`
was a missed eighth): `deploy/kueue/README.md`, `deploy/helm/README.md`,
`deploy/helm/djinn-prereqs/README.md`, `docs/deploy/kubernetes.md`,
`docs/deploy/vps.md`, and the runbook's minimum-version sentence.

## Second defect: the false webhook-deletion claim

`values.yaml` claimed that dropping `pod`/`deployment`/`statefulset` from
`integrations.frameworks` "deletes mpod/vpod, mdeployment/vdeployment and
mstatefulset/vstatefulset from the rendered MutatingWebhookConfiguration and
ValidatingWebhookConfiguration **outright**".

False. The upstream branch is a `failurePolicy` switch, not a registration
guard. Live cluster (21 mutating / 22 validating webhooks):

```
mpod         PRESENT  failurePolicy=Ignore  {"matchLabels":{"djinn.io/kueue-managed":"true"}}
vpod         PRESENT  failurePolicy=Ignore  ...
mdeployment  PRESENT  failurePolicy=Ignore  ...
vdeployment  PRESENT  failurePolicy=Ignore  ...
mstatefulset PRESENT  failurePolicy=Ignore  ...
vstatefulset PRESENT  failurePolicy=Ignore  ...
mjob/vjob    PRESENT  failurePolicy=Fail    (expected — batch/job is the cutover framework)
```

`deploy/kueue/tests/check-webhook-selectors.py` always described this
correctly, so two files contradicted each other and the wrong one was what an
operator reads as the scoping policy. Functional risk was low, but a reviewer
could have concluded core Pod CREATE is not intercepted at all. The corrected
text says what is true and load-bearing: those webhooks **are** registered,
fenced, and fail-open.

## New contract

`deploy/helm/djinn-prereqs/tests/feature-gates.sh` + `check-dra-gates.py`
assert both facts, with four **real broken renders** of the same pinned
subchart (never hand-written fixtures):

1. default render satisfies the contract
2. the exact three-gate flag is present
3. NEGATIVE: gates removed — i.e. the upstream default — is caught
4. NEGATIVE: `KueueDRAIntegration` flipped back on is caught
5. NEGATIVE: `pod` re-added flips `mpod` `Ignore -> Fail` and is caught, and
   the test proves `mpod` is still *registered* rather than deleted

Registered in `scripts/test-deploy-contracts.sh` so CI runs it. All 9 deploy
contract scripts pass locally, including the pre-existing Kueue drift checker.

It lives beside the chart rather than in `deploy/kueue/tests/` both because it
asserts chart *values* (the floor) rather than cutover scoping, and to stay off
files owned by the parallel `uoe7` work.

## Scope

Only the minimum-version sentence in
`deploy/runbooks/kueue-inert-release-zero-capture.md` was touched, per the
`uoe7` coordination constraint. No `server/**` path is touched. Vercel fails
repo-wide on an account rate limit and is not a required check.
