### PR TITLE
fix(kueue): make the zero-capture gate executable against a real cluster

### DIFF
--- a/deploy/kueue/tests/fixtures/single-node-values.yaml
+++ b/deploy/kueue/tests/fixtures/single-node-values.yaml
@@ -1,0 +1,93 @@
+# Djinn chart values for a DISPOSABLE single-node zero-capture gate cluster.
+#
+#   deploy/kueue/zero-capture-gate.sh \
+#     --context <disposable-target-context> \
+#     --designated-operator-secret <caller-owned-secret> \
+#     --values deploy/kueue/tests/fixtures/single-node-values.yaml \
+#     --set-string image.server=ghcr.io/djinnos/djinn-server:<release-under-test> \
+#     --set-string image.runtime=ghcr.io/djinnos/djinn-agent-runtime:<release-under-test>
+#
+# This file deliberately does NOT pin an image tag. The gate is
+# release-before-cutover evidence for a SPECIFIC release, so the tag under test
+# is the caller's to name on the command line and to record in the release
+# record. The committed chart default (`djinn-server:latest`, unqualified) is a
+# demo placeholder that resolves to docker.io/library/djinn-server:latest and
+# is not pullable anywhere.
+#
+# Everything below exists because the chart's committed defaults describe a
+# multi-node production cluster. Production does not run them either — see
+# docs/deploy/vps.md, which overrides the same three access modes.
+
+# The three shared volumes default to ReadWriteMany. No single-node default
+# StorageClass provisions RWX: kind's rancher.io/local-path and k3s's
+# local-path both leave the PVCs Pending forever, and the install then fails
+# with "PVC is not Bound. phase: Pending" followed by "context deadline
+# exceeded". RWO is correct on one node because RWO is enforced per-node, not
+# per-pod, so the server Pod and any Job can share the claim.
+storage:
+  mirrors:
+    accessMode: ReadWriteOnce
+    size: 2Gi
+  cache:
+    accessMode: ReadWriteOnce
+    size: 2Gi
+  projects:
+    accessMode: ReadWriteOnce
+    size: 2Gi
+
+postgres:
+  storage:
+    accessMode: ReadWriteOnce
+    size: 2Gi
+  config:
+    sharedBuffers: 512MB
+    maxConnections: 100
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+
+qdrant:
+  storage:
+    accessMode: ReadWriteOnce
+    size: 2Gi
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+
+# A disposable cluster has no DNS name and no certificate issuer.
+ingress:
+  enabled: false
+
+# The gate only needs the chart's Kueue topology and its Namespace to render,
+# and the server Deployment to go Available. Keep requests small enough that a
+# single-node control plane can still schedule the fixture Pod afterwards.
+resources:
+  server:
+    requests:
+      cpu: "100m"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+  taskrun:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+  warm:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"

--- a/deploy/kueue/tests/zero-capture-gate.sh
+++ b/deploy/kueue/tests/zero-capture-gate.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 # Hermetic contract for zero-capture-gate.sh. No cluster credentials required.
 # Usage: deploy/kueue/tests/zero-capture-gate.sh
+#
+# SCOPE — read this before quoting a pass anywhere.
+# ------------------------------------------------
+# `helm` and `kubectl` are both stubs here. NOTHING IS INSTALLED and no cluster
+# is contacted, so the install path — the only part of the gate that can fail
+# environmentally — is NOT exercised. A pass proves argument construction,
+# argument ordering and failure handling; it is not evidence that the gate can
+# run anywhere. The helm stub used to be a two-line log-and-exit-0, which is how
+# three independent install-path blockers (namespace adoption, missing values
+# passthrough, an unpullable default image) all shipped behind a green
+# contract. It is now driven to fail on demand so the gate's install-failure
+# handling is actually covered, and this script prints an explicit UNVERIFIED
+# declaration at the end so a pass cannot be read as "the gate works".
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -23,6 +36,16 @@ FIXTURE="$SCRIPT_DIR/fixtures/precutover-task-run.yaml"
 if grep -Eq '^[[:space:]]+djinn\.io/kueue-' "$FIXTURE"; then
     fail 'pre-cutover fixture must not carry a Kueue namespace or build-object label'
 fi
+# The runbook's target-cluster procedure cites this file by path. It is the
+# difference between a gate that installs a shape no cluster provisions and one
+# an operator can actually run.
+SINGLE_NODE_VALUES="$SCRIPT_DIR/fixtures/single-node-values.yaml"
+[ -f "$SINGLE_NODE_VALUES" ] || fail "single-node values file the runbook cites is missing: $SINGLE_NODE_VALUES"
+grep -Fq 'ReadWriteOnce' "$SINGLE_NODE_VALUES" || fail 'single-node values do not override the chart ReadWriteMany defaults, which no single-node default StorageClass can bind'
+if grep -Eq '^[[:space:]]+(server|runtime):[[:space:]]*[^[:space:]#]' "$SINGLE_NODE_VALUES"; then
+    fail 'single-node values pin an image tag; the release under test belongs on the command line and in the release record'
+fi
+
 cat >"$WORK/kubectl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -30,6 +53,17 @@ printf 'kubectl' >>"$FAKE_LOG"
 printf ' %q' "$@" >>"$FAKE_LOG"
 printf '\n' >>"$FAKE_LOG"
 args=" $* "
+if [[ "$args" == *' create namespace djinn '* ]] && [ -n "${FAKE_NAMESPACE_EXISTS:-}" ]; then
+    printf 'Error from server (AlreadyExists): namespaces "djinn" already exists\n' >&2
+    exit 1
+fi
+if [[ "$args" == *' get secret '* ]]; then
+    if [ -n "${FAKE_SECRET_MISSING:-}" ]; then
+        printf 'Error from server (NotFound): secrets "fake-designated-operator" not found\n' >&2
+        exit 1
+    fi
+    exit 0
+fi
 if [[ "$args" == *' get workloads '* ]] && [ "$FAKE_SCENARIO" = api-error ]; then
     printf 'simulated Kubernetes API error\n' >&2
     exit 47
@@ -42,31 +76,59 @@ elif [[ "$args" == *' get workloads '* ]]; then
     cat "$FAKE_RESPONSES/$FAKE_SCENARIO/workloads.txt"
 fi
 EOF
+# This stub INSTALLS NOTHING. It records argv so the contract can assert on the
+# arguments the gate builds, and it exits nonzero when a scenario asks it to so
+# that the gate's install-failure handling is covered rather than assumed. What
+# it records are still only arguments: no chart is rendered, no StorageClass is
+# consulted and no image is pulled.
 cat >"$WORK/helm" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'helm' >>"$FAKE_LOG"
 printf ' %q' "$@" >>"$FAKE_LOG"
 printf '\n' >>"$FAKE_LOG"
+args=" $* "
+if [ -n "${FAKE_HELM_FAIL_MATCH:-}" ] && [[ "$args" == *"$FAKE_HELM_FAIL_MATCH"* ]]; then
+    printf 'simulated helm install failure\n' >&2
+    exit 1
+fi
+exit 0
 EOF
 chmod +x "$WORK/kubectl" "$WORK/helm"
 
-run_case() {
-    local scenario=$1 expected_status=$2 expected_text=$3
-    local output="$WORK/$scenario.out"
-    : >"$WORK/$scenario.log"
-    set +e
-    # Run through bash because source mounts can reject chmod; the checks above
-    # still require the committed operator-facing entry points to be executable.
-    FAKE_LOG="$WORK/$scenario.log" \
+# Scenario knobs, read by the stubs. Set them around a call, never globally.
+FAKE_SCENARIO=success
+FAKE_NAMESPACE_EXISTS=
+FAKE_SECRET_MISSING=
+FAKE_HELM_FAIL_MATCH=
+
+run_gate() {
+    local output=$1 log=$2 status=0
+    shift 2
+    : >"$log"
+    FAKE_LOG="$log" \
     FAKE_RESPONSES="$RESPONSES" \
-    FAKE_SCENARIO="$scenario" \
+    FAKE_SCENARIO="$FAKE_SCENARIO" \
+    FAKE_NAMESPACE_EXISTS="$FAKE_NAMESPACE_EXISTS" \
+    FAKE_SECRET_MISSING="$FAKE_SECRET_MISSING" \
+    FAKE_HELM_FAIL_MATCH="$FAKE_HELM_FAIL_MATCH" \
     KUBECTL="$WORK/kubectl" \
     HELM="$WORK/helm" \
     KUEUE_GATE_POLL_SECONDS=0 \
-    bash "$GATE" --context fake-disposable --designated-operator-secret fake-designated-operator --timeout-seconds 1 >"$output" 2>&1
-    local status=$?
-    set -e
+    bash "$GATE" "$@" >"$output" 2>&1 || status=$?
+    return "$status"
+}
+
+run_case() {
+    local scenario=$1 expected_status=$2 expected_text=$3 status=0
+    shift 3
+    local output="$WORK/$scenario.out"
+    FAKE_SCENARIO=$scenario
+    run_gate "$output" "$WORK/$scenario.log" \
+        --context fake-disposable \
+        --designated-operator-secret fake-designated-operator \
+        --timeout-seconds 1 "$@" || status=$?
+    FAKE_SCENARIO=success
     if [ "$expected_status" = pass ]; then
         [ "$status" -eq 0 ] || { cat "$output" >&2; fail "$scenario unexpectedly failed"; }
     else
@@ -94,16 +156,150 @@ grep -Fq -- 'migration.designatedOperatorSecret=fake-designated-operator' "$SUCC
 grep -Fq -- "apply -n djinn -f $SCRIPT_DIR/fixtures/precutover-task-run.yaml" "$SUCCESS_LOG" || fail 'success did not apply pre-cutover fixture'
 grep -Fq -- 'get workloads -n djinn' "$SUCCESS_LOG" || fail 'success did not query namespace Workloads'
 
+# --- namespace adoption -----------------------------------------------------
+# The designated-operator Secret must exist inside `djinn` before the install
+# (the bootstrap initContainer resolves it through secretKeyRef), and Helm
+# refuses to adopt a namespace it did not create. On a fresh cluster those two
+# facts deadlock; the gate has to break the deadlock itself.
+grep -Fq -- 'create namespace djinn' "$SUCCESS_LOG" || fail 'gate never creates the namespace the designated-operator Secret has to live in'
+grep -Fq -- 'label namespace djinn app.kubernetes.io/managed-by=Helm --overwrite' "$SUCCESS_LOG" || fail 'gate does not stamp the Helm ownership label, so a pre-created namespace fails adoption'
+grep -Fq -- 'meta.helm.sh/release-name=djinn-inert-kueue-gate' "$SUCCESS_LOG" || fail 'gate does not stamp the Helm release-name annotation'
+grep -Fq -- 'meta.helm.sh/release-namespace=djinn' "$SUCCESS_LOG" || fail 'gate does not stamp the Helm release-namespace annotation'
+grep -Fq -- 'get secret fake-designated-operator -n djinn' "$SUCCESS_LOG" || fail 'gate does not verify the designated-operator Secret before a long install wait'
+# Adoption must not degrade into namespace.create=false: the chart-rendered
+# Namespace object is exactly what the inertness assertion reads.
+if grep -Fq -- 'namespace.create=false' "$SUCCESS_LOG"; then
+    fail 'gate sidesteps adoption by disabling the chart Namespace; the inertness assertion would then read an object the chart never produced'
+fi
+# The gate must never write the capture label itself. Reading it back with
+# jsonpath is the assertion; writing it would arm the namespace.
+if grep -E -- ' (label|annotate|patch) namespace ' "$SUCCESS_LOG" | grep -q 'kueue-managed'; then
+    fail 'gate writes the djinn.io/kueue-managed label; a prerequisite-release gate must never arm the namespace'
+fi
+
+# --- independent budgets ----------------------------------------------------
+# One 120s value used to govern both the whole-stack `--wait` and the fixture
+# Pod wait, which is not enough for a fresh Djinn install on any cold cluster.
+grep -Fq -- '--timeout 900s' "$SUCCESS_LOG" || fail 'chart installs did not use the default install budget'
+if grep -Fq -- '--timeout 1s' "$SUCCESS_LOG"; then
+    fail '--timeout-seconds still governs a chart install; the install and fixture waits must have independent budgets'
+fi
+[ "$(grep -c -- '--timeout 900s' "$SUCCESS_LOG")" -eq 2 ] || fail 'both the prerequisite and the Djinn install must take the install budget'
+
+# --- adopting a namespace that already exists -------------------------------
+NS_EXISTS_OUT="$WORK/ns-exists.out"
+NS_EXISTS_STATUS=0
+FAKE_NAMESPACE_EXISTS=1
+run_gate "$NS_EXISTS_OUT" "$WORK/ns-exists.log" \
+    --context fake-disposable --designated-operator-secret fake-designated-operator --timeout-seconds 1 || NS_EXISTS_STATUS=$?
+FAKE_NAMESPACE_EXISTS=
+[ "$NS_EXISTS_STATUS" -eq 0 ] || { cat "$NS_EXISTS_OUT" >&2; fail 'gate could not adopt an already-existing djinn namespace'; }
+grep -Fq -- 'already exists; adopting it into release djinn-inert-kueue-gate' "$NS_EXISTS_OUT" || { cat "$NS_EXISTS_OUT" >&2; fail 'pre-existing namespace adoption was not reported'; }
+grep -Fq -- 'label namespace djinn app.kubernetes.io/managed-by=Helm --overwrite' "$WORK/ns-exists.log" || fail 'pre-existing namespace was not stamped for adoption'
+
+# --- values passthrough -----------------------------------------------------
+# Without this the gate installs the chart's committed multi-node defaults:
+# ReadWriteMany claims nothing single-node binds, and an unqualified
+# `djinn-server:latest` that resolves to docker.io and 401s.
+VALUES_FILE="$WORK/operator-values.yaml"
+cat >"$VALUES_FILE" <<'EOF'
+storage:
+  mirrors:
+    accessMode: ReadWriteOnce
+EOF
+VALUES_OUT="$WORK/values.out"
+VALUES_STATUS=0
+run_gate "$VALUES_OUT" "$WORK/values.log" \
+    --context fake-disposable --designated-operator-secret fake-designated-operator --timeout-seconds 1 \
+    --values "$VALUES_FILE" \
+    --set image.server=registry.example/djinn-server:9.9.9 \
+    --set-string storage.cache.accessMode=ReadWriteOnce || VALUES_STATUS=$?
+[ "$VALUES_STATUS" -eq 0 ] || { cat "$VALUES_OUT" >&2; fail 'gate rejected an operator values passthrough'; }
+VALUES_LOG="$WORK/values.log"
+DJINN_INSTALL_LINE="$(grep -F -- 'upgrade --install djinn-inert-kueue-gate' "$VALUES_LOG")"
+[ -n "$DJINN_INSTALL_LINE" ] || fail 'no Djinn chart install recorded for the passthrough case'
+printf '%s\n' "$DJINN_INSTALL_LINE" | grep -Fq -- "--values $VALUES_FILE" || fail '--values was not forwarded to the Djinn chart install'
+printf '%s\n' "$DJINN_INSTALL_LINE" | grep -Fq -- '--set image.server=registry.example/djinn-server:9.9.9' || fail '--set was not forwarded to the Djinn chart install'
+printf '%s\n' "$DJINN_INSTALL_LINE" | grep -Fq -- '--set-string storage.cache.accessMode=ReadWriteOnce' || fail '--set-string was not forwarded to the Djinn chart install'
+# Helm applies --set over --values regardless of CLI order, and later --set over
+# earlier --set. The gate-owned kueue.enabled must therefore be emitted last, or
+# a caller could turn the queue topology off and make "zero Workloads" vacuous.
+printf '%s\n' "$DJINN_INSTALL_LINE" | grep -Eq -- '--set image\.server=[^ ]+ .*--set kueue\.enabled=true' || fail 'operator --set is not ordered before the gate-owned --set kueue.enabled=true, so a caller could disable the queue topology'
+# The Kueue prerequisite chart is Djinn-independent; Djinn values must not leak.
+PREREQS_INSTALL_LINE="$(grep -F -- 'upgrade --install djinn-prereqs' "$VALUES_LOG")"
+if printf '%s\n' "$PREREQS_INSTALL_LINE" | grep -Fq -- "--values $VALUES_FILE"; then
+    fail 'operator Djinn values leaked into the Kueue prerequisite install'
+fi
+
+# --- gate-owned keys are not caller-overridable -----------------------------
+reject_case() {
+    local name=$1 expected=$2 status=0
+    shift 2
+    local output="$WORK/$name.out"
+    run_gate "$output" "$WORK/$name.log" \
+        --context fake-disposable --designated-operator-secret fake-designated-operator "$@" || status=$?
+    [ "$status" -ne 0 ] || { cat "$output" >&2; fail "$name unexpectedly passed"; }
+    grep -Fq -- "$expected" "$output" || { cat "$output" >&2; fail "$name lacked diagnostic: $expected"; }
+}
+
+reject_case override-kueue 'overrides a gate-owned key (kueue.enabled)' --set kueue.enabled=false
+reject_case override-kueue-armed 'overrides a gate-owned key (kueue.armed)' --set-string kueue.armed=true
+reject_case override-operator-secret 'overrides a gate-owned key (migration.designatedOperatorSecret)' --set migration.designatedOperatorSecret=someone-else
+reject_case missing-values-file '--values file does not exist' --values "$WORK/no-such-values.yaml"
+
+# --- an install failure must fail the gate ----------------------------------
+# The install path is the only environmentally fallible part of this harness. A
+# stub that can only exit 0 leaves it with zero coverage in either direction.
+helm_failure_case() {
+    local name=$1 status=0
+    local output="$WORK/$name.out"
+    FAKE_HELM_FAIL_MATCH=$2
+    run_gate "$output" "$WORK/$name.log" \
+        --context fake-disposable --designated-operator-secret fake-designated-operator --timeout-seconds 1 || status=$?
+    FAKE_HELM_FAIL_MATCH=
+    [ "$status" -ne 0 ] || { cat "$output" >&2; fail "$name unexpectedly passed despite a failing helm install"; }
+    grep -Fq -- 'helm error while installing into context fake-disposable' "$output" || { cat "$output" >&2; fail "$name did not surface the helm failure"; }
+    if grep -Fq -- 'PASS: zero-capture prerequisite gate completed' "$output"; then
+        fail "$name reported a gate pass after a failed install"
+    fi
+}
+
+helm_failure_case prereqs-install-failure djinn-prereqs
+helm_failure_case chart-install-failure djinn-inert-kueue-gate
+
+# --- designated-operator Secret absent from the namespace -------------------
+MISSING_IN_NS_OUT="$WORK/missing-secret-in-ns.out"
+MISSING_IN_NS_STATUS=0
+FAKE_SECRET_MISSING=1
+run_gate "$MISSING_IN_NS_OUT" "$WORK/missing-secret-in-ns.log" \
+    --context fake-disposable --designated-operator-secret fake-designated-operator --timeout-seconds 1 || MISSING_IN_NS_STATUS=$?
+FAKE_SECRET_MISSING=
+[ "$MISSING_IN_NS_STATUS" -ne 0 ] || { cat "$MISSING_IN_NS_OUT" >&2; fail 'gate installed the chart with no designated-operator Secret in the namespace'; }
+grep -Fq -- 'is absent from namespace djinn' "$MISSING_IN_NS_OUT" || { cat "$MISSING_IN_NS_OUT" >&2; fail 'missing-Secret failure did not name the namespace'; }
+grep -Fq -- 'create secret generic fake-designated-operator' "$MISSING_IN_NS_OUT" || { cat "$MISSING_IN_NS_OUT" >&2; fail 'missing-Secret failure did not print an executable recipe'; }
+if grep -Fq -- 'upgrade --install djinn-inert-kueue-gate' "$WORK/missing-secret-in-ns.log"; then
+    fail 'gate proceeded to the Djinn install without the designated-operator Secret'
+fi
+
 run_case managed-namespace fail 'namespace djinn is labelled djinn.io/kueue-managed=true'
 run_case pod-pending fail 'fixture Pod did not reach Running within 1s (last phase: Pending)'
 run_case workload-captured fail 'Kueue captured a Workload in namespace djinn'
 run_case api-error fail 'kubectl API error while running: kubectl --context fake-disposable get workloads -n djinn'
 
 MISSING_SECRET_OUTPUT="$WORK/missing-secret.out"
-set +e
-KUBECTL="$WORK/kubectl" HELM="$WORK/helm" bash "$GATE" --context fake-disposable >"$MISSING_SECRET_OUTPUT" 2>&1
-MISSING_SECRET_STATUS=$?
-set -e
+MISSING_SECRET_STATUS=0
+KUBECTL="$WORK/kubectl" HELM="$WORK/helm" bash "$GATE" --context fake-disposable >"$MISSING_SECRET_OUTPUT" 2>&1 || MISSING_SECRET_STATUS=$?
 [ "$MISSING_SECRET_STATUS" -ne 0 ] || fail 'gate unexpectedly accepted a fresh install without a designated operator Secret'
 grep -Fq -- 'a caller-provided --designated-operator-secret is required for a fresh chart install' "$MISSING_SECRET_OUTPUT" || { cat "$MISSING_SECRET_OUTPUT" >&2; fail 'missing Secret rejection lacked diagnostic'; }
+
 printf 'PASS: zero-capture gate fake-kubectl contract completed\n'
+cat <<'EOF'
+UNVERIFIED: the install path of deploy/kueue/zero-capture-gate.sh was NOT
+exercised by this run. `helm` and `kubectl` were stubs; no chart was rendered or
+installed, no StorageClass was consulted, no image was pulled and no cluster was
+contacted. This contract covers argument construction, argument ordering and
+failure handling only. It is NOT evidence that the gate can execute against any
+cluster, and it is NOT the release-before-cutover evidence epic 4c9q requires.
+That evidence comes only from the target-cluster invocation documented in
+deploy/runbooks/kueue-inert-release-zero-capture.md.
+EOF

--- a/deploy/kueue/zero-capture-gate.sh
+++ b/deploy/kueue/zero-capture-gate.sh
@@ -9,6 +9,15 @@ KUBECTL="${KUBECTL:-kubectl}"
 HELM="${HELM:-helm}"
 CONTEXT="${KUEUE_GATE_CONTEXT:-}"
 TIMEOUT_SECONDS="${KUEUE_GATE_TIMEOUT_SECONDS:-120}"
+# The chart install and the fixture Pod wait are different problems with
+# different orders of magnitude, so they get separate budgets. One shared
+# 120s value fails a fresh Djinn install on every cold cluster: the install
+# has to pull djinn-server, Postgres and qdrant, bind three PVCs, run the
+# designated-operator bootstrap and the schema migration, and only then can
+# the server Deployment go Available. The fixture Pod, by contrast, is a
+# `pause` image that must appear in seconds — a long budget there would just
+# delay a genuine capture failure.
+INSTALL_TIMEOUT_SECONDS="${KUEUE_GATE_INSTALL_TIMEOUT_SECONDS:-900}"
 POLL_SECONDS="${KUEUE_GATE_POLL_SECONDS:-2}"
 RELEASE="${KUEUE_GATE_RELEASE:-djinn-inert-kueue-gate}"
 PREREQS_RELEASE="${KUEUE_GATE_PREREQS_RELEASE:-djinn-prereqs}"
@@ -22,6 +31,8 @@ JOB_NAME="zero-capture-precutover-task-run"
 PREREQS_CHART="$REPO_ROOT/deploy/helm/djinn-prereqs"
 CHART="$REPO_ROOT/deploy/helm/djinn"
 FIXTURE="$SCRIPT_DIR/tests/fixtures/precutover-task-run.yaml"
+# Operator-supplied chart values, forwarded verbatim to the Djinn chart install.
+CHART_VALUE_ARGS=()
 
 usage() {
     cat >&2 <<'EOF'
@@ -31,26 +42,61 @@ Installs the pinned Kueue prerequisite chart (deploy/helm/djinn-prereqs) and
 the inert Djinn chart in the supplied context. It never labels the djinn
 namespace. This is a prerequisite-release gate, not a cutover command.
 
+The Djinn chart's committed defaults are a multi-node production shape
+(ReadWriteMany volumes, an unqualified `djinn-server:latest` image). No
+disposable cluster satisfies them and production does not run them either, so
+the release values are the caller's to supply with --values/--set. Everything
+except the two gate-owned keys below is forwarded verbatim.
+
 Options:
   --context CONTEXT       Required disposable Kubernetes context.
   --designated-operator-secret NAME
                         Required caller-owned Secret name for the chart's
                         fresh-install migration bootstrap. Its contents are
                         never passed on the command line or read by this gate.
-  --timeout-seconds N     Bounded Pod-running wait (default: 120).
+                        It must already exist in the djinn namespace; the gate
+                        creates that namespace but never that Secret.
+  --values FILE, -f FILE  Values file forwarded to the Djinn chart install.
+                        Repeatable, merged by Helm in the order given.
+  --set KEY=VALUE         Forwarded to the Djinn chart install. Repeatable.
+  --set-string KEY=VALUE  Forwarded to the Djinn chart install. Repeatable.
+  --install-timeout-seconds N
+                        Budget for each `helm upgrade --install --wait`
+                        (default: 900). Covers image pulls, PVC binding and
+                        the schema migration on a cold cluster.
+  --timeout-seconds N     Bounded fixture Pod-running wait (default: 120).
+                        This does NOT govern the chart installs.
   --release NAME          Helm release name (default: djinn-inert-kueue-gate).
   --help                  Show this message.
 
+`kueue.enabled` and `migration.designatedOperatorSecret` are owned by this gate
+and are rejected as caller overrides: the first is what makes the run
+meaningful and the second is already a first-class flag.
+
 Environment overrides for automation: KUBECTL, HELM, KUEUE_GATE_CONTEXT,
-KUEUE_GATE_TIMEOUT_SECONDS, KUEUE_GATE_POLL_SECONDS, KUEUE_GATE_RELEASE,
-KUEUE_GATE_PREREQS_RELEASE, KUEUE_GATE_PREREQS_NAMESPACE,
-KUEUE_GATE_DESIGNATED_OPERATOR_SECRET.
+KUEUE_GATE_TIMEOUT_SECONDS, KUEUE_GATE_INSTALL_TIMEOUT_SECONDS,
+KUEUE_GATE_POLL_SECONDS, KUEUE_GATE_RELEASE, KUEUE_GATE_PREREQS_RELEASE,
+KUEUE_GATE_PREREQS_NAMESPACE, KUEUE_GATE_DESIGNATED_OPERATOR_SECRET.
 EOF
 }
 
 fail() {
     printf 'FAIL: %s\n' "$*" >&2
     exit 1
+}
+
+# Helm applies every --set/--set-string on top of every --values file, so a
+# caller values file can never quietly turn the queue topology off. A caller
+# --set can, and a gate that installed `kueue.enabled=false` would report
+# "zero Workloads captured" for the trivial reason that no queue exists —
+# the exact shape of green-against-nothing this gate is supposed to refute.
+reject_gate_owned_key() {
+    local flag=$1 assignment=$2 key=${2%%=*}
+    case "$key" in
+        kueue|kueue.*|migration.designatedOperatorSecret)
+            fail "$flag $assignment overrides a gate-owned key ($key); kueue.* is what makes this gate meaningful and migration.designatedOperatorSecret has its own --designated-operator-secret flag"
+            ;;
+    esac
 }
 
 while [ "$#" -gt 0 ]; do
@@ -63,6 +109,29 @@ while [ "$#" -gt 0 ]; do
         --designated-operator-secret)
             [ "$#" -ge 2 ] || fail '--designated-operator-secret requires a value'
             DESIGNATED_OPERATOR_SECRET=$2
+            shift 2
+            ;;
+        --values|-f)
+            [ "$#" -ge 2 ] || fail '--values requires a value'
+            [ -f "$2" ] || fail "--values file does not exist: $2"
+            CHART_VALUE_ARGS+=(--values "$2")
+            shift 2
+            ;;
+        --set)
+            [ "$#" -ge 2 ] || fail '--set requires a value'
+            reject_gate_owned_key --set "$2"
+            CHART_VALUE_ARGS+=(--set "$2")
+            shift 2
+            ;;
+        --set-string)
+            [ "$#" -ge 2 ] || fail '--set-string requires a value'
+            reject_gate_owned_key --set-string "$2"
+            CHART_VALUE_ARGS+=(--set-string "$2")
+            shift 2
+            ;;
+        --install-timeout-seconds)
+            [ "$#" -ge 2 ] || fail '--install-timeout-seconds requires a value'
+            INSTALL_TIMEOUT_SECONDS=$2
             shift 2
             ;;
         --timeout-seconds)
@@ -87,6 +156,7 @@ done
 [ -n "$DESIGNATED_OPERATOR_SECRET" ] || { usage; fail 'a caller-provided --designated-operator-secret is required for a fresh chart install'; }
 [[ "$DESIGNATED_OPERATOR_SECRET" =~ ^[a-z0-9]([-.a-z0-9]*[a-z0-9])?$ ]] || fail '--designated-operator-secret must be a valid Kubernetes Secret name'
 [[ "$TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || fail '--timeout-seconds must be a positive integer'
+[[ "$INSTALL_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || fail '--install-timeout-seconds must be a positive integer'
 [[ "$POLL_SECONDS" =~ ^[0-9]+$ ]] || fail 'KUEUE_GATE_POLL_SECONDS must be a non-negative integer'
 [ -d "$PREREQS_CHART" ] || fail "Kueue prerequisite chart is missing: $PREREQS_CHART"
 [ -f "$PREREQS_CHART/Chart.lock" ] || fail "prerequisite chart is unpinned: $PREREQS_CHART/Chart.lock is missing"
@@ -105,7 +175,7 @@ run_kubectl() {
 
 run_helm() {
     if ! "$HELM" --kube-context "$CONTEXT" "$@"; then
-        fail "helm error while installing inert chart into context $CONTEXT"
+        fail "helm error while installing into context $CONTEXT: helm --kube-context $CONTEXT $*"
     fi
 }
 
@@ -117,13 +187,58 @@ diagnostics() {
     "$KUBECTL" --context "$CONTEXT" get workloads -n "$NAMESPACE" -o wide >&2 || true
 }
 
+# The chart renders the Namespace itself (namespace.create defaults true), and
+# that rendered object is exactly what assertion 1 below inspects — so this gate
+# must NOT install with namespace.create=false. But the caller-owned
+# designated-operator Secret has to exist inside that namespace before the
+# install, because the server Pod's bootstrap initContainer resolves it through
+# secretKeyRef and never starts otherwise. Those two facts deadlock on a fresh
+# cluster: you cannot create the Secret without the namespace, and Helm refuses
+# to adopt a namespace it did not create ("exists and cannot be imported into
+# the current release: invalid ownership metadata").
+#
+# Stamping Helm's ownership metadata onto the namespace is the documented way
+# out of that adoption refusal, and it is why --context must be disposable: the
+# stamp reassigns the namespace to this release. The chart still owns and
+# re-renders the Namespace object, so the inertness assertion still reads a
+# chart-produced object rather than a hand-made one.
+prepare_namespace_for_adoption() {
+    local create_output
+    if create_output=$("$KUBECTL" --context "$CONTEXT" create namespace "$NAMESPACE" 2>&1); then
+        printf 'INFO: created namespace %s so the caller-owned designated-operator Secret can precede the install\n' "$NAMESPACE"
+    elif printf '%s' "$create_output" | grep -q 'already exists'; then
+        printf 'INFO: namespace %s already exists; adopting it into release %s\n' "$NAMESPACE" "$RELEASE"
+    else
+        printf '%s\n' "$create_output" >&2
+        fail "could not create namespace $NAMESPACE in context $CONTEXT"
+    fi
+    run_kubectl label namespace "$NAMESPACE" app.kubernetes.io/managed-by=Helm --overwrite
+    run_kubectl annotate namespace "$NAMESPACE" \
+        "meta.helm.sh/release-name=$RELEASE" \
+        "meta.helm.sh/release-namespace=$NAMESPACE" --overwrite
+}
+
 printf 'INFO: installing pinned Kueue prerequisite release %s into context %s\n' "$PREREQS_RELEASE" "$CONTEXT"
-run_helm upgrade --install "$PREREQS_RELEASE" "$PREREQS_CHART" --namespace "$PREREQS_NAMESPACE" --create-namespace --wait --timeout "${TIMEOUT_SECONDS}s"
+run_helm upgrade --install "$PREREQS_RELEASE" "$PREREQS_CHART" --namespace "$PREREQS_NAMESPACE" --create-namespace --wait --timeout "${INSTALL_TIMEOUT_SECONDS}s"
+
+prepare_namespace_for_adoption
+
+# Fail here, with the recipe, rather than 900s later with a Pod stuck in
+# CreateContainerConfigError that names no cause.
+if ! "$KUBECTL" --context "$CONTEXT" get secret "$DESIGNATED_OPERATOR_SECRET" -n "$NAMESPACE" >/dev/null 2>&1; then
+    fail "designated-operator Secret $DESIGNATED_OPERATOR_SECRET is absent from namespace $NAMESPACE; the chart's bootstrap initContainer resolves it via secretKeyRef and the install would hang. Create it first (the gate never reads, creates or prints its contents):
+  kubectl --context $CONTEXT -n $NAMESPACE create secret generic $DESIGNATED_OPERATOR_SECRET \\
+    --from-literal=user_id=<uuid> --from-literal=github_id=<numeric-github-id> --from-literal=github_login=<login>"
+fi
+
 printf 'INFO: installing inert Djinn chart release %s\n' "$RELEASE"
 # kueue.enabled=true is what makes this gate meaningful: the Djinn queue
 # topology only renders on request, and the gate exists to prove that rendering
-# it alongside the prerequisite still captures nothing.
-run_helm upgrade --install "$RELEASE" "$CHART" --namespace "$NAMESPACE" --create-namespace --wait --timeout "${TIMEOUT_SECONDS}s" --set kueue.enabled=true --set-string "migration.designatedOperatorSecret=$DESIGNATED_OPERATOR_SECRET"
+# it alongside the prerequisite still captures nothing. It is set LAST so that
+# it also wins against any caller --set that slipped past reject_gate_owned_key.
+run_helm upgrade --install "$RELEASE" "$CHART" --namespace "$NAMESPACE" --create-namespace --wait --timeout "${INSTALL_TIMEOUT_SECONDS}s" \
+    ${CHART_VALUE_ARGS[@]+"${CHART_VALUE_ARGS[@]}"} \
+    --set kueue.enabled=true --set-string "migration.designatedOperatorSecret=$DESIGNATED_OPERATOR_SECRET"
 
 namespace_label=$(run_kubectl get namespace "$NAMESPACE" -o 'jsonpath={.metadata.labels.djinn\.io/kueue-managed}')
 if [ "$namespace_label" = 'true' ]; then

--- a/deploy/runbooks/kueue-inert-release-zero-capture.md
+++ b/deploy/runbooks/kueue-inert-release-zero-capture.md
@@ -9,7 +9,8 @@ Kueue admission for build Jobs.
 
 ### Repository contract execution (no cluster)
 
-Run the deterministic fake-`kubectl` contract from a repository checkout:
+Run the deterministic stubbed-`kubectl`/`helm` contract from a repository
+checkout:
 
 ```sh
 deploy/kueue/tests/zero-capture-gate.sh

--- a/deploy/runbooks/kueue-inert-release-zero-capture.md
+++ b/deploy/runbooks/kueue-inert-release-zero-capture.md
@@ -16,30 +16,102 @@ deploy/kueue/tests/zero-capture-gate.sh
 ```
 
 This checks the harness protocol and its failure handling using captured fake
-API responses. A pass proves only the repository contract; it is not evidence
-that a release cluster was contacted, that Kueue was installed, or that any Pod
-ran on an operator cluster.
+API responses. It ends by printing an explicit `UNVERIFIED:` declaration,
+because both `helm` and `kubectl` are stubs in it: nothing is installed and no
+cluster is contacted. A pass proves only argument construction, argument
+ordering and failure handling; it is not evidence that a release cluster was
+contacted, that Kueue was installed, or that any Pod ran on an operator
+cluster. Never quote it as prerequisite evidence.
 
 ### Required target-cluster prerequisite invocation
 
 Before beginning any 4c9q Kueue cutover action, an operator must select a
-**disposable target-cluster context**, create or identify the caller-owned
-designated-operator Secret required by a fresh Djinn chart install, and run:
+**disposable target-cluster context** and run the three steps below in order.
+The context must be disposable: step 1 stamps Helm ownership metadata on the
+`djinn` namespace and step 3 installs a whole Djinn release into it.
+
+**Step 1 — create the target namespace.**
+
+```sh
+kubectl --context <disposable-target-context> create namespace djinn
+```
+
+The chart renders the `djinn` Namespace itself (`namespace.create` defaults
+true) and that rendered object is what the inertness assertion reads, so the
+gate must not be run with `namespace.create=false`. But the Secret in step 2
+has to exist *inside* that namespace before the install, because the server
+Pod's bootstrap initContainer resolves it through `secretKeyRef` and never
+starts otherwise. Helm normally refuses to adopt a namespace it did not create
+(`exists and cannot be imported into the current release: invalid ownership
+metadata`); the gate resolves that by stamping
+`app.kubernetes.io/managed-by=Helm` plus the `meta.helm.sh/release-*`
+annotations onto the namespace before installing. Running the gate against a
+cluster with no `djinn` namespace also works — the gate creates it — but then
+step 2 has nowhere to put the Secret, so do step 1 explicitly.
+
+**Step 2 — create the caller-owned designated-operator Secret.**
+
+```sh
+kubectl --context <disposable-target-context> -n djinn \
+  create secret generic <caller-owned-designated-operator-secret> \
+  --from-literal=user_id=<uuid> \
+  --from-literal=github_id=<numeric-github-id> \
+  --from-literal=github_login=<login>
+```
+
+This is the Secret that supplies the chart's required
+`migration.designatedOperatorSecret` on a fresh install. The gate takes only
+its **name**, verifies the Secret exists before starting a long install wait,
+and passes the name to Helm with `--set-string`; it never creates, reads or
+prints the contents, and never places them in shell arguments. On a disposable
+gate cluster the three values identify nothing real and placeholders are fine;
+on a cluster you intend to keep, use the release's real operator identity.
+
+**Step 3 — run the gate.**
 
 ```sh
 deploy/kueue/zero-capture-gate.sh \
   --context <disposable-target-context> \
-  --designated-operator-secret <caller-owned-designated-operator-secret>
+  --designated-operator-secret <caller-owned-designated-operator-secret> \
+  --values deploy/kueue/tests/fixtures/single-node-values.yaml \
+  --set-string image.server=ghcr.io/djinnos/djinn-server:<release-under-test> \
+  --set-string image.runtime=ghcr.io/djinnos/djinn-agent-runtime:<release-under-test>
 ```
 
-`<caller-owned-designated-operator-secret>` is the name (not the contents) of
-the Secret that supplies the chart's required
-`migration.designatedOperatorSecret` on a fresh install. Provision it in the
-target `djinn` namespace using the chart's normal bootstrap procedure before
-running the gate. The harness passes only this name to Helm with
-`--set-string`; it does not create, print, or place Secret contents in shell
-arguments. The automation equivalent is
+The automation equivalent of the Secret flag is
 `KUEUE_GATE_DESIGNATED_OPERATOR_SECRET=<secret-name>`.
+
+`--values`, `--set` and `--set-string` are forwarded verbatim to the Djinn
+chart install, and supplying release values is **required**, not optional: the
+chart's committed defaults are a multi-node production shape that no disposable
+cluster satisfies and that production does not run either (`docs/deploy/vps.md`
+overrides the same three access modes).
+
+* **Storage.** `storage.{mirrors,cache,projects}.accessMode` defaults to
+  `ReadWriteMany`. No single-node default StorageClass provisions RWX — kind's
+  and k3s's `local-path` both leave the claims `Pending` and the install dies
+  with `PVC is not Bound. phase: Pending` then `context deadline exceeded`.
+  `deploy/kueue/tests/fixtures/single-node-values.yaml` overrides all three to
+  `ReadWriteOnce`, which is correct on one node because RWO is enforced
+  per-node, not per-pod.
+* **Images.** `image.server` defaults to the unqualified `djinn-server:latest`,
+  which resolves to `docker.io/library/djinn-server:latest` and fails with
+  `pull access denied`. Name the release under test explicitly — that tag is
+  the thing this gate is evidence *about*, so it belongs on the command line
+  and in the release record, not pinned in a repository file.
+
+The gate rejects caller overrides of `kueue.*` and
+`migration.designatedOperatorSecret`, and emits its own `--set
+kueue.enabled=true` last, so no values file or `--set` can disable the queue
+topology and make "zero Workloads captured" vacuously true.
+
+The install wait and the fixture Pod wait have **independent budgets**.
+`--install-timeout-seconds` (default 900) bounds each `helm upgrade --install
+--wait`; it has to cover image pulls, PVC binding, the designated-operator
+bootstrap and the schema migration on a cold cluster. `--timeout-seconds`
+(default 120) bounds only the fixture Pod reaching `Running`. Neither needs
+overriding on a normal cluster; a pass that required raising them is worth
+investigating rather than recording.
 
 The harness installs, in this order, the pinned Kueue prerequisite chart
 `deploy/helm/djinn-prereqs` (release `djinn-prereqs`, namespace `kueue-system`)
@@ -67,8 +139,13 @@ not label the namespace or start 4c9q cutover work. A passing target-cluster
 invocation is mandatory release-before-cutover evidence; record the context,
 release timestamp, command output, and chart revision in the release record.
 
-The repository has not performed an operator target-cluster invocation and
-makes no claim that one occurred.
+A harness-validation run of this procedure was executed once against a
+disposable kind cluster, to prove the gate can execute at all — before that,
+its `helm` install path had never run anywhere and the procedure above was
+unsatisfiable on a fresh cluster. That run is evidence about the *harness*, not
+about any release: the repository has performed no operator target-cluster
+invocation, records none, and makes no claim about any release's prerequisite
+evidence.
 
 ## Failure handling
 


### PR DESCRIPTION
Closes board task `uoe7` (epic `w177`, proposal `9oga`).

`deploy/runbooks/kueue-inert-release-zero-capture.md` makes a PASSING
target-cluster invocation of `deploy/kueue/zero-capture-gate.sh` mandatory
release-before-cutover evidence for cutover epic `4c9q`. That evidence was
unobtainable: the harness could not execute at all.

The reason it was never noticed is in `deploy/kueue/tests/zero-capture-gate.sh`.
Its `helm` stub was a two-line log-and-exit-0, so the install path — the only
part of the harness that can fail environmentally — had never run anywhere.
Three independent blockers shipped behind that green contract.

**The three substantive assertions are unchanged and unweakened.** They were
verified by hand on a live cluster and they are correct; only the harness
around them is fixed.

## What was broken, and what changed

**1. The Secret procedure was unsatisfiable on a fresh cluster.** The chart
renders the `djinn` Namespace (`namespace.create` defaults true), and that
rendered object is exactly what the inertness assertion reads — so the gate
must not install with `namespace.create=false`. But the designated-operator
Secret has to exist *inside* that namespace first, because the server Pod's
bootstrap initContainer resolves it through `secretKeyRef`. On a fresh cluster
those two deadlock: no namespace means `namespaces "djinn" not found`, and a
pre-created namespace means Helm refuses to adopt it (`exists and cannot be
imported into the current release: invalid ownership metadata`). Exit 1 either
way, with the only escape documented nowhere.

The gate now creates the namespace when absent and stamps Helm's ownership
metadata on it either way, so the chart still owns and re-renders the
Namespace. It also verifies the Secret exists up front and prints the create
recipe, rather than leaving the operator with a Pod stuck on an unresolvable
`secretKeyRef` fifteen minutes later.

**2. No values passthrough.** `--values` / `--set` / `--set-string` are now
forwarded verbatim to the Djinn chart install. The chart's committed defaults
are a multi-node production shape that no disposable cluster satisfies and that
production does not run either (`docs/deploy/vps.md` overrides the same three
access modes): `ReadWriteMany` claims never bind on kind's or k3s's
`local-path`, and the install died with `PVC is not Bound. phase: Pending` then
`context deadline exceeded`. `deploy/kueue/tests/fixtures/single-node-values.yaml`
carries the single-node shape.

Opening that door required closing a hole with it: `kueue.*` and
`migration.designatedOperatorSecret` are rejected as caller overrides, and the
gate emits its own `--set kueue.enabled=true` last. Otherwise a values file
could disable the queue topology and make "zero Workloads captured" vacuously
true — the same attest-to-nothing shape this PR exists to remove.

**3. Unpullable default image.** `image.server` defaults to the unqualified
`djinn-server:latest`, which resolves to `docker.io/library/djinn-server:latest`
and 401s, sticking the server Pod at `Init:ImagePullBackOff`. It is now supplied
per run. Deliberately *not* pinned in a repository file: the tag under test is
what the gate is evidence *about*, so it belongs on the command line and in the
release record.

**Plus:** `--install-timeout-seconds` (default 900) now bounds each helm install
independently of `--timeout-seconds` (default 120), which bounds only the
fixture Pod. One shared 120s value could not cover image pulls, PVC binding, the
operator bootstrap and the schema migration on any cold cluster.

## The stubbed `helm` in the contract

The hermetic contract can no longer be read as evidence that the gate works.
Its `helm` stub is driven to fail on demand, so both install failures now have
coverage in both directions, and it ends by printing an explicit `UNVERIFIED:`
declaration stating that nothing was installed and no cluster was contacted.
New coverage: namespace creation and adoption stamping, the absent-Secret
guard, values forwarding, gate-owned-key rejection, and the independence of the
two timeout budgets.

## Acceptance evidence — the real harness, exit 0

Run end to end against a disposable kind cluster (`kind-djinn-uoe7-gate`,
Kubernetes v1.35.0, default `rancher.io/local-path` StorageClass), following
the runbook procedure verbatim, with **no timeout overrides**. Helm output
elided for length; the full log is otherwise verbatim.

```
$ kubectl --context kind-djinn-uoe7-gate create namespace djinn
namespace/djinn created

$ kubectl --context kind-djinn-uoe7-gate -n djinn create secret generic djinn-designated-operator \
    --from-literal=user_id=... --from-literal=github_id=... --from-literal=github_login=...
secret/djinn-designated-operator created

$ deploy/kueue/zero-capture-gate.sh \
    --context kind-djinn-uoe7-gate \
    --designated-operator-secret djinn-designated-operator \
    --values deploy/kueue/tests/fixtures/single-node-values.yaml \
    --set-string image.server=ghcr.io/djinnos/djinn-server:0.7.28 \
    --set-string image.runtime=ghcr.io/djinnos/djinn-agent-runtime:0.7.28

INFO: installing pinned Kueue prerequisite release djinn-prereqs into context kind-djinn-uoe7-gate
Release "djinn-prereqs" does not exist. Installing it now.
NAME: djinn-prereqs
NAMESPACE: kueue-system
STATUS: deployed
REVISION: 1
INFO: namespace djinn already exists; adopting it into release djinn-inert-kueue-gate
namespace/djinn labeled
namespace/djinn annotated
INFO: installing inert Djinn chart release djinn-inert-kueue-gate
Release "djinn-inert-kueue-gate" does not exist. Installing it now.
NAME: djinn-inert-kueue-gate
NAMESPACE: djinn
STATUS: deployed
REVISION: 1
PASS: namespace djinn is not Kueue-managed
INFO: submitting unchanged pre-cutover task-run fixture zero-capture-precutover-task-run
job.batch/zero-capture-precutover-task-run created
PASS: fixture Pod reached Running
PASS: zero Workloads captured in namespace djinn
PASS: zero-capture prerequisite gate completed for context kind-djinn-uoe7-gate

EXIT=0
```

The zero-capture result is not vacuous — the Kueue topology was genuinely
present on that cluster:

```
$ kubectl --context kind-djinn-uoe7-gate get clusterqueue,resourceflavor
clusterqueue.kueue.x-k8s.io/djinn-inert-kueue-gate-kueue            0
resourceflavor.kueue.x-k8s.io/djinn-inert-kueue-gate-kueue   59s

$ kubectl --context kind-djinn-uoe7-gate get localqueue -n djinn
djinn-inert-kueue-gate-scip       djinn-inert-kueue-gate-kueue   0   0
djinn-inert-kueue-gate-task-run   djinn-inert-kueue-gate-kueue   0   0
djinn-inert-kueue-gate-warm       djinn-inert-kueue-gate-kueue   0   0

$ kubectl --context kind-djinn-uoe7-gate get workloads -n djinn
No resources found in djinn namespace.
```

The create-namespace branch and the absent-Secret guard were exercised against
the same live API server:

```
INFO: created namespace djinn so the caller-owned designated-operator Secret can precede the install
FAIL: designated-operator Secret djinn-designated-operator is absent from namespace djinn; ...
  kubectl --context kind-djinn-uoe7-gate -n djinn create secret generic djinn-designated-operator \
    --from-literal=user_id=<uuid> --from-literal=github_id=<numeric-github-id> --from-literal=github_login=<login>
```

Cluster and local registry were destroyed afterwards.

Repository suites: `scripts/test-deploy-contracts.sh` passes (8/8, including
`deploy/kueue/tests/zero-capture-gate.sh`), and
`deploy/helm/djinn/tests/kueue-topology-render.sh` — which drives the *real*
gate script against renders of the chart — still passes in both its
`default pass` and `armed fail` directions.

## Scope

Touches only `deploy/kueue/zero-capture-gate.sh`, `deploy/kueue/tests/**`, and
the procedure sections of the runbook. The runbook's minimum-Kubernetes-version
sentence and `deploy/kueue/README.md` are left to task `srdw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
