### PR TITLE
fix(control-plane): resolve doctor checks from state, not the process-global registry

### DIFF
--- a/server/crates/djinn-control-plane/src/state.rs
+++ b/server/crates/djinn-control-plane/src/state.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use djinn_core::doctor::DoctorRegistry;
 use djinn_core::doctor::checks::retrieval::RetrievalHealthConfig;
 use djinn_core::events::EventBus;
 use djinn_core::models::DjinnSettings;
@@ -47,6 +48,19 @@ pub struct McpState {
     /// This remains absent in off-server contexts; the explicitly selected
     /// doctor probe then reports that it has not been configured.
     extension_diagnostics_probe: Option<Arc<dyn ExtensionDiagnosticsProbeOps>>,
+    /// Doctor check registry the `doctor_run` / `doctor_fix` tools resolve
+    /// checks from. `None` means "use the process-wide singleton", which is
+    /// what the server binary wants: the coordinator registers every
+    /// production check into `djinn_core::doctor::registry()` at startup and
+    /// the MCP surface must see exactly those.
+    ///
+    /// It is injectable because the singleton is keyed by check *name*, and
+    /// `register` replaces by name. Two `McpState`s alive in one process that
+    /// both register a check under the same name — the situation every
+    /// concurrently-running integration test in one test binary is in — would
+    /// otherwise clobber each other, and whichever registered last would serve
+    /// every caller, including the ones bound to a different database.
+    doctor_registry: Option<Arc<DoctorRegistry>>,
 }
 
 impl McpState {
@@ -123,6 +137,7 @@ impl McpState {
             repo_graph,
             enrichment_ops,
             extension_diagnostics_probe: None,
+            doctor_registry: None,
         }
     }
 
@@ -135,6 +150,37 @@ impl McpState {
     ) -> Self {
         self.extension_diagnostics_probe = Some(ops);
         self
+    }
+
+    /// Bind this state to a caller-owned doctor check registry instead of the
+    /// process-wide singleton. Production composition never calls this — the
+    /// server wants the singleton the coordinator populates. Test harnesses
+    /// call it so that each harness registers into, and resolves from, a
+    /// registry private to itself.
+    pub fn with_doctor_registry(mut self, registry: Arc<DoctorRegistry>) -> Self {
+        self.doctor_registry = Some(registry);
+        self
+    }
+
+    /// The doctor check registry `doctor_run` / `doctor_fix` must consult.
+    ///
+    /// Falls back to the process-wide singleton, which is the production
+    /// wiring: `djinn-coordinator` registers every real check into
+    /// [`djinn_core::doctor::registry()`] during startup.
+    pub fn doctor_registry(&self) -> &DoctorRegistry {
+        match &self.doctor_registry {
+            Some(registry) => registry,
+            None => djinn_core::doctor::registry(),
+        }
+    }
+
+    /// The injected registry, or `None` when this state falls back to the
+    /// process-wide singleton. Test harnesses use it to carry an already-bound
+    /// registry across a state rebuild instead of silently minting a second
+    /// one, which would leave the rebuilt server resolving checks the test had
+    /// registered into the original.
+    pub fn doctor_registry_override(&self) -> Option<Arc<DoctorRegistry>> {
+        self.doctor_registry.clone()
     }
 
     pub fn db(&self) -> &Database {

--- a/server/crates/djinn-control-plane/src/test_support.rs
+++ b/server/crates/djinn-control-plane/src/test_support.rs
@@ -31,7 +31,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use djinn_core::doctor::{
-    DoctorCheckRun, INJECTION_STARVATION_NAME, RETRIEVAL_ZERO_RESULT_NAME,
+    DoctorCheckRun, DoctorRegistry, INJECTION_STARVATION_NAME, RETRIEVAL_ZERO_RESULT_NAME,
     checks::retrieval::RetrievalHealthConfig,
 };
 
@@ -696,6 +696,7 @@ pub struct McpTestHarness {
     state: McpState,
     db: Database,
     server: DjinnMcpServer,
+    doctor_registry: Arc<DoctorRegistry>,
 }
 
 impl McpTestHarness {
@@ -732,8 +733,7 @@ impl McpTestHarness {
             Arc::new(StubGit),
             Arc::new(StubRepoGraph),
         );
-        let server = DjinnMcpServer::new(state.clone());
-        Self { state, db, server }
+        Self::from_state(state)
     }
 
     /// Build the normal strict-stub harness with an explicitly injected
@@ -758,22 +758,49 @@ impl McpTestHarness {
             Arc::new(StubRepoGraph),
             None,
         );
-        let server = DjinnMcpServer::new(state.clone());
-        Self { state, db, server }
+        Self::from_state(state)
     }
 
     /// Build a harness from a caller-assembled MCP state.  This is the opt-in
     /// escape hatch for integration tests that keep the normal MCP/tool dispatch
     /// path but swap one strict stub for a real actor-backed bridge (for example
     /// a real `SlotPoolHandle` in execution-control tests).
+    ///
+    /// Every constructor funnels through here, which is where each harness is
+    /// bound to a doctor registry of its own. Without that binding the
+    /// `doctor_run` / `doctor_fix` tools resolve checks from the process-wide
+    /// `djinn_core::doctor::registry()` singleton, which is shared by every
+    /// test running concurrently in the same test binary and is keyed by check
+    /// name — so two tests registering the same check name would each end up
+    /// running whichever source registered last, against the *other* test's
+    /// database. A state that already carries an injected registry keeps it,
+    /// so rebuilding state from `harness.state().clone()` does not orphan
+    /// checks the test already registered.
     pub fn from_state(state: McpState) -> Self {
+        let doctor_registry = state
+            .doctor_registry_override()
+            .unwrap_or_else(|| Arc::new(DoctorRegistry::new()));
+        let state = state.with_doctor_registry(doctor_registry.clone());
         let db = state.db().clone();
         let server = DjinnMcpServer::new(state.clone());
-        Self { state, db, server }
+        Self {
+            state,
+            db,
+            server,
+            doctor_registry,
+        }
     }
 
     pub fn db(&self) -> &Database {
         &self.db
+    }
+
+    /// The doctor check registry this harness's `doctor_run` / `doctor_fix`
+    /// resolve from. Tests must register their checks here rather than in
+    /// `djinn_core::doctor::registry()`; the global singleton is shared by
+    /// every concurrently-running test in the binary.
+    pub fn doctor_registry(&self) -> &Arc<DoctorRegistry> {
+        &self.doctor_registry
     }
 
     pub fn state(&self) -> &McpState {

--- a/server/crates/djinn-control-plane/src/tools/doctor_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/doctor_tools.rs
@@ -43,9 +43,7 @@ use rmcp::{
 };
 use serde::{Deserialize, Serialize};
 
-use djinn_core::doctor::{
-    DoctorCheck, DoctorRegistry, Finding, FindingSeverity, ResolverSnapshot, registry,
-};
+use djinn_core::doctor::{DoctorCheck, DoctorRegistry, Finding, FindingSeverity, ResolverSnapshot};
 use djinn_db::{DoctorFindingRepository, ProjectRepository, RecentDoctorFindings};
 
 use crate::server::DjinnMcpServer;
@@ -438,7 +436,7 @@ fn finding_to_entry(row: &djinn_db::DoctorFinding) -> DoctorListFindingEntry {
 impl DjinnMcpServer {
     /// Run doctor health checks.
     ///
-    /// Enumerates the global check registry, optionally runs a named subset,
+    /// Enumerates the state-resolved check registry, optionally runs a named subset,
     /// persists all emitted findings, and returns a structured report with
     /// check metadata and persisted finding ids. This path **never** invokes
     /// `fix` — fixes are opt-in and only reachable through `doctor_fix`.
@@ -461,7 +459,7 @@ impl DjinnMcpServer {
             });
         }
 
-        let reg = registry();
+        let reg = self.state.doctor_registry();
 
         // Snapshot the full directory before resolving the subset so the
         // response always shows what was available, even on error.
@@ -800,7 +798,7 @@ impl DjinnMcpServer {
             });
         }
 
-        let reg = registry();
+        let reg = self.state.doctor_registry();
 
         // Look up the check by name. Unknown check → structured error.
         let Some(check) = reg.get(&check_name) else {

--- a/server/crates/djinn-control-plane/tests/doctor_closed_parent_tools.rs
+++ b/server/crates/djinn-control-plane/tests/doctor_closed_parent_tools.rs
@@ -6,7 +6,6 @@ mod common;
 use std::sync::Arc;
 
 use djinn_control_plane::test_support::McpTestHarness;
-use djinn_core::doctor::registry;
 use djinn_db::DoctorFindingRepository;
 use serde_json::json;
 
@@ -106,7 +105,7 @@ async fn closed_parent_open_children_db_dry_run_is_read_only() {
     ));
     source.refresh().await;
     assert_eq!(source.snapshot()["findings"], json!(health_findings));
-    register_closed_parent_open_children_check(registry(), source);
+    register_closed_parent_open_children_check(harness.doctor_registry(), source);
     let response = harness
         .call_tool(
             "doctor_run",
@@ -244,7 +243,7 @@ async fn closed_parent_open_children_db_repair_applies_safe_disposition() {
     source.refresh().await;
 
     register_closed_parent_open_children_check_with_repair(
-        registry(),
+        harness.doctor_registry(),
         source.clone(),
         source.clone(),
     );
@@ -523,7 +522,7 @@ async fn closed_parent_open_children_repair_skips_external_open_dependent() {
     ));
     source.refresh().await;
     register_closed_parent_open_children_check_with_repair(
-        registry(),
+        harness.doctor_registry(),
         source.clone(),
         source.clone(),
     );
@@ -600,7 +599,7 @@ async fn closed_parent_open_children_repair_cascades_internal_blocker() {
     ));
     source.refresh().await;
     register_closed_parent_open_children_check_with_repair(
-        registry(),
+        harness.doctor_registry(),
         source.clone(),
         source.clone(),
     );
@@ -669,7 +668,7 @@ async fn closed_parent_open_children_repair_skips_stale_snapshot() {
     ));
     source.refresh().await;
     register_closed_parent_open_children_check_with_repair(
-        registry(),
+        harness.doctor_registry(),
         source.clone(),
         source.clone(),
     );

--- a/server/crates/djinn-control-plane/tests/doctor_tools.rs
+++ b/server/crates/djinn-control-plane/tests/doctor_tools.rs
@@ -24,7 +24,7 @@ use djinn_control_plane::test_support::{McpTestHarness, RecordingExtensionDiagno
 use djinn_core::auth_context::SESSION_USER_ID;
 use djinn_core::doctor::{
     DoctorCheck, DoctorCheckCadence, DoctorError, DoctorResult, Finding, FindingSeverity,
-    ResolverSnapshot, registry,
+    ResolverSnapshot,
 };
 use djinn_core::extension_diagnostics::{
     ExtensionLoadDiagnosticV1, ExtensionLoadPhase, ExtensionLoadRemedyCode, ExtensionLoadSeverity,
@@ -39,9 +39,9 @@ use serde_json::json;
 // Sample fixable check for integration tests
 // ---------------------------------------------------------------------------
 
-/// Unique name for the test check registered in the global registry.
-/// Using a module-unique name avoids interference with other tests that
-/// might touch the global registry.
+/// Unique name for the test check registered in the harness registry.
+/// Using a module-unique name keeps it clear which check a `doctor_run`
+/// subset is selecting.
 const TEST_CHECK_NAME: &str = "test.doctor_integration_40jq";
 
 /// A sample check that demonstrates the shared-resolver invariant.
@@ -173,13 +173,18 @@ impl DoctorCheck for IntegrationFixableCheck {
 // Test helpers
 // ---------------------------------------------------------------------------
 
-/// Register the integration test check in the GLOBAL registry (the one
-/// `doctor_run` / `doctor_fix` consult via `registry()`).
+/// Register the integration test check in `harness`'s own registry — the one
+/// its `doctor_run` / `doctor_fix` consult.
+///
+/// It must NOT go into `djinn_core::doctor::registry()`: that singleton is
+/// process-wide and keyed by check name, so every test in this binary would
+/// register `TEST_CHECK_NAME` over the previous one and then assert on spy
+/// handles belonging to whichever test registered last.
 ///
 /// Returns spy handles so tests can assert on `fix_called` / `run_call_count`.
-fn register_test_check() -> (Arc<AtomicBool>, Arc<AtomicU32>) {
+fn register_test_check(harness: &McpTestHarness) -> (Arc<AtomicBool>, Arc<AtomicU32>) {
     let (check, fix_called, run_count) = IntegrationFixableCheck::new();
-    registry().register(Arc::new(check));
+    harness.doctor_registry().register(Arc::new(check));
     (fix_called, run_count)
 }
 
@@ -258,7 +263,7 @@ async fn create_admin_user(db: &djinn_db::Database) -> String {
 #[tokio::test]
 async fn doctor_run_rejects_non_admin_caller() {
     let harness = doctor_test_harness().await;
-    register_test_check();
+    register_test_check(&harness);
 
     let user_id = create_non_admin_user(harness.db()).await;
 
@@ -285,7 +290,7 @@ async fn doctor_run_rejects_non_admin_caller() {
 #[tokio::test]
 async fn doctor_fix_rejects_non_admin_caller() {
     let harness = doctor_test_harness().await;
-    register_test_check();
+    register_test_check(&harness);
 
     let user_id = create_non_admin_user(harness.db()).await;
 
@@ -320,7 +325,7 @@ async fn doctor_run_allows_trusted_no_user_background_path() {
     // When there is no SESSION_USER_ID scope (unauthenticated/background),
     // require_admin returns Ok(()). This is the trusted no-user path.
     let harness = doctor_test_harness().await;
-    let (fix_called, _) = register_test_check();
+    let (fix_called, _) = register_test_check(&harness);
 
     // No SESSION_USER_ID scope — simulates background/no-user context.
     let response = harness
@@ -338,7 +343,7 @@ async fn doctor_run_allows_trusted_no_user_background_path() {
 #[tokio::test]
 async fn doctor_run_allows_admin_caller() {
     let harness = doctor_test_harness().await;
-    register_test_check();
+    register_test_check(&harness);
 
     let admin_id = create_admin_user(harness.db()).await;
 
@@ -361,7 +366,7 @@ async fn doctor_run_allows_admin_caller() {
 #[tokio::test]
 async fn doctor_run_persists_findings_and_does_not_invoke_fix() {
     let harness = doctor_test_harness().await;
-    let (fix_called, _) = register_test_check();
+    let (fix_called, _) = register_test_check(&harness);
 
     // Run the check through the MCP tool.
     let response = harness
@@ -445,7 +450,7 @@ async fn doctor_run_persists_findings_and_does_not_invoke_fix() {
 #[tokio::test]
 async fn doctor_fix_invokes_fix_for_correct_finding() {
     let harness = doctor_test_harness().await;
-    let (fix_called, _) = register_test_check();
+    let (fix_called, _) = register_test_check(&harness);
 
     // Step 1: run to persist a finding.
     let run_response = harness
@@ -492,7 +497,7 @@ async fn doctor_fix_invokes_fix_for_correct_finding() {
 #[tokio::test]
 async fn doctor_fix_rejects_mismatched_check_name() {
     let harness = doctor_test_harness().await;
-    let (_, _) = register_test_check();
+    let (_, _) = register_test_check(&harness);
 
     // Run to persist a finding owned by TEST_CHECK_NAME.
     let run_response = harness
@@ -538,7 +543,7 @@ async fn doctor_fix_rejects_mismatched_check_name() {
 #[tokio::test]
 async fn doctor_fix_rejects_nonexistent_finding_id() {
     let harness = doctor_test_harness().await;
-    register_test_check();
+    register_test_check(&harness);
 
     let fix_response = harness
         .call_tool(
@@ -562,7 +567,7 @@ async fn doctor_fix_rejects_nonexistent_finding_id() {
 #[tokio::test]
 async fn doctor_fix_rejects_unknown_check_name() {
     let harness = doctor_test_harness().await;
-    register_test_check();
+    register_test_check(&harness);
 
     let fix_response = harness
         .call_tool(
@@ -604,7 +609,7 @@ async fn doctor_fix_rejects_unknown_check_name() {
 #[tokio::test]
 async fn fix_uses_resolver_snapshot_from_persisted_finding() {
     let harness = doctor_test_harness().await;
-    let (_, _) = register_test_check();
+    let (_, _) = register_test_check(&harness);
 
     // Run to persist a finding with the resolver snapshot.
     let run_response = harness
@@ -676,7 +681,7 @@ async fn fix_uses_resolver_snapshot_from_persisted_finding() {
 #[tokio::test]
 async fn doctor_run_without_check_names_runs_all_registered() {
     let harness = doctor_test_harness().await;
-    let (_, run_count) = register_test_check();
+    let (_, run_count) = register_test_check(&harness);
 
     let response = harness
         .call_tool("doctor_run", json!({}))
@@ -756,9 +761,10 @@ async fn doctor_run_persists_jk7v_aligned_classifier_evidence() {
 
     let harness = doctor_test_harness().await;
 
-    // Register our liveness-evidence-aware check in the global registry.
-    // We use a fresh AtomicBool to track whether it was found.
-    registry().register(Arc::new(LivenessEvidenceCheck));
+    // Register our liveness-evidence-aware check in this harness's registry.
+    harness
+        .doctor_registry()
+        .register(Arc::new(LivenessEvidenceCheck));
 
     // Run through the MCP tool.
     let response = harness


### PR DESCRIPTION
## The racing shared resource

**`djinn_core::doctor::registry()`** — a process-wide `OnceLock<DoctorRegistry>` singleton, keyed by check **name**, whose `register()` *replaces* any existing entry with the same name.

`DjinnMcpServer::doctor_run` and `doctor_fix` resolved their checks from that singleton (`doctor_tools.rs:464` and `:803`). Meanwhile each `McpTestHarness` gets a genuinely isolated ephemeral Postgres database (`Database::open_in_memory()` mints `djinn_test_<uuid>` from the template) — so the **database was never the problem**. The registry was.

All five tests in `doctor_closed_parent_tools.rs` register a check under the same name, `closed_parent_open_children`, each bound to a `TaskRepositoryClosedParentOpenChildrenSource` holding *its own* database handle. Run concurrently in one test binary, the last registration wins and serves **every** concurrent caller. A test's `doctor_run`/`doctor_fix` then executes a sibling's source against the sibling's database, which is exactly what the failures said:

```
left: Object {"outcome": String("skipped_not_found"), "task_id": String("019fb448-…")}
right: Object {"outcome": String("skipped_retain"), "task_id": String("019fb448-…")}
```

The task id exists — just not in the database the check that ran was bound to.

## The fix

Make the registry an injectable dependency on `McpState` rather than an ambient global read:

- `McpState` gains `doctor_registry: Option<Arc<DoctorRegistry>>`, a `with_doctor_registry()` builder, and a `doctor_registry()` accessor that **falls back to the singleton**. That fallback is the production wiring and is unchanged: `djinn-coordinator` registers every real check into `djinn_core::doctor::registry()` at startup, and the server never calls the builder.
- `doctor_run` / `doctor_fix` read `self.state.doctor_registry()`.
- Every `McpTestHarness` constructor funnels through `from_state`, which binds the harness to a fresh `DoctorRegistry` of its own. A state that already carries an injected registry keeps it, so rebuilding state from `harness.state().clone()` (the `extension_probe_harness` pattern) does not orphan checks the test already registered.
- The two test files register into `harness.doctor_registry()` instead of the global.

No `#[serial]`, no retries, no `#[ignore]`, no single-threading.

## Verification

All runs are `cargo test -p djinn-control-plane --test <target>` with
`DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres SQLX_OFFLINE=true`.

### Before — `doctor_closed_parent_tools`, default parallelism, 8 runs

A different subset fails each time, 2–5 failures per run:

```
run 1: FAILED. 2 passed; 3 failed | db_repair_applies_safe_disposition, repair_cascades_internal_blocker, repair_skips_external_open_dependent
run 2: FAILED. 3 passed; 2 failed | db_repair_applies_safe_disposition, repair_skips_stale_snapshot
run 3: FAILED. 2 passed; 3 failed | db_repair_applies_safe_disposition, repair_cascades_internal_blocker, repair_skips_external_open_dependent
run 4: FAILED. 2 passed; 3 failed | db_repair_applies_safe_disposition, repair_cascades_internal_blocker, repair_skips_external_open_dependent
run 5: FAILED. 2 passed; 3 failed | db_repair_applies_safe_disposition, repair_cascades_internal_blocker, repair_skips_external_open_dependent
run 6: FAILED. 3 passed; 2 failed | repair_skips_external_open_dependent, repair_skips_stale_snapshot
run 7: FAILED. 3 passed; 2 failed | db_repair_applies_safe_disposition, repair_skips_stale_snapshot
run 8: FAILED. 1 passed; 4 failed | db_repair_applies_safe_disposition, repair_cascades_internal_blocker, repair_skips_external_open_dependent, repair_skips_stale_snapshot
SUMMARY: 0 clean / 8 failed
```

Clean at `--test-threads=1`: **3 clean / 0 failed**.

### Before — `doctor_tools`, default parallelism, 10 runs

The same root cause was silently breaking the sibling binary too (its `register_test_check()` also wrote `TEST_CHECK_NAME` into the global, so tests asserted on spy handles belonging to whichever test registered last):

```
SUMMARY [doctor_tools]: 0 clean / 10 failed   (3–5 failures per run, varying subset)
```

### After — `doctor_closed_parent_tools`

| command | result |
|---|---|
| `cargo test … --test doctor_closed_parent_tools` (default parallelism) × 25 | **25 clean / 0 failed** |
| `… -- --test-threads=1` × 5 | **5 clean / 0 failed** |
| `… -- --test-threads=32` × 10 | **10 clean / 0 failed** |

### After — `doctor_tools`

| command | result |
|---|---|
| `cargo test … --test doctor_tools` (default parallelism) × 20 | **20 clean / 0 failed** |

### Gates

- `cargo test -p djinn-control-plane` (whole crate): **all 32 binaries green**, 899 lib tests + every integration target, 0 failed.
- `cargo clippy -p djinn-control-plane --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean on all touched files.
- `cargo check -p djinn-server --all-targets`: clean (production `McpState` composition unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
