### PR TITLE
fix(agent): record read coverage for what the model actually receives, and gate apply_patch on the span it rewrites

### DIFF
--- a/server/crates/djinn-agent/src/extension/handlers/gate_guard/mod.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/gate_guard/mod.rs
@@ -45,8 +45,9 @@ pub(crate) async fn gate_guard_edit_check(
             // truncated diagnostic so repeated denials are consistent.
             return Err(format!(
                 "FORCE-TRUNCATED-READ: The latest read of {} was truncated \
-                 and did not observe the full file. You MUST re-read the \
-                 entire file before editing.",
+                 and did not observe the full file. Re-read the region you \
+                 are about to change with read(file_path, offset=<line>, \
+                 limit=<lines>) before editing.",
                 path.display(),
             ));
         }
@@ -56,8 +57,11 @@ pub(crate) async fn gate_guard_edit_check(
             // seen the area it's trying to mutate.
             return Err(format!(
                 "FORCE-UNCOVERED-READ: The latest read of {} does not cover \
-                 the byte range [{}, {}) you are trying to edit. You MUST \
-                 re-read the file with full coverage before editing.",
+                 the byte range [{}, {}) you are trying to edit. Re-read the \
+                 region you are about to change — read(file_path, \
+                 offset=<line>, limit=<lines>) over that range is enough. A \
+                 whole-file read of a large file is cut at the tool-result \
+                 budget and will not extend coverage past where it stopped.",
                 path.display(),
                 span_start,
                 span_end,

--- a/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/patch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/patch_tests.rs
@@ -846,3 +846,201 @@ async fn gateguard_snapshot_proves_no_edit_forced_from_deficient_reads() {
     );
     assert_eq!(snap.edit_forced.len(), 1, "exactly one path in edit_forced");
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// apply_patch gates on the span it rewrites, not the whole file
+//
+// `call_apply_patch` used to declare `0..usize::MAX` for Update ops, which
+// only `ReadCoverage::Full` can satisfy. No read of a file past the 2000-line
+// cap — or past the tool-result budget — can produce `Full`, so patching such
+// a file was unsatisfiable: the gate demanded a whole-file read while
+// `patch.rs` told the worker not to re-read the whole file. Confirmed live:
+// 18 `FORCE-UNCOVERED-READ` denials with byte range [0, 18446744073709551615)
+// across 8 of 10 sampled worker sessions, apply_patch failing 35/50 calls, and
+// 12 `python3`/`cat` heredoc source rewrites routed through `shell` to escape.
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Build a file large enough that no single read can record `Full` coverage.
+async fn seed_large_file(path: &std::path::Path, n: usize) {
+    let mut contents = String::new();
+    for i in 1..=n {
+        contents.push_str(&format!(
+            "    let value_{i} = compute_something(input_{i});\n"
+        ));
+    }
+    tokio::fs::write(path, &contents).await.expect("seed");
+}
+
+/// A windowed read that covers the patched region must let the patch through
+/// (reaching the ordinary first-edit investigation FORCE), not deny it as
+/// uncovered.
+///
+/// Non-vacuity: with the old `0..usize::MAX` span this returns
+/// FORCE-UNCOVERED-READ, because a windowed read can never be `Full`.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn apply_patch_accepts_a_read_window_covering_the_patched_span() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup_worktree("gg-patch-span-ok-");
+    let file = worktree.path().join("big.rs");
+    seed_large_file(&file, 900).await;
+
+    // Read the first window of the file — this is what a worker gets from a
+    // whole-file read of a file this size.
+    let read_args = Some(
+        serde_json::json!({ "file_path": "big.rs", "offset": 0, "limit": 100 })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("windowed read");
+
+    let session_id = worktree.path().display().to_string();
+    let rec = state
+        .file_time
+        .latest_record(&session_id, &file)
+        .await
+        .expect("record");
+    assert!(
+        !rec.is_full(),
+        "a 900-line file must not record Full coverage; the test would be vacuous otherwise"
+    );
+
+    // Patch line 10 — inside the window that was read.
+    let patch = "*** Begin Patch\n\
+                 *** Update File: big.rs\n\
+                 @@     let value_10 = compute_something(input_10);\n\
+                 -    let value_10 = compute_something(input_10);\n\
+                 +    let value_10 = compute_something_else(input_10);\n\
+                 *** End Patch\n";
+    let patch_args = Some(
+        serde_json::json!({ "patch": patch })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let err = call_apply_patch(
+        &state,
+        &patch_args,
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect_err("first covered edit still hits the investigation FORCE");
+
+    assert!(
+        !err.contains("FORCE-UNCOVERED-READ"),
+        "a read window covering the patched span must not be denied as uncovered: {err}"
+    );
+    assert!(
+        err.contains("GateGuard"),
+        "expected the ordinary first-edit investigation prompt, got: {err}"
+    );
+}
+
+/// The gate still bites: a patch aimed outside the read window is denied.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn apply_patch_still_denies_a_span_outside_the_read_window() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup_worktree("gg-patch-span-deny-");
+    let file = worktree.path().join("big.rs");
+    seed_large_file(&file, 900).await;
+
+    // Read only the first 50 lines.
+    let read_args = Some(
+        serde_json::json!({ "file_path": "big.rs", "offset": 0, "limit": 50 })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("windowed read");
+
+    // Patch line 800 — far outside the window.
+    let patch = "*** Begin Patch\n\
+                 *** Update File: big.rs\n\
+                 @@     let value_800 = compute_something(input_800);\n\
+                 -    let value_800 = compute_something(input_800);\n\
+                 +    let value_800 = compute_something_else(input_800);\n\
+                 *** End Patch\n";
+    let patch_args = Some(
+        serde_json::json!({ "patch": patch })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let err = call_apply_patch(
+        &state,
+        &patch_args,
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect_err("patch outside the read window must be denied");
+
+    assert!(
+        err.contains("FORCE-UNCOVERED-READ"),
+        "expected FORCE-UNCOVERED-READ for an unread region, got: {err}"
+    );
+
+    let contents = tokio::fs::read_to_string(&file).await.unwrap();
+    assert!(
+        contents.contains("let value_800 = compute_something(input_800);"),
+        "file must be unchanged"
+    );
+}
+
+/// A `Delete` still requires whole-file coverage — deleting destroys every
+/// byte, so the conservative span is the honest one.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn apply_patch_delete_still_requires_full_coverage() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup_worktree("gg-patch-del-");
+    let file = worktree.path().join("big.rs");
+    seed_large_file(&file, 900).await;
+
+    let read_args = Some(
+        serde_json::json!({ "file_path": "big.rs", "offset": 0, "limit": 100 })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    call_read(&state, &read_args, worktree.path())
+        .await
+        .expect("windowed read");
+
+    let patch = "*** Begin Patch\n\
+                 *** Delete File: big.rs\n\
+                 *** End Patch\n";
+    let patch_args = Some(
+        serde_json::json!({ "patch": patch })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+    let err = call_apply_patch(
+        &state,
+        &patch_args,
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect_err("delete on a partially-read file must be denied");
+
+    assert!(
+        err.contains("FORCE-UNCOVERED-READ"),
+        "delete must still demand whole-file coverage, got: {err}"
+    );
+    assert!(file.exists(), "file must not be deleted");
+}

--- a/server/crates/djinn-agent/src/extension/handlers/workspace.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/workspace.rs
@@ -925,12 +925,29 @@ pub(crate) async fn call_apply_patch(
                         }
                     })?;
 
-                // GateGuard: enforce worker read-coverage gate before
-                // mutation. Conservative: require full-file coverage for
-                // update/delete since exact touched spans are not proven
-                // from the patch parser.
-                gate_guard_edit_check(state, session_role, &worktree_key, &resolved, 0..usize::MAX)
-                    .await?;
+                // GateGuard: enforce the worker read-coverage gate before
+                // mutation, against the span the patch actually rewrites.
+                //
+                // A `Delete` destroys the whole file, so whole-file coverage
+                // is the honest requirement there. An `Update` only rewrites
+                // its located chunks; declaring `0..usize::MAX` for those made
+                // the check unsatisfiable for every file too large to read
+                // into a single `ReadCoverage::Full` record, which is the
+                // `apply_patch` deadlock workers were escaping via `shell`
+                // heredocs. Unlocatable chunks fall back to the old
+                // conservative span — `apply_patch` rejects them moments later
+                // for the same reason.
+                let span = match op {
+                    crate::patch::FileOp::Update { chunks, .. } => {
+                        match tokio::fs::read_to_string(&resolved).await {
+                            Ok(content) => crate::patch::update_span(&content, chunks, raw_path)
+                                .unwrap_or(0..usize::MAX),
+                            Err(_) => 0..usize::MAX,
+                        }
+                    }
+                    _ => 0..usize::MAX,
+                };
+                gate_guard_edit_check(state, session_role, &worktree_key, &resolved, span).await?;
             }
             crate::patch::FileOp::Add { .. } => {
                 // New files don't need FileTime assertion

--- a/server/crates/djinn-agent/src/extension/handlers/workspace.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/workspace.rs
@@ -223,6 +223,69 @@ pub(crate) async fn call_shell(
     }))
 }
 
+/// Headroom reserved inside [`crate::output_stash::MAX_TOOL_RESULT_CHARS`] for
+/// everything in a read result that is *not* the numbered listing: the JSON
+/// envelope's keys, the path value, and the trailing truncation notes appended
+/// to `content` after the budgeted listing has been built.
+const READ_RESULT_RESERVE_CHARS: usize = 1_024;
+
+/// Number of characters needed to encode `s` as the body of a JSON string.
+///
+/// A read result is handed to the model only after
+/// `output_stash::render_tool_result` serializes it as JSON, so the budget that
+/// actually matters is the *escaped* size — a numbered listing spends two
+/// characters on every `\n` and `\t` it contains.
+fn json_escaped_len(s: &str) -> usize {
+    s.chars()
+        .map(|c| match c {
+            '"' | '\\' | '\n' | '\r' | '\t' | '\u{08}' | '\u{0c}' => 2,
+            c if (c as u32) < 0x20 => 6,
+            c => c.len_utf8(),
+        })
+        .sum()
+}
+
+/// Escaped-character budget available to a read result's `content` field before
+/// the downstream tool-result clamp would fire.
+///
+/// Derived from the single shared clamp constant so the two can never drift.
+/// This does **not** widen the clamp: it makes the read handler stop at a line
+/// boundary the clamp will accept, so the window the model receives is the
+/// window the handler recorded coverage for.
+fn read_content_budget() -> usize {
+    crate::output_stash::MAX_TOOL_RESULT_CHARS.saturating_sub(READ_RESULT_RESERVE_CHARS)
+}
+
+/// Render `lines` as a numbered listing beginning at absolute index `start`,
+/// stopping early once the listing would no longer survive the tool-result
+/// clamp. Returns the listing and the number of lines actually emitted.
+///
+/// At least one line is always emitted so a single over-long line still yields
+/// a usable (if over-budget) result rather than an empty window.
+fn numbered_lines_within_budget<'a, I>(lines: I, start: usize, budget: usize) -> (String, usize)
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut numbered = String::new();
+    let mut spent = 0usize;
+    let mut emitted = 0usize;
+    for (i, line) in lines.into_iter().enumerate() {
+        let mut l = line.to_string();
+        if l.chars().count() > 2000 {
+            l = l.chars().take(2000).collect();
+        }
+        let rendered = format!("{:>6}\t{}\n", start + i + 1, l);
+        let cost = json_escaped_len(&rendered);
+        if emitted > 0 && spent + cost > budget {
+            break;
+        }
+        spent += cost;
+        numbered.push_str(&rendered);
+        emitted += 1;
+    }
+    (numbered, emitted)
+}
+
 /// Format an in-memory file body as a numbered, paginated window matching the
 /// shape `call_read` returns from the worktree path. Used for mirror-backed
 /// cross-repo reads (the whole blob is already in memory from `git show`).
@@ -231,21 +294,18 @@ fn numbered_window(content: &str, offset: usize, limit: usize, path: &str) -> se
     let total = lines.len();
     let start = offset.min(total);
     let end = start.saturating_add(limit).min(total);
-    let mut numbered = String::new();
-    for (i, line) in lines[start..end].iter().enumerate() {
-        let line_no = start + i + 1;
-        let mut l = (*line).to_string();
-        if l.chars().count() > 2000 {
-            l = l.chars().take(2000).collect();
-        }
-        numbered.push_str(&format!("{:>6}\t{}\n", line_no, l));
-    }
+    let (numbered, emitted) = numbered_lines_within_budget(
+        lines[start..end].iter().copied(),
+        start,
+        read_content_budget(),
+    );
+    let emitted_end = start + emitted;
     serde_json::json!({
         "path": path,
         "offset": start,
         "limit": limit,
         "total_lines": total,
-        "has_more": end < total,
+        "has_more": emitted_end < total,
         "content": numbered,
     })
 }
@@ -401,38 +461,53 @@ pub(crate) async fn call_read(
     let start = offset.min(total_scanned);
     let end = start.saturating_add(limit).min(total_scanned);
 
-    let mut numbered = String::new();
-    for (i, (line, _byte_end)) in all_lines[start..end].iter().enumerate() {
-        let line_no = start + i + 1;
-        numbered.push_str(&format!("{:>6}\t{}\n", line_no, line));
-    }
+    // Emit only as much of the window as will survive the downstream
+    // tool-result clamp (`output_stash::MAX_TOOL_RESULT_CHARS`). Anything past
+    // that point never reaches the model, so it must not be counted as read.
+    let (mut numbered, emitted) = numbered_lines_within_budget(
+        all_lines[start..end].iter().map(|(line, _)| line.as_str()),
+        start,
+        read_content_budget(),
+    );
+    let emitted_end = start + emitted;
+    let clamped_by_result_budget = emitted_end < end;
+
     if truncated_by_budget {
         numbered.push_str(&format!(
             "\n[file too large: truncated at {} MiB; remaining content not shown]\n",
             MAX_READ_BYTES / (1024 * 1024)
         ));
     }
+    if clamped_by_result_budget {
+        numbered.push_str(&format!(
+            "\n[tool-result budget reached after line {emitted_end}; the rest of this window was \
+             NOT shown. Continue with read(file_path, offset={emitted_end}, limit={limit}).]\n"
+        ));
+    }
 
-    // `has_more` is true if there's content past the scanned window, or if the
-    // requested window didn't reach the end of what we scanned.
-    let has_more = has_more_beyond_window || end < total_scanned;
+    // `has_more` is true if there's content past the scanned window, if the
+    // requested window didn't reach the end of what we scanned, or if the
+    // tool-result budget cut the window short.
+    let has_more = has_more_beyond_window || emitted_end < total_scanned;
 
-    // Compute read coverage metadata from the actual arguments and result.
+    // Compute read coverage metadata from what the model actually receives.
     // A read is full-file coverage only when the worker received all content
     // from the start (offset 0), there are no remaining pages, and no
-    // byte-budget truncation occurred.
+    // byte-budget truncation occurred. `has_more` now accounts for the
+    // tool-result clamp as well, so a listing the clamp would gut can never be
+    // recorded as `Full`.
     let coverage = if offset == 0 && !has_more && !truncated_by_budget {
         crate::file_time::ReadCoverage::Full
     } else {
         // Record the byte range of the window actually returned.
-        let cov_start = if start < end {
+        let cov_start = if start < emitted_end {
             line_byte_offsets[start]
         } else {
             // Empty window: point at EOF offset.
             scanned_bytes as u64
         };
-        let cov_end = if start < end {
-            Some(all_lines[end - 1].1)
+        let cov_end = if start < emitted_end {
+            Some(all_lines[emitted_end - 1].1)
         } else {
             None
         };

--- a/server/crates/djinn-agent/src/extension/tests/tool_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/tool_dispatch_tests.rs
@@ -895,3 +895,181 @@ async fn read_budget_truncated_records_truncated_coverage() {
         );
     }
 }
+
+// ─── ReadCoverage vs. the downstream tool-result clamp ────────────────────
+//
+// `output_stash::render_tool_result` clamps any result over
+// `MAX_TOOL_RESULT_CHARS` *after* `call_read` has recorded coverage. A file
+// well under both the 2000-line cap and the 8 MiB byte budget can still blow
+// that clamp, and because the numbered listing is a single enormous JSON
+// string, `smart_truncate`'s line-aware head/tail split keeps the envelope
+// keys and discards the entire listing. The tests below pin that the recorded
+// coverage describes what the model actually receives.
+
+/// Build a file of `n` lines of realistic source-code width.
+fn seed_wide_file(path: &std::path::Path, n: usize) -> String {
+    let mut contents = String::new();
+    for i in 1..=n {
+        contents.push_str(&format!(
+            "    let some_reasonable_line_of_rust_code_{i} = compute(value_{i});\n"
+        ));
+    }
+    std::fs::write(path, &contents).expect("seed file");
+    contents
+}
+
+/// A whole-file read whose result would be clamped downstream must NOT be
+/// recorded as `ReadCoverage::Full`, and must advertise `has_more`.
+///
+/// Non-vacuity: on the pre-fix code this file is under 2000 lines and under
+/// 8 MiB, so `has_more` was `false` and coverage was recorded `Full` — both
+/// assertions below failed.
+#[tokio::test]
+async fn read_clamped_by_tool_result_budget_is_not_recorded_as_full() {
+    use crate::file_time::ReadCoverage;
+
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-cov-clamp-");
+    let file = worktree.path().join("wide.rs");
+    // 900 lines x ~70 chars ~= 64k chars of numbered listing: comfortably over
+    // the 30k clamp, comfortably under the 2000-line cap and the 8 MiB budget.
+    seed_wide_file(&file, 900);
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let args = Some(
+        serde_json::json!({ "file_path": "wide.rs", "offset": 0, "limit": 2000 })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    let result = call_read(&state, &args, worktree.path())
+        .await
+        .expect("read should succeed");
+
+    assert_eq!(
+        result.get("has_more").and_then(|v| v.as_bool()),
+        Some(true),
+        "a read cut short by the tool-result budget must advertise has_more=true"
+    );
+
+    let worktree_key = worktree.path().display().to_string();
+    let rec = state
+        .file_time
+        .latest_record(&worktree_key, &file)
+        .await
+        .expect("read record should exist");
+    assert!(
+        !rec.is_full(),
+        "a read the tool-result clamp would gut must not record Full coverage, got {:?}",
+        rec.coverage
+    );
+    assert!(
+        matches!(rec.coverage, ReadCoverage::Range { .. }),
+        "expected Range coverage, got {:?}",
+        rec.coverage
+    );
+}
+
+/// The listing a clamped read returns must actually survive
+/// `render_tool_result` — i.e. the model receives the lines the handler
+/// recorded coverage for.
+///
+/// Non-vacuity: on the pre-fix code `render_tool_result` reduced this result
+/// to a ~216-character stub containing the JSON envelope keys and zero file
+/// lines, so `surviving_lines` below was 0.
+#[tokio::test]
+async fn read_result_survives_the_tool_result_clamp() {
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-cov-survive-");
+    let file = worktree.path().join("wide.rs");
+    seed_wide_file(&file, 900);
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let args = Some(
+        serde_json::json!({ "file_path": "wide.rs", "offset": 0, "limit": 2000 })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    let result = call_read(&state, &args, worktree.path())
+        .await
+        .expect("read should succeed");
+
+    let stash = std::sync::Mutex::new(crate::output_stash::OutputStash::new());
+    let rendered = crate::output_stash::render_tool_result(&stash, "call-1", "read", &result);
+
+    let surviving = rendered
+        .matches("let some_reasonable_line_of_rust_code_")
+        .count();
+    assert!(
+        surviving > 100,
+        "the rendered read result must still carry the file listing; only {surviving} \
+         lines survived render_tool_result ({} chars rendered)",
+        rendered.len()
+    );
+    assert!(
+        rendered.contains("let some_reasonable_line_of_rust_code_1 "),
+        "the first line of the window must reach the model"
+    );
+
+    // And the coverage record must not claim more than that.
+    let worktree_key = worktree.path().display().to_string();
+    let rec = state
+        .file_time
+        .latest_record(&worktree_key, &file)
+        .await
+        .expect("read record should exist");
+    assert!(!rec.is_full(), "clamped read must not record Full coverage");
+}
+
+/// Guard the legitimate `Full` case: a file whose listing fits inside the
+/// tool-result clamp must still record `Full`, or every edit in the system
+/// starts demanding a re-read.
+#[tokio::test]
+async fn read_within_tool_result_budget_still_records_full() {
+    let worktree = crate::test_helpers::test_tempdir("djinn-ext-cov-full-fits-");
+    let file = worktree.path().join("modest.rs");
+    // ~300 lines x ~70 chars ~= 21k chars: under the 30k clamp.
+    seed_wide_file(&file, 300);
+
+    let state =
+        crate::test_helpers::agent_context_from_db(create_test_db(), CancellationToken::new());
+
+    let args = Some(
+        serde_json::json!({ "file_path": "modest.rs", "offset": 0, "limit": 2000 })
+            .as_object()
+            .expect("obj")
+            .clone(),
+    );
+    let result = call_read(&state, &args, worktree.path())
+        .await
+        .expect("read should succeed");
+
+    assert_eq!(
+        result.get("has_more").and_then(|v| v.as_bool()),
+        Some(false),
+        "a read that fits the budget must not advertise has_more"
+    );
+
+    // It must genuinely pass through render_tool_result untouched.
+    let stash = std::sync::Mutex::new(crate::output_stash::OutputStash::new());
+    let rendered = crate::output_stash::render_tool_result(&stash, "call-1", "read", &result);
+    assert!(
+        !rendered.contains("djinn-output-stash"),
+        "an under-budget read must not be stashed/clamped at all"
+    );
+
+    let worktree_key = worktree.path().display().to_string();
+    let rec = state
+        .file_time
+        .latest_record(&worktree_key, &file)
+        .await
+        .expect("read record should exist");
+    assert!(
+        rec.is_full(),
+        "an under-budget whole-file read must still record Full, got {:?}",
+        rec.coverage
+    );
+}

--- a/server/crates/djinn-agent/src/patch.rs
+++ b/server/crates/djinn-agent/src/patch.rs
@@ -294,6 +294,68 @@ fn resolve_op_path(raw: &str, worktree: &Path) -> PathBuf {
     }
 }
 
+/// Byte offset at which each line of `content` starts, plus a trailing
+/// sentinel equal to `content.len()`.
+///
+/// Indices line up 1:1 with `content.lines()`, so a line index from
+/// [`find_chunk_position`] can be converted to a byte offset directly.
+fn line_byte_offsets(content: &str) -> Vec<usize> {
+    let mut offsets = Vec::new();
+    let mut pos = 0usize;
+    for line in content.split_inclusive('\n') {
+        offsets.push(pos);
+        pos += line.len();
+    }
+    offsets.push(pos);
+    offsets
+}
+
+/// The byte span of `content` that applying `chunks` would touch.
+///
+/// Used by the GateGuard read-coverage check so `apply_patch` gates on the
+/// region the patch actually rewrites instead of declaring the whole file.
+/// Declaring `0..usize::MAX` made the check unsatisfiable for any file whose
+/// read cannot produce `ReadCoverage::Full` — every file over the 2000-line
+/// read cap, and (since reads are now fitted to the tool-result clamp) every
+/// file whose listing exceeds that clamp. Workers escaped the resulting
+/// deadlock by rewriting files with `python3` heredocs through `shell`.
+///
+/// Returns `None` when any chunk cannot be located, in which case the caller
+/// should keep the conservative whole-file requirement — `apply_patch` is
+/// about to reject the patch for the same reason anyway.
+pub(crate) fn update_span(
+    content: &str,
+    chunks: &[Chunk],
+    file_path: &str,
+) -> Option<std::ops::Range<usize>> {
+    if chunks.is_empty() {
+        return None;
+    }
+    let lines: Vec<String> = content.lines().map(String::from).collect();
+    let offsets = line_byte_offsets(content);
+
+    let mut min_line = usize::MAX;
+    let mut max_line = 0usize;
+    for chunk in chunks {
+        let pos = find_chunk_position(&lines, chunk, file_path).ok()?;
+        // Context and Remove lines consume original lines; Add lines do not.
+        // A pure-insertion chunk still requires the worker to have seen the
+        // line it anchors on, hence the `.max(1)`.
+        let consumed = chunk
+            .lines
+            .iter()
+            .filter(|cl| matches!(cl, ChunkLine::Context(_) | ChunkLine::Remove(_)))
+            .count()
+            .max(1);
+        min_line = min_line.min(pos);
+        max_line = max_line.max(pos.saturating_add(consumed).min(lines.len()));
+    }
+
+    let start = *offsets.get(min_line)?;
+    let end = *offsets.get(max_line)?;
+    Some(start..end)
+}
+
 /// Apply all chunks to the file content, returning the modified content.
 fn apply_chunks(content: &str, chunks: &[Chunk], file_path: &str) -> Result<String, String> {
     let mut lines: Vec<String> = content.lines().map(String::from).collect();
@@ -395,7 +457,8 @@ fn find_chunk_position(lines: &[String], chunk: &Chunk, file_path: &str) -> Resu
     Err(format!(
         "could not locate chunk in {file_path}: context anchor '@@ {anchor}' not found in file. \
          The @@ line must contain text that appears VERBATIM in the file. If this is a large \
-         file, a whole-file `read` is TRUNCATED (middle omitted) — don't trust a full read. \
+         file, a whole-file `read` stops at the tool-result budget and reports has_more — \
+         don't assume you saw the whole file. \
          Find the target with the `lsp` tool (operation \"definition\") or output_grep, re-read \
          that exact range with read(offset, limit), and copy the anchor line character-for-character."
     ))
@@ -461,9 +524,9 @@ fn apply_single_chunk(
                     return Err(format!(
                         "context mismatch at line {mismatch_line}: expected '{text}', \
                          found '{actual}'. Your patch context does not match the file on \
-                         disk. If this is a large file, a whole-file `read` is TRUNCATED \
-                         (middle omitted) so you never saw this region — do NOT re-read \
-                         the whole file. Instead re-read just this range with \
+                         disk. If this is a large file, a whole-file `read` stops at the \
+                         tool-result budget (it reports has_more), so you may never have \
+                         seen this region. Re-read just this range with \
                          read(file_path, offset={reread_offset}, limit=60), or jump \
                          straight to the symbol with the `lsp` tool (operation \
                          \"definition\"/\"references\"), then copy the surrounding lines \


### PR DESCRIPTION
The edit gate is correct. The bookkeeping feeding it was wrong, and the `apply_patch` span made the gate unsatisfiable. Two commits, one problem each.

## What was actually happening

`call_read` decided `ReadCoverage::Full` from its own windowing only — `offset == 0`, `!has_more`, and the 8 MiB `MAX_READ_BYTES` budget. A second clamp runs afterwards: `output_stash::render_tool_result` stashes any result over `MAX_TOOL_RESULT_CHARS` (30k) and hands the model a `smart_truncate`d view.

The framing in the report was that the model "saw a slice". It saw **nothing**. The numbered listing is a single enormous JSON string, so `smart_truncate`'s line-aware 60/40 head/tail split keeps the short envelope keys and discards the entire listing. Reproduced against verbatim copies of `smart_truncate` and the `call_read` envelope:

| file | rendered JSON | what the model received | file lines surviving |
|---|---|---|---|
| 300 lines | 21,972 | full result, unclamped | 300 / 300 |
| 500 lines | 36,572 | 216 chars | **0 / 500** |
| 900 lines | 65,772 | 216 chars | **0 / 900** |
| 1900 lines | 139,674 | 219 chars | **0 / 1900** |

The 500-line case was recorded `ReadCoverage::Full`, `has_more: false`. This is confirmed in production — a live stash header from session `019fb0c8`:

```
[djinn-output-stash tool_use_id="call_UzTRRVbdf3SiUJgh4BeA2syB" tool_name="read" reason="single_threshold" full_chars="95682" preview_chars="217"]
```

95,682 characters read, **217** delivered.

## Verdicts on the three reported claims

### 1. "~318 files recorded `Full` while the model saw a slice, in session `019fb1df`" — REFUTED as stated; mechanism CONFIRMED

The mechanism is real and worse than described (zero content, not a slice). The **frequency** does not hold. Across 10 worker sessions / 471 tool calls / 229 `read` calls sampled via the djinn MCP:

- **24 of 229 read results stashed (10.5%)**, not "most".
- 3 of 10 sessions stashed zero reads.
- Session `019fb1df` made **11 read calls in total**, 1 stashed. "~318 files" cannot have come from that session.

Secondary correction: the effective boundary sits somewhat above 30,000 chars — 30,337 / 28,600 / 28,118-char reads passed through intact while a 31,829-char read stashed. When the clamp does fire it is usually a genuinely large file (82k–96k chars).

So: real bug, real severity when it fires, but occasional rather than the dominant pattern.

### 2. `apply_patch` deadlock — CONFIRMED, and the highest-severity item

- **18 `FORCE-UNCOVERED-READ` denials across 8 of the 10 sessions**, every one from `apply_patch`, every one carrying byte range `[0, 18446744073709551615)`.
- **`apply_patch` failed 35 of 50 calls (70%)**.
- **12 `python3` / `cat` heredoc source rewrites routed through `shell`** across 5 sessions — the one edit path with no gate. In `019fb0c8` a `python3 - <<'PY'` heredoc rewrote `server/crates/djinn-db/src/repositories/task/mod.rs`, the exact file that had just thrown `FORCE-UNCOVERED-READ`.
- `FORCE-TRUNCATED-READ`: 0 occurrences.

The mechanism is structural, not incidental: `0..usize::MAX` is satisfiable only by `ReadCoverage::Full`, and no read of a file past the non-overridable 2000-line cap can produce `Full`. `gate_guard` said "re-read the file with full coverage"; `patch.rs` said "do NOT re-read the whole file". Both instructions were unsatisfiable together.

Worth noting: this also means commit 1 could not ship alone. Making coverage honest would have extended the deadlock from ">2000-line files" to ">~420-line files" and pushed far more traffic onto the ungated `shell` path.

### 3. "0 `output_view`, 0 `output_grep`, 0 `code_graph`, 0 of 20 truncated reads recovered" — PARTIALLY REFUTED

Across 471 sampled tool calls: `output_view` **0** (confirmed), `code_graph` **0** (confirmed), `output_grep` **6** — the "never" is wrong. But the sharper finding survives: of those 6 greps, 3 targeted `ci_job_log` stashes, 2 targeted `shell` stashes, and **only 1 recovered a stashed `read`**. So 1 of 24 stashed reads (~4%) was ever revisited. Workers do use `output_grep`, essentially never to recover file content they needed to patch.

*(Counting caveat: any string-grep of raw session JSON over-counts these tool names, because the stash header's own closing sentence names both `output_view` and `output_grep`. Only `tool_use` block counts are sound.)*

## The fixes

**Commit 1 — `call_read` fits its window to the clamp.** Rather than widening `MAX_TOOL_RESULT_CHARS` or weakening the gate, the handler now stops emitting lines at the last line boundary the clamp will accept. The window the model receives is the window coverage is recorded for. `has_more` reports the cut and feeds the **unchanged** `Full` condition; the `Range` end comes from the last line actually emitted. The budget is derived from the clamp constant, so the two cannot drift. Same budget applied to `numbered_window` (cross-repo mirror reads), which returned the same gutted stub.

Side benefit: a 900-line read now delivers ~420 usable lines plus `has_more` and a continuation offset, instead of a 216-char stub.

**Commit 2 — `apply_patch` gates on the span it rewrites.** `patch::update_span` locates each chunk with the same `find_chunk_position` the applier uses and returns the union byte range touched. The denial becomes satisfiable by the targeted re-read `patch.rs` already recommends. `Delete` still requires whole-file coverage (it destroys every byte); unlocatable chunks still fall back to `0..usize::MAX`. The `FORCE-*` prefixes are unchanged; only the trailing guidance was reworded, along with two `patch.rs` diagnostics that described the old "middle omitted" behaviour.

## Non-vacuity

Each new test was run against the pristine pre-fix source, not just asserted to pass.

**Commit 1** — stashing only `workspace.rs`:

```
read_clamped_by_tool_result_budget_is_not_recorded_as_full ... FAILED
  assertion `left == right` failed: a read cut short by the tool-result
  budget must advertise has_more=true
    left: Some(false)
   right: Some(true)

read_result_survives_the_tool_result_clamp ... FAILED
  the rendered read result must still carry the file listing;
  only 1 lines survived render_tool_result (871 chars rendered)

read_within_tool_result_budget_still_records_full ... ok
```

The third passing pre-fix is the point: it guards the legitimate `Full` case rather than riding along. All three pass after.

**Commit 2** — stashing only `workspace.rs` + `patch.rs`:

```
apply_patch_accepts_a_read_window_covering_the_patched_span ... FAILED
  a read window covering the patched span must not be denied as uncovered:
  FORCE-UNCOVERED-READ: The latest read of .../big.rs does not cover the
  byte range [0, 18446744073709551615) you are trying to edit.

apply_patch_still_denies_a_span_outside_the_read_window ... ok
apply_patch_delete_still_requires_full_coverage ... ok
```

The failure reproduces the exact production signature found 18 times in live sessions. The two passing tests hold the gate closed on both sides.

The pre-existing `read_full_file_records_full_coverage`, `read_offset_limit_records_range_coverage`, and `read_budget_truncated_records_truncated_coverage` are unmodified and still pass.

## Known residual (not fixed here)

`djinn-slot`'s per-turn inline budget (`turn_budget.rs`, 100k chars/turn, 10k preview floor) can re-externalize an already-rendered result *after* coverage is recorded — the same class of lie, one layer further out. It was observed once in the sample (1 of 34 stashed results, `reason="turn_budget"`). Closing it needs a coverage-downgrade callback plumbed from `djinn-slot` back into `file_time`, which is a larger change than belongs here. Flagging rather than silently leaving it.

Also unreconciled, and untouched: the 2000-line read cap at `workspace.rs:285`/`:322` is still hard and non-overridable, so a file over 2000 lines still needs multiple reads regardless of the clamp.

## Verification

`cargo clippy -p djinn-agent --all-targets -- -D warnings` clean, `cargo fmt --check` clean, full `djinn-agent` lib suite **1447 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
