### PR TITLE
fix(launcher): canonical authority-protocol crate, and make resize-v2 actually reachable (ydpj-A)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
 name = "djinn-cgroup-launcher"
 version = "0.1.0"
 dependencies = [
+ "djinn-launcher-protocol",
  "libc",
  "thiserror 2.0.18",
  "workspace-hack",
@@ -1363,6 +1364,7 @@ dependencies = [
  "dirs 6.0.0",
  "djinn-core",
  "djinn-db",
+ "djinn-launcher-protocol",
  "djinn-memory",
  "djinn-spec-lint",
  "djinn-stack",
@@ -1527,6 +1529,15 @@ dependencies = [
  "tower-test",
  "tracing",
  "uuid",
+ "workspace-hack",
+]
+
+[[package]]
+name = "djinn-launcher-protocol"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
  "workspace-hack",
 ]
 

--- a/server/crates/djinn-cgroup-launcher/Cargo.toml
+++ b/server/crates/djinn-cgroup-launcher/Cargo.toml
@@ -16,6 +16,10 @@ name = "djinn-cgroup-launcher"
 path = "src/main.rs"
 
 [dependencies]
+# The canonical quota-authority protocol. A leaf crate on purpose: this binary
+# ships into every per-project image and must never reach a database client to
+# learn the two strings it shares with migration 164.
+djinn-launcher-protocol = { path = "../djinn-launcher-protocol" }
 libc = "0.2"
 thiserror = "2"
 workspace-hack.workspace = true

--- a/server/crates/djinn-cgroup-launcher/src/lease_authority.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lease_authority.rs
@@ -8,25 +8,18 @@
 
 use crate::{DEFAULT_PERIOD_US, Error};
 
-/// The component that owns an invocation leaf's CPU quota.
+/// The quota-authority protocol is **not defined here**.
 ///
-/// This is intentionally independent from [`LeaseAuthority`], which remains a
-/// per-invocation leaf-v1 armed/unarmed decision. Keeping the axes separate
-/// prevents a resize-v2 leaf from inheriting a leaf-v1 quota mutation.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum LauncherAuthorityProtocol {
-    /// The launcher owns per-leaf quota birth and fenced lift writes.
-    #[default]
-    LeafV1,
-    /// Pod resize owns quota. The launcher must never write leaf `cpu.max`.
-    ResizeV2,
-}
-
-impl LauncherAuthorityProtocol {
-    pub(crate) fn launcher_owns_leaf_quota(self) -> bool {
-        matches!(self, Self::LeafV1)
-    }
-}
+/// It is the one contract `djinn-cgroup-launcher`, `djinn-db` (migration 164's
+/// `CHECK ... IN ('leaf-v1', 'resize-v2')`) and the admission plane must all
+/// agree on, so it lives in the zero-`djinn` leaf crate
+/// [`djinn_launcher_protocol`] and is re-exported here. This crate keeps the
+/// re-export — not a copy — because a second definition is exactly how #2800
+/// shipped a wire form nothing could compare against.
+///
+/// The launcher stays a static sidecar: the protocol crate depends on `serde`
+/// (without `derive`) and on nothing else.
+pub use djinn_launcher_protocol::LauncherAuthorityProtocol;
 
 /// `cpu.max` line for a leaf with NO quota of its own.
 ///

--- a/server/crates/djinn-cgroup-launcher/src/main.rs
+++ b/server/crates/djinn-cgroup-launcher/src/main.rs
@@ -10,12 +10,21 @@
 //!
 //! Configuration is read from the environment the Job renders
 //! (`djinn-k8s::launcher`): the delegated cgroup root, control socket path, the
-//! worker-private credential path, the expected delegated-root owner uid, and the
-//! unleased/leased broker quotas. Anything missing/invalid or a delegated cgroup
-//! that fails the [`Readiness`](djinn_cgroup_launcher::Readiness) contract, exits
-//! non-zero with a NAMED error BEFORE the broker accepts a single connection.
-//! Every one of those conditions is a readiness failure, never a per-command
-//! error discovered after the pod has taken work (task grkq).
+//! worker-private credential path, the expected delegated-root owner uid, the
+//! unleased/leased broker quotas, and the quota-authority protocol
+//! ([`AUTHORITY_PROTOCOL_ENV`], optional — absent means `leaf-v1`). Anything
+//! missing/invalid or a delegated cgroup that fails the
+//! [`Readiness`](djinn_cgroup_launcher::Readiness) contract, exits non-zero with
+//! a NAMED error BEFORE the broker accepts a single connection. Every one of
+//! those conditions is a readiness failure, never a per-command error discovered
+//! after the pod has taken work (task grkq).
+//!
+//! The protocol is the ONLY thing here that decides whether the launcher writes
+//! leaf `cpu.max` at all, and it is read from the process environment for one
+//! reason: it is the only surface a Kubernetes Job can change. #2800 landed the
+//! `resize-v2` branches with no caller outside the crate's own tests, so the
+//! mechanism could not fire in production even though every acceptance criterion
+//! was true (task 78v1).
 
 use std::io::Write;
 use std::path::Path;

--- a/server/crates/djinn-cgroup-launcher/src/main.rs
+++ b/server/crates/djinn-cgroup-launcher/src/main.rs
@@ -26,7 +26,8 @@ use djinn_cgroup_launcher::bootstrap::Bootstrap;
 use djinn_cgroup_launcher::broker::{Broker, BrokerConfig, OsNonceSource};
 use djinn_cgroup_launcher::transport::UnixBrokerServer;
 use djinn_cgroup_launcher::{
-    Error as LauncherError, Launcher, LauncherConfig, NativeCgroupFs, NativeCgroupSpawn,
+    Error as LauncherError, Launcher, LauncherAuthorityProtocol, LauncherConfig, NativeCgroupFs,
+    NativeCgroupSpawn,
 };
 
 /// Worker→launcher handshake filename (holds the worker PID) written by the
@@ -35,6 +36,13 @@ const WORKER_PID_FILE: &str = "worker.pid";
 /// Bounded wait for the worker handshake files to appear (100ms × 600 = 60s).
 const HANDSHAKE_POLL: Duration = Duration::from_millis(100);
 const HANDSHAKE_ATTEMPTS: u32 = 600;
+
+/// Selects who owns leaf CPU quota for this launcher's whole lifetime.
+///
+/// Absent means `leaf-v1` — the behavior that predates the protocol existing.
+/// Anything else that is not a wire form is a readiness failure, not a default;
+/// see [`authority_protocol_from_environment`].
+const AUTHORITY_PROTOCOL_ENV: &str = "DJINN_LAUNCHER_AUTHORITY_PROTOCOL";
 
 fn main() -> ExitCode {
     match run() {
@@ -53,7 +61,17 @@ fn run() -> Result<(), MainError> {
         None | Some("serve") => {}
         Some(other) => return Err(MainError::UnknownSubcommand(other.to_string())),
     }
+    serve()
+}
 
+/// Everything downstream of argument parsing: read the environment, pass every
+/// readiness gate, bind the control socket, serve.
+///
+/// Split from [`run`] only so the readiness ordering is testable — a test
+/// binary's own `argv` is not `serve`, and the ordering claim ("an unparseable
+/// protocol exits before the socket exists") can only be proven by calling the
+/// real function and then looking for the socket.
+fn serve() -> Result<(), MainError> {
     let socket = env_required("DJINN_LAUNCHER_SOCKET")?;
     let cgroup_root = env_required("DJINN_LAUNCHER_CGROUP_ROOT")?;
     let credential_path = env_required("DJINN_LAUNCHER_CREDENTIAL_PATH")?;
@@ -67,6 +85,15 @@ fn run() -> Result<(), MainError> {
         .parse()
         .map_err(|_| MainError::InvalidEnv("DJINN_LAUNCHER_LEASED_MILLICORES"))?;
 
+    // Readiness gate 1 — the quota authority. Built HERE, with the rest of the
+    // environment, and deliberately before `Bootstrap`, before the delegated
+    // root is opened and before the control socket is bound: a launcher that
+    // cannot name its own protocol must never become reachable. This is the
+    // ONLY place the shipped binary learns it, which is the whole point of
+    // task 78v1 — #2800 landed the resize-v2 branches with no caller outside
+    // the crate's own tests, so the mechanism could not fire in production.
+    let config = launcher_config(unleased, leased, expected_uid)?;
+
     // Prepare the root supplied by the kubelet RuntimeClass before binding the broker.
     Bootstrap::new(&cgroup_root).run()?;
 
@@ -75,11 +102,7 @@ fn run() -> Result<(), MainError> {
     // root writable and not group/other-writable, owner == expected uid, exactly
     // the cpu controller delegated) and fails closed, by name, otherwise.
     let fs = NativeCgroupFs::open(&cgroup_root, expected_uid)?;
-    let launcher = Launcher::new(
-        fs,
-        NativeCgroupSpawn,
-        LauncherConfig::new(Some(unleased), Some(leased), expected_uid)?,
-    )?;
+    let launcher = Launcher::new(fs, NativeCgroupSpawn, config)?;
 
     // Readiness gate 4 — the git trust anchor. A brokered child runs as a uid
     // that owns none of the pod's volumes, so without a protected-scope
@@ -141,6 +164,53 @@ fn env_required(key: &'static str) -> Result<String, MainError> {
     std::env::var(key).map_err(|_| MainError::MissingEnv(key))
 }
 
+/// The launcher configuration the **shipped binary** runs on.
+///
+/// Quotas come from the caller (they are already parsed and named), the quota
+/// authority comes from the process environment. Kept as one named function so
+/// there is a single place the binary's config is assembled — and so the proof
+/// that resize-v2 is reachable can exercise *this*, not a test-constructed
+/// `LauncherConfig`.
+fn launcher_config(
+    unleased: u16,
+    leased: u32,
+    expected_uid: u32,
+) -> Result<LauncherConfig, MainError> {
+    Ok(
+        LauncherConfig::new(Some(unleased), Some(leased), expected_uid)?
+            .with_authority_protocol(authority_protocol_from_environment()?),
+    )
+}
+
+/// Read [`AUTHORITY_PROTOCOL_ENV`] from the process environment.
+///
+/// Three outcomes, and the third is the load-bearing one:
+///
+/// * **Absent** → [`LauncherAuthorityProtocol::LeafV1`]. Every launcher that
+///   predates this variable keeps its exact behavior, so rolling the binary out
+///   ahead of the Job template change is a no-op.
+/// * **A wire form** → that protocol.
+/// * **Anything else** (including non-UTF-8) → an error, which `run` returns
+///   before `Bootstrap`, before the delegated root is opened and before the
+///   socket exists.
+///
+/// There is deliberately no `unwrap_or_default`. `resize-v2` misspelled as
+/// `resize_v2` would silently become `leaf-v1`, and the launcher would then
+/// write leaf `cpu.max` under a Pod whose quota is owned by resize — the exact
+/// double-authority the protocol exists to prevent. A pod that cannot say which
+/// regime it is in must not take work.
+fn authority_protocol_from_environment() -> Result<LauncherAuthorityProtocol, MainError> {
+    match std::env::var(AUTHORITY_PROTOCOL_ENV) {
+        Ok(raw) => raw
+            .parse()
+            .map_err(|_| MainError::InvalidEnv(AUTHORITY_PROTOCOL_ENV)),
+        Err(std::env::VarError::NotPresent) => Ok(LauncherAuthorityProtocol::LeafV1),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err(MainError::InvalidEnv(AUTHORITY_PROTOCOL_ENV))
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 enum MainError {
     #[error("unknown subcommand: {0}")]
@@ -157,4 +227,341 @@ enum MainError {
     Launcher(#[from] LauncherError),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+}
+
+/// The reachability proofs for the shipped binary.
+///
+/// # Why these live in the binary and not in the library
+///
+/// #2800 added the `resize-v2` branches, a `with_authority_protocol` setter and
+/// a library test that drove the setter directly. All of it passed, including
+/// the privileged Launcher Kernel Boundary lane, and the mechanism still could
+/// not fire in production: `LauncherConfig::new` hard-coded `LeafV1`, the setter
+/// had three callers and all three were tests, and no environment variable
+/// reached it. A library test cannot detect that, because a library test is
+/// allowed to construct the config however it likes.
+///
+/// So these tests deliberately start from the *process environment* and call
+/// the binary's own [`launcher_config`] and [`serve`]. Revert `main.rs` to
+/// `LauncherConfig::new(...)` with no setter call and
+/// `resize_v2_is_reachable_from_the_process_environment_alone` fails on its
+/// first `cpu.max` write.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use djinn_cgroup_launcher::{
+        CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, LeaseAuthority,
+        Readiness, SpawnIntoCgroup,
+    };
+    use std::collections::{BTreeSet, HashMap};
+    use std::os::fd::RawFd;
+    use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+
+    const EXPECTED_UID: u32 = 7;
+
+    /// Serializes every test that mutates the process environment.
+    ///
+    /// `unwrap_or_else(PoisonError::into_inner)` is deliberate: a failing
+    /// assertion in one test must not turn its siblings into `PoisonError`
+    /// reports, which would hide which assertion actually broke — the exact
+    /// confusion that makes mutation testing unreadable.
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// RAII owner of [`AUTHORITY_PROTOCOL_ENV`] so a panicking assertion cannot
+    /// leak a value into the next test.
+    struct ProtocolVar;
+
+    impl ProtocolVar {
+        fn set(value: &str) -> Self {
+            // SAFETY: every writer of this variable holds `env_lock`, and this
+            // process spawns no threads that read the environment concurrently.
+            unsafe { std::env::set_var(AUTHORITY_PROTOCOL_ENV, value) };
+            Self
+        }
+
+        fn unset() -> Self {
+            // SAFETY: as above.
+            unsafe { std::env::remove_var(AUTHORITY_PROTOCOL_ENV) };
+            Self
+        }
+    }
+
+    impl Drop for ProtocolVar {
+        fn drop(&mut self) {
+            // SAFETY: as above.
+            unsafe { std::env::remove_var(AUTHORITY_PROTOCOL_ENV) };
+        }
+    }
+
+    /// Records every leaf-file write so "the launcher wrote no quota" is an
+    /// assertion about bytes, not about a flag.
+    #[derive(Default)]
+    struct RecordingFs {
+        files: HashMap<(RawFd, String), String>,
+        writes: Vec<(String, String)>,
+        next: RawFd,
+    }
+
+    impl RecordingFs {
+        fn ready() -> Self {
+            Self {
+                next: 10,
+                ..Self::default()
+            }
+        }
+    }
+
+    impl CgroupFs for RecordingFs {
+        fn readiness(&self) -> Result<Readiness, Error> {
+            Ok(Readiness {
+                mode: CgroupMode::V2,
+                root_writable: true,
+                owner_uid: EXPECTED_UID,
+                delegated_controllers: BTreeSet::from(["cpu".to_owned()]),
+            })
+        }
+        fn create_direct_child(&mut self, _: &str) -> Result<RawFd, Error> {
+            self.next += 1;
+            Ok(self.next)
+        }
+        fn write_leaf(&mut self, fd: RawFd, file: &str, value: &str) -> Result<(), Error> {
+            self.writes.push((file.to_owned(), value.to_owned()));
+            self.files.insert((fd, file.to_owned()), value.to_owned());
+            Ok(())
+        }
+        fn read_leaf(&mut self, fd: RawFd, file: &str) -> Result<String, Error> {
+            Ok(self
+                .files
+                .get(&(fd, file.to_owned()))
+                .cloned()
+                .unwrap_or_else(|| "populated 0\n".to_owned()))
+        }
+        fn remove_leaf(&mut self, _: RawFd, _: &str) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingSpawn {
+        spawned: usize,
+    }
+
+    impl SpawnIntoCgroup for RecordingSpawn {
+        fn spawn_into_cgroup(
+            &mut self,
+            _: RawFd,
+            _: &Invocation,
+            _: &CommandSpec,
+        ) -> Result<ChildProcess, Error> {
+            self.spawned += 1;
+            Ok(ChildProcess {
+                pid: 1,
+                stdout: -1,
+                stderr: -1,
+            })
+        }
+    }
+
+    fn command() -> CommandSpec {
+        CommandSpec {
+            program: "/bin/true".to_owned(),
+            argv: vec![],
+            cwd: "/workspace".to_owned(),
+            environment: vec![],
+        }
+    }
+
+    /// Drive one leaf all the way through birth, sample, fenced lift and every
+    /// terminal step, and return every `(file, value)` the launcher wrote.
+    ///
+    /// The config is built by the binary's own [`launcher_config`], so what is
+    /// under test is the path the shipped binary takes.
+    fn writes_for_a_full_leaf_lifecycle() -> Vec<(String, String)> {
+        let config = launcher_config(250, 4_000, EXPECTED_UID)
+            .expect("the launcher config must build from this environment");
+        let mut launcher = Launcher::new(RecordingFs::ready(), RecordingSpawn::default(), config)
+            .expect("the recording fs satisfies the readiness contract");
+
+        let invocation = Invocation {
+            id: "reachability".to_owned(),
+            fence: 99,
+        };
+        let (mut leaf, child) = launcher
+            .create_command(
+                "reachability",
+                invocation,
+                LeaseAuthority::Armed,
+                &command(),
+            )
+            .expect("the leaf must be created");
+        assert_eq!(child.pid, 1, "the child still spawns under either protocol");
+        launcher.sample(&leaf).expect("cpu.stat is still readable");
+        launcher
+            .fenced_lift(&mut leaf, 99)
+            .expect("a matching fence must be accepted under either protocol");
+        launcher.kill(&mut leaf).expect("kill is protocol-neutral");
+        launcher.wait_empty(&leaf).expect("the leaf drains");
+        launcher.remove(&leaf).expect("the leaf is removed");
+
+        let (fs, _) = launcher.into_parts();
+        fs.writes
+    }
+
+    /// **The reachability proof (task 78v1, AC3).**
+    ///
+    /// Nothing here constructs a `LauncherConfig` by hand. The only difference
+    /// between the two halves is one string in the process environment — which
+    /// is the only thing a Kubernetes Job can actually change.
+    #[test]
+    fn resize_v2_is_reachable_from_the_process_environment_alone() {
+        let _guard = env_lock();
+
+        let held = ProtocolVar::set("resize-v2");
+        let under_resize_v2 = writes_for_a_full_leaf_lifecycle();
+        drop(held);
+
+        assert!(
+            under_resize_v2.iter().all(|(file, _)| file != "cpu.max"),
+            "DJINN_LAUNCHER_AUTHORITY_PROTOCOL=resize-v2 must make ZERO cpu.max writes at \
+             birth, lift or teardown; the launcher wrote {under_resize_v2:?}"
+        );
+        assert_eq!(
+            under_resize_v2,
+            vec![("cgroup.kill".to_owned(), "1".to_owned())],
+            "every containment property other than quota must survive resize-v2"
+        );
+
+        let held = ProtocolVar::unset();
+        let under_default = writes_for_a_full_leaf_lifecycle();
+        drop(held);
+
+        assert_eq!(
+            under_default,
+            vec![
+                ("cpu.max".to_owned(), "25000 100000".to_owned()),
+                ("cpu.max".to_owned(), "400000 100000".to_owned()),
+                ("cgroup.kill".to_owned(), "1".to_owned()),
+            ],
+            "with the variable absent the launcher must keep writing the leaf-v1 birth quota \
+             and the fenced lift; a resize-v2 assertion that also holds here proves nothing"
+        );
+    }
+
+    /// The explicit `leaf-v1` spelling is the same regime as absence — a Job
+    /// template that names the current behavior must not change it.
+    #[test]
+    fn an_explicit_leaf_v1_is_identical_to_an_absent_variable() {
+        let _guard = env_lock();
+        let held = ProtocolVar::set("leaf-v1");
+        let explicit = writes_for_a_full_leaf_lifecycle();
+        drop(held);
+        let held = ProtocolVar::unset();
+        let absent = writes_for_a_full_leaf_lifecycle();
+        drop(held);
+        assert_eq!(explicit, absent);
+        assert_eq!(explicit[0].0, "cpu.max");
+    }
+
+    /// **AC4.** An unparseable protocol is a readiness failure, and readiness
+    /// failures happen before the launcher is reachable.
+    ///
+    /// The socket path is asserted absent afterwards, so `unwrap_or_default()`
+    /// cannot pass this by "succeeding" — it would return a *different* error
+    /// (the temp dir is not a cgroup2 filesystem), which the variant assertion
+    /// catches, and any future reordering that binds first is caught by the
+    /// path assertion.
+    #[test]
+    fn an_unparseable_protocol_exits_non_zero_before_the_socket_is_bound() {
+        let _guard = env_lock();
+
+        let directory = std::env::temp_dir().join(format!(
+            "djinn-launcher-protocol-readiness-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&directory).expect("the temp directory must be creatable");
+        let socket = directory.join("launcher.sock");
+        let _ = std::fs::remove_file(&socket);
+
+        // SAFETY: `env_lock` is held; no other thread reads the environment.
+        unsafe {
+            std::env::set_var("DJINN_LAUNCHER_SOCKET", &socket);
+            std::env::set_var("DJINN_LAUNCHER_CGROUP_ROOT", &directory);
+            std::env::set_var("DJINN_LAUNCHER_CREDENTIAL_PATH", directory.join("cred"));
+            std::env::set_var("DJINN_LAUNCHER_EXPECTED_UID", "7");
+            std::env::set_var("DJINN_LAUNCHER_UNLEASED_MILLICORES", "250");
+            std::env::set_var("DJINN_LAUNCHER_LEASED_MILLICORES", "4000");
+        }
+
+        for unparseable in ["resize-v3", "leafv1", "RESIZE-V2", "", " resize-v2"] {
+            let held = ProtocolVar::set(unparseable);
+            let outcome = serve();
+            drop(held);
+
+            match outcome {
+                Err(MainError::InvalidEnv(key)) => assert_eq!(key, AUTHORITY_PROTOCOL_ENV),
+                other => panic!(
+                    "{unparseable:?} must be refused by name before anything else is attempted, \
+                     got {other:?}"
+                ),
+            }
+            assert!(
+                !socket.exists(),
+                "{unparseable:?} must be refused BEFORE the control socket exists"
+            );
+        }
+
+        // SAFETY: `env_lock` is held.
+        unsafe {
+            for key in [
+                "DJINN_LAUNCHER_SOCKET",
+                "DJINN_LAUNCHER_CGROUP_ROOT",
+                "DJINN_LAUNCHER_CREDENTIAL_PATH",
+                "DJINN_LAUNCHER_EXPECTED_UID",
+                "DJINN_LAUNCHER_UNLEASED_MILLICORES",
+                "DJINN_LAUNCHER_LEASED_MILLICORES",
+            ] {
+                std::env::remove_var(key);
+            }
+        }
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    /// Absence is `leaf-v1` and a wire form is itself — asserted on the exact
+    /// function the binary calls, so a future refactor that stops consulting
+    /// the environment is caught here as well as by the lifecycle proof.
+    #[test]
+    fn the_environment_read_is_absent_means_leaf_v1_and_nothing_else_is_accepted() {
+        let _guard = env_lock();
+
+        let held = ProtocolVar::unset();
+        assert_eq!(
+            authority_protocol_from_environment().unwrap(),
+            LauncherAuthorityProtocol::LeafV1
+        );
+        drop(held);
+
+        for (value, expected) in [
+            ("leaf-v1", LauncherAuthorityProtocol::LeafV1),
+            ("resize-v2", LauncherAuthorityProtocol::ResizeV2),
+        ] {
+            let held = ProtocolVar::set(value);
+            assert_eq!(authority_protocol_from_environment().unwrap(), expected);
+            drop(held);
+        }
+
+        for rejected in ["resize-v3", "leaf_v1", "Leaf-V1", "resize-v2 ", "none"] {
+            let held = ProtocolVar::set(rejected);
+            let outcome = authority_protocol_from_environment();
+            drop(held);
+            assert!(
+                matches!(outcome, Err(MainError::InvalidEnv(key)) if key == AUTHORITY_PROTOCOL_ENV),
+                "{rejected:?} must be refused, got {outcome:?}"
+            );
+        }
+    }
 }

--- a/server/crates/djinn-db/Cargo.toml
+++ b/server/crates/djinn-db/Cargo.toml
@@ -16,6 +16,10 @@ anyhow = "1"
 async-trait = "0.1"
 base64 = "0.22"
 djinn-core = { path = "../djinn-core", features = ["sqlx"] }
+# The canonical launcher quota-authority protocol. `build_pod_permit` validates
+# `observed`/`effective_launcher_protocol` through its `FromStr` rather than
+# restating migration 164's `CHECK ... IN` list as inline literals.
+djinn-launcher-protocol = { path = "../djinn-launcher-protocol" }
 djinn-telemetry = { path = "../djinn-telemetry" }
 djinn-stack = { path = "../djinn-stack" }
 djinn-memory = { path = "../djinn-memory", features = ["sqlx"] }

--- a/server/crates/djinn-db/src/repositories/build_pod_permit.rs
+++ b/server/crates/djinn-db/src/repositories/build_pod_permit.rs
@@ -110,14 +110,14 @@ impl BuildPodResizeIdentity {
             && !self.launcher_container_name.trim().is_empty()
             && !self.launcher_container_id.trim().is_empty()
             && !self.image_digest.trim().is_empty()
-            && matches!(
-                self.observed_launcher_protocol.as_str(),
-                "leaf-v1" | "resize-v2"
-            )
-            && matches!(
-                self.effective_launcher_protocol.as_str(),
-                "leaf-v1" | "resize-v2"
-            )
+            && self
+                .observed_launcher_protocol
+                .parse::<djinn_launcher_protocol::LauncherAuthorityProtocol>()
+                .is_ok()
+            && self
+                .effective_launcher_protocol
+                .parse::<djinn_launcher_protocol::LauncherAuthorityProtocol>()
+                .is_ok()
             && self.admitted_cpu_millicores > 0
     }
 }

--- a/server/crates/djinn-db/tests/launcher_protocol_database_agreement.rs
+++ b/server/crates/djinn-db/tests/launcher_protocol_database_agreement.rs
@@ -1,0 +1,250 @@
+//! The enum and the database must agree, and the agreement must be checkable.
+//!
+//! Migration 164 constrains `observed_launcher_protocol` and
+//! `effective_launcher_protocol` to a literal `IN (...)` list. Before task 78v1
+//! that list was restated three times — in the migration, in
+//! `build_pod_permit.rs`'s two `matches!` arms, and (as a *different* type with
+//! no wire form at all) inside `djinn-cgroup-launcher`. Nothing forced the three
+//! to agree, and #2800 shipped precisely because nothing did.
+//!
+//! These tests iterate `LauncherAuthorityProtocol::ALL`, so adding a variant
+//! without teaching migration 164 about it fails here rather than in production
+//! on the first `CHECK` violation.
+
+use std::path::{Path, PathBuf};
+
+use djinn_db::{
+    AcquireBuildPodPermitResult, BindBuildPodPermitResult, BuildPodPermitRepository,
+    BuildPodResizeIdentity, CaptureBuildPodResizeIdentityResult, Database,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+
+fn crate_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn migration_164() -> String {
+    let path = crate_root().join("migrations_postgres/164_build_pod_resize_identity.sql");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("migration 164 must be readable at {path:?}: {error}"))
+}
+
+/// Pull the literal set out of `<column> IN ('a', 'b')`.
+fn check_constraint_set(sql: &str, column: &str) -> Vec<String> {
+    let needle = format!("{column} IN (");
+    let start = sql
+        .find(&needle)
+        .unwrap_or_else(|| panic!("migration 164 must constrain {column} with an IN list"))
+        + needle.len();
+    let end = start
+        + sql[start..]
+            .find(')')
+            .expect("the IN list must be closed in the same statement");
+    sql[start..end]
+        .split(',')
+        .map(|literal| literal.trim().trim_matches('\'').to_owned())
+        .collect()
+}
+
+/// **AC5, static half.** Every variant's wire string is in migration 164's
+/// `CHECK`, and the `CHECK` names nothing the enum cannot produce.
+///
+/// Equality in *both* directions is the point. A subset assertion would let a
+/// third variant be added silently; a superset assertion would let a wire
+/// string be removed from the enum while rows carrying it stayed legal.
+#[test]
+fn migration_164_accepts_exactly_the_protocols_the_enum_can_produce() {
+    let sql = migration_164();
+    let expected: Vec<String> = LauncherAuthorityProtocol::ALL
+        .iter()
+        .map(|protocol| protocol.as_wire().to_owned())
+        .collect();
+
+    for column in ["observed_launcher_protocol", "effective_launcher_protocol"] {
+        assert_eq!(
+            check_constraint_set(&sql, column),
+            expected,
+            "{column}'s CHECK list and the protocol enum have diverged"
+        );
+    }
+}
+
+/// **AC5, no-duplication half.** The repository validates through `FromStr`,
+/// not through its own copy of the literals.
+///
+/// The needles are assembled at compile time so this file does not match
+/// itself.
+#[test]
+fn the_permit_repository_routes_protocol_validation_through_from_str() {
+    let path = crate_root().join("src/repositories/build_pod_permit.rs");
+    let source = std::fs::read_to_string(&path).expect("the repository source must be readable");
+
+    for literal in [
+        concat!('"', "leaf-", "v1", '"'),
+        concat!('"', "resize-", "v2", '"'),
+    ] {
+        assert!(
+            !source.contains(literal),
+            "build_pod_permit.rs must not restate {literal}; migration 164 and \
+             LauncherAuthorityProtocol are the two authorities and neither is this file"
+        );
+    }
+    assert!(
+        source.contains(concat!(
+            "parse::<djinn_launcher_protocol::",
+            "LauncherAuthorityProtocol>"
+        )),
+        "build_pod_permit.rs must validate the protocol columns through the canonical FromStr"
+    );
+}
+
+/// **AC5, durable half.** Every variant is actually accepted by the live
+/// migration-164 `CHECK`, through the same repository call production uses.
+///
+/// The static test above reads the migration as text; this one makes Postgres
+/// answer. A string that parses but that the deployed schema rejects would pass
+/// the first test and fail here.
+#[tokio::test]
+async fn every_protocol_variant_is_accepted_by_the_live_check_constraint() {
+    let db = Database::ephemeral().await.unwrap();
+    let run_ids: Vec<String> = LauncherAuthorityProtocol::ALL
+        .iter()
+        .map(|protocol| format!("protocol-agreement-{}", protocol.as_wire()))
+        .collect();
+    seed_runs(&db, &run_ids).await;
+    let repository = BuildPodPermitRepository::new(db.clone());
+
+    for (index, protocol) in LauncherAuthorityProtocol::ALL.iter().enumerate() {
+        let wire = protocol.as_wire();
+        let run = run_ids[index].as_str();
+        // One live permit per variant: the pool cap is a concurrency control,
+        // not the constraint under test.
+        let permits = LauncherAuthorityProtocol::ALL.len() as i64;
+        let permit = match repository.acquire(run, permits).await {
+            AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+            outcome => panic!("{wire}: unexpected acquire outcome: {outcome:?}"),
+        };
+        assert!(matches!(
+            repository
+                .bind_or_refresh_job_uid(run, &permit.permit_id, permit.fencing_token, run)
+                .await
+                .unwrap(),
+            BindBuildPodPermitResult::Bound(_)
+        ));
+
+        let identity = identity_for(run, wire, wire);
+        let captured = repository
+            .capture_resize_identity(run, &permit.permit_id, permit.fencing_token, &identity)
+            .await
+            .unwrap();
+        let CaptureBuildPodResizeIdentityResult::Captured(row) = captured else {
+            panic!("{wire} must be accepted by migration 164's CHECK, got {captured:?}");
+        };
+        let stored = row
+            .resize_identity
+            .unwrap_or_else(|| panic!("{wire}: a captured permit must carry its identity"));
+        assert_eq!(stored.observed_launcher_protocol, wire);
+        assert_eq!(stored.effective_launcher_protocol, wire);
+        assert_eq!(
+            stored.observed_launcher_protocol.parse(),
+            Ok(*protocol),
+            "{wire} must round-trip back into the variant it came from"
+        );
+    }
+}
+
+/// A protocol the enum cannot produce is refused before it reaches the
+/// database, so the `CHECK` list and `FromStr` cannot silently diverge in the
+/// permissive direction either.
+#[tokio::test]
+async fn a_protocol_the_enum_cannot_produce_is_refused() {
+    let db = Database::ephemeral().await.unwrap();
+    seed_runs(&db, &["protocol-agreement-rejected".to_owned()]).await;
+    let repository = BuildPodPermitRepository::new(db.clone());
+    let run = "protocol-agreement-rejected";
+    let permit = match repository.acquire(run, 1).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        outcome => panic!("unexpected acquire outcome: {outcome:?}"),
+    };
+    assert!(matches!(
+        repository
+            .bind_or_refresh_job_uid(run, &permit.permit_id, permit.fencing_token, run)
+            .await
+            .unwrap(),
+        BindBuildPodPermitResult::Bound(_)
+    ));
+
+    for (observed, effective) in [
+        ("resize-v3", "resize-v2"),
+        ("resize-v2", "unknown-v9"),
+        ("Resize-V2", "resize-v2"),
+        ("resize-v2 ", "resize-v2"),
+        ("", "resize-v2"),
+    ] {
+        let identity = identity_for(run, observed, effective);
+        let outcome = repository
+            .capture_resize_identity(run, &permit.permit_id, permit.fencing_token, &identity)
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, CaptureBuildPodResizeIdentityResult::Rejected),
+            "({observed:?}, {effective:?}) must be refused, got {outcome:?}"
+        );
+    }
+}
+
+fn identity_for(run: &str, observed: &str, effective: &str) -> BuildPodResizeIdentity {
+    BuildPodResizeIdentity {
+        pod_namespace: "ns".into(),
+        pod_name: format!("pod-{run}"),
+        pod_uid: format!("uid-{run}"),
+        launcher_container_name: "launcher".into(),
+        launcher_container_id: format!("containerd://{run}"),
+        image_digest: "sha256:agreement".into(),
+        observed_launcher_protocol: observed.into(),
+        effective_launcher_protocol: effective.into(),
+        admitted_cpu_millicores: 1000,
+    }
+}
+
+async fn seed_runs(db: &Database, ids: &[String]) {
+    db.ensure_initialized().await.unwrap();
+    let pool = db.pool();
+    sqlx::query(
+        "INSERT INTO users (id, github_id, github_login) \
+         VALUES ('00000000-0000-7000-8000-000000000078', 9000000078, 'protocol-agreement')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO projects (id, name, github_owner, github_repo) \
+         VALUES ('protocol-agreement-project', 'protocol-agreement-project', 'djinnos', 'protocol-agreement')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    for (index, id) in ids.iter().enumerate() {
+        let task_id = format!("protocol-agreement-task-{index}");
+        sqlx::query(
+            "INSERT INTO tasks \
+             (id, project_id, short_id, title, description, design, labels, acceptance_criteria, memory_refs, created_by_user_id) \
+             VALUES ($1, 'protocol-agreement-project', $2, 'title', 'description', 'design', \
+                     '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '00000000-0000-7000-8000-000000000078')",
+        )
+        .bind(&task_id)
+        .bind(format!("proto-{index}"))
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO task_runs (id, project_id, task_id, trigger_type, status) \
+             VALUES ($1, 'protocol-agreement-project', $2, 'manual', 'running')",
+        )
+        .bind(id)
+        .bind(&task_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}

--- a/server/crates/djinn-launcher-protocol/Cargo.toml
+++ b/server/crates/djinn-launcher-protocol/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+publish = false
+name = "djinn-launcher-protocol"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+doctest = false
+
+# Deliberately a leaf: the launcher is a tiny static sidecar binary that must
+# never gain a `djinn-db` dependency, and `djinn-db` must never gain a
+# `djinn-cgroup-launcher` one. `serde` is here WITHOUT the `derive` feature —
+# the impls are hand-written so they delegate to `as_wire`/`FromStr` and cannot
+# drift from them.
+[dependencies]
+serde = "1"
+workspace-hack.workspace = true
+
+[dev-dependencies]
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/server/crates/djinn-launcher-protocol/src/lib.rs
+++ b/server/crates/djinn-launcher-protocol/src/lib.rs
@@ -1,0 +1,408 @@
+//! The canonical launcher quota-authority protocol, and its wire form.
+//!
+//! # Why this is its own crate
+//!
+//! Three components have to agree on exactly two strings — `leaf-v1` and
+//! `resize-v2`:
+//!
+//! * `djinn-cgroup-launcher`, a **static sidecar binary** shipped into every
+//!   per-project image. It decides whether the launcher writes leaf `cpu.max`
+//!   at all, so it must be able to name the protocol; it must NOT be able to
+//!   reach a database client, a Kubernetes client, or a runtime to get there.
+//! * `djinn-db`, which persists `observed_launcher_protocol` and
+//!   `effective_launcher_protocol` under a migration-164 `CHECK ... IN` list.
+//! * The admission/reconcile plane, which compares the two.
+//!
+//! Putting the type where the database constants live would make the sidecar
+//! depend on `djinn-db`. Putting it in the launcher would make `djinn-db`
+//! depend on the launcher. So it lives here, in a leaf that depends on nothing
+//! but `serde` (without `derive`).
+//!
+//! # Why one definition and not two
+//!
+//! PR #2800 shipped a launcher-local copy of this decision with no wire form at
+//! all, while `djinn-db` carried the strings inline in two `matches!` arms. The
+//! two could not be shown to agree, and nothing forced them to. Every consumer
+//! now routes through [`LauncherAuthorityProtocol::as_wire`] and
+//! [`LauncherAuthorityProtocol::from_str`], and a workspace-wide scan
+//! (`exactly_one_definition_of_the_protocol_exists_workspace_wide`) fails if a
+//! second definition reappears.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Wire form of [`LauncherAuthorityProtocol::LeafV1`]. Also the migration-164
+/// `CHECK` literal and the Job-rendered environment value.
+pub const LEAF_V1_WIRE: &str = "leaf-v1";
+
+/// Wire form of [`LauncherAuthorityProtocol::ResizeV2`].
+pub const RESIZE_V2_WIRE: &str = "resize-v2";
+
+/// The component that owns an invocation leaf's CPU quota.
+///
+/// This is intentionally independent from the per-invocation armed/unarmed
+/// lease decision (`djinn_cgroup_launcher::LeaseAuthority`). Keeping the axes
+/// separate prevents a `resize-v2` leaf from inheriting a `leaf-v1` quota
+/// mutation.
+///
+/// [`Self::LeafV1`] is the default because it is the behavior that predates the
+/// protocol existing: absent an explicit selection, the launcher keeps doing
+/// what it has always done. A *malformed* selection is never this default — see
+/// [`FromStr`], which has no fallback arm.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum LauncherAuthorityProtocol {
+    /// The launcher owns per-leaf quota birth and fenced lift writes.
+    #[default]
+    LeafV1,
+    /// Pod resize owns quota. The launcher must never write leaf `cpu.max`.
+    ResizeV2,
+}
+
+impl LauncherAuthorityProtocol {
+    /// Every variant, in wire-stable order.
+    ///
+    /// Exposed so agreement tests can iterate the type rather than restate its
+    /// members: adding a variant without teaching the database about it is
+    /// exactly the failure this array makes detectable.
+    pub const ALL: [Self; 2] = [Self::LeafV1, Self::ResizeV2];
+
+    /// The exact string persisted, rendered into the Job environment, and
+    /// checked by migration 164. Never localized, never re-cased.
+    pub const fn as_wire(self) -> &'static str {
+        match self {
+            Self::LeafV1 => LEAF_V1_WIRE,
+            Self::ResizeV2 => RESIZE_V2_WIRE,
+        }
+    }
+
+    /// Stable single-byte encoding for the broker's length-prefixed socket
+    /// frames, which are byte-oriented (see `djinn_cgroup_launcher::transport`).
+    ///
+    /// `0` is deliberately unassigned: the neighbouring `LeaseAuthority::wire`
+    /// uses `0` for `Unarmed`, and a zeroed or truncated frame must not decode
+    /// as a valid protocol on either axis.
+    pub const fn frame_byte(self) -> u8 {
+        match self {
+            Self::LeafV1 => 1,
+            Self::ResizeV2 => 2,
+        }
+    }
+
+    /// Decode [`Self::frame_byte`]. `None` for every unassigned byte, including
+    /// `0`; callers must treat that as an invalid frame, not as a default.
+    pub const fn from_frame_byte(byte: u8) -> Option<Self> {
+        match byte {
+            1 => Some(Self::LeafV1),
+            2 => Some(Self::ResizeV2),
+            _ => None,
+        }
+    }
+
+    /// Does the launcher write this leaf's `cpu.max`?
+    ///
+    /// Under `resize-v2` the answer is no — not even `max`, which is itself a
+    /// launcher mutation of a value Pod resize owns.
+    pub const fn launcher_owns_leaf_quota(self) -> bool {
+        matches!(self, Self::LeafV1)
+    }
+}
+
+impl fmt::Display for LauncherAuthorityProtocol {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_wire())
+    }
+}
+
+/// A string that is not exactly one of the two wire forms.
+///
+/// Carries the offending input so a fail-closed caller can name it in the error
+/// it exits on.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParseLauncherAuthorityProtocolError {
+    input: String,
+}
+
+impl ParseLauncherAuthorityProtocolError {
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+}
+
+impl fmt::Display for ParseLauncherAuthorityProtocolError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{:?} is not a launcher authority protocol (expected {LEAF_V1_WIRE:?} or {RESIZE_V2_WIRE:?})",
+            self.input
+        )
+    }
+}
+
+impl std::error::Error for ParseLauncherAuthorityProtocolError {}
+
+impl FromStr for LauncherAuthorityProtocol {
+    type Err = ParseLauncherAuthorityProtocolError;
+
+    /// Exact match only.
+    ///
+    /// No trimming, no case folding and — critically — **no fallback arm**. The
+    /// protocol decides whether a build's CPU quota is governed by the launcher
+    /// or by Pod resize; silently reading an unrecognised value as either one
+    /// is a production outage in one direction and a 16x slowdown in the other.
+    /// A caller that cannot parse must fail, not default.
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            LEAF_V1_WIRE => Ok(Self::LeafV1),
+            RESIZE_V2_WIRE => Ok(Self::ResizeV2),
+            other => Err(ParseLauncherAuthorityProtocolError {
+                input: other.to_owned(),
+            }),
+        }
+    }
+}
+
+impl serde::Serialize for LauncherAuthorityProtocol {
+    /// Delegates to [`LauncherAuthorityProtocol::as_wire`] rather than deriving,
+    /// so the serialized form cannot drift from the persisted one.
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_wire())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for LauncherAuthorityProtocol {
+    /// Delegates to [`FromStr`], so serde inherits the same closed set and the
+    /// same refusal to fall back.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct WireVisitor;
+
+        impl serde::de::Visitor<'_> for WireVisitor {
+            type Value = LauncherAuthorityProtocol;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "{LEAF_V1_WIRE:?} or {RESIZE_V2_WIRE:?}")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                value.parse().map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(WireVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// The closed set, asserted from both ends.
+    ///
+    /// The rejected inputs are the near-misses a human or a Job template
+    /// actually produces: a dropped separator, the wrong case, the next version
+    /// that does not exist yet, and whitespace a shell or a YAML block scalar
+    /// left behind.
+    #[test]
+    fn from_str_accepts_exactly_the_two_wire_forms_and_rejects_every_near_miss() {
+        assert_eq!(
+            "leaf-v1".parse::<LauncherAuthorityProtocol>(),
+            Ok(LauncherAuthorityProtocol::LeafV1)
+        );
+        assert_eq!(
+            "resize-v2".parse::<LauncherAuthorityProtocol>(),
+            Ok(LauncherAuthorityProtocol::ResizeV2)
+        );
+
+        // Accumulated rather than asserted case by case, so a fallback arm
+        // reports EVERY input it would swallow instead of stopping at the
+        // first. The task's non-vacuity bar is "at least three cases fail";
+        // this makes the count visible in the failure itself.
+        let mut swallowed = Vec::new();
+        for rejected in [
+            "",
+            " ",
+            "leafv1",
+            "LEAF-V1",
+            "Leaf-V1",
+            "leaf_v1",
+            "resize-v3",
+            "resizev2",
+            "RESIZE-V2",
+            " leaf-v1",
+            "leaf-v1 ",
+            "\tresize-v2",
+            "resize-v2\n",
+            "leaf-v1\0",
+            "leaf-v1,resize-v2",
+            "unknown-v3",
+        ] {
+            match rejected.parse::<LauncherAuthorityProtocol>() {
+                Err(refusal) => assert_eq!(
+                    refusal.input(),
+                    rejected,
+                    "the refusal must name the offending input so a fail-closed caller can log it"
+                ),
+                Ok(accepted) => swallowed.push((rejected, accepted)),
+            }
+        }
+        assert!(
+            swallowed.is_empty(),
+            "{} inputs were silently accepted as a protocol: {swallowed:?}",
+            swallowed.len()
+        );
+    }
+
+    /// Every variant round-trips through its own wire form, and the wire forms
+    /// are the literals the database and the Job template use.
+    #[test]
+    fn every_variant_round_trips_through_its_wire_form() {
+        for protocol in LauncherAuthorityProtocol::ALL {
+            assert_eq!(
+                protocol.as_wire().parse::<LauncherAuthorityProtocol>(),
+                Ok(protocol)
+            );
+            assert_eq!(protocol.to_string(), protocol.as_wire());
+        }
+        assert_eq!(
+            LauncherAuthorityProtocol::ALL
+                .map(LauncherAuthorityProtocol::as_wire)
+                .to_vec(),
+            vec!["leaf-v1", "resize-v2"],
+        );
+    }
+
+    /// The frame byte is an encoding, not a default: a zeroed or truncated
+    /// frame must decode to nothing at all.
+    #[test]
+    fn the_frame_byte_is_stable_and_zero_decodes_to_nothing() {
+        assert_eq!(LauncherAuthorityProtocol::LeafV1.frame_byte(), 1);
+        assert_eq!(LauncherAuthorityProtocol::ResizeV2.frame_byte(), 2);
+        for protocol in LauncherAuthorityProtocol::ALL {
+            assert_eq!(
+                LauncherAuthorityProtocol::from_frame_byte(protocol.frame_byte()),
+                Some(protocol)
+            );
+        }
+        for unassigned in [0u8, 3, 4, 127, 255] {
+            assert_eq!(
+                LauncherAuthorityProtocol::from_frame_byte(unassigned),
+                None,
+                "byte {unassigned} must not decode to a protocol"
+            );
+        }
+    }
+
+    /// serde is the persistence/transport form, so it must be the same two
+    /// strings and the same closed set — not a derived `"LeafV1"`.
+    #[test]
+    fn serde_is_the_wire_string_and_inherits_the_closed_set() {
+        for protocol in LauncherAuthorityProtocol::ALL {
+            let json = serde_json::to_string(&protocol).unwrap();
+            assert_eq!(json, format!("{:?}", protocol.as_wire()));
+            assert_eq!(
+                serde_json::from_str::<LauncherAuthorityProtocol>(&json).unwrap(),
+                protocol
+            );
+        }
+        for rejected in [
+            "\"\"",
+            "\"LeafV1\"",
+            "\"resize-v3\"",
+            "\"leaf-v1 \"",
+            "1",
+            "2",
+        ] {
+            assert!(
+                serde_json::from_str::<LauncherAuthorityProtocol>(rejected).is_err(),
+                "{rejected} must not deserialize into a protocol"
+            );
+        }
+    }
+
+    /// `leaf-v1` is the only protocol under which the launcher touches leaf
+    /// `cpu.max`. This is the predicate the birth and lift writes are gated on.
+    #[test]
+    fn only_leaf_v1_lets_the_launcher_write_leaf_quota() {
+        assert!(LauncherAuthorityProtocol::LeafV1.launcher_owns_leaf_quota());
+        assert!(!LauncherAuthorityProtocol::ResizeV2.launcher_owns_leaf_quota());
+        assert_eq!(
+            LauncherAuthorityProtocol::default(),
+            LauncherAuthorityProtocol::LeafV1,
+            "the default must be the pre-existing behavior, never the new one"
+        );
+    }
+
+    /// One canonical definition, or the whole point of this crate is lost.
+    ///
+    /// A second copy is exactly how #2800 shipped: the launcher had its own
+    /// type with no wire form, `djinn-db` had the strings inline, and nothing
+    /// made them agree. This scans the checkout rather than trusting a comment.
+    ///
+    /// The needle is assembled at compile time so this file does not match
+    /// itself.
+    #[test]
+    fn exactly_one_definition_of_the_protocol_exists_workspace_wide() {
+        const NEEDLE: &str = concat!("enum ", "LauncherAuthorityProtocol");
+
+        let root = repository_root();
+        let mut hits = Vec::new();
+        collect_rust_sources(&root, &mut |path, contents| {
+            if contents.contains(NEEDLE) {
+                hits.push(path.to_path_buf());
+            }
+        });
+
+        assert_eq!(
+            hits.len(),
+            1,
+            "expected exactly one definition of the protocol, found {hits:#?}"
+        );
+        assert!(
+            hits[0].ends_with("djinn-launcher-protocol/src/lib.rs"),
+            "the one definition must be this crate's, found {:?}",
+            hits[0]
+        );
+    }
+
+    /// `<checkout>/server/crates/djinn-launcher-protocol` → `<checkout>`.
+    fn repository_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(3)
+            .expect("the manifest always sits three levels below the checkout root")
+            .to_path_buf()
+    }
+
+    /// Depth-first walk of every `.rs` file under `root`, skipping build output
+    /// and nested checkouts. Written against `std` only: this crate has no
+    /// `walkdir` and is not going to acquire one.
+    fn collect_rust_sources(root: &Path, visit: &mut impl FnMut(&Path, &str)) {
+        const SKIP: &[&str] = &[
+            "target",
+            ".git",
+            "node_modules",
+            ".worktrees",
+            ".claude",
+            "dist",
+            "vendor",
+        ];
+
+        let Ok(entries) = std::fs::read_dir(root) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+                if !SKIP.contains(&name.as_ref()) {
+                    collect_rust_sources(&path, visit);
+                }
+            } else if name.ends_with(".rs")
+                && let Ok(contents) = std::fs::read_to_string(&path)
+            {
+                visit(&path, &contents);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Board task `78v1` (ydpj-A), epic `y3ww`, proposal `3i92`.

## Why this is a `bug` and not a follow-up

PR #2800 (`uvb9`) landed **inert in production**. On `origin/main`:

- `LauncherConfig::new` hard-coded `authority_protocol: LauncherAuthorityProtocol::LeafV1`.
- The only setter, `with_authority_protocol`, had exactly three callers and **all three were tests**.
- `main.rs` read six environment variables and none of them was a protocol.

So the `resize-v2` branches at leaf birth and at fenced lift were unreachable from the binary that ships in every per-project image. All three of #2800's acceptance criteria were genuinely true and the mechanism could not fire. Even the privileged **Launcher Kernel Boundary** lane passed — it exercises the path through a test-constructed `LauncherConfig`, which a library test is always free to do.

That gap is what this PR closes, and AC3 below is the test #2800 lacked.

## What changed

**New leaf crate `server/crates/djinn-launcher-protocol`.** Three components must agree on exactly two strings: the launcher sidecar, `djinn-db` (migration 164's `CHECK ... IN`), and the admission plane. Putting the type where the DB constants live would give the static sidecar a `djinn-db` dependency; putting it in the launcher would give `djinn-db` a launcher dependency. It lives below both, with `serde` (no `derive`) as its only dependency. The serde impls are hand-written and delegate to `as_wire`/`FromStr`, so the persisted form cannot drift from the parsed one.

It provides `as_wire() -> "leaf-v1" | "resize-v2"`, `FromStr` with **no fallback arm**, `Display`, a stable `frame_byte()` (`1`/`2`, with `0` deliberately unassigned so a zeroed or truncated socket frame decodes to nothing), and `ALL` for agreement tests to iterate.

**`djinn-cgroup-launcher::lease_authority` re-exports it** and the local definition is deleted — `lib.rs`'s `pub use` is untouched, so no downstream import moved.

**The reachability fix.** `main.rs` now reads `DJINN_LAUNCHER_AUTHORITY_PROTOCOL` alongside the other environment reads:

- **Absent → `leaf-v1`.** Rolling this binary out ahead of any Job-template change is a no-op.
- **Unparseable, including non-UTF-8 → a named readiness failure**, returned before `Bootstrap`, before the delegated cgroup root is opened, and before the control socket is bound. There is no `unwrap_or_default`: `resize_v2` misspelt would silently become `leaf-v1` and the launcher would write leaf `cpu.max` under a Pod whose quota is owned by resize — the exact double-authority the protocol exists to prevent.

**`build_pod_permit.rs`** validates `observed_launcher_protocol` / `effective_launcher_protocol` through the canonical `FromStr` rather than restating migration 164's literals. Only the two `matches!` arms changed.

## Acceptance criteria, with the mutation output for each

Every AC was run, then broken deliberately, and the actual failure is quoted.

### AC1 — `from_str` accepts exactly the two wire forms

`from_str_accepts_exactly_the_two_wire_forms_and_rejects_every_near_miss` checks 16 near-misses: `""`, `" "`, `leafv1`, `LEAF-V1`, `Leaf-V1`, `leaf_v1`, `resize-v3`, `resizev2`, `RESIZE-V2`, `" leaf-v1"`, `"leaf-v1 "`, `"\tresize-v2"`, `"resize-v2\n"`, `"leaf-v1\0"`, `leaf-v1,resize-v2`, `unknown-v3`. Failures are accumulated rather than asserted case-by-case, so the count is visible in the failure.

**Mutation** — `from_str` returns `Ok(Self::LeafV1)` on unknown input:

```
---- tests::from_str_accepts_exactly_the_two_wire_forms_and_rejects_every_near_miss stdout ----
16 inputs were silently accepted as a protocol: [("", LeafV1), (" ", LeafV1), ("leafv1", LeafV1),
("LEAF-V1", LeafV1), ("Leaf-V1", LeafV1), ("leaf_v1", LeafV1), ("resize-v3", LeafV1),
("resizev2", LeafV1), ("RESIZE-V2", LeafV1), (" leaf-v1", LeafV1), ("leaf-v1 ", LeafV1),
("\tresize-v2", LeafV1), ("resize-v2\n", LeafV1), ("leaf-v1\0", LeafV1),
("leaf-v1,resize-v2", LeafV1), ("unknown-v3", LeafV1)]

---- tests::serde_is_the_wire_string_and_inherits_the_closed_set stdout ----
"" must not deserialize into a protocol

test result: FAILED. 4 passed; 2 failed
```

16 cases, against a bar of 3. serde fails too, because it delegates to `FromStr`.

### AC2 — exactly one definition workspace-wide

`exactly_one_definition_of_the_protocol_exists_workspace_wide` walks every `.rs` file under the checkout (skipping `target`, `.git`, `node_modules`, nested worktrees) and counts definitions. The needle is assembled with `concat!` so the test does not match itself. Implemented as a Rust test rather than a workflow `git grep` step so it also runs locally and does not touch a shared CI file another agent may be editing.

**Mutation** — the launcher-local enum re-added to `lease_authority.rs`:

```
---- tests::exactly_one_definition_of_the_protocol_exists_workspace_wide stdout ----
assertion `left == right` failed: expected exactly one definition of the protocol, found [
    ".../server/crates/djinn-cgroup-launcher/src/lease_authority.rs",
    ".../server/crates/djinn-launcher-protocol/src/lib.rs",
]
  left: 2
 right: 1
```

### AC3 — THE REACHABILITY PROOF

`resize_v2_is_reachable_from_the_process_environment_alone` lives in the **binary's** test module, not the library's. Nothing in it constructs a `LauncherConfig` by hand: it sets the process environment, calls `main.rs`'s own `launcher_config`, and drives a recording `CgroupFs` through create → sample → fenced lift → kill → wait_empty → remove. The only difference between the two halves is one string in the environment, which is the only thing a Kubernetes Job can actually change.

Both directions are asserted — zero `cpu.max` writes under `resize-v2`, and the birth quota *plus* the lift present when the variable is absent — so a resize-v2 assertion that also held for `leaf-v1` would not pass.

**Mutation** — `main.rs` reverted so it never calls `with_authority_protocol`, i.e. exactly what `origin/main` looks like today:

```
---- tests::resize_v2_is_reachable_from_the_process_environment_alone stdout ----
DJINN_LAUNCHER_AUTHORITY_PROTOCOL=resize-v2 must make ZERO cpu.max writes at birth, lift or
teardown; the launcher wrote
[("cpu.max", "25000 100000"), ("cpu.max", "400000 100000"), ("cgroup.kill", "1")]

test result: FAILED. 2 passed; 2 failed
```

That is the production defect reproduced: under `resize-v2` the launcher writes the 250m birth quota *and* the 4000m lift.

### AC4 — unparseable exits non-zero before the socket is bound

`an_unparseable_protocol_exits_non_zero_before_the_socket_is_bound` calls the real `serve()` with a full environment and a socket path in a temp dir, then asserts the error is `InvalidEnv("DJINN_LAUNCHER_AUTHORITY_PROTOCOL")` **and** that the socket path does not exist. `run()` was split into `run()` (subcommand parsing) + `serve()` for exactly this: a test binary's `argv[1]` is not `serve`, and the ordering claim can only be proven by calling the real function and then looking for the socket.

**Mutation** — `.unwrap_or_default()` on the protocol read:

```
---- tests::an_unparseable_protocol_exits_non_zero_before_the_socket_is_bound stdout ----
"resize-v3" must be refused by name before anything else is attempted, got
Err(Launcher(DelegatedRootIsNotCgroupFs { path: "/var/tmp/djinn-launcher-protocol-readiness-2229165",
actual: 2435016766, expected: 1667723888 }))

test result: FAILED. 3 passed; 1 failed
```

The default swallowed the bad value and the run got as far as the cgroup readiness gate — a *different* error, which is what the variant assertion catches.

### AC5 — enum and database agree

`server/crates/djinn-db/tests/launcher_protocol_database_agreement.rs`, in three parts:

1. `migration_164_accepts_exactly_the_protocols_the_enum_can_produce` parses the `IN (...)` list out of migration 164 for both columns and asserts set **equality** with `ALL.map(as_wire)`. Equality in both directions, so neither a new variant nor a removed one slips through.
2. `every_protocol_variant_is_accepted_by_the_live_check_constraint` makes Postgres answer: it captures a resize identity per variant through the same repository call production uses, and round-trips the stored string back into its variant.
3. `the_permit_repository_routes_protocol_validation_through_from_str` asserts `build_pod_permit.rs` contains neither wire literal and does call the canonical `FromStr`.

**Mutation** — a third variant `ResizeV3` added to the enum:

```
---- migration_164_accepts_exactly_the_protocols_the_enum_can_produce stdout ----
assertion `left == right` failed: observed_launcher_protocol's CHECK list and the protocol enum
have diverged
  left: ["leaf-v1", "resize-v2"]
 right: ["leaf-v1", "resize-v2", "resize-v3"]

---- every_protocol_variant_is_accepted_by_the_live_check_constraint stdout ----
PgDatabaseError { code: "23514", message: "new row for relation \"build_pod_permits\" violates
check constraint \"build_pod_permits_resize_identity_check\"" ... }

test result: FAILED. 1 passed; 3 failed
```

## Scope and rollout

- The Job template does **not** yet render `DJINN_LAUNCHER_AUTHORITY_PROTOCOL`. Absent means `leaf-v1`, so this PR changes no production behavior on its own — it makes the behavior *selectable*, which is what `ydpj-B`, `z3gi`, `vf7a` and `g8jk` are blocked on.
- Wiring the protocol onto the `WorkerReadinessAssertion` handshake is **ydpj-B** and is deliberately not here. The proposal and the `y3ww` roadmap both name an `AuthorityProtocol` type and an `AuthHello` handshake; neither exists in the repository, and nothing here invents them.
- No `build_admission*.rs`, no `build_admission_reconcile.rs`, no `state/mod.rs`, and none of the `build_pod_permits_schema_contract.rs` / `migrations_build_pod_permits.rs` tests were touched.
- `server/Cargo.toml` needed no edit: `members = ["crates/*"]` already picks the new crate up. `cargo hakari verify` passes and `cargo hakari manage-deps` reports no operations.
- No sqlx query changed, so `server/.sqlx/` is untouched.

## Verification

```
cargo test -p djinn-launcher-protocol -p djinn-cgroup-launcher     # 66+4+6+... all pass
cargo test -p djinn-db --test launcher_protocol_database_agreement \
           --test build_pod_permit_repository \
           --test build_pod_permits_schema_contract                 # 10 pass, 0 fail
cargo clippy -p djinn-launcher-protocol -p djinn-cgroup-launcher -p djinn-db --all-targets
cargo check --workspace --all-targets                               # clean
bash scripts/check-file-size.sh                                     # 0 oversized
cargo hakari verify                                                 # workspace-hack works correctly
rustfmt --edition 2024 <changed files>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
