### PR TITLE
test: give metrics-asserting tests a recorder of their own

### DIFF
--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -14,11 +14,15 @@ fn rendered_counter_value(metric: &str, kind: &str) -> f64 {
         .unwrap_or(0.0)
 }
 
-/// Read one bounded strike-decision series from the process recorder. The
-/// cross-path tests take a render delta around the live coordinator call, not
-/// around the retry classifier, because the coordinator owns metric emission.
-fn rendered_strike_decision_value(decision: &str, source: &str) -> f64 {
-    let rendered = djinn_telemetry::render().unwrap();
+/// Read one bounded strike-decision series out of an already-rendered registry.
+///
+/// The cross-path tests render an [`djinn_telemetry::IsolatedRecorder`] scoped
+/// to the calling thread rather than the process recorder, so the value is
+/// exactly what the live coordinator call under test emitted — no delta, and
+/// nothing a concurrently running sibling test emitted. A series that is
+/// absent means the emission did not happen on this thread, which is a real
+/// failure rather than a zero.
+fn strike_decision_value(rendered: &str, decision: &str, source: &str) -> f64 {
     let prefix = format!(
         "djinn_dispatch_strike_decisions_total{{decision=\"{decision}\",source=\"{source}\"}} "
     );
@@ -33,8 +37,13 @@ fn rendered_strike_decision_value(decision: &str, source: &str) -> f64 {
 /// Guard the cardinality contract at the rendered recorder boundary. Dispatch
 /// identity is durable evidence and structured logging context, never a metric
 /// label: this counter may have exactly its bounded decision/source pair.
-fn assert_strike_decision_labels_are_bounded() {
-    let rendered = djinn_telemetry::render().unwrap();
+///
+/// `rendered` must come from the test's own [`djinn_telemetry::IsolatedRecorder`].
+/// Reading the process-global registry here made the guard assert on every
+/// series the *whole binary* had ever emitted, so a sibling test exercising a
+/// different — but equally bounded — source (`environmental_restart_orphan`,
+/// which this call path never emits) failed this test instead of its own.
+fn assert_strike_decision_labels_are_bounded(rendered: &str) {
     let allowed_decisions = ["counted", "exempted"];
     let allowed_sources = [
         "environmental_owner_expired",
@@ -8115,9 +8124,11 @@ async fn spawn_failed_dispatch_orphan_reaches_no_pr_terminal_cap_live() {
         .unwrap();
     let attempts = TaskAttemptRepository::new(db.clone());
     let mut actor = coordinator_actor_for_tests(&db, &tx);
-    // Capture the first persisted spawn-failure evaluation. Later loop rounds
-    // prove the cap; this delta proves the live coordinator emits exactly once.
-    let counted_before = rendered_strike_decision_value("counted", "spawn_failed");
+    // Scope a private recorder to this test's thread. Later loop rounds prove
+    // the cap; the absolute count in this registry proves the live coordinator
+    // emits exactly once, without a delta a concurrent sibling can land inside.
+    let recorder = djinn_telemetry::IsolatedRecorder::new();
+    let _metrics = recorder.scope();
 
     for strike in 1..=MAX_DISPATCH_FAILURES {
         let attempt_id = seed_pending_attempt(&db, &task.id, "lead").await;
@@ -8146,12 +8157,13 @@ async fn spawn_failed_dispatch_orphan_reaches_no_pr_terminal_cap_live() {
 
         actor.dispatch_ready_tasks(Some(&task.project_id)).await;
         if strike == 1 {
+            let rendered = recorder.render();
             assert_eq!(
-                rendered_strike_decision_value("counted", "spawn_failed") - counted_before,
+                strike_decision_value(&rendered, "counted", "spawn_failed"),
                 1.0,
                 "one live spawn_failed reappearance must emit one counted decision"
             );
-            assert_strike_decision_labels_are_bounded();
+            assert_strike_decision_labels_are_bounded(&rendered);
         }
         if strike < MAX_DISPATCH_FAILURES {
             assert_eq!(actor.dispatch_failure_streak.get(&task.id), Some(&strike));
@@ -8277,16 +8289,21 @@ async fn expired_owner_group_reap_redispatches_after_reaping_each_eligible_group
         },
     );
     // The decision is emitted by dispatch_ready_tasks, after it reads the
-    // reaper's durable evidence; rendering around this call keeps the test on
-    // the real persisted owner-expiry path.
-    let exempted_before = rendered_strike_decision_value("exempted", "environmental_owner_expired");
-    actor.dispatch_ready_tasks(Some(&task.project_id)).await;
+    // reaper's durable evidence; scoping a private recorder around this call
+    // keeps the test on the real persisted owner-expiry path while making the
+    // rendered registry contain only what this call emitted.
+    let recorder = djinn_telemetry::IsolatedRecorder::new();
+    let rendered = {
+        let _metrics = recorder.scope();
+        actor.dispatch_ready_tasks(Some(&task.project_id)).await;
+        recorder.render()
+    };
     assert_eq!(
-        rendered_strike_decision_value("exempted", "environmental_owner_expired") - exempted_before,
+        strike_decision_value(&rendered, "exempted", "environmental_owner_expired"),
         1.0,
         "one live reaped environmental interruption must emit one exempted decision"
     );
-    assert_strike_decision_labels_are_bounded();
+    assert_strike_decision_labels_are_bounded(&rendered);
     assert_eq!(
         actor.dispatched, 1,
         "evidenced interruption must redispatch"

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -5859,10 +5859,6 @@ mod tests {
     /// clone on base_branch.
     #[tokio::test]
     async fn clone_fallback_uses_base_branch_when_task_branch_verified_absent() {
-        // `timed_clone_attempt` records into the process-global Prometheus
-        // recorder; serialize with the telemetry-scrape tests so their
-        // delta assertions are not polluted by this test's samples.
-        let _guard = clone_telemetry_guard().await;
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
         let (clock, cancel) = resume_test_clock_and_cancel();
@@ -5888,10 +5884,6 @@ mod tests {
     /// prior cycle's commits stay reachable from the local ref.
     #[tokio::test]
     async fn clone_uses_task_branch_when_present() {
-        // `timed_clone_attempt` records into the process-global Prometheus
-        // recorder; serialize with the telemetry-scrape tests so their
-        // delta assertions are not polluted by this test's samples.
-        let _guard = clone_telemetry_guard().await;
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
         let mirror_path = mgr.mirror_path(RESUME_TEST_PROJECT_ID);
@@ -5926,10 +5918,6 @@ mod tests {
     /// probe cannot prove the branch is missing.
     #[tokio::test]
     async fn transient_clone_failure_does_not_fall_back_to_base_branch() {
-        // `timed_clone_attempt` records into the process-global Prometheus
-        // recorder; serialize with the telemetry-scrape tests so their
-        // delta assertions are not polluted by this test's samples.
-        let _guard = clone_telemetry_guard().await;
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
 
@@ -6300,20 +6288,20 @@ mod tests {
 
     use djinn_core::clock::TestClock;
 
-    /// The Prometheus recorder is process-global; serialize telemetry-scrape
-    /// tests behind a mutex so each assertion can use a precise delta.
-    ///
-    /// `tokio::sync::Mutex` rather than `std`: every holder is an `async` test
-    /// that awaits while holding the guard for its whole body, and a `std`
-    /// guard held across an await point blocks the executor thread instead of
-    /// the task (clippy::await_holding_lock). The `.expect("poisoned")` goes
-    /// away with it — tokio's mutex has no poisoning, so one panicking test no
-    /// longer fails every sibling that shares the lock.
-    static CLONE_TELEMETRY_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-    async fn clone_telemetry_guard() -> tokio::sync::MutexGuard<'static, ()> {
-        CLONE_TELEMETRY_MUTEX.lock().await
-    }
+    // The Prometheus recorder installed by `djinn_telemetry::init()` is
+    // process-global, so a before/after delta taken around the operation under
+    // test measures whatever the *whole binary* emitted in that window, not
+    // what the operation emitted. These tests used to serialize behind a
+    // `CLONE_TELEMETRY_MUTEX` / `CLEANUP_TELEMETRY_MUTEX` for that reason, but
+    // a mutex only excludes the tests that hold it: every other test in the
+    // binary that clones or tears down a workspace kept landing samples inside
+    // the delta window (observed as `7.0 vs 4.0`, `17.0 vs 14.0`, `18.0 vs
+    // 15.0` — over by exactly the number of concurrent siblings).
+    //
+    // Each telemetry test now scopes a `djinn_telemetry::IsolatedRecorder` to
+    // its own thread instead. The rendered registry then contains only what
+    // that test emitted, so the assertions are absolute rather than deltas,
+    // no test excludes any other, and the whole group runs in parallel.
 
     /// Count `workspace_clone_seconds_count` samples for a given outcome.
     fn clone_count(rendered: &str, outcome: &str) -> f64 {
@@ -6368,9 +6356,6 @@ mod tests {
     /// injected monotonic clock.
     #[tokio::test]
     async fn timed_clone_attempt_records_one_ok_sample() {
-        let _guard = clone_telemetry_guard().await;
-        djinn_telemetry::init().expect("telemetry init");
-
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
         let clock = Arc::new(TestClock::new(
@@ -6378,55 +6363,52 @@ mod tests {
             std::time::Instant::now(),
         ));
         let cancel = CancellationToken::new();
-
-        let before = djinn_telemetry::render().expect("render before");
-        let ok_before = clone_count(&before, "ok");
-        let ok_sum_before = clone_sum(&before, "ok");
         let elapsed = Duration::from_millis(200);
 
-        let clock_clone = clock.clone();
-        timed_clone_attempt(&*clock, &cancel, async move {
-            let result = mgr
-                .clone_ephemeral(RESUME_TEST_PROJECT_ID, RESUME_TEST_BASE)
-                .await;
-            // Advance the TestClock mono time so elapsed is deterministic.
-            clock_clone.advance_mono(elapsed);
-            result
-        })
-        .await
-        .expect("clone must succeed");
+        let recorder = djinn_telemetry::IsolatedRecorder::new();
+        let rendered = {
+            let _metrics = recorder.scope();
+            let clock_clone = clock.clone();
+            timed_clone_attempt(&*clock, &cancel, async move {
+                let result = mgr
+                    .clone_ephemeral(RESUME_TEST_PROJECT_ID, RESUME_TEST_BASE)
+                    .await;
+                // Advance the TestClock mono time so elapsed is deterministic.
+                clock_clone.advance_mono(elapsed);
+                result
+            })
+            .await
+            .expect("clone must succeed");
+            recorder.render()
+        };
 
-        let after = djinn_telemetry::render().expect("render after");
         assert_eq!(
-            clone_count(&after, "ok"),
-            ok_before + 1.0,
+            clone_count(&rendered, "ok"),
+            1.0,
             "one ok clone sample expected"
         );
         assert!(
-            (clone_sum(&after, "ok") - ok_sum_before - elapsed.as_secs_f64()).abs() < 0.001,
-            "ok clone sum delta must equal elapsed"
+            (clone_sum(&rendered, "ok") - elapsed.as_secs_f64()).abs() < 0.001,
+            "ok clone sum must equal elapsed"
         );
-        // Error/cancelled must not increase.
+        // Error/cancelled must not be recorded at all.
         assert_eq!(
-            clone_count(&after, "error"),
-            clone_count(&before, "error"),
-            "error count must not change for a successful clone"
+            clone_count(&rendered, "error"),
+            0.0,
+            "no error sample for a successful clone"
         );
         assert_eq!(
-            clone_count(&after, "cancelled"),
-            clone_count(&before, "cancelled"),
-            "cancelled count must not change for a successful clone"
+            clone_count(&rendered, "cancelled"),
+            0.0,
+            "no cancelled sample for a successful clone"
         );
-        assert_no_identity_labels(&after, "djinn_workspace_clone_seconds");
+        assert_no_identity_labels(&rendered, "djinn_workspace_clone_seconds");
     }
 
     /// A failed clone (missing mirror project) records exactly one `error`
     /// sample when the cancel token is NOT set.
     #[tokio::test]
     async fn timed_clone_attempt_records_one_error_sample() {
-        let _guard = clone_telemetry_guard().await;
-        djinn_telemetry::init().expect("telemetry init");
-
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let mgr = MirrorManager::new(tmp.path().to_path_buf());
         let clock = Arc::new(TestClock::new(
@@ -6434,48 +6416,45 @@ mod tests {
             std::time::Instant::now(),
         ));
         let cancel = CancellationToken::new();
-
-        let before = djinn_telemetry::render().expect("render before");
-        let err_before = clone_count(&before, "error");
-        let err_sum_before = clone_sum(&before, "error");
         let elapsed = Duration::from_millis(150);
 
-        let clock_clone = clock.clone();
-        let result = timed_clone_attempt(&*clock, &cancel, async move {
-            let result = mgr
-                .clone_ephemeral("nonexistent-project", RESUME_TEST_BASE)
-                .await;
-            clock_clone.advance_mono(elapsed);
-            result
-        })
-        .await;
-        assert!(result.is_err(), "clone of missing project must fail");
+        let recorder = djinn_telemetry::IsolatedRecorder::new();
+        let rendered = {
+            let _metrics = recorder.scope();
+            let clock_clone = clock.clone();
+            let result = timed_clone_attempt(&*clock, &cancel, async move {
+                let result = mgr
+                    .clone_ephemeral("nonexistent-project", RESUME_TEST_BASE)
+                    .await;
+                clock_clone.advance_mono(elapsed);
+                result
+            })
+            .await;
+            assert!(result.is_err(), "clone of missing project must fail");
+            recorder.render()
+        };
 
-        let after = djinn_telemetry::render().expect("render after");
         assert_eq!(
-            clone_count(&after, "error"),
-            err_before + 1.0,
+            clone_count(&rendered, "error"),
+            1.0,
             "one error clone sample expected"
         );
         assert!(
-            (clone_sum(&after, "error") - err_sum_before - elapsed.as_secs_f64()).abs() < 0.001,
-            "error clone sum delta must equal elapsed"
+            (clone_sum(&rendered, "error") - elapsed.as_secs_f64()).abs() < 0.001,
+            "error clone sum must equal elapsed"
         );
         assert_eq!(
-            clone_count(&after, "ok"),
-            clone_count(&before, "ok"),
-            "ok count must not change for a failed clone"
+            clone_count(&rendered, "ok"),
+            0.0,
+            "no ok sample for a failed clone"
         );
-        assert_no_identity_labels(&after, "djinn_workspace_clone_seconds");
+        assert_no_identity_labels(&rendered, "djinn_workspace_clone_seconds");
     }
 
     /// A clone that resolves (Ok or Err) while the cancel token IS set
     /// records exactly one `cancelled` sample.
     #[tokio::test]
     async fn timed_clone_attempt_records_cancelled_when_token_set() {
-        let _guard = clone_telemetry_guard().await;
-        djinn_telemetry::init().expect("telemetry init");
-
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
         let clock = Arc::new(TestClock::new(
@@ -6484,42 +6463,41 @@ mod tests {
         ));
         let cancel = CancellationToken::new();
         cancel.cancel();
-
-        let before = djinn_telemetry::render().expect("render before");
-        let cancel_before = clone_count(&before, "cancelled");
-        let cancel_sum_before = clone_sum(&before, "cancelled");
         let elapsed = Duration::from_millis(100);
 
-        // Even though the clone succeeds, the cancel token is set so the
-        // outcome is `cancelled`.
-        let clock_clone = clock.clone();
-        timed_clone_attempt(&*clock, &cancel, async move {
-            let result = mgr
-                .clone_ephemeral(RESUME_TEST_PROJECT_ID, RESUME_TEST_BASE)
-                .await;
-            clock_clone.advance_mono(elapsed);
-            result
-        })
-        .await
-        .expect("clone itself succeeds");
+        let recorder = djinn_telemetry::IsolatedRecorder::new();
+        let rendered = {
+            let _metrics = recorder.scope();
+            // Even though the clone succeeds, the cancel token is set so the
+            // outcome is `cancelled`.
+            let clock_clone = clock.clone();
+            timed_clone_attempt(&*clock, &cancel, async move {
+                let result = mgr
+                    .clone_ephemeral(RESUME_TEST_PROJECT_ID, RESUME_TEST_BASE)
+                    .await;
+                clock_clone.advance_mono(elapsed);
+                result
+            })
+            .await
+            .expect("clone itself succeeds");
+            recorder.render()
+        };
 
-        let after = djinn_telemetry::render().expect("render after");
         assert_eq!(
-            clone_count(&after, "cancelled"),
-            cancel_before + 1.0,
+            clone_count(&rendered, "cancelled"),
+            1.0,
             "one cancelled clone sample expected when token is set"
         );
         assert!(
-            (clone_sum(&after, "cancelled") - cancel_sum_before - elapsed.as_secs_f64()).abs()
-                < 0.001,
-            "cancelled clone sum delta must equal elapsed"
+            (clone_sum(&rendered, "cancelled") - elapsed.as_secs_f64()).abs() < 0.001,
+            "cancelled clone sum must equal elapsed"
         );
         assert_eq!(
-            clone_count(&after, "ok"),
-            clone_count(&before, "ok"),
-            "ok count must not change when cancel token is set"
+            clone_count(&rendered, "ok"),
+            0.0,
+            "no ok sample when the cancel token is set"
         );
-        assert_no_identity_labels(&after, "djinn_workspace_clone_seconds");
+        assert_no_identity_labels(&rendered, "djinn_workspace_clone_seconds");
     }
 
     /// Multi-attempt fallback: when task_branch clone fails and base_branch
@@ -6528,9 +6506,6 @@ mod tests {
     /// operation actually begins.
     #[tokio::test]
     async fn timed_clone_attempt_multi_attempt_fallback_records_two_samples() {
-        let _guard = clone_telemetry_guard().await;
-        djinn_telemetry::init().expect("telemetry init");
-
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
         let clock = Arc::new(TestClock::new(
@@ -6538,60 +6513,59 @@ mod tests {
             std::time::Instant::now(),
         ));
         let cancel = CancellationToken::new();
-
-        let before = djinn_telemetry::render().expect("render before");
-        let ok_before = clone_count(&before, "ok");
-        let err_before = clone_count(&before, "error");
-        let ok_sum_before = clone_sum(&before, "ok");
-        let err_sum_before = clone_sum(&before, "error");
         let err_elapsed = Duration::from_millis(120);
         let ok_elapsed = Duration::from_millis(250);
 
-        // First attempt: task_branch doesn't exist → error.
-        let clock_clone = clock.clone();
-        let first = timed_clone_attempt(&*clock, &cancel, async move {
-            let result = mgr
-                .clone_ephemeral(RESUME_TEST_PROJECT_ID, RESUME_TEST_TASK)
-                .await;
-            clock_clone.advance_mono(err_elapsed);
-            result
-        })
-        .await;
-        assert!(first.is_err(), "task_branch clone must fail (first cycle)");
+        let recorder = djinn_telemetry::IsolatedRecorder::new();
+        let rendered = {
+            let _metrics = recorder.scope();
 
-        // Second attempt (fallback): base_branch exists → ok.
-        let clock_clone2 = clock.clone();
-        timed_clone_attempt(&*clock, &cancel, async move {
-            let (mgr2, _tip2) = build_resume_test_mirror(tmp.path(), false).await;
-            let result = mgr2
-                .clone_ephemeral(RESUME_TEST_PROJECT_ID, RESUME_TEST_BASE)
-                .await;
-            clock_clone2.advance_mono(ok_elapsed);
-            result
-        })
-        .await
-        .expect("base_branch clone must succeed");
+            // First attempt: task_branch doesn't exist → error.
+            let clock_clone = clock.clone();
+            let first = timed_clone_attempt(&*clock, &cancel, async move {
+                let result = mgr
+                    .clone_ephemeral(RESUME_TEST_PROJECT_ID, RESUME_TEST_TASK)
+                    .await;
+                clock_clone.advance_mono(err_elapsed);
+                result
+            })
+            .await;
+            assert!(first.is_err(), "task_branch clone must fail (first cycle)");
 
-        let after = djinn_telemetry::render().expect("render after");
+            // Second attempt (fallback): base_branch exists → ok.
+            let clock_clone2 = clock.clone();
+            timed_clone_attempt(&*clock, &cancel, async move {
+                let (mgr2, _tip2) = build_resume_test_mirror(tmp.path(), false).await;
+                let result = mgr2
+                    .clone_ephemeral(RESUME_TEST_PROJECT_ID, RESUME_TEST_BASE)
+                    .await;
+                clock_clone2.advance_mono(ok_elapsed);
+                result
+            })
+            .await
+            .expect("base_branch clone must succeed");
+            recorder.render()
+        };
+
         assert_eq!(
-            clone_count(&after, "error"),
-            err_before + 1.0,
+            clone_count(&rendered, "error"),
+            1.0,
             "one error sample for the failed task_branch attempt"
         );
         assert_eq!(
-            clone_count(&after, "ok"),
-            ok_before + 1.0,
+            clone_count(&rendered, "ok"),
+            1.0,
             "one ok sample for the successful base_branch fallback attempt"
         );
         assert!(
-            (clone_sum(&after, "error") - err_sum_before - err_elapsed.as_secs_f64()).abs() < 0.001,
-            "error clone sum delta must equal first attempt elapsed"
+            (clone_sum(&rendered, "error") - err_elapsed.as_secs_f64()).abs() < 0.001,
+            "error clone sum must equal first attempt elapsed"
         );
         assert!(
-            (clone_sum(&after, "ok") - ok_sum_before - ok_elapsed.as_secs_f64()).abs() < 0.001,
-            "ok clone sum delta must equal fallback attempt elapsed"
+            (clone_sum(&rendered, "ok") - ok_elapsed.as_secs_f64()).abs() < 0.001,
+            "ok clone sum must equal fallback attempt elapsed"
         );
-        assert_no_identity_labels(&after, "djinn_workspace_clone_seconds");
+        assert_no_identity_labels(&rendered, "djinn_workspace_clone_seconds");
     }
 
     /// `classify_clone_outcome`: Err + not-cancelled → error. This pure
@@ -6620,24 +6594,6 @@ mod tests {
     }
 
     // ── Workspace cleanup telemetry tests (proposal zp5t) ─────────────────
-
-    /// The Prometheus recorder is process-global; serialize telemetry-scrape
-    /// tests behind a mutex so each assertion can use a precise delta.
-    ///
-    /// `tokio::sync::Mutex` for the same reason as [`CLONE_TELEMETRY_MUTEX`]:
-    /// the async holders await while holding it. This one has synchronous
-    /// `#[test]` holders too, hence the two accessors below.
-    static CLEANUP_TELEMETRY_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-    async fn cleanup_telemetry_guard() -> tokio::sync::MutexGuard<'static, ()> {
-        CLEANUP_TELEMETRY_MUTEX.lock().await
-    }
-
-    /// Synchronous `#[test]` counterpart. Panics if called from inside a
-    /// runtime — async callers must use [`cleanup_telemetry_guard`].
-    fn cleanup_telemetry_guard_blocking() -> tokio::sync::MutexGuard<'static, ()> {
-        CLEANUP_TELEMETRY_MUTEX.blocking_lock()
-    }
 
     /// Count `workspace_cleanup_seconds_count` samples for a given
     /// trigger/outcome pair.
@@ -6752,9 +6708,6 @@ mod tests {
     /// with the classified trigger.
     #[tokio::test]
     async fn timed_teardown_records_one_complete_ok_sample() {
-        let _guard = cleanup_telemetry_guard().await;
-        djinn_telemetry::init().expect("telemetry init");
-
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
         let ws = mgr
@@ -6763,59 +6716,54 @@ mod tests {
             .expect("clone");
         let clock = TestClock::new(std::time::SystemTime::UNIX_EPOCH, std::time::Instant::now());
 
-        let before = djinn_telemetry::render().expect("render before");
-        let count_before = cleanup_count(&before, "complete", "ok");
-        let sum_before = cleanup_sum(&before, "complete", "ok");
+        let recorder = djinn_telemetry::IsolatedRecorder::new();
+        let rendered = {
+            let _metrics = recorder.scope();
+            let result = timed_workspace_teardown(&clock, ws, CleanupTrigger::Complete);
+            assert!(result.is_ok(), "teardown must succeed");
+            recorder.render()
+        };
 
-        let result = timed_workspace_teardown(&clock, ws, CleanupTrigger::Complete);
-        assert!(result.is_ok(), "teardown must succeed");
-
-        let after = djinn_telemetry::render().expect("render after");
         assert_eq!(
-            cleanup_count(&after, "complete", "ok"),
-            count_before + 1.0,
+            cleanup_count(&rendered, "complete", "ok"),
+            1.0,
             "one complete/ok cleanup sample expected"
         );
         // The TestClock does not advance during the synchronous teardown, so
         // the recorded duration is ~0. Assert the sum is non-negative (the
         // teardown completed and recorded a valid sample).
-        let sum_delta = cleanup_sum(&after, "complete", "ok") - sum_before;
+        let sum = cleanup_sum(&rendered, "complete", "ok");
         assert!(
-            sum_delta >= 0.0,
-            "complete/ok sum delta must be non-negative, got {sum_delta}"
+            sum >= 0.0,
+            "complete/ok sum must be non-negative, got {sum}"
         );
-        assert_no_cleanup_identity_labels(&after);
+        assert_no_cleanup_identity_labels(&rendered);
     }
 
     /// An attached workspace teardown is a no-op and does NOT emit a sample —
     /// attached directories are never deleted or observed.
     #[test]
     fn timed_teardown_on_attached_emits_nothing() {
-        let _guard = cleanup_telemetry_guard_blocking();
-        djinn_telemetry::init().expect("telemetry init");
-
         let tmp = tempfile::tempdir().expect("tempdir");
         let ws = Workspace::attach_existing(tmp.path(), "main").expect("attach");
         assert!(!ws.is_owned(), "attached workspace must not be owned");
 
         let clock = TestClock::new(std::time::SystemTime::UNIX_EPOCH, std::time::Instant::now());
 
-        let before = djinn_telemetry::render().expect("render before");
-        let complete_ok_before = cleanup_count(&before, "complete", "ok");
-
-        // teardown_owned on Attached returns Ok and does NOT delete.
-        let result = timed_workspace_teardown(&clock, ws, CleanupTrigger::Complete);
+        let (result, rendered) = djinn_telemetry::render_isolated(|| {
+            // teardown_owned on Attached returns Ok and does NOT delete.
+            timed_workspace_teardown(&clock, ws, CleanupTrigger::Complete)
+        });
         assert!(result.is_ok(), "attached teardown must be Ok");
 
-        let after = djinn_telemetry::render().expect("render after");
         // Attached workspaces are never observed: no telemetry sample emitted.
         assert!(
             tmp.path().exists(),
             "attached directory must NOT be deleted"
         );
         assert_eq!(
-            cleanup_count(&after, "complete", "ok"),
-            complete_ok_before,
+            cleanup_count(&rendered, "complete", "ok"),
+            0.0,
             "attached teardown must NOT emit any sample"
         );
     }
@@ -6825,10 +6773,10 @@ mod tests {
     /// it returns, without relying on slow filesystem failures.
     #[test]
     fn cleanup_records_all_eight_returned_operation_outcomes() {
-        let _guard = cleanup_telemetry_guard_blocking();
-        djinn_telemetry::init().expect("telemetry init");
         let clock = TestClock::new(std::time::SystemTime::UNIX_EPOCH, std::time::Instant::now());
         let elapsed = Duration::from_millis(42);
+        let recorder = djinn_telemetry::IsolatedRecorder::new();
+        let _metrics = recorder.scope();
         for (trigger_str, trigger) in [
             ("complete", CleanupTrigger::Complete),
             ("error", CleanupTrigger::Error),
@@ -6836,14 +6784,11 @@ mod tests {
             ("shutdown", CleanupTrigger::Shutdown),
         ] {
             for (outcome_str, succeeds) in [("ok", true), ("error", false)] {
-                let before = djinn_telemetry::render().expect("render before");
-                let count_before = cleanup_count(&before, trigger_str, outcome_str);
-                let sum_before = cleanup_sum(&before, trigger_str, outcome_str);
                 let result = timed_cleanup_operation(&clock, trigger, || {
-                    let during = djinn_telemetry::render().expect("render during teardown");
+                    let during = recorder.render();
                     assert_eq!(
                         cleanup_count(&during, trigger_str, outcome_str),
-                        count_before,
+                        0.0,
                         "sample must wait for returned teardown"
                     );
                     clock.advance_mono(elapsed);
@@ -6858,30 +6803,25 @@ mod tests {
                     succeeds,
                     "injected {trigger_str}/{outcome_str} result must propagate"
                 );
-                let after = djinn_telemetry::render().expect("render after");
-                assert_eq!(
-                    cleanup_count(&after, trigger_str, outcome_str),
-                    count_before + 1.0
-                );
+                let after = recorder.render();
+                assert_eq!(cleanup_count(&after, trigger_str, outcome_str), 1.0);
                 assert!(
-                    (cleanup_sum(&after, trigger_str, outcome_str)
-                        - sum_before
-                        - elapsed.as_secs_f64())
-                    .abs()
+                    (cleanup_sum(&after, trigger_str, outcome_str) - elapsed.as_secs_f64()).abs()
                         < 0.001
                 );
             }
         }
-        assert_no_cleanup_identity_labels(&djinn_telemetry::render().expect("render labels"));
+        assert_no_cleanup_identity_labels(&recorder.render());
     }
 
     #[test]
     fn cleanup_panic_emits_nothing_until_a_later_returned_teardown() {
-        let _guard = cleanup_telemetry_guard_blocking();
-        djinn_telemetry::init().expect("telemetry init");
         let clock = TestClock::new(std::time::SystemTime::UNIX_EPOCH, std::time::Instant::now());
-        let before = djinn_telemetry::render().expect("render before");
-        let count_before = cleanup_count(&before, "complete", "ok");
+        let recorder = djinn_telemetry::IsolatedRecorder::new();
+        // The guard is held across `catch_unwind` deliberately: it drops only
+        // at the end of the test, so the recovered-from panic cannot silently
+        // put the second teardown's sample on the global recorder.
+        let _metrics = recorder.scope();
         let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             timed_cleanup_operation(
                 &clock,
@@ -6891,22 +6831,16 @@ mod tests {
         }));
         assert!(panic.is_err());
         assert_eq!(
-            cleanup_count(
-                &djinn_telemetry::render().expect("render after panic"),
-                "complete",
-                "ok"
-            ),
-            count_before
+            cleanup_count(&recorder.render(), "complete", "ok"),
+            0.0,
+            "a teardown that panicked must emit nothing"
         );
         timed_cleanup_operation(&clock, CleanupTrigger::Complete, || Ok(()))
             .expect("returned teardown");
         assert_eq!(
-            cleanup_count(
-                &djinn_telemetry::render().expect("render after returned teardown"),
-                "complete",
-                "ok"
-            ),
-            count_before + 1.0
+            cleanup_count(&recorder.render(), "complete", "ok"),
+            1.0,
+            "the later returned teardown emits exactly one sample"
         );
     }
 
@@ -6916,9 +6850,6 @@ mod tests {
     /// no-op.
     #[tokio::test]
     async fn teardown_owned_prevents_double_drop() {
-        let _guard = cleanup_telemetry_guard().await;
-        djinn_telemetry::init().expect("telemetry init");
-
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
         let ws = mgr
@@ -6929,18 +6860,16 @@ mod tests {
 
         let clock = TestClock::new(std::time::SystemTime::UNIX_EPOCH, std::time::Instant::now());
 
-        let before = djinn_telemetry::render().expect("render before");
-        let count_before = cleanup_count(&before, "complete", "ok");
-
-        // First teardown: records exactly one sample and removes the dir.
-        timed_workspace_teardown(&clock, ws, CleanupTrigger::Complete)
-            .expect("first teardown must succeed");
+        let (_, rendered) = djinn_telemetry::render_isolated(|| {
+            // First teardown: records exactly one sample and removes the dir.
+            timed_workspace_teardown(&clock, ws, CleanupTrigger::Complete)
+                .expect("first teardown must succeed");
+        });
         assert!(!path.exists(), "directory must be removed after teardown");
 
-        let after = djinn_telemetry::render().expect("render after");
         assert_eq!(
-            cleanup_count(&after, "complete", "ok"),
-            count_before + 1.0,
+            cleanup_count(&rendered, "complete", "ok"),
+            1.0,
             "exactly one cleanup sample (no duplicate from Drop)"
         );
     }
@@ -6972,9 +6901,6 @@ mod tests {
     /// emitted if teardown never returns (panic/SIGKILL are out of scope).
     #[tokio::test]
     async fn timed_teardown_records_error_on_failure() {
-        let _guard = cleanup_telemetry_guard().await;
-        djinn_telemetry::init().expect("telemetry init");
-
         let tmp = tempfile::tempdir().expect("mirrors tempdir");
         let (mgr, _tip) = build_resume_test_mirror(tmp.path(), false).await;
         let ws = mgr
@@ -6985,31 +6911,28 @@ mod tests {
 
         let clock = TestClock::new(std::time::SystemTime::UNIX_EPOCH, std::time::Instant::now());
 
-        let before = djinn_telemetry::render().expect("render before");
-        let count_before = cleanup_count(&before, "error", "error");
-        let sum_before = cleanup_sum(&before, "error", "error");
-
         // Externally delete the directory so TempDir::close() returns Err.
         std::fs::remove_dir_all(&ws_path).expect("externally delete dir");
 
-        let result = timed_workspace_teardown(&clock, ws, CleanupTrigger::Error);
+        let (result, rendered) = djinn_telemetry::render_isolated(|| {
+            timed_workspace_teardown(&clock, ws, CleanupTrigger::Error)
+        });
         assert!(
             result.is_err(),
             "teardown must fail on externally deleted dir"
         );
 
-        let after = djinn_telemetry::render().expect("render after");
         assert_eq!(
-            cleanup_count(&after, "error", "error"),
-            count_before + 1.0,
+            cleanup_count(&rendered, "error", "error"),
+            1.0,
             "one error/error cleanup sample expected"
         );
-        let sum_delta = cleanup_sum(&after, "error", "error") - sum_before;
+        let sum = cleanup_sum(&rendered, "error", "error");
         assert!(
-            sum_delta >= 0.0,
-            "error/error sum delta must be non-negative, got {sum_delta}"
+            sum >= 0.0,
+            "error/error sum must be non-negative, got {sum}"
         );
-        assert_no_cleanup_identity_labels(&after);
+        assert_no_cleanup_identity_labels(&rendered);
     }
 
     /// Regression: a persistent push_to_origin failure after WorkerDone must

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -1250,6 +1250,56 @@ pub fn render_isolated<T>(f: impl FnOnce() -> T) -> (T, String) {
     )
 }
 
+/// Test support: the `async` counterpart of [`render_isolated`].
+///
+/// [`render_isolated`] takes a closure, which an `async` test body cannot be
+/// wrapped in. This type splits the same mechanism in two: construct it, hold
+/// the guard returned by [`Self::scope`] for the region to capture, and read
+/// [`Self::render`] for a registry containing *only* what was emitted while
+/// the guard was held. Absolute assertions become exact, so a test needs
+/// neither a before/after delta (which a concurrent writer can still land
+/// inside) nor a mutex serializing it against its siblings.
+///
+/// Same soundness rule as [`render_isolated`], and it is the reason the guard
+/// is separate from the recorder: the scope is thread-local. A
+/// `#[tokio::test]` body — including a `multi_thread` one — is polled by
+/// `Runtime::block_on` on the thread that created the guard, so the body's own
+/// straight-line code is captured across `.await` points. Work the body hands
+/// to `tokio::spawn` or `spawn_blocking` runs elsewhere and records to the
+/// process-global recorder instead, where this type will not see it. That
+/// failure mode is loud rather than silent: the expected series is simply
+/// absent from [`Self::render`].
+pub struct IsolatedRecorder {
+    recorder: metrics_exporter_prometheus::PrometheusRecorder,
+}
+
+impl IsolatedRecorder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            recorder: PrometheusBuilder::new().build_recorder(),
+        }
+    }
+
+    /// Route this thread's `metrics` emissions here until the guard drops.
+    #[must_use]
+    pub fn scope(&self) -> metrics::LocalRecorderGuard<'_> {
+        metrics::set_default_local_recorder(&self.recorder)
+    }
+
+    /// Render everything recorded through this recorder so far.
+    #[must_use]
+    pub fn render(&self) -> String {
+        prioritize_dispatch_attempts(self.recorder.handle().render())
+    }
+}
+
+impl Default for IsolatedRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn prioritize_dispatch_attempts(rendered: String) -> String {
     const DISPATCH_HELP: &str = "# HELP djinn_dispatch_attempts_total";
     if rendered.starts_with(DISPATCH_HELP) {


### PR DESCRIPTION
Two pre-existing flake clusters that fail at default test concurrency, one root cause each. Test-only, plus one new test-support helper. No production behaviour is touched.

## Root cause

The `metrics` recorder installed by `djinn_telemetry::init()` is process-global, and cargo runs every test in a binary as a thread of one process. A test that reads that registry is reading whatever the **whole binary** emitted, so it is coupled to every concurrently running sibling.

**`djinn-supervisor`** — the nine workspace clone/cleanup telemetry tests took a before/after delta around the operation under test. A delta narrows the window but does not close it: any sibling that clones or tears down a workspace lands inside it. That is why the counts were over by exactly the concurrent-sibling count (`7.0 vs 4.0`, `17.0 vs 14.0`, `18.0 vs 15.0`). The two `*_TELEMETRY_MUTEX`es only excluded the tests holding them, so they bought serialization without determinism.

**`djinn-coordinator`** — `assert_strike_decision_labels_are_bounded` read the whole registry and asserted its bounded-label allowlist against every series the binary had ever emitted. A sibling exercising `environmental_restart_orphan` (a legitimate, equally bounded source that these two call paths never emit) failed *these* tests instead of its own.

## Change

New `djinn_telemetry::IsolatedRecorder` — the `async` counterpart of the existing `render_isolated`, which only works for synchronous closures. Construct it, hold the guard returned by `scope()` across the region to capture, then `render()` a registry no other test can reach. Assertions become absolute rather than deltas, both mutexes are deleted, and the whole group runs in parallel.

Soundness rule is documented on the type and is the same as `render_isolated`'s: the scope is thread-local, and a `#[tokio::test]` body (including `multi_thread`) is polled by `block_on` on the guard's thread, so straight-line code is captured across `.await`. Work handed to `tokio::spawn` / `spawn_blocking` is not — and that failure mode is loud, not silent: the expected series is simply absent.

## Evidence at default (parallel) concurrency

`djinn-supervisor --lib`, 6 consecutive runs:

| | baseline (`origin/main`) | this branch |
|---|---|---|
| run 1 | 6 failed | 189 passed |
| run 2 | 4 failed | 189 passed |
| run 3 | 6 failed | 189 passed |
| run 4 | 6 failed | 189 passed |
| run 5 | 7 failed | 189 passed |
| run 6 | 5 failed | 189 passed |

The failing set varied every baseline run, across all nine telemetry tests.

`djinn-coordinator --lib`: both `session_reaping` strike-decision tests failed on every baseline full-suite run and are green on this branch.

## Teeth checks

Assertions rewritten to absolute counts can accidentally assert nothing, so production emission was mutated and the tests re-run:

- `increment_strike_decision` given an extra `"task_id"` label → both coordinator tests fail.
- `increment_strike_decision` `.increment(1)` → `.increment(2)` → both fail with `left: 2.0 / right: 1.0`.
- `timed_clone_attempt` / `timed_cleanup_operation` record twice → **all nine** rewritten supervisor tests fail with `2.0 vs 1.0`.

All mutations reverted; the telemetry diff here is purely additive.

## Not in this PR

**Cluster B (`djinn-control-plane`, `doctor_closed_parent_tools.rs`)** was already fixed on `main` by #2820, which landed after the branch point this was reported from. Verified both directions: 8/8 green on current `main`; reverting #2820's five files reproduces it exactly (3 of 5 fail, varying set, `outcome: "skipped_not_found"`). The mechanism is *not* a shared test database — every `McpTestHarness` already gets its own ephemeral Postgres DB via `Database::open_in_memory()`. It was the process-global `djinn_core::doctor::registry()` singleton, keyed by check name, so concurrent harnesses clobbered each other's registration and ran each test's repair against a sibling's database. Nothing to do here.

**`rules::tests::batch_completion_creates_decomposition_task`** was reported alongside the coordinator metrics tests but is a **different mechanism** and is not fixed here. It has no metrics assertion; it fails its 10 s poll for a planning task that is never created (`left: 0`). It reproduces only under full-suite load (~25% of runs; 5/5 green alone, 3/3 green for the whole `rules` module) and it takes a sibling with it (`rules::tests::proposal_review_dispatched_incrementally_on_each_epic_close`). Failing-run logs show the test's own spawned coordinator *dispatching the fixture's second worker task into the live mock slot pool* moments before the test closes it, after which the actor emits nothing for the remaining 10 s. So the fixture races its own dispatch rather than the metrics registry. Fixing it means reworking the shared `spawn_coordinator` fixture in `rules.rs` on an unproven theory, in a file the follow-up `ubne`/`plcj` slices touch — reporting rather than racing, per instructions.
