### PR TITLE
chore: gitignore Linux core dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ report.json
 
 # Playwright MCP session artifacts (screenshots/console/page dumps)
 .playwright-mcp/
+
+# Linux core dumps. A tokio worker stack overflow in the djinn-coordinator test
+# suite writes ~15 MB core.<pid> files into the crate directory; on 2026-07-30
+# a 263 MB dump was swept in by `git add -A` twice and caught only at the
+# `git show --stat` check before push.
+core.[0-9]*
+core


### PR DESCRIPTION
A tokio worker stack overflow in the `djinn-coordinator` test suite writes ~15 MB `core.<pid>` files into the crate directory.

On 2026-07-30 two separate agents swept one into a staged commit via `git add -A` and caught it only at a `git show --stat` review immediately before pushing. One dump was **263 MB**. Nothing leaked, but it was luck twice rather than a guard.

Ignores `core.<pid>` and a bare `core` file. Deliberately **not** `core*`, which would match legitimately-named source paths.

Note this does not fix the underlying abort — that is pre-existing, affects only `wave`/`rules`/`status_and_stuck`, and disappears under `RUST_MIN_STACK=16777216`. Tracked separately as `de15`.