### PR TITLE
feat(kueue): Workload reconciliation replaces the admission reconciler (kh7g S5)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1513,6 +1513,7 @@ dependencies = [
  "djinn-supervisor",
  "djinn-telemetry",
  "djinn-workspace",
+ "futures",
  "http",
  "http-body-util",
  "k8s-openapi",

--- a/server/crates/djinn-db/migrations_postgres/165_kueue_workload_admission.sql
+++ b/server/crates/djinn-db/migrations_postgres/165_kueue_workload_admission.sql
@@ -1,0 +1,68 @@
+-- Durable projection of Kueue Workload admission state onto task-runs.
+--
+-- Kueue cutover slice S5 (task kh7g, proposal 9oga). This is the relation that
+-- replaces the deleted `admission_journal` — with one structural difference that
+-- is the entire point of the cutover.
+--
+-- `admission_journal` was an AUTHORITY: it reserved capacity before the object
+-- that consumed it existed, and everything downstream (settle windows, absence
+-- proofs, CAS fencing) was compensation for accounting rows no Kubernetes object
+-- owned. This table is a PROJECTION: Kueue's ClusterQueue decides, this records
+-- what it decided. Every row is derived from a live Workload observed on a
+-- watch, so a row can never outlive the object it describes — deleting the
+-- Workload deletes the row.
+--
+-- ## Why a task-run needs this at all
+--
+-- Under create-then-admit a build-capable Job is created `suspend: true` and no
+-- Pod exists until Kueue admits it. The in-pod supervisor is what creates the
+-- `task_runs` row, so between dispatch and admission djinn has NOTHING that says
+-- why a task is sitting still: no run, no session, no denial. That is exactly
+-- the shape of the 2026-07-29 outage, where the board reported `unexplained`
+-- with empty reasons for five hours. This row is the answer to "what is this
+-- task waiting for", written by the process that watched Kueue decide it.
+--
+-- ## Reversible by construction
+--
+-- `admission` moves BOTH ways. A preempted Workload returns to 'pending' with
+-- Kueue's own reason ('Preempted', 'ClusterQueueStopped', 'Deactivated'), and a
+-- re-admitted one moves back to 'admitted'. A one-way column would have made a
+-- quota eviction unrepresentable, and an unrepresentable eviction reads as a
+-- permanently-admitted run that nothing will ever finish.
+--
+-- ## Bounded
+--
+-- One row per task-run with a live Workload. `transitions` counts observed state
+-- CHANGES, not observations: a watch reconnect replays every Workload it knows
+-- about, and a projection that counted replays would inflate without bound and
+-- make "how often is this queue thrashing" unreadable.
+CREATE TABLE kueue_workload_admission (
+    -- The `task_runs.id` this Workload accounts for, resolved from the Job's
+    -- `djinn.app/task-run-id` label or its `djinn-taskrun-<uuid>` name. A
+    -- Workload that resolves to neither is not a task-run and writes nothing.
+    --
+    -- Deliberately NOT a foreign key to `task_runs`: the whole reason this table
+    -- exists is the window BEFORE the in-pod supervisor creates that row.
+    task_run_id   VARCHAR(64)  PRIMARY KEY,
+    -- `WorkloadAdmission::as_str()`. Reversible between 'pending' and 'admitted'.
+    admission     VARCHAR(32)  NOT NULL,
+    -- Kueue's own word for the current state, when it gave one. NULL is honest
+    -- ("Kueue offered no reason"), never a stand-in for a reason we lost.
+    reason        TEXT         NULL,
+    -- The observed Workload's object name, so an operator can go straight to
+    -- `kubectl -n djinn describe workload <name>`.
+    workload_name VARCHAR(253) NULL,
+    first_seen_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    observed_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    -- Observed state CHANGES since `first_seen_at`. A resync must not move this.
+    transitions   BIGINT       NOT NULL DEFAULT 0,
+    CONSTRAINT kueue_workload_admission_state_check CHECK (
+        admission IN ('pending', 'admitted', 'finished')
+    ),
+    CONSTRAINT kueue_workload_admission_transitions_nonneg CHECK (transitions >= 0),
+    CONSTRAINT kueue_workload_admission_observed_ordered CHECK (first_seen_at <= observed_at)
+);
+
+-- "What is queued right now" is the operator question this exists to answer.
+CREATE INDEX kueue_workload_admission_state_idx
+    ON kueue_workload_admission (admission, observed_at DESC);

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -133,6 +133,9 @@ pub use repositories::{
     invocation_lease_authority::{
         InvocationLeaseAuthorityRepository, InvocationLeaseAuthorityRow, InvocationLeaseMode,
     },
+    kueue_workload_admission::{
+        AdmissionApplied, KueueWorkloadAdmissionRecord, KueueWorkloadAdmissionRepository,
+    },
     legacy_settings_import::{
         LegacySettingsImport, LegacySettingsImportError, LegacySettingsImportResult,
     },

--- a/server/crates/djinn-db/src/repositories/kueue_workload_admission.rs
+++ b/server/crates/djinn-db/src/repositories/kueue_workload_admission.rs
@@ -1,0 +1,195 @@
+//! Durable projection of Kueue Workload admission state onto task-runs.
+//!
+//! Written by `djinn-server`'s `kueue_workload_reconcile` Workload reflector,
+//! which is the ONLY writer. See `migrations_postgres/165_kueue_workload_admission.sql`
+//! for why this is a projection and not an authority.
+//!
+//! # The one property worth stating twice
+//!
+//! [`KueueWorkloadAdmissionRepository::apply`] returns whether it CHANGED
+//! anything, and `transitions` counts changes rather than observations. A
+//! Kubernetes watch is not a stream of deltas: every reconnect replays the full
+//! current state of every object it is watching, so a projection that treated
+//! each observation as an event would count one admission dozens of times over a
+//! day of routine watch churn. The idempotence lives here, in SQL, rather than
+//! in the reflector's memory, so it survives a leader failover that empties that
+//! memory.
+
+use crate::database::Database;
+use crate::error::DbResult;
+
+/// Column tuple of the projection SELECTs, in declaration order.
+type AdmissionRow = (String, String, Option<String>, Option<String>, i64);
+
+/// One task-run's Kueue admission state, as the reflector last observed it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KueueWorkloadAdmissionRecord {
+    pub task_run_id: String,
+    /// `pending`, `admitted` or `finished`.
+    pub admission: String,
+    /// Kueue's own word for the state, when it gave one.
+    pub reason: Option<String>,
+    pub workload_name: Option<String>,
+    /// Observed state CHANGES since the row was created.
+    pub transitions: i64,
+}
+
+/// What one [`KueueWorkloadAdmissionRepository::apply`] call did.
+///
+/// The distinction is the whole contract: a caller cannot tell a real edge from
+/// a watch replay by inspecting the resulting row, because the resulting row is
+/// identical either way.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AdmissionApplied {
+    /// No row existed; the Workload is newly observed.
+    Recorded,
+    /// The row existed in a different state and moved. `transitions` advanced.
+    ///
+    /// `previous` is carried because the DIRECTION is what a caller acts on: a
+    /// move to `pending` from `admitted` is a quota eviction of a running build,
+    /// while a move to `pending` from nothing is a build that has simply been
+    /// queued. Collapsing them would make the reconciler interrupt task-runs
+    /// that were never admitted in the first place.
+    Transitioned { previous: String },
+    /// The row already held this state. Only `observed_at` moved.
+    Unchanged,
+}
+
+#[derive(Clone)]
+pub struct KueueWorkloadAdmissionRepository {
+    db: Database,
+}
+
+impl KueueWorkloadAdmissionRepository {
+    #[must_use]
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Record `admission` for `task_run_id`, reporting whether it was an edge.
+    ///
+    /// Idempotent on (task_run_id, admission): re-applying the same state
+    /// refreshes `observed_at` and returns [`AdmissionApplied::Unchanged`]
+    /// WITHOUT advancing `transitions`. That is what makes a watch resync free.
+    ///
+    /// The state is deliberately not forward-only. Kueue preempts admitted
+    /// Workloads for quota and re-admits them later, so 'admitted' → 'pending'
+    /// is a legal and load-bearing move; only a caller could know it was wrong,
+    /// and no caller does.
+    pub async fn apply(
+        &self,
+        task_run_id: &str,
+        admission: &str,
+        reason: Option<&str>,
+        workload_name: Option<&str>,
+    ) -> DbResult<AdmissionApplied> {
+        self.db.ensure_initialized().await?;
+        // The `prev` CTE reads the row as it stood BEFORE this statement (every
+        // CTE in one statement sees the same snapshot), which is the only way to
+        // answer "did this move?" — `RETURNING` can only see the new row, and a
+        // new row that already held this state is byte-identical to one that
+        // just reached it.
+        //
+        // `transitions` advances inside the same predicate, so the counter and
+        // the reported outcome can never disagree.
+        let previous: Option<String> = sqlx::query_scalar(
+            r#"WITH prev AS (
+                   SELECT admission FROM kueue_workload_admission WHERE task_run_id = $1
+               ), upsert AS (
+                   INSERT INTO kueue_workload_admission
+                       (task_run_id, admission, reason, workload_name)
+                   VALUES ($1, $2, $3, $4)
+                   ON CONFLICT (task_run_id) DO UPDATE
+                      SET admission     = EXCLUDED.admission,
+                          reason        = EXCLUDED.reason,
+                          workload_name = COALESCE(EXCLUDED.workload_name,
+                                                   kueue_workload_admission.workload_name),
+                          observed_at   = now(),
+                          transitions   = kueue_workload_admission.transitions
+                                        + CASE WHEN kueue_workload_admission.admission
+                                                    IS DISTINCT FROM EXCLUDED.admission
+                                               THEN 1 ELSE 0 END
+                   RETURNING task_run_id
+               )
+               SELECT (SELECT admission FROM prev) FROM upsert"#,
+        )
+        .bind(task_run_id)
+        .bind(admission)
+        .bind(reason)
+        .bind(workload_name)
+        .fetch_one(self.db.pool())
+        .await?;
+
+        Ok(match previous {
+            None => AdmissionApplied::Recorded,
+            Some(prev) if prev == admission => AdmissionApplied::Unchanged,
+            Some(previous) => AdmissionApplied::Transitioned { previous },
+        })
+    }
+
+    pub async fn get(&self, task_run_id: &str) -> DbResult<Option<KueueWorkloadAdmissionRecord>> {
+        self.db.ensure_initialized().await?;
+        let row: Option<AdmissionRow> = sqlx::query_as(
+            "SELECT task_run_id, admission, reason, workload_name, transitions
+             FROM kueue_workload_admission WHERE task_run_id = $1",
+        )
+        .bind(task_run_id)
+        .fetch_optional(self.db.pool())
+        .await?;
+        Ok(row.map(
+            |(task_run_id, admission, reason, workload_name, transitions)| {
+                KueueWorkloadAdmissionRecord {
+                    task_run_id,
+                    admission,
+                    reason,
+                    workload_name,
+                    transitions,
+                }
+            },
+        ))
+    }
+
+    /// Drop the projection for a task-run whose Workload is gone.
+    ///
+    /// Kueue garbage-collects a Workload with its owning Job, so a surviving row
+    /// would describe an object the cluster no longer has — the tombstone shape
+    /// that #2661 cost five hours of dispatch.
+    pub async fn forget(&self, task_run_id: &str) -> DbResult<()> {
+        self.db.ensure_initialized().await?;
+        sqlx::query("DELETE FROM kueue_workload_admission WHERE task_run_id = $1")
+            .bind(task_run_id)
+            .execute(self.db.pool())
+            .await?;
+        Ok(())
+    }
+
+    /// Task-runs currently waiting on Kueue quota, newest observation first.
+    ///
+    /// This is the operator answer to "why is the board sitting still" that the
+    /// deleted pre-create ledger threw away.
+    pub async fn pending(&self) -> DbResult<Vec<KueueWorkloadAdmissionRecord>> {
+        self.db.ensure_initialized().await?;
+        let rows: Vec<AdmissionRow> = sqlx::query_as(
+            "SELECT task_run_id, admission, reason, workload_name, transitions
+             FROM kueue_workload_admission
+             WHERE admission = 'pending'
+             ORDER BY observed_at DESC",
+        )
+        .fetch_all(self.db.pool())
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(
+                |(task_run_id, admission, reason, workload_name, transitions)| {
+                    KueueWorkloadAdmissionRecord {
+                        task_run_id,
+                        admission,
+                        reason,
+                        workload_name,
+                        transitions,
+                    }
+                },
+            )
+            .collect())
+    }
+}

--- a/server/crates/djinn-db/src/repositories/mod.rs
+++ b/server/crates/djinn-db/src/repositories/mod.rs
@@ -20,6 +20,7 @@ pub mod git_settings;
 pub mod image;
 pub mod init;
 pub mod invocation_lease_authority;
+pub mod kueue_workload_admission;
 pub mod legacy_settings_import;
 pub mod liveness;
 pub mod llm_call_attempt;

--- a/server/crates/djinn-k8s/Cargo.toml
+++ b/server/crates/djinn-k8s/Cargo.toml
@@ -20,6 +20,11 @@ djinn-workspace = { path = "../djinn-workspace" }
 anyhow = "1"
 async-trait = "0.1"
 bincode = "1.3"
+# Stream combinators for the Kueue Workload watch (`workload_inventory.rs`).
+# `kube::runtime::watcher` yields a `Stream`, and this is the crate that makes
+# it pollable — the same dependency `djinn-image-controller` carries for its
+# Job watcher.
+futures = "0.3"
 kube = { version = "0.95", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.23", features = ["v1_30"] }
 serde = { version = "1", features = ["derive"] }

--- a/server/crates/djinn-k8s/src/workload_inventory.rs
+++ b/server/crates/djinn-k8s/src/workload_inventory.rs
@@ -261,6 +261,520 @@ pub fn has_canonical_warm_signature(r: &WorkloadRecord) -> bool {
             .any(|c| c.contains(crate::warm_job::WARM_COMMAND_BIN) && c.contains("warm-graph"))
 }
 
+// =============================================================================
+// Kueue Workload observation (cutover slice S5, task kh7g)
+// =============================================================================
+//
+// Everything above answers "does this object still exist?" by polling. What
+// follows answers a different question — "has Kueue admitted this build, and is
+// it still admitted?" — and answers it by WATCHING, because the two failure
+// modes are not the same shape.
+//
+// A Workload's admission state is edge-triggered and reversible: Kueue admits,
+// then preempts for quota, then re-admits, and every one of those edges matters
+// to the run sitting behind it. A poll on any cadence silently collapses an
+// admit/evict/admit sequence into whatever the last sample happened to see. The
+// watch preserves the edges; the reconciler on the other end is what makes them
+// idempotent.
+//
+// # Why a hand-rolled resource type instead of the Kueue crate
+//
+// Nothing here depends on Kueue's Go types, its CRD schema version beyond the
+// group/version below, or on Kueue being installed at all. The struct models
+// only `metadata` plus the `status.conditions` this repository reads; every
+// other field the API server sends is ignored by serde. That is deliberate:
+// `kueue.armed` defaults false and no namespace carries
+// `djinn.io/kueue-managed`, so the production cluster today has NO Kueue CRDs
+// and NO Workload objects. A type that deserialised the full Kueue schema would
+// have to track their API revisions for a payload this process never reads.
+//
+// # Behaviour on a cluster with no Kueue installed
+//
+// [`KubeWorkloadWatch::run_session`] returns `Err` — the API server answers
+// `404 NotFound` for an unregistered resource — and the caller backs off and
+// retries. It never panics, never blocks another subsystem, and never mutates
+// anything, because no observation is ever produced. That is the CURRENT
+// production shape, which is why the reconciler's spawn site refuses to start
+// this watch at all unless Kueue is armed.
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+/// Re-exported because `djinn-server` reads Workload identity but does not
+/// depend on `k8s-openapi`: the owner link is half of how a Workload is resolved
+/// to a task-run, so a consumer that cannot name this type cannot exercise that
+/// half at all.
+pub use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+use kube::runtime::watcher;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+/// API group Kueue serves its `Workload` resource under.
+pub const KUEUE_GROUP: &str = "kueue.x-k8s.io";
+/// API version pinned by `deploy/helm/djinn/templates/kueue-topology.yaml`.
+pub const KUEUE_WORKLOAD_VERSION: &str = "v1beta1";
+/// Kueue's per-Job accounting object.
+pub const KUEUE_WORKLOAD_KIND: &str = "Workload";
+/// Plural, as it appears in the resource path.
+pub const KUEUE_WORKLOAD_PLURAL: &str = "workloads";
+
+/// Condition type Kueue sets once a Workload holds admitted quota.
+pub const CONDITION_ADMITTED: &str = "Admitted";
+/// Condition type Kueue sets when it takes admitted quota BACK — preemption,
+/// a stopped ClusterQueue, a failed admission check, deactivation.
+pub const CONDITION_EVICTED: &str = "Evicted";
+/// Condition type Kueue sets when the underlying Job reached a terminal state.
+pub const CONDITION_FINISHED: &str = "Finished";
+
+/// The minimal projection of a Kueue `Workload` this process reads.
+///
+/// Unknown fields (`spec`, `status.admission`, `status.requeueState`, …) are
+/// dropped by serde rather than modelled: see the module section above.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct KueueWorkload {
+    #[serde(default)]
+    pub metadata: ObjectMeta,
+    #[serde(default)]
+    pub status: KueueWorkloadStatus,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KueueWorkloadStatus {
+    #[serde(default)]
+    pub conditions: Vec<KueueWorkloadCondition>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KueueWorkloadCondition {
+    #[serde(rename = "type")]
+    pub condition_type: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl kube::Resource for KueueWorkload {
+    type DynamicType = ();
+    type Scope = kube::core::NamespaceResourceScope;
+
+    fn kind(_: &()) -> Cow<'_, str> {
+        Cow::Borrowed(KUEUE_WORKLOAD_KIND)
+    }
+    fn group(_: &()) -> Cow<'_, str> {
+        Cow::Borrowed(KUEUE_GROUP)
+    }
+    fn version(_: &()) -> Cow<'_, str> {
+        Cow::Borrowed(KUEUE_WORKLOAD_VERSION)
+    }
+    fn plural(_: &()) -> Cow<'_, str> {
+        Cow::Borrowed(KUEUE_WORKLOAD_PLURAL)
+    }
+    fn meta(&self) -> &ObjectMeta {
+        &self.metadata
+    }
+    fn meta_mut(&mut self) -> &mut ObjectMeta {
+        &mut self.metadata
+    }
+}
+
+/// Where one Workload sits in Kueue's admission lifecycle, reduced to the three
+/// answers the coordinator can act on.
+///
+/// `Pending` and `Admitted` are REVERSIBLE and the reconciler must be able to
+/// move between them in both directions: a preemption is a live Workload
+/// returning to the queue, not a terminal event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkloadAdmission {
+    /// Kueue has not (or no longer) granted this Workload quota. `reason`
+    /// carries Kueue's own word for it when there is one — `Preempted`,
+    /// `ClusterQueueStopped`, `Deactivated` — and `None` when the Workload has
+    /// simply not been looked at yet.
+    Pending { reason: Option<String> },
+    /// Kueue admitted the Workload; the Job is unsuspended and its Pod may run.
+    Admitted,
+    /// The Job behind this Workload reached a terminal state. Terminal, and
+    /// deliberately NOT folded into `Pending`: a finished build must never be
+    /// mistaken for one waiting on quota.
+    Finished { reason: Option<String> },
+}
+
+impl WorkloadAdmission {
+    /// Rendered form, used as the durable projection's state column.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending { .. } => "pending",
+            Self::Admitted => "admitted",
+            Self::Finished { .. } => "finished",
+        }
+    }
+
+    /// Kueue's own explanation, when it gave one.
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Pending { reason } | Self::Finished { reason } => reason.as_deref(),
+            Self::Admitted => None,
+        }
+    }
+
+    /// True while the build behind this Workload is waiting on quota.
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending { .. })
+    }
+}
+
+fn condition<'a>(w: &'a KueueWorkload, kind: &str) -> Option<&'a KueueWorkloadCondition> {
+    w.status
+        .conditions
+        .iter()
+        .find(|c| c.condition_type == kind && c.status.eq_ignore_ascii_case("True"))
+}
+
+/// Reduce a Workload's conditions to one admission answer.
+///
+/// # Precedence, and why `Evicted` outranks `Admitted`
+///
+/// Kueue does not clear `Admitted=True` at the instant it evicts: an evicted
+/// Workload is observable carrying BOTH conditions true while the Job is being
+/// re-suspended. Reading `Admitted` first would therefore report a preempted
+/// build as still running, which is precisely the direction that must never be
+/// wrong — an over-reported admission strands a run nothing will ever finish,
+/// while an over-reported pending merely re-observes on the next event.
+pub fn classify_workload_admission(w: &KueueWorkload) -> WorkloadAdmission {
+    if let Some(finished) = condition(w, CONDITION_FINISHED) {
+        return WorkloadAdmission::Finished {
+            reason: finished.reason.clone(),
+        };
+    }
+    if let Some(evicted) = condition(w, CONDITION_EVICTED) {
+        return WorkloadAdmission::Pending {
+            reason: evicted.reason.clone(),
+        };
+    }
+    if condition(w, CONDITION_ADMITTED).is_some() {
+        return WorkloadAdmission::Admitted;
+    }
+    WorkloadAdmission::Pending {
+        reason: w
+            .status
+            .conditions
+            .iter()
+            .find(|c| c.condition_type == CONDITION_ADMITTED)
+            .and_then(|c| c.reason.clone()),
+    }
+}
+
+/// Resolve the task-run this Workload accounts for, or `None` when it accounts
+/// for something else (a warm Job, a SCIP Job, another tenant's workload).
+///
+/// Two sources, in order, because neither alone is sufficient:
+///
+/// 1. `djinn.app/task-run-id` on the Workload itself. Kueue propagates the
+///    parent Job's labels onto the Workload it derives, so this is present for
+///    a task-run Job rendered by `job_labels()`.
+/// 2. the `djinn-taskrun-<uuid>` name of the owning Job. Kueue owner-links every
+///    Workload to the object it accounts for, and that link survives label
+///    propagation changing between Kueue releases.
+///
+/// A Workload that answers neither is NOT ours and the caller must leave every
+/// task-run untouched.
+pub fn workload_task_run_id(w: &KueueWorkload) -> Option<String> {
+    if let Some(raw) = w
+        .metadata
+        .labels
+        .as_ref()
+        .and_then(|l| l.get(crate::job::LABEL_TASK_RUN_ID))
+        && uuid::Uuid::parse_str(raw).is_ok()
+    {
+        return Some(raw.clone());
+    }
+    w.metadata
+        .owner_references
+        .as_ref()?
+        .iter()
+        .filter(|o| o.kind == "Job")
+        .find_map(|o| crate::job::task_run_id_from_job_name(&o.name))
+}
+
+/// One observation handed to the reconciler.
+#[derive(Clone, Debug, PartialEq)]
+pub enum WorkloadObservation {
+    /// A fresh list/watch session has begun; everything that follows until the
+    /// next `SessionRestarted` is a replay of current cluster state.
+    ///
+    /// The reconciler needs this edge to distinguish "Kueue changed something"
+    /// from "we reconnected and are being told the same thing again".
+    SessionRestarted,
+    /// The Workload exists with this state.
+    Applied(KueueWorkload),
+    /// The Workload is gone. Kueue garbage-collects a Workload with its owning
+    /// Job, so this is a lifecycle end, not an eviction.
+    Deleted(KueueWorkload),
+}
+
+/// The watch seam. Production watches a real API server; tests drive a scripted
+/// stream through the same reconciler.
+#[async_trait]
+pub trait WorkloadWatch: Send + Sync + 'static {
+    /// Run ONE watch session, pumping observations into `tx` until the session
+    /// ends.
+    ///
+    /// `Ok(())` means the stream ended cleanly, `Err` that it broke. The caller
+    /// re-opens either way — the distinction exists so a broken session can be
+    /// logged and backed off differently from an orderly close, not so one of
+    /// them can be treated as terminal.
+    async fn run_session(
+        &self,
+        tx: tokio::sync::mpsc::Sender<WorkloadObservation>,
+    ) -> Result<(), String>;
+}
+
+/// The production watch: `kube`'s reflector-grade `watcher` over namespaced
+/// Kueue Workloads, filtered to djinn's own build objects.
+pub struct KubeWorkloadWatch {
+    client: crate::KubeClient,
+    namespace: String,
+}
+
+impl KubeWorkloadWatch {
+    pub fn new(client: crate::KubeClient, namespace: impl Into<String>) -> Self {
+        Self {
+            client,
+            namespace: namespace.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl WorkloadWatch for KubeWorkloadWatch {
+    async fn run_session(
+        &self,
+        tx: tokio::sync::mpsc::Sender<WorkloadObservation>,
+    ) -> Result<(), String> {
+        use futures::StreamExt;
+
+        let api: kube::Api<KueueWorkload> =
+            kube::Api::namespaced(self.client.clone(), &self.namespace);
+        // Kueue derives one Workload per captured Job and copies the Job's
+        // labels onto it, so the same marker that selects djinn's build objects
+        // selects their Workloads. Without it this watch would also stream every
+        // other tenant's Workloads in the namespace.
+        let config = watcher::Config::default()
+            .labels(&format!("{}=true", crate::config::LABEL_KUEUE_BUILD_OBJECT));
+        let mut stream = watcher::watcher(api, config).boxed();
+
+        while let Some(event) = stream.next().await {
+            let observation = match event {
+                Ok(watcher::Event::Init) => WorkloadObservation::SessionRestarted,
+                Ok(watcher::Event::Apply(w) | watcher::Event::InitApply(w)) => {
+                    WorkloadObservation::Applied(w)
+                }
+                Ok(watcher::Event::Delete(w)) => WorkloadObservation::Deleted(w),
+                Ok(watcher::Event::InitDone) => continue,
+                Err(e) => return Err(e.to_string()),
+            };
+            if tx.send(observation).await.is_err() {
+                // The reconciler is gone (leadership released). Ending the
+                // session here is what lets this task be dropped instead of
+                // holding a live watch against the API server forever.
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod kueue_workload_tests {
+    use super::*;
+
+    fn condition(kind: &str, status: &str, reason: Option<&str>) -> KueueWorkloadCondition {
+        KueueWorkloadCondition {
+            condition_type: kind.to_owned(),
+            status: status.to_owned(),
+            reason: reason.map(ToOwned::to_owned),
+            message: None,
+        }
+    }
+
+    fn workload(conditions: Vec<KueueWorkloadCondition>) -> KueueWorkload {
+        KueueWorkload {
+            metadata: ObjectMeta::default(),
+            status: KueueWorkloadStatus { conditions },
+        }
+    }
+
+    #[test]
+    fn a_workload_with_no_conditions_is_pending() {
+        assert_eq!(
+            classify_workload_admission(&workload(vec![])),
+            WorkloadAdmission::Pending { reason: None }
+        );
+    }
+
+    #[test]
+    fn an_admitted_condition_reads_as_admitted() {
+        assert_eq!(
+            classify_workload_admission(&workload(vec![condition(
+                CONDITION_ADMITTED,
+                "True",
+                None
+            )])),
+            WorkloadAdmission::Admitted
+        );
+    }
+
+    /// `Admitted=False` is not admission. A classifier that looked only at the
+    /// condition's PRESENCE would report every queued Workload as admitted.
+    #[test]
+    fn an_admitted_condition_that_is_false_is_still_pending() {
+        assert_eq!(
+            classify_workload_admission(&workload(vec![condition(
+                CONDITION_ADMITTED,
+                "False",
+                Some("NoReservation")
+            )])),
+            WorkloadAdmission::Pending {
+                reason: Some("NoReservation".to_owned())
+            }
+        );
+    }
+
+    /// The precedence that actually matters: Kueue leaves `Admitted=True` in
+    /// place while it evicts, so an evicted Workload is observable carrying
+    /// both. Reading `Admitted` first would report a preempted build as running.
+    #[test]
+    fn eviction_outranks_a_stale_admitted_condition() {
+        assert_eq!(
+            classify_workload_admission(&workload(vec![
+                condition(CONDITION_ADMITTED, "True", None),
+                condition(CONDITION_EVICTED, "True", Some("Preempted")),
+            ])),
+            WorkloadAdmission::Pending {
+                reason: Some("Preempted".to_owned())
+            }
+        );
+    }
+
+    /// A finished build must never be mistaken for one waiting on quota — that
+    /// would leave the projection reporting queue pressure that does not exist.
+    #[test]
+    fn a_finished_workload_is_terminal_not_pending() {
+        let admission = classify_workload_admission(&workload(vec![
+            condition(CONDITION_ADMITTED, "True", None),
+            condition(CONDITION_EVICTED, "True", Some("Preempted")),
+            condition(CONDITION_FINISHED, "True", Some("JobFinished")),
+        ]));
+        assert_eq!(
+            admission,
+            WorkloadAdmission::Finished {
+                reason: Some("JobFinished".to_owned())
+            }
+        );
+        assert!(!admission.is_pending());
+    }
+
+    #[test]
+    fn the_task_run_label_identifies_the_run() {
+        let id = uuid::Uuid::now_v7().to_string();
+        let mut w = workload(vec![]);
+        w.metadata.labels = Some(BTreeMap::from([(
+            crate::job::LABEL_TASK_RUN_ID.to_owned(),
+            id.clone(),
+        )]));
+        assert_eq!(workload_task_run_id(&w), Some(id));
+    }
+
+    #[test]
+    fn the_owning_job_name_identifies_the_run_when_the_label_is_absent() {
+        let id = uuid::Uuid::now_v7().to_string();
+        let mut w = workload(vec![]);
+        w.metadata.owner_references = Some(vec![
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
+                kind: "Job".to_owned(),
+                name: format!("djinn-taskrun-{id}"),
+                ..Default::default()
+            },
+        ]);
+        assert_eq!(workload_task_run_id(&w), Some(id));
+    }
+
+    /// A warm Job's Workload carries the same build-object label and reaches
+    /// the same watch. It is not a task-run and must resolve to nothing.
+    #[test]
+    fn a_workload_that_is_not_a_task_run_resolves_to_nothing() {
+        let mut w = workload(vec![]);
+        w.metadata.labels = Some(BTreeMap::from([(
+            crate::config::LABEL_KUEUE_BUILD_OBJECT.to_owned(),
+            "true".to_owned(),
+        )]));
+        w.metadata.owner_references = Some(vec![
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
+                kind: "Job".to_owned(),
+                name: "djinn-warm-someproject-7".to_owned(),
+                ..Default::default()
+            },
+        ]);
+        assert_eq!(workload_task_run_id(&w), None);
+    }
+
+    /// A malformed label must not be believed just because it is present: the
+    /// fallback to the owning Job name is what makes the resolution honest.
+    #[test]
+    fn a_malformed_label_falls_through_to_the_owner_reference() {
+        let id = uuid::Uuid::now_v7().to_string();
+        let mut w = workload(vec![]);
+        w.metadata.labels = Some(BTreeMap::from([(
+            crate::job::LABEL_TASK_RUN_ID.to_owned(),
+            "not-a-uuid".to_owned(),
+        )]));
+        w.metadata.owner_references = Some(vec![
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
+                kind: "Job".to_owned(),
+                name: format!("djinn-taskrun-{id}"),
+                ..Default::default()
+            },
+        ]);
+        assert_eq!(workload_task_run_id(&w), Some(id));
+    }
+
+    /// The resource coordinates are the whole contract with the API server. A
+    /// typo here is a permanent `404` that reads as "Kueue is not installed".
+    #[test]
+    fn the_resource_coordinates_address_kueue_workloads() {
+        use kube::Resource;
+        assert_eq!(KueueWorkload::group(&()), "kueue.x-k8s.io");
+        assert_eq!(KueueWorkload::version(&()), "v1beta1");
+        assert_eq!(KueueWorkload::kind(&()), "Workload");
+        assert_eq!(KueueWorkload::plural(&()), "workloads");
+        assert_eq!(KueueWorkload::api_version(&()), "kueue.x-k8s.io/v1beta1");
+    }
+
+    /// Kueue sends far more than this type models. Unknown fields must be
+    /// dropped rather than failing the whole watch session.
+    #[test]
+    fn unmodelled_fields_do_not_break_deserialisation() {
+        let raw = serde_json::json!({
+            "apiVersion": "kueue.x-k8s.io/v1beta1",
+            "kind": "Workload",
+            "metadata": {"name": "job-djinn-taskrun-x-abcde", "namespace": "djinn"},
+            "spec": {"queueName": "djinn-task-run", "podSets": [{"count": 1, "name": "main"}]},
+            "status": {
+                "admission": {"clusterQueue": "djinn-build"},
+                "conditions": [
+                    {"type": "Admitted", "status": "True", "reason": "Admitted",
+                     "message": "The workload is admitted", "lastTransitionTime": "2026-07-30T00:00:00Z"}
+                ]
+            }
+        });
+        let parsed: KueueWorkload =
+            serde_json::from_value(raw).expect("must tolerate extra fields");
+        assert_eq!(
+            classify_workload_admission(&parsed),
+            WorkloadAdmission::Admitted
+        );
+    }
+}
+
 #[cfg(test)]
 mod call_timeout_tests {
     use super::*;

--- a/server/src/kueue_workload_reconcile.rs
+++ b/server/src/kueue_workload_reconcile.rs
@@ -1,0 +1,1092 @@
+//! Kueue Workload reconciliation — the leader-only reflector that maps Kueue's
+//! admission decisions onto task-run state.
+//!
+//! This occupies the seam vacated by `build_admission_reconcile.rs`, and the
+//! swap is not like-for-like. That module POLLED a Postgres ledger djinn wrote
+//! itself, on a 120s timer, to retire rows whose Kubernetes objects had
+//! vanished. Kueue's ClusterQueue is the capacity authority now, so there is no
+//! ledger to retire — there is an external decision-maker whose decisions this
+//! process needs to hear about.
+//!
+//! # Why a watch and not a poll
+//!
+//! Admission is edge-triggered and REVERSIBLE. Kueue admits a Workload, preempts
+//! it for quota, and admits it again; each of those edges changes what the run
+//! behind it is doing. A poll on any cadence collapses an admit/evict/admit
+//! sequence into whichever sample it happened to take, and the edge it drops —
+//! the eviction — is the one that leaves a task-run live in the database with no
+//! Pod behind it.
+//!
+//! Modelled on `djinn-image-controller/src/watcher.rs`, the repository's only
+//! real `kube::runtime::watcher` loop. Deliberately NOT modelled on
+//! `djinn-k8s/src/runtime.rs`'s `watch_infra_death`, which despite the name is a
+//! GET loop on a timer.
+//!
+//! # What it does on a cluster with no Kueue installed
+//!
+//! Nothing, and it says so once.
+//!
+//! [`spawn`] refuses to open a watch unless three things hold: the runtime is
+//! Kubernetes, `KubernetesConfig::kueue_armed` is true, and a client can be
+//! built. `kueue.armed` defaults false, no namespace carries
+//! `djinn.io/kueue-managed`, and therefore production today has no Kueue CRDs and
+//! no Workload objects at all. On that cluster this module logs one line at
+//! startup and spawns no watch, no timer and no task.
+//!
+//! That is a deliberate gate on the WIRING rather than on the ACTION, with one
+//! specific justification: an armed watch against a cluster whose `Workload`
+//! resource is unregistered gets `404 NotFound` from the API server on every
+//! reconnect, forever. Backing that off is correct but it is still a permanent
+//! error loop over a resource that will never appear, and a permanent error loop
+//! is how a real signal gets filtered out. If Kueue IS armed and the CRDs are
+//! missing, the loop runs, backs off, and complains — because then the CRDs
+//! being missing is a genuine outage.
+//!
+//! # Lifecycle: the reflector holds a `Weak`, never an `Arc`
+//!
+//! A detached loop that holds a strong `Arc` to shared state keeps that state
+//! alive past the shutdown that was supposed to drop it. This repository has
+//! already paid for that once: `RpcServices` owns the worker's single outbound
+//! frame `Sender`, orderly shutdown blocks until the last clone is gone, and one
+//! strong clone parked in a background sweep wedged the worker's exit for 30
+//! seconds (see `djinn-agent/src/context.rs:152`).
+//!
+//! So the split here is:
+//!
+//! * the SUPERVISOR task owns the one strong [`Arc<Reconciler>`]. It does
+//!   nothing but wait for the leader's cancellation token and then drop it. That
+//!   drop is the leadership lease being released.
+//! * the REFLECTOR task owns only a [`Weak<Reconciler>`]. It upgrades per
+//!   observation and releases the strong handle before it goes back to waiting,
+//!   so it never holds one across an await. When the supervisor's drop makes the
+//!   upgrade fail, the reflector returns [`ReflectorExit::LeadershipReleased`]
+//!   and its task is dropped.
+//!
+//! Two independent stop signals — the token and the dead `Weak` — is deliberate.
+//! A cancellation that is somehow never observed still stops the reflector,
+//! because the state it needs is gone.
+
+use std::sync::Arc;
+use std::sync::Weak;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use djinn_agent::runtime_bridge::{RuntimeKind, runtime_kind};
+use djinn_core::models::TaskRunStatus;
+use djinn_db::repositories::task_run::{TaskRunRepository, TerminalStatusAcceptance};
+use djinn_db::{AdmissionApplied, Database, KueueWorkloadAdmissionRepository};
+use djinn_k8s::workload_inventory::{
+    KubeWorkloadWatch, WorkloadAdmission, WorkloadObservation, WorkloadWatch,
+    classify_workload_admission, workload_task_run_id,
+};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::server::AppState;
+
+/// How long to wait before re-opening a watch session that ended or broke.
+///
+/// Matches `djinn-image-controller`'s `POST_ERROR_SLEEP`. Short enough that a
+/// routine API-server rollout costs one reconnect, long enough that an
+/// unregistered CRD does not become a hot loop.
+const RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Depth of the channel between one watch session and the reconciler.
+///
+/// Bounded on purpose: a slow sink must apply backpressure to the watch rather
+/// than buffering an unbounded replay in memory. `kube`'s watcher handles being
+/// polled slowly; it cannot handle this process running out of memory.
+const OBSERVATION_BUFFER: usize = 64;
+
+// =============================================================================
+// The sink
+// =============================================================================
+
+/// What one applied observation did to durable state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SinkOutcome {
+    /// The projection moved. This is the only outcome that counts as a
+    /// transition.
+    Transitioned {
+        previous: Option<String>,
+        interrupted_run: bool,
+    },
+    /// The projection already held this state — a watch replay, or a Workload
+    /// update that touched something this process does not read.
+    Unchanged,
+}
+
+/// Where Workload admission state lands.
+///
+/// A trait so the reflector's lifecycle can be exercised without a database.
+/// It is NOT a seam for the state tests: acceptance of "admitted drives the run
+/// out of pending" is asserted against [`DurableAdmissionSink`] and a real
+/// database, because a fake sink can only prove the reflector called something.
+#[async_trait::async_trait]
+pub trait TaskRunAdmissionSink: Send + Sync + 'static {
+    async fn apply(
+        &self,
+        task_run_id: &str,
+        admission: &WorkloadAdmission,
+        workload_name: Option<&str>,
+    ) -> Result<SinkOutcome, String>;
+
+    /// The Workload is gone. Kueue garbage-collects it with its owning Job, so
+    /// this is a lifecycle end and the projection row must go with it.
+    async fn forget(&self, task_run_id: &str) -> Result<(), String>;
+}
+
+/// The production sink: the durable projection, plus the one action a Kueue
+/// decision demands of djinn.
+pub struct DurableAdmissionSink {
+    admissions: KueueWorkloadAdmissionRepository,
+    task_runs: TaskRunRepository,
+}
+
+impl DurableAdmissionSink {
+    #[must_use]
+    pub fn new(db: Database) -> Self {
+        Self {
+            admissions: KueueWorkloadAdmissionRepository::new(db.clone()),
+            task_runs: TaskRunRepository::new(db),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskRunAdmissionSink for DurableAdmissionSink {
+    async fn apply(
+        &self,
+        task_run_id: &str,
+        admission: &WorkloadAdmission,
+        workload_name: Option<&str>,
+    ) -> Result<SinkOutcome, String> {
+        let applied = self
+            .admissions
+            .apply(
+                task_run_id,
+                admission.as_str(),
+                admission.reason(),
+                workload_name,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let previous = match applied {
+            AdmissionApplied::Unchanged => return Ok(SinkOutcome::Unchanged),
+            AdmissionApplied::Recorded => None,
+            AdmissionApplied::Transitioned { previous } => Some(previous),
+        };
+
+        // A quota eviction of an ADMITTED Workload is the one edge that has to
+        // reach beyond the projection. Kueue re-suspends the Job and deletes its
+        // Pod; the `task_runs` row the in-pod supervisor created stays `running`
+        // with nothing behind it, and nothing else in the process will notice
+        // for the length of the generic stall reaper's window. Terminalising it
+        // as `Interrupted` is what returns the task to the dispatchable
+        // population — and `Interrupted` specifically, because this is
+        // infrastructure taking the pod away, not the attempt failing.
+        //
+        // Gated on the DIRECTION, not on the destination. A Workload that has
+        // only ever been queued has no run to interrupt, and interrupting on
+        // every `pending` observation would kill runs that were never admitted.
+        let eviction = admission.is_pending() && previous.as_deref() == Some("admitted");
+        let mut interrupted_run = false;
+        if eviction {
+            match self
+                .task_runs
+                .accept_terminal_status(task_run_id, TaskRunStatus::Interrupted)
+                .await
+            {
+                Ok(TerminalStatusAcceptance::Accepted) => {
+                    interrupted_run = true;
+                    tracing::warn!(
+                        task_run_id,
+                        reason = admission.reason().unwrap_or("unspecified"),
+                        "kueue_workload_reconcile: admitted Workload evicted; the live task-run \
+                         was interrupted so its task returns to the dispatchable pool"
+                    );
+                }
+                // No live row: the Workload was evicted before the pod ever
+                // created one, or the run already finished. Both are normal and
+                // neither is an error.
+                Ok(other) => {
+                    tracing::info!(
+                        task_run_id,
+                        acceptance = ?other,
+                        "kueue_workload_reconcile: Workload evicted with no live task-run to \
+                         interrupt"
+                    );
+                }
+                Err(e) => {
+                    return Err(format!("interrupting evicted task-run {task_run_id}: {e}"));
+                }
+            }
+        }
+
+        Ok(SinkOutcome::Transitioned {
+            previous,
+            interrupted_run,
+        })
+    }
+
+    async fn forget(&self, task_run_id: &str) -> Result<(), String> {
+        self.admissions
+            .forget(task_run_id)
+            .await
+            .map_err(|e| e.to_string())
+    }
+}
+
+// =============================================================================
+// The reconciler
+// =============================================================================
+
+/// The leadership-scoped state the reflector operates on.
+///
+/// Held strongly by exactly one place — the supervisor task in [`spawn`] — so
+/// that dropping it is an unambiguous "this process is no longer the leader".
+pub struct Reconciler {
+    sink: Arc<dyn TaskRunAdmissionSink>,
+    /// Observed state CHANGES applied. Never advanced by a replay.
+    transitions: AtomicU64,
+    /// Observations handled, replays included.
+    observations: AtomicU64,
+    /// Workloads that resolved to no task-run and were left alone.
+    ignored: AtomicU64,
+    /// Watch sessions (re)established.
+    sessions: AtomicU64,
+}
+
+impl Reconciler {
+    #[must_use]
+    pub fn new(sink: Arc<dyn TaskRunAdmissionSink>) -> Self {
+        Self {
+            sink,
+            transitions: AtomicU64::new(0),
+            observations: AtomicU64::new(0),
+            ignored: AtomicU64::new(0),
+            sessions: AtomicU64::new(0),
+        }
+    }
+
+    /// Durable state changes applied since this reconciler was created.
+    #[must_use]
+    pub fn transitions(&self) -> u64 {
+        self.transitions.load(Ordering::SeqCst)
+    }
+
+    #[must_use]
+    pub fn observations(&self) -> u64 {
+        self.observations.load(Ordering::SeqCst)
+    }
+
+    #[must_use]
+    pub fn ignored(&self) -> u64 {
+        self.ignored.load(Ordering::SeqCst)
+    }
+
+    #[must_use]
+    pub fn sessions(&self) -> u64 {
+        self.sessions.load(Ordering::SeqCst)
+    }
+
+    /// Apply one observation.
+    ///
+    /// Never returns an error: a Workload this process cannot act on must not be
+    /// able to end the watch. Failures are logged and the stream continues.
+    pub async fn handle(&self, observation: WorkloadObservation) {
+        self.observations.fetch_add(1, Ordering::SeqCst);
+        match observation {
+            WorkloadObservation::SessionRestarted => {
+                self.sessions.fetch_add(1, Ordering::SeqCst);
+                tracing::debug!(
+                    "kueue_workload_reconcile: watch session established; replaying current state"
+                );
+            }
+            WorkloadObservation::Applied(workload) => {
+                // A Workload that is not ours resolves to nothing and MUST leave
+                // every task-run untouched. Warm Jobs and SCIP Jobs carry the
+                // same build-object label and reach this same stream.
+                let Some(task_run_id) = workload_task_run_id(&workload) else {
+                    self.ignored.fetch_add(1, Ordering::SeqCst);
+                    tracing::debug!(
+                        workload = workload.metadata.name.as_deref().unwrap_or("<unnamed>"),
+                        "kueue_workload_reconcile: Workload resolves to no task-run; ignored"
+                    );
+                    return;
+                };
+                let admission = classify_workload_admission(&workload);
+                let name = workload.metadata.name.clone();
+                match self
+                    .sink
+                    .apply(&task_run_id, &admission, name.as_deref())
+                    .await
+                {
+                    Ok(SinkOutcome::Transitioned {
+                        previous,
+                        interrupted_run,
+                    }) => {
+                        self.transitions.fetch_add(1, Ordering::SeqCst);
+                        tracing::info!(
+                            task_run_id,
+                            previous = previous.as_deref().unwrap_or("<new>"),
+                            admission = admission.as_str(),
+                            reason = admission.reason().unwrap_or("unspecified"),
+                            interrupted_run,
+                            "kueue_workload_reconcile: task-run admission state moved"
+                        );
+                    }
+                    Ok(SinkOutcome::Unchanged) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            task_run_id,
+                            %error,
+                            "kueue_workload_reconcile: failed to apply Workload admission state; \
+                             the next observation retries"
+                        );
+                    }
+                }
+            }
+            WorkloadObservation::Deleted(workload) => {
+                let Some(task_run_id) = workload_task_run_id(&workload) else {
+                    self.ignored.fetch_add(1, Ordering::SeqCst);
+                    return;
+                };
+                if let Err(error) = self.sink.forget(&task_run_id).await {
+                    tracing::warn!(
+                        task_run_id,
+                        %error,
+                        "kueue_workload_reconcile: failed to drop the projection for a deleted \
+                         Workload"
+                    );
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// The reflector
+// =============================================================================
+
+/// Why the reflector stopped. Both variants are ordinary; neither is a fault.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReflectorExit {
+    /// The leader's cancellation token fired.
+    Cancelled,
+    /// Every strong handle to the [`Reconciler`] is gone — leadership released.
+    LeadershipReleased,
+}
+
+/// Watch Kueue Workloads until leadership ends, re-establishing the session
+/// whenever it drops.
+///
+/// `reconciler` is a [`Weak`] BY CONTRACT, not by convenience. See the module
+/// docs: a strong handle parked here would keep leadership state alive across
+/// shutdown, and a "did the loop stop?" assertion against a strong reference
+/// passes whether or not that happened.
+pub(crate) async fn run_reflector(
+    reconciler: Weak<Reconciler>,
+    watch: Arc<dyn WorkloadWatch>,
+    cancel: CancellationToken,
+    backoff: Duration,
+) -> ReflectorExit {
+    loop {
+        if cancel.is_cancelled() {
+            return ReflectorExit::Cancelled;
+        }
+        if reconciler.upgrade().is_none() {
+            return ReflectorExit::LeadershipReleased;
+        }
+
+        let (tx, mut rx) = mpsc::channel(OBSERVATION_BUFFER);
+        let session_watch = Arc::clone(&watch);
+        let session = tokio::spawn(async move { session_watch.run_session(tx).await });
+
+        let exit = loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    session.abort();
+                    return ReflectorExit::Cancelled;
+                }
+                observation = rx.recv() => {
+                    let Some(observation) = observation else { break None };
+                    // Upgrade per observation and release before going back to
+                    // waiting: a strong handle must never be held across the
+                    // `recv()` await.
+                    let Some(state) = reconciler.upgrade() else {
+                        session.abort();
+                        break Some(ReflectorExit::LeadershipReleased);
+                    };
+                    state.handle(observation).await;
+                    drop(state);
+                }
+            }
+        };
+        if let Some(exit) = exit {
+            return exit;
+        }
+
+        match session.await {
+            Ok(Ok(())) => {
+                tracing::debug!("kueue_workload_reconcile: watch session ended; re-establishing")
+            }
+            Ok(Err(error)) => tracing::warn!(
+                %error,
+                "kueue_workload_reconcile: watch session failed; re-establishing after backoff. \
+                 A persistent 404 here means Kueue's Workload CRD is not registered in this \
+                 cluster while djinn is armed for it."
+            ),
+            Err(join_error) if join_error.is_cancelled() => {}
+            Err(join_error) => tracing::error!(
+                error = %join_error,
+                "kueue_workload_reconcile: watch session task died; re-establishing after backoff"
+            ),
+        }
+
+        tokio::select! {
+            () = cancel.cancelled() => return ReflectorExit::Cancelled,
+            () = tokio::time::sleep(backoff) => {}
+        }
+    }
+}
+
+// =============================================================================
+// Registration
+// =============================================================================
+
+/// Build the production watch, or explain why there is nothing to watch.
+///
+/// Returns `None` on every configuration where opening a watch would be wrong,
+/// and says which one it was — a silent `None` here is indistinguishable from a
+/// broken reconciler.
+async fn production_watch() -> Option<Arc<dyn WorkloadWatch>> {
+    if !matches!(runtime_kind(), RuntimeKind::Kubernetes) {
+        tracing::debug!(
+            "kueue_workload_reconcile: DJINN_RUNTIME is not kubernetes; no Workloads exist"
+        );
+        return None;
+    }
+    let config = djinn_k8s::KubernetesConfig::from_env();
+    if !config.kueue_armed {
+        tracing::info!(
+            "kueue_workload_reconcile: Kueue is not armed (DJINN_KUEUE_ARMED unset/false), so no \
+             Job is captured and no Workload exists. Not starting the Workload watch."
+        );
+        return None;
+    }
+    match djinn_k8s::try_default_client().await {
+        Ok(client) => Some(Arc::new(KubeWorkloadWatch::new(client, config.namespace))),
+        Err(error) => {
+            tracing::error!(
+                %error,
+                "kueue_workload_reconcile: Kueue is ARMED but no Kubernetes client could be \
+                 built. Admitted and evicted Workloads will not reach task-run state."
+            );
+            None
+        }
+    }
+}
+
+/// Start Workload reconciliation. Leader-only: composed exclusively from
+/// `AppState::become_leader`, at the seam the deleted build-admission reconciler
+/// used to occupy.
+///
+/// Leader-only because the sink WRITES — it moves the durable admission
+/// projection and terminalises live task-runs. Standby HTTP-only pods running
+/// this concurrently would give a preempted run two writers, which is exactly
+/// the single-active-writer invariant the coordinator advisory lock exists to
+/// hold.
+pub fn spawn(state: AppState) {
+    // Everything AppState-derived is extracted here and the handle released
+    // immediately: what survives into the background is a `Database` (a pool
+    // handle) and a `CancellationToken`, never the coordinator, the RPC
+    // services or the git actors.
+    let db = state.db().clone();
+    let cancel = state.cancel().clone();
+    drop(state);
+
+    tokio::spawn(async move {
+        let Some(watch) = production_watch().await else {
+            return;
+        };
+
+        let reconciler = Arc::new(Reconciler::new(Arc::new(DurableAdmissionSink::new(db))));
+        let reflector = tokio::spawn(run_reflector(
+            Arc::downgrade(&reconciler),
+            watch,
+            cancel.clone(),
+            RECONNECT_BACKOFF,
+        ));
+        tracing::info!("kueue_workload_reconcile: Workload reflector started (leader-only)");
+
+        // This task holds the ONE strong handle. Waiting here and then dropping
+        // it is the leadership lease; the reflector holds only a `Weak`.
+        cancel.cancelled().await;
+        drop(reconciler);
+        match reflector.await {
+            Ok(exit) => tracing::warn!(
+                ?exit,
+                "kueue_workload_reconcile: Workload reflector stopped; Kueue admission state no \
+                 longer reaches task-run state in this process"
+            ),
+            Err(error) => tracing::error!(
+                %error,
+                "kueue_workload_reconcile: Workload reflector task died"
+            ),
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use djinn_k8s::workload_inventory::{
+        CONDITION_ADMITTED, CONDITION_EVICTED, KueueWorkload, KueueWorkloadCondition,
+        KueueWorkloadStatus, OwnerReference,
+    };
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    // ── fixtures ──────────────────────────────────────────────────────────
+
+    fn condition(kind: &str, status: &str, reason: Option<&str>) -> KueueWorkloadCondition {
+        KueueWorkloadCondition {
+            condition_type: kind.to_owned(),
+            status: status.to_owned(),
+            reason: reason.map(ToOwned::to_owned),
+            message: None,
+        }
+    }
+
+    /// A Workload Kueue derived from a task-run Job, in the given state.
+    fn task_run_workload(
+        task_run_id: &str,
+        conditions: Vec<KueueWorkloadCondition>,
+    ) -> KueueWorkload {
+        let mut workload = KueueWorkload {
+            status: KueueWorkloadStatus { conditions },
+            ..Default::default()
+        };
+        workload.metadata.name = Some(format!("job-djinn-taskrun-{task_run_id}-abcde"));
+        workload.metadata.labels = Some(BTreeMap::from([
+            (
+                djinn_k8s::job::LABEL_TASK_RUN_ID.to_owned(),
+                task_run_id.to_owned(),
+            ),
+            (
+                djinn_k8s::config::LABEL_KUEUE_BUILD_OBJECT.to_owned(),
+                "true".to_owned(),
+            ),
+        ]));
+        workload
+    }
+
+    fn admitted(task_run_id: &str) -> WorkloadObservation {
+        WorkloadObservation::Applied(task_run_workload(
+            task_run_id,
+            vec![condition(CONDITION_ADMITTED, "True", Some("Admitted"))],
+        ))
+    }
+
+    fn queued(task_run_id: &str) -> WorkloadObservation {
+        WorkloadObservation::Applied(task_run_workload(
+            task_run_id,
+            vec![condition(
+                CONDITION_ADMITTED,
+                "False",
+                Some("NoReservation"),
+            )],
+        ))
+    }
+
+    /// Kueue's shape for a quota preemption: `Evicted=True` layered on top of
+    /// the `Admitted=True` it has not cleared yet.
+    fn evicted_for_quota(task_run_id: &str) -> WorkloadObservation {
+        WorkloadObservation::Applied(task_run_workload(
+            task_run_id,
+            vec![
+                condition(CONDITION_ADMITTED, "True", Some("Admitted")),
+                condition(CONDITION_EVICTED, "True", Some("Preempted")),
+            ],
+        ))
+    }
+
+    /// A warm Job's Workload: same build-object label, same watch, no task-run.
+    fn warm_workload_evicted() -> WorkloadObservation {
+        let mut workload = KueueWorkload {
+            status: KueueWorkloadStatus {
+                conditions: vec![condition(CONDITION_EVICTED, "True", Some("Preempted"))],
+            },
+            ..Default::default()
+        };
+        workload.metadata.name = Some("job-djinn-warm-proj-7-zzzzz".to_owned());
+        workload.metadata.labels = Some(BTreeMap::from([(
+            djinn_k8s::config::LABEL_KUEUE_BUILD_OBJECT.to_owned(),
+            "true".to_owned(),
+        )]));
+        workload.metadata.owner_references = Some(vec![OwnerReference {
+            kind: "Job".to_owned(),
+            name: "djinn-warm-proj-7".to_owned(),
+            ..Default::default()
+        }]);
+        WorkloadObservation::Applied(workload)
+    }
+
+    /// One scripted watch session: what it delivers, then how it ends.
+    type ScriptedSession = (Vec<WorkloadObservation>, Result<(), String>);
+
+    /// A scripted watch. Each element is one session: the observations it
+    /// delivers, then how that session ends.
+    struct ScriptedWatch {
+        sessions: Mutex<std::collections::VecDeque<ScriptedSession>>,
+        /// Repeated forever once the script is exhausted, so a lifecycle test
+        /// can keep the loop turning without an ever-growing script.
+        tail: Option<ScriptedSession>,
+    }
+
+    impl ScriptedWatch {
+        fn new(sessions: Vec<ScriptedSession>, tail: Option<ScriptedSession>) -> Arc<Self> {
+            Arc::new(Self {
+                sessions: Mutex::new(sessions.into()),
+                tail,
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WorkloadWatch for ScriptedWatch {
+        async fn run_session(&self, tx: mpsc::Sender<WorkloadObservation>) -> Result<(), String> {
+            let session = {
+                let mut sessions = self.sessions.lock().expect("scripted watch lock");
+                sessions.pop_front().or_else(|| self.tail.clone())
+            };
+            let Some((observations, outcome)) = session else {
+                // Script exhausted with no tail: park so the reflector's other
+                // stop signals are the only thing that can end it.
+                std::future::pending::<()>().await;
+                unreachable!()
+            };
+            // `SessionRestarted` is what a real watcher emits before replaying
+            // current state; the script does not have to repeat it.
+            if tx
+                .send(WorkloadObservation::SessionRestarted)
+                .await
+                .is_err()
+            {
+                return Ok(());
+            }
+            for observation in observations {
+                if tx.send(observation).await.is_err() {
+                    return Ok(());
+                }
+            }
+            outcome
+        }
+    }
+
+    /// Records what it was asked to do and nothing else. Used ONLY by the
+    /// lifecycle test, where durable state is irrelevant — the state tests run
+    /// against the real sink and a real database on purpose.
+    struct CountingSink {
+        applied: AtomicU64,
+    }
+
+    #[async_trait::async_trait]
+    impl TaskRunAdmissionSink for CountingSink {
+        async fn apply(
+            &self,
+            _task_run_id: &str,
+            _admission: &WorkloadAdmission,
+            _workload_name: Option<&str>,
+        ) -> Result<SinkOutcome, String> {
+            self.applied.fetch_add(1, Ordering::SeqCst);
+            Ok(SinkOutcome::Unchanged)
+        }
+        async fn forget(&self, _task_run_id: &str) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    /// A project, epic, task and a LIVE task-run row, as dispatch would leave
+    /// them once the pod has started.
+    async fn live_task_run(db: &Database) -> String {
+        let project = crate::test_helpers::create_test_project(db).await;
+        let epic = crate::test_helpers::create_test_epic(db, &project.id).await;
+        let task = crate::test_helpers::create_test_task(db, &project.id, &epic.id).await;
+        let task_run_id = uuid::Uuid::now_v7().to_string();
+        TaskRunRepository::new(db.clone())
+            .create(djinn_db::CreateTaskRunParams {
+                id: &task_run_id,
+                project_id: &project.id,
+                task_id: &task.id,
+                trigger_type: djinn_core::models::TaskRunTrigger::NewTask.as_str(),
+                status: Some("running"),
+                workspace_path: None,
+                mirror_ref: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .expect("create task_run");
+        task_run_id
+    }
+
+    async fn run_status(db: &Database, task_run_id: &str) -> String {
+        TaskRunRepository::new(db.clone())
+            .get(task_run_id)
+            .await
+            .expect("read task_run")
+            .expect("task_run exists")
+            .status
+    }
+
+    fn durable_reconciler(db: &Database) -> Arc<Reconciler> {
+        Arc::new(Reconciler::new(Arc::new(DurableAdmissionSink::new(
+            db.clone(),
+        ))))
+    }
+
+    // ── AC1 ───────────────────────────────────────────────────────────────
+
+    /// Both directions, against real durable state.
+    ///
+    /// The admitted half alone is satisfied by a reconciler that marks
+    /// everything admitted unconditionally, so the eviction half is the whole
+    /// test: a Workload preempted for quota must drive the task-run BACK to
+    /// pending — and must take the live run row with it, because a run whose Pod
+    /// Kueue deleted is not running any more.
+    #[tokio::test]
+    async fn admission_drives_a_task_run_out_of_pending_and_eviction_drives_it_back() {
+        let db = crate::test_helpers::create_test_db();
+        let task_run_id = live_task_run(&db).await;
+        let reconciler = durable_reconciler(&db);
+        let projection = KueueWorkloadAdmissionRepository::new(db.clone());
+
+        // Queued: waiting on Kueue quota.
+        reconciler.handle(queued(&task_run_id)).await;
+        assert_eq!(
+            projection
+                .get(&task_run_id)
+                .await
+                .expect("read projection")
+                .expect("row exists")
+                .admission,
+            "pending",
+            "a Workload Kueue has not admitted must read as pending"
+        );
+
+        // Admitted: out of pending, within one observation.
+        reconciler.handle(admitted(&task_run_id)).await;
+        let after_admission = projection
+            .get(&task_run_id)
+            .await
+            .expect("read projection")
+            .expect("row exists");
+        assert_eq!(after_admission.admission, "admitted");
+        assert_eq!(
+            after_admission.transitions, 1,
+            "pending -> admitted is exactly one transition"
+        );
+        assert!(
+            projection.pending().await.expect("read pending").is_empty(),
+            "an admitted task-run must leave the pending population"
+        );
+        assert_eq!(
+            run_status(&db, &task_run_id).await,
+            "running",
+            "admission must not disturb the live run"
+        );
+
+        // Evicted for quota: back to pending, and the live run is interrupted.
+        reconciler.handle(evicted_for_quota(&task_run_id)).await;
+        let after_eviction = projection
+            .get(&task_run_id)
+            .await
+            .expect("read projection")
+            .expect("row exists");
+        assert_eq!(
+            after_eviction.admission, "pending",
+            "a quota eviction must drive the task-run BACK to pending"
+        );
+        assert_eq!(
+            after_eviction.reason.as_deref(),
+            Some("Preempted"),
+            "Kueue's own reason is what makes a stalled board explicable"
+        );
+        assert_eq!(after_eviction.transitions, 2);
+        assert_eq!(
+            projection.pending().await.expect("read pending").len(),
+            1,
+            "the evicted task-run must be back in the pending population"
+        );
+        assert_eq!(
+            run_status(&db, &task_run_id).await,
+            "interrupted",
+            "Kueue deleted the Pod; leaving the run `running` strands it until the generic \
+             stall reaper fires"
+        );
+    }
+
+    // ── AC2 ───────────────────────────────────────────────────────────────
+
+    /// A Workload with no matching task-run is ignored — and "ignored" is
+    /// asserted as "the unrelated task-run's state did not move", not as "no
+    /// error was returned". A reconciler that resolved every unidentifiable
+    /// Workload to some default task-run would return `Ok` all day.
+    #[tokio::test]
+    async fn an_unmatched_workload_is_ignored_and_mutates_no_unrelated_task_state() {
+        let db = crate::test_helpers::create_test_db();
+        let unrelated_run = live_task_run(&db).await;
+        let reconciler = durable_reconciler(&db);
+        let projection = KueueWorkloadAdmissionRepository::new(db.clone());
+
+        // Establish real state for the unrelated run.
+        reconciler.handle(admitted(&unrelated_run)).await;
+        let before = projection
+            .get(&unrelated_run)
+            .await
+            .expect("read projection")
+            .expect("row exists");
+        assert_eq!(before.admission, "admitted");
+        let transitions_before = reconciler.transitions();
+
+        // A warm Job's Workload, evicted. Same label, same stream, not a
+        // task-run.
+        reconciler.handle(warm_workload_evicted()).await;
+
+        assert_eq!(
+            reconciler.ignored(),
+            1,
+            "a Workload that resolves to no task-run must be counted as ignored"
+        );
+        assert_eq!(
+            reconciler.transitions(),
+            transitions_before,
+            "an ignored Workload must apply nothing"
+        );
+        assert_eq!(
+            projection
+                .get(&unrelated_run)
+                .await
+                .expect("read projection")
+                .expect("row exists"),
+            before,
+            "the unrelated task-run's admission state must be byte-identical"
+        );
+        assert_eq!(
+            run_status(&db, &unrelated_run).await,
+            "running",
+            "an unmatched eviction must not interrupt somebody else's run"
+        );
+    }
+
+    // ── AC3 ───────────────────────────────────────────────────────────────
+
+    /// Leadership loss drops the reflector task.
+    ///
+    /// The proof is `Weak::upgrade` returning `None` AFTER the task has ended:
+    /// a reflector holding a strong `Arc` would keep the leadership state alive
+    /// and never reach that state, while an assertion phrased as "did the loop
+    /// stop?" against a strong reference passes either way.
+    #[tokio::test]
+    async fn releasing_leadership_drops_the_reflector_task() {
+        let sink = Arc::new(CountingSink {
+            applied: AtomicU64::new(0),
+        });
+        let reconciler = Arc::new(Reconciler::new(sink));
+        let weak = Arc::downgrade(&reconciler);
+        // Sessions that deliver one observation and then end, forever: the loop
+        // keeps turning and exercises both the per-observation upgrade and the
+        // between-session one.
+        let watch = ScriptedWatch::new(
+            vec![],
+            Some((
+                vec![admitted(&uuid::Uuid::now_v7().to_string())],
+                Ok::<(), String>(()),
+            )),
+        );
+        let cancel = CancellationToken::new();
+        let reflector = tokio::spawn(run_reflector(
+            weak.clone(),
+            watch,
+            cancel.clone(),
+            Duration::from_millis(1),
+        ));
+
+        // Let it establish and apply at least one observation.
+        for _ in 0..500 {
+            if reconciler.observations() > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert!(
+            reconciler.observations() > 0,
+            "the reflector must be running before leadership is released"
+        );
+
+        // Leadership released: drop the ONE strong handle. The cancellation
+        // token is deliberately NOT fired — this asserts the `Weak` is a real
+        // stop signal on its own.
+        drop(reconciler);
+
+        let exit = tokio::time::timeout(Duration::from_secs(5), reflector)
+            .await
+            .expect(
+                "a reflector holding a strong Arc never ends: it would keep the leadership \
+                     state alive forever",
+            )
+            .expect("reflector task must not panic");
+        assert_eq!(exit, ReflectorExit::LeadershipReleased);
+        assert!(
+            weak.upgrade().is_none(),
+            "the reflector must not have been holding a strong handle"
+        );
+        assert!(!cancel.is_cancelled(), "the token was never fired");
+    }
+
+    /// Leader-only by composition, mirroring `graph_retention`'s gate: the spawn
+    /// must appear exactly once in `AppState`, inside `become_leader`, and never
+    /// on the every-pod `initialize` path.
+    #[test]
+    fn spawn_is_composed_only_in_become_leader() {
+        let state_source = include_str!("server/state/mod.rs");
+        let spawn = "crate::kueue_workload_reconcile::spawn(self.clone())";
+        assert_eq!(
+            state_source.matches(spawn).count(),
+            1,
+            "the Workload reflector writes; exactly one pod may run it"
+        );
+        let leader = state_source
+            .find("pub async fn become_leader")
+            .expect("become_leader exists");
+        let reconcile = state_source.find(spawn).expect("spawn is composed");
+        assert!(reconcile > leader);
+        let initialize = state_source
+            .find("pub async fn initialize(&self)")
+            .expect("initialize exists");
+        assert!(
+            !state_source[initialize..leader].contains(spawn),
+            "initialize runs on every pod, including standbys"
+        );
+    }
+
+    // ── AC4 ───────────────────────────────────────────────────────────────
+
+    /// A watch disconnect re-establishes and replays, and the replay must cost
+    /// nothing.
+    ///
+    /// The assertion is on the transition COUNT — both the reconciler's and the
+    /// projection's — not on "did it reconnect". A reflector that reconnects
+    /// perfectly and re-applies every replayed Workload as a fresh event
+    /// produces a projection whose `transitions` climbs on watch churn alone,
+    /// which is exactly the number an operator would use to decide the queue is
+    /// thrashing.
+    #[tokio::test]
+    async fn a_watch_disconnect_resyncs_without_duplicating_transitions() {
+        let db = crate::test_helpers::create_test_db();
+        let task_run_id = live_task_run(&db).await;
+        let reconciler = durable_reconciler(&db);
+        let projection = KueueWorkloadAdmissionRepository::new(db.clone());
+
+        let watch = ScriptedWatch::new(
+            vec![
+                // Session 1: queue, then admit. Then the stream BREAKS.
+                (
+                    vec![queued(&task_run_id), admitted(&task_run_id)],
+                    Err("watch connection reset by peer".to_owned()),
+                ),
+                // Session 2: the reconnect replays current state verbatim.
+                (vec![admitted(&task_run_id)], Ok(())),
+            ],
+            None,
+        );
+        let cancel = CancellationToken::new();
+        let reflector = tokio::spawn(run_reflector(
+            Arc::downgrade(&reconciler),
+            watch,
+            cancel.clone(),
+            Duration::from_millis(1),
+        ));
+
+        // Wait for session 1 to have been fully applied.
+        for _ in 0..500 {
+            if reconciler.transitions() >= 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        let transitions_before = reconciler.transitions();
+        let sessions_before = reconciler.sessions();
+        let projected_before = projection
+            .get(&task_run_id)
+            .await
+            .expect("read projection")
+            .expect("row exists");
+        assert_eq!(
+            transitions_before, 2,
+            "record + pending->admitted is two applied changes"
+        );
+        assert_eq!(projected_before.admission, "admitted");
+        assert_eq!(projected_before.transitions, 1);
+
+        // Wait for the resync to be established and its replay consumed.
+        for _ in 0..500 {
+            if reconciler.sessions() > sessions_before && reconciler.observations() >= 5 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert!(
+            reconciler.sessions() > sessions_before,
+            "the broken stream must be re-established"
+        );
+
+        cancel.cancel();
+        let exit = tokio::time::timeout(Duration::from_secs(5), reflector)
+            .await
+            .expect("reflector must observe cancellation")
+            .expect("reflector task must not panic");
+        assert_eq!(exit, ReflectorExit::Cancelled);
+
+        assert_eq!(
+            reconciler.transitions(),
+            transitions_before,
+            "a resync replaying the SAME admission state must apply no further transitions"
+        );
+        assert_eq!(
+            projection
+                .get(&task_run_id)
+                .await
+                .expect("read projection")
+                .expect("row exists")
+                .transitions,
+            projected_before.transitions,
+            "the durable transition counter must not move on a watch replay"
+        );
+        assert_eq!(
+            run_status(&db, &task_run_id).await,
+            "running",
+            "a replayed admission must not touch the run"
+        );
+    }
+
+    // ── inertness ─────────────────────────────────────────────────────────
+
+    /// The current production shape: Kueue unarmed, no Workloads, no CRDs.
+    /// Nothing is watched and nothing is spawned.
+    #[tokio::test]
+    async fn an_unarmed_cluster_starts_no_watch() {
+        // `DJINN_RUNTIME` is unset in tests, so this exercises the first gate;
+        // the arming gate is asserted directly on the config default below.
+        assert!(
+            production_watch().await.is_none(),
+            "no Workload watch may be opened outside a Kubernetes runtime"
+        );
+        assert!(
+            !djinn_k8s::KubernetesConfig::from_env().kueue_armed,
+            "kueue.armed defaults false; arming is epic 4c9q's cutover step, not this slice's"
+        );
+    }
+}

--- a/server/src/kueue_workload_reconcile.rs
+++ b/server/src/kueue_workload_reconcile.rs
@@ -296,7 +296,16 @@ impl Reconciler {
     /// Never returns an error: a Workload this process cannot act on must not be
     /// able to end the watch. Failures are logged and the stream continues.
     pub async fn handle(&self, observation: WorkloadObservation) {
+        self.apply_observation(observation).await;
+        // Counted AFTER the observation has been fully applied, never before.
+        // A counter that advances on entry says "the reflector saw this", which
+        // is not the question anyone asks it — every consumer, tests included,
+        // wants "this has landed", and the two differ by exactly the width of
+        // the database round trip.
         self.observations.fetch_add(1, Ordering::SeqCst);
+    }
+
+    async fn apply_observation(&self, observation: WorkloadObservation) {
         match observation {
             WorkloadObservation::SessionRestarted => {
                 self.sessions.fetch_add(1, Ordering::SeqCst);
@@ -741,6 +750,24 @@ mod tests {
             .status
     }
 
+    /// Poll `condition` until it holds, or fail with `what`.
+    ///
+    /// Generously bounded: these tests run alongside 600 others on a loaded
+    /// machine, and a tight budget turns a slow scheduler into a flake — which
+    /// is the failure mode that gets a real assertion deleted.
+    async fn wait_until(what: &str, mut condition: impl FnMut() -> bool) {
+        // `tokio::time::Instant` rather than `std::time::Instant`: the latter is
+        // a workspace-disallowed method (`server/clippy.toml`).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        while tokio::time::Instant::now() < deadline {
+            if condition() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        panic!("timed out waiting for: {what}");
+    }
+
     fn durable_reconciler(db: &Database) -> Arc<Reconciler> {
         Arc::new(Reconciler::new(Arc::new(DurableAdmissionSink::new(
             db.clone(),
@@ -915,16 +942,10 @@ mod tests {
         ));
 
         // Let it establish and apply at least one observation.
-        for _ in 0..500 {
-            if reconciler.observations() > 0 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(2)).await;
-        }
-        assert!(
-            reconciler.observations() > 0,
-            "the reflector must be running before leadership is released"
-        );
+        wait_until("the reflector to apply its first observation", || {
+            reconciler.observations() > 0
+        })
+        .await;
 
         // Leadership released: drop the ONE strong handle. The cancellation
         // token is deliberately NOT fired — this asserts the `Weak` is a real
@@ -1010,15 +1031,15 @@ mod tests {
             Duration::from_millis(1),
         ));
 
-        // Wait for session 1 to have been fully applied.
-        for _ in 0..500 {
-            if reconciler.transitions() >= 2 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(2)).await;
-        }
+        // Wait for session 1 to have been fully applied. The capture below is
+        // taken against the OBSERVATION count, not the transition count: a
+        // reflector that duplicates on replay would otherwise be allowed to
+        // inflate the baseline and then compare it against itself.
+        wait_until("session 1 to be fully applied", || {
+            reconciler.observations() >= 3
+        })
+        .await;
         let transitions_before = reconciler.transitions();
-        let sessions_before = reconciler.sessions();
         let projected_before = projection
             .get(&task_run_id)
             .await
@@ -1031,17 +1052,13 @@ mod tests {
         assert_eq!(projected_before.admission, "admitted");
         assert_eq!(projected_before.transitions, 1);
 
-        // Wait for the resync to be established and its replay consumed.
-        for _ in 0..500 {
-            if reconciler.sessions() > sessions_before && reconciler.observations() >= 5 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(2)).await;
-        }
-        assert!(
-            reconciler.sessions() > sessions_before,
-            "the broken stream must be re-established"
-        );
+        // Wait for the resync to be established and its replay consumed: two
+        // `SessionRestarted` edges plus three applied Workloads.
+        wait_until(
+            "the broken stream to be re-established and replayed",
+            || reconciler.sessions() >= 2 && reconciler.observations() >= 5,
+        )
+        .await;
 
         cancel.cancel();
         let exit = tokio::time::timeout(Duration::from_secs(5), reflector)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod events;
 pub mod git_maintenance;
 pub mod graph_retention;
+pub mod kueue_workload_reconcile;
 pub mod leadership;
 pub mod logging;
 mod mcp_bridge;

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -2028,10 +2028,11 @@ impl AppState {
         );
         crate::mirror_fetcher::spawn(self.clone());
 
-        // NOTE: `build_admission_reconcile::spawn` deliberately no longer lives
-        // here. It is now the first statement after the topology gate opens, so
-        // no awaited initializer between the two can leave a fully-admitting
-        // leader with no reconciler. See the comment at that call site.
+        // Kueue Workload reconciliation (slice S5), at the seam vacated by the
+        // deleted `build_admission_reconcile::spawn`. Leader-only: it writes the
+        // durable admission projection and terminalises evicted task-runs.
+        // Inert until `kueue.armed` — see the module docs.
+        crate::kueue_workload_reconcile::spawn(self.clone());
 
         // Standalone SCIP-index driver (leader-only, same reasoning as
         // mirror_fetcher: it creates cluster objects). The real scheduler is


### PR DESCRIPTION
Kueue cutover slice **S5** (task `kh7g`, epic `4c9q`, proposal `9oga`). Adds `server/src/kueue_workload_reconcile.rs`: a leader-only `kube::runtime::watcher` reflector over Kueue `Workload` objects, registered at the seam S3a (#2822) vacated when it deleted `build_admission_reconcile.rs` **and** its `become_leader` call.

## The swap is not like-for-like

The deleted module POLLED a Postgres ledger djinn wrote itself, on a 120s timer, to retire rows whose Kubernetes objects had vanished. Kueue's ClusterQueue is the capacity authority now: there is no ledger to retire, there is an **external decision-maker whose decisions this process has to hear about**.

Admission is edge-triggered and REVERSIBLE — Kueue admits, preempts for quota, re-admits. A poll on any cadence collapses admit/evict/admit into whichever sample it took, and the edge it drops (the eviction) is the one that leaves a task-run `running` in the database with no Pod behind it. Modelled on `djinn-image-controller/src/watcher.rs`, the repository's only real watcher; deliberately **not** on `runtime.rs`'s `watch_infra_death`, which polls despite the name.

## What it writes, and why a new relation

A `kueue_workload_admission` projection (migration 165), one row per task-run with a live Workload, moving **both ways** between `pending` and `admitted`.

It is a **projection, not an authority** — the structural difference the whole cutover is about. `admission_journal` reserved capacity before the object that consumed it existed, and every settle window, absence proof and CAS fence downstream was compensation for accounting rows no Kubernetes object owned. Every row here is derived from a live Workload observed on a watch, so a row can never outlive the object it describes.

It exists because under create-then-admit there is a window with nothing in it. The Job is created `suspend: true`, no Pod runs, and the in-pod supervisor is what creates the `task_runs` row — so between dispatch and admission djinn has no run, no session and no denial that says why a task is sitting still. That is the exact shape of the 2026-07-29 outage where `board_health` reported `unexplained` with empty `reasons` for five hours.

**One edge reaches past the projection.** A Workload evicted from `admitted` has had its Pod deleted by Kueue, so the live `task_runs` row is terminalised `Interrupted` — infrastructure took the pod, the attempt did not fail, so it costs no quality strike. Gated on the **direction** (`previous == admitted`), never on the destination: a Workload that was only ever queued has no run to interrupt, and a destination-only gate interrupts runs that were never admitted.

## Lifecycle: `Weak`, never `Arc`

The **supervisor** task owns the one strong `Arc<Reconciler>` and does nothing but await the leader's cancellation token and drop it — that drop is the leadership lease. The **reflector** owns only a `Weak`, upgrades per observation, and releases before going back to waiting, so it never holds a strong handle across an await.

A strong handle parked in a detached loop is how `RpcServices` wedged worker shutdown for 30s (`djinn-agent/src/context.rs:152`). Two independent stop signals — the token and the dead `Weak` — is deliberate.

## Behaviour on a cluster with no Kueue installed — i.e. production today

`kueue.armed` defaults false and no namespace carries `djinn.io/kueue-managed`, so nothing is captured and **no Workload object exists anywhere**. `spawn` opens no watch unless the runtime is Kubernetes AND Kueue is armed AND a client builds; otherwise it logs one line and returns. No task, no timer, no API traffic.

No Kueue CRD is assumed: `KueueWorkload` models only `metadata` plus the `status.conditions` read here, with every other field dropped by serde, so no Kueue API revision can break deserialisation of a payload this process never reads. If Kueue IS armed and the CRDs are missing, the watch runs, gets `404`, backs off 5s and says so at `warn!` — because then a missing CRD is a genuine outage rather than the expected state.

Gating the WIRING rather than the ACTION is the one place this slice departs from house style, and the justification is specific: an armed watch against an unregistered resource is a permanent error loop, and a permanent error loop is how a real signal gets filtered out.

## Acceptance, each proven by mutation

Every criterion was re-run with the mechanism deliberately broken; the failure output is in the task report.

1. **Both directions**, against a real database — `admitted` leaves the pending population, a quota eviction returns to it AND interrupts the live run. Mutating the classifier to report `Admitted` unconditionally, and separately deleting only the `Evicted` branch (the "admission-only" shape), each fail it.
2. **An unmatched Workload** (a warm Job's — same build-object label, same stream) is counted ignored and leaves the unrelated task-run's projection **byte-identical** and its status `running`. Mutated to resolve unidentifiable Workloads to the last-seen task-run id — a plausible caching shortcut that returns `Ok` for everything — and, with the counter assertions suppressed so only the state assertions can fire, the projection comparison catches it.
3. **Leadership release drops the reflector task**, proven by `Weak::upgrade` returning `None` after the task has ended, with the cancellation token never fired. Swapping the `Weak` for a strong `Arc` makes the test time out — the loop never ends and the state never drops.
4. **A watch disconnect resyncs without duplicating transitions**: an injected stream error re-establishes the session and the replay moves neither the reconciler's transition count nor the durable one. Dropping the `IS DISTINCT FROM` idempotence guard in SQL makes the count climb 2 → 3.

## Files

- new `server/src/kueue_workload_reconcile.rs` — sink, reconciler, reflector, registration, tests
- `server/crates/djinn-k8s/src/workload_inventory.rs` — the `Workload` type, condition classification, task-run resolution, the `WorkloadWatch` seam and its `kube` implementation
- `server/src/server/state/mod.rs` — **registration only**: the four-line NOTE comment S3a left at the seam, replaced by a four-line comment plus `crate::kueue_workload_reconcile::spawn(self.clone());`
- `server/src/lib.rs` — one module declaration
- new `server/crates/djinn-db/migrations_postgres/165_kueue_workload_admission.sql` and `server/crates/djinn-db/src/repositories/kueue_workload_admission.rs`, plus one `mod` line and one re-export. The repository lives in `djinn-db` because `scripts/check-raw-sql-boundary.sh` fails any raw sqlx outside it. Runtime `sqlx::query*` only, so `server/.sqlx/` needs no regeneration — verified with `make sqlx-verify` (409 entries, up to date).
- `server/crates/djinn-k8s/Cargo.toml` — `futures = "0.3"`, the crate that makes `kube::runtime::watcher`'s stream pollable, already carried by `djinn-image-controller` for the same reason.

## Verification

- `cargo test -p djinn-server --lib` — 614 passed, run repeatedly. `cargo test -p djinn-db --lib` 1166 passed; `cargo test -p djinn-k8s --lib` 316 passed.
- `cargo clippy --lib --tests --all-features` clean on all three crates.
- `server::tests::debug::test_debug_dispatch_state_lock_contention_under_5s` flakes under the full suite **on `origin/main` as well** — confirmed by running the same suite at `90cc618d2` with no local changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
