### PR TITLE
feat(kueue): make the surviving dependents' claims true again (plcj S4)

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
+++ b/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
@@ -1031,6 +1031,13 @@ pub struct BoardHealthStrandedThreshold {
 /// record of a layer-1 build-admission attempt. Absent when the task has no
 /// lease row, or when the ledger could not be read (see
 /// `BoardHealthDispatchGateCoverage::unevaluated_gates`).
+///
+/// **Legacy population since the Kueue cutover.** The pre-create dispatch
+/// reservation was stood down and nothing acquires a `task_dispatch` lease any
+/// more, so this block is present only for rows that predate the cutover. Pool
+/// occupancy is unaffected — `BoardHealthBuildCapacity` sums every consumer
+/// kind, and the per-invocation cgroup lease still writes `task_invocation`
+/// rows from inside the task-run Pod.
 #[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct BoardHealthBuildLease {
     /// `{task_id}:{generation}` — the lease key the dispatcher asked for.
@@ -1056,9 +1063,13 @@ pub struct BoardHealthBuildLease {
 /// Pool-wide build capacity as the dispatcher's own authority reads it.
 /// Absent when the lease ledger could not be read.
 ///
-/// Since the Kueue cutover deleted the pre-create admission ledger, this is the
-/// only occupancy authority in the payload: there is no second gate that can
-/// deny before capacity is measured.
+/// The Kueue cutover deleted the pre-create admission ledger, so this is the
+/// only occupancy authority **in this payload**. It is NOT the only gate that
+/// can stop a build: Kueue's ClusterQueue now decides admission, and a Job it
+/// has not admitted stays suspended with nothing recorded in any relation
+/// `board_health` reads. `at_capacity: false` therefore still does not mean a
+/// dispatch can proceed — see `kueue_clusterqueue_admission` in
+/// `BoardHealthDispatchGateCoverage::unevaluated_gates`.
 #[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct BoardHealthBuildCapacity {
     /// Always `build_leases`, so the payload names its own authority.
@@ -1100,6 +1111,12 @@ pub struct BoardHealthBuildCapacity {
 /// a `tracing::info!` line — and thrown away. On 2026-07-29 the dispatcher knew
 /// on every tick, for five hours, precisely why it was refusing every task, and
 /// `board_health` reported `unexplained` the whole time.
+///
+/// **No writer remains.** The Kueue cutover deleted the process that recorded
+/// these rows, so an absent block is now the steady state and says nothing
+/// about whether Kueue admitted the Job. Legacy rows are still surfaced, and a
+/// new writer must not be added — a denial recorded against a deleted authority
+/// would be the replayed tombstone of #2661 in a new table.
 #[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct BoardHealthBuildAdmissionDenial {
     /// `at_capacity`, `controller_not_admitting` or `authority_unavailable`.
@@ -1155,7 +1172,9 @@ pub struct BoardHealthDispatchGateCoverage {
     pub evaluated_gates: Vec<String>,
     /// Gates the dispatcher applies that this section did not consult. Every
     /// entry is a way a task can be left queued while `gate_verdict` is
-    /// `unexplained`.
+    /// `unexplained`. Includes `kueue_clusterqueue_admission`: since the Kueue
+    /// cutover, quota is enforced by a ClusterQueue that leaves no row in any
+    /// relation `board_health` can read.
     #[serde(default)]
     pub unevaluated_gates: Vec<String>,
     /// Human-readable restatement of the bound, carried in the payload so an

--- a/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate.rs
@@ -79,6 +79,40 @@
 //! confident wrong answer rather than a missing one. `readiness` therefore
 //! arrives here the only honest way — carried on the persisted denial written
 //! by whichever process actually refused.
+//!
+//! # What the Kueue cutover changed under this section (o53p / ubne / plcj)
+//!
+//! Two of the sources above lost their producer, and saying so is the whole
+//! point of this module.
+//!
+//! * **`build_admission_denials` has no writer.** Its only producer was
+//!   `dispatch/task_dispatch.rs`'s `record_task_run_denial`, rendering a
+//!   `DenialCause` from the pre-create `BuildAdmissionController`; both were
+//!   deleted. The relation, the repository and the read below are RETAINED
+//!   deliberately — a `null` denial is the literal truth ("no recorded denial")
+//!   and legacy rows are still surfaced — but the steady state is now `null`,
+//!   and a new writer must NOT be added: a denial recorded against a deleted
+//!   authority is the replayed tombstone of #2661 in a new table.
+//! * **`task_dispatch` build-lease rows are legacy-only.** Nothing constructs
+//!   `LeaseIdentity::TaskDispatch` any more — `djinn-coordinator`'s
+//!   `no_dispatch_lease_can_ever_be_acquired_again` fails if a constructor
+//!   returns — so `build_lease_queued` / `build_lease_terminal` /
+//!   `build_lease_occupied_without_session` can only fire for rows that predate
+//!   the cutover.
+//!
+//! What is NOT inert is the part that answers "can this board dispatch at all":
+//! `build_capacity` is a ledger-wide `SUM(weight)` across EVERY consumer kind,
+//! and `task_invocation` leases are still written, from inside the task-run
+//! Pod, by the per-invocation cgroup lease that 9oga's non-goals retain. So
+//! `build_pool_at_capacity` remains a live, durable blocking reason, and the
+//! integration test `a_pool_filled_by_live_invocation_leases_blocks_the_gate`
+//! asserts it against a real ledger rather than against a legacy row shape.
+//!
+//! The blind spot the cutover OPENED is that Kueue's ClusterQueue now decides
+//! build capacity, and a Job it has not admitted is queued by Kueue with no row
+//! in any relation this section reads. That is why
+//! `kueue_clusterqueue_admission` is listed in [`UNEVALUATED_GATES`] rather
+//! than left for an operator to infer from a healthy-looking `build_capacity`.
 
 use std::collections::HashMap;
 
@@ -110,6 +144,12 @@ pub(super) const EVALUATED_GATES: &[&str] = &[
 /// and leaves no durable row to enumerate against; when it refuses, the reason
 /// arrives on the persisted denial record instead (`build_admission_denial`).
 pub(super) const UNEVALUATED_GATES: &[&str] = &[
+    // The Kueue cutover moved build capacity to a ClusterQueue. A Job Kueue has
+    // not admitted is SUSPENDED by Kueue and leaves no row in any relation this
+    // section reads, so a healthy `build_capacity` block now says strictly less
+    // than it used to. Naming the gap is the only honest option available from
+    // a Postgres read.
+    "kueue_clusterqueue_admission",
     "per_user_lane_concurrency_cap",
     "per_user_model_concurrency_cap",
     "slot_pool_capacity",
@@ -130,6 +170,11 @@ const OCCUPYING_LEASE_STATES: &[&str] = &["granted", "launching", "bound", "acti
 
 /// One `task_dispatch` build-lease row: the dispatcher's own record of a
 /// layer-1 admission attempt for a task.
+///
+/// **Legacy population.** The pre-create dispatch reservation was stood down by
+/// the Kueue cutover and nothing constructs `LeaseIdentity::TaskDispatch` any
+/// more, so this population can only shrink. The rows are still read because a
+/// board wedged behind one from before the cutover must still be explained.
 #[derive(Clone, Debug)]
 pub(super) struct DispatchLeaseRow {
     pub consumer_id: String,
@@ -410,6 +455,13 @@ fn denial_gate(
     let Some(row) = denials.get(task_id) else {
         // No row is a real answer: the permitted path DELETES it. This gate
         // was evaluated and found nothing.
+        //
+        // Post-cutover this is also the steady state, because the writer is
+        // gone (see the module docs). It stays EVALUATED rather than becoming
+        // unevaluated because the claim it makes — "this relation records no
+        // denial for this task" — is still exactly true, and the thing it must
+        // not be mistaken for is disclosed as `kueue_clusterqueue_admission` in
+        // `unevaluated_gates` instead of being smuggled in here.
         return (serde_json::Value::Null, Vec::new(), true, None);
     };
 
@@ -435,7 +487,12 @@ fn denial_gate(
                  admitted, so its presence means the most recent decision was a \
                  denial. A record older than `freshness_window_seconds` is reported \
                  but not blamed: the dispatcher retries a stranded task every tick, \
-                 so a stale row belongs to a task it has stopped considering.",
+                 so a stale row belongs to a task it has stopped considering. \
+                 The Kueue cutover deleted the pre-create controller that WROTE \
+                 these rows, so any record you see here predates it; a `null` is \
+                 now the steady state and is NOT evidence that Kueue admitted \
+                 the Job — see `kueue_clusterqueue_admission` in \
+                 `coverage.unevaluated_gates`.",
     });
 
     let reasons = if fresh {
@@ -502,12 +559,15 @@ pub(super) fn lease_gate(ledger: &LeaseLedger, task_id: &str) -> LeaseGateOutcom
         "at_capacity": at_capacity,
         "note": "LEASE authority only (`build_leases` / `build_lease_caps`, armed by the \
                  durable invocation-lease authority). `lease_authority_enforcing` says whether \
-                 THIS authority is armed and says NOTHING about the build-admission \
-                 controller, whose mode is process configuration. These numbers are \
-                 only reached AFTER the controller agrees to admit at all, so \
-                 `at_capacity: false` here is not evidence that a dispatch can proceed; \
-                 see `build_admission_denial` for what the dispatcher actually \
-                 recorded.",
+                 THIS authority is armed and says NOTHING about any other admission \
+                 authority. `occupancy` is a ledger-wide SUM(weight) across every \
+                 consumer kind, so it is live: `task_invocation` leases are written \
+                 from inside the task-run Pod by the per-invocation cgroup lease. \
+                 It is still NOT sufficient — since the Kueue cutover a Job can sit \
+                 suspended behind a ClusterQueue quota with nothing recorded here — \
+                 so `at_capacity: false` is not evidence that a dispatch can proceed; \
+                 see `build_admission_denial` for what a dispatcher actually recorded, \
+                 and `coverage.unevaluated_gates` for what nothing records at all.",
     });
 
     let lease = by_task.get(task_id);
@@ -759,12 +819,15 @@ pub(super) fn dispatch_gate_json(
             "note": "`reasons` covers only `evaluated_gates`. An empty `reasons` \
                      yields `unexplained`, which means no evaluated gate fired — \
                      NOT that the dispatcher had no reason. `build_capacity` speaks \
-                     for the LEASE ledger alone, and the build-admission controller \
-                     can refuse before occupancy is ever measured, so a healthy \
-                     `build_capacity` is not evidence that dispatch is possible. \
+                     for the LEASE ledger alone, and since the Kueue cutover a Job \
+                     can sit suspended behind a ClusterQueue quota that leaves no \
+                     row in any relation read here, so a healthy `build_capacity` \
+                     is not evidence that dispatch is possible. \
                      `build_admission_denial` is the dispatcher's OWN recorded \
                      `DenialCause` (#2661, migration 161) — the only field here \
-                     that is a decision rather than a re-derivation of one.",
+                     that is a decision rather than a re-derivation of one — but \
+                     the process that wrote it was deleted by the cutover, so a \
+                     `null` there is the steady state rather than an all-clear.",
         }),
         // Retained for backward compatibility with the initial board_health
         // contract.

--- a/server/crates/djinn-db/tests/task_tests/board_health_dispatch_gate.rs
+++ b/server/crates/djinn-db/tests/task_tests/board_health_dispatch_gate.rs
@@ -178,6 +178,112 @@ async fn a_full_pool_explains_a_task_with_no_lease_row() {
     assert_eq!(gate["build_capacity"]["at_capacity"], true);
 }
 
+/// Occupy the pool with the consumer kind production still writes.
+///
+/// `task_invocation` is the per-invocation cgroup lease taken from inside the
+/// task-run Pod, which 9oga's non-goals retain. `consumer_id` is the invocation
+/// id and `immutable_identity` is `task:{task_id}:{task_run_id}:{invocation_id}`
+/// — see `djinn-coordinator`'s `build_lease::identity`.
+async fn insert_invocation_lease(db: &Database, task_id: &str, invocation_id: &str, weight: i64) {
+    sqlx::query(
+        "INSERT INTO build_leases \
+         (consumer_kind, consumer_id, immutable_identity, state, weight, \
+          fencing_token, granted_at) \
+         VALUES ('task_invocation', $1, $2, 'active', $3, \
+                 nextval('build_lease_fencing_token_seq'), now())",
+    )
+    .bind(invocation_id)
+    .bind(format!(
+        "task:{task_id}:run-{invocation_id}:{invocation_id}"
+    ))
+    .bind(weight)
+    .execute(db.pool())
+    .await
+    .unwrap();
+}
+
+/// **The Kueue-cutover acceptance criterion (`plcj`).** The gate still returns a
+/// BLOCKING verdict for a genuinely blocked board, derived from a source that
+/// production still writes.
+///
+/// Every other blocking reason in this file is proven with a `task_dispatch`
+/// row, and nothing constructs `LeaseIdentity::TaskDispatch` any more — the
+/// pre-create dispatch reservation was stood down by the cutover, and
+/// `no_dispatch_lease_can_ever_be_acquired_again` fails if a constructor
+/// returns. Those tests therefore still pass while proving only that a legacy
+/// row shape is rendered.
+///
+/// This one fills the pool with `task_invocation` leases, which the
+/// per-invocation cgroup lease writes today, and asserts the verdict flips both
+/// ways against the real ledger: BLOCKED while the pool is full, and back to
+/// `unexplained` once it drains. A gate rewired to a constant `Ok` — or to a
+/// constant `blocked` — fails one half or the other.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_pool_filled_by_live_invocation_leases_blocks_the_gate() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let victim = stranded_task(&db, &repo, "Victim of a full invocation pool").await;
+    let compiler = stranded_task(&db, &repo, "Task-run holding the cgroup lease").await;
+
+    arm_lease_authority(&db, 2).await;
+    insert_invocation_lease(&db, &compiler.id, "inv-full-pool", 2).await;
+
+    let gate = gate_for(&repo, &victim.id).await;
+    assert_eq!(
+        gate["gate_verdict"], "blocked",
+        "a board whose lease pool is full of LIVE invocation leases is blocked: {gate:#}"
+    );
+    assert!(
+        gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("build_pool_at_capacity")),
+        "expected build_pool_at_capacity, got {:?}",
+        gate["reasons"]
+    );
+    assert_eq!(gate["build_capacity"]["occupancy"], 2);
+    assert_eq!(gate["build_capacity"]["cap"], 2);
+    assert_eq!(gate["build_capacity"]["at_capacity"], true);
+    assert!(
+        gate["build_lease"].is_null(),
+        "the victim holds no lease row of its own; the pool alone explains it"
+    );
+    // The cutover's own blind spot must be declared, not implied by a healthy
+    // number: Kueue suspends a Job it has not admitted, and that leaves no row
+    // in any relation this section reads.
+    assert!(
+        gate["coverage"]["unevaluated_gates"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("kueue_clusterqueue_admission")),
+        "the ClusterQueue gap must be disclosed: {:#}",
+        gate["coverage"]
+    );
+
+    // Drain the pool through the same relation. The verdict must FALL — this is
+    // what a constant verdict cannot do.
+    sqlx::query(
+        "UPDATE build_leases SET state = 'terminal', fencing_token = NULL, \
+         terminal_reason = 'released', terminal_at = now() \
+         WHERE consumer_kind = 'task_invocation' AND consumer_id = 'inv-full-pool'",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let gate = gate_for(&repo, &victim.id).await;
+    assert_eq!(
+        gate["build_capacity"]["occupancy"], 0,
+        "releasing the invocation lease must move the live occupancy: {gate:#}"
+    );
+    assert_eq!(gate["build_capacity"]["at_capacity"], false);
+    assert_eq!(
+        gate["gate_verdict"], "unexplained",
+        "with the pool drained no evaluated gate fires, so the verdict must fall back"
+    );
+}
+
 /// Neutralisation: with the lease ledger empty and the pool not full, nothing
 /// is claimed. The verdict must be `unexplained` — never `stranded` — and it
 /// must ship the list of gates it did not consult, so an empty `reasons` can be

--- a/server/crates/djinn-telemetry/src/kueue_retired_relation_tests.rs
+++ b/server/crates/djinn-telemetry/src/kueue_retired_relation_tests.rs
@@ -1,0 +1,526 @@
+//! The Kueue cutover's telemetry gate (`plcj`, acceptance criterion 3).
+//!
+//! # What is being asserted, and why not a grep
+//!
+//! The cutover deleted the pre-create build-admission ledger. Ten gauges and
+//! counters that only that authority ever wrote went with it — see the comment
+//! block above [`super::BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL`]. The failure
+//! mode this file guards is NOT "a stale constant survived in the source": it is
+//! **a series that still reaches Prometheus while the relation behind it is
+//! gone**. A described-but-unwritten series renders as permanently absent, which
+//! a dashboard reads as *healthy*.
+//!
+//! A `grep` over `src/` cannot tell those two apart. It fires on a comment that
+//! merely names the dead relation (this crate has several, deliberately), and it
+//! stays silent on a metric assembled at runtime. So every assertion here is
+//! made against **a live Prometheus registry**, on the names that registry
+//! actually rendered after the crate's own emission surface was driven through
+//! it.
+//!
+//! # Why an isolated registry
+//!
+//! The recorder installed by [`super::init`] is process-global and cargo runs
+//! every test in a binary as one process, so a global-registry assertion would
+//! see whatever the crate's other ~40 tests emitted, in whatever order they
+//! happened to run. PR #2824 added [`super::IsolatedRecorder`] for exactly this
+//! flake class; it is used here rather than [`super::render`].
+//!
+//! # The three tests, and what each would miss alone
+//!
+//! 1. [`no_emitted_metric_names_a_relation_the_kueue_cutover_deleted`] drives
+//!    the crate's whole public emission surface into a private registry and
+//!    asserts no rendered name carries a retired token. Alone, it would pass if
+//!    the sweep silently stopped covering the crate.
+//! 2. [`the_emission_sweep_covers_every_metric_the_crate_describes`] closes
+//!    that: every metric name `register_metrics` declares — captured live, from
+//!    a recorder that intercepts the `describe_*` calls — must appear among the
+//!    names the sweep rendered. A metric added without a sweep entry fails here
+//!    and names itself.
+//! 3. [`the_retired_relation_detector_flags_a_planted_series`] proves the
+//!    detector has teeth: the same predicate, over a registry that DID emit
+//!    `djinn_build_admission_journal_degraded`, must report it. Without this a
+//!    typo in [`RETIRED_RELATION_TOKENS`] would make tests 1 and 2 vacuous.
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
+
+use super::{IsolatedRecorder, register_metrics};
+
+/// Substrings that may not appear in any metric name this crate can emit.
+///
+/// Every entry is a relation or authority the Kueue cutover removed, not a
+/// stylistic preference:
+///
+/// * `admission_journal` — the pods-quota reservation ledger (migration 121).
+///   Its repository was deleted by `o53p`; nothing reads it.
+/// * `generation_ack` — `admission_handoff_generation_ack` (migration 149),
+///   retired with the v0→v1 handoff by `ubne`.
+/// * `admission_inventory`, `admission_transition`, `admission_occupancy`,
+///   `admission_stale`, `handoff_warning`, `seconds_since_reconcile`,
+///   `create_unknown_health`, `would_defer`, `unknown_classification` — the
+///   metric families written only by the deleted `BuildAdmissionController` and
+///   its reconciler.
+///
+/// `admission_handoff` itself is deliberately ABSENT from this list. `ubne`
+/// retired the handoff *semantics* but kept the physical row as the invocation
+/// lease's arming authority (`InvocationLeaseAuthorityRepository`), so it is a
+/// live relation, and banning its name would be a false positive.
+const RETIRED_RELATION_TOKENS: &[&str] = &[
+    "admission_journal",
+    "generation_ack",
+    "admission_inventory",
+    "admission_transition",
+    "admission_occupancy",
+    "admission_stale",
+    "handoff_warning",
+    "seconds_since_reconcile",
+    "create_unknown_health",
+    "would_defer",
+    "unknown_classification",
+];
+
+/// Metric names in `rendered` that carry a retired token.
+///
+/// Shared by the assertion and by its own neutralisation test, so the two can
+/// never drift apart.
+fn retired_offenders(names: &BTreeSet<String>) -> Vec<String> {
+    names
+        .iter()
+        .filter(|name| {
+            RETIRED_RELATION_TOKENS
+                .iter()
+                .any(|token| name.contains(token))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Metric names a Prometheus render declared, read off its `# TYPE` lines.
+///
+/// The `# TYPE` line carries the base name for every metric kind, including
+/// histograms whose samples are suffixed `_bucket` / `_sum` / `_count`, so this
+/// is the complete set of *names* the registry produced — which is exactly what
+/// the acceptance criterion is about.
+fn rendered_metric_names(rendered: &str) -> BTreeSet<String> {
+    rendered
+        .lines()
+        .filter_map(|line| line.strip_prefix("# TYPE "))
+        .filter_map(|rest| rest.split_whitespace().next())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// A recorder that answers every registration with a no-op handle and only
+/// remembers the names it was asked about.
+///
+/// This is how the described-metric inventory is obtained from the live
+/// `metrics` path rather than by reading the source: `register_metrics` is run
+/// against it and every `describe_*` key it emits is captured.
+#[derive(Default)]
+struct NameCapturingRecorder {
+    names: Mutex<BTreeSet<String>>,
+}
+
+impl NameCapturingRecorder {
+    fn capture(&self, key: &str) {
+        self.names
+            .lock()
+            .expect("name capture mutex poisoned")
+            .insert(key.to_owned());
+    }
+
+    fn names(&self) -> BTreeSet<String> {
+        self.names
+            .lock()
+            .expect("name capture mutex poisoned")
+            .clone()
+    }
+}
+
+impl Recorder for NameCapturingRecorder {
+    fn describe_counter(&self, key: KeyName, _unit: Option<Unit>, _description: SharedString) {
+        self.capture(key.as_str());
+    }
+
+    fn describe_gauge(&self, key: KeyName, _unit: Option<Unit>, _description: SharedString) {
+        self.capture(key.as_str());
+    }
+
+    fn describe_histogram(&self, key: KeyName, _unit: Option<Unit>, _description: SharedString) {
+        self.capture(key.as_str());
+    }
+
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+        self.capture(key.name());
+        Counter::noop()
+    }
+
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+        self.capture(key.name());
+        Gauge::noop()
+    }
+
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+        self.capture(key.name());
+        Histogram::noop()
+    }
+}
+
+/// Drive every public emission entry point this crate exposes exactly once.
+///
+/// Label VALUES are deliberately arbitrary where the signature accepts a
+/// `&str`: labels do not participate in a metric's name, and the closed-label
+/// contracts are already covered by the per-family tests in `lib.rs`. What
+/// matters here is that every name the crate can produce is produced.
+///
+/// Calls are grouped and ordered to match the module order in `lib.rs`, so a
+/// reviewer can walk the two side by side.
+/// `super::render_isolated`'s soundness rule applies: this is a synchronous
+/// body and every call records on the calling thread.
+#[allow(clippy::too_many_lines)]
+fn emit_every_public_metric() {
+    use super::{
+        agent_session_phase, arbiter, board_health_mismatch, breaker, build_admission,
+        build_slot_occupancy, build_slot_queue, cache_cleanup, canonical_graph_slot, cargo_cache,
+        cargo_invocation, cargo_target_seed, cargo_warm_base, cargo_warm_incremental_prune,
+        cargo_warm_step, dispatch, doctor, failover, fallback_rescue, galaxy_artifact_publication,
+        galaxy_artifact_route, graph_retention, infra_delta, inline_cleanup, jit_pitfalls,
+        liveness_metrics, memory_retrieval, pr_poller, preservation, prompt_context_metrics, psi,
+        reasoning_kill, refinement_run, reply_loop, role_class, run_dir, server_memory, slot_pool,
+        stale_sweep, task, taskrun_lifecycle, warm_cache, workspace_cleanup, workspace_clone,
+        workspace_seed, zombie,
+    };
+
+    let tick = Duration::from_millis(1);
+
+    taskrun_lifecycle::increment_job_started();
+    taskrun_lifecycle::increment_worker_completion_submitted();
+
+    breaker::increment_trip();
+    breaker::set_state("global", "model", 1.0);
+
+    zombie::increment_reap(zombie::KIND_STARTUP);
+    refinement_run::increment_reaped_phantom();
+    jit_pitfalls::increment_outcome(jit_pitfalls::OUTCOME_INJECTED);
+
+    server_memory::record_process_rss(2, 1);
+    server_memory::record_limit_bytes(4);
+    server_memory::record_process_unavailable();
+    server_memory::record_jemalloc_stats(3, 2, 1);
+    server_memory::record_jemalloc_unavailable();
+
+    task::increment_reopen();
+    task::increment_parked();
+    task::increment_parked_labeled(1, 0, 0, 1);
+
+    pr_poller::set_tracked(1);
+    pr_poller::increment_merge_failure();
+
+    inline_cleanup::increment_pr_closed();
+    inline_cleanup::increment_branch_deleted();
+    inline_cleanup::increment_skipped(inline_cleanup::REASON_DRY_RUN);
+
+    board_health_mismatch::record_page(1);
+    board_health_mismatch::record_duration(tick);
+    board_health_mismatch::record_coalesced("tick");
+    board_health_mismatch::record_outcome("ok", "tick");
+    board_health_mismatch::record_pass_age(Some("2026-07-30T00:00:00.000Z"));
+
+    doctor::set_findings("check", 1);
+    doctor::set_run_duration_seconds("check", 1.0);
+    doctor::record_run_duration("check", tick);
+    doctor::record_retrieval_refresh("ok", tick, 1.0);
+
+    cargo_cache::record_seed_hit("project");
+    cargo_cache::record_seed_cold("project", "base_missing");
+    cargo_cache::record_warm_base_freshness("project", 1.0);
+    cargo_cache::record_warm_step_fresh_count("project", "clippy", 1);
+    cargo_cache::record_warm_step_compiling_count("project", "clippy", 1);
+
+    stale_sweep::increment_pr_reaped();
+    stale_sweep::increment_branch_reaped();
+    stale_sweep::increment_pr_skipped(stale_sweep::REASON_API_ERROR);
+    stale_sweep::increment_orphan_session_reaped();
+
+    cargo_warm_step::record_step_seconds(
+        "project",
+        cargo_warm_step::STEP_CLIPPY,
+        cargo_warm_step::OUTCOME_OK,
+        1.0,
+    );
+    cargo_warm_step::increment_step(
+        "project",
+        cargo_warm_step::STEP_CLIPPY,
+        cargo_warm_step::OUTCOME_OK,
+    );
+    cargo_warm_step::set_workspace_path("project", "/workspace");
+
+    cargo_warm_base::set_units(
+        "project",
+        cargo_warm_base::PHASE_PRE_COMPILE,
+        cargo_warm_base::KIND_DEP_FILES,
+        1,
+    );
+    cargo_warm_base::increment_sweep_decision("project", cargo_warm_base::DECISION_SWEPT);
+
+    cargo_warm_incremental_prune::increment_attempt(
+        "project",
+        cargo_warm_incremental_prune::Outcome::Pruned,
+    );
+    cargo_warm_incremental_prune::add_pruned_bytes("project", 1);
+
+    cargo_target_seed::increment_seed_hit();
+    cargo_target_seed::increment_seed_fallback(cargo_target_seed::FALLBACK_REASON_UNKNOWN);
+    cargo_target_seed::add_seed_entries(cargo_target_seed::DISPOSITION_UNSEEDED, 1);
+
+    warm_cache::record_decision(
+        "project",
+        warm_cache::Outcome::Hit,
+        warm_cache::Reason::Fresh,
+    );
+
+    dispatch::increment_strike_decision(
+        dispatch::STRIKE_DECISION_COUNTED,
+        dispatch::STRIKE_SOURCE_CRASHED,
+    );
+    dispatch::increment_attempt(dispatch::OUTCOME_OK);
+    dispatch::record_cross_model_review("approved");
+    dispatch::record_last_success_timestamp(1.0);
+    dispatch::set_cooldowns_active(1);
+    dispatch::set_inflight_ledger_size(1);
+    dispatch::set_user_cap_utilization("user", "model", 1, 2);
+    dispatch::record_success_at(1.0);
+    dispatch::increment_ok();
+    dispatch::increment_cooldown();
+    dispatch::increment_cap();
+    dispatch::increment_breaker();
+    dispatch::increment_error();
+
+    slot_pool::set_slots(slot_pool::STATE_FREE, "model", 1);
+
+    preservation::increment_attempt(preservation::OUTCOME_SUCCEEDED, preservation::TRIGGER_STALL);
+
+    failover::increment_candidate_attempt("ok", "provider", "model");
+    failover::increment_candidate_accepted("provider", "model");
+    failover::increment_chain_exhausted("provider", "model");
+    failover::record_latency(tick);
+
+    liveness_metrics::record_zero_output_stall(tick, "idle", "stall", false);
+
+    prompt_context_metrics::record_total(tick);
+    prompt_context_metrics::record_child_span("knowledge", tick);
+
+    infra_delta::increment("ok", true);
+    fallback_rescue::increment_rescue();
+    reply_loop::increment_inline_char_budget_trip();
+    reasoning_kill::increment("reasoning", "idle_stall", "killed");
+
+    arbiter::record_decision("approve");
+    arbiter::record_park("stall", "parked");
+    arbiter::record_monitored_reopen("reopened");
+    arbiter::record_termination("clean");
+    arbiter::record_time_in_arbitration(1.0);
+
+    cache_cleanup::increment_pressure_unit(
+        cache_cleanup::PressureMode::DryRun,
+        cache_cleanup::PressureRung::Base,
+        cache_cleanup::PressureOutcome::Planned,
+    );
+    cache_cleanup::record_pressure_projected_allocated_bytes(
+        cache_cleanup::PressureMode::DryRun,
+        cache_cleanup::PressureRung::Base,
+        1,
+    );
+    cache_cleanup::record_pressure_reclaimed_allocated_bytes(
+        cache_cleanup::PressureMode::DryRun,
+        cache_cleanup::PressureRung::Base,
+        1,
+    );
+    cache_cleanup::increment_pressure_termination(
+        cache_cleanup::PressureMode::DryRun,
+        cache_cleanup::PressureTermination::Completed,
+    );
+    cache_cleanup::increment_cleanup_total(
+        cache_cleanup::COMPONENT_SCCACHE,
+        cache_cleanup::OUTCOME_DELETED,
+        "dry_run",
+    );
+    cache_cleanup::record_reclaimed_bytes(cache_cleanup::COMPONENT_SCCACHE, "dry_run", 1);
+    cache_cleanup::increment_candidates(cache_cleanup::COMPONENT_SCCACHE, "dry_run", 1);
+
+    // Emits nothing; called so the sweep visibly covers the module rather than
+    // leaving a reader to wonder whether it was forgotten.
+    role_class::observe(role_class::CLASS_LIGHT);
+
+    cargo_invocation::record_seconds("build", "ok", "warm", tick);
+    workspace_clone::record_seconds("ok", tick);
+    workspace_seed::record_seconds("ok", tick);
+    workspace_cleanup::record_seconds("cancel", "ok", tick);
+
+    build_slot_queue::record_wait_seconds(build_slot_queue::OUTCOME_ADMITTED, tick);
+    build_slot_occupancy::set_slots_in_use(1);
+    build_slot_occupancy::set_slots_queued(1);
+
+    // The surviving per-invocation cgroup-lease family. Everything the deleted
+    // pre-create ledger wrote used to live in this same module, which is why it
+    // is the one whose rendered names matter most here.
+    build_admission::record_shadow_invocation(true);
+    build_admission::record_lift_rejected();
+    build_admission::record_invocation_degraded("cancelled");
+
+    run_dir::set_state_count("active", 1);
+    run_dir::set_state_allocated_bytes("active", 1);
+    run_dir::set_reserved_bytes(1);
+    run_dir::set_unowned_bytes(1);
+    run_dir::increment_queue_reason("insufficient_disk");
+    run_dir::increment_quota_failure("setquota_failed");
+    run_dir::increment_reclaim("released", 1, 1);
+    run_dir::increment_seed_outcome("hit");
+    run_dir::increment_warm_base_removed();
+
+    agent_session_phase::add_phase_duration("provider_wait", "worker", tick);
+
+    psi::record_success("cpu", 1.0);
+    psi::record_failure("cpu", "unavailable");
+
+    graph_retention::increment("delete", "ok", "aged_out", 1);
+
+    canonical_graph_slot::record_install(canonical_graph_slot::Source::Warm, Some(1), 1, 1);
+    canonical_graph_slot::initialize_empty();
+    canonical_graph_slot::record_cleared();
+
+    galaxy_artifact_publication::record_build_duration(tick);
+    galaxy_artifact_publication::record_publication_duration(tick);
+    galaxy_artifact_publication::record_sizes(11, 7, 1);
+    galaxy_artifact_publication::record_success();
+    galaxy_artifact_publication::record_oversize();
+    galaxy_artifact_publication::record_failure();
+
+    galaxy_artifact_route::record_outcome("ok");
+    galaxy_artifact_route::record_chunk(17);
+
+    let retrieval = memory_retrieval::MemoryRetrievalMetrics::new();
+    retrieval
+        .observe(
+            memory_retrieval::RetrievalEntryPoint::Dispatch,
+            memory_retrieval::RetrievalOutcome::Success,
+            tick,
+            1,
+        )
+        .expect("retrieval observation");
+    retrieval
+        .observe_stage(
+            memory_retrieval::RetrievalEntryPoint::Dispatch,
+            memory_retrieval::RetrievalStage::Lexical,
+            tick,
+        )
+        .expect("retrieval stage observation");
+}
+
+/// Render the sweep into a registry no other test can reach.
+fn sweep_rendered_names() -> BTreeSet<String> {
+    let recorder = IsolatedRecorder::new();
+    {
+        let _guard = recorder.scope();
+        emit_every_public_metric();
+    }
+    rendered_metric_names(&recorder.render())
+}
+
+/// Every distinct metric name [`emit_every_public_metric`] currently produces.
+///
+/// Pinned, not bounded — see the assertion that uses it.
+const EMITTED_METRIC_NAME_COUNT: usize = 128;
+
+/// **The acceptance criterion.** No metric this crate can emit names a relation
+/// the Kueue cutover deleted — asserted on the names a live registry rendered.
+#[test]
+fn no_emitted_metric_names_a_relation_the_kueue_cutover_deleted() {
+    let names = sweep_rendered_names();
+
+    // A sweep that stopped emitting would satisfy the offender check
+    // vacuously, so the count is pinned rather than bounded. An exact number is
+    // the only form that also catches a call being REMOVED from
+    // `emit_every_public_metric`, which a floor would silently absorb.
+    assert_eq!(
+        names.len(),
+        EMITTED_METRIC_NAME_COUNT,
+        "the emission sweep rendered {} metric names instead of {}. If you \
+         added a metric, add a call to `emit_every_public_metric` and bump \
+         this number; if you removed one, bump it down. Do NOT relax this into \
+         an inequality — it is what stops the sweep from quietly narrowing \
+         until the assertion below covers nothing.",
+        names.len(),
+        EMITTED_METRIC_NAME_COUNT,
+    );
+
+    let offenders = retired_offenders(&names);
+    assert!(
+        offenders.is_empty(),
+        "these emitted metrics name a relation the Kueue cutover deleted: {offenders:?}"
+    );
+}
+
+/// The sweep must keep up with the crate.
+///
+/// Every name `register_metrics` describes is captured from the live `metrics`
+/// recorder path — not read out of the source — and must appear among the names
+/// the sweep actually rendered. A metric added without a matching sweep entry
+/// fails here and names itself, which is what stops
+/// [`no_emitted_metric_names_a_relation_the_kueue_cutover_deleted`] from
+/// quietly narrowing over time.
+#[test]
+fn the_emission_sweep_covers_every_metric_the_crate_describes() {
+    let capture = NameCapturingRecorder::default();
+    metrics::with_local_recorder(&capture, register_metrics);
+    let described = capture.names();
+    assert!(
+        described.len() >= 80,
+        "register_metrics described only {} metrics; the coverage check below \
+         would be vacuous",
+        described.len()
+    );
+
+    let emitted = sweep_rendered_names();
+    let uncovered: Vec<&String> = described
+        .iter()
+        .filter(|name| !emitted.contains(*name))
+        .collect();
+    assert!(
+        uncovered.is_empty(),
+        "these metrics are described but the emission sweep never emits them, \
+         so the retired-relation assertion does not cover them — add a call to \
+         `emit_every_public_metric`: {uncovered:?}"
+    );
+}
+
+/// Neutralisation. The detector must actually detect.
+///
+/// A registry that DID emit one of the deleted families is run through the same
+/// predicate the assertion uses. If [`RETIRED_RELATION_TOKENS`] were misspelled
+/// or emptied, the two tests above would pass while proving nothing; this one
+/// fails instead.
+#[test]
+fn the_retired_relation_detector_flags_a_planted_series() {
+    let recorder = IsolatedRecorder::new();
+    {
+        let _guard = recorder.scope();
+        // One of the ten gauges deleted with the pre-create admission ledger.
+        metrics::gauge!("djinn_build_admission_journal_degraded").set(1.0);
+    }
+    let names = rendered_metric_names(&recorder.render());
+    assert!(
+        names.contains("djinn_build_admission_journal_degraded"),
+        "the planted series must reach the isolated registry, or this test \
+         proves nothing about the detector: {names:?}"
+    );
+    assert_eq!(
+        retired_offenders(&names),
+        vec!["djinn_build_admission_journal_degraded".to_owned()],
+        "the detector used by the acceptance assertion must flag a retired \
+         relation when one is genuinely emitted"
+    );
+}

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -6401,3 +6401,7 @@ mod galaxy_artifact_route_tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "kueue_retired_relation_tests.rs"]
+mod kueue_retired_relation_tests;


### PR DESCRIPTION
Fourth of five slices of the Kueue cutover (epic `4c9q`, proposal `9oga`, task `plcj`). Branched from `a2e3b03d8` (S3b).

## The finding that shaped this PR

`plcj` was written before S3a (`32a9e0923`) and S3b (`a2e3b03d8`) landed. **All nineteen dependents it names were already re-pointed by those two slices** — `cargo check --workspace --all-targets` is clean at `a2e3b03d8` with zero edits (3m31s, exit 0). Re-pointing again would have been a no-op.

What S3a/S3b could not do mid-cutover is fix what those dependents now *mean*. Three of them were left asserting things that stopped being true when their producers were deleted, and one of those assertions is the exact shape of the 2026-07-29 five-hour board-wide outage.

## What actually remained

**1. `task_tools/types.rs` made a false claim to every `board_health` client.** S3a's own doc said, of `BoardHealthBuildCapacity`:

> "Since the Kueue cutover deleted the pre-create admission ledger, this is the only occupancy authority in the payload: there is no second gate that can deny before capacity is measured."

Kueue's ClusterQueue is precisely that second gate. On 2026-07-29 an operator read `{occupancy: 1, cap: 3, at_capacity: false}` for five hours and looked elsewhere while a different authority refused every dispatch. This doc invites the identical mistake against a new authority. Corrected, and the ClusterQueue gap is named.

**2. The gate's declared coverage no longer matched the dispatch path.** `board_health_dispatch_gate` ships `evaluated_gates` / `unevaluated_gates` so an empty `reasons` reads as the bounded claim it is. The bound moved and the list did not. `kueue_clusterqueue_admission` is now a way a task sits queued with **no row in any relation this section reads** — a Job Kueue has not admitted is suspended by Kueue. It is declared rather than left for an operator to infer from a healthy-looking number.

**3. `build_admission_denials` and the `task_dispatch` lease rows lost their writer.** Both are **RETAINED**, and no writer is added — see the decision below. What changed is that the payload now says so: the steady state is `null`, and `null` is not evidence that Kueue admitted the Job.

## Decision on `build_admission_denials`

**Keep the relation, the repository, migration 161 and the board-health read. Add no writer.**

- The `null` it reports is literally true — "no recorded denial" — so it is not a false healthy signal, which is the bar S3a set.
- Ripping it out would *lose* evidence: a board wedged behind a pre-cutover denial row must still be explainable, and the read is the only thing that can explain it.
- Adding a writer against Kueue's decision would recreate #2661 — a denial row that outlives its condition is a tombstone in a new table.
- But the honest half was missing: an absent block used to mean "the dispatcher recorded no denial", and now it also means "nobody records anything". Both the DB module docs and the client-facing type now say that, and point at `kueue_clusterqueue_admission` for what genuinely is not observable.

Note for the epic: S3a's and S3b's module docs both hand the physical `DROP` and migration-161 retirement to **`flc5`**, which does not exist on the board. The last filed slice is S5 (`kh7g`). Someone should file it — this PR deliberately does not drop anything.

Also preserved as instructed: `no_dispatch_lease_can_ever_be_acquired_again` (verified passing), and `CoordinatorDiskCapacitySource` is untouched (`nquz`'s seam).

## Acceptance criteria, with the mutation run for each

### AC1 — retained dependents compile and pass; the gate still returns a BLOCKING verdict for a genuinely blocked board

Every existing blocking proof in the suite uses a `task_dispatch` build-lease row. Nothing constructs `LeaseIdentity::TaskDispatch` any more, so those tests still pass while proving only that a **legacy row shape renders** — the gate could be inert against anything production writes and they would not notice.

Added `a_pool_filled_by_live_invocation_leases_blocks_the_gate`, which fills the pool with `task_invocation` leases — the consumer kind the per-invocation cgroup lease still writes from inside the task-run Pod, retained by 9oga's non-goals — and asserts the verdict moves **both ways** against the real ledger:

- pool full -> `gate_verdict: "blocked"`, `reasons` contains `build_pool_at_capacity`, `occupancy: 2 / cap: 2`;
- ClusterQueue gap declared in `unevaluated_gates`;
- lease released -> `occupancy: 0`, `at_capacity: false`, verdict falls back to `unexplained`.

A constant `blocked` fails the second half; a constant `Ok` fails the first.

**Mutation** — `gate_verdict = VERDICT_UNEXPLAINED` (exactly the "rewired to a constant `Ok`" shape the AC names):

```
test result: FAILED. 5 passed; 6 failed
failures:
    board_health_dispatch_gate::a_full_pool_explains_a_task_with_no_lease_row
    board_health_dispatch_gate::a_persisted_denial_cause_becomes_the_reason_for_a_stranded_task
    board_health_dispatch_gate::a_pool_filled_by_live_invocation_leases_blocks_the_gate
    board_health_dispatch_gate::clearing_a_denial_stops_it_being_reported_as_a_reason
    board_health_dispatch_gate::queued_dispatch_lease_is_reported_as_a_capacity_denial
    board_health_dispatch_gate::terminal_dispatch_lease_is_reported

  left: String("unexplained")
 right: "blocked"
```

Reverted; 11/11 pass. Also green: `djinn-db --lib board_health_dispatch_gate` (20), `djinn-db --test task_tests` (148), `djinn-control-plane --test board_tools` (7), `djinn-coordinator` `doctor_stranded_ready_e2e` and `no_dispatch_lease_can_ever_be_acquired_again`, `djinn-telemetry --lib` (87), clippy `--all-targets` clean on all three changed crates.

### AC2 — `warm_build_lease.rs` unmodified

```
$ git diff --exit-code origin/main -- server/crates/djinn-agent-worker/src/warm_build_lease.rs
exit=0
```

**Mutation** — one appended comment line:

```
+// AC2 mutation probe
MUTATED-exit=1
RESTORED-exit=0
```

### AC3 — `djinn-telemetry` emits no metric or span referencing a deleted relation, asserted on emitted names from a live registry

New module `kueue_retired_relation_tests.rs`. It is deliberately **not** a source grep: this crate keeps comments naming the dead relations on purpose, and a grep cannot distinguish those from a live series. It uses PR #2824's `IsolatedRecorder` rather than the process-global registry.

Three tests, because the first two are each vacuous alone:

1. **The criterion.** The crate's whole public emission surface (~110 entry points, every module in `lib.rs` plus `memory_retrieval`) is driven into a private registry; no rendered `# TYPE` name carries a retired token.
2. **The sweep cannot narrow.** The rendered-name count is *pinned* at 128 rather than bounded — a floor would silently absorb a deleted call — and every metric `register_metrics` describes, captured by a `Recorder` that intercepts the live `describe_*` calls, must appear among the emitted names.
3. **The detector has teeth.** The same predicate, over a registry that *did* emit `djinn_build_admission_journal_degraded`, must flag it. Without this, a typo in the token list would make 1 and 2 prove nothing.

**Mutation A** — emit a deleted gauge inside the sweep:

```
these emitted metrics name a relation the Kueue cutover deleted: ["djinn_build_admission_journal_degraded"]
```

**Mutation B** — delete one call from the sweep:

```
assertion `left == right` failed: the emission sweep rendered 127 metric names instead of 128.
  left: 127
 right: 128
```

(The first attempt at B, before the count was pinned, passed — the describe-coverage check alone did not catch it, because 26 of the 128 emitted metrics are never `describe_*`d. Pinning the count is what closed it.)

`admission_handoff` is deliberately **absent** from the banned-token list: S3b retired the handoff *semantics* but kept the physical row as the invocation lease's arming authority, so it is a live relation and banning its name would be a false positive. The list is `admission_journal`, `generation_ack`, and the nine metric families S3a deleted.

## Scope

- No `deploy/**`, no `djinn-cgroup-launcher/**`, no `djinn-launcher-protocol`. The launcher's `admission_handoff` mentions are comments only and are left for the trivial follow-up.
- `state/mod.rs` untouched — no collision with S5 (`kh7g`).
- No sqlx macros touched (all runtime `sqlx::query`), so no `.sqlx` regeneration.
- 5 files, +733/-15, of which the new telemetry test module is 486 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)