### PR TITLE
feat(rbac): grant the controller pods/resize, patch-only and namespaced (i6ug)

### DIFF
--- a/deploy/helm/djinn/templates/role-controller.yaml
+++ b/deploy/helm/djinn/templates/role-controller.yaml
@@ -26,6 +26,27 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch", "patch", "delete"]
+  # In-place Pod vertical scaling (`PATCH pods/resize`, k8s >= 1.33) for the CPU
+  # quota cutover. djinn-server, holding the controller ServiceAccount, is the
+  # ONLY resize actor: the task-run ServiceAccount has no RBAC at all, task-run
+  # Pods set `automountServiceAccountToken: false`, and their single projected
+  # token carries audience `djinn` rather than the apiserver's — so
+  # repository-controlled child code cannot reach this subresource.
+  #
+  # `patch` alone. The resize subresource accepts PATCH only, so `update` would
+  # be dead breadth, and no other verb is meaningful on a subresource that
+  # exists solely to mutate a running Pod's resources.
+  #
+  # Deliberately NAMESPACED, and deliberately without `resourceNames`. RBAC
+  # cannot express a set of Pod names that only exists at run time (one per
+  # task-run), so exact-Pod authorization is an APPLICATION invariant — the
+  # durable permit relation plus a Pod UID fence — not an RBAC one. Task Pods
+  # simply hold no resize credential to bypass that with. Do not widen this
+  # Role, or promote it cluster-wide, to compensate; tests/pods-resize-rbac.sh
+  # fails on either.
+  - apiGroups: [""]
+    resources: ["pods/resize"]
+    verbs: ["patch"]
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get", "list"]

--- a/deploy/helm/djinn/tests/pods-resize-rbac.sh
+++ b/deploy/helm/djinn/tests/pods-resize-rbac.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# Chart contract for the `pods/resize` RBAC grant and the task-run credential
+# boundary it depends on (i6ug / proposal 3i92's CPU quota cutover).
+#
+# The property under test is not "a resize rule exists". It is: djinn-server,
+# holding the controller ServiceAccount, is the ONLY actor in the cluster that
+# can call `PATCH pods/resize`, and it can do so only inside its own namespace.
+# Four facts have to hold together for that to be true, so they are asserted
+# together here — an RBAC edit cannot silently take the credential boundary
+# with it:
+#
+#   1. exactly one rule in the whole render grants pods/resize, it is exactly
+#      apiGroups [""] / resources ["pods/resize"] / verbs ["patch"], and it
+#      lives in the NAMESPACED controller Role;
+#   2. the task-run ServiceAccount is the subject of no RoleBinding and no
+#      ClusterRoleBinding (directly or via a system:serviceaccounts group);
+#   3. task-run Pods still render `automountServiceAccountToken: false`, and
+#      their one projected token still carries audience `djinn` rather than the
+#      apiserver's — so repository-controlled child code holds no apiserver
+#      credential to reach the subresource with;
+#   4. the render adds no ClusterRole and no ClusterRoleBinding beyond the
+#      pre-existing tokenreview pair, which stays djinn-server's only
+#      cluster-wide permission.
+#
+# Exact-Pod authorization is deliberately NOT an RBAC property: Kubernetes RBAC
+# cannot express a resourceNames set that only exists at run time (one Pod per
+# task-run). It is an application invariant — the durable permit relation plus
+# a Pod UID fence. This contract's job is to keep the Role from being widened
+# to compensate for that.
+#
+# Every assertion is proved non-vacuous below: each check is re-run against a
+# render (or a job.rs) mutated to violate exactly that check, and must reject
+# it for the stated reason.
+#
+# Usage: bash deploy/helm/djinn/tests/pods-resize-rbac.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# DJINN_CHART_DIR lets a caller point this same contract at a mutated copy of
+# the chart, the way deploy/preflight/tests/render-gate.sh does.
+CHART_DIR="${DJINN_CHART_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+REPO_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+JOB_RS="$REPO_DIR/server/crates/djinn-k8s/src/job.rs"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "FAIL: required test tool '$1' is not installed" >&2
+    exit 1
+  }
+}
+require_tool helm
+require_tool python3
+
+[ -f "$JOB_RS" ] || {
+  echo "FAIL: task-run Pod renderer not found at $JOB_RS" >&2
+  exit 1
+}
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+helm template pods-resize-rbac "$CHART_DIR" --is-upgrade >"$WORK/render.yaml"
+
+python3 - "$WORK/render.yaml" "$JOB_RS" <<'PY'
+import copy
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+RESIZE = 'pods/resize'
+BINDING_KINDS = ('RoleBinding', 'ClusterRoleBinding')
+ROLE_KINDS = ('Role', 'ClusterRole')
+# The one pre-existing cluster-wide permission: TokenReview, which is not a
+# namespaced resource, so it cannot be granted any other way.
+CLUSTER_SCOPED_ALLOWLIST = '-tokenreview'
+EXPECTED_AUDIENCE = 'djinn'
+
+
+def documents(path):
+    return [doc for doc in yaml.safe_load_all(Path(path).read_text(encoding='utf-8')) if doc]
+
+
+def of_kind(docs, *kinds):
+    return [doc for doc in docs if doc.get('kind') in kinds]
+
+
+def name(doc):
+    return doc.get('metadata', {}).get('name', '<unnamed>')
+
+
+def grants_resize(rule):
+    """True if `rule` authorizes any verb on the pods/resize subresource.
+
+    Checked through the wildcards, not by string equality: resources ["*"] in
+    the core group reaches pods/resize just as surely as naming it, and a
+    contract that only recognised the literal spelling would wave that through.
+    """
+    groups = rule.get('apiGroups') or []
+    resources = rule.get('resources') or []
+    if not any(group in ('', '*') for group in groups):
+        return False
+    return any(resource in (RESIZE, '*', 'pods/*') for resource in resources)
+
+
+def strip_rust_comments(text):
+    return '\n'.join(line for line in text.splitlines() if not line.lstrip().startswith('//'))
+
+
+def pod_spec_block(text):
+    """Return the task-run PodSpec struct literal, comments stripped.
+
+    Scoped by brace matching rather than grepping the whole file so the
+    assertion below reads the PodSpec djinn-server actually dispatches, not a
+    doc comment, a test fixture, or some other struct that happens to mention
+    the field.
+    """
+    marker = 'let pod_spec = PodSpec {'
+    assert marker in text, 'task-run PodSpec literal not found in job.rs'
+    start = text.index(marker)
+    cursor = start + len(marker)
+    depth = 1
+    while depth:
+        assert cursor < len(text), 'unbalanced braces in the task-run PodSpec literal'
+        if text[cursor] == '{':
+            depth += 1
+        elif text[cursor] == '}':
+            depth -= 1
+        cursor += 1
+    return strip_rust_comments(text[start:cursor])
+
+
+def validate(docs, job_rs):
+    # ---- 1. the grant itself -------------------------------------------------
+    grants = [
+        (doc, rule)
+        for doc in of_kind(docs, *ROLE_KINDS)
+        for rule in (doc.get('rules') or [])
+        if grants_resize(rule)
+    ]
+    assert len(grants) == 1, (
+        f'expected exactly one rule granting {RESIZE} in the whole render, got {len(grants)}'
+        + ''.join(f'\n  {doc["kind"]}/{name(doc)}: {rule}' for doc, rule in grants)
+    )
+    holder, rule = grants[0]
+    assert holder['kind'] == 'Role', (
+        f'the {RESIZE} grant must live in a namespaced Role; found it in '
+        f'{holder["kind"]}/{name(holder)}. RBAC cannot fence resize to one Pod, so the '
+        'namespace is the only fence the Role itself provides — do not promote it'
+    )
+    assert holder.get('metadata', {}).get('namespace'), (
+        f'Role/{name(holder)} carries the {RESIZE} grant without a namespace'
+    )
+    assert name(holder).endswith('-controller'), (
+        f'{RESIZE} is granted by Role/{name(holder)}, not the controller Role'
+    )
+    assert rule.get('apiGroups') == [''], (
+        f'{RESIZE} rule apiGroups must be exactly [""], got {rule.get("apiGroups")!r}'
+    )
+    assert rule.get('resources') == [RESIZE], (
+        f'{RESIZE} rule resources must be exactly ["{RESIZE}"], got {rule.get("resources")!r}'
+    )
+    assert rule.get('verbs') == ['patch'], (
+        f'{RESIZE} rule verbs must be exactly ["patch"], got {rule.get("verbs")!r}. '
+        'The resize subresource accepts PATCH only; any other verb is unearned breadth'
+    )
+    assert set(rule) == {'apiGroups', 'resources', 'verbs'}, (
+        f'{RESIZE} rule carries unexpected keys: {sorted(set(rule) - {"apiGroups", "resources", "verbs"})}'
+    )
+
+    # No rule anywhere in the render may use an RBAC wildcard. Nothing broader
+    # than the enumerated grants is what "and nothing broader" has to mean once
+    # a new subresource is in the Role.
+    for doc in of_kind(docs, *ROLE_KINDS):
+        for entry in doc.get('rules') or []:
+            for field in ('apiGroups', 'resources', 'verbs'):
+                assert '*' not in (entry.get(field) or []), (
+                    f'{doc["kind"]}/{name(doc)} uses an RBAC wildcard in {field}: {entry}'
+                )
+
+    # ---- 2. the task-run ServiceAccount holds no RBAC -------------------------
+    task_run = [doc for doc in of_kind(docs, 'ServiceAccount') if name(doc).endswith('-taskrun')]
+    assert len(task_run) == 1, f'expected exactly one task-run ServiceAccount, got {len(task_run)}'
+    task_run_name = name(task_run[0])
+    for binding in of_kind(docs, *BINDING_KINDS):
+        for subject in binding.get('subjects') or []:
+            assert not (
+                subject.get('kind') == 'ServiceAccount' and subject.get('name') == task_run_name
+            ), (
+                f'{binding["kind"]}/{name(binding)} binds the task-run ServiceAccount '
+                f'{task_run_name} to {binding.get("roleRef")}. Task-run Pods run '
+                'repository-controlled code; they must hold no apiserver authorization at all'
+            )
+            assert not (
+                subject.get('kind') == 'Group'
+                and str(subject.get('name', '')).startswith('system:serviceaccounts')
+            ), (
+                f'{binding["kind"]}/{name(binding)} binds the group {subject.get("name")!r}, '
+                'which covers the task-run ServiceAccount'
+            )
+
+    # ---- 3. task-run Pods carry no apiserver credential ----------------------
+    spec = pod_spec_block(job_rs)
+    assert re.search(r'automount_service_account_token:\s*Some\(false\)', spec), (
+        'the task-run PodSpec no longer sets automount_service_account_token: Some(false); '
+        'the apiserver-capable default ServiceAccount token would be projected into a Pod '
+        'running repository-controlled code'
+    )
+    stray = re.search(r'automount_service_account_token:\s*(Some\(true\)|None)', strip_rust_comments(job_rs))
+    assert not stray, (
+        f'job.rs sets automount_service_account_token: {stray.group(1)} somewhere; '
+        'the task-run Pod must never automount the apiserver token'
+    )
+    audience = re.search(r'pub const TOKEN_AUDIENCE: &str = "([^"]*)";', job_rs)
+    assert audience, 'job.rs no longer declares TOKEN_AUDIENCE'
+    assert audience.group(1) == EXPECTED_AUDIENCE, (
+        f'the task-run projected token audience is {audience.group(1)!r}, expected '
+        f'{EXPECTED_AUDIENCE!r}. An apiserver (or empty) audience would make the one token '
+        'task-run Pods do hold usable against the apiserver'
+    )
+    assert re.search(r'audience:\s*Some\(TOKEN_AUDIENCE\.to_string\(\)\)', job_rs), (
+        'the task-run projected token no longer binds its audience to TOKEN_AUDIENCE'
+    )
+
+    # ---- 4. nothing new becomes cluster-wide ---------------------------------
+    for doc in of_kind(docs, 'ClusterRole', 'ClusterRoleBinding'):
+        assert name(doc).endswith(CLUSTER_SCOPED_ALLOWLIST), (
+            f'render introduces cluster-scoped RBAC {doc["kind"]}/{name(doc)}. TokenReview '
+            'remains the only cluster-wide permission djinn-server may hold; everything '
+            'else, resize included, stays namespaced'
+        )
+    for kind in ('ClusterRole', 'ClusterRoleBinding'):
+        found = of_kind(docs, kind)
+        assert len(found) == 1, f'expected exactly one {kind} in the render, got {len(found)}'
+
+
+render_path, job_rs_path = sys.argv[1:3]
+docs = documents(render_path)
+job_rs = Path(job_rs_path).read_text(encoding='utf-8')
+
+validate(docs, job_rs)
+
+
+def resize_rule(mutant):
+    for doc in of_kind(mutant, *ROLE_KINDS):
+        for rule in doc.get('rules') or []:
+            if grants_resize(rule):
+                return doc, rule
+    raise AssertionError('mutation lost the resize rule it meant to edit')
+
+
+def expect_rejected(label, mutant_docs, mutant_job, needle):
+    try:
+        validate(mutant_docs, mutant_job)
+    except AssertionError as error:
+        assert needle in str(error), (
+            f'{label}: rejected, but for the wrong reason (wanted {needle!r}): {error}'
+        )
+        print(f'  non-vacuity OK: {label}')
+    else:
+        raise AssertionError(f'{label}: forbidden configuration was ACCEPTED')
+
+
+# (a) AC1 — widen the verbs.
+mutant = copy.deepcopy(docs)
+resize_rule(mutant)[1]['verbs'] = ['patch', 'update']
+expect_rejected('widened verbs to ["patch","update"]', mutant, job_rs, 'verbs must be exactly')
+
+# (a2) AC1 — reach the subresource through a core-group resource wildcard.
+mutant = copy.deepcopy(docs)
+holder, rule = resize_rule(mutant)
+holder['rules'].append({'apiGroups': [''], 'resources': ['*'], 'verbs': ['patch']})
+expect_rejected('core-group resource wildcard', mutant, job_rs, 'exactly one rule granting')
+
+# (a3) AC1 — drop the rule entirely; the presence check must fire.
+mutant = copy.deepcopy(docs)
+holder, rule = resize_rule(mutant)
+holder['rules'].remove(rule)
+expect_rejected('removed the resize rule', mutant, job_rs, 'exactly one rule granting')
+
+# (b) AC2 — bind the controller Role to the task-run ServiceAccount.
+mutant = copy.deepcopy(docs)
+task_run_sa = [doc for doc in of_kind(mutant, 'ServiceAccount') if name(doc).endswith('-taskrun')][0]
+controller_role = resize_rule(mutant)[0]
+mutant.append({
+    'apiVersion': 'rbac.authorization.k8s.io/v1',
+    'kind': 'RoleBinding',
+    'metadata': {'name': 'resize-taskrun', 'namespace': controller_role['metadata']['namespace']},
+    'subjects': [{
+        'kind': 'ServiceAccount',
+        'name': name(task_run_sa),
+        'namespace': controller_role['metadata']['namespace'],
+    }],
+    'roleRef': {
+        'apiGroup': 'rbac.authorization.k8s.io',
+        'kind': 'Role',
+        'name': name(controller_role),
+    },
+})
+expect_rejected('bound the task-run ServiceAccount', mutant, job_rs, 'binds the task-run ServiceAccount')
+
+# (b2) AC2 — reach the same SA through the system:serviceaccounts group.
+mutant = copy.deepcopy(docs)
+controller_role = resize_rule(mutant)[0]
+namespace = controller_role['metadata']['namespace']
+mutant.append({
+    'apiVersion': 'rbac.authorization.k8s.io/v1',
+    'kind': 'RoleBinding',
+    'metadata': {'name': 'resize-all-sa', 'namespace': namespace},
+    'subjects': [{
+        'kind': 'Group',
+        'name': f'system:serviceaccounts:{namespace}',
+        'apiGroup': 'rbac.authorization.k8s.io',
+    }],
+    'roleRef': {
+        'apiGroup': 'rbac.authorization.k8s.io',
+        'kind': 'Role',
+        'name': name(controller_role),
+    },
+})
+expect_rejected('bound system:serviceaccounts', mutant, job_rs, 'which covers the task-run ServiceAccount')
+
+# (c) AC3 — stop suppressing the automounted apiserver token.
+expect_rejected(
+    'automountServiceAccountToken flipped to true',
+    docs,
+    job_rs.replace('automount_service_account_token: Some(false)',
+                   'automount_service_account_token: Some(true)'),
+    'no longer sets automount_service_account_token: Some(false)',
+)
+
+# (c1b) AC3 — a SECOND PodSpec in the same file that does automount. The
+# task-run literal still reads Some(false), so only the file-wide check catches
+# this one.
+expect_rejected(
+    'stray automounting PodSpec elsewhere in job.rs',
+    docs,
+    job_rs + '\n    automount_service_account_token: Some(true),\n',
+    'somewhere; the task-run Pod must never automount',
+)
+
+# (c2) AC3 — widen the projected token to an apiserver-valid audience.
+expect_rejected(
+    'projected token audience emptied',
+    docs,
+    job_rs.replace('pub const TOKEN_AUDIENCE: &str = "djinn";',
+                   'pub const TOKEN_AUDIENCE: &str = "";'),
+    'projected token audience is',
+)
+
+# (d) AC4 — promote the rule to a ClusterRole.
+mutant = copy.deepcopy(docs)
+holder, rule = resize_rule(mutant)
+holder['rules'].remove(rule)
+mutant.append({
+    'apiVersion': 'rbac.authorization.k8s.io/v1',
+    'kind': 'ClusterRole',
+    'metadata': {'name': 'djinn-resize'},
+    'rules': [rule],
+})
+expect_rejected('promoted the rule to a ClusterRole', mutant, job_rs, 'must live in a namespaced Role')
+
+# (d2) AC4 — any other new cluster-scoped object, resize-free, is also refused.
+mutant = copy.deepcopy(docs)
+mutant.append({
+    'apiVersion': 'rbac.authorization.k8s.io/v1',
+    'kind': 'ClusterRoleBinding',
+    'metadata': {'name': 'djinn-extra'},
+    'subjects': [{'kind': 'ServiceAccount', 'name': 'other', 'namespace': 'djinn'}],
+    'roleRef': {'apiGroup': 'rbac.authorization.k8s.io', 'kind': 'ClusterRole', 'name': 'cluster-admin'},
+})
+expect_rejected('added an unrelated ClusterRoleBinding', mutant, job_rs, 'introduces cluster-scoped RBAC')
+
+print('PASS: pods/resize is granted once, namespaced, patch-only, and the '
+      'task-run ServiceAccount holds no apiserver credential')
+PY


### PR DESCRIPTION
Implements board task `i6ug` (epic `g8jk`, proposal `3i92`) — wave 0, RBAC prerequisite only.

## What changed

Two files:

- `deploy/helm/djinn/templates/role-controller.yaml` — one rule added:
  ```yaml
  - apiGroups: [""]
    resources: ["pods/resize"]
    verbs: ["patch"]
  ```
- `deploy/helm/djinn/tests/pods-resize-rbac.sh` — new chart contract. `scripts/test-helm-chart-contracts.sh` globs the tests directory, so it needs no registration edit; the roster goes 17 → 18.

No resize client (that is `b62u`, in flight separately), no dispatch wiring, no server code touched.

## The property under test

Not "resize is permitted" — **"djinn-server is the only resize actor."** Four facts have to hold together for that to be true, so the contract asserts them together and an RBAC edit cannot silently take the credential boundary with it:

1. Exactly one rule in the entire render grants `pods/resize`; it is exactly `apiGroups [""] / resources ["pods/resize"] / verbs ["patch"]`; and it lives in the **namespaced** controller Role.
2. The task-run ServiceAccount is the subject of no RoleBinding and no ClusterRoleBinding — directly or through a `system:serviceaccounts` group.
3. Task-run Pods still render `automountServiceAccountToken: false`, and their one projected token still carries audience `djinn` rather than the apiserver's.
4. The render adds no ClusterRole and no ClusterRoleBinding beyond the pre-existing tokenreview pair, which stays djinn-server's only cluster-wide permission.

Fact 3 is what makes the grant safe rather than merely narrow: task-run Pods run repository-controlled code (agent shell commands, `build.rs`, test targets, npm `postinstall`), and they hold no apiserver credential at all, so that code cannot call `pods/resize` even though the server can.

## Why the Role stays namespaced, with no resourceNames

Kubernetes RBAC cannot express a resource-name set that only exists at run time (one Pod per task-run). Exact-Pod authorization is therefore an **application** invariant — the durable permit relation plus a Pod UID fence — not an RBAC one. Widening the Role would not recover that property; it would only enlarge the blast radius of the actor that already holds it. AC4 exists to catch exactly that reflex, and the rule carries a comment saying so.

`resources: ["pods"]` and `resources: ["pods/resize"]` are distinct RBAC resources, so the existing `pods` rule's verbs grant nothing here — the subresource genuinely needed its own rule.

## Non-vacuity

Every check is proved non-vacuous inside the script: each is re-run against a render (or a `job.rs`) mutated to violate exactly that check, and must reject it *for the stated reason*, not merely fail. Ten mutations run on every CI execution:

```
non-vacuity OK: widened verbs to ["patch","update"]
non-vacuity OK: core-group resource wildcard
non-vacuity OK: removed the resize rule
non-vacuity OK: bound the task-run ServiceAccount
non-vacuity OK: bound system:serviceaccounts
non-vacuity OK: automountServiceAccountToken flipped to true
non-vacuity OK: stray automounting PodSpec elsewhere in job.rs
non-vacuity OK: projected token audience emptied
non-vacuity OK: promoted the rule to a ClusterRole
non-vacuity OK: added an unrelated ClusterRoleBinding
PASS: pods/resize is granted once, namespaced, patch-only, and the task-run
      ServiceAccount holds no apiserver credential
```

The `pods/resize` grant is detected *through* RBAC wildcards, not by string equality: `resources: ["*"]` in the core group reaches the subresource just as surely as naming it, and a contract that only recognised the literal spelling would wave that through. Mutation 2 above is that case.

The three mutations the ACs name were additionally run against real mutated copies of the chart (via the contract's `DJINN_CHART_DIR` seam), not just synthetic in-memory ones:

**AC1 — widen the verbs**
```
AssertionError: pods/resize rule verbs must be exactly ["patch"], got ['patch', 'update'].
The resize subresource accepts PATCH only; any other verb is unearned breadth
```

**AC2 — bind the rule to the task-run ServiceAccount**
```
AssertionError: RoleBinding/pods-resize-rbac-djinn-taskrun-resize binds the task-run
ServiceAccount pods-resize-rbac-djinn-djinn-taskrun to {'apiGroup':
'rbac.authorization.k8s.io', 'kind': 'Role', 'name': 'pods-resize-rbac-djinn-controller'}.
Task-run Pods run repository-controlled code; they must hold no apiserver authorization at all
```

**AC4 — promote the rule to a ClusterRole**
```
AssertionError: the pods/resize grant must live in a namespaced Role; found it in
ClusterRole/pods-resize-rbac-djinn-resize. RBAC cannot fence resize to one Pod, so the
namespace is the only fence the Role itself provides — do not promote it
```

## Local verification

- `bash deploy/helm/djinn/tests/pods-resize-rbac.sh` → PASS, all 10 non-vacuity mutations rejected.
- `bash scripts/test-helm-chart-contracts.sh` → 16/18 PASS. The two failures (`incident-observability-contract.sh`, `log-collector-contract.sh`) require the `vector` binary and fail identically on this machine at the merge-base — that is the pre-existing 15/17 local baseline, confirmed before this change and unchanged by it. CI installs a pinned Vector, so both pass there.
- `helm lint deploy/helm/djinn` → clean.

## Note for reviewers

Fact 3 is asserted by reading `server/crates/djinn-k8s/src/job.rs` — the field is located by brace-matching the `let pod_spec = PodSpec {` literal rather than grepping the file, so the assertion reads the PodSpec djinn-server actually dispatches. The chart-contract lane needs no Rust toolchain, which is why the property is read from source there; the runtime proof remains the existing `djinn-k8s` unit test asserting `pod.automount_service_account_token == Some(false)`.
