### PR TITLE
feat(k8s): limits-only pods/resize client for the launcher native sidecar (b62u)

### DIFF
--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -19,6 +19,7 @@ pub mod label_value;
 pub mod launcher;
 pub mod launcher_child_fs;
 mod launcher_cpu;
+pub mod pod_resize;
 pub mod private_dep_config;
 pub mod runtime;
 pub mod scip_job;

--- a/server/crates/djinn-k8s/src/pod_resize.rs
+++ b/server/crates/djinn-k8s/src/pod_resize.rs
@@ -1,0 +1,584 @@
+//! Limits-only `pods/resize` client for the `cgroup-launcher` **native sidecar**.
+//!
+//! Building block for proposal `3i92`'s CPU-quota cutover. Nothing calls this
+//! module yet: `g8jk-3` owns post-admission ceiling capture and bootstrap,
+//! `0ppk` owns the lift/drop lifecycle, and `i6ug` owns the `pods/resize` RBAC
+//! rule. This slice lands the wire contract and its identity/confirmation
+//! rules, nothing else.
+//!
+//! # The one thing this module exists to get right
+//!
+//! The resize target is a **native sidecar**: [`crate::job::build_job`] renders
+//! it through [`crate::launcher::launcher_sidecar_container`] as a restartable
+//! entry in `spec.initContainers` — *not* as a regular container. Three
+//! consequences follow, and every one of them is load-bearing:
+//!
+//! 1. The PATCH addresses `spec.initContainers[name=cgroup-launcher]`. There is
+//!    no `spec.containers[name=cgroup-launcher]` entry to address.
+//! 2. Confirmation is read from
+//!    `status.initContainerStatuses[name=cgroup-launcher].resources.limits.cpu`
+//!    and from nowhere else. `status.containerStatuses` is never a valid
+//!    confirmation source for this target — and because the worker container
+//!    can carry a *coincidentally matching* limit, reading the wrong array does
+//!    not merely read nothing, it reads a **false confirmation**. That is the
+//!    failure this module is built to make impossible.
+//! 3. Neither the HTTP status, nor the PATCH response body, nor the (mutable,
+//!    immediately-updated) `spec` is confirmation. The apiserver accepts a
+//!    resize *request* before the kubelet has actuated it; only the status
+//!    array reports actuation.
+//!
+//! # Why strategic merge patch
+//!
+//! `initContainers` carries `patchMergeKey: name`, so a **strategic** merge
+//! patch merges the single-element array into the existing entry by name. An
+//! RFC 7386 merge patch would *replace the whole array*, deleting every other
+//! init container. [`Patch::Strategic`] is therefore a correctness requirement,
+//! not a style choice.
+//!
+//! # Why confirmation compares millicores, not strings
+//!
+//! `Quantity` is canonicalised by the apiserver on the way in: a PATCH of
+//! `"4000m"` reads back as `"4"`. A string-equality confirmation would
+//! therefore never confirm a whole-core target. Confirmation parses both sides
+//! to millicores and compares numerically; the emitted PATCH value is rendered
+//! in a single canonical form so the request itself stays byte-stable.
+//!
+//! # Retries are not here
+//!
+//! [`PodResizeClient::resize_launcher_cpu`] performs exactly one GET / PATCH /
+//! GET cycle and returns a typed failure if the fresh status does not yet
+//! agree. Backoff, the 30s confirmation deadline, UID fencing, and quarantine
+//! belong to the lift/drop state machine in `0ppk` — putting a retry loop here
+//! would mean two owners for the same deadline.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use async_trait::async_trait;
+use k8s_openapi::api::core::v1::{Container, ContainerStatus, Pod};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use kube::api::{Api, Patch, PatchParams};
+use serde_json::{Value, json};
+use tracing::debug;
+
+use crate::launcher::LAUNCHER_CONTAINER_NAME;
+
+/// Name of the Pod subresource that accepts limits-only in-place resizes.
+pub const RESIZE_SUBRESOURCE: &str = "resize";
+
+/// `status.conditions[].type` the kubelet sets when a resize request has been
+/// accepted but cannot currently be actuated. Its presence means the observed
+/// limit is not authoritative, so it can never be confirmation.
+pub const POD_RESIZE_PENDING_CONDITION: &str = "PodResizePending";
+
+/// Resource key mutated by every request this module emits.
+const CPU_RESOURCE_KEY: &str = "cpu";
+
+/// Which of the two per-Pod launcher lookups failed its uniqueness check.
+///
+/// Both are checked *before* any PATCH is issued: an ambiguous identity in
+/// either place means we cannot name the resize target, and guessing (by index,
+/// or by falling through to the regular-container array) is exactly the bug
+/// this type exists to forbid.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LauncherIdentitySite {
+    /// `spec.initContainers` — where the PATCH lands.
+    SpecInitContainers,
+    /// `status.initContainerStatuses` — where confirmation is read.
+    StatusInitContainerStatuses,
+}
+
+impl LauncherIdentitySite {
+    /// Stable label, safe for logs and metrics.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SpecInitContainers => "spec.initContainers",
+            Self::StatusInitContainerStatuses => "status.initContainerStatuses",
+        }
+    }
+}
+
+impl fmt::Display for LauncherIdentitySite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Why a resize was not confirmed. Every variant is a *failure*: this client
+/// has no "probably fine" branch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NotConfirmed {
+    /// A [`POD_RESIZE_PENDING_CONDITION`] is present on the Pod. The kubelet is
+    /// telling us the request is not actuated; any limit we can read is stale
+    /// by definition.
+    ResizePending,
+    /// The launcher's init-container status carries no `resources.limits.cpu`
+    /// at all. An absent value is never a match.
+    StatusLimitAbsent,
+    /// The launcher's init-container status reports a CPU limit that is not the
+    /// target.
+    StatusStale {
+        /// Millicores currently reported by `status.initContainerStatuses`.
+        observed_millis: u64,
+        /// Millicores the PATCH requested.
+        target_millis: u64,
+    },
+    /// The launcher's init-container status reports a CPU limit that is not a
+    /// parseable quantity. Fail closed rather than guess.
+    StatusLimitUnparseable {
+        /// The raw `Quantity` string as returned by the apiserver.
+        raw: String,
+    },
+}
+
+impl fmt::Display for NotConfirmed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ResizePending => {
+                write!(f, "a `{POD_RESIZE_PENDING_CONDITION}` condition is present")
+            }
+            Self::StatusLimitAbsent => write!(
+                f,
+                "`status.initContainerStatuses[{LAUNCHER_CONTAINER_NAME}].resources.limits.cpu` is absent"
+            ),
+            Self::StatusStale {
+                observed_millis,
+                target_millis,
+            } => write!(
+                f,
+                "`status.initContainerStatuses[{LAUNCHER_CONTAINER_NAME}]` reports {observed_millis}m, want {target_millis}m"
+            ),
+            Self::StatusLimitUnparseable { raw } => write!(
+                f,
+                "`status.initContainerStatuses[{LAUNCHER_CONTAINER_NAME}]` reports unparseable cpu `{raw}`"
+            ),
+        }
+    }
+}
+
+/// Every way a limits-only resize can fail.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PodResizeError {
+    /// The Pod does not contain exactly one launcher entry at `site`. **No
+    /// PATCH is issued** when this is raised.
+    ///
+    /// Zero entries and two entries are the same error deliberately: both mean
+    /// "the launcher cannot be named", and a client that resolves either one by
+    /// positional index (`[0]`) would silently resize the wrong container.
+    #[error(
+        "launcher identity ambiguous: expected exactly one `{LAUNCHER_CONTAINER_NAME}` entry in {site}, found {found}"
+    )]
+    LauncherIdentityAmbiguous {
+        /// Which array failed the uniqueness check.
+        site: LauncherIdentitySite,
+        /// How many entries carried the launcher name.
+        found: usize,
+    },
+    /// A CPU quantity could not be parsed into millicores.
+    #[error("invalid cpu quantity `{raw}`")]
+    InvalidCpuQuantity {
+        /// The rejected input.
+        raw: String,
+    },
+    /// The PATCH was accepted but the fresh status does not confirm it.
+    #[error("resize not confirmed: {0}")]
+    NotConfirmed(NotConfirmed),
+    /// The apiserver call itself failed. Flattened to a string so the error
+    /// type stays `Clone + PartialEq` for exhaustive fixture assertions.
+    #[error("kubernetes api error during {op}: {message}")]
+    Api {
+        /// Which call failed (`get` or `patch`).
+        op: &'static str,
+        /// Rendered `kube::Error`.
+        message: String,
+    },
+}
+
+/// A CPU limit, normalised to millicores.
+///
+/// Parsing here rather than passing `&str` around means an unparseable target
+/// is rejected *before* a PATCH is built, and means confirmation can compare
+/// numerically instead of trusting the apiserver not to re-render the quantity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CpuLimit {
+    millis: u64,
+}
+
+impl CpuLimit {
+    /// Build from a millicore count.
+    #[must_use]
+    pub const fn from_millis(millis: u64) -> Self {
+        Self { millis }
+    }
+
+    /// Parse a Kubernetes CPU quantity (`"250m"`, `"4"`, `"0.5"`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PodResizeError::InvalidCpuQuantity`] for anything that is not
+    /// a non-negative decimal optionally suffixed with `m`, or for a fractional
+    /// core value that is not a whole number of millicores.
+    pub fn parse(raw: &str) -> Result<Self, PodResizeError> {
+        let invalid = || PodResizeError::InvalidCpuQuantity {
+            raw: raw.to_string(),
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(invalid());
+        }
+        if let Some(millis) = trimmed.strip_suffix('m') {
+            if millis.is_empty() || !millis.bytes().all(|b| b.is_ascii_digit()) {
+                return Err(invalid());
+            }
+            return millis
+                .parse::<u64>()
+                .map(Self::from_millis)
+                .map_err(|_| invalid());
+        }
+        if !trimmed.bytes().all(|b| b.is_ascii_digit() || b == b'.')
+            || trimmed.bytes().filter(|b| *b == b'.').count() > 1
+        {
+            return Err(invalid());
+        }
+        let cores: f64 = trimmed.parse().map_err(|_| invalid())?;
+        if !cores.is_finite() || cores < 0.0 {
+            return Err(invalid());
+        }
+        let scaled = cores * 1000.0;
+        let rounded = scaled.round();
+        if (scaled - rounded).abs() > 1e-6 {
+            return Err(invalid());
+        }
+        Ok(Self::from_millis(rounded as u64))
+    }
+
+    /// Millicores.
+    #[must_use]
+    pub const fn millis(self) -> u64 {
+        self.millis
+    }
+
+    /// Canonical wire form for the PATCH body.
+    ///
+    /// Always the `m` suffix, so the emitted request is byte-stable regardless
+    /// of how the caller spelled the value. The apiserver is free to store
+    /// `4000m` back as `4`; confirmation compares millicores, so it does not
+    /// care.
+    #[must_use]
+    pub fn as_quantity(self) -> String {
+        format!("{}m", self.millis)
+    }
+}
+
+impl fmt::Display for CpuLimit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.as_quantity())
+    }
+}
+
+/// Build the limits-only strategic-merge body for one launcher resize.
+///
+/// The result contains **exactly** `spec.initContainers[0].name` and
+/// `spec.initContainers[0].resources.limits.cpu` — no `requests`, no memory, no
+/// second field, no `spec.containers`, no other init container. Anything more
+/// would either move requests (changing scheduling and Kueue accounting) or
+/// address a container this client has no authority over.
+#[must_use]
+pub fn build_resize_patch(target: CpuLimit) -> Value {
+    json!({
+        "spec": {
+            "initContainers": [{
+                "name": LAUNCHER_CONTAINER_NAME,
+                "resources": {
+                    "limits": {
+                        CPU_RESOURCE_KEY: target.as_quantity(),
+                    }
+                }
+            }]
+        }
+    })
+}
+
+/// Locate the unique launcher entry in `spec.initContainers`.
+///
+/// # Errors
+///
+/// [`PodResizeError::LauncherIdentityAmbiguous`] when the count is not exactly
+/// one. Deliberately *not* falling back to `spec.containers`: no regular
+/// container by that name exists, so a fallback could only ever match something
+/// wrong.
+pub fn locate_launcher_spec(pod: &Pod) -> Result<&Container, PodResizeError> {
+    let entries: Vec<&Container> = pod
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.init_containers.as_ref())
+        .map(|list| {
+            list.iter()
+                .filter(|c| c.name == LAUNCHER_CONTAINER_NAME)
+                .collect()
+        })
+        .unwrap_or_default();
+    unique(entries, LauncherIdentitySite::SpecInitContainers)
+}
+
+/// Locate the unique launcher entry in `status.initContainerStatuses`.
+///
+/// # Errors
+///
+/// [`PodResizeError::LauncherIdentityAmbiguous`] when the count is not exactly
+/// one. `status.containerStatuses` is never consulted, at any count.
+pub fn locate_launcher_status(pod: &Pod) -> Result<&ContainerStatus, PodResizeError> {
+    let entries: Vec<&ContainerStatus> = pod
+        .status
+        .as_ref()
+        .and_then(|status| status.init_container_statuses.as_ref())
+        .map(|list| {
+            list.iter()
+                .filter(|c| c.name == LAUNCHER_CONTAINER_NAME)
+                .collect()
+        })
+        .unwrap_or_default();
+    unique(entries, LauncherIdentitySite::StatusInitContainerStatuses)
+}
+
+fn unique<T>(mut entries: Vec<T>, site: LauncherIdentitySite) -> Result<T, PodResizeError> {
+    if entries.len() == 1 {
+        Ok(entries.remove(0))
+    } else {
+        Err(PodResizeError::LauncherIdentityAmbiguous {
+            site,
+            found: entries.len(),
+        })
+    }
+}
+
+/// Whether the Pod carries a [`POD_RESIZE_PENDING_CONDITION`].
+///
+/// Presence alone blocks confirmation; the condition's `status` field is
+/// deliberately not consulted. The kubelet only publishes this condition while
+/// a resize is unactuated, so treating a present-but-`False` condition as
+/// "actuated" would be inferring liveness from a field we have no contract for.
+/// Fail closed: an extra unconfirmed cycle costs a GET, a false confirmation
+/// hands a lease grant to a command that never got the CPU.
+#[must_use]
+pub fn has_resize_pending_condition(pod: &Pod) -> bool {
+    pod.status
+        .as_ref()
+        .and_then(|status| status.conditions.as_ref())
+        .is_some_and(|conditions| {
+            conditions
+                .iter()
+                .any(|c| c.type_ == POD_RESIZE_PENDING_CONDITION)
+        })
+}
+
+/// Decide whether `pod` confirms that the launcher now holds `target`.
+///
+/// Reads `status.initContainerStatuses[name=cgroup-launcher]` and nothing else.
+/// The Pod's `spec`, its `status.containerStatuses`, and any HTTP metadata are
+/// all outside this function's reach by construction — it takes a whole `Pod`
+/// precisely so a test can hand it one whose *regular* container status already
+/// matches the target and watch it refuse.
+///
+/// # Errors
+///
+/// * [`PodResizeError::LauncherIdentityAmbiguous`] — no unique launcher status.
+/// * [`PodResizeError::NotConfirmed`] — a unique status was found and it does
+///   not (yet) agree, or a resize is pending.
+pub fn confirm_launcher_cpu(pod: &Pod, target: CpuLimit) -> Result<(), PodResizeError> {
+    if has_resize_pending_condition(pod) {
+        return Err(PodResizeError::NotConfirmed(NotConfirmed::ResizePending));
+    }
+    let status = locate_launcher_status(pod)?;
+    let raw = status
+        .resources
+        .as_ref()
+        .and_then(|r| r.limits.as_ref())
+        .and_then(|limits| limits.get(CPU_RESOURCE_KEY))
+        .map(|q: &Quantity| q.0.clone());
+    let Some(raw) = raw else {
+        return Err(PodResizeError::NotConfirmed(
+            NotConfirmed::StatusLimitAbsent,
+        ));
+    };
+    let observed = CpuLimit::parse(&raw)
+        .map_err(|_| PodResizeError::NotConfirmed(NotConfirmed::StatusLimitUnparseable { raw }))?;
+    if observed == target {
+        Ok(())
+    } else {
+        Err(PodResizeError::NotConfirmed(NotConfirmed::StatusStale {
+            observed_millis: observed.millis(),
+            target_millis: target.millis(),
+        }))
+    }
+}
+
+/// The two apiserver calls this client makes, behind a trait so the whole
+/// GET / PATCH / GET sequence is drivable from fixtures with no cluster.
+#[async_trait]
+pub trait PodResizeApi: Send + Sync {
+    /// Fetch the Pod fresh. Never served from a cache: identity checks and
+    /// confirmation are only meaningful against current state.
+    ///
+    /// # Errors
+    ///
+    /// [`PodResizeError::Api`] when the apiserver call fails.
+    async fn get_pod(&self, name: &str) -> Result<Pod, PodResizeError>;
+
+    /// PATCH the `resize` subresource with a strategic merge patch.
+    ///
+    /// # Errors
+    ///
+    /// [`PodResizeError::Api`] when the apiserver call fails.
+    async fn patch_resize(&self, name: &str, body: &Value) -> Result<Pod, PodResizeError>;
+}
+
+/// Real [`PodResizeApi`] over a namespaced `kube` client.
+pub struct KubePodResizeApi {
+    pods: Api<Pod>,
+    field_manager: String,
+}
+
+impl KubePodResizeApi {
+    /// Bind to one namespace.
+    #[must_use]
+    pub fn new(client: kube::Client, namespace: &str, field_manager: impl Into<String>) -> Self {
+        Self {
+            pods: Api::namespaced(client, namespace),
+            field_manager: field_manager.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl PodResizeApi for KubePodResizeApi {
+    async fn get_pod(&self, name: &str) -> Result<Pod, PodResizeError> {
+        self.pods.get(name).await.map_err(|e| PodResizeError::Api {
+            op: "get",
+            message: e.to_string(),
+        })
+    }
+
+    async fn patch_resize(&self, name: &str, body: &Value) -> Result<Pod, PodResizeError> {
+        // Strategic, not Merge: `initContainers` has `patchMergeKey: name`, so
+        // a strategic patch merges into the named entry. A Merge patch would
+        // replace the entire array and drop every other init container.
+        let params = PatchParams::apply(&self.field_manager).force();
+        self.pods
+            .patch_subresource(RESIZE_SUBRESOURCE, name, &params, &Patch::Strategic(body))
+            .await
+            .map_err(|e| PodResizeError::Api {
+                op: "patch",
+                message: e.to_string(),
+            })
+    }
+}
+
+/// Limits-only resize client for the launcher native sidecar.
+pub struct PodResizeClient<A: PodResizeApi> {
+    api: A,
+}
+
+impl<A: PodResizeApi> PodResizeClient<A> {
+    /// Wrap an API surface.
+    pub const fn new(api: A) -> Self {
+        Self { api }
+    }
+
+    /// Borrow the underlying API surface (fixtures inspect their recorder).
+    pub const fn api(&self) -> &A {
+        &self.api
+    }
+
+    /// GET the Pod, verify the launcher is uniquely identifiable in **both**
+    /// `spec.initContainers` and `status.initContainerStatuses`, PATCH the
+    /// `resize` subresource with a limits-only body, then GET again and confirm
+    /// from `status.initContainerStatuses`.
+    ///
+    /// Returns `Ok(())` only on a status-confirmed apply. One cycle, no
+    /// retries — see the module docs.
+    ///
+    /// # Errors
+    ///
+    /// * [`PodResizeError::LauncherIdentityAmbiguous`] — raised *before* the
+    ///   PATCH, so an ambiguous Pod is never mutated.
+    /// * [`PodResizeError::Api`] — the GET or the PATCH failed.
+    /// * [`PodResizeError::NotConfirmed`] — the PATCH was accepted but the
+    ///   fresh init-container status does not agree.
+    pub async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target: CpuLimit,
+    ) -> Result<(), PodResizeError> {
+        let pod = self.api.get_pod(pod_name).await?;
+        // Both identity checks run before the PATCH. Checking only the spec
+        // would let a Pod with a duplicated *status* entry be mutated and then
+        // fail confirmation — a mutation we could not confirm or undo by name.
+        locate_launcher_spec(&pod)?;
+        locate_launcher_status(&pod)?;
+
+        let body = build_resize_patch(target);
+        debug!(pod = pod_name, target = %target, "patching pods/resize (limits-only)");
+        // The PATCH response is discarded on purpose: it echoes the accepted
+        // *spec*, which is not confirmation of actuation.
+        let _accepted = self.api.patch_resize(pod_name, &body).await?;
+
+        let fresh = self.api.get_pod(pod_name).await?;
+        confirm_launcher_cpu(&fresh, target)
+    }
+}
+
+/// Read the launcher's currently *declared* CPU limit out of
+/// `spec.initContainers` — the post-admission ceiling `g8jk-3` captures.
+///
+/// This is a spec read and is therefore explicitly **not** confirmation of
+/// anything; it exists so the ceiling-capture slice does not have to re-derive
+/// the launcher lookup rules.
+///
+/// # Errors
+///
+/// * [`PodResizeError::LauncherIdentityAmbiguous`] — no unique launcher spec.
+/// * [`PodResizeError::InvalidCpuQuantity`] — the declared limit is absent or
+///   unparseable.
+pub fn declared_launcher_cpu_limit(pod: &Pod) -> Result<CpuLimit, PodResizeError> {
+    let container = locate_launcher_spec(pod)?;
+    let limits: Option<&BTreeMap<String, Quantity>> =
+        container.resources.as_ref().and_then(|r| r.limits.as_ref());
+    let raw = limits
+        .and_then(|l| l.get(CPU_RESOURCE_KEY))
+        .map(|q| q.0.clone())
+        .ok_or_else(|| PodResizeError::InvalidCpuQuantity { raw: String::new() })?;
+    CpuLimit::parse(&raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_limit_parses_millicores_and_cores() {
+        assert_eq!(CpuLimit::parse("250m").unwrap().millis(), 250);
+        assert_eq!(CpuLimit::parse("4").unwrap().millis(), 4000);
+        assert_eq!(CpuLimit::parse("0.5").unwrap().millis(), 500);
+        assert_eq!(CpuLimit::parse(" 4000m ").unwrap().millis(), 4000);
+    }
+
+    #[test]
+    fn cpu_limit_rejects_junk() {
+        for raw in ["", "m", "abc", "-1", "1.2.3", "4Gi", "250 m"] {
+            assert!(
+                CpuLimit::parse(raw).is_err(),
+                "expected `{raw}` to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_quantity_round_trips_through_apiserver_canonicalisation() {
+        // The apiserver stores `4000m` as `4`; confirmation must still match.
+        let target = CpuLimit::parse("4000m").unwrap();
+        assert_eq!(target.as_quantity(), "4000m");
+        assert_eq!(CpuLimit::parse("4").unwrap(), target);
+    }
+}

--- a/server/crates/djinn-k8s/tests/pod_resize_serialization.rs
+++ b/server/crates/djinn-k8s/tests/pod_resize_serialization.rs
@@ -1,0 +1,774 @@
+//! Wire-contract and confirmation-source tests for the limits-only
+//! `pods/resize` client (`b62u`, proposal `3i92`).
+//!
+//! Every test here drives the **public** surface of `djinn_k8s::pod_resize`
+//! against JSON Pod fixtures through a recording fake apiserver. No cluster is
+//! involved and none is needed: the properties under test are the shape of the
+//! emitted PATCH body and the choice of field consulted for confirmation.
+//!
+//! The fixtures are adversarial on purpose. Each one is built so that a
+//! specific *wrong* implementation would pass:
+//!
+//! | fixture | wrong implementation it catches |
+//! |---|---|
+//! | [`misleading_container_status_pod`] | confirming from `status.containerStatuses` |
+//! | [`duplicate_launcher_spec_pod`] / [`launcher_not_first_pod`] | resolving the launcher by index `[0]` |
+//! | [`resize_pending_pod`] | ignoring `status.conditions` |
+//! | [`spec_ahead_of_status_pod`] | confirming from the mutable `spec` |
+//! | [`FakeApi::with_flattering_patch_response`] | confirming from the PATCH response |
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use djinn_k8s::pod_resize::{
+    CpuLimit, LauncherIdentitySite, NotConfirmed, PodResizeApi, PodResizeClient, PodResizeError,
+    build_resize_patch, confirm_launcher_cpu, declared_launcher_cpu_limit, locate_launcher_spec,
+    locate_launcher_status,
+};
+use k8s_openapi::api::core::v1::Pod;
+use serde_json::{Value, json};
+
+const LAUNCHER: &str = "cgroup-launcher";
+const BIRTH: &str = "250m";
+const CEILING: &str = "4000m";
+
+fn birth() -> CpuLimit {
+    CpuLimit::parse(BIRTH).expect("birth limit parses")
+}
+
+fn ceiling() -> CpuLimit {
+    CpuLimit::parse(CEILING).expect("ceiling parses")
+}
+
+// ---------------------------------------------------------------------------
+// Fixture construction
+// ---------------------------------------------------------------------------
+
+fn container(name: &str, cpu: &str) -> Value {
+    json!({
+        "name": name,
+        "image": "example.invalid/project:latest",
+        "resources": { "limits": { "cpu": cpu }, "requests": { "cpu": "100m" } }
+    })
+}
+
+fn status(name: &str, cpu: Option<&str>) -> Value {
+    let mut entry = json!({
+        "name": name,
+        "image": "example.invalid/project:latest",
+        "imageID": "example.invalid/project@sha256:deadbeef",
+        "ready": true,
+        "restartCount": 0,
+    });
+    if let Some(cpu) = cpu {
+        entry["resources"] = json!({ "limits": { "cpu": cpu }, "requests": { "cpu": "100m" } });
+    }
+    entry
+}
+
+/// Assemble a task-run-shaped Pod: one `worker` regular container, the
+/// launcher rendered as a **restartable init container** (native sidecar).
+fn pod(
+    init_specs: Vec<Value>,
+    init_statuses: Vec<Value>,
+    container_statuses: Vec<Value>,
+    conditions: Vec<&str>,
+) -> Pod {
+    let value = json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": "taskrun-abc", "namespace": "djinn", "uid": "11111111-2222-3333-4444-555555555555" },
+        "spec": {
+            "containers": [container("worker", "2")],
+            "initContainers": init_specs,
+        },
+        "status": {
+            "phase": "Running",
+            "initContainerStatuses": init_statuses,
+            "containerStatuses": container_statuses,
+            "conditions": conditions
+                .into_iter()
+                .map(|t| json!({ "type": t, "status": "True" }))
+                .collect::<Vec<_>>(),
+        }
+    });
+    serde_json::from_value(value).expect("fixture is a valid Pod")
+}
+
+/// Nominal Pod: launcher declared at the ceiling, status agreeing with `cpu`.
+fn healthy_pod(status_cpu: &str) -> Pod {
+    pod(
+        vec![container(LAUNCHER, CEILING)],
+        vec![status(LAUNCHER, Some(status_cpu))],
+        vec![status("worker", Some("2"))],
+        vec![],
+    )
+}
+
+/// **AC2 fixture.** `status.containerStatuses` carries an entry named
+/// `cgroup-launcher` whose CPU limit *already equals the target*, while the
+/// real confirmation source — `status.initContainerStatuses` — is still stale
+/// at the ceiling.
+///
+/// No such regular-container entry exists in production; it is planted here so
+/// that an implementation reading the wrong array reports success. If this
+/// fixture ever confirms, confirmation is reading `status.containerStatuses`.
+fn misleading_container_status_pod() -> Pod {
+    pod(
+        vec![container(LAUNCHER, CEILING)],
+        vec![status(LAUNCHER, Some(CEILING))],
+        vec![
+            status("worker", Some("2")),
+            status(LAUNCHER, Some(BIRTH)), // the lie
+        ],
+        vec![],
+    )
+}
+
+/// **AC3 fixture.** Two launcher entries in `spec.initContainers`. Index `[0]`
+/// is a well-formed launcher, so an implementation that resolves by position
+/// instead of by name proceeds happily.
+fn duplicate_launcher_spec_pod() -> Pod {
+    pod(
+        vec![container(LAUNCHER, CEILING), container(LAUNCHER, "1")],
+        vec![status(LAUNCHER, Some(CEILING))],
+        vec![status("worker", Some("2"))],
+        vec![],
+    )
+}
+
+/// **AC3 fixture.** Two launcher entries in `status.initContainerStatuses`,
+/// the first of which already reports the birth target — so an index-`[0]`
+/// confirmation would report success against an ambiguous status.
+fn duplicate_launcher_status_pod() -> Pod {
+    pod(
+        vec![container(LAUNCHER, CEILING)],
+        vec![
+            status(LAUNCHER, Some(BIRTH)),
+            status(LAUNCHER, Some(CEILING)),
+        ],
+        vec![status("worker", Some("2"))],
+        vec![],
+    )
+}
+
+/// **AC3 fixture.** No launcher at all — a Pod rendered without the sidecar.
+fn absent_launcher_pod() -> Pod {
+    pod(
+        vec![container("other-sidecar", "1")],
+        vec![status("other-sidecar", Some("1"))],
+        vec![status("worker", Some("2"))],
+        vec![],
+    )
+}
+
+/// **AC3 fixture.** Exactly one launcher, but it is not at index `[0]`, and the
+/// entry that *is* at `[0]` already reports the birth target. An index-`[0]`
+/// implementation patches and confirms the wrong container.
+fn launcher_not_first_pod() -> Pod {
+    pod(
+        vec![
+            container("other-sidecar", BIRTH),
+            container(LAUNCHER, CEILING),
+        ],
+        vec![
+            status("other-sidecar", Some(BIRTH)),
+            status(LAUNCHER, Some(CEILING)),
+        ],
+        vec![status("worker", Some("2"))],
+        vec![],
+    )
+}
+
+/// **AC4 fixture.** The launcher's init-container status *already equals the
+/// target* — everything a status-only check looks at agrees — but a
+/// `PodResizePending` condition says the kubelet has not actuated the resize.
+/// An implementation that ignores `status.conditions` confirms.
+fn resize_pending_pod() -> Pod {
+    pod(
+        vec![container(LAUNCHER, CEILING)],
+        vec![status(LAUNCHER, Some(BIRTH))],
+        vec![status("worker", Some("2"))],
+        vec!["Ready", "PodResizePending"],
+    )
+}
+
+/// The mutable `spec` already shows the target (the apiserver records the
+/// request immediately) while the status lags. Confirming from `spec` passes.
+fn spec_ahead_of_status_pod() -> Pod {
+    pod(
+        vec![container(LAUNCHER, BIRTH)],
+        vec![status(LAUNCHER, Some(CEILING))],
+        vec![status("worker", Some("2"))],
+        vec![],
+    )
+}
+
+/// Launcher init-container status exists but reports no `resources` block at
+/// all — the pre-actuation shape.
+fn status_without_resources_pod() -> Pod {
+    pod(
+        vec![container(LAUNCHER, CEILING)],
+        vec![status(LAUNCHER, None)],
+        vec![status("worker", Some("2"))],
+        vec![],
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Recording fake apiserver
+// ---------------------------------------------------------------------------
+
+struct FakeApi {
+    /// Successive GET responses. The last one is repeated once exhausted.
+    gets: Mutex<Vec<Pod>>,
+    get_calls: Mutex<usize>,
+    /// Pod echoed back by the PATCH call.
+    patch_response: Pod,
+    /// Every PATCH body actually sent, in order.
+    patches: Mutex<Vec<Value>>,
+}
+
+impl FakeApi {
+    fn new(gets: Vec<Pod>) -> Self {
+        let patch_response = gets.first().cloned().expect("at least one GET fixture");
+        Self {
+            gets: Mutex::new(gets),
+            get_calls: Mutex::new(0),
+            patch_response,
+            patches: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Make the PATCH *response* already report success, so an implementation
+    /// that treats the PATCH response as confirmation passes.
+    fn with_flattering_patch_response(mut self, pod: Pod) -> Self {
+        self.patch_response = pod;
+        self
+    }
+
+    fn patch_bodies(&self) -> Vec<Value> {
+        self.patches.lock().expect("patches lock").clone()
+    }
+
+    fn patch_count(&self) -> usize {
+        self.patches.lock().expect("patches lock").len()
+    }
+}
+
+#[async_trait]
+impl PodResizeApi for FakeApi {
+    async fn get_pod(&self, _name: &str) -> Result<Pod, PodResizeError> {
+        let gets = self.gets.lock().expect("gets lock");
+        let mut calls = self.get_calls.lock().expect("get_calls lock");
+        let idx = (*calls).min(gets.len() - 1);
+        *calls += 1;
+        Ok(gets[idx].clone())
+    }
+
+    async fn patch_resize(&self, _name: &str, body: &Value) -> Result<Pod, PodResizeError> {
+        self.patches
+            .lock()
+            .expect("patches lock")
+            .push(body.clone());
+        Ok(self.patch_response.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AC1 — the PATCH body's key set is exactly {name, resources.limits.cpu}
+// ---------------------------------------------------------------------------
+
+/// Executable statement of AC1's shape rule.
+///
+/// Returned as a `Result` rather than asserted inline so the tests below can
+/// prove it is *live*: the same checker is run against deliberately mutated
+/// bodies and must reject each one. A checker that cannot fail proves nothing.
+fn assert_limits_only_shape(body: &Value) -> Result<(), String> {
+    fn keys(v: &Value, path: &str) -> Result<Vec<String>, String> {
+        v.as_object()
+            .ok_or_else(|| format!("{path} is not an object"))
+            .map(|m| m.keys().cloned().collect())
+    }
+    fn require(actual: &[String], want: &[&str], path: &str) -> Result<(), String> {
+        let mut a: Vec<&str> = actual.iter().map(String::as_str).collect();
+        a.sort_unstable();
+        let mut w = want.to_vec();
+        w.sort_unstable();
+        if a == w {
+            Ok(())
+        } else {
+            Err(format!("{path}: key set {a:?} != expected {w:?}"))
+        }
+    }
+
+    require(&keys(body, "$")?, &["spec"], "$")?;
+    let spec = &body["spec"];
+    require(&keys(spec, "$.spec")?, &["initContainers"], "$.spec")?;
+
+    let arr = spec["initContainers"]
+        .as_array()
+        .ok_or("$.spec.initContainers is not an array")?;
+    if arr.len() != 1 {
+        return Err(format!(
+            "$.spec.initContainers has {} entries, expected exactly 1",
+            arr.len()
+        ));
+    }
+
+    let entry = &arr[0];
+    require(
+        &keys(entry, "$.spec.initContainers[0]")?,
+        &["name", "resources"],
+        "$.spec.initContainers[0]",
+    )?;
+    if entry["name"] != json!(LAUNCHER) {
+        return Err(format!(
+            "$.spec.initContainers[0].name is {}, expected \"{LAUNCHER}\"",
+            entry["name"]
+        ));
+    }
+
+    let resources = &entry["resources"];
+    require(
+        &keys(resources, "$..resources")?,
+        &["limits"],
+        "$..resources",
+    )?;
+    let limits = &resources["limits"];
+    require(&keys(limits, "$..limits")?, &["cpu"], "$..limits")?;
+    if !limits["cpu"].is_string() {
+        return Err("$..limits.cpu is not a string".to_string());
+    }
+    Ok(())
+}
+
+#[test]
+fn ac1_patch_body_is_byte_exact() {
+    let body = build_resize_patch(birth());
+    assert_eq!(
+        serde_json::to_string(&body).expect("serializes"),
+        r#"{"spec":{"initContainers":[{"name":"cgroup-launcher","resources":{"limits":{"cpu":"250m"}}}]}}"#
+    );
+}
+
+#[test]
+fn ac1_patch_body_key_set_is_exactly_name_and_limits_cpu() {
+    assert_limits_only_shape(&build_resize_patch(birth())).expect("emitted body satisfies AC1");
+    assert_limits_only_shape(&build_resize_patch(ceiling())).expect("emitted body satisfies AC1");
+}
+
+/// AC1 non-vacuity: the shape checker rejects every way of saying more than
+/// `limits.cpu`. Each mutation below is applied to the real emitted body.
+#[test]
+fn ac1_shape_check_rejects_every_extra_field() {
+    /// One named way of saying more than `limits.cpu`, applied to the emitted body.
+    type BodyMutation = (&'static str, fn(&mut Value));
+
+    let mutations: Vec<BodyMutation> = vec![
+        ("requests key added", |b| {
+            b["spec"]["initContainers"][0]["resources"]["requests"] = json!({ "cpu": "250m" });
+        }),
+        ("second limits key added", |b| {
+            b["spec"]["initContainers"][0]["resources"]["limits"]["memory"] = json!("1Gi");
+        }),
+        ("second init-container entry added", |b| {
+            let extra = json!({ "name": "other", "resources": { "limits": { "cpu": "1" } } });
+            b["spec"]["initContainers"]
+                .as_array_mut()
+                .expect("array")
+                .push(extra);
+        }),
+        ("spec.containers added", |b| {
+            b["spec"]["containers"] = json!([{ "name": LAUNCHER }]);
+        }),
+        ("extra field on the entry", |b| {
+            b["spec"]["initContainers"][0]["image"] = json!("example.invalid/x:1");
+        }),
+        ("name dropped (positional targeting)", |b| {
+            b["spec"]["initContainers"][0]
+                .as_object_mut()
+                .expect("object")
+                .remove("name");
+        }),
+    ];
+
+    for (label, mutate) in mutations {
+        let mut body = build_resize_patch(birth());
+        mutate(&mut body);
+        let err = assert_limits_only_shape(&body)
+            .expect_err(&format!("mutation `{label}` must be rejected"));
+        assert!(!err.is_empty(), "rejection for `{label}` must explain why");
+    }
+}
+
+/// The emitted value survives canonicalisation: whether the caller spells the
+/// target `4000m` or `4`, the same byte-stable body is produced.
+#[test]
+fn ac1_emitted_value_is_canonical_regardless_of_caller_spelling() {
+    assert_eq!(
+        build_resize_patch(CpuLimit::parse("4000m").unwrap()),
+        build_resize_patch(CpuLimit::parse("4").unwrap())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC2 — confirmation reads only status.initContainerStatuses
+// ---------------------------------------------------------------------------
+
+/// **The criterion that matters.** A Pod whose
+/// `status.containerStatuses[cgroup-launcher].resources.limits.cpu` already
+/// equals the target while `status.initContainerStatuses` is stale must NOT
+/// confirm.
+#[test]
+fn ac2_matching_regular_container_status_does_not_confirm() {
+    let pod = misleading_container_status_pod();
+
+    // Precondition: the fixture really is misleading — the wrong array agrees.
+    let planted = pod
+        .status
+        .as_ref()
+        .and_then(|s| s.container_statuses.as_ref())
+        .expect("containerStatuses present")
+        .iter()
+        .find(|c| c.name == LAUNCHER)
+        .expect("planted launcher entry in containerStatuses");
+    assert_eq!(
+        planted
+            .resources
+            .as_ref()
+            .and_then(|r| r.limits.as_ref())
+            .and_then(|l| l.get("cpu"))
+            .map(|q| q.0.as_str()),
+        Some(BIRTH),
+        "fixture must plant a MATCHING regular-container status, else it proves nothing"
+    );
+
+    let err = confirm_launcher_cpu(&pod, birth()).expect_err("must not confirm");
+    assert_eq!(
+        err,
+        PodResizeError::NotConfirmed(NotConfirmed::StatusStale {
+            observed_millis: 4000,
+            target_millis: 250,
+        })
+    );
+}
+
+#[tokio::test]
+async fn ac2_full_cycle_refuses_the_misleading_pod() {
+    let api = FakeApi::new(vec![misleading_container_status_pod()]);
+    let client = PodResizeClient::new(api);
+    let err = client
+        .resize_launcher_cpu("taskrun-abc", birth())
+        .expect_err_async()
+        .await;
+    assert!(
+        matches!(err, PodResizeError::NotConfirmed(_)),
+        "got {err:?}"
+    );
+    assert_eq!(
+        client.api().patch_count(),
+        1,
+        "identity was fine, so the PATCH is expected — only confirmation must fail"
+    );
+}
+
+/// The mutable `spec` is not confirmation either.
+#[test]
+fn ac2_spec_agreement_does_not_confirm() {
+    let pod = spec_ahead_of_status_pod();
+    assert_eq!(
+        declared_launcher_cpu_limit(&pod).expect("spec limit readable"),
+        birth(),
+        "fixture must have the SPEC already at target"
+    );
+    let err = confirm_launcher_cpu(&pod, birth()).expect_err("spec is not confirmation");
+    assert_eq!(
+        err,
+        PodResizeError::NotConfirmed(NotConfirmed::StatusStale {
+            observed_millis: 4000,
+            target_millis: 250,
+        })
+    );
+}
+
+/// The PATCH response is not confirmation: here the response body already
+/// reports the target, but the fresh GET does not.
+#[tokio::test]
+async fn ac2_patch_response_is_not_confirmation() {
+    let api =
+        FakeApi::new(vec![healthy_pod(CEILING)]).with_flattering_patch_response(healthy_pod(BIRTH));
+    let client = PodResizeClient::new(api);
+    let err = client
+        .resize_launcher_cpu("taskrun-abc", birth())
+        .expect_err_async()
+        .await;
+    assert_eq!(
+        err,
+        PodResizeError::NotConfirmed(NotConfirmed::StatusStale {
+            observed_millis: 4000,
+            target_millis: 250,
+        })
+    );
+}
+
+/// A launcher status with no `resources` block at all is not a match.
+#[test]
+fn ac2_absent_status_limit_does_not_confirm() {
+    assert_eq!(
+        confirm_launcher_cpu(&status_without_resources_pod(), birth())
+            .expect_err("absent limit is not a match"),
+        PodResizeError::NotConfirmed(NotConfirmed::StatusLimitAbsent)
+    );
+}
+
+/// Confirmation compares millicores, so apiserver canonicalisation of
+/// `4000m` to `4` still confirms.
+#[test]
+fn ac2_confirmation_survives_quantity_canonicalisation() {
+    confirm_launcher_cpu(&healthy_pod("4"), ceiling()).expect("4 == 4000m");
+    confirm_launcher_cpu(&healthy_pod("0.25"), birth()).expect("0.25 == 250m");
+}
+
+// ---------------------------------------------------------------------------
+// AC3 — zero or duplicate launcher entries: typed error, no PATCH
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ac3_ambiguous_identity_yields_typed_error_and_no_patch() {
+    let cases: Vec<(&str, Pod, LauncherIdentitySite, usize)> = vec![
+        (
+            "zero in spec",
+            absent_launcher_pod(),
+            LauncherIdentitySite::SpecInitContainers,
+            0,
+        ),
+        (
+            "duplicate in spec",
+            duplicate_launcher_spec_pod(),
+            LauncherIdentitySite::SpecInitContainers,
+            2,
+        ),
+        (
+            "duplicate in status",
+            duplicate_launcher_status_pod(),
+            LauncherIdentitySite::StatusInitContainerStatuses,
+            2,
+        ),
+        (
+            "zero in status",
+            pod(
+                vec![container(LAUNCHER, CEILING)],
+                vec![status("other-sidecar", Some("1"))],
+                vec![status("worker", Some("2"))],
+                vec![],
+            ),
+            LauncherIdentitySite::StatusInitContainerStatuses,
+            0,
+        ),
+    ];
+
+    for (label, fixture, site, found) in cases {
+        let client = PodResizeClient::new(FakeApi::new(vec![fixture]));
+        let err = client
+            .resize_launcher_cpu("taskrun-abc", birth())
+            .expect_err_async()
+            .await;
+        assert_eq!(
+            err,
+            PodResizeError::LauncherIdentityAmbiguous { site, found },
+            "case `{label}`"
+        );
+        assert_eq!(
+            client.api().patch_count(),
+            0,
+            "case `{label}`: an ambiguous Pod must never be PATCHed"
+        );
+    }
+}
+
+/// AC3 non-vacuity: the duplicate fixtures are built so a positional `[0]`
+/// lookup would succeed. Asserting that here means the test above cannot pass
+/// by accident on a fixture that is ambiguous only in some harmless way.
+#[test]
+fn ac3_duplicate_fixtures_would_satisfy_a_positional_implementation() {
+    let dup_spec = duplicate_launcher_spec_pod();
+    let entries = dup_spec
+        .spec
+        .as_ref()
+        .and_then(|s| s.init_containers.as_ref())
+        .expect("initContainers");
+    assert_eq!(entries.len(), 2);
+    assert_eq!(
+        entries[0].name, LAUNCHER,
+        "index [0] must look like a valid launcher to a positional implementation"
+    );
+
+    let dup_status = duplicate_launcher_status_pod();
+    let statuses = dup_status
+        .status
+        .as_ref()
+        .and_then(|s| s.init_container_statuses.as_ref())
+        .expect("initContainerStatuses");
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(
+        statuses[0]
+            .resources
+            .as_ref()
+            .and_then(|r| r.limits.as_ref())
+            .and_then(|l| l.get("cpu"))
+            .map(|q| q.0.as_str()),
+        Some(BIRTH),
+        "index [0] must already report the target, so a positional confirm would succeed"
+    );
+}
+
+/// AC3 non-vacuity, the other direction: a *unique* launcher that simply is not
+/// first must still resolve correctly. A positional implementation resolves the
+/// neighbouring sidecar — which, in this fixture, already reports the target.
+#[test]
+fn ac3_launcher_is_located_by_name_not_position() {
+    let pod = launcher_not_first_pod();
+
+    let spec = locate_launcher_spec(&pod).expect("unique launcher resolves");
+    assert_eq!(spec.name, LAUNCHER);
+    assert_eq!(
+        declared_launcher_cpu_limit(&pod).expect("declared limit"),
+        ceiling(),
+        "must read the launcher's ceiling, not the decoy's birth limit"
+    );
+
+    let status = locate_launcher_status(&pod).expect("unique launcher status resolves");
+    assert_eq!(status.name, LAUNCHER);
+
+    // The decoy at index [0] already reports the target: a positional
+    // confirmation would return Ok here.
+    assert_eq!(
+        confirm_launcher_cpu(&pod, birth()).expect_err("must read the launcher, not index [0]"),
+        PodResizeError::NotConfirmed(NotConfirmed::StatusStale {
+            observed_millis: 4000,
+            target_millis: 250,
+        })
+    );
+}
+
+/// `spec.containers` is never a fallback, even when it holds a launcher-named
+/// entry.
+#[test]
+fn ac3_regular_container_array_is_never_a_fallback() {
+    let mut pod = absent_launcher_pod();
+    pod.spec
+        .as_mut()
+        .expect("spec")
+        .containers
+        .push(serde_json::from_value(container(LAUNCHER, CEILING)).expect("container"));
+
+    assert_eq!(
+        locate_launcher_spec(&pod).expect_err("must not fall back to spec.containers"),
+        PodResizeError::LauncherIdentityAmbiguous {
+            site: LauncherIdentitySite::SpecInitContainers,
+            found: 0,
+        }
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC4 — a PodResizePending condition means never confirmed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ac4_resize_pending_condition_blocks_confirmation() {
+    let pod = resize_pending_pod();
+
+    // Non-vacuity precondition: with conditions ignored, this fixture confirms.
+    // That is exactly what the `PodResizePending` check has to override.
+    let launcher = locate_launcher_status(&pod).expect("unique launcher status");
+    assert_eq!(
+        launcher
+            .resources
+            .as_ref()
+            .and_then(|r| r.limits.as_ref())
+            .and_then(|l| l.get("cpu"))
+            .map(|q| q.0.as_str()),
+        Some(BIRTH),
+        "fixture's init-container status must already MATCH the target, else the \
+         conditions check is not what makes this fail"
+    );
+
+    assert_eq!(
+        confirm_launcher_cpu(&pod, birth()).expect_err("PodResizePending must block"),
+        PodResizeError::NotConfirmed(NotConfirmed::ResizePending)
+    );
+}
+
+#[tokio::test]
+async fn ac4_resize_pending_blocks_the_full_cycle() {
+    let client = PodResizeClient::new(FakeApi::new(vec![
+        healthy_pod(CEILING),
+        resize_pending_pod(),
+    ]));
+    let err = client
+        .resize_launcher_cpu("taskrun-abc", birth())
+        .expect_err_async()
+        .await;
+    assert_eq!(
+        err,
+        PodResizeError::NotConfirmed(NotConfirmed::ResizePending)
+    );
+}
+
+/// Removing the condition from the very same fixture confirms — proving the
+/// condition, and nothing else about the fixture, is what blocks.
+#[test]
+fn ac4_same_fixture_without_the_condition_confirms() {
+    let mut pod = resize_pending_pod();
+    pod.status
+        .as_mut()
+        .expect("status")
+        .conditions
+        .as_mut()
+        .expect("conditions")
+        .retain(|c| c.type_ != "PodResizePending");
+
+    confirm_launcher_cpu(&pod, birth())
+        .expect("with the condition gone, the identical fixture confirms");
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn confirmed_resize_emits_exactly_one_limits_only_patch() {
+    let client = PodResizeClient::new(FakeApi::new(vec![healthy_pod(CEILING), healthy_pod(BIRTH)]));
+    client
+        .resize_launcher_cpu("taskrun-abc", birth())
+        .await
+        .expect("status-confirmed resize");
+
+    let bodies = client.api().patch_bodies();
+    assert_eq!(bodies.len(), 1, "exactly one PATCH per resize");
+    assert_limits_only_shape(&bodies[0]).expect("the wire body satisfies AC1");
+    assert_eq!(bodies[0], build_resize_patch(birth()));
+}
+
+// ---------------------------------------------------------------------------
+// Small helper: `expect_err` for futures, so the tests above read linearly.
+// ---------------------------------------------------------------------------
+
+trait ExpectErrAsync<T> {
+    async fn expect_err_async(self) -> PodResizeError;
+}
+
+impl<F, T> ExpectErrAsync<T> for F
+where
+    F: std::future::Future<Output = Result<T, PodResizeError>>,
+    T: std::fmt::Debug,
+{
+    async fn expect_err_async(self) -> PodResizeError {
+        match self.await {
+            Ok(v) => panic!("expected an error, got Ok({v:?})"),
+            Err(e) => e,
+        }
+    }
+}


### PR DESCRIPTION
Implements board task `b62u` — "g8jk-2: limits-only pods/resize client". Epic `g8jk`, proposal `3i92`.

Greenfield: `server/crates/djinn-k8s/src/pod_resize.rs` did not exist, and `pods/resize`, `PodResizePending`, `initContainerStatuses` had zero hits across `server/` and `deploy/`. **Nothing calls this yet, and that is correct for this slice** — `g8jk-3` owns bootstrap and ceiling capture, `0ppk` owns the lift/drop lifecycle, `i6ug` owns the RBAC rule.

## What it does

GET the Pod → locate the **unique** `spec.initContainers` entry named `cgroup-launcher` → PATCH the `resize` subresource → confirm from `status.initContainerStatuses[name=cgroup-launcher].resources.limits.cpu`.

## Why the confirmation source is the whole point

The resize target is a **native sidecar** — a restartable entry in `spec.initContainers`, not a regular container. So `status.containerStatuses` is never a valid confirmation source for it, and neither is the PATCH response, the HTTP status, nor the mutable `spec`. Every design decision here follows from that one fact.

## Two correctness details worth flagging in review

- **Strategic, not Merge.** `initContainers` carries `patchMergeKey: name`, so a strategic merge patch merges the single-element array into the named entry. An RFC 7386 merge patch would *replace the whole array*, deleting every other init container.
- **Confirmation compares millicores, not strings.** The apiserver canonicalises a PATCHed `"4000m"` back to `"4"`. A string-equality confirmation would never confirm a whole-core target — it would look like a permanently-stale status.

## Acceptance criteria — every stated mutation was run against the real source

18 tests in `tests/pod_resize_serialization.rs`, all passing. Each fixture is built so that a specific *wrong* implementation passes; below is the actual output when that wrong implementation is installed.

**AC1 — PATCH body key set is exactly `{name, resources.limits.cpu}`.** Mutation: added a `requests` key to `build_resize_patch`.

```
---- ac1_patch_body_is_byte_exact stdout ----
assertion `left == right` failed
  left: "{\"spec\":{\"initContainers\":[{\"name\":\"cgroup-launcher\",\"resources\":{\"limits\":{\"cpu\":\"250m\"},\"requests\":{\"cpu\":\"250m\"}}}]}}"
 right: "{\"spec\":{\"initContainers\":[{\"name\":\"cgroup-launcher\",\"resources\":{\"limits\":{\"cpu\":\"250m\"}}}]}}"

---- ac1_patch_body_key_set_is_exactly_name_and_limits_cpu stdout ----
emitted body satisfies AC1: "$..resources: key set [\"limits\", \"requests\"] != expected [\"limits\"]"
```
`ac1_shape_check_rejects_every_extra_field` additionally runs six mutations (requests, second limits key, second init-container entry, `spec.containers`, extra entry field, dropped `name`) through the same checker in CI, so the checker cannot silently become vacuous.

**AC2 — confirmation reads only `status.initContainerStatuses`.** The fixture plants a `status.containerStatuses[cgroup-launcher]` entry whose CPU limit **already equals the target** while `initContainerStatuses` is stale at the ceiling. Mutation: confirm from `status.containerStatuses`.

```
---- ac2_matching_regular_container_status_does_not_confirm stdout ----
must not confirm: ()
```
That `()` is the client returning `Ok` — the false confirmation this AC exists to forbid. 12 of 18 tests fail under this mutation. The suite also proves the PATCH response and the mutable `spec` are not confirmation, using the same technique.

**AC3 — zero or duplicate launcher entries yield `LauncherIdentityAmbiguous` and no PATCH.** Mutation: index `[0]` instead of locating by name.

```
---- ac3_launcher_is_located_by_name_not_position stdout ----
assertion `left == right` failed
  left: "other-sidecar"
 right: "cgroup-launcher"

---- ac3_ambiguous_identity_yields_typed_error_and_no_patch stdout ----
assertion `left == right` failed: case `zero in spec`
  left: NotConfirmed(StatusStale { observed_millis: 1000, target_millis: 250 })
 right: LauncherIdentityAmbiguous { site: SpecInitContainers, found: 0 }
```
The duplicate fixtures are asserted to be positional-implementation-friendly (`ac3_duplicate_fixtures_would_satisfy_a_positional_implementation`), so the ambiguity test cannot pass on an accident. The unmutated test also asserts `patch_count() == 0` for all four ambiguity cases.

**AC4 — a `PodResizePending` condition means never confirmed.** The fixture's init-container status *already matches the target*, so the condition check is the only thing that can make it fail. Mutation: ignore `status.conditions`.

```
---- ac4_resize_pending_condition_blocks_confirmation stdout ----
PodResizePending must block: ()

---- ac4_resize_pending_blocks_the_full_cycle stdout ----
expected an error, got Ok(())
```
`ac4_same_fixture_without_the_condition_confirms` removes the condition from that identical fixture and asserts it confirms — pinning the condition as the sole cause.

## Merge note for concurrent agents

`src/lib.rs` gains **exactly one line**, `pub mod pod_resize;`, inserted between `mod launcher_cpu;` and `pub mod private_dep_config;`. No re-exports were added, so the `pub use` blocks are untouched. `Cargo.toml` is **not** modified — every dependency used (`kube`, `k8s-openapi`, `serde_json`, `thiserror`, `async-trait`, `tracing`, dev `tokio`) was already present. `S5`/`kh7g` owns `Cargo.toml` and `workload_inventory.rs`; neither is touched here.

## Verification

- `cargo test -p djinn-k8s --lib --test pod_resize_serialization` — 308 + 18 passing.
- `cargo clippy -p djinn-k8s --all-targets` — clean.
- `rustfmt --edition 2024` on the three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)