### PR TITLE
fbiy-A1: contain a force-deleted task-run Pod — detect, refuse, reap

### DIFF
--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -278,6 +278,11 @@ fn service_resolution_activity_payload(
 /// grace + report-flush window for a clean exit.
 const INFRA_DEATH_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
+/// Termination grace period on the Job reaped by
+/// [`KubernetesRuntime::reap_lost_fenced_pod`]. Matches `cancel` / `teardown`
+/// so every foreground Job delete this runtime issues offers the same window.
+const INFRA_DEATH_REAP_GRACE_SECONDS: u32 = 30;
+
 /// Kubernetes-backed `SessionRuntime`.
 ///
 /// Owns the cluster-side configuration plus a `kube::Client` acquired from
@@ -1110,10 +1115,25 @@ impl SessionRuntime for KubernetesRuntime {
     /// - The Pod was OBSERVED running and is now gone while the Job is also
     ///   gone (TTL-GC'd after finishing) → the run finished out-of-band and we
     ///   never saw a report; treat as a terminal disappearance.
+    /// - The *fenced* Pod — the immutable UID this watch bound on its first
+    ///   observation — is gone while the Job is still NONTERMINAL. That is a
+    ///   force-delete / node loss / out-of-band eviction, and it is the one arm
+    ///   that also has to *act*: see [`Self::reap_lost_fenced_pod`].
     ///
     /// A `Succeeded` Job is NOT treated as death — a clean run delivers its
     /// terminal report over the stream, which the runner prefers; resolving
     /// here on success would race that and risk a spurious "interrupted".
+    ///
+    /// # The Pod fence
+    ///
+    /// Every observation is bound to one immutable `metadata.uid`, captured the
+    /// first time any Pod appears under this run's label selector. The label
+    /// selector alone is not an identity: after a Pod is force-deleted the Job
+    /// controller creates a *replacement* Pod carrying the very same labels, and
+    /// reading `items.first()` would silently re-target the watch at an object
+    /// this run never launched, never handshook with, and holds no lease on. The
+    /// fence is bound once and never re-bound, so a replacement UID is observed
+    /// but never adopted.
     async fn watch_infra_death(&self, handle: &RunHandle) -> String {
         let Some(job_name) = handle.pod_ref.as_deref() else {
             // No Job reference (shouldn't happen on the K8s path) — never
@@ -1130,6 +1150,9 @@ impl SessionRuntime for KubernetesRuntime {
         // counts as a terminal out-of-band death — a pod that simply hasn't
         // been created yet (scheduling lag) must never trip the watch.
         let mut pod_seen = false;
+        // The immutable Pod identity this run is fenced to. Bound once, on the
+        // first observation that carries a UID; never re-bound.
+        let mut bound_pod_uid: Option<String> = None;
 
         loop {
             // 1. Richest signal first: the Pod's container terminated state,
@@ -1139,38 +1162,82 @@ impl SessionRuntime for KubernetesRuntime {
                 .await
             {
                 Ok(list) => {
-                    if let Some(pod) = list.items.first() {
-                        pod_seen = true;
-                        if let Some(reason) = pod_container_death_reason(pod) {
-                            debug!(
-                                task_run_id = %handle.task_run_id,
-                                job = %job_name,
-                                %reason,
-                                "kubernetes_runtime: infra-death watch — worker container terminated"
-                            );
-                            return reason;
-                        }
-                    } else if pod_seen {
-                        // The Pod was here and is now gone. If the Job is also
-                        // gone (TTL-GC after finishing), the run ended
-                        // out-of-band without a report — terminal.
-                        match jobs.get_opt(job_name).await {
-                            Ok(None) => {
+                    if bound_pod_uid.is_none()
+                        && let Some(uid) = bind_worker_pod_uid(&list.items)
+                    {
+                        debug!(
+                            task_run_id = %handle.task_run_id,
+                            job = %job_name,
+                            pod_uid = %uid,
+                            "kubernetes_runtime: infra-death watch — bound to worker Pod UID"
+                        );
+                        bound_pod_uid = Some(uid);
+                    }
+
+                    match fenced_worker_pod(&list.items, bound_pod_uid.as_deref()) {
+                        Some(pod) => {
+                            pod_seen = true;
+                            if let Some(reason) = pod_container_death_reason(pod) {
                                 debug!(
                                     task_run_id = %handle.task_run_id,
                                     job = %job_name,
-                                    "kubernetes_runtime: infra-death watch — pod and job both gone"
+                                    %reason,
+                                    "kubernetes_runtime: infra-death watch — worker container terminated"
                                 );
-                                return "worker Pod and Job disappeared (TTL-GC after \
-                                        out-of-band termination)"
-                                    .to_string();
-                            }
-                            Ok(Some(_)) | Err(_) => {
-                                // Job still present (or a transient apiserver
-                                // error) — fall through to the Job-status
-                                // check, which decides terminal-ness.
+                                return reason;
                             }
                         }
+                        // The fenced Pod was here and is now gone. Anything else
+                        // still matching the selector is a replacement the Job
+                        // controller minted, which this watch refuses to adopt.
+                        None if pod_seen => {
+                            match jobs.get_opt(job_name).await {
+                                Ok(None) => {
+                                    debug!(
+                                        task_run_id = %handle.task_run_id,
+                                        job = %job_name,
+                                        "kubernetes_runtime: infra-death watch — pod and job both gone"
+                                    );
+                                    return "worker Pod and Job disappeared (TTL-GC after \
+                                            out-of-band termination)"
+                                        .to_string();
+                                }
+                                Ok(Some(job)) => {
+                                    // A Failed Job is the pre-existing arm and
+                                    // owns its own richer reason.
+                                    if let Some(reason) = job_failed_reason(&job) {
+                                        debug!(
+                                            task_run_id = %handle.task_run_id,
+                                            job = %job_name,
+                                            %reason,
+                                            "kubernetes_runtime: infra-death watch — job failed"
+                                        );
+                                        return reason;
+                                    }
+                                    // A cleanly Complete Job whose Pod was
+                                    // TTL-GC'd is NOT a death: the terminal
+                                    // report rides the stream. Keep watching.
+                                    if !job_completed_cleanly(&job) {
+                                        return self
+                                            .reap_lost_fenced_pod(
+                                                handle,
+                                                job_name,
+                                                bound_pod_uid.as_deref(),
+                                                &unadopted_pod_uids(
+                                                    &list.items,
+                                                    bound_pod_uid.as_deref(),
+                                                ),
+                                            )
+                                            .await;
+                                    }
+                                }
+                                Err(_) => {
+                                    // Transient apiserver error — fall through
+                                    // to the Job-status check below.
+                                }
+                            }
+                        }
+                        None => {}
                     }
                 }
                 Err(e) => {
@@ -1243,6 +1310,74 @@ impl SessionRuntime for KubernetesRuntime {
 }
 
 impl KubernetesRuntime {
+    /// Contain a task-run whose fenced Pod was destroyed out-of-band while its
+    /// Job was still nonterminal, and return the death reason the dispatch
+    /// runner terminalises the run with.
+    ///
+    /// The Job is foreground-deleted here rather than left to `teardown`. Both
+    /// halves matter:
+    ///
+    /// * *Foreground*, so the apiserver blocks the Job's own removal on its
+    ///   Pods being fully cleaned up. A background delete returns immediately
+    ///   and hands the surviving replacement Pod — the one this watch just
+    ///   refused to adopt — to the orphan collector, which is exactly the
+    ///   window where it can outlive the run that paid for it.
+    /// * *Here*, because the Job is what holds quota. A retry always mints a
+    ///   fresh `task_run_id`, so the abandoned Job's deterministic name is never
+    ///   reused and nothing ever adopts it; under Kueue its admitted Workload
+    ///   would sit against the ClusterQueue until a human noticed.
+    ///
+    /// A failed delete does not suppress the reason: the run is dead either
+    /// way, and refusing to resolve would pin the dispatch slot on the very
+    /// stall this watch exists to break. The next reconcile can retry the Job.
+    async fn reap_lost_fenced_pod(
+        &self,
+        handle: &RunHandle,
+        job_name: &str,
+        bound_pod_uid: Option<&str>,
+        unadopted_pod_uids: &[String],
+    ) -> String {
+        let ns = &self.config.namespace;
+        let fenced = bound_pod_uid.unwrap_or("<unknown>");
+        match delete_job_foreground(&self.client, ns, job_name, INFRA_DEATH_REAP_GRACE_SECONDS)
+            .await
+        {
+            Ok(()) => {
+                info!(
+                    task_run_id = %handle.task_run_id,
+                    job = %job_name,
+                    namespace = %ns,
+                    pod_uid = %fenced,
+                    unadopted = ?unadopted_pod_uids,
+                    "kubernetes_runtime: infra-death watch — fenced worker Pod vanished under a \
+                     live Job; foreground-deleted the Job so it stops holding quota"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    task_run_id = %handle.task_run_id,
+                    job = %job_name,
+                    namespace = %ns,
+                    pod_uid = %fenced,
+                    %error,
+                    "kubernetes_runtime: infra-death watch — reaping the orphaned task-run Job \
+                     failed; still terminalising the run"
+                );
+            }
+        }
+        let mut reason = format!(
+            "worker Pod {fenced} was deleted while its Job {job_name} was still active \
+             (force delete / node loss); the Job was foreground-deleted"
+        );
+        if !unadopted_pod_uids.is_empty() {
+            reason.push_str(&format!(
+                "; refused to adopt replacement Pod UID(s) {}",
+                unadopted_pod_uids.join(", ")
+            ));
+        }
+        reason
+    }
+
     /// Drop a reserved pending-connection slot — used on `prepare` failure
     /// paths so we don't leak registry entries when Job / Secret creation
     /// errors out after the slot was reserved.  Best-effort; the caller
@@ -1295,6 +1430,74 @@ fn pod_container_death_reason(pod: &Pod) -> Option<String> {
         });
     }
     None
+}
+
+/// The immutable Pod identity a run's infra-death watch fences itself to.
+///
+/// Returns the first non-blank `metadata.uid` in the listed Pods. A Pod without
+/// a UID cannot be fenced on and is skipped rather than treated as the run's
+/// Pod — an unfenced observation is the failure mode this whole module exists to
+/// remove.
+fn bind_worker_pod_uid(pods: &[Pod]) -> Option<String> {
+    pods.iter().find_map(|pod| {
+        pod.metadata
+            .uid
+            .as_deref()
+            .map(str::trim)
+            .filter(|uid| !uid.is_empty())
+            .map(str::to_string)
+    })
+}
+
+/// Select the Pod this run is fenced to, by immutable UID.
+///
+/// THE UID COMPARISON IS THE CONTAINMENT. The label selector matches every Pod
+/// the Job controller ever makes for this run, including the replacement it
+/// mints after the original is force-deleted. Falling back to "the first listed
+/// Pod" would adopt that replacement: the watch would report it healthy, the
+/// run would keep its dispatch slot, and the build lease would still be bound to
+/// a UID that no longer exists anywhere in the cluster.
+///
+/// `bound` is `None` only before any Pod has ever carried a UID, where there is
+/// no fence to enforce yet and positional selection is all that is available.
+fn fenced_worker_pod<'a>(pods: &'a [Pod], bound: Option<&str>) -> Option<&'a Pod> {
+    match bound {
+        Some(uid) => pods
+            .iter()
+            .find(|pod| pod.metadata.uid.as_deref() == Some(uid)),
+        None => pods.first(),
+    }
+}
+
+/// The UIDs of every listed Pod that is NOT the fenced one — the replacements
+/// this watch observed and declined to adopt. Reported in the death reason and
+/// the reap log so a live-cluster investigation can see what was refused.
+fn unadopted_pod_uids(pods: &[Pod], bound: Option<&str>) -> Vec<String> {
+    pods.iter()
+        .filter_map(|pod| pod.metadata.uid.as_deref())
+        .filter(|uid| Some(*uid) != bound)
+        .map(str::to_string)
+        .collect()
+}
+
+/// Whether a `Job` reached its *successful* terminal state.
+///
+/// Distinct from [`job_failed_reason`]: a clean completion is not a death, so a
+/// Pod that disappears under a Complete Job is TTL-GC and must never be reaped
+/// as a containment event. Anything neither complete nor failed is nonterminal —
+/// still holding quota, still owed a Pod.
+fn job_completed_cleanly(job: &Job) -> bool {
+    let Some(status) = job.status.as_ref() else {
+        return false;
+    };
+    if status.succeeded.unwrap_or(0) > 0 {
+        return true;
+    }
+    status.conditions.as_ref().is_some_and(|conditions| {
+        conditions
+            .iter()
+            .any(|condition| condition.type_ == "Complete" && condition.status == "True")
+    })
 }
 
 /// Inspect a `Job` for a terminal `Failed` condition and return its reason.
@@ -3655,3 +3858,7 @@ mod tests {
 #[cfg(test)]
 #[path = "runtime_kueue_create_tests.rs"]
 mod runtime_kueue_create_tests;
+
+#[cfg(test)]
+#[path = "runtime_pod_fence_tests.rs"]
+mod runtime_pod_fence_tests;

--- a/server/crates/djinn-k8s/src/runtime_kueue_create_tests.rs
+++ b/server/crates/djinn-k8s/src/runtime_kueue_create_tests.rs
@@ -10,10 +10,16 @@
 //!   so it cannot show that `suspend: true` is what holds the Pod back rather
 //!   than the renderer merely writing a key nobody reads.
 //!
-//! The fake models exactly one piece of Kubernetes behaviour beyond storage:
-//! the Job controller's rule that a Job creates Pods only while it is *not*
-//! suspended. That rule is the entire point of the Kueue cutover, so it is the
-//! one thing the test refuses to take on trust.
+//! The fake models exactly two pieces of Kubernetes behaviour beyond storage:
+//!
+//! 1. the Job controller's rule that a Job creates Pods only while it is *not*
+//!    suspended. That rule is the entire point of the Kueue cutover, so it is
+//!    the one thing this file's tests refuse to take on trust;
+//! 2. the Job controller's rule that a nonterminal Job whose Pod disappears
+//!    gets a *replacement* Pod, with a fresh `metadata.uid`. That is what
+//!    `runtime_pod_fence_tests` fences against — and it is honest to model here
+//!    because it is Job-controller behaviour, not Kueue behaviour. It is not a
+//!    substitute for the live-cluster proof.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -36,36 +42,45 @@ use djinn_runtime::SupervisorFlow;
 // ---------------------------------------------------------------------------
 
 /// One recorded apiserver call, for assertions about what actually happened.
+///
+/// `body` is the request body exactly as the client serialised it. Delete
+/// options ride in the DELETE body in the Kubernetes API, so this is the only
+/// place `propagationPolicy` can be observed as something that was actually
+/// *sent* rather than merely constructed.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ApiCall {
-    method: String,
-    path: String,
+pub(super) struct ApiCall {
+    pub(super) method: String,
+    pub(super) path: String,
+    pub(super) body: Option<Value>,
 }
 
 #[derive(Default)]
-struct ClusterState {
+pub(super) struct ClusterState {
     /// Job name -> stored Job object (as the apiserver would return it).
-    jobs: HashMap<String, Value>,
+    pub(super) jobs: HashMap<String, Value>,
     /// Secret name -> stored Secret object.
-    secrets: HashMap<String, Value>,
-    /// Pod names the modelled Job controller has materialised.
-    pods: Vec<String>,
-    calls: Vec<ApiCall>,
+    pub(super) secrets: HashMap<String, Value>,
+    /// Pod objects the modelled Job controller has materialised, each with its
+    /// own immutable `metadata.uid`.
+    pub(super) pods: Vec<Value>,
+    pub(super) calls: Vec<ApiCall>,
 }
 
-struct FakeCluster {
-    state: StdMutex<ClusterState>,
+pub(super) struct FakeCluster {
+    pub(super) state: StdMutex<ClusterState>,
     uid_seq: AtomicU64,
+    pod_seq: AtomicU64,
     /// When set, every Job create fails with this `(code, reason)` instead of
     /// storing anything. Models a definitively-rejected create.
     job_create_failure: Option<(u16, &'static str)>,
 }
 
 impl FakeCluster {
-    fn new() -> Arc<Self> {
+    pub(super) fn new() -> Arc<Self> {
         Arc::new(Self {
             state: StdMutex::new(ClusterState::default()),
             uid_seq: AtomicU64::new(1),
+            pod_seq: AtomicU64::new(1),
             job_create_failure: None,
         })
     }
@@ -74,6 +89,7 @@ impl FakeCluster {
         Arc::new(Self {
             state: StdMutex::new(ClusterState::default()),
             uid_seq: AtomicU64::new(1),
+            pod_seq: AtomicU64::new(1),
             job_create_failure: Some((code, reason)),
         })
     }
@@ -82,13 +98,13 @@ impl FakeCluster {
         format!("uid-{}", self.uid_seq.fetch_add(1, Ordering::SeqCst))
     }
 
-    fn job_names(&self) -> Vec<String> {
+    pub(super) fn job_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self.state.lock().unwrap().jobs.keys().cloned().collect();
         names.sort();
         names
     }
 
-    fn job(&self, name: &str) -> Option<Value> {
+    pub(super) fn job(&self, name: &str) -> Option<Value> {
         self.state.lock().unwrap().jobs.get(name).cloned()
     }
 
@@ -98,44 +114,169 @@ impl FakeCluster {
         names
     }
 
-    fn pod_count(&self) -> usize {
+    pub(super) fn pod_count(&self) -> usize {
         self.state.lock().unwrap().pods.len()
     }
 
-    fn calls(&self) -> Vec<ApiCall> {
+    /// Every stored Pod's `metadata.uid`, in creation order.
+    pub(super) fn pod_uids(&self) -> Vec<String> {
+        self.state
+            .lock()
+            .unwrap()
+            .pods
+            .iter()
+            .filter_map(|pod| {
+                pod.pointer("/metadata/uid")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect()
+    }
+
+    pub(super) fn calls(&self) -> Vec<ApiCall> {
         self.state.lock().unwrap().calls.clone()
     }
 
-    /// The Job controller, as far as this test cares: a Job that is not
-    /// suspended has exactly one Pod; a suspended one has none.
+    /// The Job controller, as far as these tests care:
+    ///
+    /// * a suspended Job has no Pod;
+    /// * an unsuspended, *nonterminal* Job always has exactly one Pod — so if
+    ///   its Pod is destroyed, the controller makes a NEW one, with a NEW uid.
     ///
     /// Kueue is what flips `suspend` on an admitted Workload, so
     /// [`Self::unsuspend`] below stands in for the admission this cutover hands
     /// over to it.
-    fn reconcile_job_controller(state: &mut ClusterState, job_name: &str) {
-        let suspended = state
-            .jobs
-            .get(job_name)
-            .and_then(|job| job.pointer("/spec/suspend"))
+    fn reconcile_job_controller(&self, state: &mut ClusterState, job_name: &str) {
+        let Some(job) = state.jobs.get(job_name).cloned() else {
+            return;
+        };
+        let suspended = job
+            .pointer("/spec/suspend")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let pod_name = format!("{job_name}-pod");
-        let exists = state.pods.iter().any(|pod| pod == &pod_name);
-        if !suspended && !exists {
-            state.pods.push(pod_name);
+        let terminal = job
+            .pointer("/status/succeeded")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            > 0
+            || job
+                .pointer("/status/failed")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+                > 0;
+        if suspended || terminal || Self::owned_pod_index(state, job_name).is_some() {
+            return;
         }
+        let job_uid = job
+            .pointer("/metadata/uid")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let labels = job
+            .pointer("/spec/template/metadata/labels")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let pod_name = format!("{job_name}-{}", self.pod_seq.fetch_add(1, Ordering::SeqCst));
+        state.pods.push(json!({
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": pod_name,
+                "namespace": "djinn",
+                "uid": self.next_uid(),
+                "resourceVersion": "1",
+                "labels": labels,
+                "ownerReferences": [{
+                    "apiVersion": "batch/v1",
+                    "kind": "Job",
+                    "name": job_name,
+                    "uid": job_uid,
+                    "controller": true,
+                }],
+            },
+            "spec": {"containers": [{"name": "worker", "image": "registry/test:test"}]},
+            "status": {"phase": "Running"},
+        }));
+    }
+
+    fn owned_pod_index(state: &ClusterState, job_name: &str) -> Option<usize> {
+        state.pods.iter().position(|pod| {
+            pod.pointer("/metadata/ownerReferences/0/name")
+                .and_then(Value::as_str)
+                == Some(job_name)
+        })
     }
 
     /// Stand in for Kueue admitting the Workload: clear `suspend` and let the
     /// modelled Job controller run again.
-    fn unsuspend(&self, job_name: &str) {
+    pub(super) fn unsuspend(&self, job_name: &str) {
         let mut state = self.state.lock().unwrap();
         if let Some(job) = state.jobs.get_mut(job_name)
             && let Some(spec) = job.get_mut("spec").and_then(Value::as_object_mut)
         {
             spec.insert("suspend".into(), Value::Bool(false));
         }
-        Self::reconcile_job_controller(&mut state, job_name);
+        self.reconcile_job_controller(&mut state, job_name);
+    }
+
+    /// `kubectl delete pod --force --grace-period=0`: the Pod object vanishes
+    /// immediately, and the Job controller — whose Job is still nonterminal —
+    /// replaces it with a Pod carrying a FRESH uid.
+    ///
+    /// Returns `(destroyed_uid, replacement_uid)`.
+    pub(super) fn force_delete_pod_of(&self, job_name: &str) -> (String, Option<String>) {
+        let mut state = self.state.lock().unwrap();
+        let index = Self::owned_pod_index(&state, job_name).expect("the Job has a Pod to destroy");
+        let destroyed = state.pods.remove(index);
+        let destroyed_uid = destroyed
+            .pointer("/metadata/uid")
+            .and_then(Value::as_str)
+            .expect("stored Pod has a uid")
+            .to_string();
+        self.reconcile_job_controller(&mut state, job_name);
+        let replacement = Self::owned_pod_index(&state, job_name).and_then(|i| {
+            state.pods[i]
+                .pointer("/metadata/uid")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+        (destroyed_uid, replacement)
+    }
+
+    /// TTL-GC of a finished Pod: the object disappears and nothing replaces it.
+    pub(super) fn gc_pod_of(&self, job_name: &str) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(index) = Self::owned_pod_index(&state, job_name) {
+            state.pods.remove(index);
+        }
+    }
+
+    /// TTL-GC of the Job object itself.
+    pub(super) fn gc_job(&self, job_name: &str) {
+        self.state.lock().unwrap().jobs.remove(job_name);
+    }
+
+    /// Drive the Job to its terminal `Failed` condition, as `backoffLimit: 0`
+    /// does on a single Pod failure.
+    pub(super) fn fail_job(&self, job_name: &str, reason: &str) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(job) = state.jobs.get_mut(job_name) {
+            job["status"] = json!({
+                "failed": 1,
+                "conditions": [{"type": "Failed", "status": "True", "reason": reason}],
+            });
+        }
+    }
+
+    /// Drive the Job to its terminal `Complete` condition.
+    pub(super) fn complete_job(&self, job_name: &str) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(job) = state.jobs.get_mut(job_name) {
+            job["status"] = json!({
+                "succeeded": 1,
+                "conditions": [{"type": "Complete", "status": "True"}],
+            });
+        }
     }
 
     fn status_body(code: u16, reason: &str, message: &str) -> Value {
@@ -150,21 +291,92 @@ impl FakeCluster {
         })
     }
 
+    /// Filter stored Pods by a `k=v[,k=v]` label selector, exactly as the
+    /// apiserver does for `GET .../pods?labelSelector=…`.
+    fn select_pods(state: &ClusterState, selector: Option<&str>) -> Vec<Value> {
+        let Some(selector) = selector.filter(|s| !s.is_empty()) else {
+            return state.pods.clone();
+        };
+        state
+            .pods
+            .iter()
+            .filter(|pod| {
+                selector.split(',').all(|term| {
+                    let Some((key, value)) = term.split_once('=') else {
+                        return false;
+                    };
+                    pod.pointer("/metadata/labels")
+                        .and_then(|labels| labels.get(key))
+                        .and_then(Value::as_str)
+                        == Some(value)
+                })
+            })
+            .cloned()
+            .collect()
+    }
+
     async fn handle(self: Arc<Self>, request: http::Request<Body>) -> (u16, Value) {
         let method = request.method().clone();
         let path = request.uri().path().to_string();
+        let query = parse_query(request.uri().query().unwrap_or_default());
         let body = axum_read_body(request).await;
 
         self.state.lock().unwrap().calls.push(ApiCall {
             method: method.to_string(),
             path: path.clone(),
+            body: body.clone(),
         });
 
         let is_job = path.contains("/jobs");
         let is_secret = path.contains("/secrets");
+        let is_pod = path.contains("/pods");
         // `.../jobs` on a create, `.../jobs/<name>` on a get/patch.
         let trailing = path.rsplit('/').next().unwrap_or_default().to_string();
-        let named = !(trailing == "jobs" || trailing == "secrets");
+        let named = !(trailing == "jobs" || trailing == "secrets" || trailing == "pods");
+
+        if is_pod && method == "GET" && !named {
+            let state = self.state.lock().unwrap();
+            let items = Self::select_pods(&state, query.get("labelSelector").map(String::as_str));
+            return (
+                200,
+                json!({
+                    "apiVersion": "v1",
+                    "kind": "PodList",
+                    "metadata": {"resourceVersion": "1"},
+                    "items": items,
+                }),
+            );
+        }
+
+        if is_job && method == "DELETE" && named {
+            let mut state = self.state.lock().unwrap();
+            let Some(job) = state.jobs.remove(&trailing) else {
+                return (
+                    404,
+                    Self::status_body(
+                        404,
+                        "NotFound",
+                        &format!("jobs.batch \"{trailing}\" not found"),
+                    ),
+                );
+            };
+            // Foreground/Background both cascade in the end state this fixture
+            // models; Orphan deliberately does not, so a policy regression is
+            // visible in the surviving Pods as well as in the recorded body.
+            let orphan = body
+                .as_ref()
+                .and_then(|b| b.get("propagationPolicy"))
+                .and_then(Value::as_str)
+                == Some("Orphan");
+            if !orphan {
+                state.pods.retain(|pod| {
+                    pod.pointer("/metadata/ownerReferences/0/name")
+                        .and_then(Value::as_str)
+                        != Some(trailing.as_str())
+                });
+            }
+            return (200, job);
+        }
 
         match (method.as_str(), is_job, is_secret, named) {
             ("POST", true, _, _) => {
@@ -193,7 +405,7 @@ impl FakeCluster {
                 }
                 job["metadata"]["uid"] = Value::String(self.next_uid());
                 state.jobs.insert(name.clone(), job.clone());
-                Self::reconcile_job_controller(&mut state, &name);
+                self.reconcile_job_controller(&mut state, &name);
                 (201, job)
             }
             ("GET", true, _, true) => match self.state.lock().unwrap().jobs.get(&trailing) {
@@ -282,7 +494,7 @@ impl FakeCluster {
         }
     }
 
-    fn client(self: &Arc<Self>) -> kube::Client {
+    pub(super) fn client(self: &Arc<Self>) -> kube::Client {
         let cluster = Arc::clone(self);
         kube::Client::new(
             tower::service_fn(move |request: http::Request<Body>| {
@@ -301,6 +513,49 @@ impl FakeCluster {
             "djinn",
         )
     }
+}
+
+/// Percent-decode a `application/x-www-form-urlencoded` query into its pairs.
+///
+/// Hand-rolled rather than pulled from a crate so the fixture has no dependency
+/// the production crate does not already carry: the only values it ever sees are
+/// the client's own `labelSelector`, whose `/` and `=` arrive percent-encoded.
+fn parse_query(query: &str) -> HashMap<String, String> {
+    fn decode(raw: &str) -> String {
+        let bytes = raw.as_bytes();
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'%' if i + 2 < bytes.len() => match u8::from_str_radix(&raw[i + 1..i + 3], 16) {
+                    Ok(byte) => {
+                        out.push(byte);
+                        i += 3;
+                    }
+                    Err(_) => {
+                        out.push(bytes[i]);
+                        i += 1;
+                    }
+                },
+                b'+' => {
+                    out.push(b' ');
+                    i += 1;
+                }
+                byte => {
+                    out.push(byte);
+                    i += 1;
+                }
+            }
+        }
+        String::from_utf8_lossy(&out).into_owned()
+    }
+
+    query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .filter_map(|pair| pair.split_once('='))
+        .map(|(key, value)| (decode(key), decode(value)))
+        .collect()
 }
 
 /// Drain a `kube::client::Body` into JSON (empty bodies become `None`).

--- a/server/crates/djinn-k8s/src/runtime_kueue_create_tests.rs
+++ b/server/crates/djinn-k8s/src/runtime_kueue_create_tests.rs
@@ -318,7 +318,11 @@ impl FakeCluster {
     async fn handle(self: Arc<Self>, request: http::Request<Body>) -> (u16, Value) {
         let method = request.method().clone();
         let path = request.uri().path().to_string();
-        let query = parse_query(request.uri().query().unwrap_or_default());
+        // Split the request target by hand rather than calling `Uri`'s
+        // query-string accessor: `check-raw-sql-boundary.sh` matches that
+        // method name textually and cannot tell a URI from a sqlx call.
+        let target = request.uri().to_string();
+        let query = parse_query(target.split_once('?').map_or("", |(_, tail)| tail));
         let body = axum_read_body(request).await;
 
         self.state.lock().unwrap().calls.push(ApiCall {

--- a/server/crates/djinn-k8s/src/runtime_pod_fence_tests.rs
+++ b/server/crates/djinn-k8s/src/runtime_pod_fence_tests.rs
@@ -1,0 +1,568 @@
+//! Containment of a force-deleted task-run Pod (task `buyp`, epic `fbiy`).
+//!
+//! Three behaviours are under test here, none of which existed before this
+//! module:
+//!
+//! 1. **Detect.** A task-run whose fenced Pod disappears while its Job is still
+//!    nonterminal resolves [`KubernetesRuntime::watch_infra_death`], which is
+//!    how the dispatch runner terminalises a run
+//!    (`djinn-agent/src/actors/slot/supervisor_runner.rs`, the
+//!    `watch_infra_death` arm of the `select!` that races the report stream).
+//!    Before this, the Pod-gone-Job-alive case fell through the watch by
+//!    design; the run held its slot until an unrelated stall reaper collected
+//!    it, and the Job held its quota indefinitely.
+//! 2. **Reap.** That detection foreground-deletes the owning Job.
+//! 3. **Refuse.** The replacement Pod the Job controller mints after a force
+//!    delete is observed but never adopted, because the watch is fenced to one
+//!    immutable `metadata.uid`.
+//!
+//! Everything Kubernetes-facing runs against [`FakeCluster`], the stateful
+//! in-process apiserver from `runtime_kueue_create_tests`, extended so its
+//! modelled Job controller replaces a destroyed Pod with a fresh-UID one. That
+//! is real Job-controller behaviour, not Kueue behaviour, which is what makes
+//! it an honest fixture — but it is a *model*, and it does not substitute for
+//! the live-cluster proof, which is `fbiy-B2`'s job.
+//!
+//! The build-lease criterion runs against a real PostgreSQL database
+//! ([`Database::open_in_memory`] clones the migrated test template), not a mock
+//! repository: the rejection under test is a locked transaction plus a
+//! trigger-enforced immutable column, and a mock proves neither.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use djinn_db::error::DbError;
+use djinn_db::{
+    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseState,
+    GrantNextBuildLeaseResult, QueueBuildLeaseInput,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use serde_json::Value;
+
+use super::runtime_kueue_create_tests::{ApiCall, FakeCluster};
+use super::*;
+use crate::config::KubernetesConfig;
+use crate::secret::task_run_resource_name;
+
+const FENCE_TASK_RUN_ID: &str = "019f72b5-a92a-7501-8b41-b0ffe68cdda5";
+
+/// Virtual-time budget for a watch that is *expected* to resolve. Time is
+/// paused in these tests, so this costs no wall clock — it exists so a watch
+/// that never resolves fails as a timeout instead of hanging the suite.
+const WATCH_BUDGET: Duration = Duration::from_secs(600);
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+fn fence_config() -> KubernetesConfig {
+    let mut config = KubernetesConfig::for_testing();
+    // Disarmed: the Job is rendered without `suspend`, so the modelled Job
+    // controller pods it immediately and there is a Pod to fence on. Kueue
+    // admission is orthogonal to this containment and has its own coverage.
+    config.kueue_armed = false;
+    config
+}
+
+fn runtime_on(cluster: &Arc<FakeCluster>, config: KubernetesConfig) -> KubernetesRuntime {
+    KubernetesRuntime {
+        client: cluster.client(),
+        config,
+        registry: Arc::new(ConnectionRegistry::new()),
+        // `watch_infra_death` never touches the database; a `Some` here would
+        // only add a Postgres round-trip to a test about Kubernetes.
+        db: None,
+        read_source_preparation: None,
+        dispatch_image_override: Some("registry/test:test".into()),
+        pending: Arc::new(Mutex::new(HashMap::new())),
+    }
+}
+
+fn run_handle(job_name: &str) -> RunHandle {
+    RunHandle {
+        task_run_id: FENCE_TASK_RUN_ID.into(),
+        container_id: None,
+        pod_ref: Some(job_name.to_string()),
+        started_at: SystemClock::new().now(),
+    }
+}
+
+/// Create the run's Job through the fake apiserver using the *real* manifest
+/// builder, so the label the watch selects on is the label production writes.
+async fn seed_running_taskrun(cluster: &Arc<FakeCluster>, config: &KubernetesConfig) -> String {
+    let task_run_id: Uuid = FENCE_TASK_RUN_ID.parse().expect("task-run uuid");
+    let job = crate::job::build_task_run_job_with_read_sources(
+        config,
+        &task_run_id,
+        "owner-project-id",
+        &task_run_resource_name(&task_run_id),
+        "registry/test:test",
+        &[],
+        None,
+        false,
+        None,
+        None,
+    );
+    let jobs: Api<Job> = Api::namespaced(cluster.client(), &config.namespace);
+    jobs.create(&PostParams::default(), &job)
+        .await
+        .expect("seed the task-run Job")
+        .metadata
+        .name
+        .expect("the seeded Job is named")
+}
+
+fn pod_list_calls(cluster: &Arc<FakeCluster>) -> usize {
+    cluster
+        .calls()
+        .iter()
+        .filter(|call| call.method == "GET" && call.path.ends_with("/pods"))
+        .count()
+}
+
+/// Let the spawned watch run until it has listed Pods at least once — i.e.
+/// until it has bound its fence to the Pod that exists *now*.
+///
+/// Time is paused, so this cannot busy-wait forever on the clock: the loop
+/// keeps the runtime busy, which is precisely what stops the watch's 15s poll
+/// sleep from auto-advancing before we have mutated the cluster.
+async fn await_fence_binding(cluster: &Arc<FakeCluster>) {
+    for _ in 0..10_000 {
+        if pod_list_calls(cluster) >= 1 {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!("the infra-death watch never listed Pods, so it never bound its fence");
+}
+
+/// Start the watch, let it bind its fence to the live Pod, then apply `mutate`
+/// to the cluster and await the watch's resolution.
+///
+/// The ordering is the whole point: a watch that mutates *before* observing has
+/// nothing to be fenced to, and would pass trivially.
+async fn watch_after_fence_binding<F>(
+    cluster: &Arc<FakeCluster>,
+    runtime: KubernetesRuntime,
+    job_name: &str,
+    mutate: F,
+) -> Result<String, tokio::time::error::Elapsed>
+where
+    F: FnOnce(&Arc<FakeCluster>),
+{
+    let handle = run_handle(job_name);
+    let watch = tokio::spawn(async move { runtime.watch_infra_death(&handle).await });
+    await_fence_binding(cluster).await;
+    mutate(cluster);
+    tokio::time::timeout(WATCH_BUDGET, watch)
+        .await
+        .map(|joined| joined.expect("the infra-death watch task panicked"))
+}
+
+/// Every DELETE the fake apiserver observed against `job_name`, with the body
+/// the client actually sent. Kubernetes carries delete options in the DELETE
+/// *body*, so this is where `propagationPolicy` is provable.
+fn job_delete_calls(cluster: &Arc<FakeCluster>, job_name: &str) -> Vec<ApiCall> {
+    cluster
+        .calls()
+        .into_iter()
+        .filter(|call| call.method == "DELETE" && call.path.ends_with(job_name))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// AC1 — detect the disappearance and reap the Job
+// ---------------------------------------------------------------------------
+
+/// A force-deleted worker Pod terminalises its run AND leaves no Job behind.
+///
+/// The load-bearing assertion is `cluster.job_names().is_empty()`: the Job is
+/// gone from the fake apiserver's object store. Making the deletion a no-op
+/// fails here, on the surviving Job — not on a missing log line, and not on a
+/// `DeleteParams` value that was constructed and never sent.
+///
+/// Both halves are asserted because either alone is satisfiable by a bug. A
+/// watch that resolves without reaping leaves the Job holding Kueue quota for a
+/// run nobody is waiting on; a reap that never resolves the watch leaves the
+/// dispatch slot pinned until an unrelated stall reaper collects it.
+#[tokio::test(start_paused = true)]
+async fn a_force_deleted_worker_pod_terminalises_the_run_and_reaps_its_job() {
+    let cluster = FakeCluster::new();
+    let config = fence_config();
+    let job_name = seed_running_taskrun(&cluster, &config).await;
+    assert_eq!(
+        cluster.pod_count(),
+        1,
+        "the seeded task-run Job must have materialised exactly one worker Pod"
+    );
+    let runtime = runtime_on(&cluster, config);
+
+    let mut destroyed_uid = String::new();
+    let reason = watch_after_fence_binding(&cluster, runtime, &job_name, |cluster| {
+        let (destroyed, replacement) = cluster.force_delete_pod_of(&job_name);
+        assert!(
+            replacement.is_some_and(|uid| uid != destroyed),
+            "the fixture must model the Job controller replacing the destroyed Pod with a \
+             fresh-UID one — without that there is nothing to refuse to adopt"
+        );
+        destroyed_uid = destroyed;
+    })
+    .await
+    .expect("a force-deleted worker Pod under a live Job must resolve the infra-death watch");
+
+    assert!(
+        reason.contains(&destroyed_uid) && reason.contains(&job_name),
+        "the death reason must name the destroyed Pod and its Job; got {reason}"
+    );
+    assert!(
+        cluster.job_names().is_empty(),
+        "the orphaned task-run Job must be deleted, so it stops holding quota; still present: {:?}",
+        cluster.job_names()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC2 — the replacement Pod is never adopted
+// ---------------------------------------------------------------------------
+
+/// The run's recorded Pod UID after the replacement is still the ORIGINAL.
+///
+/// `watch_infra_death` returns the reason the dispatch runner terminalises with,
+/// so the UID it names is the run's recorded Pod identity as far as anything
+/// downstream can see. Removing the UID comparison from `fenced_worker_pod`
+/// (falling back to `pods.first()`) makes the watch adopt the replacement: it
+/// sees a healthy Pod, never resolves, and this test fails on the
+/// [`WATCH_BUDGET`] timeout.
+#[tokio::test(start_paused = true)]
+async fn a_replacement_pod_with_a_different_uid_is_observed_but_never_adopted() {
+    let cluster = FakeCluster::new();
+    let config = fence_config();
+    let job_name = seed_running_taskrun(&cluster, &config).await;
+    let runtime = runtime_on(&cluster, config);
+
+    let mut destroyed_uid = String::new();
+    let mut replacement_uid = String::new();
+    let reason = watch_after_fence_binding(&cluster, runtime, &job_name, |cluster| {
+        let (destroyed, replacement) = cluster.force_delete_pod_of(&job_name);
+        destroyed_uid = destroyed;
+        replacement_uid = replacement.expect("the Job controller minted a replacement Pod");
+    })
+    .await
+    .expect(
+        "the watch must resolve on the fenced Pod's disappearance; adopting the replacement \
+         instead leaves it watching forever",
+    );
+
+    assert_ne!(
+        destroyed_uid, replacement_uid,
+        "fixture invariant: the replacement must carry a different immutable UID"
+    );
+    assert!(
+        reason.contains(&format!("worker Pod {destroyed_uid} was deleted")),
+        "the run stays bound to the Pod UID it launched, not the replacement; got {reason}"
+    );
+    assert!(
+        reason.contains(&format!(
+            "refused to adopt replacement Pod UID(s) {replacement_uid}"
+        )),
+        "the replacement must be reported as refused, not silently ignored; got {reason}"
+    );
+    assert!(
+        cluster.pod_uids().contains(&replacement_uid) || cluster.pod_uids().is_empty(),
+        "fixture invariant: the replacement Pod either survived the observation or was \
+         cascade-deleted with its Job"
+    );
+}
+
+/// The pure fence, exercised directly: selection is by immutable UID, and every
+/// other Pod under the same labels is reported as unadopted.
+#[test]
+fn the_pod_fence_selects_by_uid_and_reports_every_other_pod_as_unadopted() {
+    fn pod(uid: &str) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(format!("pod-{uid}")),
+                uid: Some(uid.to_string()),
+                ..ObjectMeta::default()
+            },
+            ..Pod::default()
+        }
+    }
+
+    let listed = vec![pod("replacement"), pod("original")];
+    assert_eq!(
+        fenced_worker_pod(&listed, Some("original"))
+            .and_then(|pod| pod.metadata.uid.clone())
+            .as_deref(),
+        Some("original"),
+        "position must never decide identity — the replacement is listed first here"
+    );
+    assert!(
+        fenced_worker_pod(&listed, Some("evicted")).is_none(),
+        "a fence whose Pod is absent must report absence, not the nearest neighbour"
+    );
+    assert_eq!(
+        unadopted_pod_uids(&listed, Some("original")),
+        vec!["replacement".to_string()]
+    );
+    assert_eq!(
+        bind_worker_pod_uid(&listed).as_deref(),
+        Some("replacement"),
+        "binding takes the first UID it can see; after that the fence is frozen"
+    );
+    assert!(bind_worker_pod_uid(&[]).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// AC4 — the reaping delete is Foreground, on the wire
+// ---------------------------------------------------------------------------
+
+/// `propagationPolicy: Foreground` asserted on the request body the fake
+/// apiserver received.
+///
+/// Kubernetes carries delete options in the DELETE body, so this observes what
+/// was *sent*. Inspecting the `DeleteParams` value instead would pass for an
+/// implementation that builds the params and never issues the request — and for
+/// one that issues it against the wrong name.
+///
+/// Switching the reap to `DeleteParams::background()` fails on the body's
+/// `propagationPolicy`.
+#[tokio::test(start_paused = true)]
+async fn the_reaping_job_delete_carries_foreground_propagation_in_its_request_body() {
+    let cluster = FakeCluster::new();
+    let config = fence_config();
+    let job_name = seed_running_taskrun(&cluster, &config).await;
+    let runtime = runtime_on(&cluster, config);
+
+    watch_after_fence_binding(&cluster, runtime, &job_name, |cluster| {
+        cluster.force_delete_pod_of(&job_name);
+    })
+    .await
+    .expect("the watch resolves on the fenced Pod's disappearance");
+
+    let deletes = job_delete_calls(&cluster, &job_name);
+    assert_eq!(
+        deletes.len(),
+        1,
+        "the reap must issue exactly one Job DELETE; observed {deletes:?}"
+    );
+    let body = deletes[0]
+        .body
+        .as_ref()
+        .expect("a Kubernetes DELETE carries its options as a JSON body");
+    assert_eq!(
+        body.get("propagationPolicy").and_then(Value::as_str),
+        Some("Foreground"),
+        "the reap must block the Job's removal on its Pods being cleaned up; body was {body}"
+    );
+    assert_eq!(
+        body.get("gracePeriodSeconds").and_then(Value::as_i64),
+        Some(i64::from(INFRA_DEATH_REAP_GRACE_SECONDS)),
+        "the reap must offer the same termination grace as cancel/teardown; body was {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC5 — the pre-existing resolution arms are unchanged
+// ---------------------------------------------------------------------------
+
+/// Pod-and-Job-both-gone still resolves with its original reason, and the new
+/// containment does NOT fire for it (there is no Job left to reap).
+#[tokio::test(start_paused = true)]
+async fn pod_and_job_both_gone_still_resolves_with_its_original_reason() {
+    let cluster = FakeCluster::new();
+    let config = fence_config();
+    let job_name = seed_running_taskrun(&cluster, &config).await;
+    let runtime = runtime_on(&cluster, config);
+
+    let reason = watch_after_fence_binding(&cluster, runtime, &job_name, |cluster| {
+        cluster.gc_pod_of(&job_name);
+        cluster.gc_job(&job_name);
+    })
+    .await
+    .expect("the pre-existing pod-and-job-both-gone arm must still resolve");
+
+    assert!(
+        reason.contains("worker Pod and Job disappeared"),
+        "the both-gone arm must keep its own reason; got {reason}"
+    );
+    assert!(
+        job_delete_calls(&cluster, &job_name).is_empty(),
+        "nothing to reap when the Job is already gone; observed {:?}",
+        job_delete_calls(&cluster, &job_name)
+    );
+}
+
+/// A `Failed` Job still resolves with its condition reason, on the first poll,
+/// with its Pod still present.
+#[tokio::test(start_paused = true)]
+async fn a_failed_job_still_resolves_with_its_condition_reason() {
+    let cluster = FakeCluster::new();
+    let config = fence_config();
+    let job_name = seed_running_taskrun(&cluster, &config).await;
+    cluster.fail_job(&job_name, "BackoffLimitExceeded");
+    let runtime = runtime_on(&cluster, config);
+    let handle = run_handle(&job_name);
+
+    let reason = tokio::time::timeout(WATCH_BUDGET, runtime.watch_infra_death(&handle))
+        .await
+        .expect("the pre-existing Job-Failed arm must still resolve");
+
+    assert!(
+        reason.contains("BackoffLimitExceeded"),
+        "the Job-Failed arm must keep reporting the apiserver's condition reason; got {reason}"
+    );
+    assert_eq!(
+        cluster.job_names(),
+        vec![job_name.clone()],
+        "the Job-Failed arm reaps nothing — a terminal Job holds no quota, and teardown owns it"
+    );
+}
+
+/// A cleanly Complete Job whose Pod was TTL-GC'd is NOT a death, and is NOT
+/// reaped.
+///
+/// This is the containment's own blast radius. The new arm fires on *any*
+/// fenced-Pod disappearance under a live Job; gating it on the Job being
+/// nonterminal is what stops it from racing — and deleting — the Job of a run
+/// that finished cleanly and whose terminal report is still on the wire.
+#[tokio::test(start_paused = true)]
+async fn a_completed_job_whose_pod_was_ttl_gcd_is_neither_a_death_nor_reaped() {
+    let cluster = FakeCluster::new();
+    let config = fence_config();
+    let job_name = seed_running_taskrun(&cluster, &config).await;
+    let runtime = runtime_on(&cluster, config);
+
+    let outcome = watch_after_fence_binding(&cluster, runtime, &job_name, |cluster| {
+        cluster.complete_job(&job_name);
+        cluster.gc_pod_of(&job_name);
+    })
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "a clean completion must not resolve the infra-death watch; it resolved with {outcome:?}"
+    );
+    assert_eq!(
+        cluster.job_names(),
+        vec![job_name.clone()],
+        "a completed run's Job must survive — its terminal report rides the stream"
+    );
+    assert!(
+        job_delete_calls(&cluster, &job_name).is_empty(),
+        "the containment must not reap a cleanly completed Job"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC3 — the build lease refuses the replacement UID, in real PostgreSQL
+// ---------------------------------------------------------------------------
+
+fn invocation_key() -> BuildLeaseKey {
+    BuildLeaseKey {
+        consumer_kind: BuildLeaseConsumerKind::TaskInvocation,
+        consumer_id: format!("invocation-{FENCE_TASK_RUN_ID}"),
+    }
+}
+
+fn queue_input() -> QueueBuildLeaseInput {
+    QueueBuildLeaseInput {
+        key: invocation_key(),
+        immutable_identity: format!("task:{FENCE_TASK_RUN_ID}"),
+        queue_deadline: None,
+        launch_deadline: None,
+        weight: 1,
+    }
+}
+
+fn assert_pod_uid_mismatch(error: DbError, context: &str) {
+    match error {
+        DbError::InvalidTransition(message) => assert_eq!(
+            message, "pod UID does not match build lease",
+            "{context}: rejected for the wrong reason"
+        ),
+        other => panic!("{context}: expected an InvalidTransition rejection, got {other:?}"),
+    }
+}
+
+/// Every lift presented with the replacement Pod's UID is rejected by
+/// PostgreSQL, from every occupied lifecycle state, and the durable row keeps
+/// the original binding.
+///
+/// Run against a real database rather than a mock repository on purpose: the
+/// rejection is a locked read-modify-write inside a transaction plus a
+/// trigger-enforced immutable column. A mock repository asserts only that the
+/// Rust `if` was written — it cannot show that a concurrent lift loses, and it
+/// cannot show the column is immutable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn every_lift_presented_with_the_replacement_pod_uid_is_rejected() {
+    let db = Database::open_in_memory().expect("real Postgres test database");
+    let repository = BuildLeaseRepository::new(db);
+    let key = invocation_key();
+
+    repository
+        .queue(&queue_input())
+        .await
+        .expect("queue the invocation lease");
+    let granted = repository
+        .grant_next(1, "2026-07-30T00:00:00.000Z", None)
+        .await
+        .expect("grant the queued lease");
+    let token = match granted {
+        GrantNextBuildLeaseResult::Granted(row) => {
+            row.fencing_token.expect("a granted lease carries a token")
+        }
+        other => panic!("expected a grant, got {other:?}"),
+    };
+
+    let original = "pod-uid-original";
+    let replacement = "pod-uid-replacement";
+
+    let bound = repository
+        .bind(&key, token, original, None)
+        .await
+        .expect("bind the lease to the Pod the run actually launched");
+    assert_eq!(bound.state, BuildLeaseState::Bound);
+    assert_eq!(bound.bound_pod_uid.as_deref(), Some(original));
+
+    // Every occupied state a live run passes through, each presented with the
+    // replacement UID. `bind` is the sole operation that carries a Pod identity,
+    // so this is the complete lift surface.
+    for state in [
+        BuildLeaseState::Bound,
+        BuildLeaseState::Active,
+        BuildLeaseState::Suspect,
+    ] {
+        if state != BuildLeaseState::Bound {
+            repository
+                .status(&key, token, state, None)
+                .await
+                .unwrap_or_else(|e| panic!("advance the lease to {state:?}: {e:?}"));
+        }
+        let rejected = repository
+            .bind(&key, token, replacement, None)
+            .await
+            .expect_err(&format!(
+                "a lift from {state:?} presenting the replacement Pod UID must be rejected"
+            ));
+        assert_pod_uid_mismatch(rejected, &format!("lift from {state:?}"));
+
+        // Re-presenting the ORIGINAL identity is still accepted, so the
+        // rejection is about identity and not about the state being frozen.
+        repository
+            .bind(&key, token, original, None)
+            .await
+            .unwrap_or_else(|e| panic!("replaying the original binding from {state:?}: {e:?}"));
+    }
+
+    let row = repository
+        .get(&key)
+        .await
+        .expect("read the durable lease row")
+        .expect("the lease row exists");
+    assert_eq!(
+        row.bound_pod_uid.as_deref(),
+        Some(original),
+        "no rejected lift may have moved the durable Pod binding"
+    );
+}


### PR DESCRIPTION
Implements board task `buyp` (epic `fbiy`, proposal `9oga`).

## Why this is implementation work, not test work

Epic `fbiy` reads as "add conformance evidence", but three of its four containment claims had **nothing to attest** on `origin/main`:

| Claim | State before this PR |
|---|---|
| Detect a fenced Pod's disappearance while its Job is nonterminal | **Did not exist.** `watch_infra_death` resolved only on Pod-*and*-Job-both-gone or Job-`Failed`. The Pod-gone-Job-alive case fell through *by design* — the comment said so. It read `list.items.first()` with **no UID comparison**. |
| Foreground-delete the owning Job on that detection | **Partial.** `delete_job_foreground` existed but was wired only to `cancel` and `teardown`. |
| Refuse to adopt a replacement Pod with a different UID | **Did not exist.** `WorkloadInventory::get_uid` had zero production callers. |

**Not a live bug today, and why it still matters.** A retry always mints a fresh `task_run_id`, so the deterministic Job name `djinn-taskrun-<uuid>` is never reused — a stale Job is never *adopted*. But it is also never *reaped*, and under Kueue that stale Job holds ClusterQueue quota, which is exactly what `fbiy` exists to bound.

## What changed

`server/crates/djinn-k8s/src/runtime.rs`:

- **The Pod fence.** `watch_infra_death` binds one immutable `metadata.uid` on its first observation and never re-binds. The label selector matches every Pod the Job controller ever makes for a run — including the replacement it mints after a force delete — so positional selection would silently re-target the watch at an object the run never launched and holds no build lease on.
- **The detection arm.** Fenced Pod absent + Job nonterminal ⇒ resolve the watch (which is how `supervisor_runner` terminalises a run) and foreground-delete the Job.
- **Blast-radius gate.** A cleanly `Complete` Job is excluded, so the containment cannot race a run whose terminal report is still on the wire. Both pre-existing arms keep their own reasons *and* their own precedence — `Failed` is checked before the new arm.
- Pure, separately-tested helpers: `bind_worker_pod_uid`, `fenced_worker_pod`, `unadopted_pod_uids`, `job_completed_cleanly`.

`runtime_kueue_create_tests.rs` — `FakeCluster` extended (fixture only; **no pre-existing test body changed**): Pod objects with real UIDs and ownerRefs, label-selector-honouring Pod list, Job DELETE with request-body capture, and a Job controller that replaces a destroyed Pod with a **fresh-UID** one.

`runtime_pod_fence_tests.rs` — new, 8 tests.

## Honesty about the fixture

The replacement-Pod behaviour is real **Job-controller** behaviour, not Kueue behaviour, which is what makes modelling it honest. It is still a model. It does **not** substitute for the live-cluster proof — that is `fbiy-B2`'s job, and it was blocked on this.

## Non-vacuity — every mutation run, real output

**AC1 — deletion made a no-op.** Fails on the surviving Job in `FakeCluster`, not on a log line:
```
panicked at runtime_pod_fence_tests.rs:217:
the orphaned task-run Job must be deleted, so it stops holding quota;
still present: ["djinn-taskrun-019f72b5-a92a-7501-8b41-b0ffe68cdda5"]
```

**AC2 — UID comparison removed from the fence** (`fenced_worker_pod` → `pods.first()`). The watch adopts the replacement, sees a healthy Pod and never resolves; 4 tests fail:
```
panicked at runtime_pod_fence_tests.rs:251:
the watch must resolve on the fenced Pod's disappearance; adopting the
replacement instead leaves it watching forever: Elapsed(())

panicked at runtime_pod_fence_tests.rs:291:
position must never decide identity — the replacement is listed first here
  left: Some("replacement")
 right: Some("original")
```

**AC4 — `Foreground` → `Background`.** Fails on the body `FakeCluster` received, not on `DeleteParams` construction:
```
panicked at runtime_pod_fence_tests.rs:351:
the reap must block the Job's removal on its Pods being cleaned up;
body was {"gracePeriodSeconds":30,"propagationPolicy":"Background"}
  left: Some("Background")
 right: Some("Foreground")
```

**AC3 — build-lease UID check removed** (`build_lease.rs`, reverted after the run). The test pins the exact rejection, so it distinguishes the UID fence from the state fence:
```
panicked at runtime_pod_fence_tests.rs:478:
lift from Bound: rejected for the wrong reason
  left: "cannot bind build lease from Bound"
 right: "pod UID does not match build lease"
```

**AC3 runs against a real PostgreSQL** (`Database::open_in_memory` clones the migrated test template) — not a mock repository. The rejection under test is a locked read-modify-write plus a trigger-enforced immutable column; a mock proves neither.

**AC5 — regression guard.** All 46 `runtime::` tests and all 327 `djinn-k8s` lib tests pass with **no pre-existing test modified**. Two new tests additionally drive the pre-existing arms end-to-end through the watch loop (they previously had only pure-helper coverage), plus one that proves the new arm does *not* fire on a cleanly completed Job.

## Scope

Exclusive to `runtime.rs` + the new test file, with the `FakeCluster` fixture extension the task specified. `job.rs`, `launcher.rs`, `warm_job.rs` and `deploy/**` untouched. No cluster needed; production not armed. No sqlx changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)