### PR TITLE
ci: enforce cargo fmt --check at PR/merge time

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -630,6 +630,36 @@ jobs:
       - name: Check no include! of hand-written source
         if: needs.preflight.outputs.size == 'true'
         run: ./scripts/check-include-macro.sh
+      # rustfmt is NOT in server/rust-toolchain.toml's `components`, and that
+      # file's own comment records why that matters: rustup syncs to exactly
+      # what is listed. So `rustup toolchain install` above does not guarantee
+      # rustfmt on this runner, and relying on the hosted image's default
+      # profile would be an assumption. Add it explicitly — it is a component
+      # download, a few seconds, and it makes the next step's tool a fact
+      # rather than an inherited default.
+      - name: Install rustfmt
+        if: needs.preflight.outputs.size == 'true'
+        working-directory: server
+        run: |
+          rustup toolchain install
+          rustup component add rustfmt
+      # Formatting is already enforced inside agent pods by the task-run gate
+      # (which is why `rustfmt` is baked into the image — see RUST_COMPONENTS
+      # in djinn-image-builder/src/dockerfile.rs). This is the PR/merge-time
+      # backstop for everything that bypasses that gate: human commits, and
+      # historically anything hidden from rustfmt's module walk. It does not
+      # replace the task-run gate.
+      #
+      # Routed by `size` for the same reason as the include! guard above: both
+      # police the shape of Rust source, and `size` is set for any server
+      # change. Whole-tree rather than diff-scoped — `cargo fmt` parses but
+      # never compiles, so the whole workspace costs seconds, a whole-tree
+      # check cannot be dodged by a base-SHA trick, and rustfmt resolves
+      # edition and config per crate, which a per-file invocation would lose.
+      - name: Check Rust formatting
+        if: needs.preflight.outputs.size == 'true'
+        working-directory: server
+        run: cargo fmt --all --check
       - name: Check raw-SQL boundary
         if: needs.preflight.outputs.rawSql == 'true'
         run: ./scripts/check-raw-sql-boundary.sh

--- a/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
@@ -23,8 +23,8 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use djinn_cgroup_launcher::{
-    CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
-    LauncherAuthorityProtocol, LeaseAuthority, Readiness, SpawnIntoCgroup,
+    CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher,
+    LauncherAuthorityProtocol, LauncherConfig, LeaseAuthority, Readiness, SpawnIntoCgroup,
     broker::{
         Broker, BrokerConfig, OsNonceSource, PeerCredentials, UnixPeer, WORKER_GID, WORKER_UID,
     },

--- a/server/crates/djinn-coordinator/src/build_lease_cap_arming_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_cap_arming_tests.rs
@@ -44,7 +44,8 @@ async fn an_unarmed_durable_cap_denies_every_graph_warm_lease_forever() {
     // handed to the lease service, so the resolution chain bottomed out at the
     // unarmed durable 0.
     let service = Arc::new(
-        BuildLeaseService::new(Arc::clone(&repository), 0).with_invocation_lease_authority(authority),
+        BuildLeaseService::new(Arc::clone(&repository), 0)
+            .with_invocation_lease_authority(authority),
     );
     assert!(matches!(service.recover().await, LeaseResult::Status(_)));
     assert_eq!(service.cap(), 0);
@@ -87,7 +88,8 @@ async fn an_unarmed_durable_cap_adopts_the_configured_build_slot_cap() {
     // The fixed composition: the same configured cap the v0 journal controller
     // receives from DJINN_MAX_BUILD_TASKRUNS.
     let service = Arc::new(
-        BuildLeaseService::new(Arc::clone(&repository), 3).with_invocation_lease_authority(authority),
+        BuildLeaseService::new(Arc::clone(&repository), 3)
+            .with_invocation_lease_authority(authority),
     );
     assert!(matches!(service.recover().await, LeaseResult::Status(_)));
     assert_eq!(service.cap(), 3);
@@ -143,7 +145,8 @@ async fn re_seeding_the_authority_row_alone_does_not_arm_the_lease() {
     );
 
     let configured = Arc::new(
-        BuildLeaseService::new(Arc::clone(&repository), 3).with_invocation_lease_authority(authority),
+        BuildLeaseService::new(Arc::clone(&repository), 3)
+            .with_invocation_lease_authority(authority),
     );
     assert!(matches!(configured.recover().await, LeaseResult::Status(_)));
     assert_eq!(
@@ -175,7 +178,8 @@ async fn an_armed_cap_is_never_overridden_by_the_configured_fallback() {
         .await
         .unwrap();
     let epoch_armed = Arc::new(
-        BuildLeaseService::new(Arc::clone(&repository), 9).with_invocation_lease_authority(authority),
+        BuildLeaseService::new(Arc::clone(&repository), 9)
+            .with_invocation_lease_authority(authority),
     );
     assert!(matches!(
         epoch_armed.recover().await,


### PR DESCRIPTION
## What

`cargo fmt --check` was not run anywhere in GitHub Actions. This adds it, plus the one-time sweep that makes it pass.

Two commits, deliberately separate so the formatting churn is reviewable apart from the CI change:
1. `style:` the sweep — 5 hunks across 2 files, the entire backlog on `main`.
2. `ci:` the gate.

## Where formatting was already enforced (and what this does *not* change)

`cargo fmt --check` already runs **on the agent side**: the task-run gate in agent pods runs it, which is why `rustfmt` is baked into the image (`RUST_COMPONENTS` in `server/crates/djinn-image-builder/src/dockerfile.rs`). What was missing was a check at **PR/merge time**.

This closes the gap for anything that bypasses the task-run gate — human commits, and historically anything hidden from rustfmt's module walk. The task-run gate is **not** removed and **not** duplicated.

Why the backlog is only 5 hunks now: #2815 (`include!` → `mod`) made the previously-invisible `.inc` fragments visible to rustfmt's module walk and swept them. Before that, this would have been a much larger sweep.

## Chosen lane: `server-guards` (existing job, no new job)

`cargo fmt` parses but never compiles, so this is seconds. Adding a dedicated job would cost a whole runner and its wall clock for no reason.

`server-guards` over `ci-contracts`:
- `server-guards` is already the Rust source-shape lane — file size, `include!`, raw-SQL boundary, capability/architectural boundaries. `cargo fmt --check` is the same category of check.
- `ci-contracts` verifies the CI machinery itself and is deliberately path-independent (no `if:` guard, runs on every event including docs-only). Putting a Rust check there would make every docs-only PR pay for a Rust toolchain.

The step sits immediately after the `include!` guard and is routed by the **same** `preflight.outputs.size` output, for the reason that guard's own comment already states: both police the shape of Rust source, and `size` is set for any server change.

## Whole-tree, not diff-scoped

`check-file-size.sh` is diff-scoped; this is not. Reasons:
- The backlog is now 5 hunks, so whole-tree is affordable — this is exactly why it's cheap to do now.
- A whole-tree scan cannot be dodged by a base-SHA trick (the same argument the neighbouring `include!` guard makes for scanning the whole tree).
- rustfmt resolves edition and configuration **per crate**. Feeding it a changed-file list would invoke it outside that resolution and silently weaken the check.

## Toolchain: rustfmt is installed, not assumed

This was checked rather than taken on faith. `server/rust-toolchain.toml` lists:

```toml
components = ["clippy", "rust-analyzer"]
```

No `rustfmt` — and that file's own comment records why that matters: *rustup syncs to exactly what `rust-toolchain.toml` lists*. So the existing `rustup toolchain install` in this job does **not** guarantee rustfmt, and leaning on the hosted runner image's default profile would be an assumption. The PR adds an explicit step:

```yaml
rustup toolchain install
rustup component add rustfmt
```

A component download, a few seconds. `rust-toolchain.toml` is intentionally left alone: editing it would flip the `sandboxAarch64` routing lane and change the toolchain file's hash for no benefit here.

## Verification

**1. The gate is non-vacuous — observed failing, then passing.**

Ran the exact command the new step runs. Appended a deliberately malformed function to `build_lease_cap_arming_tests.rs`:

```
Diff in .../build_lease_cap_arming_tests.rs:188:
+fn ci_gate_non_vacuity_probe() -> u32 {
+    let x = 1;
-fn ci_gate_non_vacuity_probe (   ) ->u32{let x=1;
...
=== STEP EXIT CODE: 1 (non-zero => CI step FAILS) ===
```

Reverted the probe, re-ran:

```
=== STEP EXIT CODE: 0 (0 => CI step PASSES) ===
```

**The step also runs on this very PR.** Confirmed against the real router — `planChangedScope` for this PR's file set returns `size = true`, so `server-guards` executes the new step here rather than the gate landing untested.

**2. `cd server && cargo fmt --check` exits 0** after the sweep.

**3. The sweep is formatting-only.** Verified structurally, not by eyeballing:

- `build_lease_cap_arming_tests.rs` — with **all** whitespace stripped, the file hashes **identically** before and after (`89ba0b69…`). Pure line wrapping of four `Arc::new(...)` expressions.
- `containment_and_escalation.rs` — additionally reorders `LauncherConfig` and `LauncherAuthorityProtocol` within one `use` list, so it is not whitespace-identical. Instead, the whole-file token stream split on `,{}` and sorted hashes identically before and after (`c7c35a93…`), proving the imported symbol set is a pure permutation. Rust `use` lists are order-independent.

No semantic change in either file.

**4. `actionlint -shellcheck= -pyflakes= .github/workflows/*.yml`** — exit 0.

**5. Contract suites** — `node --test scripts/ci-changed-scope.test.mjs scripts/ci-cache-policy.test.mjs scripts/ci-qa-smoke-workflow.test.mjs scripts/ci-nextest-plan.test.mjs` → **80 pass, 0 fail**.

## Note

The sweep was not compile-checked (no warm target dir; a cold full workspace build is not warranted). Both changes are provably inert: one is whitespace-identical, the other a verified permutation within a `use` list. CI compiles it either way.
