### PR TITLE
test(kueue): a disposable armed-Kueue cluster harness (fbiy-B0, 6knv)

### DIFF
--- a/.github/workflows/kueue-cluster-harness.yml
+++ b/.github/workflows/kueue-cluster-harness.yml
@@ -88,6 +88,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
+          # save-if MUST stay false. rust-cache SAVES by default, and every
+          # cache family in this repository has exactly one writer, declared in
+          # quality-gate.yml (`scripts/ci-cache-policy.test.mjs`). Without this
+          # line an opt-in lane quietly becomes a second writer to a family it
+          # does not own.
+          save-if: false
+          # server-test (codegen), not server-quality (clippy/rmeta only): this
+          # job builds and RUNS the djinn-k8s test binary.
+          shared-key: server-test
+          cache-on-failure: true
+          cache-all-crates: true
 
       # The hermetic half needs no cluster. Running it first means a broken
       # production-safety guard fails in seconds instead of after a cluster

--- a/.github/workflows/kueue-cluster-harness.yml
+++ b/.github/workflows/kueue-cluster-harness.yml
@@ -1,0 +1,121 @@
+name: Kueue Cluster Harness
+
+# OPT-IN, NON-REQUIRED lane for the disposable armed-Kueue cluster harness
+# (epic fbiy, task 6knv).
+#
+# DOES THIS RUN ANYWHERE BY DEFAULT? NO — and that is stated here rather than
+# left to be discovered.
+#
+# There is exactly one trigger, `workflow_dispatch`. This lane never runs on a
+# pull request, never runs on a push to main, never runs in the merge queue and
+# is not on any schedule. It is not a required check and cannot block a merge.
+# Nothing in this file runs unless a human presses "Run workflow".
+#
+# That is the same posture as `server/crates/djinn-k8s/tests/kind_smoke.rs`,
+# which is `#[ignore]` + `DJINN_TEST_KIND`-gated with NO lane at all
+# (`grep DJINN_TEST_KIND .github/workflows/` is empty) — and which, measured on
+# 2026-07-30, no longer even executes: it panics on a rustls CryptoProvider
+# ambiguity before its first API call. A gated harness nobody runs decays
+# silently, so the assertions in `kueue_cluster_harness.rs` that MUST NOT
+# regress — the production-safety refusals and the fixture's non-vacuity — are
+# hermetic `guard_*` tests with no `#[ignore]`, and they run on every PR inside
+# the ordinary `djinn-k8s` test lane. What needs this workflow is only the half
+# that genuinely needs an API server.
+#
+# WHY IT IS NOT REQUIRED
+# It creates a kind cluster and installs two Helm charts. That is minutes of
+# runner time and a class of infrastructure flake (image pulls, webhook
+# readiness) that must never be able to wedge the merge queue. `fbiy-B1`, `B2`
+# and `C1` are the tasks that will decide how often this is worth running.
+#
+# IT CANNOT TOUCH PRODUCTION. The runner's kubeconfig contains exactly one
+# context: the kind cluster created by the step below. Every kubectl and helm
+# call in `scripts/kind/setup-kueue-cluster.sh` is `--context`-pinned, and the
+# script refuses any context it did not create.
+
+on:
+  workflow_dispatch:
+    inputs:
+      k8s_version:
+        description: "kind node Kubernetes version (>= 1.30; Kueue 0.19 requires it)"
+        required: false
+        default: "1.31.0"
+      keep_on_failure:
+        description: "If 'true', leave the cluster running on failure for debugging"
+        required: false
+        default: "false"
+
+concurrency:
+  group: kueue-cluster-harness-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_BUILD_BUILD_DIR: target
+  RUSTC_WRAPPER: ""
+  RUSTFLAGS: "-D warnings"
+  SQLX_OFFLINE: "true"
+  DJINN_KUEUE_HARNESS_K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.31.0' }}
+
+jobs:
+  kueue-cluster-harness:
+    name: Disposable armed-Kueue cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Belt and braces: the only trigger is workflow_dispatch, and this makes a
+    # future edit that adds `pull_request` fail to turn this into a PR check by
+    # accident.
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kind, kubectl and helm
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+          chmod +x /usr/local/bin/kind
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          kind version
+          kubectl version --client=true
+          helm version --short
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: server
+
+      # The hermetic half needs no cluster. Running it first means a broken
+      # production-safety guard fails in seconds instead of after a cluster
+      # bring-up, and it is also what this lane shares with the ordinary PR
+      # lane — if these ever diverge, that is the bug.
+      - name: Hermetic guards (the half that also runs on every PR)
+        working-directory: server
+        run: cargo test -p djinn-k8s --test kueue_cluster_harness
+
+      - name: Create the disposable armed-Kueue cluster
+        run: |
+          scripts/kind/setup-kueue-cluster.sh up \
+            --k8s-version "$DJINN_KUEUE_HARNESS_K8S_VERSION" \
+            ${{ github.event.inputs.keep_on_failure == 'true' && '--keep-on-failure' || '' }}
+
+      - name: Live conformance against the armed cluster
+        working-directory: server
+        env:
+          DJINN_TEST_KUEUE_CLUSTER: "1"
+        # --test-threads=1 because the ClusterQueue's pods nominalQuota is 2:
+        # concurrent tests would contend for the very quota one of them is
+        # measuring.
+        run: cargo test -p djinn-k8s --test kueue_cluster_harness -- --ignored --test-threads=1
+
+      # `if: always()` is the point of this step. The harness deletes its own
+      # cluster when `up` fails, but a failure in the test step above happens
+      # after `up` has already succeeded, and a cancelled run skips everything.
+      # Pass or fail, the cluster AND its registry go.
+      - name: Tear down the cluster and its registry
+        if: always() && github.event.inputs.keep_on_failure != 'true'
+        run: scripts/kind/setup-kueue-cluster.sh down

--- a/deploy/helm/djinn/tests/fixtures/kueue-cluster-values.yaml
+++ b/deploy/helm/djinn/tests/fixtures/kueue-cluster-values.yaml
@@ -1,0 +1,136 @@
+# Djinn chart values for the DISPOSABLE armed-Kueue cluster harness (fbiy-B0).
+#
+# Consumed by scripts/kind/setup-kueue-cluster.sh and asserted against by
+# server/crates/djinn-k8s/tests/kueue_cluster_harness.rs.
+#
+# THIS FILE ARMS KUEUE. It is safe only because the only cluster it is ever
+# applied to is one `setup-kueue-cluster.sh` created seconds earlier and
+# deletes on the way out. Arming the production VPS is a gated operator act
+# behind `deploy/kueue/preflight.sh --mode cutover` and belongs to epic 4c9q's
+# runbook — not here, and not to fbiy.
+#
+# WHAT THIS INSTALL IS AND IS NOT
+# -------------------------------
+# It is a real `helm upgrade --install` of the real chart, so the chart's own
+# arming invariants (namespace.yaml's labelling gate, deployment-server.yaml's
+# "armed implies enabled" and RuntimeClass-stacking gates) execute for real.
+#
+# It is NOT a running Djinn. The harness proves ADMISSION topology — the
+# namespace label, the ClusterQueue quota, the three LocalQueues, and whether
+# Kueue captures a Job the real renderer produced. None of that needs a live
+# server, database or vector store, so the components that would only pull
+# hundreds of MB of images onto a throwaway node are switched off below and the
+# install is deliberately not `--wait`ed. Expect the djinn-server Deployment to
+# sit in ImagePullBackOff; that is the designed state, not a failure.
+
+namespace:
+  create: true
+  name: djinn
+
+# -----------------------------------------------------------------------------
+# The armed queue topology — the entire point of the harness
+# -----------------------------------------------------------------------------
+kueue:
+  enabled: true
+  # Labels the Namespace `djinn.io/kueue-managed=true` AND sets DJINN_KUEUE_ARMED
+  # on djinn-server. Both halves hang off this one value on purpose; see the
+  # chart's values.yaml.
+  armed: true
+  # DELIBERATELY NOT the chart default of 3.
+  #
+  # The live assertion reads the ClusterQueue's `pods` nominalQuota back off the
+  # API server and compares it against THIS number. If it matched the chart
+  # default, that assertion would pass just as well against an install that
+  # never read this file — the "green against nothing" shape fbiy exists to
+  # refute. 2 is also small enough to be a real bound on a single-node kind
+  # node, which is what fbiy-B1 will need.
+  buildPods: 2
+  # Irrelevant while namespace.create is true (the chart applies the label
+  # itself), stated so nobody reads its absence as an oversight.
+  namespaceLabelledExternally: false
+
+# -----------------------------------------------------------------------------
+# NO RuntimeClass — and that is load-bearing, not an omission
+# -----------------------------------------------------------------------------
+# `deploy/kueue/preflight.sh --mode cutover` must exit 10 against this cluster.
+# Exit 10 is "RuntimeClass djinn-cgroup-writable is absent", the ordering gate
+# that took production down twice. A harness that quietly installed the
+# RuntimeClass would turn AC4 into a check of nothing.
+#
+# These three values are the chart's shipped defaults. They are restated here
+# because the harness DEPENDS on them: if a future chart default flipped
+# `cgroupWritable.runtimeClass.enabled` on, the preflight assertion would go
+# green for the wrong reason without a single line of this file changing.
+#
+# `cgroupLauncher.mode: disabled` is required alongside them. The chart refuses
+# `kueue.armed=true` + `cgroupLauncher.mode=required` + no RuntimeClass outright
+# (templates/deployment-server.yaml), and it is right to: the task-run renderer
+# asserts the RuntimeClass and panics the coordinator otherwise. Proving the
+# RuntimeClass is absent therefore REQUIRES the launcher to be disabled — the
+# two facts are one fact. fbiy-C1, which proves the governor end to end, is the
+# task that flips both together after teaching the kind node the
+# `runc-cgroupwritable` containerd handler.
+cgroupLauncher:
+  mode: disabled
+cgroupWritable:
+  runtimeClass:
+    enabled: false
+  taskRuns:
+    enabled: false
+
+# -----------------------------------------------------------------------------
+# Everything below only exists to make the install land on one throwaway node
+# -----------------------------------------------------------------------------
+# Bundled data plane off: nothing the harness asserts reads it, and each one
+# costs an image pull and a PVC on a node that is deleted minutes later.
+postgres:
+  enabled: false
+qdrant:
+  enabled: false
+imagePipeline:
+  enabled: false
+ingress:
+  enabled: false
+monitoring:
+  enabled: false
+logCollector:
+  enabled: false
+
+# With postgres.enabled=false the chart requires an external URL. This one
+# points at nothing on purpose: no pod in this install is ever expected to
+# reach a database, and a harness that needed real credentials to prove an
+# admission contract would not be disposable.
+database:
+  externalUrl: "postgres://harness:harness@127.0.0.1:5432/djinn-kueue-harness?sslmode=disable"
+
+# The chart REFUSES to render a fresh install without this name
+# (templates/deployment-server.yaml). No Secret of this name is ever created:
+# only the djinn-server bootstrap initContainer resolves it, that container is
+# behind an image tag that does not exist here, and inventing a designated
+# operator identity is exactly the kind of fake input that would make the
+# harness look more real than it is.
+migration:
+  designatedOperatorSecret: djinn-kueue-harness-operator
+
+# kind provisions `standard` (rancher.io/local-path), which is ReadWriteOnce
+# only. The chart's committed defaults are the multi-node ReadWriteMany
+# production shape and would leave every claim unbindable here.
+storage:
+  mirrors:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+  cache:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+  projects:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+
+resources:
+  server:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"

--- a/scripts/kind/setup-kueue-cluster.sh
+++ b/scripts/kind/setup-kueue-cluster.sh
@@ -126,8 +126,13 @@ EXIT_VERSION_FLOOR=7
 
 MIN_K8S_MINOR=30
 
+# The header comment above IS the help text. Printing it rather than
+# maintaining a second copy is why the range stops at the last commented line
+# (`#   1   anything else ...`), which `awk` finds instead of a line number that
+# would silently drift on the next edit.
 usage() {
-    sed -n '2,95p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' \
+        "${BASH_SOURCE[0]}" >&2
 }
 
 fail() {

--- a/scripts/kind/setup-kueue-cluster.sh
+++ b/scripts/kind/setup-kueue-cluster.sh
@@ -315,12 +315,18 @@ fi
 
 # Disk. The host ran low on 2026-07-30 and a kind node plus a Kueue install is
 # not a small thing to discover you cannot afford halfway through.
-FREE_GIB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+#
+# An unparseable `df` is a failure, not zero free space and not a skip. Both of
+# the wrong answers are worse than stopping: "0Gi free" sends an operator
+# pruning a disk that is fine, and skipping the check reintroduces the very
+# mid-install disk exhaustion this guard exists for.
+FREE_GIB=$(df -BG --output=avail / 2>/dev/null | tail -1 | tr -dc '0-9')
+[ -n "$FREE_GIB" ] || fail 1 \
+    "could not read free space on / (df -BG --output=avail is GNU coreutils syntax). Fix the check rather than removing it."
 info "free space on /: ${FREE_GIB}Gi (floor ${MIN_FREE_GIB}Gi)"
-[ "${FREE_GIB:-0}" -ge "$MIN_FREE_GIB" ] || fail "$EXIT_LOW_DISK" \
+[ "$FREE_GIB" -ge "$MIN_FREE_GIB" ] || fail "$EXIT_LOW_DISK" \
     "only ${FREE_GIB}Gi free on / but this harness wants ${MIN_FREE_GIB}Gi. Prune before retrying (agent worktree cargo targets and cargo-target-runs are the usual culprits); do not lower the floor to get past this."
 
-CREATED_CLUSTER=false
 on_exit() {
     local status=$?
     [ "$status" -eq 0 ] && return 0
@@ -358,7 +364,6 @@ containerdConfigPatches:
 nodes:
   - role: control-plane
 EOF
-CREATED_CLUSTER=true
 
 # `kind create cluster` switches the current context to the new cluster. Every
 # call below is still pinned; this is only so a caller left on the harness

--- a/scripts/kind/setup-kueue-cluster.sh
+++ b/scripts/kind/setup-kueue-cluster.sh
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+# A DISPOSABLE kind cluster with Kueue installed and ARMED (fbiy-B0).
+#
+# WHAT THIS IS FOR
+# ----------------
+# Epic fbiy's live-cluster half asks questions that cannot be answered by a
+# rendered fixture: does Kueue mutate only `spec.suspend`, does the `pods`
+# nominalQuota actually bound admission, what does force-deleting a Workload
+# really do. Every one of those needs an API server with Kueue armed against
+# it. This script produces exactly one, and nothing else.
+#
+# It is the enabling half of `server/crates/djinn-k8s/tests/kueue_cluster_harness.rs`,
+# which is where the assertions live.
+#
+# THIS MUST NEVER ARM PRODUCTION
+# ------------------------------
+# Arming Kueue on the production VPS is a gated operator act behind
+# `deploy/kueue/preflight.sh --mode cutover` and belongs to epic 4c9q's
+# runbook. It has not happened. Nothing here is a step toward it.
+#
+# Four independent guards keep it that way, and all of them run BEFORE any
+# cluster, registry or kubeconfig is touched (`check` runs them and stops):
+#
+#   1. The cluster, its context, its registry and its registry port all carry
+#      harness-specific names, so the developer's Tilt cluster (`kind-djinn`,
+#      `kind-registry`, port 5001) is not merely "probably not selected" — it
+#      is a REFUSED name (exit 3).
+#   2. A caller-supplied `--context` that is not the context this script is
+#      about to create is refused (exit 3). It is never "used anyway". Note
+#      that every context in a Djinn developer's kubeconfig today is an EKS
+#      cluster, so "whatever is current" is the single worst default available;
+#      this script never reads the current context.
+#   3. Every `kubectl` and `helm` invocation below is pinned with
+#      `--context` / `--kube-context`. There is no unpinned call.
+#   4. `up` refuses to adopt a kind cluster that already exists (exit 6). A
+#      cluster this script did not create is one whose contents it cannot
+#      vouch for, and tearing it down on failure would then destroy someone
+#      else's work.
+#
+# KUBERNETES FLOOR: 1.30
+# ----------------------
+# Kueue 0.19.0 requires >= 1.30 and this script refuses anything older
+# (exit 7). The 1.29 floor that used to be documented was MEASURED FALSE on
+# 2026-07-30 and corrected in #2818. `k8s-openapi` is compiled against `v1_30`
+# in `server/crates/djinn-k8s/Cargo.toml`, which is the same floor from the
+# client side.
+#
+# WHAT IT DOES NOT DO — the fbiy-C1 hook
+# --------------------------------------
+# It patches containerd for REGISTRIES ONLY, exactly like
+# `scripts/kind/setup-kind.sh:59-106`. It installs NO `runc-cgroupwritable`
+# runtime handler and applies NO `djinn.io/cgroup-writable=true` node label,
+# both of which `deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml`
+# needs. That is deliberate and it is load-bearing twice over:
+#
+#   * `deploy/kueue/preflight.sh --mode cutover` must exit 10 ("RuntimeClass
+#     djinn-cgroup-writable is absent") against this cluster. Installing the
+#     RuntimeClass here would silently retire that assertion.
+#   * fbiy-C1 owns proving the governor end to end and will need a real
+#     writable-cgroup node. See `configure_node_containerd` below: the C1
+#     extension goes inside that loop, plus a node label after cluster create.
+#     Nothing else in this script has to move.
+#
+# USAGE
+#   scripts/kind/setup-kueue-cluster.sh up      # create + install + arm
+#   scripts/kind/setup-kueue-cluster.sh down    # delete cluster AND registry
+#   scripts/kind/setup-kueue-cluster.sh check   # run the guards only, touch nothing
+#
+# `up` deletes the cluster and the registry on FAILURE (that is AC3 of 6knv);
+# on success it leaves them running for the Rust harness and the caller is
+# responsible for `down`. Pass `--keep-on-failure` to keep a broken cluster for
+# debugging — it is opt-in precisely because the default must not leave
+# wreckage behind on a host that ran low on disk today.
+#
+# EXIT CODES
+#   0   ok
+#   2   usage / caller error
+#   3   refused a context or a reserved name this script must not touch
+#   4   not enough free disk
+#   5   a required tool is missing
+#   6   refused to adopt a pre-existing cluster
+#   7   Kubernetes version below the Kueue 0.19 floor
+#   1   anything else (install failure, API error, ...)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+KIND="${KIND:-kind}"
+KUBECTL_BIN="${KUBECTL:-kubectl}"
+HELM_BIN="${HELM:-helm}"
+DOCKER="${DOCKER:-docker}"
+
+# Harness-specific everything. None of these may collide with the Tilt cluster.
+CLUSTER_NAME="${DJINN_KUEUE_HARNESS_CLUSTER:-djinn-kueue-harness}"
+REG_NAME="${DJINN_KUEUE_HARNESS_REGISTRY:-djinn-kueue-harness-registry}"
+REG_PORT="${DJINN_KUEUE_HARNESS_REG_PORT:-5051}"
+KIND_IMAGE_VERSION="${DJINN_KUEUE_HARNESS_K8S_VERSION:-1.31.0}"
+MIN_FREE_GIB="${DJINN_KUEUE_HARNESS_MIN_FREE_GIB:-20}"
+INSTALL_TIMEOUT_SECONDS="${DJINN_KUEUE_HARNESS_INSTALL_TIMEOUT_SECONDS:-600}"
+VALUES_FILE="${DJINN_KUEUE_HARNESS_VALUES:-$REPO_ROOT/deploy/helm/djinn/tests/fixtures/kueue-cluster-values.yaml}"
+REQUESTED_CONTEXT=""
+KEEP_ON_FAILURE=false
+ACTION=""
+
+PREREQS_CHART="$REPO_ROOT/deploy/helm/djinn-prereqs"
+PREREQS_RELEASE="djinn-prereqs"
+PREREQS_NAMESPACE="kueue-system"
+CHART="$REPO_ROOT/deploy/helm/djinn"
+RELEASE="djinn"
+NAMESPACE="djinn"
+
+# The names this script must never touch, whatever it is asked to do.
+# `djinn` / `kind-registry` / 5001 are `scripts/kind/setup-kind.sh`'s defaults,
+# i.e. the developer's live Tilt environment.
+RESERVED_CLUSTER_NAMES=(djinn kind)
+RESERVED_REGISTRY_NAMES=(kind-registry)
+RESERVED_REG_PORTS=(5000 5001)
+
+EXIT_USAGE=2
+EXIT_REFUSED_TARGET=3
+EXIT_LOW_DISK=4
+EXIT_MISSING_TOOL=5
+EXIT_CLUSTER_EXISTS=6
+EXIT_VERSION_FLOOR=7
+
+MIN_K8S_MINOR=30
+
+usage() {
+    sed -n '2,95p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
+}
+
+fail() {
+    local code=$1
+    shift
+    printf 'FAIL: %s\n' "$*" >&2
+    exit "$code"
+}
+
+info() { printf '>>> %s\n' "$*"; }
+
+# --- Argument parsing -------------------------------------------------------
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        up|down|check)
+            [ -z "$ACTION" ] || fail "$EXIT_USAGE" "two actions given: $ACTION and $1"
+            ACTION=$1
+            shift
+            ;;
+        --context)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--context requires a value'
+            REQUESTED_CONTEXT=$2
+            shift 2
+            ;;
+        --cluster-name)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--cluster-name requires a value'
+            CLUSTER_NAME=$2
+            shift 2
+            ;;
+        --registry-name)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--registry-name requires a value'
+            REG_NAME=$2
+            shift 2
+            ;;
+        --registry-port)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--registry-port requires a value'
+            REG_PORT=$2
+            shift 2
+            ;;
+        --k8s-version)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--k8s-version requires a value'
+            KIND_IMAGE_VERSION=$2
+            shift 2
+            ;;
+        --values)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--values requires a value'
+            VALUES_FILE=$2
+            shift 2
+            ;;
+        --min-free-gib)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--min-free-gib requires a value'
+            MIN_FREE_GIB=$2
+            shift 2
+            ;;
+        --keep-on-failure)
+            KEEP_ON_FAILURE=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *) fail "$EXIT_USAGE" "unknown option: $1" ;;
+    esac
+done
+
+ACTION="${ACTION:-up}"
+
+# --- Guards (all of them run before anything is created) --------------------
+
+[[ "$CLUSTER_NAME" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] \
+    || fail "$EXIT_USAGE" "--cluster-name must be a DNS label, got: $CLUSTER_NAME"
+[[ "$REG_PORT" =~ ^[1-9][0-9]{2,4}$ ]] \
+    || fail "$EXIT_USAGE" "--registry-port must be a TCP port, got: $REG_PORT"
+[[ "$MIN_FREE_GIB" =~ ^[0-9]+$ ]] \
+    || fail "$EXIT_USAGE" "--min-free-gib must be a non-negative integer, got: $MIN_FREE_GIB"
+
+# Guard 1: reserved names. The Tilt cluster is not "unlikely to be selected";
+# it is unselectable.
+for reserved in "${RESERVED_CLUSTER_NAMES[@]}"; do
+    [ "$CLUSTER_NAME" != "$reserved" ] || fail "$EXIT_REFUSED_TARGET" \
+        "refusing to operate on kind cluster '$CLUSTER_NAME': that is the developer's Tilt cluster (scripts/kind/setup-kind.sh). This harness creates and DELETES its target, so it must own the name outright."
+done
+for reserved in "${RESERVED_REGISTRY_NAMES[@]}"; do
+    [ "$REG_NAME" != "$reserved" ] || fail "$EXIT_REFUSED_TARGET" \
+        "refusing to operate on registry '$REG_NAME': that is the Tilt registry (scripts/kind/setup-kind.sh), and 'down' deletes the registry it is given."
+done
+for reserved in "${RESERVED_REG_PORTS[@]}"; do
+    [ "$REG_PORT" != "$reserved" ] || fail "$EXIT_REFUSED_TARGET" \
+        "refusing registry port $REG_PORT: 5001 is the Tilt registry's published port and binding it would either fail or shadow it."
+done
+
+# Guard 2: the Kubernetes floor, checked on the REQUESTED image before a
+# cluster exists, and re-checked against the live API server after create.
+K8S_MAJOR=${KIND_IMAGE_VERSION%%.*}
+K8S_REST=${KIND_IMAGE_VERSION#*.}
+K8S_MINOR=${K8S_REST%%.*}
+[[ "$K8S_MAJOR" =~ ^[0-9]+$ && "$K8S_MINOR" =~ ^[0-9]+$ ]] \
+    || fail "$EXIT_USAGE" "--k8s-version must look like 1.31.0, got: $KIND_IMAGE_VERSION"
+if [ "$K8S_MAJOR" -lt 1 ] || { [ "$K8S_MAJOR" -eq 1 ] && [ "$K8S_MINOR" -lt "$MIN_K8S_MINOR" ]; }; then
+    fail "$EXIT_VERSION_FLOOR" \
+        "Kubernetes $KIND_IMAGE_VERSION is below the 1.$MIN_K8S_MINOR floor Kueue 0.19.0 requires. The 1.29 floor this repository used to document was measured false on 2026-07-30 and corrected in #2818; do not restore it."
+fi
+
+# Guard 3: the context. Derived, never discovered — this script does not read
+# the current context, because on a Djinn developer's machine every context in
+# the kubeconfig is an EKS cluster.
+CONTEXT="kind-${CLUSTER_NAME}"
+if [ -n "$REQUESTED_CONTEXT" ] && [ "$REQUESTED_CONTEXT" != "$CONTEXT" ]; then
+    fail "$EXIT_REFUSED_TARGET" \
+        "refusing --context '$REQUESTED_CONTEXT': this harness only ever targets '$CONTEXT', the context of the kind cluster it creates and deletes itself. An externally supplied context is a cluster whose contents this script cannot vouch for — and every context in a Djinn developer's kubeconfig today is a live EKS cluster (demo/staging/prod)."
+fi
+
+KUBECTL=("$KUBECTL_BIN" --context "$CONTEXT")
+HELM=("$HELM_BIN" --kube-context "$CONTEXT")
+
+if [ "$ACTION" = check ]; then
+    printf 'PASS: guards accept cluster=%s context=%s registry=%s:%s k8s=%s\n' \
+        "$CLUSTER_NAME" "$CONTEXT" "$REG_NAME" "$REG_PORT" "$KIND_IMAGE_VERSION"
+    exit 0
+fi
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || fail "$EXIT_MISSING_TOOL" "$1 is not on PATH; this harness needs docker, kind, kubectl and helm"
+}
+require_tool "$DOCKER"
+require_tool "$KIND"
+require_tool "$KUBECTL_BIN"
+require_tool "$HELM_BIN"
+
+# --- Teardown ---------------------------------------------------------------
+# Deletes only the cluster and registry NAMES this run validated above. Called
+# both by `down` and by `up`'s failure trap.
+teardown() {
+    info "deleting kind cluster ${CLUSTER_NAME}"
+    "$KIND" delete cluster --name "$CLUSTER_NAME" || true
+    if "$DOCKER" inspect "$REG_NAME" >/dev/null 2>&1; then
+        info "deleting registry container ${REG_NAME}"
+        "$DOCKER" rm -f "$REG_NAME" >/dev/null || true
+    else
+        info "registry container ${REG_NAME} is already absent"
+    fi
+    # Prove the deletion rather than asserting it: a teardown that reported
+    # success while the cluster survived is how a "disposable" harness turns
+    # into a permanent one on a host that is already at 85% disk.
+    local surviving
+    surviving=$("$KIND" get clusters 2>/dev/null | grep -Fx "$CLUSTER_NAME" || true)
+    if [ -n "$surviving" ]; then
+        printf 'FAIL: kind cluster %s survived teardown\n' "$CLUSTER_NAME" >&2
+        return 1
+    fi
+    if "$DOCKER" inspect "$REG_NAME" >/dev/null 2>&1; then
+        printf 'FAIL: registry container %s survived teardown\n' "$REG_NAME" >&2
+        return 1
+    fi
+    printf 'PASS: cluster %s and registry %s are gone\n' "$CLUSTER_NAME" "$REG_NAME"
+}
+
+if [ "$ACTION" = down ]; then
+    teardown
+    exit 0
+fi
+
+# --- up ---------------------------------------------------------------------
+
+[ -f "$VALUES_FILE" ] || fail "$EXIT_USAGE" "values file does not exist: $VALUES_FILE"
+[ -d "$PREREQS_CHART" ] || fail 1 "Kueue prerequisite chart is missing: $PREREQS_CHART"
+[ -f "$PREREQS_CHART/Chart.lock" ] || fail 1 "prerequisite chart is unpinned: $PREREQS_CHART/Chart.lock is missing"
+# Same reasoning as deploy/kueue/zero-capture-gate.sh: install the exact
+# reviewed bytes, never a resolve-at-install-time dependency.
+ls "$PREREQS_CHART"/charts/kueue-*.tgz >/dev/null 2>&1 \
+    || fail 1 "prerequisite chart has no vendored kueue dependency; run: helm dependency update $PREREQS_CHART"
+[ -d "$CHART" ] || fail 1 "Djinn chart is missing: $CHART"
+
+# Guard 4: never adopt a cluster this run did not create.
+if "$KIND" get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+    fail "$EXIT_CLUSTER_EXISTS" \
+        "kind cluster '$CLUSTER_NAME' already exists. This harness refuses to adopt it: it tears its cluster down on failure, and a cluster it did not create is one whose contents it cannot vouch for. Delete it first: $0 down --cluster-name $CLUSTER_NAME"
+fi
+
+# Disk. The host ran low on 2026-07-30 and a kind node plus a Kueue install is
+# not a small thing to discover you cannot afford halfway through.
+FREE_GIB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+info "free space on /: ${FREE_GIB}Gi (floor ${MIN_FREE_GIB}Gi)"
+[ "${FREE_GIB:-0}" -ge "$MIN_FREE_GIB" ] || fail "$EXIT_LOW_DISK" \
+    "only ${FREE_GIB}Gi free on / but this harness wants ${MIN_FREE_GIB}Gi. Prune before retrying (agent worktree cargo targets and cargo-target-runs are the usual culprits); do not lower the floor to get past this."
+
+CREATED_CLUSTER=false
+on_exit() {
+    local status=$?
+    [ "$status" -eq 0 ] && return 0
+    if [ "$KEEP_ON_FAILURE" = true ]; then
+        printf 'WARN: harness failed (status %s) and --keep-on-failure was given; cluster %s is STILL RUNNING. Delete it with: %s down --cluster-name %s\n' \
+            "$status" "$CLUSTER_NAME" "$0" "$CLUSTER_NAME" >&2
+        return 0
+    fi
+    printf 'INFO: harness failed (status %s); tearing the disposable cluster down\n' "$status" >&2
+    teardown || true
+}
+trap on_exit EXIT
+
+# 1. Registry, on a harness-specific name and port.
+if "$DOCKER" inspect "$REG_NAME" >/dev/null 2>&1; then
+    fail "$EXIT_CLUSTER_EXISTS" \
+        "registry container '$REG_NAME' already exists; this harness does not adopt one. Remove it first: $0 down --cluster-name $CLUSTER_NAME --registry-name $REG_NAME"
+fi
+info "starting registry ${REG_NAME} at 127.0.0.1:${REG_PORT}"
+"$DOCKER" run -d --restart=no \
+    -p "127.0.0.1:${REG_PORT}:5000" \
+    --network bridge \
+    --name "$REG_NAME" \
+    registry:2 >/dev/null
+
+# 2. The cluster.
+info "creating kind cluster ${CLUSTER_NAME} at Kubernetes v${KIND_IMAGE_VERSION}"
+"$KIND" create cluster --name "$CLUSTER_NAME" --image "kindest/node:v${KIND_IMAGE_VERSION}" --config=- <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+nodes:
+  - role: control-plane
+EOF
+CREATED_CLUSTER=true
+
+# `kind create cluster` switches the current context to the new cluster. Every
+# call below is still pinned; this is only so a caller left on the harness
+# context is left on a context that exists.
+info "created context ${CONTEXT} (current-context is now this disposable cluster)"
+
+# Re-check the floor against the LIVE API server. The kind node image tag is a
+# claim; `kubectl version` is the measurement. This is the same distinction
+# that made the documented 1.29 floor wrong for five minor versions.
+SERVER_MINOR=$("${KUBECTL[@]}" version -o json | sed -n 's/.*"minor": *"\([0-9]*\)".*/\1/p' | tail -1)
+[[ "$SERVER_MINOR" =~ ^[0-9]+$ ]] || fail 1 "could not read the live Kubernetes minor version from context $CONTEXT"
+[ "$SERVER_MINOR" -ge "$MIN_K8S_MINOR" ] || fail "$EXIT_VERSION_FLOOR" \
+    "the live API server reports 1.${SERVER_MINOR}, below the 1.${MIN_K8S_MINOR} floor Kueue 0.19.0 requires"
+info "live API server is Kubernetes 1.${SERVER_MINOR} (floor 1.${MIN_K8S_MINOR})"
+
+# 3. containerd registry wiring, per node.
+#
+# ============================ fbiy-C1 EXTENSION HOOK =========================
+# C1 (prove the governor end to end) needs a node that can actually run the
+# writable-cgroup RuntimeClass. Everything it must add is local to this
+# function plus one node label:
+#
+#   * write a `runc-cgroupwritable` runtime handler into the node's
+#     /etc/containerd/config.toml (plugins."io.containerd.grpc.v1.cri".containerd
+#     .runtimes.runc-cgroupwritable) and restart containerd on the node;
+#   * `kubectl label node <node> djinn.io/cgroup-writable=true`;
+#   * flip cgroupWritable.runtimeClass.enabled / cgroupWritable.taskRuns.enabled
+#     and cgroupLauncher.mode in a C1-owned values file.
+#
+# It must NOT do that here. `deploy/kueue/preflight.sh --mode cutover` exiting
+# 10 against this cluster is 6knv's AC4, and exit 10 means "RuntimeClass
+# djinn-cgroup-writable is absent". Installing the class in B0 would delete
+# that assertion without deleting a single line of the test that makes it.
+# =============================================================================
+configure_node_containerd() {
+    local registry_dir="/etc/containerd/certs.d/localhost:${REG_PORT}"
+    local in_cluster_dir="/etc/containerd/certs.d/${REG_NAME}:5000"
+    local node
+    for node in $("$KIND" get nodes --name "$CLUSTER_NAME"); do
+        "$DOCKER" exec "$node" mkdir -p "$registry_dir" "$in_cluster_dir"
+        "$DOCKER" exec -i "$node" cp /dev/stdin "$registry_dir/hosts.toml" <<EOF
+[host."http://${REG_NAME}:5000"]
+  capabilities = ["pull", "resolve"]
+EOF
+        "$DOCKER" exec -i "$node" cp /dev/stdin "$in_cluster_dir/hosts.toml" <<EOF
+[host."http://${REG_NAME}:5000"]
+  capabilities = ["pull", "resolve"]
+EOF
+    done
+}
+info 'wiring containerd registry mirrors (registries only — see the fbiy-C1 hook)'
+configure_node_containerd
+
+if [ "$("$DOCKER" inspect -f '{{json .NetworkSettings.Networks.kind}}' "$REG_NAME" 2>/dev/null)" = 'null' ]; then
+    "$DOCKER" network connect kind "$REG_NAME"
+fi
+
+# 4. The pinned Kueue prerequisite. `--wait` is mandatory here, not optional:
+# ClusterQueue and LocalQueue carry a conversion webhook, so the djinn chart's
+# topology cannot be applied until the Kueue controller is actually serving.
+info "installing pinned Kueue prerequisite ${PREREQS_RELEASE} (Kueue 0.19.0, DRA gates off)"
+"${HELM[@]}" upgrade --install "$PREREQS_RELEASE" "$PREREQS_CHART" \
+    --namespace "$PREREQS_NAMESPACE" --create-namespace \
+    --wait --timeout "${INSTALL_TIMEOUT_SECONDS}s"
+
+# 5. The djinn chart, ARMED.
+#
+# Deliberately NOT `--wait`. The harness proves an admission contract, not a
+# running Djinn: the server image tag in the values file resolves to nothing
+# here and its Deployment is expected to sit in ImagePullBackOff forever.
+# Waiting would time out on a state that is by design. Every object the
+# assertions read — the Namespace label, the ClusterQueue, the three
+# LocalQueues — is created synchronously by this call and is present the moment
+# it returns.
+info "installing djinn chart release ${RELEASE} with kueue.enabled=true kueue.armed=true"
+"${HELM[@]}" upgrade --install "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" --create-namespace \
+    --values "$VALUES_FILE" \
+    --set kueue.enabled=true --set kueue.armed=true
+
+# 6. Report what the API server actually holds, so a human reading the log sees
+# the same three facts the Rust harness asserts. These are printed, not
+# asserted: the assertions live in kueue_cluster_harness.rs, and duplicating
+# them here in a weaker form would invite someone to trust the weaker copy.
+info 'armed cluster state:'
+"${KUBECTL[@]}" get namespace "$NAMESPACE" \
+    -o 'jsonpath={.metadata.name}{" djinn.io/kueue-managed="}{.metadata.labels.djinn\.io/kueue-managed}{"\n"}'
+"${KUBECTL[@]}" get clusterqueues.kueue.x-k8s.io \
+    -o 'jsonpath={range .items[*]}{"clusterqueue "}{.metadata.name}{" pods="}{.spec.resourceGroups[0].flavors[0].resources[0].nominalQuota}{"\n"}{end}'
+"${KUBECTL[@]}" get localqueues.kueue.x-k8s.io -n "$NAMESPACE" \
+    -o 'jsonpath={range .items[*]}{"localqueue "}{.metadata.name}{"\n"}{end}'
+
+cat <<EOF
+
+>>> disposable armed-Kueue cluster '${CLUSTER_NAME}' is ready.
+
+    context:   ${CONTEXT}
+    registry:  ${REG_NAME} (127.0.0.1:${REG_PORT})
+
+Run the harness:
+
+    DJINN_TEST_KUEUE_CLUSTER=1 cargo test -p djinn-k8s --test kueue_cluster_harness -- --ignored
+
+TEAR IT DOWN when you are finished — cluster AND registry:
+
+    $0 down --cluster-name ${CLUSTER_NAME} --registry-name ${REG_NAME}
+EOF

--- a/server/crates/djinn-k8s/tests/kueue_cluster_harness.rs
+++ b/server/crates/djinn-k8s/tests/kueue_cluster_harness.rs
@@ -1,0 +1,899 @@
+// Test: eprintln is the skip-reason channel for the gated half, mirroring
+// tests/kind_smoke.rs.
+#![allow(clippy::print_stderr)]
+//! Live conformance harness for the DISPOSABLE armed-Kueue cluster (fbiy-B0).
+//!
+//! WHY THIS FILE IS NOT A FIXTURE TEST
+//! -----------------------------------
+//! Epic `fbiy` asks whether Kueue mutates only `spec.suspend`, whether the
+//! `pods` nominalQuota actually bounds admission, and what force-deleting a
+//! Workload does. None of those can be answered by a render: they are
+//! statements about a controller's behaviour against an API server. On
+//! 2026-07-30 four separate pieces of green-but-inert work in this repository
+//! were caught only by real clusters — a gate nothing could satisfy, a harness
+//! that could not execute, a documented k8s floor wrong by five minor
+//! versions, and a launcher path unreachable from its own binary. This file
+//! exists so `fbiy`'s claims cannot join them.
+//!
+//! TWO HALVES, AND ONLY ONE OF THEM NEEDS A CLUSTER
+//! ------------------------------------------------
+//! * The `guard_*` tests are HERMETIC and NOT `#[ignore]`d. They run in the
+//!   ordinary `cargo test -p djinn-k8s` lane, on every PR, with no cluster and
+//!   no network. They exercise the refusals in
+//!   `scripts/kind/setup-kueue-cluster.sh` that keep this harness off
+//!   production, plus the non-vacuity of the live assertions' own inputs.
+//! * The `live_*` tests are `#[ignore]` + `DJINN_TEST_KUEUE_CLUSTER=1` gated,
+//!   mirroring `tests/kind_smoke.rs:89-103`.
+//!
+//! That split is deliberate, and it is the answer to the thing
+//! `tests/kind_smoke.rs` gets wrong: that file is `#[ignore]` +
+//! `DJINN_TEST_KIND`-gated and **no CI lane runs it** (`grep DJINN_TEST_KIND
+//! .github/workflows/` is empty), so its assertions have never protected
+//! anything automatically. The live half here has the same property — see
+//! `.github/workflows/kueue-cluster-harness.yml`, which is `workflow_dispatch`
+//! only and NOT a required check — so the guards that must never regress were
+//! put where they run by default instead.
+//!
+//! WHY THE LIVE HALF DRIVES `kubectl` AND NOT `kube::Client`
+//! ---------------------------------------------------------
+//! Because `kube::Client` does not currently work in this workspace's test
+//! binaries at all, and finding that out is itself one of this task's results.
+//!
+//! `workspace-hack` unifies `rustls` 0.23 with BOTH the `ring` and the
+//! `aws-lc-rs` providers enabled, and nothing in `server/crates` ever calls
+//! `CryptoProvider::install_default()`. The first TLS handshake therefore
+//! panics:
+//!
+//! ```text
+//! Could not automatically determine the process-level CryptoProvider from
+//! Rustls crate features.
+//! ```
+//!
+//! MEASURED 2026-07-30: `DJINN_TEST_KIND=1 cargo test -p djinn-k8s --test
+//! kind_smoke -- --ignored` panics exactly there, against a live kind cluster,
+//! before its first API call. The file 6knv points at as the pattern to mirror
+//! is not merely un-run by CI — it is UNRUNNABLE, and has been silently so.
+//! That is the "harness that could not execute" failure class, found again.
+//!
+//! Fixing it means either installing a provider (a new dev-dependency, hence
+//! `cargo hakari generate`, hence editing `workspace-hack` — shared files this
+//! task must not touch while other agents are in the same crates) or narrowing
+//! the feature unification. Either is a real change with a real blast radius
+//! and belongs in its own PR. So this harness takes the route that needs
+//! neither: every live assertion below reads or writes through
+//! `kubectl --context kind-djinn-kueue-harness`, which is the same pinned-context
+//! discipline `deploy/kueue/zero-capture-gate.sh` and `deploy/kueue/preflight.sh`
+//! already use, and which cannot silently start targeting a cluster this
+//! harness did not create.
+//!
+//! The objects still come from the REAL renderer: `build_task_run_job` produces
+//! the Job, it is serialized and handed to the API server unmodified, and what
+//! Kueue does with it is read back off that same API server.
+//!
+//! RUNNING THE LIVE HALF
+//!
+//! ```bash
+//! scripts/kind/setup-kueue-cluster.sh up
+//! DJINN_TEST_KUEUE_CLUSTER=1 cargo test -p djinn-k8s --test kueue_cluster_harness -- --ignored
+//! scripts/kind/setup-kueue-cluster.sh down     # cluster AND registry
+//! ```
+
+use std::collections::BTreeSet;
+use std::env;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::Duration;
+
+use djinn_k8s::config::{KubernetesConfig, LABEL_KUEUE_BUILD_OBJECT, LABEL_KUEUE_QUEUE_NAME};
+use djinn_k8s::job::build_task_run_job;
+use djinn_k8s::launcher::CgroupLauncherMode;
+use k8s_openapi::api::batch::v1::Job;
+use serde_json::Value;
+
+/// The one cluster this harness may ever touch. It must equal
+/// `CLUSTER_NAME`'s default in `scripts/kind/setup-kueue-cluster.sh`; the
+/// script's `check` action is used below to keep the two from drifting.
+const HARNESS_CLUSTER: &str = "djinn-kueue-harness";
+/// kind names its context `kind-<cluster>`. Derived here for the same reason
+/// the script derives it: the CURRENT context is never consulted, because
+/// every context in a Djinn developer's kubeconfig is a live EKS cluster.
+const HARNESS_CONTEXT: &str = "kind-djinn-kueue-harness";
+const NAMESPACE: &str = "djinn";
+const KUEUE_MANAGED_LABEL: &str = "djinn.io/kueue-managed";
+/// `<djinn.fullname>-kueue` for release `djinn`, per
+/// `deploy/helm/djinn/templates/kueue-topology.yaml`.
+const CLUSTER_QUEUE: &str = "djinn-kueue";
+/// The RuntimeClass the harness deliberately does NOT install — see
+/// [`live_cutover_preflight_exits_10_against_the_armed_harness`].
+const CGROUP_WRITABLE_RUNTIME_CLASS: &str = "djinn-cgroup-writable";
+
+const SETUP_SCRIPT: &str = "scripts/kind/setup-kueue-cluster.sh";
+const VALUES_FIXTURE: &str = "deploy/helm/djinn/tests/fixtures/kueue-cluster-values.yaml";
+const CHART_VALUES: &str = "deploy/helm/djinn/values.yaml";
+const PREFLIGHT_SCRIPT: &str = "deploy/kueue/preflight.sh";
+
+/// Exit codes owned by `scripts/kind/setup-kueue-cluster.sh`.
+const EXIT_REFUSED_TARGET: i32 = 3;
+const EXIT_VERSION_FLOOR: i32 = 7;
+/// Exit code owned by `deploy/kueue/preflight.sh`: RuntimeClass absent.
+const PREFLIGHT_EXIT_MISSING_RUNTIME_CLASS: i32 = 10;
+
+fn repo_root() -> PathBuf {
+    // <repo>/server/crates/djinn-k8s
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("crate lives three levels below the repository root")
+        .to_path_buf()
+}
+
+fn run_setup_script(args: &[&str]) -> Output {
+    Command::new("bash")
+        .arg(repo_root().join(SETUP_SCRIPT))
+        .args(args)
+        .current_dir(repo_root())
+        .output()
+        .expect("setup-kueue-cluster.sh is executable")
+}
+
+fn exit_code(output: &Output) -> i32 {
+    output
+        .status
+        .code()
+        .expect("the script exits rather than dying on a signal")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+// ===========================================================================
+// Hermetic guards — these run in the ordinary test lane, on every PR.
+// ===========================================================================
+
+/// AC3, first half: the harness never targets a context it did not create.
+///
+/// `check` runs every guard and then stops without creating anything, so this
+/// is a real exercise of the production-safety refusal rather than a
+/// re-statement of it in Rust.
+///
+/// The accepting case is the non-vacuity: a `check` that refused everything
+/// (or a script that had been renamed out from under this test) would satisfy
+/// the refusals alone.
+#[test]
+fn guard_setup_script_refuses_a_context_it_did_not_create() {
+    let accepted = run_setup_script(&["check", "--context", HARNESS_CONTEXT]);
+    assert_eq!(
+        exit_code(&accepted),
+        0,
+        "the harness must accept the context of the cluster it creates; stderr: {}",
+        stderr(&accepted),
+    );
+
+    for foreign in [
+        // The three contexts actually present in a Djinn developer's
+        // kubeconfig today. All three are EKS.
+        "demo",
+        "staging",
+        "prod",
+        "arn:aws:eks:us-east-1:482965429208:cluster/eks-134-prod",
+        // The developer's live Tilt cluster.
+        "kind-djinn",
+        // A near-miss, because a prefix check would let this through.
+        "kind-djinn-kueue-harness-2",
+    ] {
+        let refused = run_setup_script(&["check", "--context", foreign]);
+        assert_eq!(
+            exit_code(&refused),
+            EXIT_REFUSED_TARGET,
+            "context {foreign} must be refused with exit {EXIT_REFUSED_TARGET}; stderr: {}",
+            stderr(&refused),
+        );
+        assert!(
+            stderr(&refused).contains(HARNESS_CONTEXT),
+            "the refusal must name the only context this harness may target; stderr: {}",
+            stderr(&refused),
+        );
+    }
+}
+
+/// AC3, second half: the names belonging to the developer's Tilt environment
+/// are refused outright, not merely defaulted away from. `down` DELETES what
+/// it is given, so "we would never pass that" is not a safety property.
+#[test]
+fn guard_setup_script_refuses_the_tilt_cluster_registry_and_port() {
+    for args in [
+        ["check", "--cluster-name", "djinn"],
+        ["check", "--registry-name", "kind-registry"],
+        ["check", "--registry-port", "5001"],
+    ] {
+        let refused = run_setup_script(&args);
+        assert_eq!(
+            exit_code(&refused),
+            EXIT_REFUSED_TARGET,
+            "{args:?} must be refused with exit {EXIT_REFUSED_TARGET}; stderr: {}",
+            stderr(&refused),
+        );
+    }
+}
+
+/// The Kueue 0.19 floor is 1.30, and the 1.29 floor this repository documented
+/// until #2818 was measured false. A harness that silently created a 1.29
+/// cluster would reproduce that bug as a test environment.
+#[test]
+fn guard_setup_script_refuses_a_kubernetes_below_the_kueue_floor() {
+    let refused = run_setup_script(&["check", "--k8s-version", "1.29.0"]);
+    assert_eq!(
+        exit_code(&refused),
+        EXIT_VERSION_FLOOR,
+        "1.29 must be refused with exit {EXIT_VERSION_FLOOR}; stderr: {}",
+        stderr(&refused),
+    );
+    // Non-vacuity: the floor is 1.30, not "refuse everything".
+    let accepted = run_setup_script(&["check", "--k8s-version", "1.30.0"]);
+    assert_eq!(
+        exit_code(&accepted),
+        0,
+        "1.30 is the floor and must be accepted; stderr: {}",
+        stderr(&accepted),
+    );
+}
+
+/// The script's default cluster name and this file's constant are two copies
+/// of one fact, and the live tests below would target a cluster that does not
+/// exist if they drifted apart.
+#[test]
+fn guard_harness_cluster_name_matches_the_setup_script_default() {
+    let defaults = run_setup_script(&["check"]);
+    assert_eq!(exit_code(&defaults), 0, "stderr: {}", stderr(&defaults));
+    let stdout = String::from_utf8_lossy(&defaults.stdout).into_owned();
+    assert!(
+        stdout.contains(&format!("cluster={HARNESS_CLUSTER} ")),
+        "the script's default cluster must be {HARNESS_CLUSTER}, got: {stdout}",
+    );
+    assert!(
+        stdout.contains(&format!("context={HARNESS_CONTEXT} ")),
+        "the script's derived context must be {HARNESS_CONTEXT}, got: {stdout}",
+    );
+}
+
+fn yaml_at(relative: &str) -> serde_yaml::Value {
+    let path = repo_root().join(relative);
+    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {relative}: {e}"));
+    serde_yaml::from_str(&text).unwrap_or_else(|e| panic!("parse {relative}: {e}"))
+}
+
+fn build_pods_in(values: &serde_yaml::Value) -> u64 {
+    values["kueue"]["buildPods"]
+        .as_u64()
+        .expect("kueue.buildPods is a number")
+}
+
+/// AC1's quota assertion compares the live ClusterQueue against the FIXTURE's
+/// `kueue.buildPods`. If the fixture happened to carry the chart's own
+/// default, that comparison would pass just as well against an install that
+/// never read the fixture — green against nothing.
+///
+/// This runs hermetically so the divergence cannot be lost in a future values
+/// edit without the ordinary PR lane saying so.
+#[test]
+fn guard_fixture_build_pods_differs_from_the_chart_default() {
+    let fixture = build_pods_in(&yaml_at(VALUES_FIXTURE));
+    let chart_default = build_pods_in(&yaml_at(CHART_VALUES));
+    assert_ne!(
+        fixture, chart_default,
+        "the harness fixture's kueue.buildPods ({fixture}) must differ from the chart default \
+         ({chart_default}), or the live nominalQuota assertion cannot tell an install that read \
+         the fixture from one that ignored it",
+    );
+}
+
+/// The fixture must NOT install the RuntimeClass, because AC4 asserts the
+/// cutover preflight exits 10 ("RuntimeClass djinn-cgroup-writable is absent")
+/// against the cluster it produces. Enabling it in the fixture would retire
+/// that assertion silently — the live test would simply start failing for a
+/// reason nobody would connect to this file.
+#[test]
+fn guard_fixture_leaves_the_cgroup_writable_runtime_class_uninstalled() {
+    let fixture = yaml_at(VALUES_FIXTURE);
+    assert_eq!(
+        fixture["cgroupWritable"]["runtimeClass"]["enabled"].as_bool(),
+        Some(false),
+        "the harness fixture must leave cgroupWritable.runtimeClass disabled",
+    );
+    assert_eq!(
+        fixture["cgroupLauncher"]["mode"].as_str(),
+        Some("disabled"),
+        "the chart refuses kueue.armed + cgroupLauncher.mode=required without the RuntimeClass, \
+         so proving the class absent requires the launcher disabled — the two are one fact",
+    );
+    assert_eq!(
+        fixture["kueue"]["armed"].as_bool(),
+        Some(true),
+        "a fixture that did not arm Kueue would make every live assertion below vacuous",
+    );
+}
+
+// ===========================================================================
+// ===========================================================================
+// Live half — #[ignore] + DJINN_TEST_KUEUE_CLUSTER=1
+// ===========================================================================
+
+/// Returns `false` when the live half is disabled; callers `return` early.
+/// Mirrors `tests/kind_smoke.rs:89-103`, including printing the skip reason so
+/// a developer knows which gate they hit.
+fn live_tests_enabled() -> bool {
+    if env::var("DJINN_TEST_KUEUE_CLUSTER").is_err() {
+        eprintln!("kueue_cluster_harness: DJINN_TEST_KUEUE_CLUSTER not set — skipping");
+        return false;
+    }
+    if !which("kubectl") {
+        eprintln!("kueue_cluster_harness: kubectl not found on PATH — skipping");
+        return false;
+    }
+    true
+}
+
+/// Minimal PATH-based which(1), copied from `tests/kind_smoke.rs` rather than
+/// pulling a crate in for one call site.
+fn which(bin: &str) -> bool {
+    env::var("PATH").is_ok_and(|path| {
+        path.split(':')
+            .any(|dir| Path::new(dir).join(bin).is_file())
+    })
+}
+
+/// The context every live call below is pinned to, after TWO independent
+/// refusals of anything else.
+///
+/// Guard 1 is the name: it must be the context of the cluster
+/// `scripts/kind/setup-kueue-cluster.sh` creates. Guard 2 is the resolved API
+/// server URL, which catches what guard 1 cannot — a kubeconfig entry NAMED
+/// `kind-djinn-kueue-harness` that points somewhere else entirely. kind always
+/// serves on loopback; no managed control plane does, and all three contexts
+/// in a Djinn developer's kubeconfig are EKS.
+///
+/// Deliberately NOT `kubectl` with no `--context` and NOT
+/// `kube::Client::try_default()`: both resolve the CURRENT context, and these
+/// tests CREATE AND DELETE objects.
+fn harness_context() -> String {
+    let requested = env::var("DJINN_TEST_KUEUE_CONTEXT").unwrap_or_else(|_| HARNESS_CONTEXT.into());
+    assert_eq!(
+        requested, HARNESS_CONTEXT,
+        "this harness only ever targets the context of the cluster \
+         scripts/kind/setup-kueue-cluster.sh creates and deletes",
+    );
+
+    let server = kubectl_raw(
+        &requested,
+        &[
+            "config",
+            "view",
+            "--minify",
+            "-o",
+            "jsonpath={.clusters[0].cluster.server}",
+        ],
+    );
+    assert!(
+        server.starts_with("https://127.0.0.1:")
+            || server.starts_with("https://localhost:")
+            || server.starts_with("https://[::1]:"),
+        "refusing to run against {server}: context {requested} does not resolve to a local kind \
+         API server, so it is not a cluster this harness created",
+    );
+    requested
+}
+
+/// Run `kubectl --context <ctx> ...` and return stdout, failing the test on a
+/// nonzero exit.
+///
+/// A nonzero status is never read as an empty result. `get workloads` on a
+/// cluster whose Kueue CRDs are missing exits nonzero, and treating that as
+/// "zero Workloads" would make every negative assertion below pass against a
+/// cluster that has no Kueue at all — the same fail-closed reasoning
+/// `deploy/kueue/preflight.sh` documents at its `get_kubectl` helper.
+fn kubectl_raw(context: &str, args: &[&str]) -> String {
+    let output = Command::new("kubectl")
+        .arg("--context")
+        .arg(context)
+        .args(args)
+        .output()
+        .expect("kubectl is on PATH");
+    assert!(
+        output.status.success(),
+        "kubectl --context {context} {args:?} failed: {}",
+        stderr(&output),
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn kubectl_json(context: &str, args: &[&str]) -> Value {
+    let mut args = args.to_vec();
+    args.extend_from_slice(&["-o", "json"]);
+    serde_json::from_str(&kubectl_raw(context, &args)).expect("kubectl -o json emits JSON")
+}
+
+/// Apply an object by piping it to `kubectl apply -f -`.
+fn kubectl_apply(context: &str, namespace: &str, object: &Value) {
+    let mut child = Command::new("kubectl")
+        .args(["--context", context, "-n", namespace, "apply", "-f", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("kubectl is on PATH");
+    child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(
+            serde_json::to_string(object)
+                .expect("object serializes")
+                .as_bytes(),
+        )
+        .expect("write manifest to kubectl");
+    let output = child.wait_with_output().expect("kubectl apply completes");
+    assert!(
+        output.status.success(),
+        "kubectl apply into {namespace} failed: {}",
+        stderr(&output),
+    );
+}
+
+/// The armed `KubernetesConfig` the live Job assertions render with.
+///
+/// `cgroup_launcher_mode: Disabled` + `task_run_cgroup_writable_enabled: false`
+/// are not a convenience: they mirror the values fixture exactly, and
+/// `build_task_run_job` asserts (i.e. PANICS) if a required launcher is
+/// rendered without the RuntimeClass. The harness proves that RuntimeClass
+/// ABSENT for AC4, so this is the only internally consistent pairing.
+/// fbiy-C1 flips both together once the kind node can run the class.
+fn armed_harness_config() -> KubernetesConfig {
+    KubernetesConfig {
+        namespace: NAMESPACE.into(),
+        kueue_armed: true,
+        // Matches the chart's `<djinn.fullname>-<kind>` LocalQueue naming for
+        // release `djinn`. Not merely asserted as a string below: a wrong
+        // prefix names a LocalQueue that does not exist, and the capture
+        // assertion is what would notice.
+        kueue_local_queue_prefix: "djinn".into(),
+        cgroup_launcher_mode: CgroupLauncherMode::Disabled,
+        task_run_cgroup_writable_enabled: false,
+        ..KubernetesConfig::for_testing()
+    }
+}
+
+/// A task-run Job straight out of the real renderer.
+fn rendered_task_run_job() -> (Job, String) {
+    let task_run_id = uuid::Uuid::now_v7();
+    let job = build_task_run_job(
+        &armed_harness_config(),
+        &task_run_id,
+        "harness-project",
+        &format!("djinn-taskrun-{task_run_id}"),
+        "registry.example/project:harness",
+        &[],
+        None,
+        false,
+        None,
+    );
+    let name = job
+        .metadata
+        .name
+        .clone()
+        .expect("the renderer names the Job");
+    (job, name)
+}
+
+fn job_as_json(job: &Job) -> Value {
+    let mut value = serde_json::to_value(job).expect("Job serializes");
+    // `k8s-openapi` omits apiVersion/kind on the typed struct; the API server
+    // needs both.
+    value["apiVersion"] = Value::String("batch/v1".into());
+    value["kind"] = Value::String("Job".into());
+    value
+}
+
+fn strip_label(job: &mut Value, label: &str) {
+    for pointer in ["/metadata/labels", "/spec/template/metadata/labels"] {
+        if let Some(labels) = job.pointer_mut(pointer).and_then(Value::as_object_mut) {
+            labels.remove(label);
+        }
+    }
+}
+
+/// Names of the Workloads in `namespace` owned by the Job `job_name`.
+fn workloads_owned_by(context: &str, namespace: &str, job_name: &str) -> Vec<String> {
+    let list = kubectl_json(
+        context,
+        &["-n", namespace, "get", "workloads.kueue.x-k8s.io"],
+    );
+    list["items"]
+        .as_array()
+        .expect("a List has items")
+        .iter()
+        .filter(|workload| {
+            workload["metadata"]["ownerReferences"]
+                .as_array()
+                .is_some_and(|owners| {
+                    owners
+                        .iter()
+                        .any(|owner| owner["kind"] == "Job" && owner["name"] == job_name)
+                })
+        })
+        .filter_map(|workload| workload["metadata"]["name"].as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+/// How long a positive capture assertion waits before concluding a Workload
+/// will never appear: 120 ticks of 500ms.
+const CAPTURE_TICKS: usize = 120;
+/// The budget a NEGATIVE assertion waits before concluding absence. It is a
+/// named constant, not a smaller literal at each call site, because "zero
+/// Workloads" is only a statement about capture if the wait was long enough to
+/// have seen one. The positive assertions above measured capture inside the
+/// first few ticks.
+const ABSENCE_TICKS: usize = 60;
+const TICK: Duration = Duration::from_millis(500);
+
+/// Poll until `job_name` owns at least one Workload, or `ticks` elapse.
+///
+/// Iteration-counted rather than deadline-based: `Instant::now` is a
+/// workspace-disallowed method (`clippy.toml`), and `tests/kind_smoke.rs`
+/// polls the same way.
+fn await_owned_workloads(
+    context: &str,
+    namespace: &str,
+    job_name: &str,
+    ticks: usize,
+) -> Vec<String> {
+    for _ in 0..ticks {
+        let owned = workloads_owned_by(context, namespace, job_name);
+        if !owned.is_empty() {
+            return owned;
+        }
+        std::thread::sleep(TICK);
+    }
+    workloads_owned_by(context, namespace, job_name)
+}
+
+fn delete_job(context: &str, namespace: &str, job_name: &str) {
+    let _ = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "-n",
+            namespace,
+            "delete",
+            "job",
+            job_name,
+            "--wait=false",
+        ])
+        .output();
+}
+
+/// AC1 — asserted against the LIVE API server, never against a render.
+///
+/// Three separate facts, because one "the topology is there" verdict would be
+/// satisfied by any one of them:
+///
+/// 1. the `djinn` namespace carries `djinn.io/kueue-managed=true` — without it
+///    Kueue's positive `managedJobsNamespaceSelector` matches nothing and the
+///    whole armed install is inert. That the label DOES this rather than merely
+///    existing is proven separately by
+///    [`live_the_namespace_label_is_what_makes_capture_happen`];
+/// 2. the ClusterQueue's `pods` nominalQuota EQUALS the values fixture's
+///    `kueue.buildPods`, read out of that file at test time rather than
+///    hard-coded here (and `guard_fixture_build_pods_differs_from_the_chart_default`
+///    keeps that number off the chart default, so the comparison can tell an
+///    install that read the fixture from one that ignored it);
+/// 3. all three LocalQueues exist, in the namespace, pointing at that
+///    ClusterQueue.
+#[test]
+#[ignore]
+fn live_armed_cluster_carries_the_label_the_quota_and_three_local_queues() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+
+    // 1. The namespace label.
+    let namespace = kubectl_json(&context, &["get", "namespace", NAMESPACE]);
+    assert_eq!(
+        namespace["metadata"]["labels"][KUEUE_MANAGED_LABEL].as_str(),
+        Some("true"),
+        "namespace {NAMESPACE} must carry {KUEUE_MANAGED_LABEL}=true on an armed cluster",
+    );
+
+    // 2. The ClusterQueue quota, compared against the fixture on disk.
+    let expected_quota = build_pods_in(&yaml_at(VALUES_FIXTURE));
+    let queue = kubectl_json(
+        &context,
+        &["get", "clusterqueues.kueue.x-k8s.io", CLUSTER_QUEUE],
+    );
+    let quota_field = queue["spec"]["resourceGroups"][0]["flavors"][0]["resources"]
+        .as_array()
+        .expect("the flavor covers resources")
+        .iter()
+        .find(|resource| resource["name"] == "pods")
+        .map(|resource| resource["nominalQuota"].clone())
+        .expect("the ClusterQueue bounds the pods resource");
+    // `nominalQuota` is a `resource.Quantity`, which the API server round-trips
+    // as a STRING ("2") even though the chart writes it as a bare number. A
+    // test that only handled the number form would fail against the very thing
+    // it is supposed to read.
+    let quota = quota_field
+        .as_u64()
+        .or_else(|| quota_field.as_str().and_then(|text| text.parse().ok()))
+        .unwrap_or_else(|| panic!("pods nominalQuota is not an integer quantity: {quota_field}"));
+    assert_eq!(
+        quota, expected_quota,
+        "the live ClusterQueue's pods nominalQuota must equal the fixture's kueue.buildPods",
+    );
+
+    // 3. The three LocalQueues, each pointing at that ClusterQueue.
+    let local_queues = kubectl_json(
+        &context,
+        &["-n", NAMESPACE, "get", "localqueues.kueue.x-k8s.io"],
+    );
+    let found: BTreeSet<String> = local_queues["items"]
+        .as_array()
+        .expect("a List has items")
+        .iter()
+        .filter(|queue| queue["spec"]["clusterQueue"] == CLUSTER_QUEUE)
+        .filter_map(|queue| queue["metadata"]["name"].as_str().map(ToOwned::to_owned))
+        .collect();
+    let expected: BTreeSet<String> = ["djinn-task-run", "djinn-warm", "djinn-scip"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    assert_eq!(
+        found, expected,
+        "all three LocalQueues must exist in {NAMESPACE} and point at {CLUSTER_QUEUE}",
+    );
+}
+
+/// AC2 — a Job produced by the REAL renderer, applied to the REAL cluster,
+/// produces exactly ONE Workload, and that Workload's `ownerReferences` names
+/// that Job.
+///
+/// Two negative controls follow. The second one contradicts this task's own
+/// acceptance criterion; see
+/// [`live_stripping_the_build_object_label_does_not_stop_capture`].
+#[test]
+#[ignore]
+fn live_real_task_run_renderer_produces_exactly_one_owned_workload() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+    let (job, job_name) = rendered_task_run_job();
+
+    // Assert the renderer's own output first. If the armed renderer ever
+    // stopped stamping these, this test must fail HERE, naming the cause,
+    // rather than silently observing zero Workloads later.
+    assert_eq!(
+        job.metadata
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.get(LABEL_KUEUE_QUEUE_NAME))
+            .map(String::as_str),
+        Some("djinn-task-run"),
+        "the armed renderer must target the chart's task-run LocalQueue",
+    );
+    assert_eq!(
+        job.spec.as_ref().and_then(|spec| spec.suspend),
+        Some(true),
+        "the armed renderer must create the Job suspended so Kueue owns admission",
+    );
+
+    kubectl_apply(&context, NAMESPACE, &job_as_json(&job));
+
+    let owned = await_owned_workloads(&context, NAMESPACE, &job_name, CAPTURE_TICKS);
+    assert_eq!(
+        owned.len(),
+        1,
+        "exactly one Kueue Workload must own the rendered Job {job_name}, got {owned:?}",
+    );
+
+    delete_job(&context, NAMESPACE, &job_name);
+}
+
+/// AC2's non-vacuity, corrected to the fence that actually exists.
+///
+/// 6knv's AC2 says to strip `djinn.io/kueue-build-object` and expect zero
+/// Workloads. MEASURED AGAINST THIS CLUSTER ON 2026-07-30, THAT IS FALSE — see
+/// [`live_stripping_the_build_object_label_does_not_stop_capture`], which
+/// asserts the contradiction instead of describing it. The label stopped being
+/// a capture fence when the byte-vendored fork's
+///
+/// ```yaml
+/// objectSelector:
+///   matchLabels:
+///     djinn.io/kueue-build-object: "true"
+/// ```
+///
+/// was retired for the pinned upstream chart, which exposes no `objectSelector`
+/// hook at any version (`deploy/kueue/README.md`, "Scope reduction:
+/// objectSelector is gone").
+///
+/// What DOES decide capture is `kueue.x-k8s.io/queue-name`: with
+/// `manageJobsWithoutQueueName` left at its upstream default (commented out in
+/// `deploy/helm/djinn-prereqs/values.yaml`, i.e. off), a Job without that label
+/// is not managed. So that is the label this control removes.
+#[test]
+#[ignore]
+fn live_stripping_the_queue_name_label_produces_zero_workloads() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+    let (job, job_name) = rendered_task_run_job();
+    let mut manifest = job_as_json(&job);
+    strip_label(&mut manifest, LABEL_KUEUE_QUEUE_NAME);
+
+    kubectl_apply(&context, NAMESPACE, &manifest);
+
+    // The same budget the positive case gets before concluding absence. A
+    // shorter wait would make "zero Workloads" a statement about latency
+    // rather than about capture.
+    let owned = await_owned_workloads(&context, NAMESPACE, &job_name, ABSENCE_TICKS);
+    assert!(
+        owned.is_empty(),
+        "a Job with no {LABEL_KUEUE_QUEUE_NAME} must not be captured, got {owned:?}",
+    );
+
+    delete_job(&context, NAMESPACE, &job_name);
+}
+
+/// The correction to 6knv's AC2, asserted rather than argued.
+///
+/// This PASSES while stripping `djinn.io/kueue-build-object` still yields a
+/// Workload — i.e. it FAILS if the label ever regains fence semantics. Either
+/// outcome is informative, and neither is reachable by reading a chart.
+#[test]
+#[ignore]
+fn live_stripping_the_build_object_label_does_not_stop_capture() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+    let (job, job_name) = rendered_task_run_job();
+    let mut manifest = job_as_json(&job);
+    strip_label(&mut manifest, LABEL_KUEUE_BUILD_OBJECT);
+
+    kubectl_apply(&context, NAMESPACE, &manifest);
+
+    let owned = await_owned_workloads(&context, NAMESPACE, &job_name, CAPTURE_TICKS);
+    assert_eq!(
+        owned.len(),
+        1,
+        "measured 2026-07-30: {LABEL_KUEUE_BUILD_OBJECT} is NOT a capture fence — the pinned \
+         upstream chart has no objectSelector hook, so capture is decided by the namespace label \
+         plus {LABEL_KUEUE_QUEUE_NAME} alone. If this now fails with zero Workloads the fence was \
+         restored and 6knv's AC2 became true; record it in deploy/kueue/README.md's \
+         scope-reduction section. Got {owned:?}",
+    );
+
+    delete_job(&context, NAMESPACE, &job_name);
+}
+
+/// AC1's label, proven to DO something rather than merely to exist.
+///
+/// The same armed Job, in a namespace without `djinn.io/kueue-managed`, must
+/// not be captured. This is what turns assertion 1 of
+/// [`live_armed_cluster_carries_the_label_the_quota_and_three_local_queues`]
+/// from "a string is present on an object" into the admission fact it stands
+/// for.
+#[test]
+#[ignore]
+fn live_the_namespace_label_is_what_makes_capture_happen() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+    let unlabelled = format!("kueue-harness-unlabelled-{}", uuid::Uuid::now_v7().simple());
+
+    kubectl_apply(
+        &context,
+        "default",
+        &serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": { "name": unlabelled },
+        }),
+    );
+
+    let (job, job_name) = rendered_task_run_job();
+    let mut manifest = job_as_json(&job);
+    // The renderer stamps `metadata.namespace` from the config (job.rs:619), so
+    // the object has to be re-homed to be applied anywhere else. Only the
+    // namespace changes: every label, the `suspend` flag and the queue-name
+    // stay exactly as the renderer produced them, which is what makes the
+    // absence of capture attributable to the namespace and nothing else.
+    manifest["metadata"]["namespace"] = Value::String(unlabelled.clone());
+    kubectl_apply(&context, &unlabelled, &manifest);
+
+    let owned = await_owned_workloads(&context, &unlabelled, &job_name, ABSENCE_TICKS);
+    assert!(
+        owned.is_empty(),
+        "Kueue must capture nothing in a namespace without {KUEUE_MANAGED_LABEL}, got {owned:?}",
+    );
+
+    let _ = Command::new("kubectl")
+        .args([
+            "--context",
+            &context,
+            "delete",
+            "namespace",
+            &unlabelled,
+            "--wait=false",
+        ])
+        .output();
+}
+
+/// AC4 — the harness reaches the REAL operator script, and that script's
+/// ordering gate is live.
+///
+/// `deploy/kueue/preflight.sh --mode cutover` must exit **10**: "RuntimeClass
+/// djinn-cgroup-writable is absent". That gate took production down twice
+/// (v0.7.25, and again on 2026-07-30) — labelling a namespace
+/// `djinn.io/kueue-managed=true` on a cluster with no RuntimeClass wedges ALL
+/// dispatch, because the Job renderer panics while Kueue holds the Job. This
+/// cluster is in exactly that shape (armed namespace, no RuntimeClass), which
+/// is why the preflight has something real to refuse.
+///
+/// The API-server check beside it is the non-vacuity: exit 10 must be the
+/// consequence of a genuinely absent RuntimeClass, not of a script that
+/// returns 10 for reasons of its own.
+#[test]
+#[ignore]
+fn live_cutover_preflight_exits_10_against_the_armed_harness() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+
+    let classes = kubectl_json(&context, &["get", "runtimeclasses.node.k8s.io"]);
+    let present: Vec<&str> = classes["items"]
+        .as_array()
+        .expect("a List has items")
+        .iter()
+        .filter_map(|class| class["metadata"]["name"].as_str())
+        .collect();
+    assert!(
+        !present.contains(&CGROUP_WRITABLE_RUNTIME_CLASS),
+        "the harness must NOT install {CGROUP_WRITABLE_RUNTIME_CLASS} — that is fbiy-C1's job, \
+         and its absence is what AC4 measures. Present: {present:?}",
+    );
+
+    let output = Command::new("bash")
+        .arg(repo_root().join(PREFLIGHT_SCRIPT))
+        .args(["--context", &context, "--mode", "cutover"])
+        // Required by the preflight before it reads anything else. It is never
+        // dialled: the RuntimeClass gate is checked first and exits before the
+        // ledger fence is reached, which is itself part of what "the ordering
+        // gate is live" means.
+        .env(
+            "DJINN_PREFLIGHT_DATABASE_URL",
+            "postgres://harness:harness@127.0.0.1:5432/djinn-kueue-harness?sslmode=disable",
+        )
+        .current_dir(repo_root())
+        .output()
+        .expect("deploy/kueue/preflight.sh is executable");
+
+    assert_eq!(
+        exit_code(&output),
+        PREFLIGHT_EXIT_MISSING_RUNTIME_CLASS,
+        "preflight --mode cutover must exit {PREFLIGHT_EXIT_MISSING_RUNTIME_CLASS} against the \
+         armed harness; stdout: {} stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr(&output),
+    );
+    assert!(
+        stderr(&output).contains(CGROUP_WRITABLE_RUNTIME_CLASS),
+        "the refusal must name the missing RuntimeClass; stderr: {}",
+        stderr(&output),
+    );
+}


### PR DESCRIPTION
Closes djinn board task `6knv` (epic `fbiy`, proposal `9oga`).

Nothing in `fbiy`'s live-cluster half — `B1` ordinary admission conformance, `B2` disruption containment, `C1` the governor end to end — can start without a cluster that has Kueue installed **and armed**. This adds one, plus the assertions that make having it worth anything.

## What landed

| File | What it is |
| --- | --- |
| `scripts/kind/setup-kueue-cluster.sh` | creates an isolated kind cluster (k8s >= 1.30), installs the pinned `deploy/helm/djinn-prereqs`, then installs the djinn chart with `kueue.enabled=true` **and** `kueue.armed=true` |
| `deploy/helm/djinn/tests/fixtures/kueue-cluster-values.yaml` | the armed values |
| `server/crates/djinn-k8s/tests/kueue_cluster_harness.rs` | 6 hermetic `guard_*` tests + 6 `#[ignore]` + `DJINN_TEST_KUEUE_CLUSTER=1` `live_*` tests |
| `.github/workflows/kueue-cluster-harness.yml` | `workflow_dispatch`-only lane |

`deploy/helm/djinn-prereqs` and `deploy/kueue/zero-capture-gate.sh` were reused, not edited. Nothing under `server/crates/djinn-k8s/src/**`, `djinn-cgroup-launcher/**`, `djinn-db/**` or `djinn-coordinator/**` was touched — no `Cargo.toml`, no `Cargo.lock`, no `workspace-hack` either (see "kind_smoke is unrunnable" below for why that mattered).

## Does the CI lane run anywhere by default? **No.**

`.github/workflows/kueue-cluster-harness.yml` has exactly one trigger, `workflow_dispatch`. It never runs on a pull request, never on a push to main, never in the merge queue, and is not scheduled. It is not a required check and cannot block a merge. Nothing in it runs unless a human presses "Run workflow".

That is the same posture as `server/crates/djinn-k8s/tests/kind_smoke.rs`, and a harness nobody runs is exactly the failure class this task exists to prevent. So the split is deliberate:

* the assertions that **must not regress** — the production-safety refusals, the fixture's non-vacuity — are hermetic `guard_*` tests with **no `#[ignore]`**. They run on every PR inside the ordinary `djinn-k8s` test binary, need no cluster, no docker and no network (the script's `check` action returns before it looks for a single tool);
* only the half that genuinely needs an API server is gated.

It is not required because creating a kind cluster and installing two Helm charts is minutes of runner time plus a class of infrastructure flake that must never be able to wedge the merge queue. `B1`/`B2`/`C1` are the tasks that decide how often it is worth running.

## This does not arm production

Arming the VPS remains a gated operator act behind `preflight.sh --mode cutover` and belongs to `4c9q`'s runbook. It has not happened, and nothing here is a step toward it. Four guards, all of which run before any cluster, registry or kubeconfig is touched:

1. the cluster (`djinn-kueue-harness`), registry (`djinn-kueue-harness-registry`) and port (`5051`) are harness-specific, and the Tilt names `djinn` / `kind-registry` / `5001` are **refused** (exit 3), not merely defaulted away from — `down` deletes what it is given, so "we would never pass that" is not a safety property;
2. the context is **derived** from the cluster the script creates, never discovered. The current context is never read, because all three contexts in this kubeconfig are EKS. A `--context` that is not the derived one is refused (exit 3);
3. every `kubectl` and `helm` call is `--context` / `--kube-context` pinned. There is no unpinned call;
4. `up` refuses to adopt a pre-existing cluster (exit 6) — it tears its cluster down on failure, and doing that to a cluster it did not create would destroy someone else's work.

The Rust harness adds a second, independent refusal: the context must resolve to a **loopback** API server, which catches a kubeconfig entry *named* `kind-djinn-kueue-harness` that points somewhere else.

## Acceptance criteria, with evidence

All of the following was measured against a live cluster created and destroyed on 2026-07-30.

### AC1 — namespace label, quota, three LocalQueues (live API server)

`live_armed_cluster_carries_the_label_the_quota_and_three_local_queues` — passes. Read back off the API server:

```
$ kubectl --context kind-djinn-kueue-harness get ns djinn -o jsonpath='...'
djinn  djinn.io/kueue-managed=true

$ kubectl --context kind-djinn-kueue-harness get clusterqueue djinn-kueue -o jsonpath='...'
djinn-kueue -> [{"name":"pods","nominalQuota":"2"}]

$ kubectl --context kind-djinn-kueue-harness -n djinn get localqueues
NAME             CLUSTERQUEUE
djinn-scip       djinn-kueue
djinn-task-run   djinn-kueue
djinn-warm       djinn-kueue
```

`2` is the fixture's `kueue.buildPods`, read out of the YAML by the test at runtime — not a literal in the test. The chart default is `3`, and `guard_fixture_build_pods_differs_from_the_chart_default` keeps them apart on every PR, so this comparison can tell an install that read the fixture from one that ignored it.

Two smaller things worth knowing: `nominalQuota` round-trips as the **string** `"2"` (it is a `resource.Quantity`) even though the chart writes a bare number, and `live_the_namespace_label_is_what_makes_capture_happen` proves the label *does* something — the same armed Job in an unlabelled namespace yields zero Workloads — so assertion 1 is an admission fact, not a string comparison.

### AC2 — exactly one Workload, owned by the Job (live API server)

`live_real_task_run_renderer_produces_exactly_one_owned_workload` — passes. The Job comes from the real `build_task_run_job` with `kueue_armed=true`, is serialized unmodified and applied. Captured off the live API while the test ran:

```
job-djinn-taskrun-019fb583-6044-7b82-8b4a-ae664ff62d4a-5eccd
  ownerRef=Job/djinn-taskrun-019fb583-6044-7b82-8b4a-ae664ff62d4a
  ownerUid=7ebe67fa-526a-400e-a964-6784495dc8d9
  queue=djinn-task-run
```

**AC2's non-vacuity as written is false, and the harness asserts the contradiction.** Stripping `djinn.io/kueue-build-object` does **not** stop capture. Measured, all three variants of the same rendered Job:

| Variant | Workloads |
| --- | --- |
| as rendered | **1**, owned by the Job |
| `djinn.io/kueue-build-object` stripped | **1**, owned by the Job |
| `kueue.x-k8s.io/queue-name` stripped | **0** |
| as rendered, in an unlabelled namespace | **0** |

The label stopped being a fence when the byte-vendored fork's `objectSelector` was retired for the pinned upstream chart, which exposes no such hook at any version — already documented in `deploy/kueue/README.md` under "Scope reduction: `objectSelector` is gone". What decides capture is the namespace label plus `kueue.x-k8s.io/queue-name` (with `manageJobsWithoutQueueName` at its upstream default, off).

So the non-vacuity control strips `queue-name` (`live_stripping_the_queue_name_label_produces_zero_workloads`), and a separate test asserts the correction (`live_stripping_the_build_object_label_does_not_stop_capture`) so it fails loudly if the fence is ever restored. Writing the AC's literal text as an assertion would have been asserting a falsehood.

### AC3 — tears down on failure, never targets a foreign context

Both halves proven, not claimed.

*Refusal* — six foreign context names are refused with exit 3 and the accepting case is asserted alongside them, so the guard cannot pass by refusing everything:

```
$ scripts/kind/setup-kueue-cluster.sh check --context staging
FAIL: refusing --context 'staging': this harness only ever targets
'kind-djinn-kueue-harness', the context of the kind cluster it creates and
deletes itself. ... every context in a Djinn developer's kubeconfig today is
a live EKS cluster (demo/staging/prod).
$ echo $?
3
```

*Teardown* — run for real against a deliberately broken values file, on a throwaway second cluster:

```
>>> installing djinn chart release djinn with kueue.enabled=true kueue.armed=true
Error: execution error at (djinn/templates/namespace.yaml:17:8): kueue.armed=true with namespace.create=false ...
INFO: harness failed (status 1); tearing the disposable cluster down
>>> deleting kind cluster djinn-kueue-teardown-proof
Deleted nodes: ["djinn-kueue-teardown-proof-control-plane"]
>>> deleting registry container djinn-kueue-teardown-proof-reg
PASS: cluster djinn-kueue-teardown-proof and registry djinn-kueue-teardown-proof-reg are gone
UP EXIT=1
```

`teardown` re-queries `kind get clusters` and `docker inspect` afterwards and fails if either survived — the deletion is proven, not reported.

### AC4 — `preflight.sh --mode cutover` exits 10

`live_cutover_preflight_exits_10_against_the_armed_harness` — passes. Verbatim:

```
$ DJINN_PREFLIGHT_DATABASE_URL=... deploy/kueue/preflight.sh \
    --context kind-djinn-kueue-harness --mode cutover
DIAGNOSTICS: RuntimeClasses present in context kind-djinn-kueue-harness:
<none>
DIAGNOSTICS: namespace djinn ALREADY carries djinn.io/kueue-managed=true while djinn-cgroup-writable is absent — dispatch is wedged NOW
FAIL: refusing to start the build-admission authority flip: RuntimeClass djinn-cgroup-writable is absent from context kind-djinn-kueue-harness. ...
$ echo $?
10
```

The harness reaches the real operator script and its ordering gate is live. The test also asserts against the API server that no such RuntimeClass exists, so exit 10 is the consequence of a genuinely absent class rather than a script returning 10 for reasons of its own.

Note what that second diagnostic line says: this cluster is *deliberately* in the shape that wedged production twice. That is the point — the preflight has something real to refuse.

## Where fbiy-C1's containerd hook goes

`configure_node_containerd()` in `scripts/kind/setup-kueue-cluster.sh`, marked with a banner comment. Like `scripts/kind/setup-kind.sh:59-106`, it patches containerd for **registries only**. C1 needs to add, all local to that function plus one label:

* a `runc-cgroupwritable` runtime handler in the node's `/etc/containerd/config.toml` (`plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc-cgroupwritable`) + a containerd restart on the node;
* `kubectl label node <node> djinn.io/cgroup-writable=true`;
* a C1-owned values file flipping `cgroupWritable.runtimeClass.enabled`, `cgroupWritable.taskRuns.enabled` and `cgroupLauncher.mode`.

C1 must **not** do that here: exit 10 above means "RuntimeClass absent", and installing the class in B0 would delete AC4 without deleting a line of the test that makes it. Those three values are restated in the fixture with a comment saying so, because they are currently chart defaults and a future default flip would turn AC4 green for the wrong reason silently.

## Found on the way: `kind_smoke.rs` is not merely un-run, it is UNRUNNABLE

The task asked me to mirror `server/crates/djinn-k8s/tests/kind_smoke.rs:89-103` and to state plainly whether the lane runs. It does not — and neither does `kind_smoke` itself, in a stronger sense than "no CI lane invokes it":

```
$ DJINN_TEST_KIND=1 cargo test -p djinn-k8s --test kind_smoke -- --ignored
thread 'kind_smoke_prepare_then_cancel' panicked at rustls-0.23.42/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

Against a live kind cluster, both of its tests panic before their first API call. `workspace-hack` unifies `rustls` 0.23 with **both** the `ring` and `aws-lc-rs` providers enabled and nothing in `server/crates` ever calls `CryptoProvider::install_default()`, so `kube::Client` cannot complete a handshake in any test binary in this workspace. That is the "harness that could not execute" failure class again, and it had been silent precisely because nothing runs the file.

I did not fix it here. Fixing it means either a new dev-dependency — hence `cargo hakari generate`, hence editing `workspace-hack`, shared files this task must not touch while other agents are in the same crates — or narrowing the feature unification. Both have real blast radius and belong in their own PR. **This is worth a follow-up task**, and it also raises a question I could not answer from the repo: how `djinn-server` reaches the API server in production given the same unification.

The live half here needs neither, because every assertion reads or writes through `kubectl --context kind-djinn-kueue-harness` — the same pinned-context discipline `zero-capture-gate.sh` and `preflight.sh` already use. The objects still come from the real renderer; only the transport differs.

## Cluster and registry: deleted

Confirmed after the run:

```
$ kind get clusters
No kind clusters found.
$ docker ps -a --format '{{.Names}}'
djinn-postgres-test          # pre-existing, not mine
$ kubectl config get-contexts -o name
demo
prod
staging
```

Both disposable clusters (the harness and the teardown-proof one) and both registries are gone, and the kubeconfig is back to its original three contexts. Disk was checked before each create (`df -h /`, floor 20Gi) and the host is at 126Gi free.

## Checks

* `cargo test -p djinn-k8s` — 319 + all binaries pass; the new file contributes 6 passed, 6 ignored
* `cargo clippy -p djinn-k8s --tests` — clean
* `cargo fmt` — clean
* live half: 6/6 pass against the armed cluster

Vercel may fail repo-wide on an account rate limit; it is not a required check.
