### PR TITLE
fi2k: propagate the catalog launcher protocol into the render and check it at READY

### DIFF
--- a/server/crates/djinn-agent-worker/src/launcher_handshake.rs
+++ b/server/crates/djinn-agent-worker/src/launcher_handshake.rs
@@ -48,8 +48,17 @@ use std::path::Path;
 use std::time::Duration;
 
 use djinn_cgroup_launcher::Error as LauncherError;
+use djinn_cgroup_launcher::LauncherAuthorityProtocol;
 use djinn_cgroup_launcher::child::{WorkerDumpability, prepare_worker_readiness};
 use djinn_cgroup_launcher::transport::UnixBrokerClient;
+
+/// The quota-authority protocol variable the render sets on BOTH the worker and
+/// the `cgroup-launcher` sidecar (`djinn_k8s::launcher`). The two containers run
+/// the same image, so the only way they can disagree is a render that set it on
+/// one and not the other — which is exactly what the READY assertion catches.
+///
+/// MUST match `AUTHORITY_PROTOCOL_ENV` in `djinn-cgroup-launcher`'s `main.rs`.
+const AUTHORITY_PROTOCOL_ENV: &str = "DJINN_LAUNCHER_AUTHORITY_PROTOCOL";
 
 /// Worker→launcher PID handshake filename. MUST match `WORKER_PID_FILE` in
 /// `djinn-cgroup-launcher` `src/main.rs`; the launcher joins it onto the
@@ -140,6 +149,30 @@ pub enum HandshakeError {
     Readiness(#[source] LauncherError),
     #[error("submit worker readiness: {0}")]
     Ready(#[source] LauncherError),
+    #[error(
+        "{AUTHORITY_PROTOCOL_ENV}={value:?} is not a launcher authority protocol; the worker \
+         will not guess which component owns invocation CPU quota"
+    )]
+    InvalidProtocol { value: String },
+}
+
+/// The protocol this worker believes the pod runs under.
+///
+/// Absent → [`LauncherAuthorityProtocol::LeafV1`], matching the launcher's own
+/// `authority_protocol_from_environment`: a render that predates the variable
+/// leaves both ends on the behavior that predates the protocol, so they still
+/// agree. A value that is *present but unparseable* is refused, never
+/// defaulted — the same rule `FromStr` enforces, for the same reason.
+fn authority_protocol_from_environment() -> Result<LauncherAuthorityProtocol, HandshakeError> {
+    match std::env::var(AUTHORITY_PROTOCOL_ENV) {
+        Ok(value) => value
+            .parse()
+            .map_err(|_| HandshakeError::InvalidProtocol { value }),
+        Err(std::env::VarError::NotPresent) => Ok(LauncherAuthorityProtocol::LeafV1),
+        Err(std::env::VarError::NotUnicode(value)) => Err(HandshakeError::InvalidProtocol {
+            value: value.to_string_lossy().into_owned(),
+        }),
+    }
 }
 
 /// Establish the required leased broker path.
@@ -154,6 +187,25 @@ pub fn establish<D: WorkerDumpability>(
     credential_path: &Path,
     dumpability: &mut D,
 ) -> LauncherHandshake {
+    match authority_protocol_from_environment() {
+        Ok(protocol) => {
+            establish_with_protocol(socket_path, credential_path, dumpability, protocol)
+        }
+        // A malformed protocol is a fail-closed outcome, not an absent mount:
+        // required mode must refuse to run, and disabled mode never gets here.
+        Err(error) => LauncherHandshake::FailedClosed(error),
+    }
+}
+
+/// [`establish`] with the protocol supplied explicitly rather than read from the
+/// environment. Tests use this so the assertion the broker checks is a value the
+/// test states, not a process-global variable a parallel test could be racing.
+pub fn establish_with_protocol<D: WorkerDumpability>(
+    socket_path: &Path,
+    credential_path: &Path,
+    dumpability: &mut D,
+    protocol: LauncherAuthorityProtocol,
+) -> LauncherHandshake {
     // Detection: the launcher IPC mount is the credential file's parent
     // directory (qut0's Memory emptyDir at LAUNCHER_IPC_DIR). Its absence is a
     // typed outcome; the explicit enforcement mode decides whether startup may
@@ -164,7 +216,13 @@ pub fn establish<D: WorkerDumpability>(
     if !mount_dir.is_dir() {
         return LauncherHandshake::AbsentMount;
     }
-    match connect_leased(socket_path, credential_path, mount_dir, dumpability) {
+    match connect_leased(
+        socket_path,
+        credential_path,
+        mount_dir,
+        dumpability,
+        protocol,
+    ) {
         Ok(client) => LauncherHandshake::Connected(Box::new(client)),
         Err(error) => LauncherHandshake::FailedClosed(error),
     }
@@ -175,6 +233,7 @@ fn connect_leased<D: WorkerDumpability>(
     credential_path: &Path,
     mount_dir: &Path,
     dumpability: &mut D,
+    protocol: LauncherAuthorityProtocol,
 ) -> Result<UnixBrokerClient, HandshakeError> {
     // 1. Publish the worker handshake the launcher's serve loop waits for. The
     //    credential is published BEFORE `worker.pid` so the launcher — which
@@ -190,7 +249,10 @@ fn connect_leased<D: WorkerDumpability>(
     // 3. Prove non-dumpability on the authenticated connection. A failure here
     //    is security-critical, so it fails closed to the in-process path rather
     //    than serving a worker that could be ptraced.
-    let readiness = prepare_worker_readiness(dumpability).map_err(HandshakeError::Readiness)?;
+    // The assertion carries the worker's own protocol: the broker refuses READY
+    // (and drops the connection) if it disagrees with the launcher's.
+    let readiness =
+        prepare_worker_readiness(dumpability, protocol).map_err(HandshakeError::Readiness)?;
     client.ready(readiness).map_err(HandshakeError::Ready)?;
     Ok(client)
 }

--- a/server/crates/djinn-agent/src/process/tests/process_lease_broker_lift_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_broker_lift_tests.rs
@@ -176,7 +176,13 @@ fn connected_client(stream: UnixStream) -> UnixBrokerClient {
     let mut client =
         UnixBrokerClient::connect(stream, CREDENTIAL).expect("the broker must authenticate us");
     client
-        .ready(prepare_worker_readiness(&mut TestDumpability).expect("readiness"))
+        .ready(
+            prepare_worker_readiness(
+                &mut TestDumpability,
+                djinn_cgroup_launcher::LauncherAuthorityProtocol::LeafV1,
+            )
+            .expect("readiness"),
+        )
         .expect("READY");
     client
 }

--- a/server/crates/djinn-cgroup-launcher/src/broker.rs
+++ b/server/crates/djinn-cgroup-launcher/src/broker.rs
@@ -188,12 +188,37 @@ impl<F: CgroupFs, S: SpawnIntoCgroup, N: NonceSource> Broker<F, S, N> {
     }
 
     /// Accept readiness only on a connection whose peer PID/UID and
-    /// worker-private credential have already been authenticated.
+    /// worker-private credential have already been authenticated, AND whose
+    /// asserted quota-authority protocol is the one this launcher runs.
+    ///
+    /// The protocol check happens here — before [`Self::begin_invocation`] can
+    /// bind anything and long before [`Self::create`] can clone a child —
+    /// because the disagreement it catches is about who writes the leaf's
+    /// `cpu.max`. A build that starts under a disagreement is not "slightly
+    /// wrong": either the launcher writes a quota Pod resize also owns, or
+    /// nobody writes one at all and the leaf inherits an unbounded ceiling.
+    ///
+    /// The mismatched connection is **dropped**, not merely left un-ready, so a
+    /// worker that ignores the refusal and sends `BEGIN` anyway is answered
+    /// `UnauthenticatedPeer` rather than finding a connection it can retry
+    /// readiness on. `transport` additionally closes the socket (see
+    /// `UnixBrokerServer::serve_connection`).
     pub fn accept_worker_readiness(
         &mut self,
         connection: ConnectionId,
-        _assertion: WorkerReadinessAssertion,
+        assertion: WorkerReadinessAssertion,
     ) -> Result<(), Error> {
+        // Look the connection up first: an unauthenticated caller learns
+        // nothing about the launcher's protocol.
+        if !self.connections.contains_key(&connection) {
+            return Err(Error::UnauthenticatedPeer);
+        }
+        let launcher = self.launcher.authority_protocol();
+        let worker = assertion.protocol();
+        if worker != launcher {
+            self.connections.remove(&connection);
+            return Err(Error::ProtocolMismatch { launcher, worker });
+        }
         self.connections
             .get_mut(&connection)
             .ok_or(Error::UnauthenticatedPeer)?
@@ -532,10 +557,15 @@ mod tests {
         }
     }
     fn broker() -> Broker<Fs, Clone, Nonces> {
+        broker_running(crate::LauncherAuthorityProtocol::LeafV1)
+    }
+    fn broker_running(protocol: crate::LauncherAuthorityProtocol) -> Broker<Fs, Clone, Nonces> {
         let launcher = Launcher::new(
             Fs::ready(),
             Clone,
-            crate::LauncherConfig::new(None, None, 0).unwrap(),
+            crate::LauncherConfig::new(None, None, 0)
+                .unwrap()
+                .with_authority_protocol(protocol),
         )
         .unwrap();
         Broker::new(
@@ -555,7 +585,10 @@ mod tests {
         }
     }
     fn readiness() -> WorkerReadinessAssertion {
-        prepare_worker_readiness(&mut ReadyDumpability).unwrap()
+        readiness_asserting(crate::LauncherAuthorityProtocol::LeafV1)
+    }
+    fn readiness_asserting(protocol: crate::LauncherAuthorityProtocol) -> WorkerReadinessAssertion {
+        prepare_worker_readiness(&mut ReadyDumpability, protocol).unwrap()
     }
     fn command() -> CommandSpec {
         CommandSpec {
@@ -667,6 +700,155 @@ mod tests {
         ));
         // A rejected fence leaves the authenticated nonce usable for a retry.
         assert!(broker.lift(connection, "one", nonce, 9).is_ok());
+    }
+
+    /// AC2. A READY that names a different quota-authority protocol is refused,
+    /// and the refusal happens before ANY invocation can be bound or any child
+    /// created — the two follow-up controls below are the ones that would
+    /// otherwise start real work under a disagreement.
+    ///
+    /// The mutation this is written against is the state of `broker.rs:195`
+    /// before this change: `_assertion: WorkerReadinessAssertion`, the payload
+    /// discarded. Restore that discard (or compare the protocol to itself) and
+    /// the first assertion below fails, because the mismatched READY is
+    /// accepted and `begin_invocation`/`create` then succeed.
+    #[test]
+    fn a_disagreeing_readiness_is_refused_before_any_begin_or_create() {
+        // The launcher runs resize-v2; the worker asserts leaf-v1.
+        let mut broker = broker_running(crate::LauncherAuthorityProtocol::ResizeV2);
+        let peer = FakePeer(UnixPeer {
+            pid: 42,
+            uid: 1000,
+            gid: 1000,
+        });
+        let connection = broker.authenticate(&peer, b"private").unwrap();
+
+        let refusal = broker
+            .accept_worker_readiness(
+                connection,
+                readiness_asserting(crate::LauncherAuthorityProtocol::LeafV1),
+            )
+            .expect_err(
+                "a worker asserting leaf-v1 to a resize-v2 launcher must be refused; accepting it \
+                 lets a build run with nobody writing the leaf quota",
+            );
+        assert!(
+            matches!(
+                refusal,
+                Error::ProtocolMismatch {
+                    launcher: crate::LauncherAuthorityProtocol::ResizeV2,
+                    worker: crate::LauncherAuthorityProtocol::LeafV1,
+                }
+            ),
+            "the refusal must name both sides, got {refusal:?}"
+        );
+        // The refusal names both protocols in its rendered form too: this is
+        // what reaches the pod's logs.
+        let rendered = refusal.to_string();
+        assert!(
+            rendered.contains("resize-v2") && rendered.contains("leaf-v1"),
+            "the refusal must name both protocols, got: {rendered}"
+        );
+
+        // Nothing may proceed on that connection.
+        assert!(
+            matches!(
+                broker.begin_invocation(
+                    connection,
+                    Invocation {
+                        id: "one".into(),
+                        fence: 9,
+                    },
+                ),
+                Err(Error::UnauthenticatedPeer)
+            ),
+            "the mismatched connection must be dropped, not merely left un-ready"
+        );
+        assert!(
+            matches!(
+                broker.create(
+                    connection,
+                    "one",
+                    ControlNonce([0; 32]),
+                    "leaf",
+                    LeaseAuthority::Armed,
+                    &command(),
+                ),
+                Err(Error::UnauthenticatedPeer)
+            ),
+            "no leaf may be created on a connection whose readiness was refused"
+        );
+
+        // And the agreeing case still works, so the check is a comparison and
+        // not a blanket refusal.
+        let mut agreeing = broker_running(crate::LauncherAuthorityProtocol::ResizeV2);
+        let connection = agreeing.authenticate(&peer, b"private").unwrap();
+        agreeing
+            .accept_worker_readiness(
+                connection,
+                readiness_asserting(crate::LauncherAuthorityProtocol::ResizeV2),
+            )
+            .expect("matching protocols must be accepted");
+        assert!(
+            agreeing
+                .begin_invocation(
+                    connection,
+                    Invocation {
+                        id: "one".into(),
+                        fence: 9,
+                    },
+                )
+                .is_ok()
+        );
+    }
+
+    /// The proof bytes are still checked, and the protocol byte is not allowed
+    /// to be inferred: a legacy 16-byte payload (no protocol at all) is refused
+    /// rather than read as `leaf-v1`.
+    #[test]
+    fn a_protocol_less_or_zeroed_readiness_payload_does_not_decode() {
+        let valid = readiness_asserting(crate::LauncherAuthorityProtocol::ResizeV2).wire_bytes();
+        assert_eq!(valid.len(), 17, "16 proof bytes plus one protocol byte");
+        assert_eq!(
+            valid[16],
+            crate::LauncherAuthorityProtocol::ResizeV2.frame_byte()
+        );
+
+        // The pre-#2823 wire form: proof only.
+        assert!(matches!(
+            WorkerReadinessAssertion::from_wire(&valid[..16]),
+            Err(Error::InvalidWorker)
+        ));
+        // An unassigned protocol byte, including the zero a truncated or
+        // memset frame would carry.
+        for byte in [0_u8, 3, 255] {
+            let mut bytes = valid;
+            bytes[16] = byte;
+            assert!(
+                matches!(
+                    WorkerReadinessAssertion::from_wire(&bytes),
+                    Err(Error::InvalidWorker)
+                ),
+                "protocol byte {byte} must not decode"
+            );
+        }
+        // An all-zero proof stays refused with a valid protocol byte.
+        let mut zeroed = [0_u8; 17];
+        zeroed[16] = crate::LauncherAuthorityProtocol::LeafV1.frame_byte();
+        assert!(matches!(
+            WorkerReadinessAssertion::from_wire(&zeroed),
+            Err(Error::InvalidWorker)
+        ));
+        // Round-trip: every protocol survives the wire.
+        for protocol in crate::LauncherAuthorityProtocol::ALL {
+            let bytes = readiness_asserting(protocol).wire_bytes();
+            assert_eq!(
+                WorkerReadinessAssertion::from_wire(&bytes)
+                    .expect("valid frame")
+                    .protocol(),
+                protocol
+            );
+        }
     }
 
     #[test]

--- a/server/crates/djinn-cgroup-launcher/src/child.rs
+++ b/server/crates/djinn-cgroup-launcher/src/child.rs
@@ -2,27 +2,70 @@
 
 use std::os::fd::RawFd;
 
-use crate::Error;
+use crate::{Error, LauncherAuthorityProtocol};
 
 pub const CHILD_UID: u32 = 1001;
 pub const ARTIFACT_GID: u32 = 1000;
+
+/// Length of the readiness proof itself, before the protocol byte.
+const PROOF_BYTES: usize = 16;
+/// Wire length of a [`WorkerReadinessAssertion`]: the proof plus exactly one
+/// [`LauncherAuthorityProtocol::frame_byte`]. A frame of any other length is
+/// refused rather than zero-extended — see [`WorkerReadinessAssertion::from_wire`].
+const ASSERTION_BYTES: usize = PROOF_BYTES + 1;
+
 /// Assertion emitted by the trusted worker only after it locally disabled and
 /// re-read its own dumpability state. It is accepted only on an already
 /// authenticated worker connection.
+///
+/// It carries the worker's own [`LauncherAuthorityProtocol`] as well as the
+/// proof. The launcher and the worker binary are copied from the *same* image
+/// (`djinn-image-builder`'s `dockerfile.rs`), so the two agree by construction —
+/// the point of putting the protocol on this frame is that a disagreement is
+/// *observable* instead of silent. Before this field existed, a launcher started
+/// with `DJINN_LAUNCHER_AUTHORITY_PROTOCOL=resize-v2` next to a worker that
+/// believed it was on `leaf-v1` produced no error anywhere: the launcher simply
+/// never wrote leaf `cpu.max`, and the build ran at whatever quota the pod
+/// happened to have. The broker now refuses that pairing at READY, before any
+/// invocation exists.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WorkerReadinessAssertion {
-    proof: [u8; 16],
+    proof: [u8; PROOF_BYTES],
+    protocol: LauncherAuthorityProtocol,
 }
 impl WorkerReadinessAssertion {
-    pub(crate) fn wire_bytes(self) -> [u8; 16] {
-        self.proof
+    /// The quota-authority protocol the WORKER believes this pod runs under.
+    pub fn protocol(self) -> LauncherAuthorityProtocol {
+        self.protocol
     }
+
+    pub(crate) fn wire_bytes(self) -> [u8; ASSERTION_BYTES] {
+        let mut bytes = [0_u8; ASSERTION_BYTES];
+        bytes[..PROOF_BYTES].copy_from_slice(&self.proof);
+        bytes[PROOF_BYTES] = self.protocol.frame_byte();
+        bytes
+    }
+
+    /// Decode a READY payload.
+    ///
+    /// Fail-closed on every axis: a frame that is not exactly
+    /// [`ASSERTION_BYTES`] long is refused (a 16-byte frame from a
+    /// protocol-unaware peer included — the two binaries ride one image, so
+    /// there is no rolling-skew case to accommodate), an all-zero proof is
+    /// refused, and a protocol byte outside
+    /// [`LauncherAuthorityProtocol::from_frame_byte`] is refused rather than
+    /// defaulted. `0` is unassigned precisely so a truncated or zeroed frame
+    /// cannot decode as `leaf-v1`.
     pub(crate) fn from_wire(bytes: &[u8]) -> Result<Self, Error> {
-        let proof: [u8; 16] = bytes.try_into().map_err(|_| Error::InvalidWorker)?;
+        let bytes: [u8; ASSERTION_BYTES] = bytes.try_into().map_err(|_| Error::InvalidWorker)?;
+        let (proof, protocol) = bytes.split_at(PROOF_BYTES);
+        let proof: [u8; PROOF_BYTES] = proof.try_into().map_err(|_| Error::InvalidWorker)?;
         if proof.iter().all(|byte| *byte == 0) {
             return Err(Error::InvalidWorker);
         }
-        Ok(Self { proof })
+        let protocol =
+            LauncherAuthorityProtocol::from_frame_byte(protocol[0]).ok_or(Error::InvalidWorker)?;
+        Ok(Self { proof, protocol })
     }
 }
 
@@ -54,8 +97,15 @@ impl WorkerDumpability for NativeWorkerDumpability {
 }
 
 /// Run this in the worker process before sending readiness to the broker.
+///
+/// `protocol` is the worker's OWN view of the pod's quota authority (from
+/// `DJINN_LAUNCHER_AUTHORITY_PROTOCOL`, the same variable the launcher reads).
+/// It is a required argument rather than a defaulted field so a caller cannot
+/// assert `leaf-v1` by omission — that is the failure mode this whole frame
+/// exists to make impossible.
 pub fn prepare_worker_readiness(
     syscalls: &mut impl WorkerDumpability,
+    protocol: LauncherAuthorityProtocol,
 ) -> Result<WorkerReadinessAssertion, Error> {
     syscalls.set_non_dumpable()?;
     if syscalls.get_dumpable()? != 0 {
@@ -63,11 +113,11 @@ pub fn prepare_worker_readiness(
     }
     // The proof is carried by the authenticated socket; it prevents the
     // privileged server from manufacturing readiness from an empty frame.
-    let mut proof = [0_u8; 16];
+    let mut proof = [0_u8; PROOF_BYTES];
     let mut entropy = std::fs::File::open("/dev/urandom").map_err(Error::Io)?;
     use std::io::Read;
     entropy.read_exact(&mut proof).map_err(Error::Io)?;
-    Ok(WorkerReadinessAssertion { proof })
+    Ok(WorkerReadinessAssertion { proof, protocol })
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -473,7 +523,9 @@ mod tests {
             get_result: Ok(0),
             calls: vec![],
         };
-        assert!(prepare_worker_readiness(&mut dumpability).is_ok());
+        assert!(
+            prepare_worker_readiness(&mut dumpability, LauncherAuthorityProtocol::LeafV1).is_ok()
+        );
         assert_eq!(dumpability.calls, ["set", "get"]);
     }
 
@@ -490,7 +542,10 @@ mod tests {
                 get_result,
                 calls: vec![],
             };
-            assert!(prepare_worker_readiness(&mut dumpability).is_err());
+            assert!(
+                prepare_worker_readiness(&mut dumpability, LauncherAuthorityProtocol::LeafV1)
+                    .is_err()
+            );
             assert_eq!(
                 dumpability.calls,
                 if set_ok {

--- a/server/crates/djinn-cgroup-launcher/src/control_rejection.rs
+++ b/server/crates/djinn-cgroup-launcher/src/control_rejection.rs
@@ -56,6 +56,12 @@ pub enum ControlRejection {
     Nonce,
     /// The connection has not presented a valid worker readiness assertion.
     Worker,
+    /// The worker's READY named a different quota-authority protocol than the
+    /// launcher is running. Distinct from [`Self::Worker`] on purpose: the
+    /// assertion was well-formed and the peer is the authenticated worker —
+    /// what failed is the agreement, which points the operator at the image /
+    /// catalog declaration rather than at the worker's dumpability.
+    Protocol,
     /// Peer credentials or the worker-private pod credential did not match.
     Credential,
     /// The command request is malformed, over-budget, or outside the allow-list.
@@ -90,6 +96,7 @@ impl ControlRejection {
             E::InvalidInvocationBinding => Self::Binding,
             E::InvalidNonce => Self::Nonce,
             E::InvalidWorker => Self::Worker,
+            E::ProtocolMismatch { .. } => Self::Protocol,
             E::UnauthenticatedPeer | E::InvalidCredential => Self::Credential,
             E::InvalidCommand => Self::Command,
             E::InvalidControl | E::StillPopulated | E::UnsafeLeafName => Self::State,
@@ -112,6 +119,7 @@ impl ControlRejection {
             Self::State => 10,
             Self::Kernel => 11,
             Self::Malformed => 12,
+            Self::Protocol => 13,
             Self::Unspecified => 0,
         }
     }
@@ -133,6 +141,7 @@ impl ControlRejection {
             10 => Self::State,
             11 => Self::Kernel,
             12 => Self::Malformed,
+            13 => Self::Protocol,
             _ => Self::Unspecified,
         }
     }
@@ -154,6 +163,11 @@ impl ControlRejection {
             Self::Binding => "the control is not bound to the active launcher invocation",
             Self::Nonce => "the control nonce was stale, forged, or replayed",
             Self::Worker => "the connection has not presented a valid worker readiness assertion",
+            Self::Protocol => {
+                "the worker and the launcher disagree about which component owns invocation CPU \
+                 quota; the image's declared launcher authority protocol and the rendered \
+                 DJINN_LAUNCHER_AUTHORITY_PROTOCOL must name the same one"
+            }
             Self::Credential => "peer or worker-private credential authentication failed",
             Self::Command => {
                 "the command request is malformed, over-budget, or outside the broker allow-list"
@@ -194,6 +208,7 @@ mod tests {
             ControlRejection::State,
             ControlRejection::Kernel,
             ControlRejection::Malformed,
+            ControlRejection::Protocol,
             ControlRejection::Unspecified,
         ] {
             assert_eq!(ControlRejection::from_code(category.code()), category);

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -362,6 +362,13 @@ impl<F: CgroupFs, S: SpawnIntoCgroup> Launcher<F, S> {
         self.config.leased_quota
     }
 
+    /// The quota-authority protocol this launcher was configured with — the
+    /// value every leaf is born under, and the one the broker checks an
+    /// arriving worker's READY assertion against.
+    pub fn authority_protocol(&self) -> LauncherAuthorityProtocol {
+        self.config.authority_protocol()
+    }
+
     /// The `cpu.max` line a leaf is born at under `authority`.
     ///
     /// Exposed so the behavioural proof asserts against the same function the
@@ -619,6 +626,19 @@ pub enum Error {
     InvalidEvents,
     #[error("worker identity or non-dumpability check failed")]
     InvalidWorker,
+    /// The READY assertion named a quota-authority protocol this launcher is
+    /// not running. Refused before any invocation is bound, because the two
+    /// sides disagreeing about who owns `cpu.max` is not a state any build may
+    /// start in: under one reading the launcher writes the leaf quota, under
+    /// the other Pod resize does, and nothing would report the difference.
+    #[error(
+        "worker asserted launcher authority protocol {worker}, but this launcher is running \
+         {launcher}; refusing readiness before any invocation is bound"
+    )]
+    ProtocolMismatch {
+        launcher: LauncherAuthorityProtocol,
+        worker: LauncherAuthorityProtocol,
+    },
     #[error("unix peer did not match the authenticated worker")]
     UnauthenticatedPeer,
     #[error("worker-private launcher credential did not match")]

--- a/server/crates/djinn-cgroup-launcher/src/transport.rs
+++ b/server/crates/djinn-cgroup-launcher/src/transport.rs
@@ -104,7 +104,20 @@ impl<F: CgroupFs, S: SpawnIntoCgroup, N: NonceSource> UnixBrokerServer<F, S, N> 
                 Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
                 Err(e) => return Err(e),
             };
-            reply(&mut s, self.dispatch(c, &r))?
+            let outcome = self.dispatch(c, &r);
+            // A protocol disagreement ends the CONNECTION, not just the frame.
+            // The categorized refusal is still written first — the worker must
+            // be able to log why it was dropped — but the serve loop then
+            // returns, so no BEGIN or CREATE can follow on this socket even if
+            // the peer ignores the refusal and keeps writing frames.
+            let terminal = match &outcome {
+                Err(Error::ProtocolMismatch { launcher, worker }) => Some((*launcher, *worker)),
+                _ => None,
+            };
+            reply(&mut s, outcome)?;
+            if let Some((launcher, worker)) = terminal {
+                return Err(Error::ProtocolMismatch { launcher, worker });
+            }
         }
     }
     fn dispatch(&mut self, c: ConnectionId, r: &[u8]) -> Result<Vec<u8>, Error> {
@@ -776,10 +789,19 @@ mod tests {
         }
     }
     fn broker<S: SpawnIntoCgroup>(counts: Counts, clone: S) -> Broker<FakeFs, S, TestNonces> {
+        broker_running(counts, clone, crate::LauncherAuthorityProtocol::LeafV1)
+    }
+    fn broker_running<S: SpawnIntoCgroup>(
+        counts: Counts,
+        clone: S,
+        protocol: crate::LauncherAuthorityProtocol,
+    ) -> Broker<FakeFs, S, TestNonces> {
         let launcher = Launcher::new(
             FakeFs(counts),
             clone,
-            LauncherConfig::new(None, None, unsafe { libc::geteuid() }).unwrap(),
+            LauncherConfig::new(None, None, unsafe { libc::geteuid() })
+                .unwrap()
+                .with_authority_protocol(protocol),
         )
         .unwrap();
         Broker::new(
@@ -813,7 +835,13 @@ mod tests {
     }
     fn ready(client: &mut UnixBrokerClient) {
         client
-            .ready(crate::child::prepare_worker_readiness(&mut ReadyDumpability).unwrap())
+            .ready(
+                crate::child::prepare_worker_readiness(
+                    &mut ReadyDumpability,
+                    crate::LauncherAuthorityProtocol::LeafV1,
+                )
+                .unwrap(),
+            )
             .unwrap();
     }
 
@@ -917,6 +945,58 @@ mod tests {
             assert_eq!(counts.leaves.load(Ordering::SeqCst), 0, "{name}");
             assert_eq!(counts.clones.load(Ordering::SeqCst), 0, "{name}");
         }
+    }
+
+    /// AC2, over the real socket: a mismatched READY is refused with its own
+    /// category AND the serve loop returns, so the connection is closed before
+    /// a BEGIN or CREATE frame can be dispatched on it. No leaf, no clone.
+    #[test]
+    fn unix_protocol_mismatch_refuses_ready_and_closes_the_connection() {
+        let counts = Counts::new();
+        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+        thread::scope(|scope| {
+            // The launcher runs resize-v2; `ready()` asserts leaf-v1.
+            let mut server = UnixBrokerServer::new(broker_running(
+                counts.clone(),
+                NoClone(counts.clone()),
+                crate::LauncherAuthorityProtocol::ResizeV2,
+            ));
+            let task = scope.spawn(move || server.serve_connection(server_stream));
+            let mut client = UnixBrokerClient::connect(client_stream, b"test-credential").unwrap();
+
+            let refused = client
+                .ready(
+                    crate::child::prepare_worker_readiness(
+                        &mut ReadyDumpability,
+                        crate::LauncherAuthorityProtocol::LeafV1,
+                    )
+                    .unwrap(),
+                )
+                .expect_err("a disagreeing READY must be refused");
+            assert!(
+                matches!(refused, Error::ControlRejected(ControlRejection::Protocol)),
+                "the worker must learn WHY it was dropped, got {refused:?}"
+            );
+
+            // The socket is gone: the next control cannot be served at all.
+            assert!(
+                client
+                    .begin(Invocation {
+                        id: "after-mismatch".into(),
+                        fence: 1,
+                    })
+                    .is_err(),
+                "no BEGIN may be dispatched after a refused READY"
+            );
+            drop(client);
+            let served = task.join().unwrap();
+            assert!(
+                matches!(served, Err(Error::ProtocolMismatch { .. })),
+                "the serve loop must END on a protocol mismatch, got {served:?}"
+            );
+        });
+        assert_eq!(counts.leaves.load(Ordering::SeqCst), 0);
+        assert_eq!(counts.clones.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/server/crates/djinn-cgroup-launcher/tests/brokered_lease_lift_boundary.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/brokered_lease_lift_boundary.rs
@@ -232,7 +232,11 @@ fn the_brokered_lift_control_moves_cpu_max_from_unleased_to_leased() {
             // The real `prctl` seam, not a double: the broker's readiness gate
             // is satisfied exactly the way the worker satisfies it.
             .ready(
-                prepare_worker_readiness(&mut NativeWorkerDumpability).expect("worker readiness"),
+                prepare_worker_readiness(
+                    &mut NativeWorkerDumpability,
+                    djinn_cgroup_launcher::LauncherAuthorityProtocol::LeafV1,
+                )
+                .expect("worker readiness"),
             )
             .expect("READY");
         client

--- a/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
@@ -23,8 +23,8 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use djinn_cgroup_launcher::{
-    CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
-    LauncherAuthorityProtocol, LeaseAuthority, Readiness, SpawnIntoCgroup,
+    CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher,
+    LauncherAuthorityProtocol, LauncherConfig, LeaseAuthority, Readiness, SpawnIntoCgroup,
     broker::{
         Broker, BrokerConfig, OsNonceSource, PeerCredentials, UnixPeer, WORKER_GID, WORKER_UID,
     },
@@ -192,8 +192,8 @@ fn command() -> CommandSpec {
     }
 }
 
-fn worker_readiness() -> WorkerReadinessAssertion {
-    prepare_worker_readiness(&mut ReadyDumpability).expect("worker readiness")
+fn worker_readiness(protocol: LauncherAuthorityProtocol) -> WorkerReadinessAssertion {
+    prepare_worker_readiness(&mut ReadyDumpability, protocol).expect("worker readiness")
 }
 
 const POD_CREDENTIAL: &[u8] = b"per-pod-private-credential";
@@ -215,6 +215,7 @@ fn broker() -> Broker<FakeCgroup, FakeClone, OsNonceSource> {
 
 fn authenticated_ready(
     broker: &mut Broker<FakeCgroup, FakeClone, OsNonceSource>,
+    protocol: LauncherAuthorityProtocol,
 ) -> djinn_cgroup_launcher::broker::ConnectionId {
     let peer = FakePeer(UnixPeer {
         pid: 42,
@@ -225,7 +226,7 @@ fn authenticated_ready(
         .authenticate(&peer, POD_CREDENTIAL)
         .expect("authenticate worker");
     broker
-        .accept_worker_readiness(connection, worker_readiness())
+        .accept_worker_readiness(connection, worker_readiness(protocol))
         .expect("accept worker readiness");
     connection
 }
@@ -255,7 +256,7 @@ fn authenticated_broker_gives_each_command_a_fresh_250m_leaf_and_one_explicit_li
         OsNonceSource,
     )
     .expect("broker");
-    let connection = authenticated_ready(&mut broker);
+    let connection = authenticated_ready(&mut broker, LauncherAuthorityProtocol::LeafV1);
 
     let first = Invocation {
         id: "first-command".to_owned(),
@@ -337,7 +338,7 @@ fn authenticated_resize_v2_broker_lifecycle_is_quota_neutral() {
         OsNonceSource,
     )
     .expect("broker");
-    let connection = authenticated_ready(&mut broker);
+    let connection = authenticated_ready(&mut broker, LauncherAuthorityProtocol::ResizeV2);
     let nonce = broker
         .begin_invocation(
             connection,
@@ -541,7 +542,7 @@ fn ac3_peer_authentication_rejects_wrong_pid_uid_child_and_sibling() {
 #[test]
 fn ac3_forged_own_or_sibling_controls_and_nonce_replay_are_rejected() {
     let mut broker = broker();
-    let connection_a = authenticated_ready(&mut broker);
+    let connection_a = authenticated_ready(&mut broker, LauncherAuthorityProtocol::LeafV1);
     let nonce0 = broker
         .begin_invocation(
             connection_a,
@@ -554,7 +555,7 @@ fn ac3_forged_own_or_sibling_controls_and_nonce_replay_are_rejected() {
 
     // A second authenticated worker connection (a sibling session) may not
     // drive an invocation bound to another connection.
-    let connection_b = authenticated_ready(&mut broker);
+    let connection_b = authenticated_ready(&mut broker, LauncherAuthorityProtocol::LeafV1);
     assert!(matches!(
         broker.create(
             connection_b,

--- a/server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs
@@ -416,7 +416,12 @@ fn worker_main(
         unsafe { libc::_exit(11) };
     }
     // A real prctl on a real process: from here the worker is non-dumpable.
-    if prepare_worker_readiness(&mut NativeWorkerDumpability).is_err() {
+    if prepare_worker_readiness(
+        &mut NativeWorkerDumpability,
+        djinn_cgroup_launcher::LauncherAuthorityProtocol::LeafV1,
+    )
+    .is_err()
+    {
         say!("fail:non-dumpable readiness");
         unsafe { libc::_exit(12) };
     }
@@ -430,7 +435,12 @@ fn worker_main(
             unsafe { libc::_exit(14) };
         }
     };
-    match prepare_worker_readiness(&mut NativeWorkerDumpability).map(|r| client.ready(r)) {
+    match prepare_worker_readiness(
+        &mut NativeWorkerDumpability,
+        djinn_cgroup_launcher::LauncherAuthorityProtocol::LeafV1,
+    )
+    .map(|r| client.ready(r))
+    {
         Ok(Ok(())) => {}
         Ok(Err(error)) | Err(error) => {
             say!("fail:worker readiness: {error}");

--- a/server/crates/djinn-db/src/repositories/project.rs
+++ b/server/crates/djinn-db/src/repositories/project.rs
@@ -1,6 +1,7 @@
 // djinn:allow-oversize — legacy module over size-guard threshold; split when touched substantively.
 use djinn_core::events::{DjinnEventEnvelope, EventBus};
 use djinn_core::models::Project;
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
 use sqlx::Row;
 
 use crate::Result;
@@ -905,11 +906,13 @@ impl ProjectRepository {
                 digest: None,
                 from_catalog: None,
                 last_error: None,
+                authority_protocol: None,
             }));
         };
 
         let img = sqlx::query(
-            "SELECT tag, registry_digest, status, last_error FROM images WHERE id = $1",
+            "SELECT tag, registry_digest, status, last_error, launcher_authority_protocol \
+             FROM images WHERE id = $1",
         )
         .bind(&image_id)
         .fetch_optional(self.db.pool())
@@ -921,6 +924,13 @@ impl ProjectRepository {
                 digest: i.get("registry_digest"),
                 from_catalog: Some(image_id),
                 last_error: i.get("last_error"),
+                // Parsed, never passed through as a string: migration 166's
+                // CHECK and this parse are the same closed set, so a row that
+                // somehow holds an unknown value fails the RESOLVE rather than
+                // reaching the render as an unrecognised protocol.
+                authority_protocol: parse_declared_protocol(
+                    i.get::<Option<String>, _>("launcher_authority_protocol"),
+                )?,
             },
             // FK RESTRICT makes a dangling selection impossible in practice;
             // treat it as "not ready" rather than panicking.
@@ -930,6 +940,7 @@ impl ProjectRepository {
                 digest: None,
                 from_catalog: Some(image_id),
                 last_error: None,
+                authority_protocol: None,
             },
         }))
     }
@@ -1006,6 +1017,15 @@ pub struct ProjectImage {
 /// precedence is applied — see [`ProjectRepository::resolve_dispatch_image`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DispatchImage {
+    /// The launcher quota-authority protocol this image DECLARED at build time
+    /// (`images.launcher_authority_protocol`, migration 166), or `None` for an
+    /// image that declared nothing.
+    ///
+    /// `None` is not "leaf-v1": it is "this artifact never said". The render
+    /// decides what an undeclared image may do (see
+    /// `djinn_k8s::launcher::render_authority_protocol`); conflating the two
+    /// here would put the decision in the place least able to fail closed.
+    pub authority_protocol: Option<LauncherAuthorityProtocol>,
     /// The `ready` tag to pull, or `None` when the resolved image isn't
     /// built yet (caller hard-fails task dispatch / skips warming).
     pub tag: Option<String>,
@@ -1035,6 +1055,27 @@ impl DispatchImage {
             Some(digest) => Some(format!("{}@{}", strip_tag_suffix(tag), digest)),
             None => Some(tag.to_string()),
         }
+    }
+}
+
+/// Parse `images.launcher_authority_protocol` for a dispatch resolution.
+///
+/// `NULL` and the empty string are "declared nothing" — the shape every image
+/// built before migration 166 holds. Anything else must be one of the two wire
+/// forms: the column is already constrained by migration 166's `CHECK`, so a
+/// value that fails here means the constraint was bypassed, and resolving it to
+/// a default is precisely how a `resize-v2` image would end up dispatched as
+/// `leaf-v1` (or the reverse) with nothing reporting it.
+fn parse_declared_protocol(raw: Option<String>) -> Result<Option<LauncherAuthorityProtocol>> {
+    match raw.as_deref() {
+        None | Some("") => Ok(None),
+        Some(value) => value.parse().map(Some).map_err(|_| {
+            crate::Error::InvalidData(format!(
+                "images.launcher_authority_protocol = {value:?} is not a launcher authority \
+                 protocol; refusing to resolve a dispatch image whose quota authority cannot \
+                 be named"
+            ))
+        }),
     }
 }
 
@@ -1625,6 +1666,109 @@ mod tests {
             updated.graph_orphan_ignore,
             vec!["crates/test-support/src/db.rs".to_string()]
         );
+    }
+
+    /// AC3. The declared protocol survives the round trip to a **freshly
+    /// constructed** repository — the resolution reads the column, it does not
+    /// echo a value the same process just wrote.
+    ///
+    /// Every read below goes through a `ProjectRepository::new(...)` created
+    /// after the write, over a `Database` handle that is itself re-derived, so
+    /// nothing in-process can be serving the answer from memory. Making
+    /// `resolve_dispatch_image` return `authority_protocol: None`
+    /// unconditionally fails the first assertion.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn declared_authority_protocol_survives_readback_through_a_fresh_repository() {
+        use crate::repositories::image::ImageRepository;
+
+        let db = test_db();
+        db.ensure_initialized().await.unwrap();
+        ProjectRepository::new(db.clone(), EventBus::noop())
+            .create_with_id("proto-p1", "proto", "test", "proto-p1")
+            .await
+            .unwrap();
+
+        for protocol in LauncherAuthorityProtocol::ALL {
+            let image_id = format!("img-{}", protocol.as_wire());
+            let images = ImageRepository::new(db.clone());
+            images
+                .create(&image_id, &format!("Rust {protocol}"), None, "{}")
+                .await
+                .unwrap();
+            // Migration 166 requires a digest alongside a declaration.
+            images
+                .mark_ready(
+                    &image_id,
+                    &format!("reg/djinn-image-{}:hash", protocol.as_wire()),
+                    Some("sha256:abc"),
+                    Some(protocol),
+                )
+                .await
+                .unwrap();
+            images
+                .set_project_image("proto-p1", Some(&image_id))
+                .await
+                .unwrap();
+
+            let resolved = ProjectRepository::new(db.clone(), EventBus::noop())
+                .resolve_dispatch_image("proto-p1")
+                .await
+                .unwrap()
+                .expect("project resolves");
+            assert_eq!(
+                resolved.authority_protocol,
+                Some(protocol),
+                "a {protocol} image must resolve as {protocol}, not as a default"
+            );
+            assert_eq!(resolved.digest.as_deref(), Some("sha256:abc"));
+        }
+
+        // An image that declared nothing resolves to `None` — "never said",
+        // which the render treats differently from either protocol.
+        let images = ImageRepository::new(db.clone());
+        images
+            .create("img-legacy", "Rust legacy", None, "{}")
+            .await
+            .unwrap();
+        images
+            .mark_ready("img-legacy", "reg/djinn-image-legacy:hash", None, None)
+            .await
+            .unwrap();
+        images
+            .set_project_image("proto-p1", Some("img-legacy"))
+            .await
+            .unwrap();
+        let resolved = ProjectRepository::new(db.clone(), EventBus::noop())
+            .resolve_dispatch_image("proto-p1")
+            .await
+            .unwrap()
+            .expect("project resolves");
+        assert_eq!(resolved.authority_protocol, None);
+        assert_eq!(resolved.digest, None);
+    }
+
+    /// A column value outside the closed set fails the resolution instead of
+    /// silently becoming `leaf-v1`. Migration 166's CHECK is the first door;
+    /// this is the second, and it is the one that would catch a constraint
+    /// dropped in a future migration.
+    #[test]
+    fn an_unparseable_declared_protocol_refuses_to_resolve() {
+        assert_eq!(parse_declared_protocol(None).unwrap(), None);
+        assert_eq!(parse_declared_protocol(Some(String::new())).unwrap(), None);
+        for protocol in LauncherAuthorityProtocol::ALL {
+            assert_eq!(
+                parse_declared_protocol(Some(protocol.as_wire().to_owned())).unwrap(),
+                Some(protocol)
+            );
+        }
+        for rejected in ["leaf-v2", "LEAF-V1", "resize-v2 ", "unknown"] {
+            let err = parse_declared_protocol(Some(rejected.to_owned()))
+                .expect_err("{rejected} must not resolve");
+            assert!(
+                err.to_string().contains(rejected),
+                "the refusal must name the offending value, got: {err}"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -49,7 +49,8 @@ pub use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
 // capability the runtime discards, nor omit one the runtime needs.
 use djinn_cgroup_launcher::bootstrap::RETAINED_CAPABILITY_NAMES;
 use djinn_cgroup_launcher::{
-    CgroupMode, Error as LauncherError, LeasedQuota, Readiness, UnleasedQuota,
+    CgroupMode, Error as LauncherError, LauncherAuthorityProtocol, LeasedQuota, Readiness,
+    UnleasedQuota,
 };
 pub use djinn_runtime::RoleResourceClass;
 
@@ -139,6 +140,21 @@ pub const LAUNCHER_CREDENTIAL_PATH: &str = "/var/run/djinn/launcher/credential";
 pub const LAUNCHER_CGROUP_ROOT: &str = "/sys/fs/cgroup";
 /// RuntimeClass that delegates the writable cgroup hierarchy to task-run Pods.
 pub const TASK_RUN_CGROUP_RUNTIME_CLASS: &str = "djinn-cgroup-writable";
+
+/// Environment variable carrying the quota-authority protocol into the pod.
+///
+/// Read by the launcher sidecar's `main.rs`
+/// (`djinn-cgroup-launcher::AUTHORITY_PROTOCOL_ENV`) and by the worker's
+/// `launcher_handshake`, which asserts it to the broker at READY. The two
+/// containers run the same image, so setting it on one and not the other is the
+/// one disagreement that can actually occur — which is why
+/// [`apply_launcher_authority_protocol`] writes both, and why the broker refuses
+/// a READY that disagrees.
+///
+/// Before this constant existed, `DJINN_LAUNCHER_AUTHORITY_PROTOCOL` was read by
+/// the shipped binary (#2823) and emitted by **nothing**: every production
+/// launcher fell through to `leaf-v1` no matter what the image declared.
+pub const AUTHORITY_PROTOCOL_ENV: &str = "DJINN_LAUNCHER_AUTHORITY_PROTOCOL";
 
 /// Whether an enforcement task-run Pod renders the cgroup-launcher sidecar.
 ///
@@ -506,6 +522,120 @@ pub enum RenderValidationError {
     UnsupportedLeaseQuota { limit: String, min: u32, max: u32 },
     #[error("cgroup launcher mode is `required`, but task-run RuntimeClass assignment is disabled")]
     MissingDelegatedRuntimeClass,
+    #[error(
+        "the resolved image declares no launcher authority protocol and carries no immutable \
+         registry digest, so the server cannot know which component owns invocation CPU quota in \
+         it. Rebuild the catalog image: builds since the protocol declaration landed record both. \
+         Refused before the Job exists rather than dispatching under a guess."
+    )]
+    UndeclarableAuthorityProtocol,
+    #[error(
+        "cgroup launcher mode is `required`, but the rendered Job has no `{container}` container \
+         to carry {env}. The launcher would start with no protocol selection and silently fall \
+         back to leaf-v1, which is the exact silence this render exists to remove."
+    )]
+    MissingLauncherSidecar {
+        container: &'static str,
+        env: &'static str,
+    },
+}
+
+/// Decide the protocol a Job must render, from what the resolved catalog image
+/// declared and whether it is digest-pinned.
+///
+/// * **Declared** → that protocol. Migration 166 guarantees a declaring image is
+///   also digest-pinned, so the value names a specific artifact.
+/// * **Undeclared but digest-pinned** → [`LauncherAuthorityProtocol::LeafV1`].
+///   These are the images built before the declaration existed. `leaf-v1` is
+///   what they have always run, and the digest is what makes "these bytes"
+///   meaningful — so the render states it explicitly rather than relying on the
+///   launcher's absent-variable default.
+/// * **Neither** → refused. Nothing identifies the artifact and nothing states
+///   its quota authority; the alternative is dispatching on a guess about who
+///   writes `cpu.max`, in a system where guessing wrong is either an unbounded
+///   build or a 16x-throttled one.
+///
+/// A per-deployment allowlist for undeclared, undigested images is task vf7a's
+/// job and deliberately not here: an allowlist that arrives with the fence it is
+/// supposed to open is not a fence.
+pub fn render_authority_protocol(
+    declared: Option<LauncherAuthorityProtocol>,
+    digest: Option<&str>,
+) -> Result<LauncherAuthorityProtocol, RenderValidationError> {
+    if let Some(declared) = declared {
+        return Ok(declared);
+    }
+    match digest.map(str::trim).filter(|digest| !digest.is_empty()) {
+        Some(_) => Ok(LauncherAuthorityProtocol::LeafV1),
+        None => Err(RenderValidationError::UndeclarableAuthorityProtocol),
+    }
+}
+
+/// Write [`AUTHORITY_PROTOCOL_ENV`] onto the rendered Job's launcher sidecar and
+/// worker containers.
+///
+/// This runs after `build_task_run_job` rather than inside it because the
+/// protocol is a property of the resolved *catalog image*, which only the
+/// dispatch path has (`djinn_k8s::runtime`), while the Job builder is a pure
+/// function of the config — the same split `build_resources::apply_resolved_resources`
+/// already uses for per-project resource overrides.
+///
+/// Fail-closed: in `required` mode a Job with no `cgroup-launcher` container is
+/// an error, not a silent skip. Under `disabled` mode there is no sidecar and no
+/// broker, so there is nothing to agree about and this is a no-op.
+pub fn apply_launcher_authority_protocol(
+    job: &mut k8s_openapi::api::batch::v1::Job,
+    mode: CgroupLauncherMode,
+    protocol: LauncherAuthorityProtocol,
+) -> Result<(), RenderValidationError> {
+    if !mode.renders_sidecar() {
+        return Ok(());
+    }
+    let missing = || RenderValidationError::MissingLauncherSidecar {
+        container: LAUNCHER_CONTAINER_NAME,
+        env: AUTHORITY_PROTOCOL_ENV,
+    };
+    let pod = job
+        .spec
+        .as_mut()
+        .and_then(|spec| spec.template.spec.as_mut())
+        .ok_or_else(missing)?;
+
+    let sidecar = pod
+        .init_containers
+        .as_mut()
+        .and_then(|containers| {
+            containers
+                .iter_mut()
+                .find(|container| container.name == LAUNCHER_CONTAINER_NAME)
+        })
+        .ok_or_else(missing)?;
+    set_env(sidecar, AUTHORITY_PROTOCOL_ENV, protocol.as_wire());
+
+    // The worker asserts the SAME value to the broker at READY. Setting it on
+    // the sidecar alone would make every armed pod fail its own handshake as
+    // soon as a resize-v2 image exists.
+    for worker in pod
+        .containers
+        .iter_mut()
+        .filter(|container| container.name == "worker")
+    {
+        set_env(worker, AUTHORITY_PROTOCOL_ENV, protocol.as_wire());
+    }
+    Ok(())
+}
+
+/// Set (or replace) one environment entry on a container, so re-applying is
+/// idempotent rather than appending a second, shadowed definition.
+fn set_env(container: &mut Container, name: &str, value: &str) {
+    let env = container.env.get_or_insert_with(Vec::new);
+    match env.iter_mut().find(|entry| entry.name == name) {
+        Some(existing) => {
+            existing.value = Some(value.to_string());
+            existing.value_from = None;
+        }
+        None => env.push(env_var(name, value)),
+    }
 }
 
 /// Map a supported/unsupported cgroup-delegation profile string onto the

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -514,8 +514,18 @@ impl SessionRuntime for KubernetesRuntime {
         let project_image_tag = self.dispatch_image_override.clone();
         #[cfg(not(test))]
         let project_image_tag: Option<String> = None;
-        let project_image_tag = match project_image_tag {
-            Some(tag) => tag,
+        // The launcher authority protocol travels WITH the resolved image: it
+        // is what the artifact declared at build time (migration 166), and the
+        // rendered Job must carry it into the pod or #2823's reachable
+        // `resize-v2` branch has nothing feeding it. Resolved here, applied to
+        // the Job below, BEFORE any Job is created.
+        let (project_image_tag, authority_protocol) = match project_image_tag {
+            // Test-only image override: no catalog row exists, so the render
+            // uses the pre-protocol behavior the override has always implied.
+            Some(tag) => (
+                tag,
+                djinn_cgroup_launcher::LauncherAuthorityProtocol::LeafV1,
+            ),
             None => {
                 let dispatch_image = repo
                     .resolve_dispatch_image(&spec.project_id)
@@ -526,10 +536,23 @@ impl SessionRuntime for KubernetesRuntime {
                             spec.project_id
                         ))
                     })?;
-                match dispatch_image.as_ref().and_then(|d| d.pull_ref()) {
-                    Some(pull_ref) => pull_ref,
-                    None => return Err(RuntimeError::DevcontainerMissing(spec.project_id.clone())),
-                }
+                let Some(dispatch_image) = dispatch_image else {
+                    return Err(RuntimeError::DevcontainerMissing(spec.project_id.clone()));
+                };
+                let Some(pull_ref) = dispatch_image.pull_ref() else {
+                    return Err(RuntimeError::DevcontainerMissing(spec.project_id.clone()));
+                };
+                let protocol = crate::launcher::render_authority_protocol(
+                    dispatch_image.authority_protocol,
+                    dispatch_image.digest.as_deref(),
+                )
+                .map_err(|error| {
+                    RuntimeError::Prepare(format!(
+                        "launcher authority protocol for project {}: {error}",
+                        spec.project_id
+                    ))
+                })?;
+                (pull_ref, protocol)
             }
         };
 
@@ -771,6 +794,24 @@ impl SessionRuntime for KubernetesRuntime {
             read_source_cache_sub_path.as_deref(),
         );
         crate::build_resources::apply_resolved_resources(&mut job, resolved_task_resources);
+        // Carry the image's quota authority into the pod. Fails closed before
+        // the Job is POSTed: an armed render with no launcher container would
+        // otherwise start a launcher that silently defaults to leaf-v1.
+        if let Err(error) = crate::launcher::apply_launcher_authority_protocol(
+            &mut job,
+            self.config.cgroup_launcher_mode,
+            authority_protocol,
+        ) {
+            self.drop_pending(&task_run_id_str).await;
+            let secrets_bg = secrets.clone();
+            let name = resource_name.clone();
+            tokio::spawn(async move {
+                let _ = secrets_bg.delete(&name, &DeleteParams::default()).await;
+            });
+            return Err(RuntimeError::Prepare(format!(
+                "launcher authority protocol render: {error}"
+            )));
+        }
         let jobs: Api<Job> = Api::namespaced(self.client.clone(), ns);
         let created_job = match create_or_adopt_task_run_job(&jobs, &job, &resource_name).await {
             Ok(j) => j,

--- a/server/crates/djinn-k8s/tests/launcher_authority_protocol_render.rs
+++ b/server/crates/djinn-k8s/tests/launcher_authority_protocol_render.rs
@@ -1,0 +1,371 @@
+//! The catalog protocol reaches the pod, or no pod is created (task fi2k).
+//!
+//! #2823 made `resize-v2` reachable from the shipped launcher binary by reading
+//! `DJINN_LAUNCHER_AUTHORITY_PROTOCOL` in its `main.rs`. Nothing emitted that
+//! variable, so every production launcher fell through to `leaf-v1` regardless
+//! of what the image declared — a merged, tested feature that was inert in
+//! production. These tests assert the two halves of the connection:
+//!
+//! * **AC1** — the rendered Job carries the resolved image's protocol on the
+//!   `cgroup-launcher` init container (and on the worker, which asserts the same
+//!   value to the broker at READY).
+//! * **AC4** — an image that declares no protocol AND carries no immutable
+//!   digest is refused before any Kubernetes object is POSTed.
+//!
+//! AC4 runs through the REAL `KubernetesRuntime::prepare` against a recording
+//! fake apiserver, because "fails closed" is a claim about the number of Jobs
+//! created, not about a function returning `Err`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use djinn_cgroup_launcher::LauncherAuthorityProtocol;
+use djinn_core::events::EventBus;
+use djinn_core::models::TaskRunTrigger;
+use djinn_db::Database;
+use djinn_db::repositories::image::ImageRepository;
+use djinn_db::repositories::project::ProjectRepository;
+use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::launcher::{
+    AUTHORITY_PROTOCOL_ENV, CgroupLauncherMode, LAUNCHER_CONTAINER_NAME, RenderValidationError,
+    apply_launcher_authority_protocol, render_authority_protocol,
+};
+use djinn_k8s::runtime::KubernetesRuntime;
+use djinn_runtime::spec::{SupervisorFlow, TaskRunSpec};
+use djinn_runtime::{ResolvedCredentials, SessionRuntime};
+use djinn_supervisor::ConnectionRegistry;
+use k8s_openapi::api::batch::v1::Job;
+
+/// Read one container's environment value, if present.
+fn env_of(job: &Job, container: &str, name: &str) -> Option<String> {
+    let pod = job.spec.as_ref()?.template.spec.as_ref()?;
+    let all = pod
+        .init_containers
+        .iter()
+        .flatten()
+        .chain(pod.containers.iter());
+    all.filter(|candidate| candidate.name == container)
+        .flat_map(|candidate| candidate.env.iter().flatten())
+        .find(|entry| entry.name == name)
+        .and_then(|entry| entry.value.clone())
+}
+
+fn task_run_job(config: &KubernetesConfig) -> Job {
+    djinn_k8s::job::build_task_run_job(
+        config,
+        &uuid::Uuid::nil(),
+        "project-1",
+        "djinn-task-run-secret",
+        "registry.example/proj:tag",
+        &[],
+        None,
+        false,
+        None,
+    )
+}
+
+/// AC1. A `resize-v2` catalog image renders `resize-v2`; a `leaf-v1` image
+/// renders `leaf-v1`. Both land on `spec.initContainers[name=cgroup-launcher]`.
+///
+/// Non-vacuity, as stated by the AC: hardcode `leaf-v1` in
+/// `apply_launcher_authority_protocol` (or in `render_authority_protocol`) and
+/// the `resize-v2` case below fails, naming the value it actually rendered.
+#[test]
+fn the_rendered_launcher_sidecar_carries_the_images_declared_protocol() {
+    let config = KubernetesConfig::for_testing();
+    assert!(
+        config.cgroup_launcher_mode.renders_sidecar(),
+        "this test is about the armed render"
+    );
+
+    for protocol in LauncherAuthorityProtocol::ALL {
+        // A declaring image is digest-pinned (migration 166), and the render
+        // resolves the declaration it made.
+        let resolved = render_authority_protocol(Some(protocol), Some("sha256:abc"))
+            .expect("a declared protocol resolves");
+        assert_eq!(resolved, protocol);
+
+        let mut job = task_run_job(&config);
+        assert_eq!(
+            env_of(&job, LAUNCHER_CONTAINER_NAME, AUTHORITY_PROTOCOL_ENV),
+            None,
+            "the base render must not already carry a protocol, or this test would \
+             pass without the propagation"
+        );
+
+        apply_launcher_authority_protocol(&mut job, config.cgroup_launcher_mode, resolved)
+            .expect("the armed render has a launcher sidecar");
+
+        assert_eq!(
+            env_of(&job, LAUNCHER_CONTAINER_NAME, AUTHORITY_PROTOCOL_ENV).as_deref(),
+            Some(protocol.as_wire()),
+            "the {protocol} sidecar must be told it is running {protocol}"
+        );
+        // The worker asserts the same value to the broker at READY; if only the
+        // sidecar were told, every resize-v2 pod would fail its own handshake.
+        assert_eq!(
+            env_of(&job, "worker", AUTHORITY_PROTOCOL_ENV).as_deref(),
+            Some(protocol.as_wire()),
+            "the worker must assert the same protocol the launcher runs"
+        );
+
+        // It is a container environment ENTRY, exactly once — a second,
+        // shadowed definition would be a coin flip at container start.
+        let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+        for container in pod
+            .init_containers
+            .iter()
+            .flatten()
+            .chain(pod.containers.iter())
+        {
+            let occurrences = container
+                .env
+                .iter()
+                .flatten()
+                .filter(|entry| entry.name == AUTHORITY_PROTOCOL_ENV)
+                .count();
+            assert!(
+                occurrences <= 1,
+                "{} carries {occurrences} copies of {AUTHORITY_PROTOCOL_ENV}",
+                container.name
+            );
+        }
+
+        // Re-applying is idempotent, not additive.
+        apply_launcher_authority_protocol(&mut job, config.cgroup_launcher_mode, resolved)
+            .expect("re-apply");
+        assert_eq!(
+            env_of(&job, LAUNCHER_CONTAINER_NAME, AUTHORITY_PROTOCOL_ENV).as_deref(),
+            Some(protocol.as_wire())
+        );
+    }
+}
+
+/// An undeclared but digest-pinned image — every image built before the
+/// declaration existed — renders `leaf-v1`, the behavior it has always had.
+/// An image with neither is refused.
+#[test]
+fn an_undeclared_image_renders_leaf_v1_only_when_it_is_digest_pinned() {
+    assert_eq!(
+        render_authority_protocol(None, Some("sha256:abc")).unwrap(),
+        LauncherAuthorityProtocol::LeafV1
+    );
+    for absent in [None, Some(""), Some("   ")] {
+        let refusal = render_authority_protocol(None, absent)
+            .expect_err("an image with no declaration and no digest must be refused");
+        assert!(matches!(
+            refusal,
+            RenderValidationError::UndeclarableAuthorityProtocol
+        ));
+    }
+    // A declaration still wins over a missing digest: migration 166 makes that
+    // row impossible, and if it ever existed the declaration is the stronger
+    // statement.
+    assert_eq!(
+        render_authority_protocol(Some(LauncherAuthorityProtocol::ResizeV2), None).unwrap(),
+        LauncherAuthorityProtocol::ResizeV2
+    );
+}
+
+/// A disabled launcher renders no sidecar, so there is no protocol to agree
+/// about and nothing to write.
+#[test]
+fn a_disabled_launcher_render_is_left_alone() {
+    let config = KubernetesConfig::for_testing();
+    let mut job = task_run_job(&config);
+    apply_launcher_authority_protocol(
+        &mut job,
+        CgroupLauncherMode::Disabled,
+        LauncherAuthorityProtocol::ResizeV2,
+    )
+    .expect("a disabled render has nothing to configure");
+    assert_eq!(
+        env_of(&job, LAUNCHER_CONTAINER_NAME, AUTHORITY_PROTOCOL_ENV),
+        None
+    );
+
+    // But an ARMED render whose sidecar is missing is an error, never a
+    // silent skip: the launcher would boot with no selection at all.
+    let mut sidecarless = task_run_job(&config);
+    sidecarless
+        .spec
+        .as_mut()
+        .unwrap()
+        .template
+        .spec
+        .as_mut()
+        .unwrap()
+        .init_containers = None;
+    let refusal = apply_launcher_authority_protocol(
+        &mut sidecarless,
+        CgroupLauncherMode::Required,
+        LauncherAuthorityProtocol::ResizeV2,
+    )
+    .expect_err("an armed render with no launcher container must be refused");
+    assert!(matches!(
+        refusal,
+        RenderValidationError::MissingLauncherSidecar { .. }
+    ));
+}
+
+/// AC4. An image with neither a declaration nor a digest produces **zero**
+/// Kubernetes objects: the refusal happens inside `prepare`, before the Secret
+/// POST and long before the Job POST.
+///
+/// Non-vacuity: make `render_authority_protocol` fall through to
+/// `Ok(LauncherAuthorityProtocol::LeafV1)` when both inputs are absent and this
+/// test fails on the `POST:` assertion, listing the objects that were created.
+#[tokio::test]
+async fn a_protocol_less_undigested_image_creates_zero_kubernetes_objects() {
+    // Sanity: the SAME flow with a digest-pinned image reaches the POSTs, so
+    // the zero below is caused by the refusal and not by an inert harness.
+    let (created, digest_pinned) = prepare_with_image(Some("sha256:abc"), None).await;
+    assert!(
+        digest_pinned.is_ok(),
+        "a digest-pinned image must still dispatch: {digest_pinned:?}"
+    );
+    assert!(
+        created.iter().any(|event| event == "POST:Job"),
+        "the harness must be able to reach the Job POST, got {created:?}"
+    );
+
+    let (created, refused) = prepare_with_image(None, None).await;
+    // The count first: this is the claim. A render that falls through to a
+    // default is caught HERE, naming the objects it created.
+    assert!(
+        created.is_empty(),
+        "an undeclarable image must create NOTHING, got {created:?}"
+    );
+    let error = refused.expect_err("an undeclarable image must not dispatch");
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("registry digest") || rendered.contains("launcher authority protocol"),
+        "the refusal must name what is missing, got: {rendered}"
+    );
+
+    // And a declaring image dispatches, carrying its declaration.
+    let (created, declared) = prepare_with_image(
+        Some("sha256:abc"),
+        Some(LauncherAuthorityProtocol::ResizeV2),
+    )
+    .await;
+    assert!(
+        declared.is_ok(),
+        "a declaring image dispatches: {declared:?}"
+    );
+    assert!(created.iter().any(|event| event == "POST:Job"));
+}
+
+/// Drive `KubernetesRuntime::prepare` against a recording fake apiserver with a
+/// seeded catalog image, returning every POST it made and the outcome.
+async fn prepare_with_image(
+    digest: Option<&str>,
+    protocol: Option<LauncherAuthorityProtocol>,
+) -> (Vec<String>, Result<(), String>) {
+    use http::Response;
+    use kube::client::Body;
+    use tower::service_fn;
+
+    let created: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let events = created.clone();
+    let client = kube::Client::new(
+        service_fn(move |request: http::Request<Body>| {
+            let events = events.clone();
+            async move {
+                let path = request.uri().path().to_string();
+                let (event, body) = if path.contains("/secrets") {
+                    (
+                        "POST:Secret",
+                        serde_json::json!({
+                            "apiVersion": "v1", "kind": "Secret",
+                            "metadata": {"name": "task-secret"}
+                        }),
+                    )
+                } else {
+                    (
+                        "POST:Job",
+                        serde_json::json!({
+                            "apiVersion": "batch/v1", "kind": "Job",
+                            "metadata": {"name": "task-job", "uid": "job-uid"}
+                        }),
+                    )
+                };
+                if request.method() == http::Method::POST {
+                    events.lock().unwrap().push(event.into());
+                }
+                Ok::<_, std::io::Error>(
+                    Response::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string().into_bytes()))
+                        .unwrap(),
+                )
+            }
+        }),
+        "djinn",
+    );
+
+    let db = Database::open_in_memory().expect("in-memory database");
+    db.ensure_initialized().await.expect("migrations");
+    let project_id = format!(
+        "proj-{}-{}",
+        digest.unwrap_or("nodigest"),
+        protocol.map(|p| p.as_wire()).unwrap_or("undeclared")
+    );
+    ProjectRepository::new(db.clone(), EventBus::noop())
+        .create_with_id(&project_id, &project_id, "test", &project_id)
+        .await
+        .expect("seed project");
+    let images = ImageRepository::new(db.clone());
+    let image_id = format!("img-{project_id}");
+    images
+        .create(&image_id, &image_id, None, "{}")
+        .await
+        .expect("seed image");
+    images
+        .mark_ready(
+            &image_id,
+            "registry.example/djinn-image-test:hash",
+            digest,
+            protocol,
+        )
+        .await
+        .expect("mark the seeded image ready");
+    images
+        .set_project_image(&project_id, Some(&image_id))
+        .await
+        .expect("select the catalog image");
+
+    let runtime = KubernetesRuntime::from_client_with_db(
+        client,
+        KubernetesConfig::for_testing(),
+        Arc::new(ConnectionRegistry::new()),
+        db,
+    );
+    let spec = TaskRunSpec {
+        task_run_id: uuid::Uuid::now_v7().to_string(),
+        task_attempt_id: None,
+        task_id: "task-protocol-render".into(),
+        project_id: project_id.clone(),
+        trigger: TaskRunTrigger::NewTask,
+        base_branch: "main".into(),
+        task_branch: "task/protocol-render".into(),
+        flow: SupervisorFlow::NewTask,
+        model_id_per_role: HashMap::new(),
+        read_source_project_ids: Vec::new(),
+        knowledge_injection: djinn_core::models::KnowledgeInjectionConfig::default(),
+        github_owner: None,
+        github_install_token: None,
+        commit_author_name: None,
+        commit_author_email: None,
+        resume_lifecycle_metadata: None,
+        is_evidence_spike: false,
+    };
+    let outcome = runtime
+        .prepare(&spec, &ResolvedCredentials::default())
+        .await
+        .map(|_| ())
+        .map_err(|error| error.to_string());
+    let observed = created.lock().unwrap().clone();
+    (observed, outcome)
+}


### PR DESCRIPTION
Implements djinn board task `fi2k` (epic `y3ww`, proposal `3i92`), wave 1 piece B.

## Why

PR #2823 made `resize-v2` **reachable** from the shipped launcher binary by reading `DJINN_LAUNCHER_AUTHORITY_PROTOCOL` in `main.rs`. **No renderer emitted that variable**, so in production every launcher fell through to `leaf-v1` regardless of what the image declared — merged, tested, and inert. This PR connects the catalog declaration (#2831, migration 166) to the pod, and makes the launcher check the agreement instead of discarding it.

## The three pieces

**1. Catalog → `DispatchImage`** (`djinn-db/src/repositories/project.rs`)

`DispatchImage` gains `authority_protocol: Option<LauncherAuthorityProtocol>`, read by `resolve_dispatch_image` from `images.launcher_authority_protocol`. `None` means *declared nothing*, never `leaf-v1` — the render, not the DB layer, decides what an undeclared image may do. A column value outside the closed set fails the resolution rather than defaulting (migration 166's `CHECK` is the first door; this is the second).

**2. `DispatchImage` → the rendered Job** (`djinn-k8s/src/{launcher.rs,runtime.rs}`)

* `render_authority_protocol(declared, digest)`: a declaration wins; an undeclared but **digest-pinned** image renders `leaf-v1` (what it has always run); an image with **neither** is refused.
* `apply_launcher_authority_protocol(&mut Job, mode, protocol)`: writes `DJINN_LAUNCHER_AUTHORITY_PROTOCOL` onto the `cgroup-launcher` init container **and** the `worker` container — the worker asserts the same value to the broker at READY, so setting only the sidecar would make every `resize-v2` pod fail its own handshake. Idempotent (set, not append). In `required` mode a Job with no launcher container is an error, not a silent skip.
* `runtime::prepare` resolves the protocol with the image and applies it to the built Job **before** the Job is POSTed — the same post-render seam `build_resources::apply_resolved_resources` already uses, which is why `job.rs` is untouched.

**3. The launcher actually checks READY** (`djinn-cgroup-launcher`, `djinn-agent-worker`)

* `WorkerReadinessAssertion` carries the worker's protocol: a 17-byte frame (16-byte proof + one `frame_byte`). A 16-byte protocol-less frame does not decode; nor does a `0`/unassigned protocol byte, so a truncated or zeroed frame cannot read as `leaf-v1`.
* `Broker::accept_worker_readiness` compares it against the launcher's own configured protocol and, on disagreement, **drops the connection** and returns `Error::ProtocolMismatch`. `transport::serve_connection` writes the categorized refusal (new `ControlRejection::Protocol`, code 13) and then **ends the serve loop**, so no `BEGIN` or `CREATE` can follow. Before this, `broker.rs:195` took `_assertion: WorkerReadinessAssertion` and discarded the payload entirely.
* The worker reads the same variable in `launcher_handshake` (absent → `leaf-v1`, matching the launcher; present-but-unparseable → fail closed) and passes it to `prepare_worker_readiness`, which now takes the protocol as a required argument so no caller can assert `leaf-v1` by omission.

**There is no `AuthHello`** — the proposal and the `y3ww` roadmap both name one, it has zero hits repo-wide. The seams used are the existing `transport.rs` frames and `WorkerReadinessAssertion`.

**Why the server-side refusal is at render time**: the launcher and worker binaries are copied from the *same* agent-worker image (`dockerfile.rs:276`), so they always agree within an image. The mismatch that matters is server-catalog vs image, so the server refuses to create the Job. The broker check is defence in depth for the in-image case.

## Acceptance criteria, and the mutation each was run against

Every AC's stated mutation was applied and the test re-run; the real failure output is below.

**AC1** — resize-v2 renders `resize-v2`, leaf-v1 renders `leaf-v1`, on `spec.initContainers[name=cgroup-launcher]`.
Mutation: hardcode `leaf-v1` in `apply_launcher_authority_protocol`.
```
the_rendered_launcher_sidecar_carries_the_images_declared_protocol
assertion `left == right` failed: the resize-v2 sidecar must be told it is running resize-v2
  left: Some("leaf-v1")
 right: Some("resize-v2")
```

**AC2** — the broker rejects a mismatched READY before any `CREATE` or `BEGIN`.
Mutation: restore `_assertion: WorkerReadinessAssertion` so the payload is ignored again.
```
a_disagreeing_readiness_is_refused_before_any_begin_or_create
a worker asserting leaf-v1 to a resize-v2 launcher must be refused; accepting it
lets a build run with nobody writing the leaf quota: ()
```

**AC3** — `authority_protocol` survives readback through a **newly constructed** repository.
Mutation: return `None` unconditionally.
```
declared_authority_protocol_survives_readback_through_a_fresh_repository
assertion `left == right` failed: a leaf-v1 image must resolve as leaf-v1, not as a default
  left: None
 right: Some(LeafV1)
```

**AC4** — zero Jobs created when the resolved image has neither a declaration nor a digest. Driven through the real `KubernetesRuntime::prepare` against a recording fake apiserver, because "fails closed" is a claim about objects created, not about a function returning `Err`. The same harness reaches `POST:Job` for a digest-pinned image, so the zero is caused by the refusal and not by an inert test.
Mutation: fall through to a default in `render_authority_protocol`.
```
a_protocol_less_undigested_image_creates_zero_kubernetes_objects
an undeclarable image must create NOTHING, got ["POST:Secret", "POST:Job"]
```

## Deploy note (please read before merging)

A catalog image with **neither** a protocol declaration **nor** a registry digest can no longer dispatch — it is refused at render with zero Jobs created. Images built since #2831 record both. The per-deployment allowlist for legacy digestless images is task `vf7a`, which this task blocks; if the production catalog image predates #2831 and has no `registry_digest`, rebuild it (or land `vf7a`) before deploying.

## Concurrency

`buyp` (#2833, `feat/contain-force-deleted-taskrun-pod`) was still open at branch time, so the `runtime.rs` edit is deliberately minimal — **three hunks**: the image-resolution `match` at ~L514-556 now also produces the protocol, and one `apply_launcher_authority_protocol` guard at ~L797-812 before `create_or_adopt_task_run_job`. Nothing in the Pod deletion/containment paths #2833 owns is touched. `build_pod_permit.rs`, `job.rs`, `deploy/**` and `djinn-coordinator` are untouched. Out of scope as specified: authority-mode fencing (`z3gi`), the legacy digest allowlist (`vf7a`), Kubernetes resize behaviour (`g8jk`).

## Notes

* No new definition of `LauncherAuthorityProtocol` — the one in `djinn-launcher-protocol` is reused everywhere, and #2823's workspace-wide single-definition check still passes.
* No migration, no sqlx macro change (`resolve_dispatch_image` uses the non-macro `sqlx::query` form the module already used), so no `.sqlx` regeneration.
