### PR TITLE
feat(db): enforce authority mode flips with an empty durable drain fence (z3gi)

### DIFF
--- a/server/crates/djinn-db/migrations_postgres/167_launcher_authority_mode.sql
+++ b/server/crates/djinn-db/migrations_postgres/167_launcher_authority_mode.sql
@@ -1,0 +1,67 @@
+-- The server-wide launcher quota-authority mode.
+--
+-- Exactly one component may own a task-run's CPU quota: the launcher's
+-- per-invocation cgroup leaf (`leaf-v1`) or Kubernetes in-place Pod resize
+-- (`resize-v2`). The vocabulary is `djinn_launcher_protocol::
+-- LauncherAuthorityProtocol` — the same two wire forms migration 164 pins for
+-- `build_pod_permits.{observed,effective}_launcher_protocol` and migration 166
+-- pins for `images.launcher_authority_protocol`. There is no third value and no
+-- "both" state: a Pod admitted under a mode it does not declare is refused
+-- before shell dispatch rather than run under two quota writers or none.
+--
+-- WHY THIS IS ITS OWN RELATION AND NOT `admission_handoff`
+--
+-- `admission_handoff` looks like the obvious home: it is already a singleton
+-- authority row with an epoch CAS fence and a `v1_mode`. It is the wrong home
+-- for three independent reasons.
+--
+--   1. It is a DIFFERENT authority. Since PR #2825 the row's `epoch`,
+--      `v1_mode` and `cap` are read by `InvocationLeaseAuthorityRepository` as
+--      the arming authority and reference cap of the PER-INVOCATION cgroup CPU
+--      lease. That answers "is this invocation allowed to lift its own quota".
+--      This relation answers "which component is allowed to write quota at
+--      all". Conflating them puts two unrelated kill switches behind one lock.
+--   2. Its epoch is a shared fence. `set_mode_and_cap` bumps `epoch` on every
+--      write, so an operator moving the lease cap would invalidate an
+--      in-flight authority-mode CAS, and an authority-mode flip would
+--      invalidate an in-flight lease-cap change. Neither operator did anything
+--      wrong; the collision is purely an artifact of sharing a row.
+--   3. The relation is mid-retirement. `phase`, `v0_mode`,
+--      `emergency_ack_epoch` and `invocation_ack_epoch` are dead columns whose
+--      DROP is owned by `flc5` (task `0rld`).
+--      `InvocationLeaseAuthorityRepository` selects exactly `name, epoch,
+--      v1_mode, cap, updated_at` SPECIFICALLY so that DROP is not a breaking
+--      change. A column added here would either be dropped out from under this
+--      feature or would block `flc5`.
+--
+-- The singleton shape below is the `build_pod_permit_pools` / `org_ai_policy`
+-- convention: one literal key, guarded by a CHECK so a second, silently
+-- unread authority row cannot be created by accident.
+CREATE TABLE launcher_authority_mode (
+    mode_key   VARCHAR(32)  NOT NULL PRIMARY KEY,
+    -- The one component permitted to write task-run CPU quota.
+    mode       VARCHAR(32)  NOT NULL,
+    -- Compare-and-swap fence for operator writes, and nothing more. It is not
+    -- an acknowledgement protocol: no reader waits on it and no reader is
+    -- disarmed by it.
+    epoch      BIGINT       NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT launcher_authority_mode_singleton_check
+        CHECK (mode_key = 'global'),
+    CONSTRAINT launcher_authority_mode_mode_check
+        CHECK (mode IN ('leaf-v1', 'resize-v2')),
+    CONSTRAINT launcher_authority_mode_epoch_check
+        CHECK (epoch >= 0)
+);
+
+-- Seeded at `leaf-v1`: the behavior that predates the protocol existing. A
+-- deployment that upgrades into this migration keeps writing launcher leaf
+-- quota exactly as it does today, and moving to `resize-v2` is an explicit,
+-- drain-fenced operator action.
+--
+-- The seed is deliberately part of the migration rather than a startup
+-- fixup. An ABSENT row is not "the default mode"; the repository reports it as
+-- `Uninitialized` and every caller fails closed, because a mode nobody wrote
+-- must never be read as a mode somebody chose.
+INSERT INTO launcher_authority_mode (mode_key, mode) VALUES ('global', 'leaf-v1')
+ON CONFLICT (mode_key) DO NOTHING;

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -136,6 +136,11 @@ pub use repositories::{
     kueue_workload_admission::{
         AdmissionApplied, KueueWorkloadAdmissionRecord, KueueWorkloadAdmissionRepository,
     },
+    launcher_authority_mode::{
+        LauncherAuthorityDrainCensus, LauncherAuthorityModeRepository, LauncherAuthorityModeRow,
+        LauncherProtocolAdmission, SetLauncherAuthorityModeResult,
+        decide_launcher_protocol_admission,
+    },
     legacy_settings_import::{
         LegacySettingsImport, LegacySettingsImportError, LegacySettingsImportResult,
     },

--- a/server/crates/djinn-db/src/repositories/build_pod_permit.rs
+++ b/server/crates/djinn-db/src/repositories/build_pod_permit.rs
@@ -80,6 +80,38 @@ impl BuildPodPermitState {
     }
 }
 
+/// The nonterminal resize/lease lifecycle states introduced by migration 164.
+///
+/// This is the single Rust-side definition of that set. It is deliberately a
+/// `const` rather than six string literals repeated at each use site: the
+/// authority-mode drain fence
+/// ([`crate::repositories::launcher_authority_mode`]) partitions the active
+/// permits on exactly this set, and a seventh resize state added to
+/// [`BuildPodPermitState`] but forgotten in one hand-written `IN (...)` list
+/// would be a Pod that is live, owed a drop, and invisible to the fence that
+/// exists to refuse a flip while it is.
+pub(crate) const NONTERMINAL_RESIZE_STATES: [BuildPodPermitState; 6] = [
+    BuildPodPermitState::BirthConfirmed,
+    BuildPodPermitState::LiftApplying,
+    BuildPodPermitState::Lifted,
+    BuildPodPermitState::DropRequired,
+    BuildPodPermitState::DropApplying,
+    BuildPodPermitState::Quarantined,
+];
+
+/// Render states as a SQL literal list body, e.g. `'lifted', 'quarantined'`.
+///
+/// The spellings come from [`BuildPodPermitState::as_str`], which migration
+/// 164's `build_pod_permits_state_check` already constrains, so a list built
+/// this way cannot drift from the durable vocabulary.
+pub(crate) fn sql_state_list(states: &[BuildPodPermitState]) -> String {
+    states
+        .iter()
+        .map(|state| format!("'{}'", state.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Write-once native-sidecar resize identity for one Pod UID.
 ///
 /// The whole struct is all-or-nothing in the database
@@ -480,10 +512,10 @@ impl BuildPodPermitRepository {
     /// 164.
     pub async fn list_nonterminal_resize(&self) -> DbResult<Vec<BuildPodPermitRow>> {
         self.db.ensure_initialized().await?;
+        let nonterminal = sql_state_list(&NONTERMINAL_RESIZE_STATES);
         sqlx::query_as::<_, DbRow>(&format!(
             "SELECT {ROW_COLUMNS} FROM build_pod_permits \
-             WHERE state IN ('birth_confirmed', 'lift_applying', 'lifted', \
-                             'drop_required', 'drop_applying', 'quarantined') \
+             WHERE state IN ({nonterminal}) \
              ORDER BY acquired_at, task_run_id"
         ))
         .fetch_all(self.db.pool())

--- a/server/crates/djinn-db/src/repositories/launcher_authority_mode.rs
+++ b/server/crates/djinn-db/src/repositories/launcher_authority_mode.rs
@@ -1,0 +1,465 @@
+//! The server-wide launcher quota-authority mode, and the drain fence that
+//! guards every change to it.
+//!
+//! # What this is
+//!
+//! One singleton row (migration 167) naming the single component permitted to
+//! write task-run CPU quota:
+//!
+//! * [`LauncherAuthorityProtocol::LeafV1`] — the launcher owns the birth and
+//!   fenced lift writes on its per-invocation cgroup leaf.
+//! * [`LauncherAuthorityProtocol::ResizeV2`] — Kubernetes in-place Pod resize
+//!   owns the launcher sidecar's `limits.cpu`, and the launcher must never
+//!   write leaf `cpu.max`.
+//!
+//! There is no mode admitting both writers, and none admitting neither. That is
+//! the whole point: [`admit_declared_protocol`] refuses a Pod whose image
+//! declares the other protocol *before* it can dispatch a shell, so a Pod never
+//! runs with two quota authorities or with zero.
+//!
+//! # Why the flip needs a fence at all
+//!
+//! A running Pod's quota authority is fixed at the moment its image was built
+//! and its identity captured. Flipping the server mode under a live Pod does
+//! not migrate it — it strands it: a `leaf-v1` Pod under `resize-v2` authority
+//! has a launcher that already wrote its leaf quota and a server that believes
+//! Kubernetes owns it, and a `resize-v2` Pod under `leaf-v1` authority has
+//! nobody writing quota at all. So a flip is only sound from a fully drained
+//! state, and "drained" must be established transactionally rather than
+//! observed and hoped for.
+//!
+//! # Why the count cannot race
+//!
+//! [`LauncherAuthorityModeRepository::set_mode`] takes the SAME
+//! `build_pod_permit_pools` row lock that
+//! [`crate::BuildPodPermitRepository::acquire`] takes before it counts and
+//! inserts. While the flip transaction is open, no new permit row can come into
+//! existence: a concurrent admission blocks on that lock and only proceeds once
+//! the flip has committed or rolled back. A zero-count observation therefore
+//! cannot be invalidated by a row that appears a microsecond later — which is
+//! the exact shape of the 2026-07-25 wedge in the neighbouring admission
+//! subsystem, where a settle-window read that could not distinguish "measured
+//! empty" from "not measured" was treated as empty.
+//!
+//! Existing rows can still change state under the lock (a capture moves
+//! `job_created` → `birth_confirmed`), so the census is a SINGLE statement over
+//! one snapshot. Two sequential counts could otherwise see a row in neither
+//! bucket, or in both.
+//!
+//! # Reads and errors are never empty
+//!
+//! Every failure mode in this module has its own outcome and none of them is
+//! "drained":
+//!
+//! | situation | outcome |
+//! |---|---|
+//! | singleton row absent | [`SetLauncherAuthorityModeResult::Uninitialized`] |
+//! | pool row / relation missing, query failed, lock timed out | [`SetLauncherAuthorityModeResult::Unavailable`] |
+//! | stale CAS epoch | [`SetLauncherAuthorityModeResult::EpochConflict`] |
+//! | either drain dimension nonzero | [`SetLauncherAuthorityModeResult::DrainNotEmpty`] |
+//!
+//! [`LauncherAuthorityModeRepository::drain_census`] returns `DbResult` rather
+//! than a census, so a caller cannot accidentally read a failed count as zero.
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Postgres, Transaction};
+
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+
+use crate::database::Database;
+use crate::error::{DbError, DbResult};
+use crate::repositories::build_pod_permit::{NONTERMINAL_RESIZE_STATES, sql_state_list};
+
+/// The physical singleton key, guarded by `launcher_authority_mode_singleton_check`.
+const MODE_KEY: &str = "global";
+
+/// The `build_pod_permit_pools` key that migration 162 declares and
+/// [`crate::BuildPodPermitRepository::acquire`] locks. Restated here because
+/// the fence is only real if both transactions contend on the *same* row.
+const PERMIT_POOL_KEY: &str = "global";
+
+const MODE_COLUMNS: &str = "mode, epoch, updated_at::text";
+
+/// The durable authority-mode record.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LauncherAuthorityModeRow {
+    /// The one component permitted to write task-run CPU quota.
+    pub mode: LauncherAuthorityProtocol,
+    /// Compare-and-swap fence for operator writes.
+    pub epoch: i64,
+    /// RFC3339-formatted by PostgreSQL.
+    pub updated_at: String,
+}
+
+/// A bounded, per-dimension census of everything that blocks an authority flip.
+///
+/// The two dimensions partition the active permits exactly — every permit that
+/// is not `released` falls in precisely one — so `pending + nonterminal` is the
+/// total live occupancy and a future lifecycle state cannot land outside both.
+///
+/// This is the typed diagnostic the operational preflight (`xowm`) consumes: it
+/// says not just *that* a flip is blocked but *which* dimension blocks it, so
+/// "a Pod is still scheduled" and "a Pod still owes a drop" are distinguishable
+/// without a second query.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LauncherAuthorityDrainCensus {
+    /// Permits holding capacity without a resize lifecycle: `acquired` and
+    /// `job_created`. A live or pending task-run Pod whose identity has not
+    /// been captured.
+    pub pending_pod_permits: i64,
+    /// Permits in one of the six nonterminal resize/lease lifecycle states from
+    /// migration 164, i.e. a Pod that may still be lifted or still owes a drop.
+    pub nonterminal_resize_leases: i64,
+}
+
+impl LauncherAuthorityDrainCensus {
+    /// Total live occupancy across both dimensions.
+    #[must_use]
+    pub const fn total(self) -> i64 {
+        self.pending_pod_permits + self.nonterminal_resize_leases
+    }
+
+    /// Both dimensions empty. Deliberately an `AND` over the dimensions rather
+    /// than `total() == 0` on a single number, so the predicate reads the same
+    /// way the requirement is stated and a future third dimension has an
+    /// obvious place to be conjoined.
+    #[must_use]
+    pub const fn is_drained(self) -> bool {
+        self.pending_pod_permits == 0 && self.nonterminal_resize_leases == 0
+    }
+}
+
+/// The outcome of one guarded authority-mode compare-and-swap.
+///
+/// Only [`Self::Flipped`] and [`Self::Unchanged`] mean the requested mode is in
+/// effect, and both are only reachable from a transactionally fenced, fully
+/// drained snapshot at the expected epoch.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SetLauncherAuthorityModeResult {
+    /// The mode changed. `previous` is what it changed from.
+    Flipped {
+        row: LauncherAuthorityModeRow,
+        previous: LauncherAuthorityProtocol,
+        drain: LauncherAuthorityDrainCensus,
+    },
+    /// Same-mode replay. Idempotent — no write, no epoch bump — but reached
+    /// only after the same epoch check and the same drain fence a real flip
+    /// passes, so it cannot be used to launder a flip past a live Pod.
+    Unchanged {
+        row: LauncherAuthorityModeRow,
+        drain: LauncherAuthorityDrainCensus,
+    },
+    /// At least one drain dimension is nonzero. The mode is unchanged and
+    /// `drain` names which dimension refused.
+    DrainNotEmpty {
+        row: LauncherAuthorityModeRow,
+        drain: LauncherAuthorityDrainCensus,
+    },
+    /// `expected_epoch` did not match. `row` carries the epoch that did.
+    EpochConflict { row: LauncherAuthorityModeRow },
+    /// The singleton row is absent. Never treated as a default mode.
+    Uninitialized,
+    /// A read, a lock, or the census failed. Never treated as drained.
+    Unavailable,
+}
+
+/// The admission verdict for one Pod's declared launcher protocol.
+///
+/// Only [`Self::Admitted`] may dispatch a shell.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LauncherProtocolAdmission {
+    /// The declared protocol is exactly the configured authority.
+    Admitted { mode: LauncherAuthorityProtocol },
+    /// The image explicitly declares the *other* protocol. Admitting it would
+    /// give the Pod two quota writers or none.
+    ProtocolMismatch {
+        mode: LauncherAuthorityProtocol,
+        declared: LauncherAuthorityProtocol,
+    },
+    /// The stored declaration is not one of the two wire forms. Refused rather
+    /// than defaulted: [`LauncherAuthorityProtocol`] has no fallback arm
+    /// precisely because guessing is an outage in one direction and a silent
+    /// 16x slowdown in the other.
+    UnknownProtocol {
+        mode: LauncherAuthorityProtocol,
+        declared: String,
+    },
+    /// A legacy image built before the handshake existed. Whether an exact,
+    /// signed, immutable digest may map "no declaration" to `leaf-v1` is the
+    /// legacy digest allowlist, owned by `vf7a`. Until that lands this is a
+    /// refusal in BOTH modes, never an admission: an unlisted no-handshake
+    /// image under `resize-v2` runs with no quota authority at all.
+    UndeclaredProtocol { mode: LauncherAuthorityProtocol },
+    /// The authority mode could not be read. Never resolved to a default.
+    AuthorityUnavailable,
+}
+
+impl LauncherProtocolAdmission {
+    #[must_use]
+    pub const fn is_admitted(&self) -> bool {
+        matches!(self, Self::Admitted { .. })
+    }
+}
+
+/// Decide one admission against an already-read authority mode.
+///
+/// Split out from the repository so the decision is a total, side-effect-free
+/// function over its two inputs: the same verdict is reachable from a preflight
+/// that has already read the mode without spending a second round trip, and it
+/// is exhaustively testable without a database.
+#[must_use]
+pub fn decide_launcher_protocol_admission(
+    mode: LauncherAuthorityProtocol,
+    declared: Option<&str>,
+) -> LauncherProtocolAdmission {
+    let Some(declared) = declared else {
+        return LauncherProtocolAdmission::UndeclaredProtocol { mode };
+    };
+    match declared.parse::<LauncherAuthorityProtocol>() {
+        Ok(declared) if declared == mode => LauncherProtocolAdmission::Admitted { mode },
+        Ok(declared) => LauncherProtocolAdmission::ProtocolMismatch { mode, declared },
+        Err(_) => LauncherProtocolAdmission::UnknownProtocol {
+            mode,
+            declared: declared.to_owned(),
+        },
+    }
+}
+
+/// Transactional Postgres repository for the authority-mode singleton.
+pub struct LauncherAuthorityModeRepository {
+    db: Database,
+}
+
+impl LauncherAuthorityModeRepository {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Read the singleton without taking a write lock.
+    ///
+    /// `Ok(None)` means the row is absent, which is not a mode. An unreadable
+    /// relation is an `Err`, never `None`: the two must stay distinguishable or
+    /// a caller would fail closed on one and default on the other.
+    pub async fn read(&self) -> DbResult<Option<LauncherAuthorityModeRow>> {
+        self.db.ensure_initialized().await?;
+        let row = sqlx::query_as::<_, ModeDbRow>(&format!(
+            "SELECT {MODE_COLUMNS} FROM launcher_authority_mode WHERE mode_key = $1"
+        ))
+        .bind(MODE_KEY)
+        .fetch_optional(self.db.pool())
+        .await?;
+        row.map(TryInto::try_into).transpose()
+    }
+
+    /// Count both drain dimensions in one snapshot, without locking.
+    ///
+    /// This is the read-only diagnostic for preflight and board health. It is
+    /// deliberately NOT the fence: an unlocked census is a report about the
+    /// past, and only [`Self::set_mode`] — which holds the permit pool lock
+    /// while it counts — may authorize a flip from one.
+    pub async fn drain_census(&self) -> DbResult<LauncherAuthorityDrainCensus> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        let census = drain_census_tx(&mut tx).await?;
+        tx.commit().await?;
+        Ok(census)
+    }
+
+    /// Compare-and-swap the authority mode behind an empty durable drain fence.
+    ///
+    /// The transaction, in order:
+    ///
+    /// 1. locks the authority singleton `FOR UPDATE`, serializing operators;
+    /// 2. rejects a stale `expected_epoch`;
+    /// 3. locks the `build_pod_permit_pools` singleton `FOR UPDATE` — the same
+    ///    row [`crate::BuildPodPermitRepository::acquire`] locks before it
+    ///    counts and inserts, which is what makes the census below unraceable;
+    /// 4. counts both drain dimensions in ONE statement;
+    /// 5. refuses unless BOTH are zero;
+    /// 6. only then writes, bumping the epoch.
+    ///
+    /// **Lock order is authority row, then permit pool row, and never the
+    /// reverse.** `acquire` takes only the pool lock, so no cycle exists today;
+    /// a future writer that needs both must take them in this order.
+    ///
+    /// The same-mode replay check happens at step 5b, *after* the fence, so an
+    /// operator cannot use a no-op replay to skip the validation a real flip
+    /// requires.
+    ///
+    /// Errors collapse into [`SetLauncherAuthorityModeResult::Unavailable`]
+    /// with the cause logged, matching `acquire`'s fail-closed shape: there is
+    /// no successful fallback for unavailable durable storage.
+    pub async fn set_mode(
+        &self,
+        expected_epoch: i64,
+        next: LauncherAuthorityProtocol,
+    ) -> SetLauncherAuthorityModeResult {
+        match self.set_mode_inner(expected_epoch, next).await {
+            Ok(result) => result,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    requested_mode = next.as_wire(),
+                    expected_epoch,
+                    "launcher authority mode flip unavailable; mode left unchanged"
+                );
+                SetLauncherAuthorityModeResult::Unavailable
+            }
+        }
+    }
+
+    async fn set_mode_inner(
+        &self,
+        expected_epoch: i64,
+        next: LauncherAuthorityProtocol,
+    ) -> DbResult<SetLauncherAuthorityModeResult> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+
+        let current = sqlx::query_as::<_, ModeDbRow>(&format!(
+            "SELECT {MODE_COLUMNS} FROM launcher_authority_mode WHERE mode_key = $1 FOR UPDATE"
+        ))
+        .bind(MODE_KEY)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(current) = current else {
+            tx.commit().await?;
+            return Ok(SetLauncherAuthorityModeResult::Uninitialized);
+        };
+        let current: LauncherAuthorityModeRow = current.try_into()?;
+        if current.epoch != expected_epoch {
+            tx.commit().await?;
+            return Ok(SetLauncherAuthorityModeResult::EpochConflict { row: current });
+        }
+
+        // The fence. Admission cannot insert a permit while this is held.
+        let pool: Option<String> = sqlx::query_scalar(
+            "SELECT pool_key FROM build_pod_permit_pools WHERE pool_key = $1 FOR UPDATE",
+        )
+        .bind(PERMIT_POOL_KEY)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if pool.is_none() {
+            // A missing pool means admission is not serialized by anything this
+            // transaction holds, so the census below would be unfenced. That is
+            // an unavailable fence, not an empty one. `acquire` reaches the same
+            // verdict from the same observation, and for the same reason.
+            return Err(DbError::Internal(
+                "build pod permit global pool is missing; the authority drain fence is unavailable"
+                    .into(),
+            ));
+        }
+
+        // `?`, not a default. A failed count is not a count of zero.
+        //
+        // PostgreSQL happens to defend this a second time — a statement error
+        // aborts the surrounding transaction, so the `UPDATE` below could not
+        // commit even if this propagation were removed — but that is a property
+        // of the engine, not of this function, and it disappears the moment the
+        // census is hoisted out of the flip transaction. Keep the `?`.
+        let drain = drain_census_tx(&mut tx).await?;
+        if !drain.is_drained() {
+            tx.commit().await?;
+            return Ok(SetLauncherAuthorityModeResult::DrainNotEmpty {
+                row: current,
+                drain,
+            });
+        }
+
+        if current.mode == next {
+            tx.commit().await?;
+            return Ok(SetLauncherAuthorityModeResult::Unchanged {
+                row: current,
+                drain,
+            });
+        }
+
+        let updated = sqlx::query_as::<_, ModeDbRow>(&format!(
+            "UPDATE launcher_authority_mode \
+             SET mode = $1, epoch = epoch + 1, updated_at = now() \
+             WHERE mode_key = $2 AND epoch = $3 RETURNING {MODE_COLUMNS}"
+        ))
+        .bind(next.as_wire())
+        .bind(MODE_KEY)
+        .bind(expected_epoch)
+        .fetch_one(&mut *tx)
+        .await?;
+        let row: LauncherAuthorityModeRow = updated.try_into()?;
+        tx.commit().await?;
+        Ok(SetLauncherAuthorityModeResult::Flipped {
+            row,
+            previous: current.mode,
+            drain,
+        })
+    }
+
+    /// Admit or refuse a Pod's declared launcher protocol under the configured
+    /// authority. This is the pre-dispatch rejection point.
+    ///
+    /// A missing singleton row and an unreadable relation both yield
+    /// [`LauncherProtocolAdmission::AuthorityUnavailable`], which is a refusal.
+    pub async fn admit_declared_protocol(
+        &self,
+        declared: Option<&str>,
+    ) -> LauncherProtocolAdmission {
+        match self.read().await {
+            Ok(Some(row)) => decide_launcher_protocol_admission(row.mode, declared),
+            Ok(None) => {
+                tracing::warn!("launcher authority mode is unseeded; refusing protocol admission");
+                LauncherProtocolAdmission::AuthorityUnavailable
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "launcher authority mode unreadable; refusing protocol admission");
+                LauncherProtocolAdmission::AuthorityUnavailable
+            }
+        }
+    }
+}
+
+/// Both drain dimensions from one snapshot of `build_pod_permits`.
+///
+/// `state <> 'released'` is the active predicate migration 162 established;
+/// the `FILTER` split is the migration-164 nonterminal resize set against its
+/// complement, so the two counts partition the active rows exactly.
+async fn drain_census_tx(
+    tx: &mut Transaction<'_, Postgres>,
+) -> DbResult<LauncherAuthorityDrainCensus> {
+    let nonterminal = sql_state_list(&NONTERMINAL_RESIZE_STATES);
+    let (pending, resize): (i64, i64) = sqlx::query_as(&format!(
+        "SELECT \
+           count(*) FILTER (WHERE state NOT IN ({nonterminal}))::bigint, \
+           count(*) FILTER (WHERE state IN ({nonterminal}))::bigint \
+         FROM build_pod_permits WHERE state <> 'released'"
+    ))
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok(LauncherAuthorityDrainCensus {
+        pending_pod_permits: pending,
+        nonterminal_resize_leases: resize,
+    })
+}
+
+#[derive(sqlx::FromRow)]
+struct ModeDbRow {
+    mode: String,
+    epoch: i64,
+    updated_at: String,
+}
+
+impl TryFrom<ModeDbRow> for LauncherAuthorityModeRow {
+    type Error = DbError;
+
+    fn try_from(row: ModeDbRow) -> DbResult<Self> {
+        Ok(Self {
+            // No fallback to the enum's `Default`. A value the migration's
+            // CHECK should have made impossible is corruption, and reading it
+            // as `leaf-v1` would silently re-arm the launcher under a server
+            // that believes resize owns quota.
+            mode: row.mode.parse().map_err(|_| {
+                DbError::InvalidData(format!("invalid launcher authority mode `{}`", row.mode))
+            })?,
+            epoch: row.epoch,
+            updated_at: row.updated_at,
+        })
+    }
+}

--- a/server/crates/djinn-db/src/repositories/mod.rs
+++ b/server/crates/djinn-db/src/repositories/mod.rs
@@ -21,6 +21,7 @@ pub mod image;
 pub mod init;
 pub mod invocation_lease_authority;
 pub mod kueue_workload_admission;
+pub mod launcher_authority_mode;
 pub mod legacy_settings_import;
 pub mod liveness;
 pub mod llm_call_attempt;

--- a/server/crates/djinn-db/tests/launcher_authority_mode_drain_fence.rs
+++ b/server/crates/djinn-db/tests/launcher_authority_mode_drain_fence.rs
@@ -1,0 +1,620 @@
+//! The authority-mode flip, its drain fence, and the pre-dispatch admission
+//! point — against real PostgreSQL.
+//!
+//! Every fence test here runs on `Database::ephemeral()`, a real migrated
+//! Postgres database. None of them substitutes a fake or in-memory repository
+//! for the thing under test: the property being asserted is that a `FOR UPDATE`
+//! row lock serializes two transactions, and no fake can be wrong about that in
+//! the way production would be.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use djinn_db::{
+    AcquireBuildPodPermitResult, BindBuildPodPermitResult, BuildPodPermitRepository,
+    BuildPodResizeIdentity, CaptureBuildPodResizeIdentityResult, Database,
+    LauncherAuthorityDrainCensus, LauncherAuthorityModeRepository, LauncherProtocolAdmission,
+    SetLauncherAuthorityModeResult, decide_launcher_protocol_admission,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+
+const LEAF: LauncherAuthorityProtocol = LauncherAuthorityProtocol::LeafV1;
+const RESIZE: LauncherAuthorityProtocol = LauncherAuthorityProtocol::ResizeV2;
+
+/// Seed the FK chain `users -> projects -> tasks -> task_runs` so real permit
+/// rows can exist. `build_pod_permits.task_run_id` is a restricted foreign key,
+/// so a drain dimension cannot be faked by inserting a bare row.
+async fn seed_runs(db: &Database, ids: &[&str]) {
+    db.ensure_initialized().await.unwrap();
+    let pool = db.pool();
+    sqlx::query(
+        "INSERT INTO users (id, github_id, github_login) \
+         VALUES ('00000000-0000-7000-8000-000000000167', 9000000167, 'authority-mode-fence')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO projects (id, name, github_owner, github_repo) \
+         VALUES ('authority-mode-project', 'authority-mode-project', 'djinnos', 'authority-mode')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    for (index, id) in ids.iter().enumerate() {
+        let task_id = format!("authority-mode-task-{index}");
+        sqlx::query(
+            "INSERT INTO tasks \
+             (id, project_id, short_id, title, description, design, labels, acceptance_criteria, memory_refs, created_by_user_id) \
+             VALUES ($1, 'authority-mode-project', $2, 'title', 'description', 'design', \
+                     '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '00000000-0000-7000-8000-000000000167')",
+        )
+        .bind(&task_id)
+        .bind(format!("auth-{index}"))
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO task_runs (id, project_id, task_id, trigger_type, status) \
+             VALUES ($1, 'authority-mode-project', $2, 'manual', 'running')",
+        )
+        .bind(id)
+        .bind(&task_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+fn resize_identity(pod_uid: &str, protocol: LauncherAuthorityProtocol) -> BuildPodResizeIdentity {
+    BuildPodResizeIdentity {
+        pod_namespace: "djinn".into(),
+        pod_name: format!("pod-{pod_uid}"),
+        pod_uid: pod_uid.into(),
+        launcher_container_name: "cgroup-launcher".into(),
+        launcher_container_id: format!("containerd://{pod_uid}"),
+        image_digest: "sha256:0123456789abcdef".into(),
+        observed_launcher_protocol: protocol.as_wire().into(),
+        effective_launcher_protocol: protocol.as_wire().into(),
+        admitted_cpu_millicores: 4000,
+    }
+}
+
+/// Drive one permit all the way into a nonterminal resize state, which is drain
+/// dimension two.
+async fn park_in_nonterminal_resize(
+    permits: &BuildPodPermitRepository,
+    task_run_id: &str,
+    pod_uid: &str,
+) {
+    let row = match permits.acquire(task_run_id, 8).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        outcome => panic!("expected an acquired permit, got {outcome:?}"),
+    };
+    assert!(matches!(
+        permits
+            .bind_or_refresh_job_uid(task_run_id, &row.permit_id, row.fencing_token, "job-uid")
+            .await
+            .unwrap(),
+        BindBuildPodPermitResult::Bound(_)
+    ));
+    assert!(matches!(
+        permits
+            .capture_resize_identity(
+                task_run_id,
+                &row.permit_id,
+                row.fencing_token,
+                &resize_identity(pod_uid, RESIZE),
+            )
+            .await
+            .unwrap(),
+        CaptureBuildPodResizeIdentityResult::Captured(_)
+    ));
+}
+
+async fn current(modes: &LauncherAuthorityModeRepository) -> (LauncherAuthorityProtocol, i64) {
+    let row = modes
+        .read()
+        .await
+        .unwrap()
+        .expect("migration 167 seeds the singleton");
+    (row.mode, row.epoch)
+}
+
+/// Activation then rollback, each from a drained snapshot, each bumping the CAS
+/// fence exactly once.
+///
+/// MUTATION: drop `epoch = epoch + 1` from the `UPDATE` in `set_mode_inner` and
+/// the epoch assertions fail — a flip that does not move the fence lets a stale
+/// operator write replay on top of it.
+#[tokio::test]
+async fn flip_forward_then_roll_back_from_a_drained_snapshot() {
+    let db = Database::ephemeral().await.unwrap();
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+
+    // Migration 167 seeds the pre-existing behavior, never the new one.
+    let (mode, epoch) = current(&modes).await;
+    assert_eq!(
+        mode, LEAF,
+        "a fresh deployment must keep launcher authority"
+    );
+    assert_eq!(epoch, 0);
+
+    // leaf-v1 -> resize-v2 (activation).
+    let flipped = modes.set_mode(epoch, RESIZE).await;
+    let SetLauncherAuthorityModeResult::Flipped {
+        row,
+        previous,
+        drain,
+    } = flipped
+    else {
+        panic!("expected a flip from a drained snapshot, got {flipped:?}");
+    };
+    assert_eq!(previous, LEAF);
+    assert_eq!(row.mode, RESIZE);
+    assert_eq!(row.epoch, 1);
+    assert_eq!(drain, LauncherAuthorityDrainCensus::default());
+    assert!(drain.is_drained() && drain.total() == 0);
+    assert_eq!(current(&modes).await, (RESIZE, 1));
+
+    // resize-v2 -> leaf-v1 (rollback), from the epoch the flip left behind.
+    let rolled_back = modes.set_mode(1, LEAF).await;
+    let SetLauncherAuthorityModeResult::Flipped { row, previous, .. } = rolled_back else {
+        panic!("expected a rollback, got {rolled_back:?}");
+    };
+    assert_eq!(previous, RESIZE);
+    assert_eq!(row.mode, LEAF);
+    assert_eq!(row.epoch, 2);
+    assert_eq!(current(&modes).await, (LEAF, 2));
+
+    // The fence is a fence in both directions: replaying the activation at the
+    // now-stale epoch is refused and changes nothing.
+    let stale = modes.set_mode(1, RESIZE).await;
+    let SetLauncherAuthorityModeResult::EpochConflict { row } = stale else {
+        panic!("expected a stale-epoch refusal, got {stale:?}");
+    };
+    assert_eq!(row.epoch, 2);
+    assert_eq!(current(&modes).await, (LEAF, 2));
+}
+
+/// A same-mode replay is idempotent — but only after passing the identical
+/// epoch check and drain fence a real flip passes.
+///
+/// MUTATION: hoist the `current.mode == next` early return above the drain
+/// census in `set_mode_inner` and the second half of this test fails: the
+/// replay returns `Unchanged` while a live permit is still occupying the pool,
+/// which is precisely the "validation bypassed by a no-op" hole.
+#[tokio::test]
+async fn same_mode_replay_is_idempotent_but_never_skips_the_fence() {
+    let db = Database::ephemeral().await.unwrap();
+    seed_runs(&db, &["replay-occupant"]).await;
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    let permits = BuildPodPermitRepository::new(db.clone());
+
+    // Drained: the replay is a no-op that neither writes nor bumps the epoch.
+    let replay = modes.set_mode(0, LEAF).await;
+    let SetLauncherAuthorityModeResult::Unchanged { row, drain } = replay else {
+        panic!("expected an idempotent replay, got {replay:?}");
+    };
+    assert_eq!(row.mode, LEAF);
+    assert_eq!(row.epoch, 0, "an idempotent replay must not move the fence");
+    assert!(drain.is_drained());
+    assert_eq!(current(&modes).await, (LEAF, 0));
+
+    // Occupied: the SAME no-op request is now refused with the same verdict a
+    // real flip would get.
+    assert!(matches!(
+        permits.acquire("replay-occupant", 8).await,
+        AcquireBuildPodPermitResult::Acquired { .. }
+    ));
+    let blocked = modes.set_mode(0, LEAF).await;
+    let SetLauncherAuthorityModeResult::DrainNotEmpty { row, drain } = blocked else {
+        panic!("a replay must not bypass the drain fence, got {blocked:?}");
+    };
+    assert_eq!(row.mode, LEAF);
+    assert_eq!(drain.pending_pod_permits, 1);
+    assert_eq!(current(&modes).await, (LEAF, 0));
+}
+
+/// Drain dimension one — a live task-run Pod holding a permit with no resize
+/// lifecycle — blocks a flip on its own, with dimension two at zero.
+///
+/// MUTATION: weaken `LauncherAuthorityDrainCensus::is_drained` to
+/// `self.nonterminal_resize_leases == 0` and this flip succeeds while a
+/// scheduled Pod is still live.
+#[tokio::test]
+async fn a_pending_pod_permit_alone_refuses_the_flip() {
+    let db = Database::ephemeral().await.unwrap();
+    seed_runs(&db, &["pending-acquired", "pending-bound"]).await;
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    let permits = BuildPodPermitRepository::new(db.clone());
+
+    // `acquired` — a permit taken before the Job exists.
+    assert!(matches!(
+        permits.acquire("pending-acquired", 8).await,
+        AcquireBuildPodPermitResult::Acquired { .. }
+    ));
+    // `job_created` — a Job observed, no resize identity captured yet.
+    let bound = match permits.acquire("pending-bound", 8).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        outcome => panic!("unexpected outcome: {outcome:?}"),
+    };
+    assert!(matches!(
+        permits
+            .bind_or_refresh_job_uid(
+                "pending-bound",
+                &bound.permit_id,
+                bound.fencing_token,
+                "job-uid"
+            )
+            .await
+            .unwrap(),
+        BindBuildPodPermitResult::Bound(_)
+    ));
+
+    let census = modes.drain_census().await.unwrap();
+    assert_eq!(
+        census,
+        LauncherAuthorityDrainCensus {
+            pending_pod_permits: 2,
+            nonterminal_resize_leases: 0,
+        },
+        "dimension one must be nonzero with dimension two independently at zero"
+    );
+
+    let refused = modes.set_mode(0, RESIZE).await;
+    let SetLauncherAuthorityModeResult::DrainNotEmpty { drain, .. } = refused else {
+        panic!("expected the flip to be refused, got {refused:?}");
+    };
+    assert_eq!(drain.pending_pod_permits, 2);
+    assert_eq!(drain.nonterminal_resize_leases, 0);
+    assert_eq!(
+        current(&modes).await,
+        (LEAF, 0),
+        "a refused flip must not change the mode or the fence"
+    );
+}
+
+/// Drain dimension two — a nonterminal resize/lease lifecycle row — blocks a
+/// flip on its own, with dimension one at zero.
+///
+/// MUTATION: weaken `is_drained` to `self.pending_pod_permits == 0` and this
+/// flip succeeds while a Pod still owes a drop. Equivalently, delete a state
+/// from `NONTERMINAL_RESIZE_STATES` and the row silently reclassifies into
+/// dimension one, which this test's exact-census assertion also catches.
+#[tokio::test]
+async fn a_nonterminal_resize_lease_alone_refuses_the_flip() {
+    let db = Database::ephemeral().await.unwrap();
+    seed_runs(&db, &["resize-occupant"]).await;
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    let permits = BuildPodPermitRepository::new(db.clone());
+
+    park_in_nonterminal_resize(&permits, "resize-occupant", "pod-uid-a").await;
+
+    let census = modes.drain_census().await.unwrap();
+    assert_eq!(
+        census,
+        LauncherAuthorityDrainCensus {
+            pending_pod_permits: 0,
+            nonterminal_resize_leases: 1,
+        },
+        "dimension two must be nonzero with dimension one independently at zero"
+    );
+    assert!(!census.is_drained());
+
+    let refused = modes.set_mode(0, RESIZE).await;
+    let SetLauncherAuthorityModeResult::DrainNotEmpty { drain, .. } = refused else {
+        panic!("expected the flip to be refused, got {refused:?}");
+    };
+    assert_eq!(drain.pending_pod_permits, 0);
+    assert_eq!(drain.nonterminal_resize_leases, 1);
+    assert_eq!(current(&modes).await, (LEAF, 0));
+
+    // Draining that dimension — an explicit fenced release — reopens the flip.
+    let row = permits.active("resize-occupant").await.unwrap().unwrap();
+    permits
+        .release(
+            "resize-occupant",
+            &row.permit_id,
+            row.fencing_token,
+            "drained",
+        )
+        .await
+        .unwrap();
+    assert!(modes.drain_census().await.unwrap().is_drained());
+    assert!(matches!(
+        modes.set_mode(0, RESIZE).await,
+        SetLauncherAuthorityModeResult::Flipped { .. }
+    ));
+}
+
+/// The fence is transactional, not a lucky call order.
+///
+/// A concurrent admission holds the `build_pod_permit_pools` row lock — exactly
+/// what `BuildPodPermitRepository::acquire` holds while it counts and inserts —
+/// and inserts a permit without committing. The flip must not be able to
+/// observe a zero census in that window; it must block on the same lock and,
+/// once admission commits, see the row.
+///
+/// MUTATION: remove `FOR UPDATE` from the pool `SELECT` in `set_mode_inner`.
+/// The flip then completes immediately inside the window, the
+/// `tokio::time::timeout` returns `Ok`, and this test fails on the "must not
+/// have completed" assertion — the flip having committed a mode change over a
+/// task-run Pod that was already being admitted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_concurrent_admission_cannot_be_raced_by_a_zero_count() {
+    let db = Database::ephemeral().await.unwrap();
+    seed_runs(&db, &["racing-admission"]).await;
+    let modes = Arc::new(LauncherAuthorityModeRepository::new(db.clone()));
+
+    assert!(
+        modes.drain_census().await.unwrap().is_drained(),
+        "the race starts from a genuinely empty pool"
+    );
+
+    // Stand in for an in-flight `acquire`: same lock, same insert, uncommitted.
+    let mut admission = db.pool().begin().await.unwrap();
+    sqlx::query("SELECT pool_key FROM build_pod_permit_pools WHERE pool_key = 'global' FOR UPDATE")
+        .execute(&mut *admission)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO build_pod_permits (task_run_id) VALUES ('racing-admission')")
+        .execute(&mut *admission)
+        .await
+        .unwrap();
+
+    let mut flip = tokio::spawn({
+        let modes = Arc::clone(&modes);
+        async move { modes.set_mode(0, RESIZE).await }
+    });
+
+    // The flip must be BLOCKED, not merely late. An unfenced read would have
+    // committed a mode change several orders of magnitude faster than this.
+    if let Ok(joined) = tokio::time::timeout(Duration::from_millis(750), &mut flip).await {
+        panic!(
+            "the flip observed the pool without waiting on the admission lock and returned {:?}",
+            joined.unwrap()
+        );
+    }
+
+    // Release the lock; the already-blocked flip now proceeds and must see the
+    // row that was invisible to it a moment ago.
+    admission.commit().await.unwrap();
+    let flip = tokio::time::timeout(Duration::from_secs(15), flip)
+        .await
+        .expect("the flip must proceed once the admission lock is released")
+        .unwrap();
+
+    let SetLauncherAuthorityModeResult::DrainNotEmpty { drain, .. } = flip else {
+        panic!("the committed admission must refuse the flip, got {flip:?}");
+    };
+    assert_eq!(drain.pending_pod_permits, 1);
+    assert_eq!(
+        current(&modes).await,
+        (LEAF, 0),
+        "no mode change may survive a raced admission"
+    );
+}
+
+/// A repository error is never an empty drain.
+///
+/// MUTATION A: make `drain_census` swallow its error (`.unwrap_or_default()`).
+/// The preflight diagnostic then reports a fully drained pool for a relation it
+/// could not read, and the `is_err()` assertion below fails.
+///
+/// MUTATION B: drop the `pool.is_none()` guard in `set_mode_inner`. The flip
+/// then commits against a fence it never actually held — the third block below
+/// fails with `Flipped` where `Unavailable` is required.
+///
+/// Note on what this test does NOT prove on its own: replacing the `?` on
+/// `drain_census_tx` INSIDE `set_mode_inner` with `.unwrap_or_default()` is
+/// survivable, because a failed statement aborts the enclosing PostgreSQL
+/// transaction and the subsequent `UPDATE` errors anyway. That is defense in
+/// depth from the engine, not from the code, and it evaporates if the census is
+/// ever hoisted out of the flip transaction. The `?` is load-bearing for that
+/// future, and the comment at the call site says so.
+#[tokio::test]
+async fn an_unreadable_permit_relation_is_unavailable_and_never_drained() {
+    let db = Database::ephemeral().await.unwrap();
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    assert!(modes.drain_census().await.unwrap().is_drained());
+
+    sqlx::query("DROP TABLE build_pod_permits CASCADE")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    // The read-only diagnostic surfaces the failure as an error, never as a
+    // zero census a caller could mistake for "drained".
+    assert!(
+        modes.drain_census().await.is_err(),
+        "an unreadable census must not resolve to zero"
+    );
+    assert_eq!(
+        modes.set_mode(0, RESIZE).await,
+        SetLauncherAuthorityModeResult::Unavailable
+    );
+    assert_eq!(current(&modes).await, (LEAF, 0));
+
+    // The pool relation is the fence itself; losing it is equally unavailable.
+    let db = Database::ephemeral().await.unwrap();
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    BuildPodPermitRepository::new(db.clone())
+        .drop_pool_relation_for_test()
+        .await
+        .unwrap();
+    assert_eq!(
+        modes.set_mode(0, RESIZE).await,
+        SetLauncherAuthorityModeResult::Unavailable
+    );
+    assert_eq!(current(&modes).await, (LEAF, 0));
+
+    // A present relation with no singleton row is also unfenced, not empty.
+    let db = Database::ephemeral().await.unwrap();
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    BuildPodPermitRepository::new(db.clone())
+        .delete_global_pool_for_test()
+        .await
+        .unwrap();
+    assert_eq!(
+        modes.set_mode(0, RESIZE).await,
+        SetLauncherAuthorityModeResult::Unavailable
+    );
+    assert_eq!(current(&modes).await, (LEAF, 0));
+}
+
+/// An absent authority row is not a default mode.
+///
+/// MUTATION: have `TryFrom<ModeDbRow>` or the `None` arm fall back to
+/// `LauncherAuthorityProtocol::default()` and an unseeded deployment silently
+/// admits `leaf-v1` Pods and flips without ever having been configured.
+#[tokio::test]
+async fn an_absent_authority_row_is_uninitialized_not_a_default() {
+    let db = Database::ephemeral().await.unwrap();
+    db.ensure_initialized().await.unwrap();
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    sqlx::query("DELETE FROM launcher_authority_mode WHERE mode_key = 'global'")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    assert_eq!(modes.read().await.unwrap(), None);
+    assert_eq!(
+        modes.set_mode(0, RESIZE).await,
+        SetLauncherAuthorityModeResult::Uninitialized
+    );
+    assert_eq!(
+        modes.admit_declared_protocol(Some(LEAF.as_wire())).await,
+        LauncherProtocolAdmission::AuthorityUnavailable
+    );
+
+    // An unreadable relation is likewise a refusal, not an admission.
+    sqlx::query("DROP TABLE launcher_authority_mode")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    assert!(modes.read().await.is_err());
+    assert_eq!(
+        modes.admit_declared_protocol(Some(RESIZE.as_wire())).await,
+        LauncherProtocolAdmission::AuthorityUnavailable
+    );
+}
+
+/// The pre-dispatch admission point, read through the durable mode.
+///
+/// MUTATION: relax `decide_launcher_protocol_admission` so a mismatch or an
+/// unparseable declaration falls through to `Admitted`, and the accumulated
+/// list below names every input that was let through.
+#[tokio::test]
+async fn admission_admits_exactly_the_configured_authority() {
+    let db = Database::ephemeral().await.unwrap();
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+
+    // Under leaf authority.
+    assert_eq!(
+        modes.admit_declared_protocol(Some("leaf-v1")).await,
+        LauncherProtocolAdmission::Admitted { mode: LEAF }
+    );
+    assert_eq!(
+        modes.admit_declared_protocol(Some("resize-v2")).await,
+        LauncherProtocolAdmission::ProtocolMismatch {
+            mode: LEAF,
+            declared: RESIZE,
+        }
+    );
+
+    // Under resize authority, after a real fenced flip.
+    assert!(matches!(
+        modes.set_mode(0, RESIZE).await,
+        SetLauncherAuthorityModeResult::Flipped { .. }
+    ));
+    assert_eq!(
+        modes.admit_declared_protocol(Some("resize-v2")).await,
+        LauncherProtocolAdmission::Admitted { mode: RESIZE }
+    );
+    assert_eq!(
+        modes.admit_declared_protocol(Some("leaf-v1")).await,
+        LauncherProtocolAdmission::ProtocolMismatch {
+            mode: RESIZE,
+            declared: LEAF,
+        }
+    );
+
+    // Nothing outside the closed set is ever admitted, in either mode. The
+    // near-misses are what a Job template, a shell, or a YAML scalar actually
+    // produces.
+    let mut admitted = Vec::new();
+    for mode in LauncherAuthorityProtocol::ALL {
+        for declared in [
+            None,
+            Some(""),
+            Some(" "),
+            Some("leafv1"),
+            Some("LEAF-V1"),
+            Some("leaf_v1"),
+            Some("resize-v3"),
+            Some("RESIZE-V2"),
+            Some(" leaf-v1"),
+            Some("resize-v2 "),
+            Some("leaf-v1,resize-v2"),
+            Some("unknown-v3"),
+        ] {
+            let verdict = decide_launcher_protocol_admission(mode, declared);
+            if verdict.is_admitted() {
+                admitted.push((mode, declared));
+            }
+            match (declared, &verdict) {
+                (None, LauncherProtocolAdmission::UndeclaredProtocol { .. }) => {}
+                (Some(raw), LauncherProtocolAdmission::UnknownProtocol { declared, .. }) => {
+                    assert_eq!(declared, raw, "the refusal must name the offending value");
+                }
+                (declared, verdict) => {
+                    panic!("{declared:?} under {mode} produced an unexpected verdict {verdict:?}")
+                }
+            }
+        }
+    }
+    assert!(
+        admitted.is_empty(),
+        "{} malformed or absent declarations were admitted: {admitted:?}",
+        admitted.len()
+    );
+}
+
+/// Migration 167's `CHECK ... IN (...)` list is derived from, and must equal,
+/// [`LauncherAuthorityProtocol::ALL`].
+///
+/// MUTATION: add a third variant to the enum without teaching migration 167
+/// about it and this fails here, rather than in production on the first `CHECK`
+/// violation from an operator flipping to a mode the database refuses to store.
+#[test]
+fn migration_167_constrains_exactly_the_protocol_wire_forms() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations_postgres/167_launcher_authority_mode.sql");
+    let sql = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("migration 167 must be readable at {path:?}: {error}"));
+
+    let needle = "mode IN (";
+    let start = sql
+        .find(needle)
+        .expect("migration 167 must constrain `mode` with an IN list")
+        + needle.len();
+    let end = start + sql[start..].find(')').expect("the IN list must be closed");
+    let mut constrained: Vec<String> = sql[start..end]
+        .split(',')
+        .map(|value| value.trim().trim_matches('\'').to_owned())
+        .collect();
+    constrained.sort();
+
+    let mut expected: Vec<String> = LauncherAuthorityProtocol::ALL
+        .iter()
+        .map(|protocol| protocol.as_wire().to_owned())
+        .collect();
+    expected.sort();
+
+    assert_eq!(constrained, expected);
+    assert!(
+        sql.contains("VALUES ('global', 'leaf-v1')"),
+        "the seed must be the pre-existing launcher behavior, never the new one"
+    );
+}


### PR DESCRIPTION
Implements board task `z3gi` (epic `y3ww`, proposal `3i92`).

A typed, persisted server authority mode selecting **exactly one** quota writer — `leaf-v1` launcher leaf quota or `resize-v2` Pod resize — whose every change is transactional and fails closed unless *both* drain dimensions are empty.

## Where the mode lives, and why not in `admission_handoff`

New singleton relation `launcher_authority_mode` (migration **167**), seeded at `leaf-v1` — the behavior that predates the protocol existing, so a deployment that upgrades into this migration keeps writing launcher leaf quota exactly as it does today.

`admission_handoff` looks like the obvious home and is the wrong one, for three independent reasons the migration records in full:

1. **It is a different authority.** Since #2825 that row's `epoch`, `v1_mode` and `cap` are read by `InvocationLeaseAuthorityRepository` as the arming authority and reference cap of the **per-invocation cgroup CPU lease** — "may this invocation lift its own quota". This relation answers "which component may write quota at all".
2. **Its epoch is a shared fence.** `set_mode_and_cap` bumps `epoch` on every write, so an operator moving the lease cap would invalidate an in-flight authority-mode CAS and vice versa. Neither operator did anything wrong; the collision is pure row-sharing.
3. **It is mid-retirement.** `InvocationLeaseAuthorityRepository` selects exactly `name, epoch, v1_mode, cap, updated_at` *specifically* so `flc5`'s (task `0rld`) DROP of the retired columns is not a breaking change. A column added there would be moved out from under this feature, or would block `flc5`.

The vocabulary is `djinn_launcher_protocol::LauncherAuthorityProtocol` from `ydpj-A` — no second definition. A test derives migration 167's `CHECK ... IN (...)` list from `LauncherAuthorityProtocol::ALL`, so a third variant cannot be added without teaching the database about it.

## The fence

`LauncherAuthorityModeRepository::set_mode`, in one transaction:

1. lock the authority singleton `FOR UPDATE` — serializes operators;
2. reject a stale CAS `expected_epoch`;
3. lock the `build_pod_permit_pools` singleton `FOR UPDATE` — **the same row `BuildPodPermitRepository::acquire` locks before it counts and inserts**;
4. census both drain dimensions in **one** statement;
5. refuse unless **both** are zero;
6. only then write, bumping the epoch.

Step 3 is what makes step 4 unraceable. While the flip transaction is open, no new permit row can come into existence: a concurrent admission blocks on that lock and proceeds only once the flip has committed or rolled back. A zero-count observation therefore cannot be invalidated by a row that appears a microsecond later — which is the exact shape of the 2026-07-25 wedge in the neighbouring admission subsystem, where a read that could not distinguish "measured empty" from "not measured" was treated as empty.

Existing rows *can* still change state under that lock (a capture moves `job_created` → `birth_confirmed`), so the census is a single statement over one snapshot; two sequential counts could see a row in neither bucket or in both.

Lock order is **authority row, then permit pool row, never the reverse**. `acquire` takes only the pool lock, so no cycle exists today; the invariant is stated at the call site for the next writer that needs both.

## Two independently nonzero dimensions

The dimensions partition the active permits exactly:

| dimension | states | meaning |
|---|---|---|
| `pending_pod_permits` | `acquired`, `job_created` | a live/pending task-run Pod holding a permit, identity not captured |
| `nonterminal_resize_leases` | the six migration-164 resize states | a Pod that may still be lifted or still owes a drop |

Their sum is total live occupancy and no future lifecycle state can fall outside both. Each is independently nonzero and independently refuses a flip. The nonterminal set is now a single `const` in `build_pod_permit.rs` rather than a hand-written `IN (...)` list per use site — a seventh resize state added to the enum but forgotten in one list would otherwise be a Pod that is live, owed a drop, and invisible to the fence that exists to refuse a flip while it is.

Reuses `BuildPodPermitRepository` and `4acu`'s identity lifecycle. **No parallel occupancy table.**

## No read or error is ever empty

| situation | outcome |
|---|---|
| singleton row absent | `Uninitialized` |
| pool row/relation missing, query failed, lock timed out | `Unavailable` |
| stale CAS epoch | `EpochConflict` |
| either dimension nonzero | `DrainNotEmpty` |

`drain_census()` returns `DbResult`, so a failed count cannot be read as zero. `TryFrom<ModeDbRow>` refuses an unknown durable spelling rather than falling back to `LauncherAuthorityProtocol::default()`, which would silently re-arm the launcher under a server that believes resize owns quota.

Same-mode replay is idempotent — no write, no epoch bump — but the check sits **after** the epoch check and the drain fence, so a no-op cannot launder a flip past a live Pod.

## Admission

`decide_launcher_protocol_admission(mode, declared)` is the pre-dispatch rejection point, also reachable as `LauncherAuthorityModeRepository::admit_declared_protocol` which reads the durable mode:

- explicit `leaf-v1` admits only under leaf authority; explicit `resize-v2` only under resize authority;
- an unparseable declaration is `UnknownProtocol` and names the offending value — never defaulted, because `LauncherAuthorityProtocol` has no fallback arm precisely because guessing is an outage in one direction and a silent 16x slowdown in the other;
- an **absent** declaration is `UndeclaredProtocol`, a refusal in both modes. Whether an exact signed immutable digest may map "no declaration" to `leaf-v1` is the legacy allowlist owned by `vf7a`; refusing is the fail-closed placeholder, not a guess;
- an unreadable or unseeded authority is `AuthorityUnavailable`.

`LauncherAuthorityDrainCensus` is the typed diagnostic `xowm`'s stock-chart preflight consumes: it says *which* dimension blocks a flip, not merely that one does.

## Reachability, stated plainly

This lands the persistence, the guarded CAS, and the typed decision function. It is **not** wired into the Kubernetes dispatch path, and that is deliberate rather than an oversight: the wiring sites (`djinn-k8s/src/runtime.rs`, `djinn-db/.../project.rs`'s `DispatchImage`) are held by `fi2k` right now, and the decision is not yet total for real dispatch until `vf7a` supplies the legacy digest allowlist. `g8jk`/`xowm` are the consumers. Everything here is exercised end-to-end against real PostgreSQL.

## Out of scope

Kubernetes resize PATCH/status confirmation (`g8jk` — `b62u`/#2830 already landed the limits-only client), recovery retries (`0ppk`), the operational preflight (`xowm`), the legacy digest allowlist (`vf7a`).

## Testing

Nine tests on `Database::ephemeral()` — real migrated PostgreSQL, no `Fake`/`Mock` for the thing under test. The concurrency case uses a real transactional fence, not a chosen call order: it holds the permit pool lock with an uncommitted insert and asserts the flip is *blocked*, then sees the row once the lock releases.

Every test was verified by mutating the source and observing it fail:

| mutation | test | real failure |
|---|---|---|
| remove `epoch = epoch + 1` | flip/rollback | `left: 0, right: 1` |
| hoist same-mode return above the census | replay | `a replay must not bypass the drain fence, got Unchanged { ... }` |
| `is_drained` ignores pending permits | dimension one | `expected the flip to be refused, got Flipped { ... pending_pod_permits: 2 }` |
| `is_drained` ignores resize leases | dimension two | `assertion failed: !census.is_drained()` |
| drop `FOR UPDATE` on the pool row | concurrency | `the flip observed the pool without waiting on the admission lock and returned Flipped { ... }` |
| `drain_census` swallows its error | unavailable | `an unreadable census must not resolve to zero` |
| missing pool row treated as fenced | unavailable | `left: Flipped { ... }, right: Unavailable` |
| absent singleton falls back to default | uninitialized | `left: EpochConflict { ... }, right: Uninitialized` |
| admission falls through to `Admitted` | admission matrix | `left: Admitted { mode: LeafV1 }, right: ProtocolMismatch { ... }` |

One negative result worth recording: replacing the `?` on `drain_census_tx` **inside** `set_mode_inner` with `.unwrap_or_default()` is survivable, because a failed statement aborts the enclosing PostgreSQL transaction and the subsequent `UPDATE` errors anyway. That is defense in depth from the engine, not from the code, and it evaporates the moment the census is hoisted out of the flip transaction. The `?` is kept and the call site says why; the two mutations that *are* caught cover the same property from the diagnostic path and the pool guard.

Full `cargo test -p djinn-db`: **1168 unit + all integration targets pass**, no failures. `cargo clippy -p djinn-db --all-targets` clean, `cargo check --workspace --all-targets` clean, `check-raw-sql-boundary.sh` clean, `rustfmt --edition 2024` on every changed file. No `sqlx::query!` macros were added, so `server/.sqlx/` is unchanged. Migration numbering is contiguous at 167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
