### PR TITLE
fix(slot): downgrade read coverage when the turn budget re-externalizes a result

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/reply_loop/mod.rs
+++ b/server/crates/djinn-agent/src/actors/slot/reply_loop/mod.rs
@@ -245,6 +245,24 @@ impl djinn_slot::host::SlotToolDispatcher for AgentToolDispatcher {
             preview_chars,
         )
     }
+    fn note_result_externalized<'a>(
+        &'a self,
+        tool_name: &'a str,
+        rendered: &'a str,
+        worktree_path: &'a std::path::Path,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        // The turn budget just discarded a payload this dispatcher produced.
+        // `call_read` recorded read coverage from that payload, and the edit
+        // gate trusts the record, so it has to stop claiming the model saw it.
+        Box::pin(
+            crate::extension::handlers::downgrade_externalized_read_coverage(
+                &self.app_state,
+                tool_name,
+                rendered,
+                worktree_path,
+            ),
+        )
+    }
     fn persist_tool_results_before_compaction(
         &self,
         results: &[djinn_slot::host::PreCompactionToolResult],

--- a/server/crates/djinn-agent/src/extension/handlers.rs
+++ b/server/crates/djinn-agent/src/extension/handlers.rs
@@ -79,6 +79,7 @@ pub(crate) use file_mode::call_set_file_mode;
 pub(crate) use task_admin::call_task_kill_session;
 pub(crate) use workspace::{
     call_apply_patch, call_code_search, call_edit, call_read, call_shell, call_write,
+    downgrade_externalized_read_coverage,
 };
 
 // Re-export task_epic functions used by the local fallback dispatch.

--- a/server/crates/djinn-agent/src/extension/handlers/gate_guard/mod.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/gate_guard/mod.rs
@@ -185,6 +185,7 @@ mod tests {
     }
 
     mod edit_tests;
+    mod externalized_read_tests;
     mod patch_tests;
     mod write_tests;
 }

--- a/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/externalized_read_tests.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/gate_guard/tests/externalized_read_tests.rs
@@ -1,0 +1,315 @@
+//! The per-turn inline-character budget in `djinn-slot` can replace an
+//! already-rendered tool result with a stash stub *after* `call_read` recorded
+//! coverage for it. These tests pin the agent side of that seam: the recorded
+//! coverage must describe the stub the model receives, not the payload the
+//! handler produced.
+
+use super::*;
+use crate::extension::handlers::downgrade_externalized_read_coverage;
+use crate::output_stash::{OutputStash, externalize_rendered_tool_result, render_tool_result};
+
+/// Default preview floor the turn budget hands to the externalization seam
+/// (`djinn_slot::reply_loop::turn_budget::DEFAULT_TURN_INLINE_PREVIEW_FLOOR`).
+/// Mirrored rather than imported: `djinn-agent` depends on `djinn-slot`, and
+/// the constant is crate-private there.
+const TURN_BUDGET_PREVIEW_FLOOR: usize = 10_000;
+
+/// Seed a file whose whole-file read fits inside the tool-result clamp (so it
+/// legitimately records `Full`) but is comfortably larger than the turn
+/// budget's preview floor (so the turn budget can select it).
+fn seed_modest_file(path: &std::path::Path, n: usize) {
+    let mut contents = String::new();
+    for i in 1..=n {
+        contents.push_str(&format!(
+            "    let some_reasonable_line_of_rust_code_{i} = compute(value_{i});\n"
+        ));
+    }
+    std::fs::write(path, &contents).expect("seed file");
+}
+
+fn read_args(file_name: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+    Some(
+        serde_json::json!({ "file_path": file_name, "offset": 0, "limit": 2000 })
+            .as_object()
+            .unwrap()
+            .clone(),
+    )
+}
+
+fn edit_args(file_name: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+    Some(
+        serde_json::json!({
+            "path": file_name,
+            "old_text": "let some_reasonable_line_of_rust_code_7 = compute(value_7);",
+            "new_text": "let some_reasonable_line_of_rust_code_7 = compute(value_8);",
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    )
+}
+
+/// Reproduce the production rendering chain for one tool result: the dispatch
+/// path's `render_result`, then the turn budget's externalization seam.
+/// Returns `(rendered, stub)`.
+fn render_then_externalize(value: &serde_json::Value, tool_name: &str) -> (String, String) {
+    let stash = std::sync::Mutex::new(OutputStash::new());
+    let rendered = render_tool_result(&stash, "call-1", tool_name, value);
+    let stub = externalize_rendered_tool_result(
+        &stash,
+        "call-1",
+        tool_name,
+        &rendered,
+        TURN_BUDGET_PREVIEW_FLOOR,
+    );
+    (rendered, stub)
+}
+
+/// A read the turn budget re-externalizes must not keep `Full` coverage, and
+/// the edit gate must deny on the strength of the downgrade.
+///
+/// Non-vacuity: the read here is a legitimate `Full` (asserted before the
+/// downgrade), and the stub is asserted to carry zero lines of the file — so
+/// every post-downgrade assertion is about the externalization alone.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn turn_budget_externalization_downgrades_read_coverage_and_denies_the_edit() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup_worktree("gg-ext-downgrade-");
+    let file = worktree.path().join("modest.rs");
+    seed_modest_file(&file, 300);
+    let session_id = worktree.path().display().to_string();
+
+    let value = call_read(&state, &read_args("modest.rs"), worktree.path())
+        .await
+        .expect("read should succeed");
+
+    // Precondition: this read is a legitimate whole-file read.
+    let rec = state
+        .file_time
+        .latest_record(&session_id, &file)
+        .await
+        .expect("read record");
+    assert!(
+        rec.is_full(),
+        "a read inside both clamps must record Full, or this test proves nothing: {:?}",
+        rec.coverage
+    );
+
+    let (rendered, stub) = render_then_externalize(&value, "read");
+    assert!(
+        stub.starts_with("[djinn-output-stash"),
+        "the turn budget must have externalized this result: {}",
+        &stub[..stub.len().min(120)]
+    );
+    // The whole point: the stub the model receives carries none of the file.
+    assert_eq!(
+        stub.matches("let some_reasonable_line_of_rust_code_")
+            .count(),
+        0,
+        "the externalized stub must not carry file lines, or the coverage claim \
+         would not be a lie: {stub}"
+    );
+
+    downgrade_externalized_read_coverage(&state, "read", &rendered, worktree.path()).await;
+
+    let rec = state
+        .file_time
+        .latest_record(&session_id, &file)
+        .await
+        .expect("read record survives the downgrade");
+    assert!(
+        !rec.is_full(),
+        "coverage must not stay Full for a result the model never received: {:?}",
+        rec.coverage
+    );
+    assert!(
+        rec.truncated,
+        "an externalized read observed nothing and must be flagged truncated"
+    );
+
+    // The side effect that matters: the edit gate denies.
+    let err = call_edit(
+        &state,
+        &edit_args("modest.rs"),
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect_err("an externalized read must not authorize an edit");
+    assert!(
+        err.contains("FORCE-TRUNCATED-READ"),
+        "expected the truncated-read denial, got: {err}"
+    );
+
+    let content = std::fs::read_to_string(&file).expect("read back");
+    assert!(
+        content.contains("let some_reasonable_line_of_rust_code_7 = compute(value_7);"),
+        "the file must be unchanged after the denial"
+    );
+    let snap = state.file_time.gateguard_snapshot(&session_id).await;
+    assert!(
+        snap.edit_forced.is_empty(),
+        "a denied edit must not populate edit_forced, got: {:?}",
+        snap.edit_forced
+    );
+}
+
+/// The legitimate `Full` case is untouched: a read that survives both clamps
+/// and is *not* externalized keeps `Full` coverage and reaches the ordinary
+/// first-edit investigation prompt. If this breaks, every edit in the system
+/// starts demanding a re-read.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn read_that_is_not_externalized_keeps_full_coverage_and_admits_the_edit() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup_worktree("gg-ext-untouched-");
+    let file = worktree.path().join("modest.rs");
+    seed_modest_file(&file, 300);
+    let session_id = worktree.path().display().to_string();
+
+    let value = call_read(&state, &read_args("modest.rs"), worktree.path())
+        .await
+        .expect("read should succeed");
+
+    // Under budget, the turn budget never runs the seam at all.
+    let stash = std::sync::Mutex::new(OutputStash::new());
+    let rendered = render_tool_result(&stash, "call-1", "read", &value);
+    assert!(
+        !rendered.contains("djinn-output-stash"),
+        "an under-clamp read must not be stashed by render_result"
+    );
+
+    let rec = state
+        .file_time
+        .latest_record(&session_id, &file)
+        .await
+        .expect("read record");
+    assert!(rec.is_full(), "expected Full, got {:?}", rec.coverage);
+    assert!(!rec.truncated, "an unclamped read is not truncated");
+
+    let err = call_edit(
+        &state,
+        &edit_args("modest.rs"),
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect_err("the first covered edit still hits the investigation FORCE");
+    assert!(
+        !err.contains("FORCE-TRUNCATED-READ") && !err.contains("FORCE-UNCOVERED-READ"),
+        "a whole-file read must not be denied for coverage: {err}"
+    );
+    assert!(
+        err.contains("GateGuard"),
+        "expected the ordinary investigation prompt, got: {err}"
+    );
+}
+
+/// Only `read` results carry coverage. Externalizing anything else must leave
+/// the read record alone — otherwise a large `shell` result in the same turn
+/// would silently revoke an unrelated read.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn externalizing_a_non_read_result_leaves_read_coverage_intact() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup_worktree("gg-ext-other-tool-");
+    let file = worktree.path().join("modest.rs");
+    seed_modest_file(&file, 300);
+    let session_id = worktree.path().display().to_string();
+
+    call_read(&state, &read_args("modest.rs"), worktree.path())
+        .await
+        .expect("read should succeed");
+
+    let shell_value = serde_json::json!({
+        "ok": true,
+        "exit_code": 0,
+        "stdout": "x".repeat(40_000),
+        "stderr": "",
+    });
+    let (rendered, _stub) = render_then_externalize(&shell_value, "shell");
+    downgrade_externalized_read_coverage(&state, "shell", &rendered, worktree.path()).await;
+
+    let rec = state
+        .file_time
+        .latest_record(&session_id, &file)
+        .await
+        .expect("read record");
+    assert!(
+        rec.is_full(),
+        "a non-read externalization must not touch read coverage: {:?}",
+        rec.coverage
+    );
+    assert!(!rec.truncated);
+}
+
+/// `apply_patch` still lands on an ordinary file: read, investigate, patch.
+/// This is the deadlock #2821 removed — the downgrade must not re-arm it for
+/// results the turn budget never touched.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn apply_patch_still_succeeds_on_a_normal_file() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup_worktree("gg-ext-patch-ok-");
+    let file = worktree.path().join("modest.rs");
+    seed_modest_file(&file, 300);
+
+    call_read(&state, &read_args("modest.rs"), worktree.path())
+        .await
+        .expect("read should succeed");
+
+    let patch = "*** Begin Patch\n\
+                 *** Update File: modest.rs\n\
+                 @@     let some_reasonable_line_of_rust_code_7 = compute(value_7);\n\
+                 -    let some_reasonable_line_of_rust_code_7 = compute(value_7);\n\
+                 +    let some_reasonable_line_of_rust_code_7 = compute(value_777);\n\
+                 *** End Patch\n";
+    let patch_args = Some(
+        serde_json::json!({ "patch": patch })
+            .as_object()
+            .unwrap()
+            .clone(),
+    );
+
+    let err = call_apply_patch(
+        &state,
+        &patch_args,
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect_err("the first covered edit hits the investigation FORCE");
+    assert!(
+        !err.contains("FORCE-UNCOVERED-READ") && !err.contains("FORCE-TRUNCATED-READ"),
+        "apply_patch on a freshly read file must not be denied for coverage: {err}"
+    );
+
+    // The patch invalidated nothing (it was denied), but the investigation
+    // gate is now satisfied; re-read as the worker would and patch for real.
+    call_read(&state, &read_args("modest.rs"), worktree.path())
+        .await
+        .expect("re-read");
+    call_apply_patch(
+        &state,
+        &patch_args,
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect("apply_patch must succeed once the investigation gate is satisfied");
+
+    let content = std::fs::read_to_string(&file).expect("read back");
+    assert!(
+        content.contains("let some_reasonable_line_of_rust_code_7 = compute(value_777);"),
+        "the patch must have been applied"
+    );
+}

--- a/server/crates/djinn-agent/src/extension/handlers/workspace.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/workspace.rs
@@ -1,3 +1,11 @@
+// djinn:allow-oversize
+//
+// The worktree tool handlers: `read`, `write`, `edit`, `apply_patch`,
+// `code_search`, `shell`. They share the FileTime read-coverage bookkeeping and
+// the GateGuard edit checks, so they are kept together deliberately. Splitting
+// them is a behaviour-bearing refactor of production dispatch and is out of
+// scope for the read-coverage fix that pushed this file over MAX_BYTES.
+
 use super::gate_guard::{gate_guard_edit_check, gate_guard_shell_check};
 use super::shell_exec::{effective_shell_timeout_ms, finish_shell};
 use super::workspace_helpers::{
@@ -254,6 +262,73 @@ fn json_escaped_len(s: &str) -> usize {
 /// window the handler recorded coverage for.
 fn read_content_budget() -> usize {
     crate::output_stash::MAX_TOOL_RESULT_CHARS.saturating_sub(READ_RESULT_RESERVE_CHARS)
+}
+
+/// The extension tool name whose results record read coverage.
+const READ_TOOL_NAME: &str = "read";
+
+/// Recover the resolved file path from an already-rendered `read` result.
+///
+/// `call_read` returns a JSON object whose `path` is
+/// `resolved_path.display().to_string()` — the exact key `FileTime` records
+/// under — and `render_tool_result` hands that object to the model as pretty
+/// JSON. Parsing it back is therefore an identity lookup on the payload the
+/// model was going to receive, not a heuristic on prose.
+///
+/// Returns `None` when the text is not the read handler's own envelope (e.g. a
+/// result some other layer already replaced), in which case there is nothing to
+/// downgrade.
+fn externalized_read_path(rendered: &str) -> Option<std::path::PathBuf> {
+    serde_json::from_str::<serde_json::Value>(rendered)
+        .ok()?
+        .get("path")?
+        .as_str()
+        .map(std::path::PathBuf::from)
+}
+
+/// Downgrade the read-coverage record behind a tool result that the per-turn
+/// inline-character budget re-externalized after the handler recorded it.
+///
+/// `call_read` records coverage for the window it emits, sized against
+/// `output_stash::MAX_TOOL_RESULT_CHARS`. That is the last clamp *inside* the
+/// handler, but not the last clamp overall: `djinn-slot`'s turn budget runs
+/// after every tool in the turn has been dispatched and can replace a rendered
+/// result with a stash stub. Nothing of a numbered listing survives that stub
+/// (its preview is a line-aware head/tail split and the listing is one giant
+/// JSON line), so the record must stop claiming coverage the model never got.
+///
+/// Anything that is not a `read` result carries no coverage and is ignored.
+pub(crate) async fn downgrade_externalized_read_coverage(
+    state: &AgentContext,
+    tool_name: &str,
+    rendered: &str,
+    worktree_path: &Path,
+) {
+    if tool_name != READ_TOOL_NAME {
+        return;
+    }
+    let Some(path) = externalized_read_path(rendered) else {
+        tracing::warn!(
+            worktree = %worktree_path.display(),
+            "read result externalized by the turn budget carried no resolvable path; \
+             read coverage could not be downgraded"
+        );
+        return;
+    };
+    // Cross-repo (mirror-backed) reads never record coverage, and a file read
+    // twice in one turn keeps only the later record; both land here as a
+    // no-op or as a conservative downgrade of the surviving record.
+    let downgraded = state
+        .file_time
+        .mark_read_unobserved(&worktree_path.display().to_string(), &path)
+        .await;
+    if downgraded {
+        tracing::info!(
+            path = %path.display(),
+            "read coverage downgraded: the turn budget externalized this result \
+             after the read handler recorded it"
+        );
+    }
 }
 
 /// Render `lines` as a numbered listing beginning at absolute index `start`,

--- a/server/crates/djinn-agent/src/file_time.rs
+++ b/server/crates/djinn-agent/src/file_time.rs
@@ -225,6 +225,39 @@ impl FileTime {
         Ok(())
     }
 
+    /// Downgrade an existing read record for `path` to "the model observed
+    /// none of it".
+    ///
+    /// The read handler records coverage from the window it emits, but it is
+    /// not the last layer that can shrink a tool result: `djinn-slot`'s
+    /// per-turn inline-character budget can replace an already-rendered result
+    /// with a stash stub *after* the handler recorded coverage for it. The stub
+    /// preview is a line-aware head/tail split of the rendered JSON, and a
+    /// numbered listing is a single enormous JSON line — so none of the file
+    /// survives into the transcript. The honest record for that read is a
+    /// zero-width, truncated one.
+    ///
+    /// Only mutates a record that already exists: it never fabricates one, and
+    /// it leaves `read_at`/`modified_at_when_read` untouched so the
+    /// modified-since-read check is unaffected. Returns `true` when a record
+    /// was downgraded.
+    pub async fn mark_read_unobserved(&self, session_id: &str, path: &Path) -> bool {
+        let normalized = normalize(path);
+        let mut guard = self.inner.write().await;
+        let Some(record) = guard
+            .get_mut(session_id)
+            .and_then(|by_path| by_path.get_mut(&normalized))
+        else {
+            return false;
+        };
+        record.coverage = ReadCoverage::Range {
+            start: 0,
+            end: Some(0),
+        };
+        record.truncated = true;
+        true
+    }
+
     /// Forget any recorded read for `path` in this session, so the next
     /// `assert` falls into the "must be read before modification" path and
     /// forces the model to re-read before editing again.

--- a/server/crates/djinn-slot/src/host.rs
+++ b/server/crates/djinn-slot/src/host.rs
@@ -215,6 +215,28 @@ pub trait SlotToolDispatcher: Send + Sync + 'static {
         rendered: &str,
         preview_chars: usize,
     ) -> String;
+    /// Tell the host that `rendered` — a result it produced and that the
+    /// dispatch path already returned — has just been replaced by an
+    /// externalized stub, so `rendered` will never reach the model.
+    ///
+    /// The host records per-call bookkeeping while it produces a result; the
+    /// worker read-coverage record is the one that matters, because a later
+    /// edit is gated on it. That record is written inside the tool handler,
+    /// which cannot see the turn-level budget applied here, so without this
+    /// notification the host would keep vouching for a payload the model never
+    /// received. Hosts that keep no such bookkeeping do nothing.
+    ///
+    /// Called once per externalized result, after the stub has replaced the
+    /// content and before the results become transcript blocks.
+    ///
+    /// Deliberately has **no default implementation**: a silent default would
+    /// let a new host reintroduce that lie without a compile error.
+    fn note_result_externalized<'a>(
+        &'a self,
+        tool_name: &'a str,
+        rendered: &'a str,
+        worktree_path: &'a std::path::Path,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
     /// Durably preserve inline results before compaction mutates them.
     ///
     /// This additive seam defaults to a no-op so existing host dispatchers stay

--- a/server/crates/djinn-slot/src/reply_loop/tool_dispatch.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tool_dispatch.rs
@@ -528,7 +528,7 @@ pub(super) async fn collect_tool_results(
     // largest shrinking tool-result candidates until the projected inline-char
     // total fits the configured budget or no candidate can shrink below the
     // configured preview floor.
-    super::turn_budget::apply_turn_inline_budget_pass(&mut collected, ctx);
+    super::turn_budget::apply_turn_inline_budget_pass(&mut collected, ctx).await;
     collected
         .into_iter()
         .map(CollectedToolResult::into_content_block)

--- a/server/crates/djinn-slot/src/reply_loop/tool_dispatch_budget_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tool_dispatch_budget_tests.rs
@@ -493,7 +493,7 @@ async fn under_budget_turn_is_unchanged_byte_for_byte() {
         budget: 100_000_000,
         preview_floor: 10_000,
     };
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let snapshot_after: Vec<String> = results
         .iter()
         .map(|r| match &r.content[0] {
@@ -522,7 +522,7 @@ async fn largest_first_selection_externalizes_the_biggest_candidate() {
         collected_text(0, "call-big", "shell", &big),
         collected_text(1, "call-small", "read", &small),
     ];
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let big_text = match &results[0].content[0] {
         ContentBlock::Text { text } => text.as_str(),
         _ => panic!("expected text"),
@@ -551,7 +551,7 @@ async fn non_shrinking_stub_is_skipped() {
     let body = "x".repeat(41);
     let original = body.clone();
     let mut results = vec![collected_text(0, "call-0", "read", &body)];
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let text = match &results[0].content[0] {
         ContentBlock::Text { text } => text.clone(),
         _ => panic!("expected text"),
@@ -579,7 +579,7 @@ async fn preview_floor_prevents_fitting_allows_overflow() {
         collected_text(0, "call-0", "read", &body_a),
         collected_text(1, "call-1", "read", &body_b),
     ];
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let text_a = match &results[0].content[0] {
         ContentBlock::Text { text } => text.clone(),
         _ => panic!("expected text"),
@@ -706,7 +706,7 @@ async fn externalization_preserves_tool_use_id_and_name_in_stub() {
     };
     let big = "Z".repeat(5_000);
     let mut results = vec![collected_text(7, "call-preserve-id", "code_search", &big)];
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let text = match &results[0].content[0] {
         ContentBlock::Text { text } => text.clone(),
         _ => panic!("expected text"),
@@ -783,7 +783,7 @@ async fn budget_trip_reports_tool_name_missing_for_unselected_nameless_result() 
         .finish();
     let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
     let _guard = tracing::dispatcher::set_default(&dispatch);
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let output = logs.output();
     assert!(
         output.contains("tool_name_missing=true"),
@@ -825,7 +825,7 @@ async fn under_budget_turn_does_not_increment_budget_trip_counter() {
     };
     let body = "x".repeat(1_000);
     let mut results = vec![collected_text(0, "call-0", "read", &body)];
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let after = render().expect("render after pass");
     let after_value = budget_trip_counter_value(&after);
     assert_eq!(
@@ -856,7 +856,7 @@ async fn over_budget_turn_increments_budget_trip_counter_by_one_for_multiple_ext
         collected_text(0, "call-a", "shell", &big_a),
         collected_text(1, "call-b", "read", &big_b),
     ];
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let externalized = results
         .iter()
         .filter(|r| {
@@ -894,7 +894,7 @@ async fn over_budget_turn_increments_budget_trip_counter_by_one_when_residual_ov
         collected_text(0, "call-0", "read", &body_a),
         collected_text(1, "call-1", "read", &body_b),
     ];
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     for result in &results {
         let text = match result.content.first() {
             Some(ContentBlock::Text { text }) => text.as_str(),
@@ -939,7 +939,7 @@ async fn budget_trip_structured_event_retains_required_fields() {
         .finish();
     let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
     let _guard = tracing::dispatcher::set_default(&dispatch);
-    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config);
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
     let output = logs.output();
     for field in [
         "inline_chars_pre=",
@@ -962,4 +962,198 @@ fn budget_trip_counter_name_is_coupled_to_telemetry_constant() {
     let after = render().expect("render after increment");
     let after_value = budget_trip_counter_value(&after);
     assert_eq!(after_value, before_value + 1.0, "bad counter increment");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Host notification: every externalized result is reported back
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Wraps the shared mock and records every `note_result_externalized` call.
+///
+/// The host records read coverage while it produces a result; this pass is the
+/// only place a result can shrink afterwards, so the notification is the only
+/// thing standing between an externalized read and an edit gate that still
+/// believes the model saw the file.
+struct NotifyRecordingDispatcher {
+    inner: crate::test_helpers::MockToolDispatcher,
+    notified: std::sync::Mutex<Vec<(String, String)>>,
+}
+
+impl NotifyRecordingDispatcher {
+    fn new() -> Self {
+        Self {
+            inner: crate::test_helpers::MockToolDispatcher,
+            notified: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn notified(&self) -> Vec<(String, String)> {
+        self.notified.lock().expect("notified lock").clone()
+    }
+}
+
+impl crate::host::SlotToolDispatcher for NotifyRecordingDispatcher {
+    fn is_stash_tool(&self, tool_name: &str) -> bool {
+        self.inner.is_stash_tool(tool_name)
+    }
+    fn handle_stash_call(
+        &self,
+        tool_name: &str,
+        arguments: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Result<String, String> {
+        self.inner.handle_stash_call(tool_name, arguments)
+    }
+    fn render_result(
+        &self,
+        tool_use_id: &str,
+        tool_name: &str,
+        value: &serde_json::Value,
+    ) -> String {
+        self.inner.render_result(tool_use_id, tool_name, value)
+    }
+    fn externalize_rendered_result(
+        &self,
+        tool_use_id: &str,
+        tool_name: &str,
+        rendered: &str,
+        preview_chars: usize,
+    ) -> String {
+        self.inner
+            .externalize_rendered_result(tool_use_id, tool_name, rendered, preview_chars)
+    }
+    fn note_result_externalized<'a>(
+        &'a self,
+        tool_name: &'a str,
+        rendered: &'a str,
+        _worktree_path: &'a std::path::Path,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        self.notified
+            .lock()
+            .expect("notified lock")
+            .push((tool_name.to_string(), rendered.to_string()));
+        Box::pin(async {})
+    }
+    fn dispatch_extension_tool<'a>(
+        &'a self,
+        tool_name: &'a str,
+        arguments: Option<serde_json::Map<String, serde_json::Value>>,
+        worktree_path: &'a std::path::Path,
+        task_id: &'a str,
+        role_name: &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = djinn_core::tool_call::ToolCallOutcome> + Send + 'a>,
+    > {
+        self.inner
+            .dispatch_extension_tool(tool_name, arguments, worktree_path, task_id, role_name)
+    }
+    fn is_mcp_tool(&self, tool_name: &str) -> bool {
+        self.inner.is_mcp_tool(tool_name)
+    }
+    fn dispatch_mcp_tool<'a>(
+        &'a self,
+        tool_name: &'a str,
+        arguments: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>,
+    > {
+        self.inner.dispatch_mcp_tool(tool_name, arguments)
+    }
+    fn mcp_server_for_tool(&self, tool_name: &str) -> Option<String> {
+        self.inner.mcp_server_for_tool(tool_name)
+    }
+    fn is_resource_tool(&self, tool_name: &str) -> bool {
+        self.inner.is_resource_tool(tool_name)
+    }
+    fn dispatch_resource_tool<'a>(
+        &'a self,
+        tool_name: &'a str,
+        arguments: Option<serde_json::Map<String, serde_json::Value>>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String, String>> + Send + 'a>>
+    {
+        self.inner.dispatch_resource_tool(tool_name, arguments)
+    }
+    fn clear_stash(&self) {
+        self.inner.clear_stash()
+    }
+}
+
+/// The budget pass must hand the host the payload it discarded, for every
+/// result it externalizes and only those — that payload is how the host
+/// identifies the read-coverage record it has to downgrade.
+#[tokio::test]
+async fn externalized_results_are_reported_to_the_host_with_the_discarded_payload() {
+    use crate::test_helpers::{agent_context_from_db, create_test_db};
+    use tokio_util::sync::CancellationToken;
+    let db = create_test_db();
+    let mut ctx = agent_context_from_db(db, CancellationToken::new());
+    let recorder = std::sync::Arc::new(NotifyRecordingDispatcher::new());
+    ctx.tool_dispatcher = Some(recorder.clone());
+    let worktree_path = std::path::Path::new("/tmp");
+    let tool_metadata = ToolRuntimeMetadataMap::new();
+    let dispatch_ctx = test_dispatch_context(&ctx, &tool_metadata, worktree_path);
+
+    let read_payload = serde_json::json!({
+        "path": "/tmp/big.rs",
+        "content": "L".repeat(20_000),
+    })
+    .to_string();
+    let untouched = "S".repeat(50);
+    let mut results = vec![
+        collected_text(0, "call-read", "read", &read_payload),
+        collected_text(1, "call-small", "shell", &untouched),
+    ];
+    let config = TurnInlineBudgetConfig {
+        budget: 1_000,
+        preview_floor: 100,
+    };
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
+
+    // The read result really was replaced by a stub.
+    let read_text = match &results[0].content[0] {
+        ContentBlock::Text { text } => text.as_str(),
+        _ => panic!("expected text"),
+    };
+    assert!(
+        read_text.starts_with("[djinn-output-stash"),
+        "the read result must have been externalized"
+    );
+
+    let notified = recorder.notified();
+    assert_eq!(
+        notified.len(),
+        1,
+        "exactly the externalized result must be reported, got {notified:?}"
+    );
+    assert_eq!(notified[0].0, "read", "the tool name must be reported");
+    assert_eq!(
+        notified[0].1, read_payload,
+        "the host must receive the payload that was discarded, not the stub"
+    );
+}
+
+/// An under-budget turn externalizes nothing, so it must notify nothing —
+/// otherwise every read in a quiet turn would have its coverage revoked.
+#[tokio::test]
+async fn under_budget_turn_reports_no_externalization() {
+    use crate::test_helpers::{agent_context_from_db, create_test_db};
+    use tokio_util::sync::CancellationToken;
+    let db = create_test_db();
+    let mut ctx = agent_context_from_db(db, CancellationToken::new());
+    let recorder = std::sync::Arc::new(NotifyRecordingDispatcher::new());
+    ctx.tool_dispatcher = Some(recorder.clone());
+    let worktree_path = std::path::Path::new("/tmp");
+    let tool_metadata = ToolRuntimeMetadataMap::new();
+    let dispatch_ctx = test_dispatch_context(&ctx, &tool_metadata, worktree_path);
+
+    let mut results = vec![collected_text(0, "call-read", "read", &"L".repeat(20_000))];
+    let config = TurnInlineBudgetConfig {
+        budget: 100_000,
+        preview_floor: 10_000,
+    };
+    apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
+
+    assert!(
+        recorder.notified().is_empty(),
+        "an under-budget turn must not report any externalization"
+    );
 }

--- a/server/crates/djinn-slot/src/reply_loop/tool_dispatch_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tool_dispatch_tests.rs
@@ -100,6 +100,15 @@ impl crate::host::SlotToolDispatcher for PhaseScriptedDispatcher {
     fn externalize_rendered_result(&self, _: &str, _: &str, rendered: &str, _: usize) -> String {
         rendered.to_string()
     }
+    fn note_result_externalized<'a>(
+        &'a self,
+        _: &'a str,
+        _: &'a str,
+        _: &'a std::path::Path,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        // This dispatcher keeps no per-call bookkeeping to downgrade.
+        Box::pin(async {})
+    }
     fn dispatch_extension_tool<'a>(
         &'a self,
         name: &'a str,

--- a/server/crates/djinn-slot/src/reply_loop/turn_budget.rs
+++ b/server/crates/djinn-slot/src/reply_loop/turn_budget.rs
@@ -96,17 +96,25 @@ fn apply_externalized_stub(result: &mut CollectedToolResult, stub: String) -> (u
 /// projected total fits the budget or no remaining candidate can shrink below
 /// the preview floor; residual overflow is permitted when the floor prevents
 /// fitting. A budget trip emits distinct char-unit telemetry.
-pub(super) fn apply_turn_inline_budget_pass(
+///
+/// Every result this pass externalizes is reported back to the host through
+/// [`SlotToolDispatcher::note_result_externalized`](crate::host::SlotToolDispatcher::note_result_externalized)
+/// before the pass returns. This is the only place a result can be shrunk after
+/// its originating handler recorded bookkeeping for it, so the notification
+/// lives inline with the replacement rather than being handed to a caller that
+/// could forget to make it.
+pub(super) async fn apply_turn_inline_budget_pass(
     results: &mut [CollectedToolResult],
     ctx: &ToolDispatchContext<'_>,
 ) {
-    apply_turn_inline_budget_pass_with_config(results, ctx, TurnInlineBudgetConfig::from_env());
+    apply_turn_inline_budget_pass_with_config(results, ctx, TurnInlineBudgetConfig::from_env())
+        .await;
 }
 
 /// Config-injectable core of [`apply_turn_inline_budget_pass`] so unit tests can
 /// drive the policy deterministically without touching process-wide environment
 /// variables (which race under parallel test execution).
-pub(super) fn apply_turn_inline_budget_pass_with_config(
+pub(super) async fn apply_turn_inline_budget_pass_with_config(
     results: &mut [CollectedToolResult],
     ctx: &ToolDispatchContext<'_>,
     config: TurnInlineBudgetConfig,
@@ -189,9 +197,19 @@ pub(super) fn apply_turn_inline_budget_pass_with_config(
             externalized[idx] = true;
             continue;
         }
+        // Keep the payload that is about to be discarded: the host needs it to
+        // identify the bookkeeping it recorded when it produced this result.
+        let discarded = rendered.to_string();
+        let tool_name = result.tool_name.clone();
         let (_original, _new) = apply_externalized_stub(result, stub);
         externalized[idx] = true;
         externalized_count += 1;
+        // The model will receive the stub, not `discarded`. Anything the host
+        // recorded from the full payload — read coverage, which the edit gate
+        // trusts — has to be downgraded to match.
+        ctx.tool_dispatcher
+            .note_result_externalized(&tool_name, &discarded, ctx.worktree_path)
+            .await;
     }
 
     let inline_chars_post = total_inline_chars(results);

--- a/server/crates/djinn-slot/src/test_helpers.rs
+++ b/server/crates/djinn-slot/src/test_helpers.rs
@@ -56,6 +56,15 @@ impl SlotToolDispatcher for MockToolDispatcher {
     ) -> String {
         mock_externalize_rendered_result(tool_use_id, tool_name, rendered, preview_chars)
     }
+    fn note_result_externalized<'a>(
+        &'a self,
+        _tool_name: &'a str,
+        _rendered: &'a str,
+        _worktree_path: &'a std::path::Path,
+    ) -> Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        // The mock keeps no per-call bookkeeping to downgrade.
+        Box::pin(async {})
+    }
     fn dispatch_extension_tool<'a>(
         &'a self,
         tool_name: &'a str,
@@ -194,6 +203,16 @@ impl SlotToolDispatcher for ConfigurableToolDispatcher {
         preview_chars: usize,
     ) -> String {
         mock_externalize_rendered_result(tool_use_id, tool_name, rendered, preview_chars)
+    }
+    fn note_result_externalized<'a>(
+        &'a self,
+        _tool_name: &'a str,
+        _rendered: &'a str,
+        _worktree_path: &'a std::path::Path,
+    ) -> Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        // The configurable dispatcher keeps no per-call bookkeeping to
+        // downgrade.
+        Box::pin(async {})
     }
     fn persist_tool_results_before_compaction(
         &self,


### PR DESCRIPTION
## Confirmed, not refuted

The residual flagged in #2821 is real and reachable. Source evidence, in order:

1. **Coverage is recorded during dispatch.** `call_read`
   (`server/crates/djinn-agent/src/extension/handlers/workspace.rs:520`) calls
   `file_time.read_with_coverage(...)` before it returns its JSON value. It is
   reached through `SlotToolDispatcher::dispatch_extension_tool`, i.e. inside
   `dispatch_single_tool`.
2. **The budget pass runs strictly after all of that.**
   `collect_tool_results` (`server/crates/djinn-slot/src/reply_loop/tool_dispatch.rs:517-531`)
   awaits `collect_tool_results_internal` — which dispatches every serial,
   parallel and streaming tool of the turn — then calls
   `turn_budget::apply_turn_inline_budget_pass` on the merged results. The
   ordering permits the lie: nothing between those two points can revise a
   record written in step 1.
3. **The externalized result carries none of the file.** A `read` result over
   the preview floor (10k chars) is a candidate; the stub is
   `format!("{header}\n{preview_body}{hint}")` with
   `preview_body = smart_truncate(rendered, preview_chars)`
   (`djinn-agent/src/output_stash/mod.rs:1096`). `smart_truncate` splits on
   lines; the pretty-printed read envelope is `{`, one ~29k-char `"content"`
   line, then the small keys — so the head loop keeps `{` and the tail loop
   keeps the envelope keys, and the entire listing is dropped. This is the same
   mechanism #2821 measured at "a ~217-character stub with zero lines of the
   file", one layer further out.
4. **Reachability.** Each result is clamped to 30k by `render_tool_result`, and
   the budget is 100k, so four large results in one turn trip it; the greedy
   largest-first selection then picks the read. `ReadRecord` outlives the turn
   (only `invalidate` clears it), so the stale `Full` is still there when the
   next turn's edit is gated.

#2821 does **not** already cover this: its fix sizes the emitted window against
`MAX_TOOL_RESULT_CHARS`, which is the last clamp *inside* the handler. The turn
budget is a second, later clamp the handler cannot see.

## The fix

Coverage stays decided where the final payload is visible, in one place:

* `SlotToolDispatcher::note_result_externalized(tool_name, rendered, worktree_path)`
  (`djinn-slot/src/host.rs`) — the host is told which payload was discarded.
* `turn_budget` calls it **inline with each replacement**, not by returning a
  list a caller could forget to consume.
* `AgentToolDispatcher` implements it by mapping a `read` payload back to its
  resolved path — the `path` field `call_read` emits is the exact key
  `FileTime` records under, so this is an identity lookup on the payload, not a
  heuristic — and calling the new `FileTime::mark_read_unobserved`, which
  rewrites that record to `Range { start: 0, end: Some(0) }` + `truncated: true`
  and leaves `read_at`/`modified_at_when_read` alone.

The gate then denies with the existing `FORCE-TRUNCATED-READ`, which asks for a
targeted `read(file_path, offset, limit)` — the behaviour #2821 steered toward.

The seam has **no default implementation**: a silent default would let a new
host reintroduce the lie without a compile error.

Deliberately unchanged: `MAX_TOOL_RESULT_CHARS`, the turn budget and preview
floor, the edit gate, and coverage for every turn the budget does not trip
(only `read` results are downgraded, and only the ones actually externalized).

## Non-vacuity

Both new assertions were run against a stubbed body — "what stays green if the
body does nothing?"

**A. `FileTime::mark_read_unobserved` body removed** (record left untouched,
still returns `true`):

```
turn_budget_externalization_downgrades_read_coverage_and_denies_the_edit ... FAILED
  panicked at externalized_read_tests.rs:121:
  coverage must not stay Full for a result the model never received: Full
test result: FAILED. 3 passed; 1 failed
```

The other three tests in the module stayed green, so they guard rather than
ride along.

**B. the `note_result_externalized` call removed from `turn_budget`:**

```
externalized_results_are_reported_to_the_host_with_the_discarded_payload ... FAILED
  assertion `left == right` failed: exactly the externalized result must be
  reported, got []
test result: FAILED. 20 passed; 1 failed
```

Restored, both pass.

## Regression checks

* **Legitimate `Full` still records `Full`** —
  `read_that_is_not_externalized_keeps_full_coverage_and_admits_the_edit`: a
  300-line file survives `render_tool_result` unstashed, records `Full`,
  `truncated: false`, and its edit reaches the ordinary GateGuard investigation
  prompt with no `FORCE-UNCOVERED-READ` / `FORCE-TRUNCATED-READ`. Passes.
* **`apply_patch` still lands on a normal file** —
  `apply_patch_still_succeeds_on_a_normal_file`: read → investigation FORCE
  (asserted *not* to be a coverage denial) → re-read → `apply_patch` succeeds
  and the file content is asserted changed. The #2821 deadlock is not re-armed.
  Passes.
* `externalizing_a_non_read_result_leaves_read_coverage_intact`: a 40k `shell`
  result externalized in the same turn must not revoke an unrelated read.
* `under_budget_turn_reports_no_externalization`: a quiet turn notifies nothing.

## Suites

* `cargo test -p djinn-agent --lib` — 1451 passed, 0 failed, 1 ignored.
* `cargo test -p djinn-slot --lib -- --test-threads=1` — 544 passed, 1 failed;
  the single failure (`llm_extraction_semantic_duplicate_skips_create_and_boosts_existing_confidence`)
  reproduces identically on `main` (542 passed, same 1 failed) and is untouched
  by this branch.
* `cargo clippy -p djinn-slot -p djinn-agent --all-targets -- -D warnings` — clean.
* `cargo fmt --all --check` — clean (the whole-tree gate #2834 added; this
  branch has been rebased onto `main` past that commit so it is tested against
  the same gate CI runs).
* `./scripts/check-file-size.sh --all` and changed-file mode — 0 violations.

### Pre-existing flake, not introduced here

`tool_dispatch_budget_tests` fails intermittently under parallel execution on
`main`: `collect_tool_results_budget_pass_externalizes_largest_serial_parallel_streaming`
does `std::env::set_var("DJINN_TURN_INLINE_CHAR_BUDGET", …)` while
`over_budget_turn_increments_budget_trip_counter_by_one_when_residual_overflow_remains`
does `remove_var` on the same names, with no serialization. Measured on
pristine `main`, 8 consecutive runs of that module: **4 failed**, including the
exact `externalization failed` assertion. Serial runs are green on both `main`
and this branch. Left alone — it is orthogonal to this fix and wants its own
change (an env guard, or moving those two onto the config-injectable entry
point that already exists for exactly this reason).

### Size guard: `workspace.rs` carries `// djinn:allow-oversize`

CI's `check-file-size.sh` failed this branch on
`server/crates/djinn-agent/src/extension/handlers/workspace.rs`
(1304 lines, 53762 bytes) — **under** `MAX_LINES=1500`, over
`MAX_BYTES=51200`. On `main` that file is 50933 bytes: **267 bytes of
headroom**. The change adds 2829, most of it the explanatory comments on the
new downgrade path.

Resolved with the marker, not by splitting and not by shaving:

* Splitting the worktree tool handlers (`read`, `write`, `edit`, `apply_patch`,
  `code_search`, `shell` — they share the FileTime read-coverage bookkeeping
  and the GateGuard edit checks) is a behaviour-bearing refactor of production
  dispatch. Doing it here would bury a correctness fix inside unrelated churn.
* Cutting the comments back under 51200 would be evading the guard rather than
  answering it, and at 267 bytes of headroom the next person to touch this file
  trips the same wire from a standing start.

Recording the pattern rather than quietly working around it: this is the
**second time today** the guard has blocked a correctness fix, both on
`MAX_BYTES` rather than `MAX_LINES`, both on files sitting within ~300 bytes of
the threshold — #2815 hit it on `proposal_tools/create.rs` (141 bytes under,
tipped over by its own explanatory comment). For scale, 101 files in the tree
already carry the marker; this makes 102. That is evidence for the separately
tracked question of whether this guard should be retired or re-cut, and is
**not** acted on here — marker only, thresholds and script untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

