### PR TITLE
4wx3: render a resize-v2-only launcher CPU ceiling

### DIFF
--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -98,12 +98,20 @@ pub const VOLUME_OWNERSHIP_ON_ROOT_MISMATCH: &str = "fsgroup-on-root-mismatch";
 /// short bursts, so the launcher receives everything the worker does not use.
 /// Node-level fairness is set by the pod's total request, which is unchanged.
 pub const LAUNCHER_CPU_REQUEST: &str = "50m";
+/// [`LAUNCHER_CPU_REQUEST`] in millicores, for the numeric comparison in
+/// [`RenderValidationError::LauncherCpuCeilingBelowRequest`]. The two are
+/// asserted to agree by `launcher_tests::the_launcher_cpu_request_constants_agree`,
+/// so this is a spelling of the same value, not a second source of truth.
+pub const LAUNCHER_CPU_REQUEST_MILLICORES: u32 = 50;
 /// Launcher sidecar memory **request**: also the broker's steady footprint.
 /// The build's peak lives in the limit, not the request — the same
 /// request-is-steady/limit-is-peak shape the worker container already uses.
 pub const LAUNCHER_MEMORY_REQUEST: &str = "64Mi";
 
-// NOTE (task 7deu, defect 1): there is deliberately NO `LAUNCHER_CPU_LIMIT`.
+// NOTE (task 7deu, defect 1): there is deliberately NO unconditional
+// `LAUNCHER_CPU_LIMIT`, and under `leaf-v1` there is no launcher CPU limit at
+// all. Task 4wx3 added one for `resize-v2` ONLY; the history below is why that
+// conditionality is the whole point.
 //
 // This constant used to be "250m", matching goxi's normative resource matrix.
 // It was the single reason the whole feature was a no-op. Under `nsdelegate` the
@@ -117,11 +125,22 @@ pub const LAUNCHER_MEMORY_REQUEST: &str = "64Mi";
 // blind. With the limit removed, the same pod reported `nr_throttled 40/40` on
 // the unleased leaf and 1.995 cores of measured post-lift throughput.
 //
-// The ceiling did not disappear, it moved to where the work is: the invocation
-// leaf's own `cpu.max`, unleased at [`LAUNCHER_UNLEASED_MILLICORES`] and lifted
-// to [`launcher_leased_millicores`]. Removing a container CPU limit also makes
-// the kubelet leave the POD cgroup's `cpu.max` unset, which is required — a pod
-// ceiling would reintroduce exactly the ancestor clamp this removes.
+// Under `leaf-v1` the ceiling did not disappear, it moved to where the work is:
+// the invocation leaf's own `cpu.max`, unleased at
+// [`LAUNCHER_UNLEASED_MILLICORES`] and lifted to [`launcher_leased_millicores`].
+// Removing a container CPU limit also makes the kubelet leave the POD cgroup's
+// `cpu.max` unset, which is required — a pod ceiling would reintroduce exactly
+// the ancestor clamp this removes.
+//
+// Under `resize-v2` the arithmetic inverts, because
+// [`LauncherAuthorityProtocol::launcher_owns_leaf_quota`] is FALSE: the launcher
+// never writes a leaf `cpu.max`, not even `max`. There is therefore no leaf
+// ceiling for a container limit to clamp *below* — the container limit IS the
+// ceiling, and pod resize is what moves it. Rendering it unconditionally would
+// reinstate the measurement above verbatim, which is why
+// [`apply_launcher_cpu_ceiling`] gates on the protocol and why the leaf-v1 arm
+// of `launcher_tests::the_launcher_cpu_ceiling_is_rendered_only_under_resize_v2`
+// asserts the ABSENCE of the key rather than a value.
 
 /// Volume name for the worker↔launcher IPC surface (broker control socket +
 /// worker-private launcher credential). Memory-backed emptyDir, mounted into the
@@ -422,7 +441,7 @@ pub fn launcher_sidecar_container(
             // Sourced from the pod's own declared CPU limit so a brokered build
             // picks exactly the parallelism an unbrokered one would.
             env_var(
-                "DJINN_LAUNCHER_LEASED_MILLICORES",
+                LEASED_MILLICORES_ENV,
                 &launcher_leased_millicores(config).to_string(),
             ),
             // The worker-written, launcher-read-only git config the trust anchor
@@ -450,9 +469,16 @@ pub fn launcher_sidecar_container(
                     Quantity(LAUNCHER_MEMORY_REQUEST.to_string()),
                 ),
             ])),
-            // NO CPU LIMIT — see the note where `LAUNCHER_CPU_LIMIT` used to be.
-            // A limit here becomes an ancestor clamp on every invocation leaf and
-            // silently caps every build at the launcher's own quota.
+            // NO CPU LIMIT HERE — see the note where `LAUNCHER_CPU_LIMIT` used
+            // to be. Under leaf-v1 a limit here becomes an ancestor clamp on
+            // every invocation leaf and silently caps every build at the
+            // launcher's own quota.
+            //
+            // This builder is a pure function of the config and cannot know the
+            // authority protocol, which is a property of the resolved catalog
+            // image. The resize-v2 ceiling is therefore applied at the same
+            // post-render seam that writes [`AUTHORITY_PROTOCOL_ENV`] — see
+            // [`apply_launcher_cpu_ceiling`]. leaf-v1 keeps this shape exactly.
             //
             // The MEMORY limit is the worker's, not a sidecar's: when the
             // launcher is armed every command runs in this container's cgroup,
@@ -472,10 +498,10 @@ pub fn launcher_sidecar_container(
 
 // Rendered CPU quantities live beside this module and are re-exported here,
 // so `crate::launcher::*` remains the single import path.
-use crate::launcher_cpu::parse_cpu_millicores;
 pub use crate::launcher_cpu::{
-    launcher_leased_millicores, retune_launcher_lease, warm_job_millicores,
+    LEASED_MILLICORES_ENV, launcher_leased_millicores, retune_launcher_lease, warm_job_millicores,
 };
+use crate::launcher_cpu::{parse_cpu_millicores, rendered_lease_millicores};
 
 /// Fail-closed render/startup validation for an enforcement task-run.
 ///
@@ -538,6 +564,26 @@ pub enum RenderValidationError {
         container: &'static str,
         env: &'static str,
     },
+    #[error(
+        "the resolved authority protocol is {protocol}, but the rendered `{container}` sidecar \
+         carries no usable {env} value (found: {found}). Under resize-v2 the launcher never writes \
+         a leaf `cpu.max`, so the sidecar's own CPU limit is the ONLY ceiling a brokered build has \
+         and there is nothing left to derive it from. Refused rather than rendering a sidecar \
+         whose builds are bounded only by the node."
+    )]
+    UnresolvableLauncherCpuCeiling {
+        protocol: LauncherAuthorityProtocol,
+        container: &'static str,
+        env: &'static str,
+        found: String,
+    },
+    #[error(
+        "the resize-v2 launcher CPU ceiling {ceiling}m is below the sidecar's own CPU request \
+         {request}. Kubernetes rejects a container whose limit is under its request, so this \
+         renders a Pod that never admits at all rather than a build that merely runs slowly — \
+         refused here, while the number is still a number."
+    )]
+    LauncherCpuCeilingBelowRequest { ceiling: u32, request: &'static str },
 }
 
 /// Decide the protocol a Job must render, from what the resolved catalog image
@@ -580,6 +626,12 @@ pub fn render_authority_protocol(
 /// function of the config — the same split `build_resources::apply_resolved_resources`
 /// already uses for per-project resource overrides.
 ///
+/// It also applies the protocol-conditional launcher CPU ceiling
+/// ([`apply_launcher_cpu_ceiling`]), because that is a second thing the
+/// resolved protocol — and only the resolved protocol — decides about the
+/// sidecar. Keeping the two in one function means a render can never carry the
+/// `resize-v2` env with a `leaf-v1` resource shape, or the reverse.
+///
 /// Fail-closed: in `required` mode a Job with no `cgroup-launcher` container is
 /// an error, not a silent skip. Under `disabled` mode there is no sidecar and no
 /// broker, so there is nothing to agree about and this is a no-op.
@@ -610,7 +662,11 @@ pub fn apply_launcher_authority_protocol(
                 .find(|container| container.name == LAUNCHER_CONTAINER_NAME)
         })
         .ok_or_else(missing)?;
+    // Resolve the ceiling BEFORE mutating anything, so a refusal leaves the
+    // caller's Job exactly as it found it.
+    let ceiling = resolve_launcher_cpu_ceiling(sidecar, protocol)?;
     set_env(sidecar, AUTHORITY_PROTOCOL_ENV, protocol.as_wire());
+    apply_launcher_cpu_ceiling(sidecar, ceiling);
 
     // The worker asserts the SAME value to the broker at READY. Setting it on
     // the sidecar alone would make every armed pod fail its own handshake as
@@ -635,6 +691,79 @@ fn set_env(container: &mut Container, name: &str, value: &str) {
             existing.value_from = None;
         }
         None => env.push(env_var(name, value)),
+    }
+}
+
+/// The launcher sidecar's `limits.cpu`, in millicores, for `protocol` — or
+/// [`None`] when the protocol must render no CPU limit at all.
+///
+/// * **leaf-v1 → `None`.** The launcher owns the leaf's `cpu.max`
+///   ([`LauncherAuthorityProtocol::launcher_owns_leaf_quota`]), so a container
+///   limit here is an ancestor clamp that silently caps every build at the
+///   launcher's own quota. That is task 7deu's defect 1, measured; see the note
+///   where `LAUNCHER_CPU_LIMIT` used to be. This arm exists so that regression
+///   cannot return through the resize-v2 door.
+/// * **resize-v2 → the lease ceiling.** The launcher writes no leaf quota under
+///   this protocol, so nothing else bounds a brokered build; pod resize moves
+///   this limit, and this limit is what it moves.
+///
+/// The value is read back off the rendered sidecar rather than recomputed from
+/// the config, because `build_resources::apply_resolved_resources` runs first
+/// and may have re-pointed the lease at a per-project `cpu_limit` override — see
+/// [`crate::launcher_cpu::rendered_lease_millicores`].
+fn resolve_launcher_cpu_ceiling(
+    sidecar: &Container,
+    protocol: LauncherAuthorityProtocol,
+) -> Result<Option<u32>, RenderValidationError> {
+    if protocol.launcher_owns_leaf_quota() {
+        return Ok(None);
+    }
+    let ceiling = rendered_lease_millicores(sidecar).map_err(|found| {
+        RenderValidationError::UnresolvableLauncherCpuCeiling {
+            protocol,
+            container: LAUNCHER_CONTAINER_NAME,
+            env: LEASED_MILLICORES_ENV,
+            found,
+        }
+    })?;
+    // A limit under the container's own request is not a slow pod, it is a Pod
+    // the apiserver rejects. Catch it here, where the number is still a number
+    // and the failure names the ceiling.
+    if ceiling < LAUNCHER_CPU_REQUEST_MILLICORES {
+        return Err(RenderValidationError::LauncherCpuCeilingBelowRequest {
+            ceiling,
+            request: LAUNCHER_CPU_REQUEST,
+        });
+    }
+    Ok(Some(ceiling))
+}
+
+/// Write (or clear) the launcher sidecar's `limits.cpu`.
+///
+/// Clearing on the [`None`] arm keeps re-application total rather than additive:
+/// applying leaf-v1 over a previously resize-v2 render must leave no stale
+/// clamp behind. The clear never *creates* an empty `resources`/`limits` map, so
+/// the leaf-v1 manifest is byte-identical to one this function never touched.
+/// `requests` and `limits.memory` are not addressed on either arm.
+fn apply_launcher_cpu_ceiling(sidecar: &mut Container, ceiling: Option<u32>) {
+    match ceiling {
+        Some(millicores) => {
+            sidecar
+                .resources
+                .get_or_insert_with(ResourceRequirements::default)
+                .limits
+                .get_or_insert_with(BTreeMap::new)
+                .insert("cpu".to_string(), Quantity(format!("{millicores}m")));
+        }
+        None => {
+            if let Some(limits) = sidecar
+                .resources
+                .as_mut()
+                .and_then(|resources| resources.limits.as_mut())
+            {
+                limits.remove("cpu");
+            }
+        }
     }
 }
 

--- a/server/crates/djinn-k8s/src/launcher_cpu.rs
+++ b/server/crates/djinn-k8s/src/launcher_cpu.rs
@@ -7,9 +7,20 @@
 //! motion, re-exported through `launcher` so no import path changes.
 
 use djinn_cgroup_launcher::LeasedQuota;
+use k8s_openapi::api::core::v1::Container;
 
 use crate::KubernetesConfig;
 use crate::launcher::LAUNCHER_CONTAINER_NAME;
+
+/// Environment variable carrying the lease ceiling (bare millicores) into the
+/// launcher sidecar.
+///
+/// Named once because three places have to agree on it: the sidecar render
+/// (`launcher::launcher_sidecar_container`), the post-render retune below, and
+/// the `resize-v2` CPU ceiling (`launcher::apply_launcher_authority_protocol`),
+/// which reads this value back out rather than recomputing it — see
+/// [`rendered_lease_millicores`].
+pub const LEASED_MILLICORES_ENV: &str = "DJINN_LAUNCHER_LEASED_MILLICORES";
 
 /// Re-point the rendered launcher's lease ceiling at `cpu_limit`.
 ///
@@ -33,11 +44,41 @@ pub fn retune_launcher_lease(pod: &mut k8s_openapi::api::core::v1::PodSpec, cpu_
             continue;
         }
         for env in container.env.iter_mut().flatten() {
-            if env.name == "DJINN_LAUNCHER_LEASED_MILLICORES" {
+            if env.name == LEASED_MILLICORES_ENV {
                 env.value = Some(value.clone());
             }
         }
     }
+}
+
+/// The lease ceiling actually rendered onto a launcher sidecar, in millicores.
+///
+/// Deliberately reads the container back rather than recomputing
+/// [`launcher_leased_millicores`] from the config: [`retune_launcher_lease`]
+/// may already have re-pointed it at a per-project
+/// `build_resources.task.cpu_limit` override, and a `resize-v2` CPU ceiling
+/// derived from the deployment default would then clamp such a pod *below* the
+/// lease its own launcher grants — the 7deu ancestor clamp, re-entered through
+/// the override path.
+///
+/// `Err` carries the raw value for the error message; `Ok` is a value that
+/// parses as a positive millicore count. The env is written as bare millicores
+/// (no `m` suffix) by both writers, so this parse is deliberately strict.
+pub(crate) fn rendered_lease_millicores(container: &Container) -> Result<u32, String> {
+    let raw = container
+        .env
+        .iter()
+        .flatten()
+        .find(|entry| entry.name == LEASED_MILLICORES_ENV)
+        .and_then(|entry| entry.value.as_deref());
+    let Some(raw) = raw else {
+        return Err("unset".to_string());
+    };
+    raw.trim()
+        .parse::<u32>()
+        .ok()
+        .filter(|millicores| *millicores > 0)
+        .ok_or_else(|| format!("{raw:?}"))
 }
 
 /// The CPU quota (millicores) a granted lease lifts an invocation leaf to.

--- a/server/crates/djinn-k8s/src/launcher_tests.rs
+++ b/server/crates/djinn-k8s/src/launcher_tests.rs
@@ -550,3 +550,407 @@ fn a_resolved_cpu_limit_override_retunes_the_lease() {
     retune_launcher_lease(&mut pod, "not-a-quantity");
     assert_eq!(leased(&pod), "6500");
 }
+
+// ---------------------------------------------------------------------------
+// Task 4wx3: the resize-v2-only launcher CPU ceiling.
+//
+// The 7deu measurement (see the note in `launcher.rs` where `LAUNCHER_CPU_LIMIT`
+// used to be) is the whole reason these tests assert an ABSENCE on the leaf-v1
+// arm. A container CPU limit on the launcher is an ancestor clamp over every
+// invocation leaf; under leaf-v1 the launcher writes those leaves' `cpu.max`, so
+// the clamp silently caps every build. Under resize-v2 the launcher writes no
+// leaf quota at all, so the container limit is the only ceiling there is.
+// ---------------------------------------------------------------------------
+
+/// Build the real task-run Job, so these assertions run against the manifest
+/// dispatch actually submits rather than a hand-assembled `Container`.
+fn rendered_task_run_job(config: &KubernetesConfig) -> k8s_openapi::api::batch::v1::Job {
+    crate::job::build_task_run_job(
+        config,
+        &Uuid::nil(),
+        "project-1",
+        "djinn-task-run-secret",
+        "registry.example/proj:tag",
+        &[],
+        None,
+        false,
+        None,
+    )
+}
+
+fn launcher_of(job: &k8s_openapi::api::batch::v1::Job) -> &Container {
+    job.spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .and_then(|pod| pod.init_containers.as_ref())
+        .and_then(|containers| {
+            containers
+                .iter()
+                .find(|container| container.name == LAUNCHER_CONTAINER_NAME)
+        })
+        .expect("the armed render carries the launcher sidecar")
+}
+
+fn quantities(
+    map: Option<&BTreeMap<String, k8s_openapi::apimachinery::pkg::api::resource::Quantity>>,
+) -> BTreeMap<String, String> {
+    map.map(|map| {
+        map.iter()
+            .map(|(key, value)| (key.clone(), value.0.clone()))
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
+fn launcher_limits(job: &k8s_openapi::api::batch::v1::Job) -> BTreeMap<String, String> {
+    quantities(
+        launcher_of(job)
+            .resources
+            .as_ref()
+            .and_then(|resources| resources.limits.as_ref()),
+    )
+}
+
+fn launcher_requests(job: &k8s_openapi::api::batch::v1::Job) -> BTreeMap<String, String> {
+    quantities(
+        launcher_of(job)
+            .resources
+            .as_ref()
+            .and_then(|resources| resources.requests.as_ref()),
+    )
+}
+
+/// Read one env value off a container, or `None`.
+fn env_value(container: &Container, name: &str) -> Option<String> {
+    container
+        .env
+        .iter()
+        .flatten()
+        .find(|entry| entry.name == name)
+        .and_then(|entry| entry.value.clone())
+}
+
+fn apply(
+    job: &mut k8s_openapi::api::batch::v1::Job,
+    protocol: LauncherAuthorityProtocol,
+) -> Result<(), RenderValidationError> {
+    apply_launcher_authority_protocol(job, CgroupLauncherMode::Required, protocol)
+}
+
+/// Overwrite (or remove) the rendered lease-ceiling env on the launcher sidecar,
+/// so the ceiling guards can be driven to states the two current writers of that
+/// variable cannot themselves produce.
+fn set_lease_env(job: &mut k8s_openapi::api::batch::v1::Job, value: Option<&str>) {
+    let pod = job
+        .spec
+        .as_mut()
+        .and_then(|spec| spec.template.spec.as_mut())
+        .expect("rendered pod spec");
+    for container in pod.init_containers.iter_mut().flatten() {
+        if container.name != LAUNCHER_CONTAINER_NAME {
+            continue;
+        }
+        let env = container.env.get_or_insert_with(Vec::new);
+        match value {
+            Some(value) => {
+                for entry in env.iter_mut() {
+                    if entry.name == LEASED_MILLICORES_ENV {
+                        entry.value = Some(value.to_string());
+                    }
+                }
+            }
+            None => env.retain(|entry| entry.name != LEASED_MILLICORES_ENV),
+        }
+    }
+}
+
+/// The millicore spelling of [`LAUNCHER_CPU_REQUEST`] used by the below-request
+/// guard is the same number as the string the manifest carries.
+#[test]
+fn the_launcher_cpu_request_constants_agree() {
+    assert_eq!(
+        LAUNCHER_CPU_REQUEST,
+        format!("{LAUNCHER_CPU_REQUEST_MILLICORES}m")
+    );
+}
+
+/// **AC1.** A leaf-v1 render has NO `cpu` key in the launcher sidecar's limits;
+/// a resize-v2 render has exactly the configured lease ceiling.
+///
+/// Non-vacuity, exactly as the AC words it: delete the
+/// `protocol.launcher_owns_leaf_quota()` early return in
+/// `resolve_launcher_cpu_ceiling` — i.e. render the ceiling unconditionally —
+/// and the leaf-v1 assertion below fails. That mutation is the literal 7deu
+/// defect-1 regression: an ancestor clamp on every invocation leaf, measured at
+/// 0.25 of a core against a leaf set to 4.
+#[test]
+fn the_launcher_cpu_ceiling_is_rendered_only_under_resize_v2() {
+    let cfg = KubernetesConfig::for_testing();
+
+    let mut leaf_v1 = rendered_task_run_job(&cfg);
+    apply(&mut leaf_v1, LauncherAuthorityProtocol::LeafV1).expect("leaf-v1 renders");
+    let limits = launcher_limits(&leaf_v1);
+    assert!(
+        !limits.contains_key("cpu"),
+        "leaf-v1 must render no launcher CPU limit; a limit here clamps every \
+         invocation leaf the launcher lifts (7deu defect 1). Got: {limits:?}"
+    );
+
+    let mut resize_v2 = rendered_task_run_job(&cfg);
+    apply(&mut resize_v2, LauncherAuthorityProtocol::ResizeV2).expect("resize-v2 renders");
+    assert_eq!(
+        launcher_limits(&resize_v2).get("cpu").map(String::as_str),
+        Some(format!("{}m", launcher_leased_millicores(&cfg)).as_str()),
+    );
+    // Stated absolutely once as well, so a change to the default is visible.
+    assert_eq!(
+        launcher_limits(&resize_v2).get("cpu").map(String::as_str),
+        Some("4000m")
+    );
+}
+
+/// The ceiling is the lease the launcher will actually grant, including a
+/// per-project `build_resources.task.cpu_limit` override — which
+/// `apply_resolved_resources` applies BEFORE the protocol seam runs. Deriving
+/// the ceiling from the deployment default instead would clamp such a pod below
+/// its own lease: the 7deu ancestor clamp, re-entered through the override path.
+#[test]
+fn the_resize_v2_ceiling_tracks_a_per_project_cpu_limit_override() {
+    let cfg = KubernetesConfig::for_testing();
+    let mut job = rendered_task_run_job(&cfg);
+    let pod = job
+        .spec
+        .as_mut()
+        .and_then(|spec| spec.template.spec.as_mut())
+        .expect("rendered pod spec");
+    retune_launcher_lease(pod, "8");
+    apply(&mut job, LauncherAuthorityProtocol::ResizeV2).expect("resize-v2 renders");
+    assert_eq!(
+        launcher_limits(&job).get("cpu").map(String::as_str),
+        Some("8000m"),
+        "the container ceiling must equal the lease ceiling, not the deployment default"
+    );
+}
+
+/// Re-applying leaf-v1 over a resize-v2 render must leave no stale clamp: the
+/// rendered resource shape is a total statement of the protocol, not an
+/// additive one.
+#[test]
+fn re_rendering_leaf_v1_clears_a_resize_v2_ceiling() {
+    let cfg = KubernetesConfig::for_testing();
+    let mut job = rendered_task_run_job(&cfg);
+    apply(&mut job, LauncherAuthorityProtocol::ResizeV2).expect("resize-v2 renders");
+    assert!(launcher_limits(&job).contains_key("cpu"));
+    apply(&mut job, LauncherAuthorityProtocol::LeafV1).expect("leaf-v1 renders");
+    assert!(
+        !launcher_limits(&job).contains_key("cpu"),
+        "a leaf-v1 re-render must not inherit the resize-v2 clamp"
+    );
+}
+
+/// **AC2.** The sidecar's requests are byte-identical across both renders — and
+/// to the untouched builder output — and the memory limit is unchanged.
+///
+/// Non-vacuity: change either request value in one arm (or have
+/// `apply_launcher_cpu_ceiling` write into `requests` rather than `limits`) and
+/// the byte-equality below fails.
+#[test]
+fn the_launcher_requests_and_memory_limit_are_identical_across_protocols() {
+    let cfg = KubernetesConfig::for_testing();
+    let baseline_requests = launcher_requests(&rendered_task_run_job(&cfg));
+    assert_eq!(
+        baseline_requests,
+        BTreeMap::from([
+            ("cpu".to_string(), LAUNCHER_CPU_REQUEST.to_string()),
+            ("memory".to_string(), LAUNCHER_MEMORY_REQUEST.to_string()),
+        ]),
+        "the request is the broker's steady footprint; it is not the build's"
+    );
+
+    for protocol in LauncherAuthorityProtocol::ALL {
+        let mut job = rendered_task_run_job(&cfg);
+        apply(&mut job, protocol).expect("both protocols render");
+        assert_eq!(
+            launcher_requests(&job),
+            baseline_requests,
+            "{protocol} must not disturb the launcher's requests"
+        );
+        assert_eq!(
+            launcher_limits(&job).get("memory").map(String::as_str),
+            Some(cfg.memory_limit.as_str()),
+            "{protocol} must not disturb the launcher's memory limit — every \
+             brokered command's memory peak lands in this container's cgroup"
+        );
+    }
+}
+
+/// **AC3.** A resize-v2 ceiling below the sidecar's own CPU request is a render
+/// error, not a Pod the apiserver rejects at admission.
+///
+/// Non-vacuity: delete the `ceiling < LAUNCHER_CPU_REQUEST_MILLICORES` arm in
+/// `resolve_launcher_cpu_ceiling` and this renders `limits.cpu: 10m` against
+/// `requests.cpu: 50m` — a structurally invalid Pod — instead of failing.
+#[test]
+fn a_resize_v2_ceiling_below_the_launcher_cpu_request_is_refused() {
+    let cfg = KubernetesConfig::for_testing();
+    let mut job = rendered_task_run_job(&cfg);
+    set_lease_env(&mut job, Some("10"));
+    let error = apply(&mut job, LauncherAuthorityProtocol::ResizeV2)
+        .expect_err("a 10m ceiling under a 50m request must not render");
+    assert!(
+        matches!(
+            error,
+            RenderValidationError::LauncherCpuCeilingBelowRequest { ceiling: 10, .. }
+        ),
+        "unexpected error: {error:?}"
+    );
+    // A refusal leaves the Job as it found it rather than half-applied.
+    assert!(!launcher_limits(&job).contains_key("cpu"));
+    assert_eq!(
+        env_value(launcher_of(&job), AUTHORITY_PROTOCOL_ENV),
+        None,
+        "a refused render must not have already written the protocol"
+    );
+    // leaf-v1 is unaffected: its launcher container carries no ceiling at all,
+    // so there is nothing that could sit below the request.
+    let mut leaf_v1 = rendered_task_run_job(&cfg);
+    set_lease_env(&mut leaf_v1, Some("10"));
+    apply(&mut leaf_v1, LauncherAuthorityProtocol::LeafV1)
+        .expect("leaf-v1 has no ceiling to check");
+}
+
+/// **AC3, the config-level door.** The same 10m stated as the pod CPU limit
+/// never reaches a render at all: `validate_enforcement_render` refuses it
+/// before the Job is built, because 10m maps onto no usable lease quota.
+#[test]
+fn a_ten_millicore_pod_cpu_limit_never_arms() {
+    let mut cfg = KubernetesConfig::for_testing();
+    cfg.cpu_limit = "10m".to_string();
+    let error = validate_enforcement_render(&cfg)
+        .expect_err("10m must not arm enforcement under either protocol");
+    assert!(
+        matches!(error, RenderValidationError::UnsupportedLeaseQuota { .. }),
+        "unexpected error: {error:?}"
+    );
+}
+
+/// A resize-v2 render whose ceiling cannot be resolved at all is refused rather
+/// than rendered without one. Under resize-v2 the launcher never writes leaf
+/// `cpu.max`, so "no container limit" does not mean "the leaf bounds it" — it
+/// means the build is bounded only by the node.
+#[test]
+fn an_unresolvable_resize_v2_ceiling_is_refused() {
+    let cfg = KubernetesConfig::for_testing();
+    for lease in [None, Some(""), Some("   "), Some("4000m"), Some("0")] {
+        let mut job = rendered_task_run_job(&cfg);
+        set_lease_env(&mut job, lease);
+        let error = apply(&mut job, LauncherAuthorityProtocol::ResizeV2)
+            .expect_err("an unresolvable lease ceiling must not render");
+        assert!(
+            matches!(
+                error,
+                RenderValidationError::UnresolvableLauncherCpuCeiling { .. }
+            ),
+            "lease {lease:?}: unexpected error {error:?}"
+        );
+        assert!(!launcher_limits(&job).contains_key("cpu"));
+    }
+}
+
+/// **AC4.** No non-launcher container's resources change under either protocol.
+///
+/// Asserted structurally over the WHOLE rendered manifest: every container in
+/// `initContainers` and `containers` is discovered from the serialized Job and
+/// its `resources` compared, so a resource change on the worker — or on a
+/// backing-service sidecar, or on a container that does not exist yet — is
+/// caught without this test naming it. The container SET is compared too, so
+/// dropping a container is not silently "nothing's resources changed".
+#[test]
+fn no_non_launcher_container_resources_change_under_either_protocol() {
+    let cfg = KubernetesConfig::for_testing();
+
+    fn container_resources(
+        job: &k8s_openapi::api::batch::v1::Job,
+    ) -> BTreeMap<String, serde_json::Value> {
+        let document = serde_json::to_value(job).expect("the Job serializes");
+        let pod = &document["spec"]["template"]["spec"];
+        ["initContainers", "containers"]
+            .into_iter()
+            .flat_map(|field| {
+                pod[field]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(move |container| {
+                        (
+                            format!(
+                                "{field}/{}",
+                                container["name"].as_str().unwrap_or("<unnamed>")
+                            ),
+                            container
+                                .get("resources")
+                                .cloned()
+                                .unwrap_or(serde_json::Value::Null),
+                        )
+                    })
+            })
+            .collect()
+    }
+
+    let launcher_key = format!("initContainers/{LAUNCHER_CONTAINER_NAME}");
+    let baseline = container_resources(&rendered_task_run_job(&cfg));
+    assert!(
+        baseline.contains_key(&launcher_key) && baseline.len() > 1,
+        "the manifest must carry the launcher AND something else, or this test \
+         proves nothing: {baseline:?}"
+    );
+
+    for protocol in LauncherAuthorityProtocol::ALL {
+        let mut job = rendered_task_run_job(&cfg);
+        apply(&mut job, protocol).expect("both protocols render");
+        let after = container_resources(&job);
+        assert_eq!(
+            baseline.keys().collect::<Vec<_>>(),
+            after.keys().collect::<Vec<_>>(),
+            "{protocol} changed the rendered container set"
+        );
+        for (key, before) in &baseline {
+            if key == &launcher_key {
+                continue;
+            }
+            assert_eq!(
+                Some(before),
+                after.get(key),
+                "{protocol} changed the resources of container {key}"
+            );
+        }
+    }
+}
+
+/// A `disabled` render carries no sidecar to hold a ceiling, and asking for one
+/// is a no-op rather than an error — the same shape the protocol env has.
+#[test]
+fn a_disabled_render_gets_no_launcher_ceiling() {
+    let mut cfg = KubernetesConfig::for_testing();
+    cfg.cgroup_launcher_mode = CgroupLauncherMode::Disabled;
+    let mut job = rendered_task_run_job(&cfg);
+    apply_launcher_authority_protocol(
+        &mut job,
+        CgroupLauncherMode::Disabled,
+        LauncherAuthorityProtocol::ResizeV2,
+    )
+    .expect("disabled is a no-op");
+    let pod = job
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .expect("rendered pod spec");
+    assert!(
+        !pod.init_containers
+            .iter()
+            .flatten()
+            .any(|container| container.name == LAUNCHER_CONTAINER_NAME),
+        "a disabled render carries no launcher sidecar at all"
+    );
+}


### PR DESCRIPTION
Task `4wx3` (epic `g8jk`, proposal `3i92`). Blocks `g8jk-3`, `xowm-1`, `xowm-4`.

## The proposal was wrong about the starting state

3i92 says the Pod "is rendered with the launcher's configured full CPU ceiling,
currently 4000m, at `spec.initContainers[name=cgroup-launcher].resources.limits.cpu`".
Verified on `origin/main` before writing a line: **that is false.** `launcher.rs`
rendered `requests {cpu: 50m, memory: 64Mi}` and `limits {memory}` only, with an
explicit prohibition in place of the CPU limit and a `NOTE (task 7deu, defect 1)`
explaining it. The 4000m the proposal named is the **worker container's** limit
(`config.cpu_limit`), which the launcher receives as the derived
`DJINN_LAUNCHER_LEASED_MILLICORES` env var via `launcher_leased_millicores`.

So this ceiling is new, previously unplanned work — and it is conditional on
`resize-v2` for a reason this repo has already paid for once.

## Why conditional

Under `leaf-v1` the launcher owns each invocation leaf's `cpu.max`. A CPU limit
on the launcher **container** is then an ancestor clamp over every one of those
leaves. Task 7deu measured it: a leaf set to a full 4 cores burned 1.25s of CPU
over a 5s window with two spinners — exactly 0.25 core, the container limit —
and the leaf's own `nr_throttled` read `0`, because the throttling happened at
the parent. That blindness broke goxi's throttle-based heavy detection too.

Under `resize-v2`, `LauncherAuthorityProtocol::launcher_owns_leaf_quota()` is
**false**: the launcher never writes a leaf `cpu.max`, not even `max`. There is
no leaf ceiling left for a container limit to clamp below — the container limit
*is* the ceiling, and pod resize is what moves it. Without one, a brokered build
is bounded only by the node.

## What changed

`limits.cpu` on the `cgroup-launcher` sidecar, **only** under `resize-v2`,
resolved through the canonical `LauncherAuthorityProtocol::launcher_owns_leaf_quota()`
(`djinn-launcher-protocol`, #2823) rather than a hard-coded protocol string.

It lands at the same post-render seam that already writes
`DJINN_LAUNCHER_AUTHORITY_PROTOCOL` (#2836, built on rather than around):
`launcher::apply_launcher_authority_protocol`. `job.rs` and `runtime.rs` are
untouched. The sidecar builder is a pure function of the config and cannot know
the resolved catalog image's protocol; keeping both protocol-derived facts in
one function means a render can never carry the `resize-v2` env with a `leaf-v1`
resource shape, or the reverse.

**The value is read back off the rendered sidecar's lease env, not recomputed
from `launcher_leased_millicores(config)`.** `apply_resolved_resources` runs
first (`runtime.rs:801` before `:805`) and may already have re-pointed the lease
at a per-project `build_resources.task.cpu_limit` override. A ceiling derived
from the deployment default would clamp such a pod *below* the lease its own
launcher grants — the 7deu ancestor clamp, re-entered through the override path.
`the_resize_v2_ceiling_tracks_a_per_project_cpu_limit_override` pins this.

Two fail-closed guards, both new `RenderValidationError` variants:

* `UnresolvableLauncherCpuCeiling` — a `resize-v2` render whose ceiling cannot
  be resolved is refused, not rendered without one.
* `LauncherCpuCeilingBelowRequest` — a ceiling under the sidecar's own 50m
  request is refused here, where the number is still a number, rather than
  becoming a Pod the apiserver rejects at admission.

`requests` are byte-identical across both renders, the memory limit is
unchanged, and re-applying `leaf-v1` over a `resize-v2` render *clears* the
ceiling rather than leaving a stale clamp.

## ⚠️ Knock-on that `g8jk-3`, `0ppk` and `xowm-4` must not get wrong

Today the pod cgroup is **unbounded**, because the launcher carries no CPU limit
while the worker does — the kubelet leaves the pod slice's `cpu.max` unset
whenever any container in the pod has no CPU limit.

After this change, a default `resize-v2` render makes the pod slice
worker + launcher, so the kubelet sets pod `cpu.max` to **4250m** rather than
leaving it unset. That is a transition from *unset* to *a number*, not an
increment of an existing number.

**Any downstream test asserting pod-slice `cpu.max` must assert the DELTA equal
to the launcher limit change, never an absolute value.** The proposal's own
"250m to the captured ceiling" arithmetic is wrong for exactly this reason: it
starts from a captured ceiling that does not exist on `main`. A `leaf-v1` render
is unchanged and its pod slice stays unset.

## AC verification — every mutation run, real output

All four ACs were driven by mutating the shipped code and observing the failure.

**AC1** — leaf-v1 renders no `cpu` key; resize-v2 renders exactly the configured
value. Mutation: delete the `protocol.launcher_owns_leaf_quota()` early return in
`resolve_launcher_cpu_ceiling`, i.e. render the ceiling unconditionally — the
literal 7deu defect-1 regression. 3 tests fail:

```
---- launcher::tests::the_launcher_cpu_ceiling_is_rendered_only_under_resize_v2 stdout ----
leaf-v1 must render no launcher CPU limit; a limit here clamps every invocation
leaf the launcher lifts (7deu defect 1). Got: {"cpu": "4000m", "memory": "4Gi"}

---- launcher::tests::re_rendering_leaf_v1_clears_a_resize_v2_ceiling stdout ----
a leaf-v1 re-render must not inherit the resize-v2 clamp

---- launcher::tests::a_resize_v2_ceiling_below_the_launcher_cpu_request_is_refused stdout ----
leaf-v1 has no ceiling to check: LauncherCpuCeilingBelowRequest { ceiling: 10, request: "50m" }

test result: FAILED. 39 passed; 3 failed
```

`{"cpu": "4000m"}` on a leaf-v1 sidecar is the regression, reproduced.

**AC2** — requests byte-identical across both renders, memory limit unchanged.
Mutation: have `apply_launcher_cpu_ceiling` write into `requests` instead of
`limits`. 4 tests fail, the AC2 one naming the changed request:

```
---- launcher::tests::the_launcher_requests_and_memory_limit_are_identical_across_protocols ----
assertion `left == right` failed: resize-v2 must not disturb the launcher's requests
  left: {"cpu": "4000m", "memory": "64Mi"}
 right: {"cpu": "50m", "memory": "64Mi"}

test result: FAILED. 38 passed; 4 failed
```

**AC3** — a resize-v2 ceiling below `LAUNCHER_CPU_REQUEST` is a render error.
Mutation: delete the `ceiling < LAUNCHER_CPU_REQUEST_MILLICORES` arm:

```
---- launcher::tests::a_resize_v2_ceiling_below_the_launcher_cpu_request_is_refused ----
a 10m ceiling under a 50m request must not render: ()

test result: FAILED. 41 passed; 1 failed
```

The AC's literal `cpu_limit=10m` is covered separately by
`a_ten_millicore_pod_cpu_limit_never_arms`: stated as the *pod* CPU limit, 10m
never reaches a render at all — `validate_enforcement_render` refuses it with
`UnsupportedLeaseQuota`, since `LeasedQuota::MIN_MILLICORES` is 1000. The new
guard is the second door, reachable by any future writer of the lease env.

**AC4** — no non-launcher container's resources change, asserted structurally
over the whole manifest. The test serializes the Job and discovers every
container in `initContainers` and `containers` from the document, comparing each
`resources` block plus the container set itself — nothing is named by hand.
Mutation: also apply the ceiling to the worker container:

```
---- launcher::tests::no_non_launcher_container_resources_change_under_either_protocol ----
assertion `left == right` failed: leaf-v1 changed the resources of container containers/worker
  left:  {"limits": {"cpu": "4", "memory": "4Gi"}, "requests": {"cpu": "1", "memory": "2Gi"}}
 right: {"limits": {"memory": "4Gi"}, "requests": {"cpu": "1", "memory": "2Gi"}}

test result: FAILED. 41 passed; 1 failed
```

Unmutated: `337 passed; 0 failed` (`djinn-k8s --lib`), plus #2836's
`launcher_authority_protocol_render` integration suite `4 passed; 0 failed`.

## Housekeeping

* `cargo fmt --check -p djinn-k8s` is clean (enforced in CI since #2834). Only
  the three files owned by this task were formatted; the known pre-existing
  drift in `build_lease_cap_arming_tests.rs` is left alone, as it belongs to
  another owner.
* `check-file-size.sh` passes — `launcher.rs` is 42553 bytes against the 51200
  ceiling, and `launcher_cpu.rs` absorbed the shared helper to keep it there.
* `check-raw-sql-boundary.sh` passes.
* No changes to `job.rs`, `runtime.rs`, `build_pod_permit.rs` or `deploy/**`.
  Pod CPU **requests** are untouched, so bin-packing and build admission are
  unaffected.
