### PR TITLE
feat(db): fence no-handshake legacy images by immutable digest (vf7a)

### DIFF
--- a/server/crates/djinn-db/src/launcher_compatibility.rs
+++ b/server/crates/djinn-db/src/launcher_compatibility.rs
@@ -1,0 +1,965 @@
+//! The admission compatibility decision for pre-protocol ("no-handshake")
+//! catalog images, and the signed inventory of digests that opens it.
+//!
+//! # What this decides
+//!
+//! Since migration 166 an image may **declare** which component owns the CPU
+//! quota of the invocation leaf its `djinn-cgroup-launcher` sidecar creates
+//! ([`LauncherAuthorityProtocol`]). Every image built before that declaration
+//! existed says nothing, and `NULL` is not `leaf-v1`: it is *this artifact
+//! never said*.
+//!
+//! Task `z3gi` (#2837) already owns the decision for artifacts that *did*
+//! speak: [`decide_launcher_protocol_admission`] compares a declaration against
+//! the persisted `launcher_authority_mode` singleton and admits only an exact
+//! agreement. Its [`LauncherProtocolAdmission::UndeclaredProtocol`] verdict is
+//! a refusal *pending this task* — its own doc comment says so.
+//!
+//! [`decide_admission`] here is that decision **composed with** the legacy
+//! allowlist, and it is the only place a missing declaration can become an
+//! effective quota authority. It is not a second implementation: every
+//! artifact that declares anything is routed straight through z3gi's verdict,
+//! untouched. The legacy arm requires all of:
+//!
+//! * the artifact is identified by an **exact, canonical, immutable digest**
+//!   (`sha256:` + 64 lowercase hex — never a tag, never an image name), **and**
+//! * that digest is listed in a signed inventory of known pre-protocol
+//!   artifacts, **and**
+//! * the persisted authority mode is [`LauncherAuthorityProtocol::LeafV1`],
+//!   which is the behavior those artifacts were built against.
+//!
+//! Everything else is refused *before* a Job is rendered, let alone before a
+//! shell runs inside one: a declaration that disagrees with the mode, an
+//! unparseable declaration, an unreadable authority singleton, a missing
+//! declaration under `resize-v2`, a malformed digest, a digest the inventory
+//! does not list, and an inventory that fails its own provenance/signature
+//! validation.
+//!
+//! # What this deliberately does NOT decide
+//!
+//! An undeclared image with **no digest at all** is [`AdmissionDecision::Undeclarable`],
+//! not a rejection *here*. Migration 166 keeps such rows legal on purpose — a
+//! pre-existing `status = 'ready'` row with `registry_digest IS NULL` also has
+//! a `NULL` protocol, and the CHECK is scoped to declaring rows so the upgrade
+//! cannot strand a live catalog. The refusal for that shape already lives one
+//! layer out, in `djinn_k8s::launcher::render_authority_protocol` (#2836),
+//! which refuses to render a Job for an image that identifies neither itself
+//! nor its quota authority. Duplicating it here as a resolution *error* would
+//! turn a reporting path (dispatch readiness, warm, indexer) into a failure
+//! path for a row the database is explicitly allowed to hold.
+//!
+//! So there is still exactly one effective authority per admitted dispatch, and
+//! exactly one fence per rejected one.
+//!
+//! # Arming
+//!
+//! [`LegacyDigestInventory::Unconfigured`] — no inventory source in the
+//! deployment's environment — keeps the pre-existing rule for the *membership*
+//! test only: an undeclared, canonically digest-pinned image still maps to
+//! `leaf-v1` under `leaf-v1` mode, exactly as #2836 ships today. An inventory
+//! that is not configured cannot classify any digest as "unknown", and making
+//! the absence of a config file retroactively strand every already-built
+//! digest-pinned image is precisely the wedge migration 166 refused to create.
+//!
+//! The moment a deployment configures an inventory, membership is required and
+//! a miss is a rejection. Every *other* rejection class — mode disagreement,
+//! missing declaration under `resize-v2`, malformed digest, unusable inventory
+//! — is unconditional and needs no configuration to bite.
+//!
+//! The server authority mode is **not** configured here: it is the durable
+//! `launcher_authority_mode` singleton z3gi's migration 167 seeds, read through
+//! [`LauncherAuthorityModeRepository`](crate::repositories::launcher_authority_mode::LauncherAuthorityModeRepository).
+//! An absent or unreadable singleton is
+//! [`LauncherProtocolAdmission::AuthorityUnavailable`] — a refusal, never a
+//! default.
+//!
+//! # Configuration (read at process start, so a restart re-reads it)
+//!
+//! | variable | meaning |
+//! |---|---|
+//! | `DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY` | path to the inventory document |
+//! | `DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_PUBLIC_KEY` | base64 raw Ed25519 public key (32 bytes) |
+//! | `DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_SIGNATURE` | base64 Ed25519 signature (64 bytes) over the document's exact bytes |
+//!
+//! Document shape:
+//!
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "issuer": "platform-ops",
+//!   "issued_at": "2026-07-30T00:00:00Z",
+//!   "digests": ["sha256:7822b7de...64 lowercase hex..."]
+//! }
+//! ```
+//!
+//! Every validation failure — unreadable file, absent key, absent signature,
+//! bad base64, wrong key/signature length, failed verification, unknown schema
+//! version, malformed digest entry — produces
+//! [`LegacyDigestInventory::Unusable`], which rejects **all** legacy
+//! compatibility rather than falling back to the unarmed rule. Fail closed
+//! means a broken inventory is stricter than no inventory, never looser.
+//!
+//! To build the document for a live deployment, enumerate the exact rows that
+//! need it with
+//! [`ImageRepository::legacy_pre_protocol_digests`](crate::repositories::image::ImageRepository::legacy_pre_protocol_digests).
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::sync::OnceLock;
+
+use base64::Engine as _;
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+
+use crate::repositories::launcher_authority_mode::{
+    LauncherProtocolAdmission, decide_launcher_protocol_admission,
+};
+
+/// Environment variable holding the path of the legacy digest inventory.
+pub const INVENTORY_PATH_ENV: &str = "DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY";
+/// Environment variable holding the base64 Ed25519 public key.
+pub const INVENTORY_PUBLIC_KEY_ENV: &str = "DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_PUBLIC_KEY";
+/// Environment variable holding the base64 Ed25519 signature.
+pub const INVENTORY_SIGNATURE_ENV: &str = "DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_SIGNATURE";
+
+/// The only schema version [`LegacyDigestInventory`] accepts.
+pub const INVENTORY_SCHEMA_VERSION: u32 = 1;
+
+const DIGEST_PREFIX: &str = "sha256:";
+const DIGEST_HEX_LEN: usize = 64;
+const ED25519_PUBLIC_KEY_LEN: usize = 32;
+const ED25519_SIGNATURE_LEN: usize = 64;
+
+// ── digests ─────────────────────────────────────────────────────────────────
+
+/// A canonical, immutable OCI manifest digest: `sha256:` followed by exactly 64
+/// lowercase hex characters.
+///
+/// Uppercase hex is rejected rather than normalized. Two spellings of the same
+/// digest would make "exact inventory match" a comparison between whichever
+/// spelling each side happened to write, and the whole point of comparing
+/// digests instead of tags is that the comparison is exact.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PreProtocolDigest(String);
+
+impl PreProtocolDigest {
+    /// Parse a canonical digest. `Err` carries the offending input so a
+    /// fail-closed caller can name it.
+    pub fn parse(raw: &str) -> Result<Self, MalformedDigest> {
+        let candidate = raw.trim();
+        let malformed = || MalformedDigest {
+            input: candidate.to_owned(),
+        };
+        let hex = candidate
+            .strip_prefix(DIGEST_PREFIX)
+            .ok_or_else(malformed)?;
+        if hex.len() != DIGEST_HEX_LEN {
+            return Err(malformed());
+        }
+        if !hex
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        {
+            return Err(malformed());
+        }
+        Ok(Self(candidate.to_owned()))
+    }
+
+    /// The canonical `sha256:<64 hex>` text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for PreProtocolDigest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// A digest that is not exactly `sha256:` + 64 lowercase hex.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MalformedDigest {
+    input: String,
+}
+
+impl MalformedDigest {
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+}
+
+impl fmt::Display for MalformedDigest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{:?} is not a canonical immutable digest (expected \"sha256:\" followed by exactly \
+             64 lowercase hex characters)",
+            self.input
+        )
+    }
+}
+
+// ── inventory ───────────────────────────────────────────────────────────────
+
+/// Why a configured inventory cannot be used. Every variant means "grant no
+/// legacy compatibility at all".
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InventoryFault {
+    /// The document path is configured but could not be read.
+    Unreadable { path: String, error: String },
+    /// The document is configured but no verification key was supplied.
+    PublicKeyMissing,
+    /// The document is configured but no signature was supplied.
+    SignatureMissing,
+    /// The key or signature is not base64, or is the wrong length.
+    ProvenanceMalformed(String),
+    /// Ed25519 verification of the document bytes failed under the configured key.
+    SignatureInvalid,
+    /// The document is not the JSON shape this module accepts.
+    DocumentMalformed(String),
+    /// A `digests` entry is not a canonical immutable digest.
+    DigestMalformed(MalformedDigest),
+}
+
+impl fmt::Display for InventoryFault {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unreadable { path, error } => {
+                write!(formatter, "inventory {path:?} could not be read: {error}")
+            }
+            Self::PublicKeyMissing => write!(
+                formatter,
+                "inventory is configured but {INVENTORY_PUBLIC_KEY_ENV} is not set; an unsigned \
+                 inventory is never trusted"
+            ),
+            Self::SignatureMissing => write!(
+                formatter,
+                "inventory is configured but {INVENTORY_SIGNATURE_ENV} is not set; an unsigned \
+                 inventory is never trusted"
+            ),
+            Self::ProvenanceMalformed(detail) => {
+                write!(formatter, "inventory provenance is malformed: {detail}")
+            }
+            Self::SignatureInvalid => write!(
+                formatter,
+                "inventory signature does not verify against {INVENTORY_PUBLIC_KEY_ENV}"
+            ),
+            Self::DocumentMalformed(detail) => {
+                write!(formatter, "inventory document is malformed: {detail}")
+            }
+            Self::DigestMalformed(digest) => {
+                write!(formatter, "inventory lists a bad digest: {digest}")
+            }
+        }
+    }
+}
+
+/// Who issued a verified inventory, carried so a rejection or an admission can
+/// name the document it was decided against.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InventoryProvenance {
+    pub issuer: String,
+    pub issued_at: String,
+}
+
+/// The set of pre-protocol artifacts a deployment vouches for.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LegacyDigestInventory {
+    /// No inventory source configured. The membership test is unarmed; see the
+    /// module docs. Every other fence still applies.
+    Unconfigured,
+    /// A signature-verified inventory. Only these digests get compatibility.
+    Verified {
+        provenance: InventoryProvenance,
+        digests: BTreeSet<PreProtocolDigest>,
+    },
+    /// Configured but unusable. No digest gets compatibility.
+    Unusable(InventoryFault),
+}
+
+/// The wire shape of the inventory document.
+#[derive(Debug, serde::Deserialize)]
+struct InventoryDocument {
+    schema_version: u32,
+    #[serde(default)]
+    issuer: String,
+    #[serde(default)]
+    issued_at: String,
+    digests: Vec<String>,
+}
+
+impl LegacyDigestInventory {
+    /// Build a verified inventory directly, for tests and for callers that
+    /// obtained the document through some path other than the environment.
+    pub fn verified<I>(issuer: &str, issued_at: &str, digests: I) -> Self
+    where
+        I: IntoIterator<Item = PreProtocolDigest>,
+    {
+        Self::Verified {
+            provenance: InventoryProvenance {
+                issuer: issuer.to_owned(),
+                issued_at: issued_at.to_owned(),
+            },
+            digests: digests.into_iter().collect(),
+        }
+    }
+
+    /// The process-wide inventory, read from the environment on first use.
+    ///
+    /// A restart re-reads the document, which is how an operator adds an
+    /// artifact to the inventory. Nothing re-reads it in-process: an allowlist
+    /// that can change under a running dispatch is not an allowlist.
+    pub fn process() -> &'static Self {
+        static INVENTORY: OnceLock<LegacyDigestInventory> = OnceLock::new();
+        INVENTORY.get_or_init(Self::from_env)
+    }
+
+    /// Read the inventory the deployment configured, verifying its provenance.
+    pub fn from_env() -> Self {
+        let Some(path) = non_empty_env(INVENTORY_PATH_ENV) else {
+            return Self::Unconfigured;
+        };
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return Self::Unusable(InventoryFault::Unreadable {
+                    path,
+                    error: error.to_string(),
+                });
+            }
+        };
+        Self::from_signed_document(
+            &bytes,
+            non_empty_env(INVENTORY_PUBLIC_KEY_ENV).as_deref(),
+            non_empty_env(INVENTORY_SIGNATURE_ENV).as_deref(),
+        )
+    }
+
+    /// Verify `document` against `public_key_b64`/`signature_b64` and parse it.
+    ///
+    /// Exposed so the provenance rules are testable without writing files or
+    /// mutating process environment.
+    pub fn from_signed_document(
+        document: &[u8],
+        public_key_b64: Option<&str>,
+        signature_b64: Option<&str>,
+    ) -> Self {
+        let Some(public_key_b64) = public_key_b64 else {
+            return Self::Unusable(InventoryFault::PublicKeyMissing);
+        };
+        let Some(signature_b64) = signature_b64 else {
+            return Self::Unusable(InventoryFault::SignatureMissing);
+        };
+        let public_key = match decode_fixed(public_key_b64, ED25519_PUBLIC_KEY_LEN, "public key") {
+            Ok(bytes) => bytes,
+            Err(fault) => return Self::Unusable(fault),
+        };
+        let signature = match decode_fixed(signature_b64, ED25519_SIGNATURE_LEN, "signature") {
+            Ok(bytes) => bytes,
+            Err(fault) => return Self::Unusable(fault),
+        };
+        if ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, &public_key)
+            .verify(document, &signature)
+            .is_err()
+        {
+            return Self::Unusable(InventoryFault::SignatureInvalid);
+        }
+
+        let parsed: InventoryDocument = match serde_json::from_slice(document) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                return Self::Unusable(InventoryFault::DocumentMalformed(error.to_string()));
+            }
+        };
+        if parsed.schema_version != INVENTORY_SCHEMA_VERSION {
+            return Self::Unusable(InventoryFault::DocumentMalformed(format!(
+                "schema_version {} is not {INVENTORY_SCHEMA_VERSION}",
+                parsed.schema_version
+            )));
+        }
+        let mut digests = BTreeSet::new();
+        for raw in &parsed.digests {
+            match PreProtocolDigest::parse(raw) {
+                Ok(digest) => {
+                    digests.insert(digest);
+                }
+                Err(malformed) => {
+                    return Self::Unusable(InventoryFault::DigestMalformed(malformed));
+                }
+            }
+        }
+        Self::Verified {
+            provenance: InventoryProvenance {
+                issuer: parsed.issuer,
+                issued_at: parsed.issued_at,
+            },
+            digests,
+        }
+    }
+
+    /// Is `digest` vouched for? `Err` when the inventory cannot answer.
+    fn vouches_for(&self, digest: &PreProtocolDigest) -> Result<bool, &InventoryFault> {
+        match self {
+            // Unarmed: the membership question has no configured answer, so it
+            // is not asked. See the module docs.
+            Self::Unconfigured => Ok(true),
+            Self::Verified { digests, .. } => Ok(digests.contains(digest)),
+            Self::Unusable(fault) => Err(fault),
+        }
+    }
+}
+
+fn decode_fixed(value: &str, len: usize, what: &str) -> Result<Vec<u8>, InventoryFault> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value.trim())
+        .map_err(|error| {
+            InventoryFault::ProvenanceMalformed(format!("{what} is not base64: {error}"))
+        })?;
+    if bytes.len() != len {
+        return Err(InventoryFault::ProvenanceMalformed(format!(
+            "{what} is {} bytes, expected {len}",
+            bytes.len()
+        )));
+    }
+    Ok(bytes)
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+// ── the decision ────────────────────────────────────────────────────────────
+
+/// What admission concluded about one resolved catalog image.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AdmissionDecision {
+    /// The single effective quota authority for this dispatch.
+    Admitted(LauncherAuthorityProtocol),
+    /// The artifact declares no protocol and carries no digest, so there is no
+    /// compatibility claim to evaluate and none may be invented. The render
+    /// (`djinn_k8s::launcher::render_authority_protocol`) refuses the Job.
+    Undeclarable,
+}
+
+/// Why an image may not dispatch.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AdmissionRejection {
+    /// z3gi's verdict on a declaration refused it: it named the other protocol,
+    /// it was unparseable, or the authority singleton could not be read. Carried
+    /// verbatim rather than restated, so there is exactly one vocabulary for
+    /// "this declaration may not run here".
+    Declared(LauncherProtocolAdmission),
+    /// No declaration, and the persisted authority is not the protocol legacy
+    /// artifacts were built against.
+    MissingDeclarationUnderMode {
+        mode: LauncherAuthorityProtocol,
+        digest: String,
+    },
+    /// No declaration, and the identifying digest is not canonical.
+    MalformedDigest(MalformedDigest),
+    /// No declaration, and the inventory does not vouch for the digest.
+    UninventoriedDigest(PreProtocolDigest),
+    /// No declaration, and the configured inventory cannot be trusted.
+    InventoryUnusable(InventoryFault),
+}
+
+impl fmt::Display for AdmissionRejection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Declared(LauncherProtocolAdmission::ProtocolMismatch { mode, declared }) => {
+                write!(
+                    formatter,
+                    "the image declares launcher authority protocol {declared} but this server \
+                     runs {mode}; dispatching would put two components in charge of one leaf's \
+                     cpu.max, so the image must be rebuilt against {mode}"
+                )
+            }
+            Self::Declared(LauncherProtocolAdmission::UnknownProtocol { mode, declared }) => {
+                write!(
+                    formatter,
+                    "the image declares launcher authority protocol {declared:?}, which is not a \
+                     protocol this plane knows; refusing to guess that it means {mode}"
+                )
+            }
+            Self::Declared(LauncherProtocolAdmission::AuthorityUnavailable) => write!(
+                formatter,
+                "the launcher authority mode singleton (migration 167) could not be read; \
+                 refusing every dispatch rather than resolving it to a default"
+            ),
+            // `Admitted` and `UndeclaredProtocol` never reach this arm —
+            // `admit_with_legacy_inventory` converts both — but a refusal must
+            // still render rather than panic.
+            Self::Declared(other) => write!(
+                formatter,
+                "the image's declared launcher authority protocol was refused: {other:?}"
+            ),
+            Self::MissingDeclarationUnderMode { mode, digest } => write!(
+                formatter,
+                "the image at {digest} declares no launcher authority protocol and this server \
+                 runs {mode}; a no-handshake artifact may only be admitted under \
+                 {leaf}, so the image must be rebuilt",
+                leaf = LauncherAuthorityProtocol::LeafV1
+            ),
+            Self::MalformedDigest(malformed) => write!(
+                formatter,
+                "the image declares no launcher authority protocol and is not pinned to an \
+                 immutable manifest digest: {malformed}. Compatibility is granted to exact \
+                 digests only — never to a tag or an image name"
+            ),
+            Self::UninventoriedDigest(digest) => write!(
+                formatter,
+                "the image at {digest} declares no launcher authority protocol and is not listed \
+                 in the pre-protocol digest inventory ({INVENTORY_PATH_ENV}); rebuild it so it \
+                 declares a protocol, or add this exact digest to the signed inventory"
+            ),
+            Self::InventoryUnusable(fault) => write!(
+                formatter,
+                "the image declares no launcher authority protocol and the pre-protocol digest \
+                 inventory cannot be trusted, so no legacy compatibility is granted: {fault}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AdmissionRejection {}
+
+/// **The centralized admission compatibility decision.**
+///
+/// `mode` is the persisted `launcher_authority_mode` (migration 167),
+/// `declared` is the artifact's own build-metadata declaration (migration 166),
+/// `digest` is `images.registry_digest`, and `inventory` is the deployment's
+/// signed pre-protocol allowlist.
+///
+/// The declaration arm is delegated wholesale to
+/// [`decide_launcher_protocol_admission`]; only its
+/// [`LauncherProtocolAdmission::UndeclaredProtocol`] refusal — the one z3gi
+/// explicitly reserved for this task — is reinterpreted here, and only on the
+/// evidence the module docs list.
+///
+/// Only digests are compared. `tag` is deliberately not a parameter: a tag is
+/// mutable naming that can be made to claim anything, and `djinn-image-controller`
+/// already has a fixture whose repository segment and tag suffix both read
+/// `resize-v2` for an artifact that declares `leaf-v1`.
+pub fn decide_admission(
+    mode: LauncherAuthorityProtocol,
+    declared: Option<LauncherAuthorityProtocol>,
+    digest: Option<&str>,
+    inventory: &LegacyDigestInventory,
+) -> Result<AdmissionDecision, AdmissionRejection> {
+    admit_with_legacy_inventory(
+        decide_launcher_protocol_admission(mode, declared.map(LauncherAuthorityProtocol::as_wire)),
+        digest,
+        inventory,
+    )
+}
+
+/// Reinterpret an already-computed [`LauncherProtocolAdmission`] in the light of
+/// the legacy digest inventory.
+///
+/// Exposed so a caller that has already spent the authority-singleton read (a
+/// preflight, a diagnostic) reaches the same verdict without a second round
+/// trip — the same split z3gi made between its repository method and its pure
+/// decision.
+pub fn admit_with_legacy_inventory(
+    verdict: LauncherProtocolAdmission,
+    digest: Option<&str>,
+    inventory: &LegacyDigestInventory,
+) -> Result<AdmissionDecision, AdmissionRejection> {
+    let mode = match verdict {
+        // The artifact spoke and agrees with the authority. Nothing legacy
+        // about it; the inventory is not consulted at all.
+        LauncherProtocolAdmission::Admitted { mode } => {
+            return Ok(AdmissionDecision::Admitted(mode));
+        }
+        // The one verdict this task owns.
+        LauncherProtocolAdmission::UndeclaredProtocol { mode } => mode,
+        // Every other refusal stands exactly as z3gi decided it.
+        refused => return Err(AdmissionRejection::Declared(refused)),
+    };
+
+    // No declaration. Without a digest there is nothing to check a claim
+    // against; that shape is refused at the render, not resolved here.
+    let Some(raw) = digest.map(str::trim).filter(|d| !d.is_empty()) else {
+        return Ok(AdmissionDecision::Undeclarable);
+    };
+
+    let digest = PreProtocolDigest::parse(raw).map_err(AdmissionRejection::MalformedDigest)?;
+
+    if mode != LauncherAuthorityProtocol::LeafV1 {
+        return Err(AdmissionRejection::MissingDeclarationUnderMode {
+            mode,
+            digest: digest.as_str().to_owned(),
+        });
+    }
+
+    match inventory.vouches_for(&digest) {
+        Ok(true) => Ok(AdmissionDecision::Admitted(
+            LauncherAuthorityProtocol::LeafV1,
+        )),
+        Ok(false) => Err(AdmissionRejection::UninventoriedDigest(digest)),
+        Err(fault) => Err(AdmissionRejection::InventoryUnusable(fault.clone())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A canonical digest fixture: `sha256:` + 64 lowercase hex.
+    pub(super) fn digest(seed: char) -> String {
+        format!("sha256:{}", seed.to_string().repeat(DIGEST_HEX_LEN))
+    }
+
+    fn inventory_with(seed: char) -> LegacyDigestInventory {
+        LegacyDigestInventory::verified(
+            "ops",
+            "now",
+            [PreProtocolDigest::parse(&digest(seed)).unwrap()],
+        )
+    }
+
+    #[test]
+    fn only_canonical_lowercase_sha256_digests_parse() {
+        assert_eq!(
+            PreProtocolDigest::parse(&digest('a')).unwrap().as_str(),
+            digest('a')
+        );
+        for rejected in [
+            "sha256:abc",                          // too short
+            &digest('a')[..70],                    // truncated
+            &format!("{}0", digest('a')),          // too long
+            &digest('a').to_uppercase(),           // uppercase prefix + hex
+            &format!("sha256:{}", "A".repeat(64)), // uppercase hex
+            &format!("sha512:{}", "a".repeat(64)), // wrong algorithm
+            &"a".repeat(64),                       // no prefix
+            &format!("sha256:{}", "g".repeat(64)), // non-hex
+            "reg/djinn-image-i1:hash",             // a tag
+        ] {
+            assert!(
+                PreProtocolDigest::parse(rejected).is_err(),
+                "{rejected:?} must not parse as a canonical digest"
+            );
+        }
+    }
+
+    /// A declaration is routed straight to z3gi's decision, which admits only
+    /// an exact agreement with the persisted authority.
+    #[test]
+    fn a_declaration_is_honored_only_when_it_matches_the_authority_mode() {
+        for mode in LauncherAuthorityProtocol::ALL {
+            for declared in LauncherAuthorityProtocol::ALL {
+                let outcome = decide_admission(
+                    mode,
+                    Some(declared),
+                    Some(&digest('a')),
+                    &LegacyDigestInventory::Unconfigured,
+                );
+                if declared == mode {
+                    assert_eq!(outcome, Ok(AdmissionDecision::Admitted(declared)));
+                } else {
+                    assert_eq!(
+                        outcome,
+                        Err(AdmissionRejection::Declared(
+                            LauncherProtocolAdmission::ProtocolMismatch { mode, declared }
+                        ))
+                    );
+                }
+            }
+        }
+    }
+
+    /// The refusals z3gi owns pass through untouched, inventory or not: the
+    /// legacy allowlist may only reinterpret `UndeclaredProtocol`.
+    #[test]
+    fn only_the_undeclared_verdict_is_reinterpreted() {
+        let inventory = inventory_with('a');
+        for verdict in [
+            LauncherProtocolAdmission::ProtocolMismatch {
+                mode: LauncherAuthorityProtocol::LeafV1,
+                declared: LauncherAuthorityProtocol::ResizeV2,
+            },
+            LauncherProtocolAdmission::UnknownProtocol {
+                mode: LauncherAuthorityProtocol::LeafV1,
+                declared: "leaf-v9".into(),
+            },
+            LauncherProtocolAdmission::AuthorityUnavailable,
+        ] {
+            assert_eq!(
+                admit_with_legacy_inventory(verdict.clone(), Some(&digest('a')), &inventory),
+                Err(AdmissionRejection::Declared(verdict.clone())),
+                "{verdict:?} must survive the legacy arm unchanged"
+            );
+        }
+        // And an admitted declaration is not re-decided either.
+        assert_eq!(
+            admit_with_legacy_inventory(
+                LauncherProtocolAdmission::Admitted {
+                    mode: LauncherAuthorityProtocol::ResizeV2
+                },
+                None,
+                &LegacyDigestInventory::Unusable(InventoryFault::SignatureInvalid),
+            ),
+            Ok(AdmissionDecision::Admitted(
+                LauncherAuthorityProtocol::ResizeV2
+            ))
+        );
+    }
+
+    #[test]
+    fn a_missing_declaration_never_survives_resize_v2() {
+        // Even the inventoried digest is refused: resize-v2 is not the behavior
+        // a no-handshake artifact was built against.
+        assert!(matches!(
+            decide_admission(
+                LauncherAuthorityProtocol::ResizeV2,
+                None,
+                Some(&digest('a')),
+                &inventory_with('a')
+            ),
+            Err(AdmissionRejection::MissingDeclarationUnderMode { .. })
+        ));
+    }
+
+    #[test]
+    fn an_armed_inventory_admits_only_the_exact_digests_it_lists() {
+        let inventory = inventory_with('a');
+        assert_eq!(
+            decide_admission(
+                LauncherAuthorityProtocol::LeafV1,
+                None,
+                Some(&digest('a')),
+                &inventory
+            ),
+            Ok(AdmissionDecision::Admitted(
+                LauncherAuthorityProtocol::LeafV1
+            ))
+        );
+        assert!(matches!(
+            decide_admission(
+                LauncherAuthorityProtocol::LeafV1,
+                None,
+                Some(&digest('b')),
+                &inventory
+            ),
+            Err(AdmissionRejection::UninventoriedDigest(_))
+        ));
+    }
+
+    #[test]
+    fn a_malformed_digest_is_rejected_even_while_the_inventory_is_unarmed() {
+        assert!(matches!(
+            decide_admission(
+                LauncherAuthorityProtocol::LeafV1,
+                None,
+                Some("sha256:abc"),
+                &LegacyDigestInventory::Unconfigured
+            ),
+            Err(AdmissionRejection::MalformedDigest(_))
+        ));
+    }
+
+    #[test]
+    fn an_unusable_inventory_is_stricter_than_no_inventory() {
+        let unusable = LegacyDigestInventory::Unusable(InventoryFault::SignatureInvalid);
+        assert!(matches!(
+            decide_admission(
+                LauncherAuthorityProtocol::LeafV1,
+                None,
+                Some(&digest('a')),
+                &unusable
+            ),
+            Err(AdmissionRejection::InventoryUnusable(_))
+        ));
+        // The same inputs against the unarmed inventory are admitted, so the
+        // rejection above is caused by the fault and not by the digest.
+        assert_eq!(
+            decide_admission(
+                LauncherAuthorityProtocol::LeafV1,
+                None,
+                Some(&digest('a')),
+                &LegacyDigestInventory::Unconfigured
+            ),
+            Ok(AdmissionDecision::Admitted(
+                LauncherAuthorityProtocol::LeafV1
+            ))
+        );
+    }
+
+    #[test]
+    fn an_artifact_with_neither_declaration_nor_digest_is_left_undeclarable() {
+        for absent in [None, Some(""), Some("   ")] {
+            for mode in LauncherAuthorityProtocol::ALL {
+                assert_eq!(
+                    decide_admission(mode, None, absent, &LegacyDigestInventory::Unconfigured),
+                    Ok(AdmissionDecision::Undeclarable),
+                    "an unidentified artifact must not be given an authority here; \
+                     render_authority_protocol refuses it"
+                );
+            }
+        }
+    }
+
+    /// An unreadable authority singleton refuses every artifact, legacy or not.
+    #[test]
+    fn an_unavailable_authority_refuses_even_an_inventoried_digest() {
+        assert_eq!(
+            admit_with_legacy_inventory(
+                LauncherProtocolAdmission::AuthorityUnavailable,
+                Some(&digest('a')),
+                &inventory_with('a'),
+            ),
+            Err(AdmissionRejection::Declared(
+                LauncherProtocolAdmission::AuthorityUnavailable
+            ))
+        );
+    }
+}
+
+#[cfg(test)]
+mod provenance_tests {
+    use super::tests::digest;
+    use super::*;
+    use ring::signature::KeyPair as _;
+
+    fn signing_key() -> ring::signature::Ed25519KeyPair {
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+        ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap()
+    }
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    fn document() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "schema_version": 1,
+            "issuer": "platform-ops",
+            "issued_at": "2026-07-30T00:00:00Z",
+            "digests": [digest('a'), digest('b')],
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn a_correctly_signed_document_verifies_and_yields_its_digests() {
+        let key = signing_key();
+        let doc = document();
+        let signature = key.sign(&doc);
+        let inventory = LegacyDigestInventory::from_signed_document(
+            &doc,
+            Some(&b64(key.public_key().as_ref())),
+            Some(&b64(signature.as_ref())),
+        );
+        let LegacyDigestInventory::Verified {
+            provenance,
+            digests,
+        } = inventory
+        else {
+            panic!("a correctly signed document must verify, got {inventory:?}");
+        };
+        assert_eq!(provenance.issuer, "platform-ops");
+        assert_eq!(digests.len(), 2);
+        assert!(digests.contains(&PreProtocolDigest::parse(&digest('a')).unwrap()));
+    }
+
+    /// Every provenance failure lands on `Unusable`, never on `Unconfigured` —
+    /// a tampered inventory must be stricter than an absent one.
+    #[test]
+    fn every_provenance_failure_fails_closed() {
+        let key = signing_key();
+        let doc = document();
+        let good_sig = b64(key.sign(&doc).as_ref());
+        let good_key = b64(key.public_key().as_ref());
+
+        let cases: Vec<(&str, LegacyDigestInventory)> = vec![
+            (
+                "no key",
+                LegacyDigestInventory::from_signed_document(&doc, None, Some(&good_sig)),
+            ),
+            (
+                "no signature",
+                LegacyDigestInventory::from_signed_document(&doc, Some(&good_key), None),
+            ),
+            (
+                "key is not base64",
+                LegacyDigestInventory::from_signed_document(&doc, Some("!!!"), Some(&good_sig)),
+            ),
+            (
+                "key is the wrong length",
+                LegacyDigestInventory::from_signed_document(
+                    &doc,
+                    Some(&b64(&[0u8; 16])),
+                    Some(&good_sig),
+                ),
+            ),
+            (
+                "signature is the wrong length",
+                LegacyDigestInventory::from_signed_document(
+                    &doc,
+                    Some(&good_key),
+                    Some(&b64(&[0u8; 8])),
+                ),
+            ),
+            (
+                "signature is for a different key",
+                LegacyDigestInventory::from_signed_document(
+                    &doc,
+                    Some(&b64(signing_key().public_key().as_ref())),
+                    Some(&good_sig),
+                ),
+            ),
+            (
+                "document was tampered with after signing",
+                LegacyDigestInventory::from_signed_document(
+                    &[doc.clone(), b" ".to_vec()].concat(),
+                    Some(&good_key),
+                    Some(&good_sig),
+                ),
+            ),
+        ];
+        for (name, inventory) in cases {
+            assert!(
+                matches!(inventory, LegacyDigestInventory::Unusable(_)),
+                "{name} must fail closed, got {inventory:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_signed_but_malformed_document_still_fails_closed() {
+        let key = signing_key();
+        for (name, body) in [
+            (
+                "unknown schema version",
+                serde_json::json!({"schema_version": 2, "digests": []}),
+            ),
+            (
+                "missing digests",
+                serde_json::json!({"schema_version": 1, "issuer": "ops"}),
+            ),
+            (
+                "a tag instead of a digest",
+                serde_json::json!({"schema_version": 1, "digests": ["reg/img:tag"]}),
+            ),
+            (
+                "an uppercase digest",
+                serde_json::json!({"schema_version": 1, "digests": [digest('a').to_uppercase()]}),
+            ),
+        ] {
+            let doc = serde_json::to_vec(&body).unwrap();
+            let inventory = LegacyDigestInventory::from_signed_document(
+                &doc,
+                Some(&b64(key.public_key().as_ref())),
+                Some(&b64(key.sign(&doc).as_ref())),
+            );
+            assert!(
+                matches!(inventory, LegacyDigestInventory::Unusable(_)),
+                "{name} must fail closed, got {inventory:?}"
+            );
+        }
+    }
+}

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -3,6 +3,7 @@ pub mod background;
 pub mod crypto;
 pub mod database;
 pub mod error;
+pub mod launcher_compatibility;
 pub mod migrations;
 pub mod note_hash;
 pub mod repositories;
@@ -55,6 +56,10 @@ pub use database::{
     SqliteVecStatus, default_db_path, test_database_base_url,
 };
 pub use error::{DbError as Error, DbResult as Result, SpecLintRejected, SpecLintViolation};
+pub use launcher_compatibility::{
+    AdmissionDecision, AdmissionRejection, InventoryFault, LegacyDigestInventory,
+    PreProtocolDigest, admit_with_legacy_inventory, decide_admission,
+};
 #[cfg(any(test, feature = "test-support"))]
 pub use repositories::repo_graph_generation::ReservedPublicationFailureStage;
 pub use repositories::tool_call_evaluator::{
@@ -129,7 +134,7 @@ pub use repositories::{
     },
     extension_load_diagnostic::{ExtensionLoadDiagnosticRepository, InsertExtensionLoadDiagnostic},
     git_settings::GitSettingsRepository,
-    image::{Image, ImageRepository, ImageStatus, SelectedCatalogImage},
+    image::{Image, ImageRepository, ImageStatus, PreProtocolImage, SelectedCatalogImage},
     invocation_lease_authority::{
         InvocationLeaseAuthorityRepository, InvocationLeaseAuthorityRow, InvocationLeaseMode,
     },

--- a/server/crates/djinn-db/src/repositories/image.rs
+++ b/server/crates/djinn-db/src/repositories/image.rs
@@ -75,11 +75,38 @@ impl Image {
     /// `leaf-v1` is the behavior that predates the declaration, so it is the
     /// only correct reading of an undeclared row — every already-built image on
     /// a live deployment is one of those and must keep dispatching.
+    ///
+    /// **This is a description of the artifact, not an admission decision.** It
+    /// answers "what would this run as", and knows nothing about the server's
+    /// authority mode or the pre-protocol digest inventory. The decision that
+    /// governs dispatch is
+    /// [`decide_admission`](crate::launcher_compatibility::decide_admission),
+    /// reached through
+    /// [`resolve_dispatch_image`](crate::repositories::project::ProjectRepository::resolve_dispatch_image).
+    /// Reading this as permission is how an undeclared, uninventoried artifact
+    /// would reach a shell under a guessed authority.
     pub fn effective_launcher_protocol(
         &self,
     ) -> std::result::Result<LauncherAuthorityProtocol, ParseLauncherAuthorityProtocolError> {
         Ok(self.declared_launcher_protocol()?.unwrap_or_default())
     }
+}
+
+/// A `ready` catalog image that declares no launcher authority protocol but IS
+/// pinned to an immutable manifest digest — the exact population the signed
+/// pre-protocol digest inventory exists to vouch for.
+///
+/// Produced by [`ImageRepository::legacy_pre_protocol_digests`] so an operator
+/// builds the inventory document from the catalog itself rather than by hand.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreProtocolImage {
+    pub image_id: String,
+    pub name: String,
+    pub tag: Option<String>,
+    /// Raw `images.registry_digest`. Not validated here — an entry that is not
+    /// a canonical `sha256:<64 hex>` must be visible to the operator building
+    /// the document, not silently dropped from it.
+    pub registry_digest: String,
 }
 
 /// A catalog image currently selected by at least one project, with the
@@ -294,6 +321,39 @@ impl ImageRepository {
         Ok(())
     }
 
+    /// Enumerate the `ready`, digest-pinned images that declare no launcher
+    /// authority protocol.
+    ///
+    /// This is the candidate set for the signed pre-protocol digest inventory:
+    /// exactly the artifacts that predate migration 166 and can still be named
+    /// exactly. Rows with no digest are *not* returned — there is no immutable
+    /// identity to vouch for, so the inventory cannot admit them and
+    /// `render_authority_protocol` refuses them; the fix for those is a
+    /// rebuild, not an allowlist entry.
+    ///
+    /// Ordered by id so a document generated twice from the same catalog is
+    /// byte-identical, which is what makes its signature reproducible.
+    pub async fn legacy_pre_protocol_digests(&self) -> Result<Vec<PreProtocolImage>> {
+        self.db.ensure_initialized().await?;
+        let rows = sqlx::query(
+            "SELECT id, name, tag, registry_digest FROM images \
+             WHERE status = 'ready' AND launcher_authority_protocol IS NULL \
+               AND registry_digest IS NOT NULL AND registry_digest <> '' \
+             ORDER BY id",
+        )
+        .fetch_all(self.db.pool())
+        .await?;
+        Ok(rows
+            .iter()
+            .map(|r| PreProtocolImage {
+                image_id: r.get("id"),
+                name: r.get("name"),
+                tag: r.get("tag"),
+                registry_digest: r.get("registry_digest"),
+            })
+            .collect())
+    }
+
     pub async fn mark_failed(&self, id: &str, error: &str) -> Result<()> {
         self.db.ensure_initialized().await?;
         sqlx::query("UPDATE images SET status = 'failed', last_error = $2 WHERE id = $1")
@@ -448,6 +508,12 @@ mod tests {
 
     use crate::repositories::project::ProjectRepository;
 
+    /// A canonical immutable manifest digest: `sha256:` + 64 lowercase hex.
+    /// The launcher-authority fence compares digests exactly, so fixtures that
+    /// have to survive dispatch must use a well-formed one.
+    const CANONICAL_DIGEST: &str =
+        "sha256:7822b7de0000000000000000000000000000000000000000000000000000cafe";
+
     async fn seed_project(db: &Database, id: &str) {
         db.ensure_initialized().await.unwrap();
         ProjectRepository::new(db.clone(), EventBus::noop())
@@ -545,8 +611,16 @@ mod tests {
         );
 
         // Mark the catalog image ready with a digest → digest-pinned pull ref.
+        // The digest is canonical (`sha256:` + 64 lowercase hex) because the
+        // launcher-authority fence compares digests exactly; a placeholder like
+        // `sha256:abc` names no artifact and is refused before dispatch.
         images
-            .mark_ready("i1", "reg/djinn-image-i1:hash", Some("sha256:abc"), None)
+            .mark_ready(
+                "i1",
+                "reg/djinn-image-i1:hash",
+                Some(CANONICAL_DIGEST),
+                None,
+            )
             .await
             .unwrap();
         let d = projects
@@ -557,7 +631,7 @@ mod tests {
         assert_eq!(d.from_catalog.as_deref(), Some("i1"));
         assert_eq!(
             d.pull_ref().as_deref(),
-            Some("reg/djinn-image-i1@sha256:abc"),
+            Some(format!("reg/djinn-image-i1@{CANONICAL_DIGEST}").as_str()),
             "ready catalog image with a digest dispatches on the digest-pinned ref"
         );
 

--- a/server/crates/djinn-db/src/repositories/project.rs
+++ b/server/crates/djinn-db/src/repositories/project.rs
@@ -6,6 +6,10 @@ use sqlx::Row;
 
 use crate::Result;
 use crate::database::Database;
+use crate::launcher_compatibility::{
+    AdmissionDecision, LegacyDigestInventory, admit_with_legacy_inventory,
+};
+use crate::repositories::launcher_authority_mode::LauncherAuthorityModeRepository;
 
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct ProjectConfig {
@@ -61,11 +65,34 @@ fn normalize_json_string_list(raw: &str) -> core::result::Result<String, String>
 pub struct ProjectRepository {
     db: Database,
     events: EventBus,
+    /// The deployment's signed inventory of pre-protocol digests. Held here
+    /// because [`ProjectRepository::resolve_dispatch_image`] is the seam every
+    /// dispatch passes through, and the decision must be made before a Job is
+    /// rendered rather than after a shell is running under a guessed authority.
+    ///
+    /// The *authority mode* is deliberately not held: it is z3gi's durable
+    /// `launcher_authority_mode` singleton, read per resolution so a flip takes
+    /// effect on the next dispatch rather than on the next process restart.
+    legacy_digest_inventory: LegacyDigestInventory,
 }
 
 impl ProjectRepository {
     pub fn new(db: Database, events: EventBus) -> Self {
-        Self { db, events }
+        Self {
+            db,
+            events,
+            legacy_digest_inventory: LegacyDigestInventory::process().clone(),
+        }
+    }
+
+    /// Override the pre-protocol digest inventory for this repository.
+    ///
+    /// The process-wide inventory is read from the environment once, which is
+    /// the right shape for a deployment-scoped document and the wrong shape for
+    /// a test.
+    pub fn with_legacy_digest_inventory(mut self, inventory: LegacyDigestInventory) -> Self {
+        self.legacy_digest_inventory = inventory;
+        self
     }
 
     pub async fn list(&self) -> Result<Vec<Project>> {
@@ -850,10 +877,15 @@ impl ProjectRepository {
         // builds (keyed by project_id); a project that selects a shared
         // catalog image stays `image_status = 'none'` forever even after the
         // catalog image is built, which would defer its dispatch indefinitely.
-        // `resolve_dispatch_image` returns `Ok(None)` only for an unknown
+        // `resolve_dispatch_image_row` returns `Ok(None)` only for an unknown
         // project (already handled above), so a `None` here is treated as the
         // not-dispatchable `none` status.
-        let image_status = match self.resolve_dispatch_image(project_id).await? {
+        //
+        // The *unfenced* row on purpose. Readiness reports what the catalog
+        // holds; it is not a dispatch, so a launcher-authority rejection must
+        // not turn a status query into an error. The fence lives on
+        // `resolve_dispatch_image`, which is what dispatch calls.
+        let image_status = match self.resolve_dispatch_image_row(project_id).await? {
             Some(img) => img.status,
             None => ProjectImageStatus::NONE.to_string(),
         };
@@ -884,9 +916,83 @@ impl ProjectRepository {
     /// image that isn't `ready` comes back with `tag = None` so the caller
     /// hard-fails (task dispatch) or skips (warm) — never a silent downgrade.
     ///
+    /// ## Launcher-authority admission
+    ///
+    /// A resolution that is actually dispatchable (`ready` + a tag) also runs
+    /// the centralized compatibility decision
+    /// ([`crate::launcher_compatibility::decide_admission`]) and **fails the
+    /// resolve** when the artifact may not run under this server's quota
+    /// authority — an explicit protocol mismatch, a missing declaration under
+    /// `resize-v2`, a non-canonical digest, a digest the signed inventory does
+    /// not list, or an inventory that cannot be trusted. This is the last seam
+    /// before `djinn_k8s::runtime::prepare` builds a Job, so the refusal lands
+    /// before any Kubernetes object exists and long before a shell runs.
+    ///
+    /// A `ready` row with **no digest and no declaration** is *not* an error
+    /// here: migration 166 deliberately keeps that row legal so an upgrade
+    /// cannot strand a live catalog, and `render_authority_protocol` (#2836)
+    /// already refuses to render a Job for it. It resolves with
+    /// `authority_protocol: None`.
+    ///
     /// Non-macro `sqlx::query` form (like [`ImageRepository`]) so the
     /// migration-46 columns don't require regenerating the offline cache.
     pub async fn resolve_dispatch_image(&self, project_id: &str) -> Result<Option<DispatchImage>> {
+        let Some(image) = self.resolve_dispatch_image_row(project_id).await? else {
+            return Ok(None);
+        };
+        Ok(Some(self.admit_dispatch_image(project_id, image).await?))
+    }
+
+    /// Apply the launcher-authority admission decision to a resolved row.
+    async fn admit_dispatch_image(
+        &self,
+        project_id: &str,
+        mut image: DispatchImage,
+    ) -> Result<DispatchImage> {
+        // Nothing that cannot be pulled can dispatch, so nothing about its
+        // quota authority is decidable — or needs to be. Keeping the decision
+        // behind `pull_ref` is what lets the readiness/warm/indexer callers
+        // resolve a `building` or unassigned image without tripping a fence
+        // that only governs dispatch, and it means an unassigned project costs
+        // no authority read.
+        if image.pull_ref().is_none() {
+            image.authority_protocol = None;
+            return Ok(image);
+        }
+        // z3gi's verdict first: the persisted authority singleton against the
+        // artifact's own declaration. An unreadable singleton is a refusal
+        // inside `admit_declared_protocol`, never a default.
+        let verdict = LauncherAuthorityModeRepository::new(self.db.clone())
+            .admit_declared_protocol(
+                image
+                    .declared_authority_protocol
+                    .map(LauncherAuthorityProtocol::as_wire),
+            )
+            .await;
+        match admit_with_legacy_inventory(
+            verdict,
+            image.digest.as_deref(),
+            &self.legacy_digest_inventory,
+        ) {
+            Ok(AdmissionDecision::Admitted(protocol)) => {
+                image.authority_protocol = Some(protocol);
+                Ok(image)
+            }
+            Ok(AdmissionDecision::Undeclarable) => {
+                image.authority_protocol = None;
+                Ok(image)
+            }
+            Err(rejection) => Err(crate::Error::InvalidData(format!(
+                "project {project_id} resolves to catalog image {} which may not dispatch: \
+                 {rejection}",
+                image.from_catalog.as_deref().unwrap_or("<none>")
+            ))),
+        }
+    }
+
+    /// The unfenced resolution: exactly the catalog-precedence read, with
+    /// `authority_protocol` still holding the raw declaration.
+    async fn resolve_dispatch_image_row(&self, project_id: &str) -> Result<Option<DispatchImage>> {
         self.db.ensure_initialized().await?;
         let row = sqlx::query("SELECT selected_image_id FROM projects WHERE id = $1")
             .bind(project_id)
@@ -906,6 +1012,7 @@ impl ProjectRepository {
                 digest: None,
                 from_catalog: None,
                 last_error: None,
+                declared_authority_protocol: None,
                 authority_protocol: None,
             }));
         };
@@ -928,9 +1035,11 @@ impl ProjectRepository {
                 // CHECK and this parse are the same closed set, so a row that
                 // somehow holds an unknown value fails the RESOLVE rather than
                 // reaching the render as an unrecognised protocol.
-                authority_protocol: parse_declared_protocol(
+                declared_authority_protocol: parse_declared_protocol(
                     i.get::<Option<String>, _>("launcher_authority_protocol"),
                 )?,
+                // Overwritten by `admit_dispatch_image`.
+                authority_protocol: None,
             },
             // FK RESTRICT makes a dangling selection impossible in practice;
             // treat it as "not ready" rather than panicking.
@@ -940,6 +1049,7 @@ impl ProjectRepository {
                 digest: None,
                 from_catalog: Some(image_id),
                 last_error: None,
+                declared_authority_protocol: None,
                 authority_protocol: None,
             },
         }))
@@ -1021,10 +1131,18 @@ pub struct DispatchImage {
     /// (`images.launcher_authority_protocol`, migration 166), or `None` for an
     /// image that declared nothing.
     ///
-    /// `None` is not "leaf-v1": it is "this artifact never said". The render
-    /// decides what an undeclared image may do (see
-    /// `djinn_k8s::launcher::render_authority_protocol`); conflating the two
-    /// here would put the decision in the place least able to fail closed.
+    /// `None` is not "leaf-v1": it is "this artifact never said". This field is
+    /// the artifact's own claim, never a decision — it is the *input* to
+    /// [`crate::launcher_compatibility::decide_admission`].
+    pub declared_authority_protocol: Option<LauncherAuthorityProtocol>,
+    /// The **single effective quota authority** admission granted this
+    /// dispatch, or `None` when the artifact identifies neither itself nor its
+    /// authority and `djinn_k8s::launcher::render_authority_protocol` must
+    /// refuse the Job.
+    ///
+    /// A resolution that produced this field at all has already passed the
+    /// compatibility fence: every rejected combination fails
+    /// [`ProjectRepository::resolve_dispatch_image`] outright.
     pub authority_protocol: Option<LauncherAuthorityProtocol>,
     /// The `ready` tag to pull, or `None` when the resolved image isn't
     /// built yet (caller hard-fails task dispatch / skips warming).
@@ -1165,6 +1283,10 @@ mod tests {
     use crate::repositories::repo_graph_cache::{RepoGraphCacheInsert, RepoGraphCacheRepository};
 
     use super::*;
+
+    /// A canonical immutable manifest digest: `sha256:` + 64 lowercase hex.
+    const CANONICAL_DIGEST: &str =
+        "sha256:7822b7de0000000000000000000000000000000000000000000000000000cafe";
 
     #[test]
     fn dispatch_readiness_gates_on_image_only_not_graph_warm() {
@@ -1677,9 +1799,15 @@ mod tests {
     /// nothing in-process can be serving the answer from memory. Making
     /// `resolve_dispatch_image` return `authority_protocol: None`
     /// unconditionally fails the first assertion.
+    ///
+    /// Each read runs with the persisted `launcher_authority_mode` singleton
+    /// (migration 167) flipped to the protocol under test, because a
+    /// declaration that disagrees with the authority is refused rather than
+    /// resolved — that disagreement has its own test.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn declared_authority_protocol_survives_readback_through_a_fresh_repository() {
         use crate::repositories::image::ImageRepository;
+        use crate::repositories::launcher_authority_mode::SetLauncherAuthorityModeResult;
 
         let db = test_db();
         db.ensure_initialized().await.unwrap();
@@ -1700,7 +1828,7 @@ mod tests {
                 .mark_ready(
                     &image_id,
                     &format!("reg/djinn-image-{}:hash", protocol.as_wire()),
-                    Some("sha256:abc"),
+                    Some(CANONICAL_DIGEST),
                     Some(protocol),
                 )
                 .await
@@ -1710,17 +1838,35 @@ mod tests {
                 .await
                 .unwrap();
 
+            // Flip the durable authority through z3gi's own fence, so the
+            // resolution reads a mode that really is stored.
+            let modes = LauncherAuthorityModeRepository::new(db.clone());
+            let epoch = modes.read().await.unwrap().expect("seeded").epoch;
+            assert!(
+                matches!(
+                    modes.set_mode(epoch, protocol).await,
+                    SetLauncherAuthorityModeResult::Flipped { .. }
+                        | SetLauncherAuthorityModeResult::Unchanged { .. }
+                ),
+                "the authority singleton must be settable to {protocol}"
+            );
+
             let resolved = ProjectRepository::new(db.clone(), EventBus::noop())
                 .resolve_dispatch_image("proto-p1")
                 .await
                 .unwrap()
                 .expect("project resolves");
             assert_eq!(
-                resolved.authority_protocol,
+                resolved.declared_authority_protocol,
                 Some(protocol),
                 "a {protocol} image must resolve as {protocol}, not as a default"
             );
-            assert_eq!(resolved.digest.as_deref(), Some("sha256:abc"));
+            assert_eq!(
+                resolved.authority_protocol,
+                Some(protocol),
+                "the admitted authority is the artifact's own declaration"
+            );
+            assert_eq!(resolved.digest.as_deref(), Some(CANONICAL_DIGEST));
         }
 
         // An image that declared nothing resolves to `None` — "never said",
@@ -1743,6 +1889,7 @@ mod tests {
             .await
             .unwrap()
             .expect("project resolves");
+        assert_eq!(resolved.declared_authority_protocol, None);
         assert_eq!(resolved.authority_protocol, None);
         assert_eq!(resolved.digest, None);
     }

--- a/server/crates/djinn-db/tests/launcher_admission_compatibility_matrix.rs
+++ b/server/crates/djinn-db/tests/launcher_admission_compatibility_matrix.rs
@@ -1,0 +1,625 @@
+//! **AC1 + AC3.** The mixed-artifact admission matrix.
+//!
+//! Three artifact shapes — a real no-handshake legacy build, an explicit
+//! `leaf-v1` build, and an explicit `resize-v2` build — resolved through the
+//! **real** [`ImageRepository`] and [`ProjectRepository`] against **both**
+//! server authority modes and every state the pre-protocol digest inventory can
+//! be in.
+//!
+//! Nothing here stubs the decision. Each row writes an `images` row through
+//! `mark_ready` (so migration 166's CHECK and the repository's own digest guard
+//! both apply), flips the durable `launcher_authority_mode` singleton through
+//! z3gi's own drain fence (migration 167), selects the image from a `projects`
+//! row, and reads it back through `resolve_dispatch_image` — the seam
+//! `djinn_k8s::runtime::prepare` calls before it builds a Job. An "admitted"
+//! cell therefore proves the whole path, and a "rejected" cell proves the
+//! refusal lands before any Kubernetes object exists — long before a shell
+//! runs.
+//!
+//! Before this task both halves of that path were inert: z3gi's
+//! `decide_launcher_protocol_admission` had no dispatch caller, and #2836's
+//! render read the artifact's declaration with nothing consulting the persisted
+//! authority. `resolve_dispatch_image` is where they meet.
+//!
+//! The invariant every admitted cell asserts is **exactly one** effective quota
+//! authority: the admitted protocol equals the server mode, and (when the
+//! artifact declared anything at all) equals the declaration too. Two
+//! components writing one leaf's `cpu.max` is the failure this matrix exists to
+//! make impossible.
+
+use djinn_db::launcher_compatibility::{
+    AdmissionDecision, AdmissionRejection, InventoryFault, LegacyDigestInventory,
+    PreProtocolDigest, decide_admission,
+};
+use djinn_db::repositories::launcher_authority_mode::{
+    LauncherAuthorityModeRepository, LauncherProtocolAdmission, SetLauncherAuthorityModeResult,
+};
+use djinn_db::{Database, ImageRepository, ProjectRepository};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+
+/// Canonical `sha256:` + 64 lowercase hex. `seed` distinguishes artifacts.
+fn digest(seed: &str) -> String {
+    let mut hex = seed.to_owned();
+    hex.truncate(8);
+    format!("sha256:{hex}{}", "0".repeat(64 - hex.len()))
+}
+
+fn inventoried(seed: &str) -> LegacyDigestInventory {
+    LegacyDigestInventory::verified(
+        "platform-ops",
+        "2026-07-30T00:00:00Z",
+        [PreProtocolDigest::parse(&digest(seed)).unwrap()],
+    )
+}
+
+/// One catalog artifact, written through the real repositories.
+struct Artifact {
+    label: &'static str,
+    declared: Option<LauncherAuthorityProtocol>,
+    digest: Option<String>,
+}
+
+impl Artifact {
+    /// The exact shape a live deployment already holds: `ready`, no
+    /// declaration, pinned to an immutable digest.
+    fn legacy_no_handshake() -> Self {
+        Self {
+            label: "legacy no-handshake (digest-pinned)",
+            declared: None,
+            digest: Some(digest("1eeac9de")),
+        }
+    }
+
+    /// The other legacy shape migration 166 deliberately keeps legal: `ready`,
+    /// no declaration, `registry_digest IS NULL`.
+    fn legacy_no_handshake_undigested() -> Self {
+        Self {
+            label: "legacy no-handshake (no digest)",
+            declared: None,
+            digest: None,
+        }
+    }
+
+    fn declaring(protocol: LauncherAuthorityProtocol) -> Self {
+        Self {
+            label: match protocol {
+                LauncherAuthorityProtocol::LeafV1 => "explicit leaf-v1",
+                LauncherAuthorityProtocol::ResizeV2 => "explicit resize-v2",
+            },
+            declared: Some(protocol),
+            digest: Some(digest("dec1a2ed")),
+        }
+    }
+}
+
+/// Seed a project selecting one artifact, and hand back a resolver bound to
+/// `mode` + `inventory`.
+async fn resolve(
+    artifact: &Artifact,
+    mode: LauncherAuthorityProtocol,
+    inventory: LegacyDigestInventory,
+) -> djinn_db::Result<Option<djinn_db::DispatchImage>> {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create_with_id("p1", "p-1", "test", "p1")
+        .await
+        .unwrap();
+    let images = ImageRepository::new(db.clone());
+    images.create("i1", "Fixture", None, "{}").await.unwrap();
+    images
+        .mark_ready(
+            "i1",
+            "reg/djinn-image-i1:contenthash",
+            artifact.digest.as_deref(),
+            artifact.declared,
+        )
+        .await
+        .expect("the fixture must be writable through the real repository");
+    images.set_project_image("p1", Some("i1")).await.unwrap();
+
+    // The authority mode is the DURABLE singleton migration 167 seeds, flipped
+    // through z3gi's own drain fence — not a value this test hands the
+    // resolver. A fresh database has no live permits, so the fence lets the
+    // flip through and the resolution reads a mode that is really stored.
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    let epoch = modes
+        .read()
+        .await
+        .unwrap()
+        .expect("migration 167 seeds the singleton")
+        .epoch;
+    assert!(
+        matches!(
+            modes.set_mode(epoch, mode).await,
+            SetLauncherAuthorityModeResult::Flipped { .. }
+                | SetLauncherAuthorityModeResult::Unchanged { .. }
+        ),
+        "the authority singleton must be settable to {mode}"
+    );
+
+    ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .with_legacy_digest_inventory(inventory)
+        .resolve_dispatch_image("p1")
+        .await
+}
+
+/// **AC3.** Every admitted combination yields exactly one effective quota
+/// authority, and it is the server's mode.
+///
+/// Mutation that fails it: make `decide_admission` return
+/// `Ok(AdmissionDecision::Admitted(declared))` for a declaration that does not
+/// equal `mode` (i.e. drop the `declared == mode` guard). The `resize-v2`
+/// declaration under `leaf-v1` then resolves, and the `assert_eq!` on
+/// `admitted == mode` fails naming both protocols.
+#[tokio::test]
+async fn every_admitted_combination_has_exactly_one_effective_authority() {
+    let mut admitted_cells = 0;
+    for mode in LauncherAuthorityProtocol::ALL {
+        for artifact in [
+            Artifact::legacy_no_handshake(),
+            Artifact::legacy_no_handshake_undigested(),
+            Artifact::declaring(LauncherAuthorityProtocol::LeafV1),
+            Artifact::declaring(LauncherAuthorityProtocol::ResizeV2),
+        ] {
+            // The inventory vouches for the legacy artifact, so the only thing
+            // that can reject it in this sweep is the mode.
+            let inventory = inventoried("1eeac9de");
+            let resolved = resolve(&artifact, mode, inventory).await;
+
+            let Ok(Some(image)) = resolved else {
+                continue; // rejected; the rejection sweeps below cover why
+            };
+            let Some(admitted) = image.authority_protocol else {
+                // Undeclarable: no digest, no declaration. The render refuses
+                // it; there is no authority to be one-of.
+                assert!(
+                    image.digest.is_none() && image.declared_authority_protocol.is_none(),
+                    "{}: only an unidentified artifact may resolve without an authority",
+                    artifact.label
+                );
+                continue;
+            };
+
+            admitted_cells += 1;
+            assert_eq!(
+                admitted, mode,
+                "{} admitted under mode {mode} must run under {mode} and nothing else",
+                artifact.label
+            );
+            if let Some(declared) = image.declared_authority_protocol {
+                assert_eq!(
+                    admitted, declared,
+                    "{}: an admitted declaration is never reinterpreted",
+                    artifact.label
+                );
+            }
+        }
+    }
+    assert_eq!(
+        admitted_cells, 3,
+        "the matrix must actually admit something: leaf-v1 mode admits the legacy and the \
+         leaf-v1 artifacts, resize-v2 mode admits the resize-v2 artifact"
+    );
+}
+
+/// **AC1, the compatibility grant.** A missing protocol becomes `leaf-v1` only
+/// for an exact inventoried digest under `leaf-v1` mode.
+///
+/// Mutation that fails it: make `LegacyDigestInventory::vouches_for` return
+/// `Ok(true)` for the `Verified` arm regardless of membership. The
+/// "uninventoried" assertion below then resolves instead of erroring.
+#[tokio::test]
+async fn a_missing_protocol_is_admitted_only_for_an_exact_inventoried_digest() {
+    let artifact = Artifact::legacy_no_handshake();
+
+    let admitted = resolve(
+        &artifact,
+        LauncherAuthorityProtocol::LeafV1,
+        inventoried("1eeac9de"),
+    )
+    .await
+    .expect("an inventoried legacy digest is admitted")
+    .expect("project resolves");
+    assert_eq!(
+        admitted.authority_protocol,
+        Some(LauncherAuthorityProtocol::LeafV1)
+    );
+    assert_eq!(admitted.declared_authority_protocol, None);
+
+    // A different digest, correctly formed, that the inventory does not list.
+    let rejected = resolve(
+        &artifact,
+        LauncherAuthorityProtocol::LeafV1,
+        inventoried("d1ffe2ed"),
+    )
+    .await
+    .expect_err("an uninventoried digest must not dispatch");
+    let rendered = rejected.to_string();
+    assert!(
+        rendered.contains("not listed in the pre-protocol digest inventory"),
+        "the refusal must say the digest is not vouched for, got: {rendered}"
+    );
+    assert!(
+        rendered.contains(&digest("1eeac9de")),
+        "the refusal must name the exact digest an operator has to add, got: {rendered}"
+    );
+}
+
+/// **AC1, the resize-v2 half.** No missing-protocol artifact survives
+/// `resize-v2`, inventoried or not.
+///
+/// Mutation that fails it: delete the `mode != LeafV1` arm in
+/// `decide_admission`. Both `expect_err`s below then return `Ok`.
+#[tokio::test]
+async fn no_missing_protocol_artifact_survives_resize_v2() {
+    for inventory in [
+        inventoried("1eeac9de"), // even vouched for
+        LegacyDigestInventory::Unconfigured,
+    ] {
+        let error = resolve(
+            &Artifact::legacy_no_handshake(),
+            LauncherAuthorityProtocol::ResizeV2,
+            inventory,
+        )
+        .await
+        .expect_err("a no-handshake artifact must never be admitted under resize-v2");
+        assert!(
+            error
+                .to_string()
+                .contains("declares no launcher authority protocol"),
+            "got: {error}"
+        );
+    }
+}
+
+/// **AC1, the mutable-tag half.** An artifact whose only identity is a tag is
+/// never admitted, and neither is one whose digest is not canonical.
+///
+/// Note the split, which is migration 166's and #2836's, not a new one:
+///
+/// * a digest that *exists* but is not canonical is a positive claim that fails
+///   → the resolve errors;
+/// * `registry_digest IS NULL` is the shape migration 166 deliberately keeps
+///   legal so an upgrade cannot strand a live catalog → it resolves with **no
+///   authority**, and `render_authority_protocol` refuses to build the Job.
+///
+/// Either way nothing dispatches. Mutation that fails it: make
+/// `PreProtocolDigest::parse` accept any string starting with `sha256:` — the
+/// malformed sweep then resolves.
+#[tokio::test]
+async fn a_mutable_tag_without_a_verified_digest_never_dispatches() {
+    // Not canonical: short, uppercase, wrong algorithm, and a bare tag.
+    for bad in [
+        "sha256:abc",
+        "SHA256:7822B7DE0000000000000000000000000000000000000000000000000000CAFE",
+        "sha512:7822b7de0000000000000000000000000000000000000000000000000000cafe",
+        "reg/djinn-image-i1:contenthash",
+    ] {
+        let artifact = Artifact {
+            label: "malformed digest",
+            declared: None,
+            digest: Some(bad.to_owned()),
+        };
+        let error = resolve(
+            &artifact,
+            LauncherAuthorityProtocol::LeafV1,
+            LegacyDigestInventory::Unconfigured,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("is not a canonical immutable digest"),
+            "{bad:?} must be refused as a non-canonical digest, got: {error}"
+        );
+    }
+
+    // The digestless legacy row: resolvable, but carrying no authority.
+    let undigested = resolve(
+        &Artifact::legacy_no_handshake_undigested(),
+        LauncherAuthorityProtocol::LeafV1,
+        LegacyDigestInventory::Unconfigured,
+    )
+    .await
+    .expect("migration 166 keeps this row legal, so the resolve must not error")
+    .expect("project resolves");
+    assert_eq!(
+        undigested.authority_protocol, None,
+        "an unidentified artifact must reach the render with no authority, so the render \
+         refuses rather than the resolver inventing one"
+    );
+    assert!(
+        undigested.pull_ref().is_some(),
+        "#2831's anti-wedge guard: the row itself stays resolvable"
+    );
+}
+
+/// **AC1, the explicit-mismatch half.** A declaration the server does not run
+/// is refused, in both directions.
+///
+/// Mutation that fails it: replace the `declared == mode` comparison in
+/// `decide_admission` with `true`. Both directions then resolve.
+#[tokio::test]
+async fn an_explicit_protocol_mismatch_is_refused_in_both_directions() {
+    for mode in LauncherAuthorityProtocol::ALL {
+        for declared in LauncherAuthorityProtocol::ALL {
+            if declared == mode {
+                continue;
+            }
+            let error = resolve(
+                &Artifact::declaring(declared),
+                mode,
+                LegacyDigestInventory::Unconfigured,
+            )
+            .await
+            .expect_err("a declaration that disagrees with the server must not dispatch");
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains(declared.as_wire()) && rendered.contains(mode.as_wire()),
+                "the refusal must name both protocols, got: {rendered}"
+            );
+        }
+    }
+}
+
+/// **AC2, the fail-closed half.** An inventory that fails its own validation
+/// rejects every legacy artifact — it never falls back to the unarmed rule.
+///
+/// Mutation that fails it: make `LegacyDigestInventory::vouches_for` return
+/// `Ok(true)` for the `Unusable` arm (i.e. treat a broken inventory like an
+/// absent one). The first assertion then resolves.
+#[tokio::test]
+async fn an_unusable_inventory_rejects_rather_than_falling_back() {
+    let error = resolve(
+        &Artifact::legacy_no_handshake(),
+        LauncherAuthorityProtocol::LeafV1,
+        LegacyDigestInventory::Unusable(InventoryFault::SignatureInvalid),
+    )
+    .await
+    .expect_err("a legacy artifact must not be admitted on an untrusted inventory");
+    assert!(
+        error.to_string().contains("cannot be trusted"),
+        "got: {error}"
+    );
+
+    // A DECLARING artifact does not consult the inventory at all, so a broken
+    // inventory must not take the whole catalog down with it.
+    let declaring = resolve(
+        &Artifact::declaring(LauncherAuthorityProtocol::LeafV1),
+        LauncherAuthorityProtocol::LeafV1,
+        LegacyDigestInventory::Unusable(InventoryFault::SignatureInvalid),
+    )
+    .await
+    .expect("a declaring artifact is admitted on its own declaration")
+    .expect("project resolves");
+    assert_eq!(
+        declaring.authority_protocol,
+        Some(LauncherAuthorityProtocol::LeafV1)
+    );
+}
+
+/// The deliberate, tested behavior change: arming the inventory is what makes a
+/// previously-dispatchable undeclared artifact stop dispatching.
+///
+/// This is the one case where the fence takes something away, so it is stated
+/// explicitly rather than left as a surprise. Before an inventory exists the
+/// membership question has no configured answer and is not asked — which is
+/// exactly what keeps a live catalog of pre-#2831 digest-pinned images
+/// dispatching across the upgrade. Configuring an inventory arms it.
+#[tokio::test]
+async fn arming_the_inventory_is_what_narrows_an_undeclared_artifact() {
+    let artifact = Artifact::legacy_no_handshake();
+
+    let unarmed = resolve(
+        &artifact,
+        LauncherAuthorityProtocol::LeafV1,
+        LegacyDigestInventory::Unconfigured,
+    )
+    .await
+    .expect("with no inventory configured the pre-existing rule stands")
+    .expect("project resolves");
+    assert_eq!(
+        unarmed.authority_protocol,
+        Some(LauncherAuthorityProtocol::LeafV1)
+    );
+
+    // The same artifact, once an inventory exists that does not list it.
+    assert!(
+        resolve(
+            &artifact,
+            LauncherAuthorityProtocol::LeafV1,
+            inventoried("d1ffe2ed"),
+        )
+        .await
+        .is_err(),
+        "an armed inventory that omits this digest must stop it dispatching"
+    );
+}
+
+/// The pure decision and the repository seam agree cell for cell.
+///
+/// The matrix above proves the decision through the database. This proves the
+/// database path is not a second implementation: for every combination, the
+/// admitted protocol the repository reports is exactly what
+/// [`decide_admission`] returns for the same inputs.
+#[tokio::test]
+async fn the_repository_seam_reports_exactly_what_the_decision_returns() {
+    for mode in LauncherAuthorityProtocol::ALL {
+        for inventory in [
+            LegacyDigestInventory::Unconfigured,
+            inventoried("1eeac9de"),
+            inventoried("d1ffe2ed"),
+            LegacyDigestInventory::Unusable(InventoryFault::SignatureInvalid),
+        ] {
+            for artifact in [
+                Artifact::legacy_no_handshake(),
+                Artifact::legacy_no_handshake_undigested(),
+                Artifact::declaring(LauncherAuthorityProtocol::LeafV1),
+                Artifact::declaring(LauncherAuthorityProtocol::ResizeV2),
+            ] {
+                let expected = decide_admission(
+                    mode,
+                    artifact.declared,
+                    artifact.digest.as_deref(),
+                    &inventory,
+                );
+                let observed = resolve(&artifact, mode, inventory.clone()).await;
+                match (expected, observed) {
+                    (Ok(AdmissionDecision::Admitted(protocol)), Ok(Some(image))) => {
+                        assert_eq!(
+                            image.authority_protocol,
+                            Some(protocol),
+                            "{} under {mode}",
+                            artifact.label
+                        );
+                    }
+                    (Ok(AdmissionDecision::Undeclarable), Ok(Some(image))) => {
+                        assert_eq!(
+                            image.authority_protocol, None,
+                            "{} under {mode}",
+                            artifact.label
+                        );
+                    }
+                    (Err(rejection), Err(error)) => {
+                        assert!(
+                            error.to_string().contains(&rejection.to_string()),
+                            "{} under {mode}: the repository must surface the decision's own \
+                             reason, got {error}",
+                            artifact.label
+                        );
+                    }
+                    (expected, observed) => panic!(
+                        "{} under {mode}: the decision and the repository disagree \
+                         ({expected:?} vs {observed:?})",
+                        artifact.label
+                    ),
+                }
+            }
+        }
+    }
+}
+
+/// Non-vacuity for the rejection assertions above: the shapes they reject are
+/// rejected by the *decision*, not by an unwritable fixture.
+#[test]
+fn the_rejection_reasons_are_distinct_and_none_is_a_catch_all() {
+    let leaf = LauncherAuthorityProtocol::LeafV1;
+    let resize = LauncherAuthorityProtocol::ResizeV2;
+    let listed = digest("1eeac9de");
+    let unlisted = digest("d1ffe2ed");
+    let inventory = inventoried("1eeac9de");
+
+    assert!(matches!(
+        decide_admission(leaf, Some(resize), Some(&listed), &inventory),
+        Err(AdmissionRejection::Declared(
+            LauncherProtocolAdmission::ProtocolMismatch { .. }
+        ))
+    ));
+    assert!(matches!(
+        decide_admission(resize, None, Some(&listed), &inventory),
+        Err(AdmissionRejection::MissingDeclarationUnderMode { .. })
+    ));
+    assert!(matches!(
+        decide_admission(leaf, None, Some("sha256:abc"), &inventory),
+        Err(AdmissionRejection::MalformedDigest(_))
+    ));
+    assert!(matches!(
+        decide_admission(leaf, None, Some(&unlisted), &inventory),
+        Err(AdmissionRejection::UninventoriedDigest(_))
+    ));
+    assert!(matches!(
+        decide_admission(
+            leaf,
+            None,
+            Some(&listed),
+            &LegacyDigestInventory::Unusable(InventoryFault::SignatureInvalid)
+        ),
+        Err(AdmissionRejection::InventoryUnusable(_))
+    ));
+    // …and the one combination that is admitted really is admitted, so the
+    // five above are not all failing for the same reason.
+    assert_eq!(
+        decide_admission(leaf, None, Some(&listed), &inventory),
+        Ok(AdmissionDecision::Admitted(leaf))
+    );
+}
+
+/// The authority is durable state, not a parameter: with the singleton gone,
+/// even a perfectly inventoried legacy artifact stops dispatching.
+///
+/// This is the one input the caller cannot supply, so it is the one that proves
+/// the resolver really reads z3gi's row rather than defaulting to `leaf-v1`.
+/// Mutation that fails it: make `admit_declared_protocol`'s `Ok(None)` arm
+/// return `Admitted { mode: LauncherAuthorityProtocol::default() }`. The
+/// `expect_err` below returns `Ok`.
+#[tokio::test]
+async fn an_unreadable_authority_singleton_refuses_every_dispatch() {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create_with_id("p1", "p-1", "test", "p1")
+        .await
+        .unwrap();
+    let images = ImageRepository::new(db.clone());
+    images.create("i1", "Fixture", None, "{}").await.unwrap();
+    images
+        .mark_ready(
+            "i1",
+            "reg/djinn-image-i1:contenthash",
+            Some(&digest("1eeac9de")),
+            None,
+        )
+        .await
+        .unwrap();
+    images.set_project_image("p1", Some("i1")).await.unwrap();
+
+    // Sanity: the same artifact dispatches while the singleton is present, so
+    // the refusal below is caused by its absence and not by the fixture.
+    let inventory = inventoried("1eeac9de");
+    assert_eq!(
+        ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+            .with_legacy_digest_inventory(inventory.clone())
+            .resolve_dispatch_image("p1")
+            .await
+            .unwrap()
+            .expect("project resolves")
+            .authority_protocol,
+        Some(LauncherAuthorityProtocol::LeafV1)
+    );
+
+    sqlx::query("DELETE FROM launcher_authority_mode")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    assert!(
+        LauncherAuthorityModeRepository::new(db.clone())
+            .read()
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    let error = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .with_legacy_digest_inventory(inventory)
+        .resolve_dispatch_image("p1")
+        .await
+        .expect_err("an unreadable authority must refuse, never default");
+    assert!(
+        error.to_string().contains("could not be read"),
+        "got: {error}"
+    );
+
+    // The same shape, decided purely.
+    assert_eq!(
+        djinn_db::admit_with_legacy_inventory(
+            LauncherProtocolAdmission::AuthorityUnavailable,
+            Some(&digest("1eeac9de")),
+            &inventoried("1eeac9de"),
+        ),
+        Err(AdmissionRejection::Declared(
+            LauncherProtocolAdmission::AuthorityUnavailable
+        ))
+    );
+}

--- a/server/crates/djinn-image-controller/tests/protocol_catalog_and_preservation.rs
+++ b/server/crates/djinn-image-controller/tests/protocol_catalog_and_preservation.rs
@@ -1,0 +1,363 @@
+//! **AC2 + AC4.** What newly built artifacts must declare, and what fencing
+//! them must not cost.
+//!
+//! AC2 is the producer side: every image this repository generates declares its
+//! launcher authority protocol in its own build metadata *and* captures an
+//! immutable manifest digest, so it never needs the legacy compatibility path
+//! at all. The inventory exists for artifacts that predate the declaration —
+//! never as a destination for new ones.
+//!
+//! AC4 is the "no retirement" clause. Compatibility is a decision about which
+//! artifacts may dispatch; nothing about it may be satisfied by deleting a
+//! containment asset. The assertions below name the launcher and broker
+//! binaries, the RuntimeClass and node conformance assets, the broker mount
+//! surface, the credential-boundary tests, child-UID execution, `cgroup.kill`,
+//! and `wait_empty` — and fail if any of them stops existing.
+
+use std::path::{Path, PathBuf};
+
+use djinn_db::launcher_compatibility::PreProtocolDigest;
+use djinn_db::{Database, ImageRepository, ProjectRepository, launcher_compatibility};
+use djinn_image_builder::dockerfile::{
+    AgentWorkerImage, DECLARED_LAUNCHER_PROTOCOL, LAUNCHER_PROTOCOL_ENV, LAUNCHER_PROTOCOL_LABEL,
+    generate_dockerfile,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+
+fn repo_root() -> PathBuf {
+    // server/crates/djinn-image-controller → repository root
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("the crate must live three levels below the repository root")
+        .to_path_buf()
+}
+
+fn read(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("{relative} must exist and be readable: {error}"))
+}
+
+// ── AC2: what a newly built artifact declares ───────────────────────────────
+
+/// Every Dockerfile this generator emits declares the protocol in build
+/// metadata — a LABEL on the artifact and the env var the sidecar reads out of
+/// the same image — and it declares one of the two canonical wire forms.
+///
+/// Mutation that fails it: delete the `emit_launcher_protocol` call from
+/// `generate_dockerfile`. Both `assert!(contains)` calls below fail, naming the
+/// config whose Dockerfile lost its declaration.
+#[test]
+fn every_generated_image_declares_its_protocol_in_build_metadata() {
+    let worker = AgentWorkerImage::new("djinn/agent-worker", "sha256-test");
+    for (name, config_json) in [
+        ("empty", r#"{"schema_version":1}"#),
+        (
+            "rust",
+            r#"{"schema_version":1,"languages":{"rust":{"default_toolchain":"1.84.0"}}}"#,
+        ),
+        (
+            "node",
+            r#"{"schema_version":1,"languages":{"node":{"default_version":"22"}}}"#,
+        ),
+    ] {
+        let config: djinn_stack::environment::EnvironmentConfig =
+            serde_json::from_str(config_json).unwrap_or_else(|e| panic!("{name}: {e}"));
+        let dockerfile = generate_dockerfile(&config, &worker)
+            .unwrap_or_else(|e| panic!("{name} must generate: {e}"))
+            .dockerfile;
+
+        let declared = DECLARED_LAUNCHER_PROTOCOL.as_wire();
+        assert!(
+            dockerfile.contains(&format!("LABEL {LAUNCHER_PROTOCOL_LABEL}=\"{declared}\"")),
+            "{name}: the artifact must carry the protocol LABEL, got:\n{dockerfile}"
+        );
+        assert!(
+            dockerfile.contains(&format!("ENV {LAUNCHER_PROTOCOL_ENV}={declared}")),
+            "{name}: the artifact must carry the protocol env var, got:\n{dockerfile}"
+        );
+        assert!(
+            LauncherAuthorityProtocol::ALL.contains(&DECLARED_LAUNCHER_PROTOCOL),
+            "{name}: the declaration must be one of the canonical wire forms"
+        );
+    }
+}
+
+/// The build Job echoes the declaration back out of the image it just built, so
+/// the watcher records what the *artifact* says rather than what the tag claims.
+///
+/// Mutation that fails it: remove the `DJINN_LAUNCHER_PROTOCOL=` echo from
+/// `build_job.rs`'s script. The `assert!` fails naming the sentinel.
+#[test]
+fn the_build_job_echoes_the_declaration_as_a_sentinel() {
+    let source = read("server/crates/djinn-image-controller/src/build_job.rs");
+    assert!(
+        source.contains("DJINN_LAUNCHER_PROTOCOL=${LAUNCHER_AUTHORITY_PROTOCOL}"),
+        "build_job.rs must echo the protocol sentinel the watcher parses"
+    );
+    assert!(
+        source.contains(LAUNCHER_PROTOCOL_LABEL),
+        "build_job.rs must read the declaration out of the artifact's own LABEL"
+    );
+}
+
+/// A newly cataloged artifact carries BOTH a declaration and an immutable
+/// digest, and therefore never consults the inventory: the compatibility path
+/// is unreachable for it.
+///
+/// Mutation that fails it: drop the digest requirement from
+/// `ImageRepository::mark_ready` and mark the row ready with
+/// `registry_digest = NULL`. The `expect_err` below returns `Ok`.
+#[tokio::test]
+async fn a_newly_cataloged_artifact_declares_a_protocol_and_pins_a_digest() {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create_with_id("p1", "p-1", "test", "p1")
+        .await
+        .unwrap();
+    let images = ImageRepository::new(db.clone());
+    images
+        .create("new", "Newly built", None, "{}")
+        .await
+        .unwrap();
+
+    let digest = format!("sha256:{}", "ab".repeat(32));
+    images
+        .mark_ready(
+            "new",
+            "reg/djinn-image-new:contenthash",
+            Some(&digest),
+            Some(DECLARED_LAUNCHER_PROTOCOL),
+        )
+        .await
+        .unwrap();
+    images.set_project_image("p1", Some("new")).await.unwrap();
+
+    let row = images.get("new").await.unwrap().expect("row");
+    assert_eq!(
+        row.declared_launcher_protocol().unwrap(),
+        Some(DECLARED_LAUNCHER_PROTOCOL)
+    );
+    assert_eq!(row.registry_digest.as_deref(), Some(digest.as_str()));
+
+    // The inventory is EMPTY and the artifact still dispatches: a declaring
+    // image is admitted on its own declaration, never on an allowlist entry.
+    // (Migration 167 seeds the authority singleton at `leaf-v1`, which is what
+    // `DECLARED_LAUNCHER_PROTOCOL` is, so no flip is needed here.)
+    let resolved = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .with_legacy_digest_inventory(launcher_compatibility::LegacyDigestInventory::verified(
+            "ops",
+            "now",
+            [],
+        ))
+        .resolve_dispatch_image("p1")
+        .await
+        .unwrap()
+        .expect("project resolves");
+    assert_eq!(
+        resolved.authority_protocol,
+        Some(DECLARED_LAUNCHER_PROTOCOL)
+    );
+
+    // And a declaring artifact can never be written without a digest, so a new
+    // build cannot fall into the legacy population by accident.
+    images.create("bad", "No digest", None, "{}").await.unwrap();
+    images
+        .mark_ready(
+            "bad",
+            "reg/djinn-image-bad:contenthash",
+            None,
+            Some(DECLARED_LAUNCHER_PROTOCOL),
+        )
+        .await
+        .expect_err("a declaring build with no digest must be refused");
+}
+
+/// The inventory is built from the catalog, not from guesswork:
+/// `legacy_pre_protocol_digests` returns exactly the `ready`, undeclared,
+/// digest-pinned rows — and nothing else.
+///
+/// Mutation that fails it: drop `launcher_authority_protocol IS NULL` from the
+/// query. The declaring row appears and the length assertion fails.
+#[tokio::test]
+async fn the_inventory_candidate_set_is_exactly_the_ready_undeclared_digest_pinned_rows() {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let images = ImageRepository::new(db.clone());
+
+    let legacy_digest = format!("sha256:{}", "1e".repeat(32));
+    for (id, digest, protocol) in [
+        ("a-legacy-pinned", Some(legacy_digest.as_str()), None),
+        ("b-legacy-digestless", None, None),
+        (
+            "c-declaring",
+            Some("sha256:cc"),
+            Some(DECLARED_LAUNCHER_PROTOCOL),
+        ),
+    ] {
+        images.create(id, id, None, "{}").await.unwrap();
+        images
+            .mark_ready(id, &format!("reg/{id}:hash"), digest, protocol)
+            .await
+            .unwrap();
+    }
+    // A row that never went ready must not be vouched for either.
+    images.create("d-building", "d", None, "{}").await.unwrap();
+    images.mark_building("d-building", "hash").await.unwrap();
+
+    let candidates = images.legacy_pre_protocol_digests().await.unwrap();
+    let ids: Vec<&str> = candidates.iter().map(|c| c.image_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["a-legacy-pinned"],
+        "only a ready, undeclared, digest-pinned row belongs in the inventory"
+    );
+    assert_eq!(candidates[0].registry_digest, legacy_digest);
+    // The candidate is directly usable as an inventory entry.
+    assert!(PreProtocolDigest::parse(&candidates[0].registry_digest).is_ok());
+}
+
+// ── AC4: no retirement is used to satisfy compatibility ─────────────────────
+
+/// The launcher and broker binaries, the RuntimeClass and node conformance
+/// assets, the broker mount surface, the credential-boundary tests, child-UID
+/// execution, `cgroup.kill`, and `wait_empty` all still exist.
+///
+/// Every needle below is a *behavior* anchor, not a filename: deleting the file
+/// fails the read, and gutting the file while keeping its name fails the
+/// `contains`. Mutation that fails it: delete
+/// `Launcher::wait_empty` from `djinn-cgroup-launcher/src/lib.rs` — the
+/// `wait_empty` assertion fails naming the missing symbol.
+#[test]
+fn no_containment_asset_was_retired_to_make_compatibility_work() {
+    struct Asset {
+        what: &'static str,
+        file: &'static str,
+        needles: &'static [&'static str],
+    }
+
+    let assets = [
+        Asset {
+            what: "the launcher binary",
+            file: "server/crates/djinn-cgroup-launcher/Cargo.toml",
+            needles: &["[[bin]]", "name = \"djinn-cgroup-launcher\""],
+        },
+        Asset {
+            what: "cgroup.kill and wait_empty",
+            file: "server/crates/djinn-cgroup-launcher/src/lib.rs",
+            needles: &["cgroup.kill", "fn wait_empty"],
+        },
+        Asset {
+            what: "the broker and its wait_empty control",
+            file: "server/crates/djinn-cgroup-launcher/src/broker.rs",
+            needles: &["fn wait_empty", "WorkerReadinessAssertion"],
+        },
+        Asset {
+            what: "child UID execution",
+            file: "server/crates/djinn-cgroup-launcher/src/child.rs",
+            needles: &["CHILD_UID: u32 = 1001", "fn set_uid", "set_uid(CHILD_UID)"],
+        },
+        Asset {
+            what: "the worker-side process broker",
+            file: "server/crates/djinn-agent/src/process_broker.rs",
+            needles: &["wait_empty"],
+        },
+        Asset {
+            what: "the credential-boundary test",
+            file: "server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs",
+            needles: &["credential_and_control_descriptors_are_closed_before_credential_drop"],
+        },
+        Asset {
+            what: "the rendered credential/mount boundary",
+            file: "server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs",
+            needles: &["credential"],
+        },
+        Asset {
+            what: "the broker mount surface",
+            file: "server/crates/djinn-k8s/src/launcher.rs",
+            needles: &[
+                "VOLUME_LAUNCHER_IPC",
+                "LAUNCHER_SOCKET_PATH",
+                "LAUNCHER_CREDENTIAL_PATH",
+                "TASK_RUN_CGROUP_RUNTIME_CLASS",
+            ],
+        },
+        Asset {
+            what: "the RuntimeClass manifest",
+            file: "deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml",
+            needles: &[
+                "kind: RuntimeClass",
+                "name: djinn-cgroup-writable",
+                "handler: runc-cgroupwritable",
+            ],
+        },
+        Asset {
+            what: "the node conformance program",
+            file: "deploy/node/k3s/djinn-cgroup-writable-conformance.sh",
+            needles: &["djinn.io/cgroup-writable"],
+        },
+    ];
+
+    for asset in assets {
+        let source = read(asset.file);
+        for needle in asset.needles {
+            assert!(
+                source.contains(needle),
+                "{} was retired: {} no longer contains {needle:?}. No retirement may be used \
+                 to satisfy launcher-authority compatibility",
+                asset.what,
+                asset.file
+            );
+        }
+    }
+}
+
+/// The compatibility decision has exactly one definition, and neither the
+/// image-controller nor the image-builder carries a second copy of the rule.
+///
+/// Mutation that fails it: reimplement the "undeclared + digest ⇒ leaf-v1" rule
+/// inline in the controller. The scan finds `LeafV1` reached without going
+/// through `decide_admission` and fails.
+#[test]
+fn the_compatibility_rule_is_not_restated_outside_its_module() {
+    let module = read("server/crates/djinn-db/src/launcher_compatibility.rs");
+    assert!(
+        module.contains("pub fn decide_admission("),
+        "the centralized decision must live in launcher_compatibility.rs"
+    );
+    // …and it composes z3gi's decision rather than restating it.
+    assert!(
+        module.contains("decide_launcher_protocol_admission("),
+        "the declaration arm must delegate to z3gi's decision, not reimplement it"
+    );
+
+    // The resolver reaches the decision through that module, not through a
+    // local reimplementation.
+    let project = read("server/crates/djinn-db/src/repositories/project.rs");
+    assert!(
+        project.contains("admit_with_legacy_inventory(")
+            && project.contains("admit_declared_protocol("),
+        "resolve_dispatch_image must route through the centralized decision and the persisted \
+         authority singleton"
+    );
+
+    for (label, file) in [
+        (
+            "the image controller",
+            "server/crates/djinn-image-controller/src/watcher.rs",
+        ),
+        (
+            "the image builder",
+            "server/crates/djinn-image-builder/src/dockerfile.rs",
+        ),
+    ] {
+        let source = read(file);
+        assert!(
+            !source.contains("unwrap_or_default()") || !source.contains("registry_digest"),
+            "{label} must not derive an effective protocol from a digest; that decision \
+             belongs to decide_admission"
+        );
+    }
+}

--- a/server/crates/djinn-k8s/tests/launcher_authority_protocol_render.rs
+++ b/server/crates/djinn-k8s/tests/launcher_authority_protocol_render.rs
@@ -36,6 +36,15 @@ use djinn_runtime::{ResolvedCredentials, SessionRuntime};
 use djinn_supervisor::ConnectionRegistry;
 use k8s_openapi::api::batch::v1::Job;
 
+/// A canonical immutable manifest digest: `sha256:` + 64 lowercase hex.
+///
+/// The dispatch-path fixtures below must use a well-formed digest because
+/// `resolve_dispatch_image` now runs task vf7a's admission compatibility fence,
+/// which compares digests exactly. `render_authority_protocol`'s own unit
+/// assertions are unaffected — it takes the digest as an opaque presence check.
+const CANONICAL_DIGEST: &str =
+    "sha256:7822b7de0000000000000000000000000000000000000000000000000000cafe";
+
 /// Read one container's environment value, if present.
 fn env_of(job: &Job, container: &str, name: &str) -> Option<String> {
     let pod = job.spec.as_ref()?.template.spec.as_ref()?;
@@ -219,7 +228,11 @@ fn a_disabled_launcher_render_is_left_alone() {
 async fn a_protocol_less_undigested_image_creates_zero_kubernetes_objects() {
     // Sanity: the SAME flow with a digest-pinned image reaches the POSTs, so
     // the zero below is caused by the refusal and not by an inert harness.
-    let (created, digest_pinned) = prepare_with_image(Some("sha256:abc"), None).await;
+    //
+    // The digest is canonical (`sha256:` + 64 lowercase hex): task vf7a's
+    // admission compatibility fence compares digests exactly, so a placeholder
+    // like `sha256:abc` is refused as a non-digest before the render is reached.
+    let (created, digest_pinned) = prepare_with_image(Some(CANONICAL_DIGEST), None).await;
     assert!(
         digest_pinned.is_ok(),
         "a digest-pinned image must still dispatch: {digest_pinned:?}"
@@ -245,7 +258,7 @@ async fn a_protocol_less_undigested_image_creates_zero_kubernetes_objects() {
 
     // And a declaring image dispatches, carrying its declaration.
     let (created, declared) = prepare_with_image(
-        Some("sha256:abc"),
+        Some(CANONICAL_DIGEST),
         Some(LauncherAuthorityProtocol::ResizeV2),
     )
     .await;
@@ -307,9 +320,14 @@ async fn prepare_with_image(
 
     let db = Database::open_in_memory().expect("in-memory database");
     db.ensure_initialized().await.expect("migrations");
+    // Bounded to `projects.id`'s varchar(36); the digest is only summarized.
     let project_id = format!(
         "proj-{}-{}",
-        digest.unwrap_or("nodigest"),
+        if digest.is_some() {
+            "digested"
+        } else {
+            "nodigest"
+        },
         protocol.map(|p| p.as_wire()).unwrap_or("undeclared")
     );
     ProjectRepository::new(db.clone(), EventBus::noop())
@@ -335,6 +353,22 @@ async fn prepare_with_image(
         .set_project_image(&project_id, Some(&image_id))
         .await
         .expect("select the catalog image");
+
+    // `resolve_dispatch_image` now admits against the DURABLE authority
+    // singleton (migration 167) before `prepare` renders anything (task vf7a),
+    // so a declaring fixture only dispatches when the server actually runs the
+    // protocol it declares. Align the singleton with the fixture's declaration;
+    // the mismatch case has its own tests in `djinn-db`.
+    if let Some(protocol) = protocol {
+        let modes = djinn_db::LauncherAuthorityModeRepository::new(db.clone());
+        let epoch = modes
+            .read()
+            .await
+            .expect("read the authority singleton")
+            .expect("migration 167 seeds it")
+            .epoch;
+        modes.set_mode(epoch, protocol).await;
+    }
 
     let runtime = KubernetesRuntime::from_client_with_db(
         client,


### PR DESCRIPTION
Closes task `vf7a` (epic `y3ww`, proposal `3i92`).

## The gap

Two decisions had landed with **no dispatch caller**:

* **z3gi (#2837)** shipped `decide_launcher_protocol_admission(mode, declared)` — the persisted `launcher_authority_mode` singleton against an artifact's declaration — and its own doc says `UndeclaredProtocol` is "a refusal in BOTH modes … owned by `vf7a`". Nothing called it from a dispatch.
* **#2836** shipped `render_authority_protocol(declared, digest)`, which reads the artifact's declaration but never consults the persisted authority.

`ProjectRepository::resolve_dispatch_image` — the seam `djinn_k8s::runtime::prepare` already calls before it builds a Job — is where they meet.

## The decision

`djinn_db::launcher_compatibility::decide_admission` is the centralized compatibility function. It is **not** a second implementation: every artifact that declared something is routed verbatim through z3gi's verdict; only `UndeclaredProtocol` is reinterpreted. A missing protocol becomes effective `leaf-v1` only when **all** of:

* the artifact is pinned to a **canonical immutable digest** — `sha256:` + exactly 64 lowercase hex, compared **exactly**, never a tag and never an image name;
* that digest is listed in the deployment's **signed** pre-protocol inventory;
* the persisted authority mode (migration 167) is `leaf-v1`.

Every other combination refuses **before a Job is rendered**:

| shape | outcome |
|---|---|
| declaration disagrees with the authority | `Declared(ProtocolMismatch)` |
| declaration unparseable | `Declared(UnknownProtocol)` |
| authority singleton absent/unreadable | `Declared(AuthorityUnavailable)` |
| no declaration, mode `resize-v2` | `MissingDeclarationUnderMode` |
| no declaration, non-canonical digest | `MalformedDigest` |
| no declaration, digest not inventoried | `UninventoriedDigest` |
| no declaration, inventory untrusted | `InventoryUnusable` |
| no declaration, **no digest at all** | `Undeclarable` — see below |

## The inventory

An Ed25519-signed JSON document (`schema_version`, `issuer`, `issued_at`, `digests`) named by `DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY`, verified against `..._PUBLIC_KEY` / `..._SIGNATURE` over the document's **exact bytes**, read once per process so a restart re-reads it.

Every validation failure — unreadable file, absent key, absent signature, bad base64, wrong key/signature length, failed verification, unknown schema version, malformed digest entry — yields `Unusable`, which grants **no** compatibility to anything. A broken inventory is stricter than no inventory, never looser.

`ImageRepository::legacy_pre_protocol_digests()` enumerates exactly the `ready` / undeclared / digest-pinned rows, ordered by id, so an operator builds the document from the catalog rather than by hand (and so the same catalog produces byte-identical, re-signable output).

## #2831's anti-wedge guard survives

A pre-existing `status = 'ready'` row with `registry_digest IS NULL` still resolves and still yields a pull ref. It is `Undeclarable`: it carries **no** authority, and #2836's `render_authority_protocol` refuses it exactly as it does on `main` today. `a_preexisting_ready_row_with_no_digest_still_dispatches_under_leaf_v1` passes unchanged.

Making that shape a resolve **error** would break a row migration 166 deliberately keeps legal, and would turn the readiness/warm/indexer callers that share the resolver into failure paths. `get_dispatch_readiness` reads the unfenced row for the same reason. Migration 166's CHECK is untouched and still scoped to declaring rows.

## Arming

With **no inventory configured**, the *membership* test is unarmed: an undeclared, canonically digest-pinned image still maps to `leaf-v1` under `leaf-v1` mode — exactly #2836's rule. An inventory that does not exist cannot classify a digest as "unknown", and letting an absent config file retroactively strand every already-built digest-pinned image is precisely the wedge migration 166 refused to create. Configuring an inventory arms it. Every other rejection class above is unconditional.

`arming_the_inventory_is_what_narrows_an_undeclared_artifact` asserts both halves, so the one case where the fence takes something away is stated rather than discovered.

## Test matrix

`server/crates/djinn-db/tests/launcher_admission_compatibility_matrix.rs` — 10 tests. Three artifact shapes (real no-handshake legacy, explicit `leaf-v1`, explicit `resize-v2`) × both authority modes × four inventory states, driven through the **real** `ImageRepository::mark_ready` (so migration 166's CHECK and the repository's digest guard apply), the **real** `LauncherAuthorityModeRepository::set_mode` drain fence, and the **real** `resolve_dispatch_image`. No stub.

Every admitted cell asserts **exactly one** effective quota authority: admitted == mode, and (when declared) == declaration. `the_repository_seam_reports_exactly_what_the_decision_returns` sweeps all 32 combinations and asserts the DB path and the pure function agree cell for cell.

`server/crates/djinn-image-controller/tests/protocol_catalog_and_preservation.rs` — 6 tests covering AC2 (generated Dockerfiles declare the LABEL + ENV, `build_job.rs` echoes the sentinel, a newly cataloged artifact declares + pins and never consults the inventory, a declaring build with no digest is refused) and AC4.

## AC4 — no retirement

`no_containment_asset_was_retired_to_make_compatibility_work` asserts behaviour anchors, not filenames, across: the `djinn-cgroup-launcher` binary, `cgroup.kill` and `wait_empty` (launcher **and** broker **and** the worker-side process broker), `CHILD_UID = 1001` / `set_uid(CHILD_UID)`, the credential-boundary tests, the rendered credential/mount boundary, the broker mount surface (`VOLUME_LAUNCHER_IPC`, `LAUNCHER_SOCKET_PATH`, `LAUNCHER_CREDENTIAL_PATH`, `TASK_RUN_CGROUP_RUNTIME_CLASS`), the RuntimeClass manifest, and the k3s node conformance program. Nothing was deleted; no retirement is used to satisfy compatibility.

## Fixture honesty

Two fixtures used `sha256:abc` as a digest. It names no artifact, so the fence now refuses it; both are canonical 64-hex. That is the fence working — and it is why `a_protocol_less_undigested_image_creates_zero_kubernetes_objects`, which drives the **real** `KubernetesRuntime::prepare` against a recording fake apiserver, caught it. That test now also aligns the authority singleton with its declaring fixture, because a `resize-v2` image no longer dispatches while the server runs `leaf-v1`.

## Mutations (all run, real failures)

| mutation | test that fails |
|---|---|
| inventory membership always `true` | `a_missing_protocol_is_admitted_only_for_an_exact_inventoried_digest` |
| drop the `mode != LeafV1` guard | `no_missing_protocol_artifact_survives_resize_v2` |
| accept any `sha256:`-prefixed string | `a_mutable_tag_without_a_verified_digest_never_dispatches` |
| `Unusable` falls back to admitted | `an_unusable_inventory_rejects_rather_than_falling_back` |
| admit a mismatched declaration | `every_admitted_combination_has_exactly_one_effective_authority` |
| **skip the fence at the resolve seam** | **9 of 10 matrix tests** |
| drop `IS NULL` from the candidate query | `the_inventory_candidate_set_is_exactly_the_ready_undeclared_digest_pinned_rows` |
| drop `emit_launcher_protocol` | `every_generated_image_declares_its_protocol_in_build_metadata` |
| retire the RuntimeClass handler | `no_containment_asset_was_retired_to_make_compatibility_work` |

## Scope

Touched: `djinn-db/src/{launcher_compatibility.rs,lib.rs,repositories/{image.rs,project.rs}}`, two new test files, and the two fixture digests in `djinn-k8s/tests/launcher_authority_protocol_render.rs`.

Untouched: `djinn-cgroup-launcher/**`, `djinn-launcher-protocol/**`, `djinn-k8s/src/{launcher.rs,launcher_cpu.rs,job.rs,runtime.rs}`, `deploy/**`, `scripts/kind/**`. No new migration (main is at 167; none was needed — the inventory is deployment config, not schema). No `.sqlx` change (runtime `sqlx::query`, matching the rest of `image.rs`).

## DEPLOY NOTE

Leaving the three env vars unset preserves today's behavior exactly. To arm the fence: generate the document from `legacy_pre_protocol_digests()`, sign it with Ed25519, and set `DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY`, `..._PUBLIC_KEY`, `..._SIGNATURE`. The production catalog image is digest-pinned (`djinn-image-019ea3c1-…@sha256:7822b7de…`), so it is in the candidate set and dispatches either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
