### PR TITLE
feat(resize): post-admission ceiling capture and birth downsize before dispatch (g3th)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1789,6 +1789,7 @@ dependencies = [
  "djinn-graph",
  "djinn-image-controller",
  "djinn-k8s",
+ "djinn-launcher-protocol",
  "djinn-memory",
  "djinn-provider",
  "djinn-runtime",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,6 +48,7 @@ djinn-git = { path = "crates/djinn-git" }
 djinn-graph = { path = "crates/djinn-graph" }
 djinn-image-controller = { path = "crates/djinn-image-controller" }
 djinn-k8s = { path = "crates/djinn-k8s" }
+djinn-launcher-protocol = { path = "crates/djinn-launcher-protocol" }
 djinn-control-plane = { path = "crates/djinn-control-plane" }
 djinn-provider = { path = "crates/djinn-provider" }
 djinn-runtime = { path = "crates/djinn-runtime" }

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -2057,6 +2057,251 @@ pub async fn list_taskrun_jobs(
     Ok(refs)
 }
 
+// ── Post-admission launcher observation (g8jk-3) ───────────────────────────
+//
+// The resize bootstrap that consumes this lives in
+// `djinn_server::task_run_resize_bootstrap`. The split is deliberate: the
+// mechanics of reading a stored Pod belong to the crate that owns the Kubernetes
+// types, and the policy — what to capture, when to refuse, when to delete —
+// belongs beside the durable permit relation. Nothing below decides anything; it
+// reports what the apiserver has stored.
+
+/// One fresh read of the *stored* launcher sidecar, flattened to plain data.
+///
+/// Every field here comes from the object the apiserver persisted, never from
+/// the render input. That is the whole point of post-admission capture: a
+/// mutating admission webhook may have changed what was rendered, and a value
+/// derived from the render would report the ceiling we asked for rather than the
+/// ceiling the Pod actually has.
+///
+/// Fields that a still-starting Pod legitimately lacks are [`Option`], and the
+/// caller decides whether their absence is "not yet" or "never". This type
+/// deliberately makes no such judgement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObservedLauncherSidecar {
+    /// `metadata.namespace` of the stored Pod.
+    pub namespace: String,
+    /// `metadata.name` of the stored Pod.
+    pub pod_name: String,
+    /// `metadata.uid` — the fence every later resize and delete is bound to.
+    pub pod_uid: String,
+    /// The launcher's container name, as it appears in `spec.initContainers`.
+    pub launcher_container_name: String,
+    /// `status.initContainerStatuses[..].containerID`. Absent until the kubelet
+    /// has actually started the sidecar.
+    pub launcher_container_id: Option<String>,
+    /// `status.initContainerStatuses[..].imageID` — the resolved artifact, not
+    /// the possibly-mutable tag in the spec.
+    pub image_digest: Option<String>,
+    /// The launcher's own `DJINN_LAUNCHER_AUTHORITY_PROTOCOL` value, read off
+    /// the stored spec. Absent for images rendered before the protocol existed.
+    pub observed_protocol: Option<String>,
+    /// The persisted `spec.initContainers[cgroup-launcher].resources.limits.cpu`
+    /// in millicores — the admitted ceiling. Absent under `leaf-v1`, which
+    /// renders no launcher CPU limit at all.
+    pub admitted_cpu_millicores: Option<u64>,
+}
+
+/// Why a stored Pod could not be flattened into an [`ObservedLauncherSidecar`].
+///
+/// Both variants are failures, but they are not the same failure: `Incomplete`
+/// describes a Pod that has not finished being admitted and may complete on the
+/// next read, while `Ambiguous` describes a Pod whose launcher cannot be *named*
+/// and never will be by waiting.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum LauncherObservationError {
+    /// A `metadata` field the fence depends on is not populated yet.
+    #[error("stored Pod is missing `metadata.{field}`")]
+    Incomplete {
+        /// The absent metadata field.
+        field: &'static str,
+    },
+    /// The launcher is not uniquely identifiable in the stored Pod.
+    #[error("{0}")]
+    Ambiguous(#[from] crate::pod_resize::PodResizeError),
+    /// The apiserver read itself failed, or resolved to more than one Pod.
+    #[error("{0}")]
+    Api(String),
+}
+
+/// Flatten a stored Pod into the launcher facts the resize bootstrap needs.
+///
+/// The launcher must be uniquely identifiable in **both** `spec.initContainers`
+/// and `status.initContainerStatuses` before any field is read, for the reason
+/// [`crate::pod_resize`] documents at length: the worker container can carry a
+/// coincidentally matching CPU limit, so resolving the launcher by anything less
+/// than a unique name match does not read nothing, it reads the wrong thing.
+///
+/// # Errors
+///
+/// [`LauncherObservationError`] — see its variants.
+pub fn observe_launcher_sidecar(
+    pod: &Pod,
+) -> Result<ObservedLauncherSidecar, LauncherObservationError> {
+    let namespace = non_empty(pod.metadata.namespace.as_deref())
+        .ok_or(LauncherObservationError::Incomplete { field: "namespace" })?;
+    let pod_name = non_empty(pod.metadata.name.as_deref())
+        .ok_or(LauncherObservationError::Incomplete { field: "name" })?;
+    let pod_uid = non_empty(pod.metadata.uid.as_deref())
+        .ok_or(LauncherObservationError::Incomplete { field: "uid" })?;
+
+    let spec = crate::pod_resize::locate_launcher_spec(pod)?;
+    let status = crate::pod_resize::locate_launcher_status(pod)?;
+
+    // The declared limit is read through `declared_launcher_cpu_limit`, which is
+    // documented as a spec read and explicitly NOT confirmation of anything. It
+    // is the right source here precisely because capture is a statement about
+    // what was admitted, not about what the kubelet has actuated.
+    let admitted_cpu_millicores = crate::pod_resize::declared_launcher_cpu_limit(pod)
+        .ok()
+        .map(|limit| limit.millis());
+
+    Ok(ObservedLauncherSidecar {
+        namespace,
+        pod_name,
+        pod_uid,
+        launcher_container_name: spec.name.clone(),
+        launcher_container_id: non_empty(status.container_id.as_deref()),
+        image_digest: non_empty(Some(status.image_id.as_str())),
+        observed_protocol: spec.env.as_ref().and_then(|env| {
+            env.iter()
+                .find(|entry| entry.name == crate::launcher::AUTHORITY_PROTOCOL_ENV)
+                .and_then(|entry| non_empty(entry.value.as_deref()))
+        }),
+        admitted_cpu_millicores,
+    })
+}
+
+fn non_empty(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+/// Fresh, label-scoped read of the single live Pod for `task_run_id`.
+///
+/// Never served from a cache. More than one labelled Pod is an error rather than
+/// a choice: a replacement Pod standing beside the original is exactly the
+/// situation in which picking either one is wrong, and it is the same rule
+/// [`terminate_taskrun_pod_exact`] already applies before it deletes anything.
+///
+/// # Errors
+///
+/// A rendered `kube::Error` on list failure, or an ambiguity message when the
+/// label selector does not resolve to exactly one Pod.
+pub async fn get_taskrun_pod_fresh(
+    client: &kube::Client,
+    namespace: &str,
+    task_run_id: &str,
+) -> Result<Option<Pod>, String> {
+    let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
+    let selector = format!("{}={task_run_id}", crate::job::LABEL_TASK_RUN_ID);
+    let listed = pods
+        .list(&ListParams::default().labels(&selector))
+        .await
+        .map_err(|e| format!("list task-run Pods: {e}"))?
+        .items;
+    match listed.len() {
+        0 => Ok(None),
+        1 => Ok(listed.into_iter().next()),
+        found => Err(format!(
+            "task-run {task_run_id} resolves to {found} Pods; refusing to pick one"
+        )),
+    }
+}
+
+/// The three apiserver operations the resize bootstrap performs, bound to one
+/// namespace and one field manager.
+///
+/// It exists so `djinn-server` can drive the bootstrap without depending on
+/// `kube` or `k8s-openapi` directly, and so the bootstrap's own tests can
+/// substitute a fake for all three at once.
+pub struct TaskRunPodResizeSurface {
+    client: kube::Client,
+    namespace: String,
+    field_manager: String,
+}
+
+impl TaskRunPodResizeSurface {
+    /// Bind to one namespace.
+    pub fn new(
+        client: kube::Client,
+        namespace: impl Into<String>,
+        field_manager: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            namespace: namespace.into(),
+            field_manager: field_manager.into(),
+        }
+    }
+
+    /// Build from a live runtime, reusing its client and configured namespace.
+    #[must_use]
+    pub fn from_runtime(runtime: &KubernetesRuntime) -> Self {
+        Self::new(
+            runtime.client().clone(),
+            runtime.config().namespace.clone(),
+            "djinn-task-run-resize",
+        )
+    }
+
+    /// Fresh GET, then flatten. `Ok(None)` means no Pod exists yet.
+    ///
+    /// # Errors
+    ///
+    /// [`LauncherObservationError`] — the list failed or was ambiguous
+    /// (`Api`), the Pod is not fully admitted (`Incomplete`), or the launcher
+    /// cannot be named (`Ambiguous`).
+    pub async fn observe_launcher(
+        &self,
+        task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        let Some(pod) = get_taskrun_pod_fresh(&self.client, &self.namespace, task_run_id)
+            .await
+            .map_err(LauncherObservationError::Api)?
+        else {
+            return Ok(None);
+        };
+        observe_launcher_sidecar(&pod).map(Some)
+    }
+
+    /// One limits-only resize of the launcher sidecar, confirmed through
+    /// `status.initContainerStatuses`.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::pod_resize::PodResizeError`]; in particular `NotConfirmed` when
+    /// the PATCH was accepted but the fresh status does not yet agree.
+    pub async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), crate::pod_resize::PodResizeError> {
+        let api = crate::pod_resize::KubePodResizeApi::new(
+            self.client.clone(),
+            &self.namespace,
+            self.field_manager.clone(),
+        );
+        crate::pod_resize::PodResizeClient::new(api)
+            .resize_launcher_cpu(
+                pod_name,
+                crate::pod_resize::CpuLimit::from_millis(target_millicores),
+            )
+            .await
+    }
+
+    /// UID-fenced destruction of exactly the observed Pod, plus its Job.
+    ///
+    /// # Errors
+    ///
+    /// The rendered failure from [`terminate_taskrun_pod_exact`].
+    pub async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        terminate_taskrun_pod_exact(&self.client, &self.namespace, task_run_id, pod_uid).await
+    }
+}
+
 /// Delete a Job with `Foreground` propagation and the given grace period,
 /// treating 404 as success for idempotency.
 async fn delete_job_foreground(
@@ -3893,6 +4138,189 @@ mod tests {
         drop(stream);
         server.cancel();
         let _ = tokio::time::timeout(Duration::from_secs(2), server.join).await;
+    }
+
+    // ── observe_launcher_sidecar (g8jk-3) ─────────────────────────────────
+
+    mod launcher_observation {
+        use super::*;
+        use crate::launcher::{AUTHORITY_PROTOCOL_ENV, LAUNCHER_CONTAINER_NAME};
+        use k8s_openapi::api::core::v1::{
+            Container, ContainerStatus, EnvVar, PodSpec, PodStatus, ResourceRequirements,
+        };
+        use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+        use std::collections::BTreeMap;
+
+        fn cpu_limit(quantity: &str) -> ResourceRequirements {
+            ResourceRequirements {
+                limits: Some(BTreeMap::from([(
+                    "cpu".to_owned(),
+                    Quantity(quantity.to_owned()),
+                )])),
+                ..ResourceRequirements::default()
+            }
+        }
+
+        fn container(name: &str, quantity: Option<&str>, protocol: Option<&str>) -> Container {
+            Container {
+                name: name.to_owned(),
+                resources: quantity.map(cpu_limit),
+                env: protocol.map(|value| {
+                    vec![EnvVar {
+                        name: AUTHORITY_PROTOCOL_ENV.to_owned(),
+                        value: Some(value.to_owned()),
+                        value_from: None,
+                    }]
+                }),
+                ..Container::default()
+            }
+        }
+
+        fn status(
+            name: &str,
+            container_id: Option<&str>,
+            image_id: Option<&str>,
+        ) -> ContainerStatus {
+            ContainerStatus {
+                name: name.to_owned(),
+                container_id: container_id.map(ToOwned::to_owned),
+                image_id: image_id.unwrap_or_default().to_owned(),
+                ..ContainerStatus::default()
+            }
+        }
+
+        fn pod(
+            init: Vec<Container>,
+            regular: Vec<Container>,
+            statuses: Vec<ContainerStatus>,
+        ) -> Pod {
+            Pod {
+                metadata: ObjectMeta {
+                    name: Some("taskrun-pod".to_owned()),
+                    namespace: Some("djinn".to_owned()),
+                    uid: Some("pod-uid-1".to_owned()),
+                    ..ObjectMeta::default()
+                },
+                spec: Some(PodSpec {
+                    init_containers: Some(init),
+                    containers: regular,
+                    ..PodSpec::default()
+                }),
+                status: Some(PodStatus {
+                    init_container_statuses: Some(statuses),
+                    ..PodStatus::default()
+                }),
+            }
+        }
+
+        #[test]
+        fn reads_the_stored_launcher_spec_and_status() {
+            let observed = observe_launcher_sidecar(&pod(
+                vec![container(
+                    LAUNCHER_CONTAINER_NAME,
+                    Some("3800m"),
+                    Some("resize-v2"),
+                )],
+                vec![container("worker", Some("4"), None)],
+                vec![status(
+                    LAUNCHER_CONTAINER_NAME,
+                    Some("containerd://abc"),
+                    Some("registry/img@sha256:feed"),
+                )],
+            ))
+            .expect("observation");
+            assert_eq!(observed.pod_uid, "pod-uid-1");
+            assert_eq!(observed.namespace, "djinn");
+            assert_eq!(observed.pod_name, "taskrun-pod");
+            assert_eq!(observed.launcher_container_name, LAUNCHER_CONTAINER_NAME);
+            assert_eq!(
+                observed.launcher_container_id.as_deref(),
+                Some("containerd://abc")
+            );
+            assert_eq!(
+                observed.image_digest.as_deref(),
+                Some("registry/img@sha256:feed")
+            );
+            assert_eq!(observed.observed_protocol.as_deref(), Some("resize-v2"));
+            // 3800m, NOT the worker's coincidental 4 cores.
+            assert_eq!(observed.admitted_cpu_millicores, Some(3800));
+        }
+
+        #[test]
+        fn a_still_starting_sidecar_reports_absent_fields_rather_than_failing() {
+            let observed = observe_launcher_sidecar(&pod(
+                vec![container(LAUNCHER_CONTAINER_NAME, Some("4000m"), None)],
+                vec![],
+                vec![status(LAUNCHER_CONTAINER_NAME, None, None)],
+            ))
+            .expect("observation");
+            assert_eq!(observed.launcher_container_id, None);
+            assert_eq!(observed.image_digest, None);
+            assert_eq!(observed.observed_protocol, None);
+            assert_eq!(observed.admitted_cpu_millicores, Some(4000));
+        }
+
+        #[test]
+        fn a_leaf_v1_render_carries_no_ceiling_to_observe() {
+            let observed = observe_launcher_sidecar(&pod(
+                vec![container(LAUNCHER_CONTAINER_NAME, None, Some("leaf-v1"))],
+                vec![container("worker", Some("4"), None)],
+                vec![status(
+                    LAUNCHER_CONTAINER_NAME,
+                    Some("containerd://a"),
+                    Some("i"),
+                )],
+            ))
+            .expect("observation");
+            assert_eq!(observed.admitted_cpu_millicores, None);
+            assert_eq!(observed.observed_protocol.as_deref(), Some("leaf-v1"));
+        }
+
+        #[test]
+        fn an_unnameable_launcher_is_rejected_at_both_sites() {
+            // Zero spec entries.
+            let missing = observe_launcher_sidecar(&pod(
+                vec![container("worker", Some("4"), None)],
+                vec![],
+                vec![status(LAUNCHER_CONTAINER_NAME, Some("c"), Some("i"))],
+            ));
+            assert!(matches!(
+                missing,
+                Err(LauncherObservationError::Ambiguous(
+                    crate::pod_resize::PodResizeError::LauncherIdentityAmbiguous { found: 0, .. }
+                ))
+            ));
+
+            // Two status entries.
+            let duplicated = observe_launcher_sidecar(&pod(
+                vec![container(LAUNCHER_CONTAINER_NAME, Some("4000m"), None)],
+                vec![],
+                vec![
+                    status(LAUNCHER_CONTAINER_NAME, Some("c1"), Some("i")),
+                    status(LAUNCHER_CONTAINER_NAME, Some("c2"), Some("i")),
+                ],
+            ));
+            assert!(matches!(
+                duplicated,
+                Err(LauncherObservationError::Ambiguous(
+                    crate::pod_resize::PodResizeError::LauncherIdentityAmbiguous { found: 2, .. }
+                ))
+            ));
+        }
+
+        #[test]
+        fn a_pod_without_a_uid_is_incomplete_not_observable() {
+            let mut without_uid = pod(
+                vec![container(LAUNCHER_CONTAINER_NAME, Some("4000m"), None)],
+                vec![],
+                vec![status(LAUNCHER_CONTAINER_NAME, Some("c"), Some("i"))],
+            );
+            without_uid.metadata.uid = None;
+            assert_eq!(
+                observe_launcher_sidecar(&without_uid),
+                Err(LauncherObservationError::Incomplete { field: "uid" })
+            );
+        }
     }
 }
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,6 +18,7 @@ pub mod scip_index_watcher;
 pub mod server;
 pub mod server_memory;
 pub mod sse;
+pub mod task_run_resize_bootstrap;
 
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_helpers;

--- a/server/src/task_run_resize_bootstrap.rs
+++ b/server/src/task_run_resize_bootstrap.rs
@@ -1,0 +1,879 @@
+//! Post-admission ceiling capture and birth downsize, before dispatch.
+//!
+//! This is where proposal `3i92` stops being building blocks and starts
+//! governing real Pods. It composes four merged slices and adds no new
+//! Kubernetes or SQL primitives of its own:
+//!
+//! * `4acu` — [`BuildPodPermitRepository::capture_resize_identity`], the
+//!   write-once identity, and the **partial unique index on `pod_uid`**.
+//! * `g8jk-1` — the `resize-v2`-only launcher CPU ceiling in the render.
+//! * `g8jk-2` — [`djinn_k8s::pod_resize`], the limits-only `pods/resize`
+//!   client that confirms through `status.initContainerStatuses`.
+//! * `g8jk-4` — the namespaced, patch-only `pods/resize` RBAC rule.
+//!
+//! # The sequence
+//!
+//! Once the Pod has a UID and the launcher sidecar is admitted: **fresh GET**,
+//! read the **persisted**
+//! `spec.initContainers[name=cgroup-launcher].resources.limits.cpu`. That value
+//! is the admitted ceiling — it includes any mutating-admission result
+//! *precisely because* it comes from the stored Pod rather than the render
+//! input. Write it once, with the Pod UID and the effective protocol. **Then**
+//! resize down to [`BIRTH_CPU_MILLICORES`] and confirm through
+//! `status.initContainerStatuses`. Only after that confirmation may the worker
+//! session be admitted to dispatch.
+//!
+//! A test that compares the stored ceiling against the *render input* proves
+//! nothing and would pass on a broken implementation: the whole reason capture
+//! happens after admission is that a mutating webhook may have changed what was
+//! rendered.
+//!
+//! # `birth_confirmed` is a capture state, not a confirmation state
+//!
+//! Migration 164's `capture_resize_identity` sets `state = 'birth_confirmed'`
+//! as part of the *capture*, which happens before the birth resize is even
+//! issued. The durable state name therefore overstates: a row sitting in
+//! `birth_confirmed` proves an identity was captured, **not** that the launcher
+//! is at 250m.
+//!
+//! Two consequences, both load-bearing:
+//!
+//! 1. The dispatch gate keys on the in-process confirmed outcome of *this*
+//!    bootstrap (see [`DispatchGate`]), never on the row's state.
+//! 2. A bootstrap resumed after a server restart re-issues the birth resize
+//!    for a row already in `birth_confirmed`. That is idempotent by
+//!    construction — resize to a value the launcher already holds confirms
+//!    immediately.
+//!
+//! # Why the ceiling is read from the row, not re-derived
+//!
+//! Re-observation after a successful birth downsize reads **250m**, because
+//! that is what the Pod now declares. The captured ceiling therefore has to
+//! come from the durable row on every resumed pass, and capture may only be
+//! *attempted* when the row carries no identity yet. Deriving the ceiling from
+//! a fresh observation on resume would compare 250m against the stored ceiling,
+//! call it a conflicting recapture, and delete a healthy Pod.
+//!
+//! # `leaf-v1` never reaches capture, and cannot
+//!
+//! `g8jk-1` renders `limits.cpu` on the launcher under `resize-v2` **only** —
+//! under `leaf-v1` a container limit there is an ancestor clamp over every
+//! invocation leaf (task `7deu` measured a leaf set to 4 cores burning 0.25).
+//! Migration 164 in turn requires `admitted_cpu_millicores > 0` for any
+//! identity at all. So a `leaf-v1` Pod has no ceiling to capture and the schema
+//! would reject one if it did: bootstrap is structurally `resize-v2`-only, and
+//! `leaf-v1` dispatch is untouched by this module.
+//!
+//! # Replacement Pods: reject-and-delete
+//!
+//! See [`RefusalReason::ConflictingCapture`]. `build_pod_permits` has PRIMARY
+//! KEY `task_run_id`, `capture_resize_identity` predicates on
+//! `state = 'job_created' AND pod_uid IS NULL`, and the migration-164 trigger
+//! makes a captured identity immutable. Exactly one capture per task run is
+//! possible, ever.
+//!
+//! Release-and-reacquire was considered and is **not available**:
+//! [`BuildPodPermitRepository::acquire`] deliberately refuses to resurrect a
+//! released row under the same task-run id (`AlreadyReleased`), and the trigger
+//! has no edge back to `job_created`. Making it available would take a new
+//! migration and a change to `build_pod_permit.rs` — that is, it would take
+//! dismantling the write-once guarantee this design rests on.
+//!
+//! So a replacement Pod for the same task run is refused and UID-fenced
+//! deleted, and the run is not dispatched. Recovery is a **new task run**, with
+//! a new `task_run_id` and therefore a new permit. This is stated here rather
+//! than left for someone to discover during an incident.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use djinn_db::{
+    BuildPodPermitRepository, BuildPodPermitRow, BuildPodPermitState, BuildPodResizeIdentity,
+    CaptureBuildPodResizeIdentityResult, Error as DbError,
+};
+use djinn_k8s::launcher::LAUNCHER_CPU_REQUEST_MILLICORES;
+use djinn_k8s::pod_resize::PodResizeError;
+use djinn_k8s::runtime::{
+    LauncherObservationError, ObservedLauncherSidecar, TaskRunPodResizeSurface,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use tracing::{info, warn};
+
+/// The CPU limit every `resize-v2` launcher sidecar is downsized to before its
+/// worker session may dispatch. Lifts move it up, bounded by the captured
+/// ceiling; that lifecycle belongs to `0ppk`.
+pub const BIRTH_CPU_MILLICORES: u64 = 250;
+
+/// The Postgres SQLSTATE for a unique-violation. It is the *only* signal that
+/// distinguishes "another permit already owns this Pod UID" from "the database
+/// did not answer", and those two must not be conflated: the first is a
+/// permanent authority conflict that must delete the Pod, the second is a
+/// transient condition that must not.
+const UNIQUE_VIOLATION: &str = "23505";
+
+// ── The apiserver seam ─────────────────────────────────────────────────────
+
+/// The three Kubernetes operations bootstrap performs.
+///
+/// Behind a trait so the whole sequence is drivable from fixtures with no
+/// cluster, and so this crate needs no `kube` / `k8s-openapi` dependency of its
+/// own. The production implementation is
+/// [`djinn_k8s::runtime::TaskRunPodResizeSurface`].
+#[async_trait]
+pub trait TaskRunPodSurface: Send + Sync {
+    /// Fresh GET of the single Pod labelled for this task run, flattened to the
+    /// launcher facts. `Ok(None)` means no Pod exists yet.
+    ///
+    /// # Errors
+    ///
+    /// [`LauncherObservationError`] when the read fails, the Pod is not fully
+    /// admitted, or the launcher cannot be uniquely named.
+    async fn observe_launcher(
+        &self,
+        task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError>;
+
+    /// One limits-only resize of the launcher sidecar, confirmed through
+    /// `status.initContainerStatuses`.
+    ///
+    /// # Errors
+    ///
+    /// [`PodResizeError`]; `NotConfirmed` when the PATCH was accepted but the
+    /// fresh status does not yet agree.
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError>;
+
+    /// UID-fenced destruction of exactly the observed Pod.
+    ///
+    /// # Errors
+    ///
+    /// The rendered failure from the fenced-deletion protocol.
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String>;
+}
+
+#[async_trait]
+impl TaskRunPodSurface for TaskRunPodResizeSurface {
+    async fn observe_launcher(
+        &self,
+        task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        Self::observe_launcher(self, task_run_id).await
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        Self::resize_launcher_cpu(self, pod_name, target_millicores).await
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        Self::uid_fenced_delete(self, task_run_id, pod_uid).await
+    }
+}
+
+// ── Inputs and outcomes ────────────────────────────────────────────────────
+
+/// The permit a bootstrap acts under. Every durable write is fenced by all
+/// three fields, so a stale actor cannot advance a lifecycle it no longer owns.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PermitBinding {
+    /// Task run whose permit row this is (`build_pod_permits` PRIMARY KEY).
+    pub task_run_id: String,
+    /// Immutable permit identity.
+    pub permit_id: String,
+    /// Monotonic ownership fence.
+    pub fencing_token: i64,
+}
+
+/// Why bootstrap could not proceed *yet*. Every variant is retryable and none
+/// of them touches the Pod.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum NotReady {
+    /// No Pod carries this task run's label yet.
+    #[error("no Pod exists for this task run yet")]
+    PodAbsent,
+    /// The permit row has no Job UID bound yet, so `capture_resize_identity`'s
+    /// `state = 'job_created'` predicate cannot hold.
+    #[error("permit is still `acquired`; no Job UID has been bound")]
+    JobNotBound,
+    /// A `metadata` field the fence depends on is not populated yet.
+    #[error("stored Pod is not fully admitted: {0}")]
+    PodIncomplete(String),
+    /// The kubelet has not started the sidecar, so it has no container ID or
+    /// resolved image ID to fence the identity with.
+    #[error("launcher sidecar has not started: `{field}` is absent")]
+    LauncherNotStarted {
+        /// Which status field is still absent.
+        field: &'static str,
+    },
+    /// The PATCH was accepted but the fresh init-container status does not
+    /// agree yet. Backoff and the 30s confirmation deadline belong to `0ppk`.
+    #[error("birth downsize not confirmed yet: {0}")]
+    BirthUnconfirmed(String),
+    /// The apiserver call failed. Transport failures are not authority
+    /// failures.
+    #[error("kubernetes unavailable: {0}")]
+    KubernetesUnavailable(String),
+    /// Durable storage could not answer. Deliberately **not** a refusal: a Pod
+    /// must not be destroyed because Postgres blinked.
+    #[error("durable storage unavailable: {0}")]
+    StorageUnavailable(String),
+}
+
+/// Why bootstrap refused, permanently, for this Pod.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum RefusalReason {
+    /// The launcher is not uniquely identifiable in `spec.initContainers` or in
+    /// `status.initContainerStatuses`. Zero and two are the same error: both
+    /// mean the resize target cannot be named, and resolving either by
+    /// positional index would address the wrong container.
+    #[error("launcher identity is unusable: {0}")]
+    LauncherNotNameable(String),
+    /// `resize-v2` was resolved but the stored Pod declares no launcher CPU
+    /// limit. Under this protocol the launcher writes no leaf quota, so a
+    /// missing container limit means a brokered build is bounded only by the
+    /// node.
+    #[error("resize-v2 Pod declares no launcher CPU ceiling")]
+    NoAdmittedCeiling,
+    /// The admitted ceiling is below the launcher's own CPU request. Kubernetes
+    /// would reject such a container outright; if one is nevertheless stored,
+    /// the Pod is not one we can govern.
+    #[error("admitted ceiling {ceiling}m is below the launcher CPU request {request}m")]
+    CeilingBelowLauncherRequest {
+        /// Millicores read back from the stored Pod.
+        ceiling: u64,
+        /// The launcher sidecar's own request, in millicores.
+        request: u64,
+    },
+    /// The admitted ceiling is below the birth limit, so the "birth downsize"
+    /// would be an *upsize* past the admitted ceiling. Refused rather than
+    /// oversubscribed.
+    #[error("admitted ceiling {ceiling}m is below the birth limit {birth}m")]
+    CeilingBelowBirthLimit {
+        /// Millicores read back from the stored Pod.
+        ceiling: u64,
+        /// [`BIRTH_CPU_MILLICORES`].
+        birth: u64,
+    },
+    /// The stored Pod reports a different authority protocol than the server
+    /// resolved for it. Exactly one authority governs an admitted Pod.
+    #[error("launcher reports protocol `{observed}` but the server resolved `{effective}`")]
+    ProtocolMismatch {
+        /// What the stored launcher sidecar declares.
+        observed: String,
+        /// What the server resolved for this dispatch.
+        effective: String,
+    },
+    /// The stored Pod declares no protocol at all under `resize-v2`. Mapping a
+    /// missing handshake onto an effective protocol is the signed legacy-digest
+    /// allowlist's job (`vf7a`) and is never permitted under resize authority.
+    #[error("launcher declares no authority protocol under resize-v2")]
+    ProtocolMissing,
+    /// A `leaf-v1` Pod carries a launcher CPU limit. Under `leaf-v1` the
+    /// launcher owns each invocation leaf's `cpu.max`, so a container limit
+    /// here is an ancestor clamp that silently throttles every build — task
+    /// `7deu`'s measured defect. The render never produces this, so its
+    /// presence means something else wrote it.
+    #[error("leaf-v1 Pod carries a launcher CPU ceiling of {ceiling}m")]
+    LeafAuthorityCarriesCeiling {
+        /// Millicores read back from the stored Pod.
+        ceiling: u64,
+    },
+    /// The permit row already holds an identity, and it is not this Pod's — or
+    /// the repository refused the capture outright. **This is the
+    /// replacement-Pod path.** See the module docs: reject-and-delete, because
+    /// exactly one capture per task run is possible and release-and-reacquire
+    /// does not exist.
+    #[error("permit already holds a conflicting resize identity")]
+    ConflictingCapture,
+    /// Another permit row already owns this Pod UID. Caught by
+    /// `build_pod_permits_pod_uid_key`, migration 164's partial unique index —
+    /// the per-row write-once predicate cannot see across task runs, so without
+    /// that index two runs would each capture the same Pod with different
+    /// ceilings and both believe they held authority.
+    #[error("Pod UID is already captured by another permit")]
+    PodUidClaimedByAnotherPermit,
+    /// The permit row is not the one this caller holds. A stale owner must not
+    /// destroy the live owner's Pod, so this refusal retains it.
+    #[error("permit identity or fencing token does not match the durable row")]
+    StalePermit,
+    /// The row has moved past bootstrap into the lift/drop lifecycle that
+    /// `0ppk` owns. Not ours to re-drive, and not ours to delete.
+    #[error("permit is in resize state `{state}`, past bootstrap")]
+    PastBootstrap {
+        /// The durable state observed.
+        state: String,
+    },
+    /// The launcher cannot be resized at all: an ambiguous target, or a CPU
+    /// quantity the client refuses to build a PATCH from.
+    #[error("birth downsize is unissuable: {0}")]
+    BirthUnissuable(String),
+}
+
+/// What happened to the Pod as a result of a refusal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PodDisposition {
+    /// The Pod was left alone — either nothing exists to fence, or destroying
+    /// it is not this caller's right.
+    Retained,
+    /// A UID-fenced delete was issued for exactly the observed Pod. The inner
+    /// result is the delete's own outcome: a failed delete does not turn a
+    /// refusal into an admission.
+    UidFencedDeleted(Result<(), String>),
+}
+
+/// The result of one bootstrap pass.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BootstrapOutcome {
+    /// `resize-v2`: the admitted ceiling is durable, the birth limit is
+    /// confirmed through `status.initContainerStatuses`, and dispatch is
+    /// admitted.
+    BirthConfirmed {
+        /// The Pod this run is fenced to.
+        pod_uid: String,
+        /// The write-once ceiling, read back from the durable row.
+        admitted_cpu_millicores: i64,
+    },
+    /// `leaf-v1`: nothing to capture and nothing to resize. Dispatch proceeds
+    /// under launcher leaf authority, exactly as it did before this module.
+    LeafAuthority,
+    /// Retry. The Pod is untouched and dispatch is not admitted.
+    NotReady(NotReady),
+    /// Fail closed. Dispatch is not admitted, permanently for this task run.
+    Refused {
+        /// Why.
+        reason: RefusalReason,
+        /// What happened to the Pod.
+        disposition: PodDisposition,
+    },
+}
+
+impl BootstrapOutcome {
+    /// Whether this outcome admits the worker session to dispatch.
+    #[must_use]
+    pub const fn admits_dispatch(&self) -> bool {
+        matches!(self, Self::BirthConfirmed { .. } | Self::LeafAuthority)
+    }
+}
+
+// ── The dispatch gate ──────────────────────────────────────────────────────
+
+/// Proof that a task run's birth limit is confirmed (or that it is a `leaf-v1`
+/// run that never had one).
+///
+/// The constructor is private to this module, so the only way to obtain one is
+/// [`DispatchGate::admit`] after a bootstrap that actually confirmed. A caller
+/// that needs this token to dispatch cannot dispatch early by mistake — it
+/// cannot build the token at all.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DispatchAdmission {
+    task_run_id: String,
+    authority: AdmittedAuthority,
+}
+
+/// Which authority governs an admitted run's CPU quota.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdmittedAuthority {
+    /// The launcher owns each invocation leaf's `cpu.max`.
+    Leaf,
+    /// Kubernetes owns the launcher container's limit; the birth downsize is
+    /// confirmed.
+    Resize,
+}
+
+impl DispatchAdmission {
+    /// The task run this admission is for.
+    #[must_use]
+    pub fn task_run_id(&self) -> &str {
+        &self.task_run_id
+    }
+
+    /// Which authority governs it.
+    #[must_use]
+    pub const fn authority(&self) -> AdmittedAuthority {
+        self.authority
+    }
+}
+
+/// Why dispatch was refused.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum DispatchRefused {
+    /// No bootstrap has confirmed a birth limit for this task run. An unknown
+    /// task run lands here too: fail closed, a run this module has never seen
+    /// is not a run whose quota authority is established.
+    #[error("birth limit is not confirmed for task run {task_run_id}")]
+    BirthNotConfirmed {
+        /// The refused task run.
+        task_run_id: String,
+    },
+}
+
+/// The gate that stands between a confirmed birth downsize and dispatch.
+#[derive(Debug, Default)]
+pub struct DispatchGate {
+    admitted: Mutex<HashMap<String, AdmittedAuthority>>,
+    dispatches_before_birth_confirmation: AtomicU64,
+}
+
+impl DispatchGate {
+    /// A gate that admits nothing.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn record_admissible(&self, task_run_id: &str, authority: AdmittedAuthority) {
+        self.admitted
+            .lock()
+            .expect("dispatch gate poisoned")
+            .insert(task_run_id.to_owned(), authority);
+    }
+
+    fn authority_of(&self, task_run_id: &str) -> Option<AdmittedAuthority> {
+        self.admitted
+            .lock()
+            .expect("dispatch gate poisoned")
+            .get(task_run_id)
+            .copied()
+    }
+
+    /// Admit a task run to dispatch, or refuse it.
+    ///
+    /// # Errors
+    ///
+    /// [`DispatchRefused::BirthNotConfirmed`] when no bootstrap has confirmed
+    /// this task run — including when it has never been seen at all.
+    pub fn admit(&self, task_run_id: &str) -> Result<DispatchAdmission, DispatchRefused> {
+        match self.authority_of(task_run_id) {
+            Some(authority) => Ok(DispatchAdmission {
+                task_run_id: task_run_id.to_owned(),
+                authority,
+            }),
+            None => Err(DispatchRefused::BirthNotConfirmed {
+                task_run_id: task_run_id.to_owned(),
+            }),
+        }
+    }
+
+    /// Called by the dispatch site at the moment a worker session actually
+    /// starts.
+    ///
+    /// This exists to make the gate's *absence* observable rather than merely
+    /// assertable. With [`Self::admit`] standing in front of the dispatch site
+    /// this counter is structurally unreachable and stays zero; delete the gate
+    /// and it becomes non-zero on the first early dispatch, whether or not
+    /// anyone remembered to write an assertion about ordering.
+    pub fn record_dispatch_started(&self, task_run_id: &str) {
+        if self.authority_of(task_run_id).is_none() {
+            self.dispatches_before_birth_confirmation
+                .fetch_add(1, Ordering::SeqCst);
+            warn!(
+                task_run_id,
+                "task_run_resize_bootstrap: dispatch started before the birth limit was confirmed"
+            );
+        }
+    }
+
+    /// How many dispatches have started without a confirmed birth limit.
+    #[must_use]
+    pub fn dispatches_before_birth_confirmation(&self) -> u64 {
+        self.dispatches_before_birth_confirmation
+            .load(Ordering::SeqCst)
+    }
+}
+
+// ── The bootstrap ──────────────────────────────────────────────────────────
+
+/// Composes the durable permit relation, the `pods/resize` client, and the
+/// UID-fenced deletion protocol into one pass.
+pub struct TaskRunResizeBootstrap {
+    permits: BuildPodPermitRepository,
+    surface: Arc<dyn TaskRunPodSurface>,
+    gate: Arc<DispatchGate>,
+}
+
+impl TaskRunResizeBootstrap {
+    /// Wire a bootstrap to a permit repository, an apiserver surface, and a
+    /// gate.
+    #[must_use]
+    pub fn new(
+        permits: BuildPodPermitRepository,
+        surface: Arc<dyn TaskRunPodSurface>,
+        gate: Arc<DispatchGate>,
+    ) -> Self {
+        Self {
+            permits,
+            surface,
+            gate,
+        }
+    }
+
+    /// The gate this bootstrap admits through.
+    #[must_use]
+    pub fn gate(&self) -> &Arc<DispatchGate> {
+        &self.gate
+    }
+
+    /// Run one bootstrap pass for `permit` under the server-resolved
+    /// `effective` protocol.
+    ///
+    /// Idempotent: a pass that has already captured and confirmed returns
+    /// [`BootstrapOutcome::BirthConfirmed`] again without a second capture, and
+    /// re-issues a resize the launcher already satisfies.
+    pub async fn bootstrap(
+        &self,
+        permit: &PermitBinding,
+        effective: LauncherAuthorityProtocol,
+    ) -> BootstrapOutcome {
+        // 1. The durable row first. It decides whether capture is even
+        //    attemptable, and on a resumed pass it — not a fresh observation —
+        //    is the authority on the captured ceiling.
+        let row = match self.permits.active(&permit.task_run_id).await {
+            Ok(Some(row)) => row,
+            Ok(None) => {
+                return BootstrapOutcome::Refused {
+                    reason: RefusalReason::StalePermit,
+                    disposition: PodDisposition::Retained,
+                };
+            }
+            Err(error) => {
+                return BootstrapOutcome::NotReady(NotReady::StorageUnavailable(error.to_string()));
+            }
+        };
+        if row.permit_id != permit.permit_id || row.fencing_token != permit.fencing_token {
+            return BootstrapOutcome::Refused {
+                reason: RefusalReason::StalePermit,
+                disposition: PodDisposition::Retained,
+            };
+        }
+        match row.state {
+            BuildPodPermitState::Acquired => {
+                return BootstrapOutcome::NotReady(NotReady::JobNotBound);
+            }
+            BuildPodPermitState::JobCreated | BuildPodPermitState::BirthConfirmed => {}
+            other => {
+                return BootstrapOutcome::Refused {
+                    reason: RefusalReason::PastBootstrap {
+                        state: format!("{other:?}"),
+                    },
+                    disposition: PodDisposition::Retained,
+                };
+            }
+        }
+
+        // 2. Fresh GET of the stored Pod. Never the render input: capture
+        //    exists to observe what admission actually produced.
+        let observed = match self.surface.observe_launcher(&permit.task_run_id).await {
+            Ok(Some(observed)) => observed,
+            Ok(None) => return BootstrapOutcome::NotReady(NotReady::PodAbsent),
+            Err(LauncherObservationError::Incomplete { field }) => {
+                return BootstrapOutcome::NotReady(NotReady::PodIncomplete(format!(
+                    "metadata.{field}"
+                )));
+            }
+            Err(LauncherObservationError::Api(error)) => {
+                return BootstrapOutcome::NotReady(NotReady::KubernetesUnavailable(error));
+            }
+            Err(error @ LauncherObservationError::Ambiguous(_)) => {
+                // No Pod UID is available here by construction — the launcher
+                // could not be named, so there is nothing to fence a delete to.
+                return BootstrapOutcome::Refused {
+                    reason: RefusalReason::LauncherNotNameable(error.to_string()),
+                    disposition: PodDisposition::Retained,
+                };
+            }
+        };
+
+        // 3. Protocol agreement, before anything durable is written.
+        if let Some(outcome) = self.check_protocol(permit, &observed, effective).await {
+            return outcome;
+        }
+        if effective.launcher_owns_leaf_quota() {
+            // leaf-v1: no ceiling exists to capture and migration 164 would
+            // reject an identity without one. Dispatch under leaf authority,
+            // exactly as it did before this module existed.
+            self.gate
+                .record_admissible(&permit.task_run_id, AdmittedAuthority::Leaf);
+            return BootstrapOutcome::LeafAuthority;
+        }
+
+        // 4. Establish the write-once ceiling: from the durable row when one is
+        //    already captured, otherwise by capturing this observation.
+        let ceiling = match row.resize_identity.as_ref() {
+            Some(identity) => {
+                if identity.pod_uid != observed.pod_uid {
+                    // The replacement-Pod path. See the module docs.
+                    return self
+                        .refuse_and_delete(permit, &observed, RefusalReason::ConflictingCapture)
+                        .await;
+                }
+                identity.admitted_cpu_millicores
+            }
+            None => match self.capture(permit, &observed, effective).await {
+                Ok(row) => match row.resize_identity {
+                    Some(identity) => identity.admitted_cpu_millicores,
+                    None => {
+                        // A captured row without an identity is impossible under
+                        // `build_pod_permits_resize_state_identity_check`; treat
+                        // it as storage the caller cannot trust rather than
+                        // inventing a ceiling.
+                        return BootstrapOutcome::NotReady(NotReady::StorageUnavailable(
+                            "captured permit row carries no resize identity".to_owned(),
+                        ));
+                    }
+                },
+                Err(outcome) => return outcome,
+            },
+        };
+
+        // 5. Birth downsize, confirmed through `status.initContainerStatuses`.
+        //    Only now is the ceiling a number this module has authority over.
+        match self
+            .surface
+            .resize_launcher_cpu(&observed.pod_name, BIRTH_CPU_MILLICORES)
+            .await
+        {
+            Ok(()) => {}
+            Err(PodResizeError::NotConfirmed(reason)) => {
+                return BootstrapOutcome::NotReady(NotReady::BirthUnconfirmed(reason.to_string()));
+            }
+            Err(error @ PodResizeError::Api { .. }) => {
+                return BootstrapOutcome::NotReady(NotReady::KubernetesUnavailable(
+                    error.to_string(),
+                ));
+            }
+            Err(error) => {
+                return self
+                    .refuse_and_delete(
+                        permit,
+                        &observed,
+                        RefusalReason::BirthUnissuable(error.to_string()),
+                    )
+                    .await;
+            }
+        }
+
+        self.gate
+            .record_admissible(&permit.task_run_id, AdmittedAuthority::Resize);
+        info!(
+            task_run_id = %permit.task_run_id,
+            pod_uid = %observed.pod_uid,
+            admitted_cpu_millicores = ceiling,
+            birth_millicores = BIRTH_CPU_MILLICORES,
+            "task_run_resize_bootstrap: birth limit confirmed; dispatch admitted"
+        );
+        BootstrapOutcome::BirthConfirmed {
+            pod_uid: observed.pod_uid,
+            admitted_cpu_millicores: ceiling,
+        }
+    }
+
+    /// Protocol agreement and the ceiling's own sanity, both of which must hold
+    /// before any durable write. Returns `Some(outcome)` when bootstrap must
+    /// stop.
+    async fn check_protocol(
+        &self,
+        permit: &PermitBinding,
+        observed: &ObservedLauncherSidecar,
+        effective: LauncherAuthorityProtocol,
+    ) -> Option<BootstrapOutcome> {
+        if let Some(declared) = observed.observed_protocol.as_deref()
+            && declared != effective.as_wire()
+        {
+            return Some(
+                self.refuse_and_delete(
+                    permit,
+                    observed,
+                    RefusalReason::ProtocolMismatch {
+                        observed: declared.to_owned(),
+                        effective: effective.as_wire().to_owned(),
+                    },
+                )
+                .await,
+            );
+        }
+
+        if effective.launcher_owns_leaf_quota() {
+            // A leaf-v1 Pod must carry no launcher CPU limit at all.
+            return match observed.admitted_cpu_millicores {
+                Some(ceiling) => Some(
+                    self.refuse_and_delete(
+                        permit,
+                        observed,
+                        RefusalReason::LeafAuthorityCarriesCeiling { ceiling },
+                    )
+                    .await,
+                ),
+                None => None,
+            };
+        }
+
+        if observed.observed_protocol.is_none() {
+            return Some(
+                self.refuse_and_delete(permit, observed, RefusalReason::ProtocolMissing)
+                    .await,
+            );
+        }
+        let Some(ceiling) = observed.admitted_cpu_millicores else {
+            return Some(
+                self.refuse_and_delete(permit, observed, RefusalReason::NoAdmittedCeiling)
+                    .await,
+            );
+        };
+        if ceiling < u64::from(LAUNCHER_CPU_REQUEST_MILLICORES) {
+            return Some(
+                self.refuse_and_delete(
+                    permit,
+                    observed,
+                    RefusalReason::CeilingBelowLauncherRequest {
+                        ceiling,
+                        request: u64::from(LAUNCHER_CPU_REQUEST_MILLICORES),
+                    },
+                )
+                .await,
+            );
+        }
+        if ceiling < BIRTH_CPU_MILLICORES {
+            return Some(
+                self.refuse_and_delete(
+                    permit,
+                    observed,
+                    RefusalReason::CeilingBelowBirthLimit {
+                        ceiling,
+                        birth: BIRTH_CPU_MILLICORES,
+                    },
+                )
+                .await,
+            );
+        }
+        None
+    }
+
+    /// The write-once capture. Every non-success is classified here, because
+    /// the three failure shapes have three different correct responses.
+    async fn capture(
+        &self,
+        permit: &PermitBinding,
+        observed: &ObservedLauncherSidecar,
+        effective: LauncherAuthorityProtocol,
+    ) -> Result<BuildPodPermitRow, BootstrapOutcome> {
+        let (Some(launcher_container_id), Some(image_digest), Some(observed_protocol)) = (
+            observed.launcher_container_id.clone(),
+            observed.image_digest.clone(),
+            observed.observed_protocol.clone(),
+        ) else {
+            return Err(BootstrapOutcome::NotReady(NotReady::LauncherNotStarted {
+                field: if observed.launcher_container_id.is_none() {
+                    "status.initContainerStatuses[].containerID"
+                } else {
+                    "status.initContainerStatuses[].imageID"
+                },
+            }));
+        };
+        let Some(ceiling) = observed.admitted_cpu_millicores else {
+            return Err(BootstrapOutcome::Refused {
+                reason: RefusalReason::NoAdmittedCeiling,
+                disposition: PodDisposition::Retained,
+            });
+        };
+        let Ok(admitted_cpu_millicores) = i64::try_from(ceiling) else {
+            return Err(self
+                .refuse_and_delete(permit, observed, RefusalReason::NoAdmittedCeiling)
+                .await);
+        };
+
+        let identity = BuildPodResizeIdentity {
+            pod_namespace: observed.namespace.clone(),
+            pod_name: observed.pod_name.clone(),
+            pod_uid: observed.pod_uid.clone(),
+            launcher_container_name: observed.launcher_container_name.clone(),
+            launcher_container_id,
+            image_digest,
+            observed_launcher_protocol: observed_protocol,
+            effective_launcher_protocol: effective.as_wire().to_owned(),
+            admitted_cpu_millicores,
+        };
+
+        match self
+            .permits
+            .capture_resize_identity(
+                &permit.task_run_id,
+                &permit.permit_id,
+                permit.fencing_token,
+                &identity,
+            )
+            .await
+        {
+            Ok(
+                CaptureBuildPodResizeIdentityResult::Captured(row)
+                | CaptureBuildPodResizeIdentityResult::AlreadyCaptured(row),
+            ) => Ok(row),
+            Ok(CaptureBuildPodResizeIdentityResult::Rejected) => Err(self
+                .refuse_and_delete(permit, observed, RefusalReason::ConflictingCapture)
+                .await),
+            Err(error) if is_unique_violation(&error) => Err(self
+                .refuse_and_delete(
+                    permit,
+                    observed,
+                    RefusalReason::PodUidClaimedByAnotherPermit,
+                )
+                .await),
+            Err(error) => Err(BootstrapOutcome::NotReady(NotReady::StorageUnavailable(
+                error.to_string(),
+            ))),
+        }
+    }
+
+    /// Fail closed: UID-fenced delete exactly the observed Pod, then refuse.
+    ///
+    /// Deletion is the fail-safe because no repository-controlled command has
+    /// run yet — the bootstrap window sits entirely before dispatch — so the
+    /// cost of destroying the Pod is one dispatch, while the cost of keeping it
+    /// is a live Pod whose quota nobody has authority over.
+    async fn refuse_and_delete(
+        &self,
+        permit: &PermitBinding,
+        observed: &ObservedLauncherSidecar,
+        reason: RefusalReason,
+    ) -> BootstrapOutcome {
+        let deleted = self
+            .surface
+            .uid_fenced_delete(&permit.task_run_id, &observed.pod_uid)
+            .await;
+        warn!(
+            task_run_id = %permit.task_run_id,
+            pod_uid = %observed.pod_uid,
+            %reason,
+            delete_failed = deleted.is_err(),
+            "task_run_resize_bootstrap: refusing dispatch and UID-fenced deleting the Pod"
+        );
+        BootstrapOutcome::Refused {
+            reason,
+            disposition: PodDisposition::UidFencedDeleted(deleted),
+        }
+    }
+}
+
+/// Whether a durable error is the unique-violation raised by
+/// `build_pod_permits_pod_uid_key`.
+fn is_unique_violation(error: &DbError) -> bool {
+    let DbError::Sqlx(error) = error else {
+        return false;
+    };
+    error
+        .as_database_error()
+        .and_then(sqlx::error::DatabaseError::code)
+        .is_some_and(|code| code == UNIQUE_VIOLATION)
+}
+
+#[cfg(test)]
+#[path = "task_run_resize_bootstrap_tests.rs"]
+mod tests;

--- a/server/src/task_run_resize_bootstrap_tests.rs
+++ b/server/src/task_run_resize_bootstrap_tests.rs
@@ -1,0 +1,856 @@
+//! Tests for [`super`], the post-admission ceiling capture and birth downsize.
+//!
+//! Split out of the module itself only because the two together exceed the
+//! repository's file-size guard. `#[path]` keeps them one compilation unit, so
+//! these tests still reach the module's private items.
+
+use super::*;
+use djinn_db::{
+    AcquireBuildPodPermitResult, BindBuildPodPermitResult, CreateTaskRunParams, Database,
+    EffectiveCreatorProvenance, ProjectRepository, TaskRepository, TaskRunRepository,
+    UserRepository,
+};
+use djinn_k8s::pod_resize::NotConfirmed;
+use std::sync::Mutex as StdMutex;
+
+const CEILING: u64 = 4000;
+
+// ── Fixtures ───────────────────────────────────────────────────────────
+
+/// What the fake apiserver has stored, and what it was asked to do.
+#[derive(Default)]
+struct FakeSurfaceState {
+    observation: Option<Result<Option<ObservedLauncherSidecar>, LauncherObservationError>>,
+    resize_results: Vec<Result<(), PodResizeError>>,
+    resizes: Vec<(String, u64)>,
+    deletes: Vec<(String, String)>,
+}
+
+struct FakeSurface {
+    state: StdMutex<FakeSurfaceState>,
+}
+
+impl FakeSurface {
+    fn new(observation: Result<Option<ObservedLauncherSidecar>, LauncherObservationError>) -> Self {
+        Self {
+            state: StdMutex::new(FakeSurfaceState {
+                observation: Some(observation),
+                ..FakeSurfaceState::default()
+            }),
+        }
+    }
+
+    fn observing(observed: ObservedLauncherSidecar) -> Self {
+        Self::new(Ok(Some(observed)))
+    }
+
+    fn with_resize_results(self, results: Vec<Result<(), PodResizeError>>) -> Self {
+        self.state
+            .lock()
+            .expect("fake surface")
+            .resize_results
+            .extend(results);
+        self
+    }
+
+    fn resizes(&self) -> Vec<(String, u64)> {
+        self.state.lock().expect("fake surface").resizes.clone()
+    }
+
+    fn deletes(&self) -> Vec<(String, String)> {
+        self.state.lock().expect("fake surface").deletes.clone()
+    }
+}
+
+#[async_trait]
+impl TaskRunPodSurface for FakeSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.state
+            .lock()
+            .expect("fake surface")
+            .observation
+            .clone()
+            .expect("observation configured")
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        let mut state = self.state.lock().expect("fake surface");
+        state.resizes.push((pod_name.to_owned(), target_millicores));
+        if state.resize_results.is_empty() {
+            Ok(())
+        } else {
+            state.resize_results.remove(0)
+        }
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        self.state
+            .lock()
+            .expect("fake surface")
+            .deletes
+            .push((task_run_id.to_owned(), pod_uid.to_owned()));
+        Ok(())
+    }
+}
+
+/// The value the Job manifest was RENDERED with. Every ceiling assertion in
+/// this module compares against the *stored* value instead; a test that
+/// substituted this constant would be asserting the render input, which is
+/// exactly the assertion that proves nothing.
+const RENDERED_CEILING: u64 = 4000;
+
+fn observed(
+    pod_uid: &str,
+    ceiling: Option<u64>,
+    protocol: Option<&str>,
+) -> ObservedLauncherSidecar {
+    ObservedLauncherSidecar {
+        namespace: "djinn".to_owned(),
+        pod_name: format!("taskrun-{pod_uid}"),
+        pod_uid: pod_uid.to_owned(),
+        launcher_container_name: "cgroup-launcher".to_owned(),
+        launcher_container_id: Some(format!("containerd://{pod_uid}")),
+        image_digest: Some("registry/img@sha256:feed".to_owned()),
+        observed_protocol: protocol.map(ToOwned::to_owned),
+        admitted_cpu_millicores: ceiling,
+    }
+}
+
+fn resize_v2(pod_uid: &str, ceiling: u64) -> ObservedLauncherSidecar {
+    observed(pod_uid, Some(ceiling), Some("resize-v2"))
+}
+
+async fn seed_task_run(db: &Database, suffix: &str) -> String {
+    let user = UserRepository::new(db.clone())
+        .upsert_from_github(
+            i64::try_from(uuid::Uuid::now_v7().as_u128() % 8_000_000_000_000_000_000)
+                .expect("github id"),
+            &format!("resize-bootstrap-{suffix}-{}", uuid::Uuid::now_v7()),
+            None,
+            None,
+        )
+        .await
+        .expect("seed user");
+    let project = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create(
+            &format!("resize-bootstrap-{suffix}"),
+            "djinnos",
+            &format!("resize-bootstrap-{suffix}"),
+        )
+        .await
+        .expect("seed project");
+    let task = TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create_in_project_with_provenance(
+            &project.id,
+            None,
+            EffectiveCreatorProvenance::explicit_user_id(&user.id),
+            "resize bootstrap",
+            "description",
+            "design",
+            "task",
+            2,
+            "owner",
+            None,
+            None,
+        )
+        .await
+        .expect("seed task");
+    let task_run_id = uuid::Uuid::now_v7().to_string();
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: &task_run_id,
+            project_id: &project.id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed task run");
+    task_run_id
+}
+
+/// A permit that has reached `job_created` — the only state from which
+/// `capture_resize_identity` can succeed.
+async fn bound_permit(
+    permits: &BuildPodPermitRepository,
+    task_run_id: &str,
+    job_uid: &str,
+) -> PermitBinding {
+    let row = match permits.acquire(task_run_id, 16).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        other => panic!("unexpected acquire outcome: {other:?}"),
+    };
+    match permits
+        .bind_or_refresh_job_uid(task_run_id, &row.permit_id, row.fencing_token, job_uid)
+        .await
+        .expect("bind job uid")
+    {
+        BindBuildPodPermitResult::Bound(row) => PermitBinding {
+            task_run_id: task_run_id.to_owned(),
+            permit_id: row.permit_id,
+            fencing_token: row.fencing_token,
+        },
+        other => panic!("unexpected bind outcome: {other:?}"),
+    }
+}
+
+fn bootstrap_with(
+    db: &Database,
+    surface: Arc<dyn TaskRunPodSurface>,
+) -> (TaskRunResizeBootstrap, Arc<DispatchGate>) {
+    let gate = Arc::new(DispatchGate::new());
+    (
+        TaskRunResizeBootstrap::new(
+            BuildPodPermitRepository::new(db.clone()),
+            surface,
+            Arc::clone(&gate),
+        ),
+        gate,
+    )
+}
+
+async fn stored_identity(db: &Database, task_run_id: &str) -> BuildPodResizeIdentity {
+    BuildPodPermitRepository::new(db.clone())
+        .active(task_run_id)
+        .await
+        .expect("read permit")
+        .expect("permit row")
+        .resize_identity
+        .expect("resize identity")
+}
+
+// ── AC1: the stored ceiling is the value read back from the live Pod ───
+
+/// AC1. The Job was rendered with [`RENDERED_CEILING`]; a mutating
+/// admission webhook lowered the persisted launcher limit to 3600m. The
+/// stored ceiling must be the MUTATED value.
+///
+/// Non-vacuity: substitute `RENDERED_CEILING` for the asserted 3600 and
+/// this test fails — which is the point. A test written against the render
+/// input would pass on an implementation that never reads the Pod at all.
+#[tokio::test]
+async fn the_stored_ceiling_is_the_mutated_value_the_apiserver_persisted() {
+    const MUTATED_BY_WEBHOOK: u64 = 3600;
+    assert_ne!(
+        MUTATED_BY_WEBHOOK, RENDERED_CEILING,
+        "the fixture must actually differ from the render input"
+    );
+
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "ac1").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-ac1").await;
+
+    // The Pod the apiserver STORED, not the one that was rendered.
+    let surface = Arc::new(FakeSurface::observing(resize_v2(
+        "pod-uid-ac1",
+        MUTATED_BY_WEBHOOK,
+    )));
+    let (bootstrap, gate) = bootstrap_with(&db, Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>);
+
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::BirthConfirmed {
+            pod_uid: "pod-uid-ac1".to_owned(),
+            admitted_cpu_millicores: i64::try_from(MUTATED_BY_WEBHOOK).unwrap(),
+        }
+    );
+
+    let identity = stored_identity(&db, &task_run_id).await;
+    assert_eq!(
+        identity.admitted_cpu_millicores,
+        i64::try_from(MUTATED_BY_WEBHOOK).unwrap(),
+        "the stored ceiling must be the persisted value, not the render input"
+    );
+    assert_eq!(identity.pod_uid, "pod-uid-ac1");
+    assert_eq!(identity.effective_launcher_protocol, "resize-v2");
+    assert_eq!(identity.observed_launcher_protocol, "resize-v2");
+
+    // And the birth downsize went to 250m, not to the render's ceiling.
+    assert_eq!(
+        surface.resizes(),
+        vec![("taskrun-pod-uid-ac1".to_owned(), BIRTH_CPU_MILLICORES)]
+    );
+    assert!(gate.admit(&task_run_id).is_ok());
+}
+
+// ── AC2: no dispatch before the birth limit is confirmed ───────────────
+
+/// AC2. An unconfirmed birth downsize does not admit dispatch, and the
+/// gate is what stops it.
+///
+/// Non-vacuity: the fake dispatcher calls
+/// [`DispatchGate::record_dispatch_started`] the way a real dispatch site
+/// would. With the gate in front of it the counter stays zero; remove the
+/// gate — dispatch unconditionally — and it becomes non-zero.
+#[tokio::test]
+async fn dispatch_is_refused_until_the_birth_limit_is_confirmed() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "ac2").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-ac2").await;
+
+    let surface = Arc::new(
+        FakeSurface::observing(resize_v2("pod-uid-ac2", CEILING)).with_resize_results(vec![
+            Err(PodResizeError::NotConfirmed(NotConfirmed::StatusStale {
+                observed_millis: CEILING,
+                target_millis: BIRTH_CPU_MILLICORES,
+            })),
+            Ok(()),
+        ]),
+    );
+    let (bootstrap, gate) = bootstrap_with(&db, Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>);
+
+    // Pass 1: capture succeeds, birth is NOT confirmed.
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert!(
+        matches!(
+            outcome,
+            BootstrapOutcome::NotReady(NotReady::BirthUnconfirmed(_))
+        ),
+        "unexpected outcome: {outcome:?}"
+    );
+    assert!(!outcome.admits_dispatch());
+
+    // The gate refuses, so the dispatch site is never reached.
+    let refused = gate.admit(&task_run_id);
+    assert_eq!(
+        refused,
+        Err(DispatchRefused::BirthNotConfirmed {
+            task_run_id: task_run_id.clone(),
+        })
+    );
+    if refused.is_ok() {
+        gate.record_dispatch_started(&task_run_id);
+    }
+    assert_eq!(
+        gate.dispatches_before_birth_confirmation(),
+        0,
+        "the gate must keep the dispatch site unreached"
+    );
+
+    // Pass 2 (the resumed bootstrap): the same identity replays as
+    // AlreadyCaptured and the resize confirms.
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert!(outcome.admits_dispatch(), "unexpected outcome: {outcome:?}");
+    let admission = gate
+        .admit(&task_run_id)
+        .expect("admitted after confirmation");
+    assert_eq!(admission.authority(), AdmittedAuthority::Resize);
+    gate.record_dispatch_started(&task_run_id);
+    assert_eq!(gate.dispatches_before_birth_confirmation(), 0);
+
+    // Two resize attempts, both at the birth limit, never at the ceiling.
+    assert_eq!(
+        surface.resizes(),
+        vec![
+            ("taskrun-pod-uid-ac2".to_owned(), BIRTH_CPU_MILLICORES),
+            ("taskrun-pod-uid-ac2".to_owned(), BIRTH_CPU_MILLICORES),
+        ]
+    );
+    // A Pod that merely has not confirmed yet is not destroyed.
+    assert!(surface.deletes().is_empty());
+}
+
+/// AC2's counter is not decoration: a dispatch site reached without the
+/// gate registers, which is what makes removing the gate detectable.
+#[test]
+fn the_counter_moves_when_a_dispatch_site_is_reached_unconfirmed() {
+    let gate = DispatchGate::new();
+    assert_eq!(gate.dispatches_before_birth_confirmation(), 0);
+    gate.record_dispatch_started("never-bootstrapped");
+    assert_eq!(gate.dispatches_before_birth_confirmation(), 1);
+}
+
+// ── AC3: the partial unique index is load-bearing ──────────────────────
+
+/// AC3. Two DIFFERENT task runs, each holding its own permit, observe the
+/// SAME Pod UID with different ceilings. The second is refused without
+/// mutating the first row, and its Pod is UID-fenced deleted.
+///
+/// Non-vacuity: `capture_resize_identity`'s own predicate
+/// (`state = 'job_created' AND pod_uid IS NULL`) is satisfied for the
+/// second row — its permit has never captured anything. Only migration
+/// 164's `build_pod_permits_pod_uid_key` partial unique index can see
+/// across task runs. Drop that index and the second capture SUCCEEDS, both
+/// permits believe they hold authority over one Pod, and this test fails.
+#[tokio::test]
+async fn a_second_task_run_cannot_capture_the_same_pod_uid() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let first_run = seed_task_run(&db, "ac3a").await;
+    let second_run = seed_task_run(&db, "ac3b").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let first = bound_permit(&permits, &first_run, "job-uid-ac3a").await;
+    let second = bound_permit(&permits, &second_run, "job-uid-ac3b").await;
+
+    let first_surface = Arc::new(FakeSurface::observing(resize_v2("shared-pod-uid", CEILING)));
+    let (first_bootstrap, _) = bootstrap_with(
+        &db,
+        Arc::clone(&first_surface) as Arc<dyn TaskRunPodSurface>,
+    );
+    assert!(
+        first_bootstrap
+            .bootstrap(&first, LauncherAuthorityProtocol::ResizeV2)
+            .await
+            .admits_dispatch()
+    );
+
+    // A different ceiling for the same Pod UID, under a different permit.
+    let second_surface = Arc::new(FakeSurface::observing(resize_v2("shared-pod-uid", 2000)));
+    let (second_bootstrap, second_gate) = bootstrap_with(
+        &db,
+        Arc::clone(&second_surface) as Arc<dyn TaskRunPodSurface>,
+    );
+    let outcome = second_bootstrap
+        .bootstrap(&second, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::Refused {
+            reason: RefusalReason::PodUidClaimedByAnotherPermit,
+            disposition: PodDisposition::UidFencedDeleted(Ok(())),
+        },
+        "without build_pod_permits_pod_uid_key this capture succeeds"
+    );
+    assert_eq!(
+        second_surface.deletes(),
+        vec![(second_run.clone(), "shared-pod-uid".to_owned())]
+    );
+    assert!(second_surface.resizes().is_empty());
+    assert!(second_gate.admit(&second_run).is_err());
+
+    // The first row is untouched: same ceiling, same protocol.
+    let first_identity = stored_identity(&db, &first_run).await;
+    assert_eq!(
+        first_identity.admitted_cpu_millicores,
+        i64::try_from(CEILING).unwrap()
+    );
+    // The loser wrote nothing at all.
+    assert!(
+        BuildPodPermitRepository::new(db.clone())
+            .active(&second_run)
+            .await
+            .expect("read loser permit")
+            .expect("loser row")
+            .resize_identity
+            .is_none()
+    );
+}
+
+/// AC3's other arm: the same task run, the same Pod UID, a DIFFERENT
+/// ceiling. Caught by the per-row write-once predicate rather than the
+/// index, and it must not mutate the stored row either.
+#[tokio::test]
+async fn a_recapture_with_a_different_ceiling_is_refused_without_mutating_the_row() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "ac3c").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-ac3c").await;
+
+    let surface = Arc::new(FakeSurface::observing(resize_v2("pod-uid-ac3c", CEILING)));
+    let (bootstrap, _) = bootstrap_with(&db, surface as Arc<dyn TaskRunPodSurface>);
+    assert!(
+        bootstrap
+            .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+            .await
+            .admits_dispatch()
+    );
+
+    // Same Pod, different ceiling. The stored ceiling is authority: the
+    // resumed pass uses the ROW, so the changed spec is simply ignored and
+    // the birth downsize replays. Nothing durable moves.
+    let mutated = Arc::new(FakeSurface::observing(resize_v2("pod-uid-ac3c", 1000)));
+    let (bootstrap, _) = bootstrap_with(&db, Arc::clone(&mutated) as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::BirthConfirmed {
+            pod_uid: "pod-uid-ac3c".to_owned(),
+            admitted_cpu_millicores: i64::try_from(CEILING).unwrap(),
+        },
+        "a post-bootstrap spec change must not alter the write-once ceiling"
+    );
+    assert_eq!(
+        stored_identity(&db, &task_run_id)
+            .await
+            .admitted_cpu_millicores,
+        i64::try_from(CEILING).unwrap()
+    );
+    assert!(mutated.deletes().is_empty());
+}
+
+// ── AC4: the replacement-Pod path ──────────────────────────────────────
+
+/// AC4. A replacement Pod for the SAME task run carries a new UID. Exactly
+/// one capture per task run is possible, ever, so the decision is
+/// **reject-and-delete**: the replacement is UID-fenced deleted, the
+/// original identity is left intact, and dispatch is refused.
+///
+/// Release-and-reacquire is asserted here to be unavailable, not merely
+/// unchosen: releasing the permit and re-acquiring under the same task-run
+/// id returns `AlreadyReleased`, by design.
+#[tokio::test]
+async fn a_replacement_pod_for_the_same_task_run_is_rejected_and_deleted() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "ac4").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-ac4").await;
+
+    let original = Arc::new(FakeSurface::observing(resize_v2(
+        "pod-uid-original",
+        CEILING,
+    )));
+    let (bootstrap, _) = bootstrap_with(&db, original as Arc<dyn TaskRunPodSurface>);
+    assert!(
+        bootstrap
+            .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+            .await
+            .admits_dispatch()
+    );
+
+    let replacement = Arc::new(FakeSurface::observing(resize_v2(
+        "pod-uid-replacement",
+        CEILING,
+    )));
+    let (bootstrap, gate) =
+        bootstrap_with(&db, Arc::clone(&replacement) as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::Refused {
+            reason: RefusalReason::ConflictingCapture,
+            disposition: PodDisposition::UidFencedDeleted(Ok(())),
+        }
+    );
+    assert_eq!(
+        replacement.deletes(),
+        vec![(task_run_id.clone(), "pod-uid-replacement".to_owned())]
+    );
+    assert!(replacement.resizes().is_empty());
+    assert!(gate.admit(&task_run_id).is_err());
+
+    // The original identity is untouched.
+    assert_eq!(
+        stored_identity(&db, &task_run_id).await.pod_uid,
+        "pod-uid-original"
+    );
+
+    // And the alternative — release-and-reacquire — does not exist.
+    let released = permits
+        .release(
+            &task_run_id,
+            &permit.permit_id,
+            permit.fencing_token,
+            "replacement-pod",
+        )
+        .await
+        .expect("release");
+    assert!(
+        matches!(released, djinn_db::ReleaseBuildPodPermitResult::Released(_)),
+        "unexpected release outcome: {released:?}"
+    );
+    let reacquired = permits.acquire(&task_run_id, 16).await;
+    assert!(
+        matches!(
+            reacquired,
+            AcquireBuildPodPermitResult::AlreadyReleased { .. }
+        ),
+        "release-and-reacquire must be unavailable, got {reacquired:?}"
+    );
+}
+
+// ── Fail-closed boundaries ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_protocol_mismatch_refuses_and_deletes_before_any_capture() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "mismatch").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-mismatch").await;
+
+    let surface = Arc::new(FakeSurface::observing(observed(
+        "pod-uid-mismatch",
+        Some(CEILING),
+        Some("leaf-v1"),
+    )));
+    let (bootstrap, _) = bootstrap_with(&db, Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>);
+
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::Refused {
+            reason: RefusalReason::ProtocolMismatch {
+                observed: "leaf-v1".to_owned(),
+                effective: "resize-v2".to_owned(),
+            },
+            disposition: PodDisposition::UidFencedDeleted(Ok(())),
+        }
+    );
+    assert!(
+        BuildPodPermitRepository::new(db.clone())
+            .active(&task_run_id)
+            .await
+            .expect("read permit")
+            .expect("row")
+            .resize_identity
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn a_resize_v2_pod_without_a_stored_ceiling_is_refused_and_deleted() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "noceiling").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-noceiling").await;
+
+    let surface = Arc::new(FakeSurface::observing(observed(
+        "pod-uid-noceiling",
+        None,
+        Some("resize-v2"),
+    )));
+    let (bootstrap, _) = bootstrap_with(&db, surface as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::Refused {
+            reason: RefusalReason::NoAdmittedCeiling,
+            disposition: PodDisposition::UidFencedDeleted(Ok(())),
+        }
+    );
+}
+
+#[tokio::test]
+async fn a_ceiling_below_the_birth_limit_is_refused_rather_than_upsized() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "lowceiling").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-lowceiling").await;
+
+    let surface = Arc::new(FakeSurface::observing(resize_v2("pod-uid-low", 100)));
+    let (bootstrap, _) = bootstrap_with(&db, Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::Refused {
+            reason: RefusalReason::CeilingBelowBirthLimit {
+                ceiling: 100,
+                birth: BIRTH_CPU_MILLICORES,
+            },
+            disposition: PodDisposition::UidFencedDeleted(Ok(())),
+        }
+    );
+    assert!(
+        surface.resizes().is_empty(),
+        "no resize may be issued past the admitted ceiling"
+    );
+}
+
+#[tokio::test]
+async fn a_leaf_v1_pod_captures_nothing_and_dispatches_under_leaf_authority() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "leaf").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-leaf").await;
+
+    let surface = Arc::new(FakeSurface::observing(observed(
+        "pod-uid-leaf",
+        None,
+        Some("leaf-v1"),
+    )));
+    let (bootstrap, gate) = bootstrap_with(&db, Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::LeafV1)
+        .await;
+
+    assert_eq!(outcome, BootstrapOutcome::LeafAuthority);
+    assert!(surface.resizes().is_empty());
+    assert!(surface.deletes().is_empty());
+    assert_eq!(
+        gate.admit(&task_run_id)
+            .expect("leaf admission")
+            .authority(),
+        AdmittedAuthority::Leaf
+    );
+    assert!(
+        BuildPodPermitRepository::new(db.clone())
+            .active(&task_run_id)
+            .await
+            .expect("read permit")
+            .expect("row")
+            .resize_identity
+            .is_none(),
+        "migration 164 requires admitted_cpu_millicores > 0, so leaf-v1 cannot capture"
+    );
+}
+
+/// A `leaf-v1` Pod that nevertheless carries a launcher CPU limit is the
+/// 7deu ancestor clamp, re-entered. Refuse and delete.
+#[tokio::test]
+async fn a_leaf_v1_pod_carrying_a_ceiling_is_refused_and_deleted() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "leafclamp").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-leafclamp").await;
+
+    let surface = Arc::new(FakeSurface::observing(observed(
+        "pod-uid-leafclamp",
+        Some(CEILING),
+        Some("leaf-v1"),
+    )));
+    let (bootstrap, gate) = bootstrap_with(&db, surface as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::LeafV1)
+        .await;
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::Refused {
+            reason: RefusalReason::LeafAuthorityCarriesCeiling { ceiling: CEILING },
+            disposition: PodDisposition::UidFencedDeleted(Ok(())),
+        }
+    );
+    assert!(gate.admit(&task_run_id).is_err());
+}
+
+#[tokio::test]
+async fn a_still_starting_launcher_is_retried_rather_than_captured_or_deleted() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "starting").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-starting").await;
+
+    let mut starting = resize_v2("pod-uid-starting", CEILING);
+    starting.launcher_container_id = None;
+    let surface = Arc::new(FakeSurface::observing(starting));
+    let (bootstrap, gate) = bootstrap_with(&db, Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::NotReady(NotReady::LauncherNotStarted {
+            field: "status.initContainerStatuses[].containerID",
+        })
+    );
+    assert!(surface.deletes().is_empty());
+    assert!(surface.resizes().is_empty());
+    assert!(gate.admit(&task_run_id).is_err());
+}
+
+#[tokio::test]
+async fn an_unnameable_launcher_is_refused_without_a_delete_it_cannot_fence() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "ambiguous").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let permit = bound_permit(&permits, &task_run_id, "job-uid-ambiguous").await;
+
+    let surface = Arc::new(FakeSurface::new(Err(LauncherObservationError::Ambiguous(
+        PodResizeError::LauncherIdentityAmbiguous {
+            site: djinn_k8s::pod_resize::LauncherIdentitySite::SpecInitContainers,
+            found: 2,
+        },
+    ))));
+    let (bootstrap, gate) = bootstrap_with(&db, Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+
+    assert!(
+        matches!(
+            outcome,
+            BootstrapOutcome::Refused {
+                reason: RefusalReason::LauncherNotNameable(_),
+                disposition: PodDisposition::Retained,
+            }
+        ),
+        "unexpected outcome: {outcome:?}"
+    );
+    assert!(surface.deletes().is_empty());
+    assert!(gate.admit(&task_run_id).is_err());
+}
+
+#[tokio::test]
+async fn a_stale_permit_cannot_destroy_the_live_owners_pod() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "stale").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let live = bound_permit(&permits, &task_run_id, "job-uid-stale").await;
+    let stale = PermitBinding {
+        fencing_token: live.fencing_token + 1,
+        ..live.clone()
+    };
+
+    let surface = Arc::new(FakeSurface::observing(resize_v2("pod-uid-stale", CEILING)));
+    let (bootstrap, gate) = bootstrap_with(&db, Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>);
+    let outcome = bootstrap
+        .bootstrap(&stale, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+
+    assert_eq!(
+        outcome,
+        BootstrapOutcome::Refused {
+            reason: RefusalReason::StalePermit,
+            disposition: PodDisposition::Retained,
+        }
+    );
+    assert!(surface.deletes().is_empty());
+    assert!(gate.admit(&task_run_id).is_err());
+}
+
+#[tokio::test]
+async fn a_permit_without_a_bound_job_is_not_ready_to_capture() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let task_run_id = seed_task_run(&db, "unbound").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = match permits.acquire(&task_run_id, 16).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        other => panic!("unexpected acquire outcome: {other:?}"),
+    };
+    let permit = PermitBinding {
+        task_run_id: task_run_id.clone(),
+        permit_id: row.permit_id,
+        fencing_token: row.fencing_token,
+    };
+
+    let surface = Arc::new(FakeSurface::observing(resize_v2(
+        "pod-uid-unbound",
+        CEILING,
+    )));
+    let (bootstrap, _) = bootstrap_with(&db, surface as Arc<dyn TaskRunPodSurface>);
+    assert_eq!(
+        bootstrap
+            .bootstrap(&permit, LauncherAuthorityProtocol::ResizeV2)
+            .await,
+        BootstrapOutcome::NotReady(NotReady::JobNotBound)
+    );
+}


### PR DESCRIPTION
Task `g3th` (epic `g8jk`, proposal `3i92`). Composes four merged slices into the
first thing in `3i92` that governs a real Pod: `4acu`'s write-once resize
identity (#2795), `g8jk-2`'s limits-only `pods/resize` client (#2830),
`g8jk-1`'s `resize-v2`-only launcher ceiling (#2840), and `g8jk-4`'s `pods/resize`
RBAC (#2829). No new Kubernetes or SQL primitive is added here.

## The sequence

Once the Pod has a UID and the launcher sidecar is admitted: **fresh GET**, read
the **persisted** `spec.initContainers[name=cgroup-launcher].resources.limits.cpu`.
That value is the admitted ceiling — it includes any mutating-admission result
precisely because it comes from the stored Pod rather than the render input.
Write it once with the Pod UID and the effective protocol. **Then** resize down
to 250m and confirm through `status.initContainerStatuses`. Only that
confirmation admits the worker session to dispatch.

## Four things this slice had to decide rather than assume

**1. `birth_confirmed` is a capture state, not a confirmation state.** Migration
164's `capture_resize_identity` sets `state = 'birth_confirmed'` as part of the
*capture*, before the birth resize is even issued. A row in that state proves an
identity was captured, **not** that the launcher is at 250m. So the dispatch gate
keys on this bootstrap's in-process confirmed outcome and never on the row's
state, and a bootstrap resumed after a server restart re-issues the birth resize
— idempotent by construction, since resizing to a value already held confirms
immediately.

**2. The ceiling comes from the row on every resumed pass, never from a fresh
observation.** Re-observation after a successful downsize reads **250m**, because
that is what the Pod now declares. Deriving the ceiling from the Pod on resume
would compare 250m against the stored ceiling, call it a conflicting recapture,
and delete a healthy Pod. Capture is therefore only *attempted* when the row
carries no identity yet.

**3. `leaf-v1` cannot capture, structurally.** #2840 renders `limits.cpu` on the
launcher under `resize-v2` only, and migration 164 requires
`admitted_cpu_millicores > 0` for any identity at all. Bootstrap is
`resize-v2`-only and `leaf-v1` dispatch is untouched by this module. A `leaf-v1`
Pod that nevertheless carries a launcher ceiling is `7deu`'s measured ancestor
clamp re-entered, and is refused and deleted.

**4. Replacement Pods: reject-and-delete.** See below.

## AC1 — the stored ceiling is the value read back from the live Pod

`the_stored_ceiling_is_the_mutated_value_the_apiserver_persisted` renders at
4000m and has the "webhook" store 3600m. The captured
`admitted_cpu_millicores` must be 3600.

Mutation run — substituting the render input for the stored Pod:

```
left:  BirthConfirmed { pod_uid: "pod-uid-ac1", admitted_cpu_millicores: 4000 }
right: BirthConfirmed { pod_uid: "pod-uid-ac1", admitted_cpu_millicores: 3600 }
test ... FAILED
```

## AC2 — no dispatch before the birth limit is confirmed

`DispatchAdmission` has a private constructor, so the only way to obtain one is
`DispatchGate::admit` after a bootstrap that actually confirmed. Alongside it,
`record_dispatch_started` — what a real dispatch site calls — increments
`dispatches_before_birth_confirmation` when the run has no confirmed birth. With
the gate in front, that counter is structurally unreachable and stays 0.

Mutation run — gate removed, dispatch unconditional:

```
assertion `left == right` failed: the gate must keep the dispatch site unreached
  left: 1
 right: 0
test ... FAILED
```

## AC3 — `build_pod_permits_pod_uid_key` is load-bearing, not decoration

`a_second_task_run_cannot_capture_the_same_pod_uid`: two **different** task runs,
each with its own permit, observe the same Pod UID with different ceilings
(4000m and 2000m). `capture_resize_identity`'s own predicate
(`state = 'job_created' AND pod_uid IS NULL`) is satisfied for the second row —
its permit has never captured anything. Only the partial unique index can see
across task runs.

Mutation run — `DROP INDEX build_pod_permits_pod_uid_key` on the test template:

```
assertion `left == right` failed: without build_pod_permits_pod_uid_key this capture succeeds
  left:  BirthConfirmed { pod_uid: "shared-pod-uid", admitted_cpu_millicores: 2000 }
 right: Refused { reason: PodUidClaimedByAnotherPermit, disposition: UidFencedDeleted(Ok(())) }
test ... FAILED
```

That is exactly the failure the AC names: without the index the second run
captures the same Pod with a *different* ceiling and both permits believe they
hold write-once authority. The index was restored immediately afterwards.

A consequence worth stating: a cross-task-run duplicate surfaces as a Postgres
**23505**, not as `CaptureBuildPodResizeIdentityResult::Rejected` — the
repository's per-row predicate cannot see it, so the unique violation propagates
as a `DbError`. That SQLSTATE is classified separately from every other database
error on purpose: the first is a permanent authority conflict that must delete
the Pod, the second is transient and must not.

## AC4 — the replacement-Pod path is decided, not deferred

**Reject-and-delete**, and the reasoning is that the alternative does not exist:

- `build_pod_permits` has PRIMARY KEY `task_run_id`; capture predicates on
  `state = 'job_created' AND pod_uid IS NULL`; the migration-164 trigger makes a
  captured identity immutable. Exactly one capture per task run is possible, ever.
- Release-and-reacquire is not merely unchosen — `acquire()` deliberately refuses
  to resurrect a released row under the same task-run id (`AlreadyReleased`), and
  the trigger has no edge back to `job_created`. Making it available would take a
  new migration and a change to `build_pod_permit.rs`, i.e. dismantling the
  write-once guarantee the whole design rests on.

So a replacement Pod for the same task run is UID-fenced deleted, the original
identity is left intact, and the run is not dispatched. Recovery is a **new task
run** with a new `task_run_id` and therefore a new permit.
`a_replacement_pod_for_the_same_task_run_is_rejected_and_deleted` asserts both
the chosen behaviour and the unavailability of the alternative.

## Boundaries held

`server/src/` gains no `kube` or `k8s-openapi` dependency. Everything Pod-typed
lives behind `TaskRunPodResizeSurface` in `djinn-k8s::runtime`, which the server
drives through a local trait — so `check-k8s-boundary.sh` holds and the whole
GET / capture / PATCH / confirm / delete sequence is drivable from fixtures with
no cluster. `check-raw-sql-boundary.sh`, `check-file-size.sh` and
`check-migrations-immutable.sh` all pass; no migration was added (167 remains
head) and no sqlx query changed, so `server/.sqlx/` is untouched.

## Not wired to production dispatch, and cannot be yet

`BuildPodPermitRepository` has **no production caller at all** on `main` today —
neither `acquire` nor `bind_or_refresh_job_uid` is called from `server/src` or
from `runtime.rs::prepare`. There is therefore no permit for the dispatch path to
bootstrap against, and wiring one is `0ppk-1b`'s call site. The gate is enforced
at this module's boundary; `runtime.rs` gains only the observation and resize
surface it needs.

## Note on pod-slice `cpu.max`

Nothing here asserts an absolute pod-slice `cpu.max`. Before #2840 the slice's
`cpu.max` was **unset** (the launcher had no CPU limit while the worker did);
after it, a default `resize-v2` render makes the slice worker+launcher and the
kubelet sets 4250m. That is *unset → a value*, not an increment, so `3i92`'s own
"250m to the captured ceiling" arithmetic is wrong. Any future pod-slice
assertion must be a **delta** equal to the launcher limit change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
