### PR TITLE
feat(resize): server-derived resize authorization and ceiling clamp, no Kubernetes (0ppk-1a, 17nm)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -672,6 +672,15 @@ jobs:
       - name: Check raw-SQL boundary
         if: needs.preflight.outputs.rawSql == 'true'
         run: ./scripts/check-raw-sql-boundary.sh
+      # 0ppk-1a acceptance criterion 3. Routed by `size` like the include! and
+      # rustfmt guards above: `size` is set for any server change, and this is a
+      # whole-tree grep with no build, so a base-SHA trick cannot dodge it.
+      - name: Self-test resize-authorization boundary guard
+        if: needs.preflight.outputs.size == 'true'
+        run: ./scripts/test-check-resize-authorization-boundary.sh
+      - name: Check resize-authorization boundary
+        if: needs.preflight.outputs.size == 'true'
+        run: ./scripts/check-resize-authorization-boundary.sh
       - name: Self-test capability boundary detectors
         if: needs.preflight.outputs.capability == 'true'
         run: ./scripts/test-capability-boundaries.sh

--- a/scripts/check-resize-authorization-boundary.sh
+++ b/scripts/check-resize-authorization-boundary.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Resize-authorization storage-independence guard (0ppk-1a, acceptance criterion 3).
+#
+# WHY THIS EXISTS
+#
+# Proposal 9oga's `flc5` (task `0rld`) will DROP the retired admission-handoff
+# relations. Slice S3b already re-homed the invocation lease's arming authority
+# onto `InvocationLeaseAuthorityRepository`, and every 3i92 task has been specced
+# against the TYPES -- `InvocationLiftDecision`, and the `leaf-v1` / `resize-v2`
+# `LauncherAuthorityProtocol` -- rather than against the storage, precisely so
+# this code survives that DROP without a migration-day edit.
+#
+# Nothing about that produces a compile error if it stops being true. A single
+# convenience read of the retired relation added to the authorization module
+# would compile, pass, and then take production's resize authorization down on
+# the day the DROP migration runs. Text is exactly the right granularity for the
+# assertion, because the failure is "this module names that relation at all".
+#
+# WHAT IS CHECKED
+#
+#   1. The guarded files exist. A guard whose subject was deleted or renamed
+#      must fail loudly rather than pass vacuously.
+#   2. No guarded file contains a banned token (the retired relation and its
+#      retired companion columns), in code OR in a comment. A comment that names
+#      it is a comment that invites a reader to read it.
+#   3. Each required type is still named by the module. Deleting the predicate
+#      would otherwise satisfy check 2 perfectly.
+#
+# Usage:
+#   ./scripts/check-resize-authorization-boundary.sh
+#   GUARD_ROOT=/path/to/fixture ./scripts/check-resize-authorization-boundary.sh
+#     (self-test hook; see scripts/test-check-resize-authorization-boundary.sh)
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)
+ROOT=${GUARD_ROOT:-$REPO_ROOT}
+
+cd "$ROOT"
+
+GUARDED_FILES="
+server/crates/djinn-coordinator/src/resize_authorization.rs
+server/crates/djinn-coordinator/src/resize_authorization_tests.rs
+"
+
+# The retired handoff relation and the protocol columns flc5 drops with it.
+BANNED_TOKENS="
+admission_handoff
+admission_handoff_generation_ack
+emergency_ack_epoch
+invocation_ack_epoch
+"
+
+# The types the should-we-lift-at-all predicate must be written against.
+REQUIRED_TYPES="
+InvocationLiftDecision
+LauncherAuthorityProtocol
+"
+
+# Only the module itself must name the types; the test file is free not to.
+TYPED_FILE=server/crates/djinn-coordinator/src/resize_authorization.rs
+
+status=0
+
+for file in $GUARDED_FILES; do
+    if [ ! -f "$file" ]; then
+        echo "FAIL: guarded file is missing: $file" >&2
+        echo "      The resize-authorization boundary guard has no subject. If the" >&2
+        echo "      module moved, update GUARDED_FILES in $0." >&2
+        status=1
+        continue
+    fi
+    for token in $BANNED_TOKENS; do
+        if grep -n -- "$token" "$file" >/dev/null 2>&1; then
+            echo "FAIL: $file references the retired relation token '$token':" >&2
+            grep -n -- "$token" "$file" >&2
+            echo "      This module must depend on the lift-decision TYPES, never on" >&2
+            echo "      storage flc5 (task 0rld) is going to DROP." >&2
+            status=1
+        fi
+    done
+done
+
+if [ -f "$TYPED_FILE" ]; then
+    for type_name in $REQUIRED_TYPES; do
+        if ! grep -n -- "$type_name" "$TYPED_FILE" >/dev/null 2>&1; then
+            echo "FAIL: $TYPED_FILE no longer names '$type_name'." >&2
+            echo "      The should-we-lift-at-all predicate must be written against" >&2
+            echo "      that type. Removing it satisfies the ban above vacuously." >&2
+            status=1
+        fi
+    done
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "OK: resize authorization depends on the lift-decision types, not on retired storage."
+fi
+
+exit "$status"

--- a/scripts/test-check-resize-authorization-boundary.sh
+++ b/scripts/test-check-resize-authorization-boundary.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# Self-test harness for scripts/check-resize-authorization-boundary.sh.
+#
+# A guard nobody has watched fail is not a guard. This drives the production
+# guard against synthetic trees under a scratch directory (always torn down) via
+# its GUARD_ROOT hook, and proves it fires on each of the three failures it
+# claims to catch:
+#
+#   * a banned retired-relation token, in CODE;
+#   * the same token in a COMMENT (the raw-SQL guard's lesson: text guards are
+#     comment-blind unless you decide otherwise, and here we decide they are not);
+#   * a deleted guarded file, which must fail rather than pass vacuously;
+#   * a module that stopped naming a required type, which would otherwise satisfy
+#     the ban perfectly by having no predicate left at all.
+#
+# Run from anywhere:
+#
+#   sh scripts/test-check-resize-authorization-boundary.sh
+#
+# Exits 0 on success, 1 if any assertion failed. Pure POSIX shell; no cargo.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+GUARD="$SCRIPT_DIR/check-resize-authorization-boundary.sh"
+SCRATCH="$REPO_ROOT/.resize-authorization-guard-selftest"
+REL_DIR=server/crates/djinn-coordinator/src
+MODULE="$REL_DIR/resize_authorization.rs"
+TESTS="$REL_DIR/resize_authorization_tests.rs"
+
+cleanup() {
+    rm -rf -- "$SCRATCH" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+if [ ! -f "$GUARD" ]; then
+    printf 'FATAL: production guard not found at %s\n' "$GUARD" >&2
+    exit 2
+fi
+
+PASS=0
+FAIL=0
+
+pass() {
+    PASS=$((PASS + 1))
+    printf '  ok   %s\n' "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf '  FAIL %s\n' "$1" >&2
+}
+
+# Build a clean, passing fixture tree from scratch.
+fixture() {
+    rm -rf -- "$SCRATCH"
+    mkdir -p -- "$SCRATCH/$REL_DIR"
+    cat >"$SCRATCH/$MODULE" <<'EOF'
+// A clean module: it names the required types and no retired storage.
+use djinn_supervisor::services::InvocationLiftDecision;
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+EOF
+    cat >"$SCRATCH/$TESTS" <<'EOF'
+// A clean test file.
+EOF
+}
+
+# Run the guard against the scratch tree; echo its exit code.
+run_guard() {
+    set +e
+    GUARD_ROOT="$SCRATCH" "$GUARD" >/dev/null 2>&1
+    code=$?
+    set -e
+    printf '%s' "$code"
+}
+
+expect() {
+    want=$1
+    label=$2
+    got=$(run_guard)
+    if [ "$got" = "$want" ]; then
+        pass "$label"
+    else
+        fail "$label (expected exit $want, got $got)"
+    fi
+}
+
+printf 'Self-testing %s\n' "$GUARD"
+
+fixture
+expect 0 "a clean module passes"
+
+fixture
+printf 'let row = read("admission_handoff");\n' >>"$SCRATCH/$MODULE"
+expect 1 "a retired-relation read in CODE fails"
+
+fixture
+printf '// see the admission_handoff row for context\n' >>"$SCRATCH/$MODULE"
+expect 1 "a retired-relation mention in a COMMENT fails"
+
+fixture
+printf 'let e = row.emergency_ack_epoch;\n' >>"$SCRATCH/$MODULE"
+expect 1 "a retired companion column fails"
+
+fixture
+printf '// the invocation_ack_epoch is current\n' >>"$SCRATCH/$TESTS"
+expect 1 "the guard covers the TEST file too"
+
+fixture
+rm -f -- "$SCRATCH/$MODULE"
+expect 1 "a deleted guarded file fails rather than passing vacuously"
+
+fixture
+cat >"$SCRATCH/$MODULE" <<'EOF'
+// The predicate was deleted. No banned token, and no predicate either.
+EOF
+expect 1 "a module that no longer names the required types fails"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1296,6 +1296,7 @@ dependencies = [
  "djinn-db",
  "djinn-git",
  "djinn-k8s",
+ "djinn-launcher-protocol",
  "djinn-lsp",
  "djinn-memory",
  "djinn-orchestration-types",

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -21,10 +21,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use djinn_core::clock::{Clock, SystemClock};
 use djinn_supervisor::services::{
-    InvocationLiftAuthority, InvocationLiftDecision, LeaseAbandonRequest, LeaseBindRequest,
-    LeaseDeadlines, LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest,
-    LeaseReleaseRequest, LeaseResult, LeaseState, LeaseStatus, LeaseStatusRequest,
-    SupervisorServices, TaskInvocationLeaseIdentity, WatchdogTerminationRequest,
+    DegradedUnleasedReason, InvocationLiftAuthority, InvocationLiftDecision, LeaseAbandonRequest,
+    LeaseBindRequest, LeaseDeadlines, LeaseFencingToken, LeaseGrantRequest, LeaseIdentity,
+    LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseState, LeaseStatus,
+    LeaseStatusRequest, SupervisorServices, TaskInvocationLeaseIdentity,
+    WatchdogTerminationRequest,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -1447,6 +1448,20 @@ fn degrade_reason(result: &LeaseResult) -> &'static str {
         }) => "released",
         LeaseResult::Abandoned { .. } => "abandoned",
         LeaseResult::LeaseUnavailable => "lease_unavailable",
+        // The lease is live; the server refused to authorize a Pod resize for
+        // it. Bounded because `DegradedUnleasedReason` is a closed enum, and
+        // carried through as a label because "which uncertainty" is the whole
+        // operational value of the degrade — a run of `NotTheInvocationOwner`
+        // is an attack signal, a run of `PermitAbsent` is a wiring bug.
+        LeaseResult::DegradedUnleased { reason } => match reason {
+            DegradedUnleasedReason::NotTheInvocationOwner => "not_the_invocation_owner",
+            DegradedUnleasedReason::FencingTokenMismatch => "fencing_token_mismatch",
+            DegradedUnleasedReason::PermitAbsent => "permit_absent",
+            DegradedUnleasedReason::ResizeIdentityUnknown => "resize_identity_unknown",
+            DegradedUnleasedReason::ProtocolNotResizable => "protocol_not_resizable",
+            DegradedUnleasedReason::CeilingUnusable => "ceiling_unusable",
+            DegradedUnleasedReason::AuthorizationUnreadable => "authorization_unreadable",
+        },
         _ => "unclassified",
     }
 }
@@ -1492,6 +1507,22 @@ fn lease_failure_classify(
             state: LeaseState::Cancelled | LeaseState::Released,
             ..
         }) => *unleased = true,
+        // A refused resize authorization is a SETTLED answer, and this arm is
+        // what makes that true at the only place it is consumed.
+        //
+        // Without it the result falls to `_ => {}`: nothing latches, `fence`
+        // stays `None`, and the next poll reads the still-live lease as
+        // `Status(Launching)` — which re-enters the grant arm above and asks
+        // the same question again, for as long as the child runs. Every input
+        // to the answer is durable (who owns the invocation, which Pod the
+        // permit was captured against, what ceiling was admitted), so the spin
+        // could only ever re-collect the same refusal.
+        //
+        // Latching `unleased` is exactly the documented handling on
+        // [`LeaseResult::DegradedUnleased`]: proceed unleased. It sets no
+        // `output`, so the command is slowed and never failed, and the durable
+        // lease is still reconciled to terminal after the loop.
+        LeaseResult::DegradedUnleased { .. } => *unleased = true,
         _ => {}
     }
 }

--- a/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
@@ -408,6 +408,67 @@ async fn repeated_unavailability_still_fails() {
     assert!(launcher.lifts() == 0);
 }
 
+/// `0ppk-1a` acceptance criterion 4, at the consumer.
+///
+/// The coordinator refusing to authorize a Pod resize returns
+/// [`LeaseResult::DegradedUnleased`] — deliberately a RESULT and not an `Err`,
+/// because every input to that answer is durable and settled. This proves the
+/// runner honours that: it degrades once, keeps the child alive at the unleased
+/// quota, and never asks again.
+///
+/// The lease is scripted to stay LIVE (`Launching`, same fence) on every later
+/// status poll, which is what production would report — the refusal is about
+/// the resize, not about the lease. That is precisely the shape that makes the
+/// re-ask possible, so it is the shape this test pins.
+///
+/// NON-VACUITY (run, do not assume): delete the `DegradedUnleased` arm from
+/// `lease_failure_classify` so the result falls through to `_ => {}`, and
+/// `grant_calls` climbs past 1 — the runner re-enters the grant arm on every
+/// poll and re-collects the same settled refusal for the life of the child.
+#[tokio::test]
+async fn a_refused_resize_authorization_degrades_once_and_never_re_asks() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![granted(1)],
+        vec![LeaseResult::DegradedUnleased {
+            reason: djinn_supervisor::services::DegradedUnleasedReason::NotTheInvocationOwner,
+        }],
+        // The lease itself is untouched by the refusal and stays live.
+        vec![status(LeaseState::Launching, Some(1)); 8],
+    ));
+    let launcher = Arc::new(DegradeLauncher::completing());
+    let runner = LeaseInvocationRunner::new(
+        services.clone(),
+        services.clone(),
+        launcher.clone(),
+        clock(),
+    );
+    let output = runner
+        .output(command(), config(), CancellationToken::new())
+        .await
+        .expect("a refused resize authorization must not fail the command");
+
+    // Slow, not dead, and not lifted.
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+    assert_eq!(output.process.output.status.code(), Some(0));
+    assert_eq!(
+        launcher.killed_while_running(),
+        0,
+        "a refused resize authorization must never kill a running child"
+    );
+    assert_eq!(
+        launcher.lifts(),
+        0,
+        "the leaf must stay at the broker's unleased quota"
+    );
+    assert_eq!(
+        services.grant_calls.load(Ordering::SeqCst),
+        1,
+        "SETTLED means asked exactly once: a durable refusal cannot become an \
+         authorization by re-asking, and a re-ask loop would spend the whole \
+         invocation re-collecting it"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Production composition seam: the real `DirectServices` lease authority over a
 // real durable repository, driven by the real runner — no hand-built lease

--- a/server/crates/djinn-coordinator/Cargo.toml
+++ b/server/crates/djinn-coordinator/Cargo.toml
@@ -28,6 +28,11 @@ djinn-orchestration-types = { path = "../djinn-orchestration-types" }
 djinn-slot = { path = "../djinn-slot" }
 djinn-stack = { path = "../djinn-stack" }
 djinn-k8s = { path = "../djinn-k8s" }
+# The zero-dependency wire contract for `leaf-v1` / `resize-v2`. Depended on
+# directly, not through `djinn-k8s`, so `resize_authorization` can compare
+# migration 164's persisted protocol against the shared TYPE without acquiring a
+# Kubernetes dependency of its own.
+djinn-launcher-protocol = { path = "../djinn-launcher-protocol" }
 anyhow = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/server/crates/djinn-coordinator/src/build_lease.rs
+++ b/server/crates/djinn-coordinator/src/build_lease.rs
@@ -15,7 +15,6 @@ use djinn_db::{
     BuildLeaseTerminalReason, GrantNextBuildLeaseResult, InvocationLeaseAuthorityRepository,
     QueueBuildLeaseInput, QueueBuildLeaseResult,
 };
-use djinn_runtime::BuildSlotWeight;
 use djinn_supervisor::services::{
     LeaseAbandonRequest, LeaseBindRequest, LeaseCancelRequest, LeaseDeadlines, LeaseFencingToken,
     LeaseGrant, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest, LeaseReleaseRequest,
@@ -23,6 +22,8 @@ use djinn_supervisor::services::{
 };
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use tokio::sync::Mutex;
+
+use crate::resize_authorization::ResizeAuthority;
 
 /// Deterministic deadline clock seam, expressed in contract milliseconds.
 pub trait LeaseClock: Send + Sync {
@@ -184,65 +185,7 @@ impl LeaseTelemetry for MetricsLeaseTelemetry {
     }
 }
 
-/// Rendered CPU facts the weight policy is derived from, in millicores.
-///
-/// Supplied by composition from the SAME `KubernetesConfig` that renders the
-/// manifests, so the weight a workload is charged and the CPU it is actually
-/// given can never drift. Deliberately not read from the environment here: the
-/// grant path must have no opinion about where capacity facts come from, which
-/// is what lets a node-derived cap replace the configured one later without
-/// touching this module.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct BuildSlotWeights {
-    /// One build slot, in millicores: the quota a granted lease actually runs
-    /// under (`launcher_leased_millicores`, the task-run pod's `cpu_limit`).
-    pub slot_millicores: u32,
-    /// The graph-warm Job's rendered CPU request.
-    pub warm_millicores: u32,
-}
-
-impl Default for BuildSlotWeights {
-    /// The default render: a warm Job and a leased task invocation both request
-    /// 4000m, so both weigh exactly one slot. See [`BuildSlotWeight`] for why
-    /// equal weight is the measured answer rather than an approximation.
-    fn default() -> Self {
-        Self {
-            slot_millicores: 4_000,
-            warm_millicores: 4_000,
-        }
-    }
-}
-
-impl BuildSlotWeights {
-    /// Weight of a graph-warm Job.
-    #[must_use]
-    pub fn warm(&self) -> BuildSlotWeight {
-        BuildSlotWeight::for_millicores(self.warm_millicores, self.slot_millicores)
-    }
-
-    /// Weight of a layer-1 dispatch reservation for a build-capable task-run.
-    /// Light task-runs never reach here: dispatch does not acquire for them.
-    #[must_use]
-    pub fn dispatch(&self) -> BuildSlotWeight {
-        BuildSlotWeight::for_millicores(self.slot_millicores, self.slot_millicores)
-    }
-
-    /// Weight of a layer-2 invocation escalation.
-    ///
-    /// `holds_dispatch_slot` is the durable answer from
-    /// [`djinn_db::BuildLeaseRepository::has_occupying_dispatch`], never
-    /// anything the invocation itself asserted. That matters: weight is the
-    /// difference between occupying capacity and not, so a value the sandboxed
-    /// pod could supply would be a way to escape the cap.
-    #[must_use]
-    pub fn invocation(&self, holds_dispatch_slot: bool) -> BuildSlotWeight {
-        if holds_dispatch_slot {
-            BuildSlotWeight::REENTRANT
-        } else {
-            BuildSlotWeight::for_millicores(self.slot_millicores, self.slot_millicores)
-        }
-    }
-}
+pub use crate::build_slot_weights::BuildSlotWeights;
 
 /// Coordinator policy owner over the one repository-global FIFO.
 pub struct BuildLeaseService {
@@ -287,6 +230,11 @@ pub struct BuildLeaseService {
     /// denies nothing. Defaults to `false` so a process that has not read the
     /// authority cannot start enforcing a cap nobody armed.
     dispatch_enforcing: AtomicBool,
+    /// Server-derived Pod-resize authorization for the grant path. `None` in
+    /// every composition on `main` — see [`crate::resize_authorization`] for why
+    /// arming it before `0ppk-1b` creates the permits would degrade every
+    /// production invocation to unleased.
+    resize_authority: Option<Arc<ResizeAuthority>>,
     /// Keeps queue+local-drain atomic in this process. Database advisory locks
     /// serialize the same decisions across replacement coordinators.
     operation: Mutex<()>,
@@ -324,8 +272,16 @@ impl BuildLeaseService {
             authority: None,
             observed_epoch: AtomicI64::new(-1),
             dispatch_enforcing: AtomicBool::new(false),
+            resize_authority: None,
             operation: Mutex::new(()),
         }
+    }
+
+    /// Install the server-derived Pod-resize authorization on the grant path.
+    #[must_use]
+    pub fn with_resize_authority(mut self, authority: Arc<ResizeAuthority>) -> Self {
+        self.resize_authority = Some(authority);
+        self
     }
 
     /// Install the rendered CPU facts that per-row weight is derived from.
@@ -558,13 +514,31 @@ impl BuildLeaseService {
         }
     }
 
-    /// A fenced grant acknowledgement moves the durable row to launching.
+    /// A fenced grant acknowledgement moves the durable row to launching, and is
+    /// the ONE place a Pod resize is authorized.
+    ///
+    /// The destructuring is load-bearing: it is exhaustive, so a coordinate
+    /// field added to [`LeaseGrantRequest`] — a namespace, a Pod name, a
+    /// container index, a CPU target — stops compiling here rather than silently
+    /// becoming something the grant path could honour.
     pub async fn grant(&self, request: LeaseGrantRequest) -> LeaseResult {
-        self.transition(
-            request.identity,
-            request.fencing_token,
-            BuildLeaseState::Launching,
-            LeaseOperation::Grant,
+        let LeaseGrantRequest {
+            identity,
+            fencing_token,
+        } = request;
+        let granted = self
+            .transition(
+                identity.clone(),
+                fencing_token.clone(),
+                BuildLeaseState::Launching,
+                LeaseOperation::Grant,
+            )
+            .await;
+        ResizeAuthority::fold_into_grant(
+            self.resize_authority.as_deref(),
+            &identity,
+            &fencing_token,
+            granted,
         )
         .await
     }

--- a/server/crates/djinn-coordinator/src/build_slot_weights.rs
+++ b/server/crates/djinn-coordinator/src/build_slot_weights.rs
@@ -1,0 +1,70 @@
+//! Rendered CPU facts the build-slot weight policy is derived from.
+//!
+//! Split verbatim out of `build_lease.rs`, which the resize-authorization hook
+//! left 43 bytes under the 51200-byte source-size guard. The contract is
+//! self-contained — it names no lease, no repository and no clock, only the
+//! projection from rendered millicores onto slot weight — and `build_lease`
+//! re-exports it, so every existing `crate::build_lease::BuildSlotWeights` path
+//! still resolves.
+
+use djinn_runtime::BuildSlotWeight;
+
+/// Rendered CPU facts the weight policy is derived from, in millicores.
+///
+/// Supplied by composition from the SAME `KubernetesConfig` that renders the
+/// manifests, so the weight a workload is charged and the CPU it is actually
+/// given can never drift. Deliberately not read from the environment here: the
+/// grant path must have no opinion about where capacity facts come from, which
+/// is what lets a node-derived cap replace the configured one later without
+/// touching this module.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BuildSlotWeights {
+    /// One build slot, in millicores: the quota a granted lease actually runs
+    /// under (`launcher_leased_millicores`, the task-run pod's `cpu_limit`).
+    pub slot_millicores: u32,
+    /// The graph-warm Job's rendered CPU request.
+    pub warm_millicores: u32,
+}
+
+impl Default for BuildSlotWeights {
+    /// The default render: a warm Job and a leased task invocation both request
+    /// 4000m, so both weigh exactly one slot. See [`BuildSlotWeight`] for why
+    /// equal weight is the measured answer rather than an approximation.
+    fn default() -> Self {
+        Self {
+            slot_millicores: 4_000,
+            warm_millicores: 4_000,
+        }
+    }
+}
+
+impl BuildSlotWeights {
+    /// Weight of a graph-warm Job.
+    #[must_use]
+    pub fn warm(&self) -> BuildSlotWeight {
+        BuildSlotWeight::for_millicores(self.warm_millicores, self.slot_millicores)
+    }
+
+    /// Weight of a layer-1 dispatch reservation for a build-capable task-run.
+    /// Light task-runs never reach here: dispatch does not acquire for them.
+    #[must_use]
+    pub fn dispatch(&self) -> BuildSlotWeight {
+        BuildSlotWeight::for_millicores(self.slot_millicores, self.slot_millicores)
+    }
+
+    /// Weight of a layer-2 invocation escalation.
+    ///
+    /// `holds_dispatch_slot` is the durable answer from
+    /// [`djinn_db::BuildLeaseRepository::has_occupying_dispatch`], never
+    /// anything the invocation itself asserted. That matters: weight is the
+    /// difference between occupying capacity and not, so a value the sandboxed
+    /// pod could supply would be a way to escape the cap.
+    #[must_use]
+    pub fn invocation(&self, holds_dispatch_slot: bool) -> BuildSlotWeight {
+        if holds_dispatch_slot {
+            BuildSlotWeight::REENTRANT
+        } else {
+            BuildSlotWeight::for_millicores(self.slot_millicores, self.slot_millicores)
+        }
+    }
+}

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -52,6 +52,8 @@ pub mod build_admission;
 pub mod build_lease;
 /// Retirement of occupying build leases whose Kubernetes object is provably gone.
 pub mod build_lease_reclaim;
+/// Rendered CPU facts the build-slot weight policy is derived from.
+pub mod build_slot_weights;
 pub mod cargo_warm_base_gc;
 pub(crate) mod ci_preflight_gate;
 pub mod ci_reproduction;
@@ -121,6 +123,7 @@ pub async fn record_supervisor_rework_reopen(
     .await;
 }
 
+pub mod resize_authorization;
 pub mod resource_monitor;
 pub mod roles;
 /// Production wiring that arms the observe-only disk dimension at coordinator
@@ -198,6 +201,8 @@ mod build_lease_deadline_echo_tests;
 mod build_lease_integration_tests;
 #[cfg(test)]
 mod invocation_cpu_boundary_tests;
+#[cfg(test)]
+mod resize_authorization_tests;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 #[cfg(test)]

--- a/server/crates/djinn-coordinator/src/resize_authorization.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization.rs
@@ -1,0 +1,486 @@
+//! Server-derived Pod-resize authorization and ceiling clamp. **No Kubernetes.**
+//!
+//! This is the first slice of proposal `3i92`'s `0ppk` epic: the authorization
+//! and clamp layer that `0ppk-1b`'s `pods/resize` PATCH path will sit on top of.
+//! Nothing here calls Kubernetes, and nothing here may — the only outward edge
+//! is [`PodResizeIntentSink`], which `0ppk-1b` replaces with the real
+//! limits-only resize client.
+//!
+//! # The security property: the worker sends no coordinates
+//!
+//! A worker escalating an invocation continues to send exactly what it has
+//! always sent — `LeaseGrantRequest { identity, fencing_token }`. It supplies no
+//! namespace, no Pod name, no container name, no container array index and no
+//! CPU target, and there is nowhere in the request for it to put one. Every one
+//! of those is derived here, server-side, from the durable
+//! `BuildPodPermitRow::resize_identity` that was captured against the immutable
+//! Pod UID.
+//!
+//! That matters because the task-run ServiceAccount is deliberately
+//! unprivileged: `#2829` granted `pods/resize` to the *controller* only,
+//! patch-only and namespaced, and task Pods carry
+//! `automountServiceAccountToken: false`. A task run therefore cannot resize any
+//! Pod by talking to the API server — but it *can* talk to the coordinator. So
+//! "this grant may only ever move this task run's own Pod" is an **application**
+//! invariant, and this module is where it lives.
+//!
+//! # Ownership is decided by the durable row, never by the request
+//!
+//! [`ResizeAuthority::authorize`] never keys the permit lookup on the task run
+//! the caller named. It reads the durable invocation-lease row, recovers the
+//! owning task run from the row's **immutable identity** (recorded at queue time
+//! and fenced against change by `LeaseIdentityConflict`), and refuses unless the
+//! caller's claim matches it. The permit — and therefore the namespace, the Pod
+//! name, the container name and the ceiling — is then resolved from the *durable*
+//! owner. A caller that names another task run's invocation is refused at step
+//! 4, before any permit is read and long before any Kubernetes call could exist.
+//!
+//! # The clamp
+//!
+//! The target is `min(configured_leased_millicores, admitted_cpu_millicores)`.
+//! The ceiling is the value `g8jk-3` captured from the **stored** Pod after
+//! admission, so it already includes whatever a mutating webhook did to the
+//! render. Lifting above it would ask the kubelet for CPU the Pod was never
+//! admitted for; the clamp is what makes a misconfigured
+//! `DJINN_LAUNCHER_LEASED_MILLICORES` a slow build rather than a rejected or
+//! evicted Pod.
+//!
+//! # What is NOT reachable yet, deliberately
+//!
+//! [`BuildPodPermitRepository`] still has no production caller on `main`:
+//! neither `acquire` nor `bind_or_refresh_job_uid` is called from `server/src`
+//! or `runtime::prepare`. So no permit row exists in production, and
+//! [`ResizeAuthority`] is consequently **not composed into `AppState`** by this
+//! slice — [`crate::build_lease::BuildLeaseService`] holds it as an `Option` and
+//! behaves exactly as it does today when it is `None`. Wiring the authority and
+//! the permit's creation together is `0ppk-1b`'s job. Composing it here, against
+//! a relation nothing writes, would degrade every production invocation to
+//! unleased on its first grant.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use djinn_db::{
+    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseRow, BuildLeaseState,
+    BuildPodPermitRepository, BuildPodResizeIdentity,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use djinn_supervisor::services::{
+    DegradedUnleasedReason, InvocationLiftAuthority, InvocationLiftDecision, LeaseFencingToken,
+    LeaseIdentity, LeaseResult, LeaseState, TaskInvocationLeaseIdentity,
+};
+
+/// One fully server-derived resize request.
+///
+/// Every field comes from the durable permit row or from the process's own
+/// rendered configuration. There is deliberately no constructor that takes a
+/// caller-supplied value: the only way to build one is
+/// [`ResizeAuthority::authorize`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PodResizeIntent {
+    pub pod_namespace: String,
+    pub pod_name: String,
+    /// The immutable Pod UID the permit's identity was captured against. Carried
+    /// so `0ppk-1b` can fence its PATCH on the object it believes it is moving —
+    /// Pod *names* are reused, UIDs are not.
+    pub pod_uid: String,
+    pub launcher_container_name: String,
+    /// Already clamped to the stored ceiling. See [`ResizeAuthority::authorize`].
+    pub target_millicores: i64,
+    /// The ceiling this target was clamped against, carried for the assertion
+    /// that `target_millicores <= admitted_cpu_millicores` can be made on the
+    /// intent itself rather than on a value a test had to re-derive.
+    pub admitted_cpu_millicores: i64,
+}
+
+/// The one outward edge of this module, and the seam `0ppk-1b` replaces.
+///
+/// This exists so "zero Kubernetes calls" is assertable on a **counter** rather
+/// than on a returned error. A refusal that still emitted an intent would return
+/// the same `DegradedUnleased` as a refusal that emitted none, and only the
+/// counter can tell those apart — which is the whole failure mode acceptance
+/// criterion 1 is written against.
+pub trait PodResizeIntentSink: Send + Sync {
+    /// Called exactly once per authorized resize, and never for a refusal.
+    fn record(&self, intent: &PodResizeIntent);
+}
+
+/// A sink that only counts. Used by this crate's tests and by any composition
+/// that wants the authorization decision without the PATCH.
+#[derive(Debug, Default)]
+pub struct CountingPodResizeIntentSink {
+    intents: std::sync::Mutex<Vec<PodResizeIntent>>,
+    calls: AtomicU64,
+}
+
+impl CountingPodResizeIntentSink {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many times the Kubernetes boundary was reached. This is the
+    /// "zero Kubernetes calls" counter.
+    #[must_use]
+    pub fn calls(&self) -> u64 {
+        self.calls.load(Ordering::Acquire)
+    }
+
+    /// Every intent recorded, in order.
+    #[must_use]
+    pub fn intents(&self) -> Vec<PodResizeIntent> {
+        self.intents
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// How many recorded intents asked for more CPU than the ceiling they were
+    /// clamped against. This is acceptance criterion 2's counter, and it is
+    /// computed from the intent itself rather than from a value the test
+    /// restated, so removing the clamp cannot leave it reading zero.
+    #[must_use]
+    pub fn intents_above_ceiling(&self) -> usize {
+        self.intents()
+            .iter()
+            .filter(|intent| intent.target_millicores > intent.admitted_cpu_millicores)
+            .count()
+    }
+}
+
+impl PodResizeIntentSink for CountingPodResizeIntentSink {
+    fn record(&self, intent: &PodResizeIntent) {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        if let Ok(mut guard) = self.intents.lock() {
+            guard.push(intent.clone());
+        }
+    }
+}
+
+/// Whether a refusal is an authorization denial or an uncertainty.
+///
+/// Both refuse, both emit zero intents and both surface to the caller as
+/// [`LeaseResult::DegradedUnleased`]. They are kept apart because a denial means
+/// a caller asked for something that is not its own — which is worth a `WARN`
+/// and, eventually, an alert — while an uncertainty means this server could not
+/// prove the resize is allowed, which is an operational fact about the server.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefusalClass {
+    Denied,
+    Uncertain,
+}
+
+/// A refusal, with the reason that reaches the caller.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResizeRefusal {
+    pub class: RefusalClass,
+    pub reason: DegradedUnleasedReason,
+}
+
+impl ResizeRefusal {
+    const fn denied(reason: DegradedUnleasedReason) -> Self {
+        Self {
+            class: RefusalClass::Denied,
+            reason,
+        }
+    }
+    const fn uncertain(reason: DegradedUnleasedReason) -> Self {
+        Self {
+            class: RefusalClass::Uncertain,
+            reason,
+        }
+    }
+}
+
+/// Everything this layer can decide about one grant.
+///
+/// There is no `Err` here on purpose. See [`LeaseResult::DegradedUnleased`] for
+/// why an uncertainty on this path must not be expressible as something a caller
+/// could classify as retryable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResizeAuthorizationOutcome {
+    /// Server-derived and clamped. The only variant `0ppk-1b` may PATCH.
+    Authorized(PodResizeIntent),
+    /// Refused. Zero intents were recorded.
+    Refused(ResizeRefusal),
+    /// The durable authority is not armed to enforce, so no invocation is lifted
+    /// at all and there is nothing to authorize.
+    ///
+    /// Deliberately NOT a refusal: `Shadow` clamps by design and `Unleased`
+    /// means the leaf was born with no quota of its own, so neither is a
+    /// degrade — the lease result is passed through untouched. It records zero
+    /// intents like a refusal does.
+    NotLifting(InvocationLiftDecision),
+}
+
+/// The server-side resize authorization.
+///
+/// # Should we lift at all?
+///
+/// That predicate is [`InvocationLiftDecision`] — the agent/launcher-side
+/// projection of the durable invocation-lease authority — read through the
+/// injected [`InvocationLiftAuthority`], and the Pod's own
+/// [`LauncherAuthorityProtocol`]. Both are TYPES. This module never reads the
+/// retired handoff-protocol columns that `9oga`'s `flc5` will DROP, which is
+/// what lets it survive that migration unchanged;
+/// `scripts/check-resize-authorization-boundary.sh` is the CI assertion that
+/// keeps it true.
+pub struct ResizeAuthority {
+    leases: Arc<BuildLeaseRepository>,
+    permits: Arc<BuildPodPermitRepository>,
+    lift: Arc<dyn InvocationLiftAuthority>,
+    /// `DJINN_LAUNCHER_LEASED_MILLICORES` as this process rendered it —
+    /// `djinn_k8s::launcher_cpu::launcher_leased_millicores(config)`. Passed as
+    /// a plain number rather than a `KubernetesConfig` so this module has no
+    /// Kubernetes dependency at all, in either direction.
+    configured_leased_millicores: i64,
+    sink: Arc<dyn PodResizeIntentSink>,
+}
+
+impl ResizeAuthority {
+    #[must_use]
+    pub fn new(
+        leases: Arc<BuildLeaseRepository>,
+        permits: Arc<BuildPodPermitRepository>,
+        lift: Arc<dyn InvocationLiftAuthority>,
+        configured_leased_millicores: i64,
+        sink: Arc<dyn PodResizeIntentSink>,
+    ) -> Self {
+        Self {
+            leases,
+            permits,
+            lift,
+            configured_leased_millicores,
+            sink,
+        }
+    }
+
+    /// Authorize one grant, deriving every coordinate server-side.
+    ///
+    /// The order of the steps is the security property, not a style choice:
+    /// ownership is settled from durable state **before** a permit is read, and
+    /// no code path can reach [`PodResizeIntentSink::record`] without having
+    /// passed it.
+    ///
+    /// 1. Should we lift at all? Only [`InvocationLiftDecision::Lift`] proceeds.
+    /// 2. Read the durable invocation-lease row for the named invocation.
+    /// 3. Fence it against the presented token.
+    /// 4. Recover the OWNING task run from the row's immutable identity and
+    ///    refuse unless the caller's claim matches, in full.
+    /// 5. Resolve the permit from the **durable owner's** task-run id.
+    /// 6. Require a captured write-once resize identity on a resizable protocol.
+    /// 7. Clamp the target to the stored ceiling and emit the intent.
+    pub async fn authorize(
+        &self,
+        claim: &TaskInvocationLeaseIdentity,
+        fencing_token: &LeaseFencingToken,
+    ) -> ResizeAuthorizationOutcome {
+        let decision = self.lift.invocation_lift_decision().await;
+        if decision != InvocationLiftDecision::Lift {
+            return ResizeAuthorizationOutcome::NotLifting(decision);
+        }
+
+        let row = match self
+            .leases
+            .get(&BuildLeaseKey {
+                consumer_kind: BuildLeaseConsumerKind::TaskInvocation,
+                consumer_id: claim.invocation_id.clone(),
+            })
+            .await
+        {
+            Ok(Some(row)) => row,
+            // An invocation with no durable row is not a resizable subject. It
+            // is an uncertainty rather than a denial: the row may simply have
+            // been terminalized between the grant and this read.
+            Ok(None) => {
+                return Self::refuse(ResizeRefusal::uncertain(
+                    DegradedUnleasedReason::PermitAbsent,
+                ));
+            }
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    invocation_id = %claim.invocation_id,
+                    "resize authorization: durable lease row unreadable; degrading unleased"
+                );
+                return Self::refuse(ResizeRefusal::uncertain(
+                    DegradedUnleasedReason::AuthorizationUnreadable,
+                ));
+            }
+        };
+
+        if row.fencing_token != Some(fencing_token.0 as i64) {
+            return Self::refuse(ResizeRefusal::denied(
+                DegradedUnleasedReason::FencingTokenMismatch,
+            ));
+        }
+
+        let Some(owner) = durable_owner(&row) else {
+            tracing::error!(
+                identity = %row.immutable_identity,
+                "resize authorization: durable immutable identity is unparseable; degrading unleased"
+            );
+            return Self::refuse(ResizeRefusal::uncertain(
+                DegradedUnleasedReason::AuthorizationUnreadable,
+            ));
+        };
+        if owner != *claim {
+            tracing::warn!(
+                claimed_task_run_id = %claim.task_run_id,
+                owning_task_run_id = %owner.task_run_id,
+                invocation_id = %claim.invocation_id,
+                "resize authorization DENIED: the caller does not own the invocation it named"
+            );
+            return Self::refuse(ResizeRefusal::denied(
+                DegradedUnleasedReason::NotTheInvocationOwner,
+            ));
+        }
+
+        // From here on the task-run id is the DURABLE owner's, never the claim's.
+        // They are equal at this point; using `owner` keeps that a property of
+        // the code rather than of the comparison two lines above.
+        let permit = match self.permits.active(&owner.task_run_id).await {
+            Ok(Some(permit)) => permit,
+            Ok(None) => {
+                return Self::refuse(ResizeRefusal::uncertain(
+                    DegradedUnleasedReason::PermitAbsent,
+                ));
+            }
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    task_run_id = %owner.task_run_id,
+                    "resize authorization: build-pod permit unreadable; degrading unleased"
+                );
+                return Self::refuse(ResizeRefusal::uncertain(
+                    DegradedUnleasedReason::AuthorizationUnreadable,
+                ));
+            }
+        };
+        let Some(identity) = permit.resize_identity else {
+            return Self::refuse(ResizeRefusal::uncertain(
+                DegradedUnleasedReason::ResizeIdentityUnknown,
+            ));
+        };
+
+        match clamp(&identity, self.configured_leased_millicores) {
+            Ok(intent) => {
+                self.sink.record(&intent);
+                ResizeAuthorizationOutcome::Authorized(intent)
+            }
+            Err(refusal) => Self::refuse(refusal),
+        }
+    }
+
+    /// Every refusal funnels through here, and no refusal touches the sink.
+    const fn refuse(refusal: ResizeRefusal) -> ResizeAuthorizationOutcome {
+        ResizeAuthorizationOutcome::Refused(refusal)
+    }
+
+    /// Fold the authorization into the lease result a grant returns.
+    ///
+    /// Called from [`crate::build_lease::BuildLeaseService::grant`]. When no
+    /// authority is composed — which is every composition on `main`, see this
+    /// module's header — the grant result is returned byte-for-byte unchanged.
+    pub async fn fold_into_grant(
+        authority: Option<&Self>,
+        identity: &LeaseIdentity,
+        fencing_token: &LeaseFencingToken,
+        granted: LeaseResult,
+    ) -> LeaseResult {
+        let (Some(authority), LeaseIdentity::TaskInvocation(claim)) = (authority, identity) else {
+            return granted;
+        };
+        // A grant that did not actually take is not a resize question. Only a
+        // durable state that this token really owns is worth authorizing, and
+        // this mirrors the acceptance test the worker itself applies in
+        // `djinn_agent::process` before it lifts.
+        let took = matches!(
+            &granted,
+            LeaseResult::Status(status)
+                if matches!(
+                    status.state,
+                    LeaseState::Launching | LeaseState::Bound | LeaseState::Active
+                ) && status.fencing_token.as_ref() == Some(fencing_token)
+        );
+        if !took {
+            return granted;
+        }
+        match authority.authorize(claim, fencing_token).await {
+            ResizeAuthorizationOutcome::Authorized(_)
+            | ResizeAuthorizationOutcome::NotLifting(_) => granted,
+            ResizeAuthorizationOutcome::Refused(refusal) => LeaseResult::DegradedUnleased {
+                reason: refusal.reason,
+            },
+        }
+    }
+}
+
+/// Recover the task run that durably owns an invocation lease.
+///
+/// The immutable identity is written once by
+/// [`crate::build_lease`]'s `identity()` as `task:<task>:<run>:<invocation>` and
+/// is fenced against change by `LeaseIdentityConflict`, so it — not the request
+/// — is the record of who owns the row. Ids are UUIDs and carry no `:`, and the
+/// invocation segment is taken as the remainder so a malformed tail cannot be
+/// silently truncated into a match.
+fn durable_owner(row: &BuildLeaseRow) -> Option<TaskInvocationLeaseIdentity> {
+    if row.state == BuildLeaseState::Terminal {
+        return None;
+    }
+    let mut parts = row.immutable_identity.splitn(4, ':');
+    let ("task", Some(task_id), Some(task_run_id), Some(invocation_id)) =
+        (parts.next()?, parts.next(), parts.next(), parts.next())
+    else {
+        return None;
+    };
+    if task_id.is_empty() || task_run_id.is_empty() || invocation_id.is_empty() {
+        return None;
+    }
+    Some(TaskInvocationLeaseIdentity {
+        task_id: task_id.to_string(),
+        task_run_id: task_run_id.to_string(),
+        invocation_id: invocation_id.to_string(),
+    })
+}
+
+/// The clamp: `min(configured, admitted)`, on a resizable protocol only.
+///
+/// Split out as a free function so the ceiling arithmetic is testable without a
+/// database, and so acceptance criterion 2's mutation ("remove the clamp") is a
+/// one-line edit at a single site rather than something that could be half-done.
+fn clamp(
+    identity: &BuildPodResizeIdentity,
+    configured_leased_millicores: i64,
+) -> Result<PodResizeIntent, ResizeRefusal> {
+    // `leaf-v1` renders no launcher `limits.cpu` at all, so a container limit
+    // there would be an ancestor clamp over every process in the Pod. Parsing
+    // through the shared protocol type rather than comparing string literals is
+    // what keeps this agreeing with migration 164's CHECK constraint.
+    let protocol: LauncherAuthorityProtocol = identity
+        .effective_launcher_protocol
+        .parse()
+        .map_err(|_| ResizeRefusal::uncertain(DegradedUnleasedReason::ProtocolNotResizable))?;
+    if protocol != LauncherAuthorityProtocol::ResizeV2 {
+        return Err(ResizeRefusal::uncertain(
+            DegradedUnleasedReason::ProtocolNotResizable,
+        ));
+    }
+    let ceiling = identity.admitted_cpu_millicores;
+    if ceiling <= 0 || configured_leased_millicores <= 0 {
+        return Err(ResizeRefusal::uncertain(
+            DegradedUnleasedReason::CeilingUnusable,
+        ));
+    }
+    // THE CLAMP. Removing the `.min(ceiling)` here is acceptance criterion 2's
+    // stated mutation, and it must make `intents_above_ceiling()` report 1.
+    let target_millicores = configured_leased_millicores.min(ceiling);
+    Ok(PodResizeIntent {
+        pod_namespace: identity.pod_namespace.clone(),
+        pod_name: identity.pod_name.clone(),
+        pod_uid: identity.pod_uid.clone(),
+        launcher_container_name: identity.launcher_container_name.clone(),
+        target_millicores,
+        admitted_cpu_millicores: ceiling,
+    })
+}

--- a/server/crates/djinn-coordinator/src/resize_authorization_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization_tests.rs
@@ -313,16 +313,16 @@ async fn a_task_run_naming_another_invocation_is_denied_with_zero_kubernetes_cal
         )
         .await;
     assert_eq!(
+        fixture.sink.calls(),
+        0,
+        "ZERO Kubernetes calls: the denial must land before any Pod is named"
+    );
+    assert_eq!(
         refused,
         LeaseResult::DegradedUnleased {
             reason: DegradedUnleasedReason::NotTheInvocationOwner
         },
         "a task run naming another task run's invocation must be denied"
-    );
-    assert_eq!(
-        fixture.sink.calls(),
-        0,
-        "ZERO Kubernetes calls: the denial must land before any Pod is named"
     );
     assert!(
         fixture.sink.intents().is_empty(),
@@ -434,11 +434,17 @@ async fn a_configured_lift_above_the_stored_ceiling_clamps_to_the_ceiling() {
             LauncherAuthorityProtocol::ResizeV2,
         )
         .await;
-    assert!(
-        CONFIGURED_LEASED > ADMITTED_CEILING,
-        "precondition: the configured lift must exceed the stored ceiling, or \
-         this test cannot distinguish a clamp from a passthrough"
-    );
+    // The precondition that makes this test able to tell a clamp from a
+    // passthrough. A `const` block so it is checked at COMPILE time: editing
+    // either constant into agreement should fail the build, not produce a test
+    // that still passes while asserting nothing.
+    const {
+        assert!(
+            CONFIGURED_LEASED > ADMITTED_CEILING,
+            "the configured lift must exceed the stored ceiling, or this test \
+             cannot distinguish a clamp from a passthrough"
+        );
+    }
 
     let token = fixture
         .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
@@ -450,13 +456,13 @@ async fn a_configured_lift_above_the_stored_ceiling_clamps_to_the_ceiling() {
     let intents = fixture.sink.intents();
     assert_eq!(intents.len(), 1);
     assert_eq!(
-        intents[0].target_millicores, ADMITTED_CEILING,
-        "the target must be min(configured 4000m, admitted 2500m)"
-    );
-    assert_eq!(
         fixture.sink.intents_above_ceiling(),
         0,
         "ZERO PATCH intents above the stored ceiling"
+    );
+    assert_eq!(
+        intents[0].target_millicores, ADMITTED_CEILING,
+        "the target must be min(configured 4000m, admitted 2500m)"
     );
 }
 

--- a/server/crates/djinn-coordinator/src/resize_authorization_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization_tests.rs
@@ -1,0 +1,715 @@
+//! The server-derived resize authorization, proved against a real Postgres.
+//!
+//! There is no `Fake` or `Mock` repository here for anything under test. The
+//! permits, the lease FIFO and the durable invocation-lease authority are the
+//! production types over an ephemeral Postgres database, because every property
+//! asserted below is a property of durable rows: who owns an invocation, which
+//! Pod a permit was captured against, and what ceiling was admitted. A double
+//! whose `active()` returned a struct literal would agree with all of it and
+//! prove none of it.
+//!
+//! The ONE double is [`CountingPodResizeIntentSink`], and it is deliberately on
+//! the far side of the boundary: it stands in for the Kubernetes `pods/resize`
+//! PATCH that `0ppk-1b` owns. "Zero Kubernetes calls" is only assertable if
+//! something counts calls, and a returned `DegradedUnleased` cannot tell a
+//! refusal that emitted no intent apart from one that emitted an intent and then
+//! reported a degrade anyway.
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use djinn_db::{
+    AcquireBuildPodPermitResult, BuildLeaseRepository, BuildPodPermitRepository,
+    BuildPodResizeIdentity, CaptureBuildPodResizeIdentityResult, Database,
+    InvocationLeaseAuthorityRepository, InvocationLeaseMode,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use djinn_supervisor::services::{
+    DegradedUnleasedReason, DurableInvocationLiftAuthority, InvocationLiftAuthority,
+    InvocationLiftDecision, LeaseDeadlines, LeaseFencingToken, LeaseGrantRequest, LeaseIdentity,
+    LeaseQueueRequest, LeaseResult, TaskInvocationLeaseIdentity,
+};
+
+use crate::build_lease::BuildLeaseService;
+use crate::resize_authorization::{
+    CountingPodResizeIntentSink, RefusalClass, ResizeAuthority, ResizeAuthorizationOutcome,
+};
+
+/// `DJINN_MAX_BUILD_TASKRUNS` stand-in — large enough that capacity never
+/// participates in an authorization assertion.
+const CONFIGURED_CAP: i64 = 9;
+
+/// `DJINN_LAUNCHER_LEASED_MILLICORES` as the default render sets it.
+const CONFIGURED_LEASED: i64 = 4_000;
+
+/// The ceiling `g8jk-3` captured from the STORED Pod. Deliberately BELOW
+/// [`CONFIGURED_LEASED`] — a mutating webhook shrank what was rendered — so the
+/// clamp has something to bite on and an unclamped target is a different number
+/// rather than a coincidence.
+const ADMITTED_CEILING: i64 = 2_500;
+
+const OWNER_RUN: &str = "01983f00-0000-7000-8000-00000000a001";
+const OWNER_TASK: &str = "01983f00-0000-7000-8000-00000000b001";
+const OWNER_INVOCATION: &str = "01983f00-0000-7000-8000-00000000c001";
+
+const INTRUDER_RUN: &str = "01983f00-0000-7000-8000-00000000a002";
+const INTRUDER_TASK: &str = "01983f00-0000-7000-8000-00000000b002";
+
+fn identity(task: &str, run: &str, invocation: &str) -> LeaseIdentity {
+    LeaseIdentity::TaskInvocation(TaskInvocationLeaseIdentity {
+        task_id: task.into(),
+        task_run_id: run.into(),
+        invocation_id: invocation.into(),
+    })
+}
+
+/// The permit identity a task run's Pod is captured with. Every coordinate is
+/// distinct per task run so an intent built from the WRONG permit is visibly the
+/// wrong Pod rather than an equal-looking one.
+fn resize_identity(
+    run: &str,
+    ceiling: i64,
+    protocol: LauncherAuthorityProtocol,
+) -> BuildPodResizeIdentity {
+    BuildPodResizeIdentity {
+        pod_namespace: format!("ns-{run}"),
+        pod_name: format!("pod-{run}"),
+        pod_uid: format!("uid-{run}"),
+        launcher_container_name: format!("cgroup-launcher-{run}"),
+        launcher_container_id: format!("containerd://{run}"),
+        image_digest: format!("sha256:{run}"),
+        observed_launcher_protocol: protocol.as_wire().into(),
+        effective_launcher_protocol: protocol.as_wire().into(),
+        admitted_cpu_millicores: ceiling,
+    }
+}
+
+/// `build_pod_permits.task_run_id` is a real foreign key onto `task_runs`, so a
+/// permit cannot be acquired for a task run that does not exist. Seeded through
+/// the repositories rather than with hand-written SQL — `djinn-coordinator` is
+/// outside the raw-SQL boundary, and the FK chain (user → project → task → run)
+/// is exactly what the guard exists to keep out of this crate.
+async fn seed_task_runs(db: &Database, runs: &[&str]) {
+    let project_id = uuid::Uuid::now_v7().to_string();
+    djinn_db::test_support::seed_project(db, &project_id, &format!("proj-{project_id}")).await;
+    let task_id = djinn_db::test_support::seed_task_row(
+        db,
+        djinn_db::test_support::UsageTestTaskSeed {
+            project_id: &project_id,
+            status: "open",
+            close_reason: None,
+            total_reopen_count: 0,
+        },
+    )
+    .await;
+    let repository = djinn_db::TaskRunRepository::new(db.clone());
+    for run in runs {
+        repository
+            .create(djinn_db::CreateTaskRunParams {
+                id: run,
+                project_id: &project_id,
+                task_id: &task_id,
+                trigger_type: "manual",
+                status: Some("running"),
+                workspace_path: None,
+                mirror_ref: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .expect("seed the task run the permit is keyed on");
+    }
+}
+
+/// A live coordinator composition: the real lease FIFO, the real permit
+/// relation, the real durable lift authority, and the resize authorization
+/// installed on the grant path.
+struct Fixture {
+    service: Arc<BuildLeaseService>,
+    permits: Arc<BuildPodPermitRepository>,
+    sink: Arc<CountingPodResizeIntentSink>,
+    authority: Arc<ResizeAuthority>,
+    _db: Database,
+}
+
+impl Fixture {
+    async fn armed() -> Self {
+        Self::with_mode(InvocationLeaseMode::Enforce).await
+    }
+
+    async fn with_mode(mode: InvocationLeaseMode) -> Self {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        seed_task_runs(&db, &[OWNER_RUN, INTRUDER_RUN]).await;
+
+        let lease_authority = Arc::new(InvocationLeaseAuthorityRepository::new(db.clone()));
+        let seeded = lease_authority.seed_baseline().await.unwrap();
+        lease_authority
+            .set_mode_and_cap(seeded.epoch, mode, Some(CONFIGURED_CAP))
+            .await
+            .unwrap();
+
+        let leases = Arc::new(BuildLeaseRepository::new(db.clone()));
+        let permits = Arc::new(BuildPodPermitRepository::new(db.clone()));
+        let sink = Arc::new(CountingPodResizeIntentSink::new());
+        let lift: Arc<dyn InvocationLiftAuthority> = Arc::new(DurableInvocationLiftAuthority::new(
+            db.clone(),
+            "resize-authorization-tests",
+        ));
+        let authority = Arc::new(ResizeAuthority::new(
+            Arc::clone(&leases),
+            Arc::clone(&permits),
+            lift,
+            CONFIGURED_LEASED,
+            Arc::clone(&sink) as Arc<dyn crate::resize_authorization::PodResizeIntentSink>,
+        ));
+
+        let service = Arc::new(
+            BuildLeaseService::new(Arc::clone(&leases), CONFIGURED_CAP)
+                .with_invocation_lease_authority(Arc::clone(&lease_authority))
+                .with_resize_authority(Arc::clone(&authority)),
+        );
+        assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+
+        Self {
+            service,
+            permits,
+            sink,
+            authority,
+            _db: db,
+        }
+    }
+
+    /// Create the permit row and capture its write-once resize identity — the
+    /// two writes `0ppk-1b` will make from the live dispatch path, and which
+    /// nothing on `main` makes yet. Seeded directly here on purpose; see the
+    /// module header of `resize_authorization`.
+    async fn seed_permit(&self, run: &str, ceiling: i64, protocol: LauncherAuthorityProtocol) {
+        let AcquireBuildPodPermitResult::Acquired { row, .. } =
+            self.permits.acquire(run, CONFIGURED_CAP).await
+        else {
+            panic!("the permit pool must admit {run}");
+        };
+        // `capture_resize_identity` only fires from `job_created`, which is the
+        // state a Job-backed dispatch reaches before its Pod has a UID.
+        let bound = self
+            .permits
+            .bind_or_refresh_job_uid(
+                run,
+                &row.permit_id,
+                row.fencing_token,
+                &format!("job-{run}"),
+            )
+            .await;
+        assert!(
+            matches!(bound, Ok(djinn_db::BindBuildPodPermitResult::Bound(_))),
+            "binding the Job UID must succeed: {bound:?}"
+        );
+        let captured = self
+            .permits
+            .capture_resize_identity(
+                run,
+                &row.permit_id,
+                row.fencing_token,
+                &resize_identity(run, ceiling, protocol),
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(captured, CaptureBuildPodResizeIdentityResult::Captured(_)),
+            "the write-once resize identity must capture: {captured:?}"
+        );
+    }
+
+    /// Escalate an invocation onto the FIFO and return the fencing token the
+    /// durable row was minted with.
+    async fn granted(&self, task: &str, run: &str, invocation: &str) -> LeaseFencingToken {
+        match self
+            .service
+            .queue(LeaseQueueRequest {
+                identity: identity(task, run, invocation),
+                deadlines: LeaseDeadlines {
+                    queue_deadline_ms: 0,
+                    launch_deadline_ms: 0,
+                },
+            })
+            .await
+        {
+            LeaseResult::Granted(grant) => grant.fencing_token,
+            other => panic!("expected a grant for {invocation}, got {other:?}"),
+        }
+    }
+
+    /// Acknowledge the grant — the call that authorizes the resize.
+    async fn grant(&self, id: LeaseIdentity, token: &LeaseFencingToken) -> LeaseResult {
+        self.service
+            .grant(LeaseGrantRequest {
+                identity: id,
+                fencing_token: token.clone(),
+            })
+            .await
+    }
+}
+
+// ─── AC1: no coordinates, and a foreign invocation is denied ────────────────
+
+/// **ACCEPTANCE CRITERION 1, the structural half.**
+///
+/// The worker sends no coordinates because there is nowhere to put one. This
+/// destructuring is exhaustive: adding `pod_name`, `container_index` or
+/// `target_millicores` to [`LeaseGrantRequest`] makes this file stop compiling,
+/// which is a stronger statement than any runtime assertion could make about a
+/// field that does not exist.
+#[test]
+fn a_grant_request_carries_no_pod_coordinates_and_no_cpu_target() {
+    let LeaseGrantRequest {
+        identity: _,
+        fencing_token: _,
+    } = LeaseGrantRequest {
+        identity: identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION),
+        fencing_token: LeaseFencingToken(1),
+    };
+}
+
+/// **ACCEPTANCE CRITERION 1, the behavioural half.**
+///
+/// Two task runs, two permits, two Pods. The intruder holds a live grant of its
+/// own and names the OWNER's invocation. It must be refused, and — the part that
+/// matters — the Kubernetes boundary must not be reached at all. Asserted on the
+/// counter, not on the returned value: a denial that had already emitted a PATCH
+/// intent would return exactly the same `DegradedUnleased`.
+///
+/// NON-VACUITY (run, do not assume): make `ResizeAuthority::authorize` accept a
+/// caller-supplied target — short-circuiting derivation and emitting the intent
+/// straight from the request — and `calls()` here becomes non-zero.
+#[tokio::test]
+async fn a_task_run_naming_another_invocation_is_denied_with_zero_kubernetes_calls() {
+    let fixture = Fixture::armed().await;
+    fixture
+        .seed_permit(
+            OWNER_RUN,
+            ADMITTED_CEILING,
+            LauncherAuthorityProtocol::ResizeV2,
+        )
+        .await;
+    fixture
+        .seed_permit(INTRUDER_RUN, 16_000, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+    assert_eq!(
+        fixture.sink.calls(),
+        0,
+        "precondition: queueing must not reach the Kubernetes boundary"
+    );
+
+    // The intruder presents the owner's invocation id and fencing token under
+    // its OWN task and run. Everything it controls is in this request.
+    let refused = fixture
+        .grant(
+            identity(INTRUDER_TASK, INTRUDER_RUN, OWNER_INVOCATION),
+            &token,
+        )
+        .await;
+    assert_eq!(
+        refused,
+        LeaseResult::DegradedUnleased {
+            reason: DegradedUnleasedReason::NotTheInvocationOwner
+        },
+        "a task run naming another task run's invocation must be denied"
+    );
+    assert_eq!(
+        fixture.sink.calls(),
+        0,
+        "ZERO Kubernetes calls: the denial must land before any Pod is named"
+    );
+    assert!(
+        fixture.sink.intents().is_empty(),
+        "and no intent may have been derived for the intruder's Pod either"
+    );
+}
+
+/// The intruder cannot reach the owner's Pod, and the owner still can. Without
+/// this the previous test would pass on an authority that refuses everything.
+///
+/// It is also where "derived SERVER-SIDE" is proved: the intent's namespace, Pod
+/// name, Pod UID and container name are the OWNER's durable permit values, and
+/// the intruder's differently-named permit — live in the same database, with a
+/// 16000m ceiling — is never selected.
+#[tokio::test]
+async fn the_owner_is_authorized_against_its_own_durable_permit() {
+    let fixture = Fixture::armed().await;
+    fixture
+        .seed_permit(
+            OWNER_RUN,
+            ADMITTED_CEILING,
+            LauncherAuthorityProtocol::ResizeV2,
+        )
+        .await;
+    fixture
+        .seed_permit(INTRUDER_RUN, 16_000, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+    let granted = fixture
+        .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
+        .await;
+    assert!(
+        matches!(granted, LeaseResult::Status(_)),
+        "an authorized grant returns the lease status unchanged: {granted:?}"
+    );
+
+    let intents = fixture.sink.intents();
+    assert_eq!(intents.len(), 1, "exactly one Kubernetes intent");
+    let intent = &intents[0];
+    assert_eq!(intent.pod_namespace, format!("ns-{OWNER_RUN}"));
+    assert_eq!(intent.pod_name, format!("pod-{OWNER_RUN}"));
+    assert_eq!(intent.pod_uid, format!("uid-{OWNER_RUN}"));
+    assert_eq!(
+        intent.launcher_container_name,
+        format!("cgroup-launcher-{OWNER_RUN}")
+    );
+    assert_eq!(
+        intent.admitted_cpu_millicores, ADMITTED_CEILING,
+        "the ceiling must come from the OWNER's permit, not the intruder's 16000m"
+    );
+}
+
+/// A stale or guessed fencing token is a denial, and it too costs zero calls.
+#[tokio::test]
+async fn a_mismatched_fencing_token_is_denied_with_zero_kubernetes_calls() {
+    let fixture = Fixture::armed().await;
+    fixture
+        .seed_permit(
+            OWNER_RUN,
+            ADMITTED_CEILING,
+            LauncherAuthorityProtocol::ResizeV2,
+        )
+        .await;
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+
+    let refused = fixture
+        .authority
+        .authorize(
+            &TaskInvocationLeaseIdentity {
+                task_id: OWNER_TASK.into(),
+                task_run_id: OWNER_RUN.into(),
+                invocation_id: OWNER_INVOCATION.into(),
+            },
+            &LeaseFencingToken(token.0 + 1),
+        )
+        .await;
+    match refused {
+        ResizeAuthorizationOutcome::Refused(refusal) => {
+            assert_eq!(refusal.class, RefusalClass::Denied);
+            assert_eq!(refusal.reason, DegradedUnleasedReason::FencingTokenMismatch);
+        }
+        other => panic!("a foreign fencing token must be denied, got {other:?}"),
+    }
+    assert_eq!(fixture.sink.calls(), 0, "ZERO Kubernetes calls");
+}
+
+// ─── AC2: the ceiling clamp ─────────────────────────────────────────────────
+
+/// **ACCEPTANCE CRITERION 2.**
+///
+/// The process is configured to lift to 4000m; the Pod was admitted at 2500m.
+/// The target must be the stored ceiling, and NO intent may ask for more than
+/// the ceiling it was clamped against.
+///
+/// NON-VACUITY (run, do not assume): delete `.min(ceiling)` in
+/// `resize_authorization::clamp` and `intents_above_ceiling()` becomes 1.
+#[tokio::test]
+async fn a_configured_lift_above_the_stored_ceiling_clamps_to_the_ceiling() {
+    let fixture = Fixture::armed().await;
+    fixture
+        .seed_permit(
+            OWNER_RUN,
+            ADMITTED_CEILING,
+            LauncherAuthorityProtocol::ResizeV2,
+        )
+        .await;
+    assert!(
+        CONFIGURED_LEASED > ADMITTED_CEILING,
+        "precondition: the configured lift must exceed the stored ceiling, or \
+         this test cannot distinguish a clamp from a passthrough"
+    );
+
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+    fixture
+        .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
+        .await;
+
+    let intents = fixture.sink.intents();
+    assert_eq!(intents.len(), 1);
+    assert_eq!(
+        intents[0].target_millicores, ADMITTED_CEILING,
+        "the target must be min(configured 4000m, admitted 2500m)"
+    );
+    assert_eq!(
+        fixture.sink.intents_above_ceiling(),
+        0,
+        "ZERO PATCH intents above the stored ceiling"
+    );
+}
+
+/// The clamp is a `min`, not a constant: a ceiling ABOVE the configured lift
+/// must leave the configured value alone. Without this, hard-coding
+/// `target = ceiling` would pass the test above.
+#[tokio::test]
+async fn a_ceiling_above_the_configured_lift_does_not_raise_the_target() {
+    let fixture = Fixture::armed().await;
+    fixture
+        .seed_permit(OWNER_RUN, 16_000, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+    fixture
+        .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
+        .await;
+
+    let intents = fixture.sink.intents();
+    assert_eq!(intents.len(), 1);
+    assert_eq!(
+        intents[0].target_millicores, CONFIGURED_LEASED,
+        "a generous ceiling must not lift the process above what it configured"
+    );
+    assert_eq!(fixture.sink.intents_above_ceiling(), 0);
+}
+
+// ─── AC3: the lift predicate is written against the TYPES ───────────────────
+
+/// **ACCEPTANCE CRITERION 3.**
+///
+/// The should-we-lift-at-all question is [`InvocationLiftDecision`], read
+/// through the durable authority, plus the Pod's own
+/// [`LauncherAuthorityProtocol`]. Disarming the authority must stop the resize
+/// dead — with zero Kubernetes calls — while leaving the lease itself untouched,
+/// because `Shadow` and `Unleased` are deliberate states, not degrades.
+///
+/// The other half of this criterion is
+/// `scripts/check-resize-authorization-boundary.sh`, which fails if the module
+/// ever reads the retired relation `flc5` will DROP.
+#[tokio::test]
+async fn only_an_enforcing_authority_authorizes_a_resize() {
+    for (mode, expected) in [
+        (InvocationLeaseMode::Off, InvocationLiftDecision::Unleased),
+        (InvocationLeaseMode::Shadow, InvocationLiftDecision::Shadow),
+    ] {
+        let fixture = Fixture::with_mode(mode).await;
+        fixture
+            .seed_permit(
+                OWNER_RUN,
+                ADMITTED_CEILING,
+                LauncherAuthorityProtocol::ResizeV2,
+            )
+            .await;
+        let token = fixture
+            .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+            .await;
+        let granted = fixture
+            .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
+            .await;
+        assert!(
+            matches!(granted, LeaseResult::Status(_)),
+            "{mode:?} is not a degrade: the lease result passes through"
+        );
+        assert_eq!(
+            fixture.sink.calls(),
+            0,
+            "{mode:?} must reach the Kubernetes boundary ZERO times"
+        );
+
+        let outcome = fixture
+            .authority
+            .authorize(
+                &TaskInvocationLeaseIdentity {
+                    task_id: OWNER_TASK.into(),
+                    task_run_id: OWNER_RUN.into(),
+                    invocation_id: OWNER_INVOCATION.into(),
+                },
+                &token,
+            )
+            .await;
+        assert_eq!(
+            outcome,
+            ResizeAuthorizationOutcome::NotLifting(expected),
+            "the lift predicate must be the decision TYPE, in {mode:?}"
+        );
+    }
+}
+
+/// A `leaf-v1` Pod has no launcher `limits.cpu` to move, so it is not a
+/// resizable subject. The comparison is against the shared protocol type, which
+/// is what keeps it agreeing with migration 164's CHECK constraint.
+#[tokio::test]
+async fn a_leaf_v1_pod_is_not_resizable_and_costs_zero_kubernetes_calls() {
+    let fixture = Fixture::armed().await;
+    fixture
+        .seed_permit(
+            OWNER_RUN,
+            ADMITTED_CEILING,
+            LauncherAuthorityProtocol::LeafV1,
+        )
+        .await;
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+    let refused = fixture
+        .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
+        .await;
+    assert_eq!(
+        refused,
+        LeaseResult::DegradedUnleased {
+            reason: DegradedUnleasedReason::ProtocolNotResizable
+        }
+    );
+    assert_eq!(fixture.sink.calls(), 0, "ZERO Kubernetes calls");
+    assert_eq!(
+        LauncherAuthorityProtocol::from_str("resize-v2").unwrap(),
+        LauncherAuthorityProtocol::ResizeV2,
+        "the wire spelling this module parses is the shared type's, not a literal"
+    );
+}
+
+// ─── AC4: every uncertainty is a DegradedUnleased, never an Err ─────────────
+
+/// **ACCEPTANCE CRITERION 4.**
+///
+/// Each row is an uncertainty the authorization can hit, driven end to end
+/// through the real grant path. Every one must surface as
+/// [`LeaseResult::DegradedUnleased`] with its own reason — never as
+/// `LeaseUnavailable`, which the invocation runner treats as retryable and would
+/// re-ask until the queue deadline burned.
+///
+/// NON-VACUITY (run, do not assume): collapse `DegradedUnleased` into the
+/// success arm — return `granted` from the `Refused` branch of
+/// `ResizeAuthority::fold_into_grant` — and every assertion below fails.
+#[tokio::test]
+async fn every_uncertainty_degrades_unleased_rather_than_erroring() {
+    // No permit at all: the shape production is in TODAY, since nothing on
+    // `main` creates one.
+    let fixture = Fixture::armed().await;
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+    let degraded = fixture
+        .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
+        .await;
+    assert_eq!(
+        degraded,
+        LeaseResult::DegradedUnleased {
+            reason: DegradedUnleasedReason::PermitAbsent
+        },
+        "a missing permit is a settled degrade, not a retryable error"
+    );
+    assert_ne!(
+        degraded,
+        LeaseResult::LeaseUnavailable,
+        "LeaseUnavailable means ASK AGAIN; this answer cannot change by asking"
+    );
+    assert_eq!(fixture.sink.calls(), 0, "ZERO Kubernetes calls");
+
+    // A permit exists but its write-once resize identity was never captured —
+    // the window between `acquire` and `g8jk-3`'s post-admission capture.
+    let fixture = Fixture::armed().await;
+    let acquired = fixture.permits.acquire(OWNER_RUN, CONFIGURED_CAP).await;
+    assert!(
+        matches!(acquired, AcquireBuildPodPermitResult::Acquired { .. }),
+        "the permit pool must admit the owner: {acquired:?}"
+    );
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+    let degraded = fixture
+        .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
+        .await;
+    assert_eq!(
+        degraded,
+        LeaseResult::DegradedUnleased {
+            reason: DegradedUnleasedReason::ResizeIdentityUnknown
+        },
+        "an uncaptured Pod identity is a settled degrade"
+    );
+    assert_eq!(fixture.sink.calls(), 0, "ZERO Kubernetes calls");
+}
+
+/// A refusal must not disturb the durable lease. The invocation still holds its
+/// slot and its fencing token; it simply runs unleased. Degrading a lease into
+/// nonexistence would be a capacity leak dressed as a safety measure.
+#[tokio::test]
+async fn a_degraded_resize_leaves_the_lease_itself_intact() {
+    let fixture = Fixture::armed().await;
+    let token = fixture
+        .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
+        .await;
+    let degraded = fixture
+        .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
+        .await;
+    assert!(matches!(degraded, LeaseResult::DegradedUnleased { .. }));
+
+    match fixture
+        .service
+        .status(djinn_supervisor::services::LeaseStatusRequest {
+            identity: identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION),
+        })
+        .await
+    {
+        LeaseResult::Status(status) => {
+            assert_eq!(
+                status.fencing_token,
+                Some(token),
+                "the lease keeps the fence it was granted"
+            );
+            assert_eq!(
+                status.state,
+                djinn_supervisor::services::LeaseState::Launching,
+                "and the grant still advanced the durable row"
+            );
+        }
+        other => panic!("the lease must still be readable: {other:?}"),
+    }
+}
+
+/// Without an authority composed — every composition on `main` — the grant path
+/// is byte-for-byte what it was. This is the reachability claim the PR makes,
+/// asserted rather than described.
+#[tokio::test]
+async fn an_uncomposed_authority_leaves_the_grant_path_unchanged() {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let leases = Arc::new(BuildLeaseRepository::new(db.clone()));
+    let service = BuildLeaseService::new(Arc::clone(&leases), CONFIGURED_CAP);
+    assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+
+    let LeaseResult::Granted(grant) = service
+        .queue(LeaseQueueRequest {
+            identity: identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION),
+            deadlines: LeaseDeadlines {
+                queue_deadline_ms: 0,
+                launch_deadline_ms: 0,
+            },
+        })
+        .await
+    else {
+        panic!("the invocation must be granted");
+    };
+    let granted = service
+        .grant(LeaseGrantRequest {
+            identity: identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION),
+            fencing_token: grant.fencing_token,
+        })
+        .await;
+    assert!(
+        matches!(granted, LeaseResult::Status(_)),
+        "with no resize authority composed the grant is unchanged: {granted:?}"
+    );
+}

--- a/server/crates/djinn-supervisor/src/services/lease.rs
+++ b/server/crates/djinn-supervisor/src/services/lease.rs
@@ -217,6 +217,39 @@ pub struct LeaseGrant {
     pub fencing_token: LeaseFencingToken,
     pub deadlines: LeaseDeadlines,
 }
+/// Why a lease that is otherwise live may not have its Pod resized, and must
+/// therefore run at the unleased quota.
+///
+/// Every variant is a **settled** answer. None of them is transient, and none of
+/// them becomes true by waiting: the correct response to all of them is to keep
+/// running unleased. They are separated only so the log line and the metric can
+/// tell an authorization DENIAL (`NotTheInvocationOwner`, `FencingTokenMismatch`
+/// — a caller reaching for something that is not its own) apart from an
+/// UNCERTAINTY (everything else — the server could not prove the resize is
+/// allowed), because the first is an attack signal and the second is an
+/// operational one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DegradedUnleasedReason {
+    /// The task run presenting this grant is not the task run the durable lease
+    /// row records as the invocation's owner. An authorization DENIAL.
+    NotTheInvocationOwner,
+    /// The presented fencing token is not the one the durable row was minted
+    /// with. An authorization DENIAL.
+    FencingTokenMismatch,
+    /// No durable build-pod permit is active for the owning task run, so there
+    /// is no server-side relation to derive Pod coordinates from.
+    PermitAbsent,
+    /// The permit exists but carries no write-once Pod resize identity yet.
+    ResizeIdentityUnknown,
+    /// The Pod's effective launcher protocol cannot express a Pod resize.
+    ProtocolNotResizable,
+    /// The stored admitted ceiling is not a usable CPU quantity.
+    CeilingUnusable,
+    /// The durable state needed to decide could not be read at all. A DEFECT —
+    /// reported as a settled degrade because an unreadable authority is not
+    /// permission, and a retry cannot turn it into one.
+    AuthorizationUnreadable,
+}
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LeaseResult {
     Queued(LeaseStatus),
@@ -237,6 +270,26 @@ pub enum LeaseResult {
     },
     LeaseWaitTimeout {
         timeout_credit: Option<TimeoutCredit>,
+    },
+    /// The lease itself is live, but the server would not authorize a resize
+    /// for it: this invocation MUST run at the unleased quota.
+    ///
+    /// # Why this is a result and not an `Err`
+    ///
+    /// `LeaseUnavailable` and a transport `Err` both mean *ask again* — the
+    /// invocation runner treats them as retryable and keeps polling. Every
+    /// input to a resize authorization is durable and settled: who owns the
+    /// invocation, which Pod the permit was captured against, what ceiling was
+    /// admitted. None of those change because a caller retried, so surfacing an
+    /// uncertainty as an error would spend the queue deadline re-asking a
+    /// question whose answer is fixed, while the child runs clamped the whole
+    /// time. That is the shape of the 30s-invocation-deadline degrade this lease
+    /// path has already paid for once.
+    ///
+    /// So the answer is stated once, positively, with the reason attached, and
+    /// the caller's only correct handling is to proceed unleased.
+    DegradedUnleased {
+        reason: DegradedUnleasedReason,
     },
     LeaseUnavailable,
 }


### PR DESCRIPTION
Implements board task `17nm` — **0ppk-1a: server-derived resize authorization and ceiling clamp, no Kubernetes**. Epic `0ppk`, proposal `3i92`.

This is the authorization and clamp layer that `0ppk-1b`'s `pods/resize` PATCH path will sit on top of. It contains **no Kubernetes calls**, and none are permitted: the module's only outward edge is a `PodResizeIntentSink` that `0ppk-1b` replaces with the real limits-only client.

## Written against `grant_lease`, not `queue_lease`

`3i92`'s implementation map says *"LEASE: rpc.rs — RpcServices queue_lease"*. That is wrong. `rpc.rs:408-419` is a **pure forwarder** with no grant or deny logic — it round-trips a `ServiceRpcRequest` and returns whatever comes back. The real implementation is `DirectServices::grant_lease` → `BuildLeaseService::grant`, and the worker-side threshold crossing is `process.rs:836`. The lift hook belongs on the **grant** path, and that is where it went: `BuildLeaseService::grant` is now the one place a Pod resize is authorized.

## The security property

The worker sends no coordinates. It continues to send exactly `LeaseGrantRequest { identity, fencing_token }` — no namespace, no Pod name, no container name, no array index, no CPU target, and nowhere in the request to put one.

`ResizeAuthority::authorize` never keys the permit lookup on the task run the caller *named*. It reads the durable invocation-lease row, recovers the owning task run from that row's **immutable identity** (written once at queue time, fenced against change by `LeaseIdentityConflict`), and refuses unless the caller's claim matches it in full. Only then is the permit resolved — from the durable owner — and the namespace, Pod name, Pod UID, container name and ceiling read off it. A caller naming another task run's invocation is refused at step 4, **before any permit is read** and long before any Kubernetes call could exist.

This is load-bearing because the task-run ServiceAccount is deliberately unprivileged: #2829 granted `pods/resize` to the *controller* only, patch-only and namespaced, and task Pods carry `automountServiceAccountToken: false`. A task run cannot resize any Pod by talking to the apiserver — but it *can* talk to the coordinator. Exact-Pod authorization is an application invariant, not an RBAC one, and this module is where it lives.

## Composed, not rebuilt

- **#2844** (`g8jk-3`) — the ceiling clamped against is `admitted_cpu_millicores` from `BuildPodPermitRow::resize_identity`, captured post-admission from the **stored** Pod, so it already includes whatever a mutating webhook did to the render.
- **#2830** — the limits-only client is `0ppk-1b`'s to wire; nothing here duplicates it.
- **#2837 / #2843** — the launcher authority protocol is compared through the shared `LauncherAuthorityProtocol` **type**, not against string literals, which is what keeps it agreeing with migration 164's CHECK constraint.

## Reachability — stated plainly

**`ResizeAuthority` is not composed into `AppState` by this PR, and cannot fire in production.**

`BuildPodPermitRepository` still has **no production caller** on `main`: neither `acquire` nor `bind_or_refresh_job_uid` is reached from `server/src` or `runtime::prepare`. No permit row exists in production. `BuildLeaseService` therefore holds the authority as an `Option` and, when it is `None` — which is every composition on `main` — the grant path is byte-for-byte what it was. That is asserted, not merely described, by `an_uncomposed_authority_leaves_the_grant_path_unchanged`.

Composing it here, against a relation nothing writes, would degrade **every** production invocation to unleased on its first grant. The live call site belongs to `0ppk-1b`. So the tests seed the permit directly, through the real repository, and say so.

## One thing found and fixed beyond the AC set

`LeaseResult::DegradedUnleased` documents that "the caller's only correct handling is to proceed unleased". At its one existing consumer that was not true: `lease_failure_classify` in `process.rs` had no arm for it, so it fell to `_ => {}`. Nothing latched, `fence` stayed `None`, and the next poll read the still-live lease as `Status(Launching)` — which re-enters the grant arm and asks the same question again, for the life of the child. Every input to the answer is durable, so the spin could only ever re-collect the same refusal.

Added the arm (`*unleased = true`, the existing one-way degrade latch that stops all further lease requests) and a bounded metric label per reason. `a_refused_resize_authorization_degrades_once_and_never_re_asks` pins it on `grant_calls == 1`. Not reachable today for the same reason as everything else above — but `0ppk-1b` would have inherited the spin the moment it composed the authority.

## Acceptance criteria

Each mutation below was actually run; outputs are in the task report.

**AC1 — a task run naming another invocation is DENIED with zero Kubernetes calls.**
Two halves. Structural: `a_grant_request_carries_no_pod_coordinates_and_no_cpu_target` destructures `LeaseGrantRequest` exhaustively, so adding a `pod_name` / `container_index` / `target_millicores` field stops this file compiling. Behavioural: `a_task_run_naming_another_invocation_is_denied_with_zero_kubernetes_calls` gives the intruder a live grant and a permit of its own (16000m ceiling, differently-named Pod), has it present the owner's invocation id, and asserts on the **counter** — `sink.calls() == 0` — not on the returned error, because a denial that had already emitted a PATCH intent returns the identical `DegradedUnleased`. `the_owner_is_authorized_against_its_own_durable_permit` is the non-refuse-everything control and is where "derived server-side" is proved: the intent carries the *owner's* namespace, Pod name, Pod UID and container name.

**AC2 — a configured lift above the stored ceiling clamps, with zero PATCH intents above it.**
Configured 4000m, admitted 2500m. `intents_above_ceiling()` is computed from `target_millicores > admitted_cpu_millicores` **on the intent itself**, not from a number the test restated, so removing the clamp cannot leave it reading zero. `a_ceiling_above_the_configured_lift_does_not_raise_the_target` stops `target = ceiling` from passing.

**AC3 — the predicate is written against the TYPES, and a CI grep keeps it that way.**
`InvocationLiftDecision` (through the durable authority) plus `LauncherAuthorityProtocol`. `scripts/check-resize-authorization-boundary.sh` fails if the module names `admission_handoff` or its retired companion columns **in code or in a comment**, fails if a guarded file goes missing, and fails if the required types stop being named (so deleting the predicate cannot satisfy the ban vacuously). `scripts/test-check-resize-authorization-boundary.sh` self-tests all seven of those, and both are wired into `quality-gate.yml`. This is what lets the module survive `flc5` (task `0rld`) dropping the retired admission relations.

**AC4 — `DegradedUnleased` for every uncertainty, never an `Err`.**
Seven closed reasons, split into authorization DENIALS (`NotTheInvocationOwner`, `FencingTokenMismatch`) and UNCERTAINTIES. `every_uncertainty_degrades_unleased_rather_than_erroring` drives them end to end through the real grant path and asserts `!= LeaseUnavailable`, which the invocation runner treats as retryable. `a_degraded_resize_leaves_the_lease_itself_intact` proves a refusal does not disturb the durable lease — degrading a lease into nonexistence would be a capacity leak dressed as a safety measure.

## Tests

Real Postgres throughout (`Database::open_in_memory` is the ephemeral template-cloned Postgres harness). No `Fake` or `Mock` for anything under test — the permits, the lease FIFO and the durable lift authority are all production types over real rows, because every property asserted is a property of durable rows. The one double is `CountingPodResizeIntentSink`, deliberately on the far side of the boundary, standing in for the PATCH `0ppk-1b` owns.

## Scope

`BuildSlotWeights` moved to its own module verbatim (no behaviour change) — the grant hook would otherwise have pushed `build_lease.rs` past the 51200-byte file-size guard. `djinn-k8s/src/{runtime.rs,pod_resize.rs}` and `deploy/**` are untouched. No migration needed.

## Mutation evidence (actually run, real output)

Baseline: `cargo test -p djinn-coordinator --lib resize_authorization_tests` → **11 passed, 0 failed** (real Postgres). `cargo test -p djinn-agent --lib lease_degrade_tests` → **11 passed, 0 failed**.

**AC1** — make `authorize` trust the caller's claimed task run instead of the durable owner (`if owner != *claim` → `if false`, permit keyed on `claim.task_run_id`):

```
assertion `left == right` failed: ZERO Kubernetes calls: the denial must land before any Pod is named
  left: 1
 right: 0
```

The zero-call counter becomes non-zero, exactly as the AC predicts.

**AC2** — delete `.min(ceiling)` in `resize_authorization::clamp`:

```
assertion `left == right` failed: ZERO PATCH intents above the stored ceiling
  left: 1
 right: 0
```

The counter becomes 1, exactly as the AC predicts.

**AC3** — append `// admission_handoff` to the real module and run the real guard:

```
FAIL: server/crates/djinn-coordinator/src/resize_authorization.rs references the retired relation token 'admission_handoff':
488:// admission_handoff
      This module must depend on the lift-decision TYPES, never on
      storage flc5 (task 0rld) is going to DROP.
```

Caught in a **comment**, which is the point — a comment naming the relation invites a reader to read it. The guard's own self-test is `7 passed, 0 failed`, covering code, comment, companion columns, the test file, a deleted subject, and a module that stopped naming the required types.

**AC4** — collapse `Refused` into the success arm of `fold_into_grant`:

```
test result: FAILED. 7 passed; 4 failed
  a_degraded_resize_leaves_the_lease_itself_intact
  a_leaf_v1_pod_is_not_resizable_and_costs_zero_kubernetes_calls
  a_task_run_naming_another_invocation_is_denied_with_zero_kubernetes_calls
  every_uncertainty_degrades_unleased_rather_than_erroring
```

**The worker-side fix** — remove the `DegradedUnleased` arm from `lease_failure_classify`:

```
assertion `left == right` failed: SETTLED means asked exactly once: a durable refusal
cannot become an authorization by re-asking...
  left: 2
 right: 1
```

The re-ask is real, not theoretical.

Guards: `check-resize-authorization-boundary.sh` OK, its self-test 7/7, `check-raw-sql-boundary.sh` OK, `check-file-size.sh` 0 oversized, `cargo fmt --all --check` clean, `cargo clippy -p djinn-coordinator --all-targets` clean.
