### PR TITLE
fix(k8s-tests): make the live-cluster test binaries runnable — install a rustls CryptoProvider (d2ae)

### DIFF
--- a/server/crates/djinn-k8s/tests/kind_smoke.rs
+++ b/server/crates/djinn-k8s/tests/kind_smoke.rs
@@ -19,6 +19,10 @@
 //! DJINN_TEST_KIND=1 cargo test -p djinn-k8s --test kind_smoke -- --ignored
 //! ```
 //!
+//! Both tests additionally need the isolated test Postgres that
+//! `DJINN_TEST_DATABASE_URL` points at — see [`seeded_db`] for why a cluster
+//! smoke test grew a database dependency.
+//!
 //! TWO THINGS THIS FILE HAS TO DO BEFORE IT MAY BUILD A `kube::Client`
 //!
 //! 1. Install a process-level rustls `CryptoProvider`. Until this was added
@@ -55,7 +59,12 @@ use std::env;
 use std::process::Command;
 use std::time::Duration;
 
+use djinn_cgroup_launcher::LauncherAuthorityProtocol;
+use djinn_core::events::EventBus;
 use djinn_core::models::TaskRunTrigger;
+use djinn_db::Database;
+use djinn_db::repositories::image::ImageRepository;
+use djinn_db::repositories::project::ProjectRepository;
 use djinn_k8s::config::KubernetesConfig;
 use djinn_k8s::runtime::KubernetesRuntime;
 use djinn_runtime::{ResolvedCredentials, SessionRuntime, SupervisorFlow, TaskRunSpec};
@@ -68,6 +77,16 @@ mod support;
 /// Namespace the smoke tests write into. Assumed to exist — `make kind-up` in
 /// Phase 2 PR 4 creates it; otherwise we `kubectl create ns` it below.
 const TEST_NAMESPACE: &str = "djinn-test";
+
+/// A well-formed immutable manifest digest — `sha256:` + 64 lowercase hex.
+///
+/// Required, not decorative: migration 164 refuses to mark ready any image that
+/// declares a launcher authority protocol without capturing a digest, and
+/// `resolve_dispatch_image`'s vf7a admission fence compares digests exactly.
+/// The same constant, for the same reason, as
+/// `tests/launcher_authority_protocol_render.rs`.
+const CANONICAL_DIGEST: &str =
+    "sha256:7822b7de0000000000000000000000000000000000000000000000000000cafe";
 
 /// Minimal PATH-based which(1). Avoids pulling the `which` crate into this
 /// workspace for a single call site.
@@ -172,6 +191,82 @@ fn test_config() -> KubernetesConfig {
     cfg
 }
 
+/// Bring up an isolated Postgres and seed the one project row `prepare()`
+/// insists on, returning the handle the runtime is built with.
+///
+/// WHY A DATABASE IS IN A CLUSTER SMOKE TEST. `prepare()` has resolved the
+/// per-project devcontainer image out of the database since Phase 3 PR 5, and
+/// it hard-fails rather than falling back to `config.image`. `kind_smoke.rs`
+/// still built its runtime with `KubernetesRuntime::from_client`, which leaves
+/// `db: None` — so even after the rustls provider was installed, both tests
+/// died on
+///
+/// ```text
+/// KubernetesRuntime constructed without a database handle;
+/// `with_db` / `from_client_with_db` is required to dispatch task-run Jobs
+/// ```
+///
+/// a second, independent rot in the same unrun file. Measured 2026-07-31
+/// against a live kind cluster, before this was added.
+///
+/// The fixture is the same one `tests/launcher_authority_protocol_render.rs`
+/// uses — project, catalog image marked ready, project pointed at it, and the
+/// durable launcher-authority singleton aligned with what the image declares,
+/// because migration 167's fence refuses a dispatch whose declaration the
+/// server does not actually run. The digest is well-formed and required:
+/// migration 164 refuses to mark ready any image that declares a protocol
+/// without capturing an immutable one.
+///
+/// The pull ref is deliberately unresolvable: nothing here waits for a Pod, and
+/// both tests delete the Job long before the kubelet gives up pulling.
+async fn seeded_db(project_id: &str) -> Database {
+    let db = Database::open_in_memory().expect(
+        "kind_smoke: open an isolated test database — DJINN_TEST_DATABASE_URL must point at a \
+         Postgres carrying the `djinn_test_template` template database",
+    );
+    db.ensure_initialized()
+        .await
+        .expect("kind_smoke: migrations");
+
+    ProjectRepository::new(db.clone(), EventBus::noop())
+        .create_with_id(project_id, project_id, "test", project_id)
+        .await
+        .expect("kind_smoke: seed project");
+
+    let images = ImageRepository::new(db.clone());
+    let image_id = format!("img-{project_id}");
+    images
+        .create(&image_id, &image_id, None, "{}")
+        .await
+        .expect("kind_smoke: seed catalog image");
+    images
+        .mark_ready(
+            &image_id,
+            "registry.invalid/djinn-kind-smoke:never-pulled",
+            Some(CANONICAL_DIGEST),
+            Some(LauncherAuthorityProtocol::LeafV1),
+        )
+        .await
+        .expect("kind_smoke: mark the seeded image ready");
+    images
+        .set_project_image(project_id, Some(&image_id))
+        .await
+        .expect("kind_smoke: select the catalog image");
+
+    let modes = djinn_db::LauncherAuthorityModeRepository::new(db.clone());
+    let epoch = modes
+        .read()
+        .await
+        .expect("kind_smoke: read the launcher-authority singleton")
+        .expect("kind_smoke: migration 167 seeds the launcher-authority singleton")
+        .epoch;
+    modes
+        .set_mode(epoch, LauncherAuthorityProtocol::LeafV1)
+        .await;
+
+    db
+}
+
 /// A tiny spec suitable for the smoke tests — the `Planning` flow is just the
 /// planner, so there is nothing here that would demand real mirror volumes.
 fn sample_spec(task_id: &str) -> TaskRunSpec {
@@ -210,11 +305,14 @@ async fn kind_smoke_prepare_then_cancel() {
 
     let client = kind_client().await;
 
+    let spec = sample_spec("task-kind-smoke-prep");
+    let db = seeded_db(&spec.project_id).await;
+
     let config = test_config();
     let registry = std::sync::Arc::new(djinn_supervisor::ConnectionRegistry::new());
-    let runtime = KubernetesRuntime::from_client(client.clone(), config.clone(), registry);
+    let runtime =
+        KubernetesRuntime::from_client_with_db(client.clone(), config.clone(), registry, db);
 
-    let spec = sample_spec("task-kind-smoke-prep");
     let credentials = ResolvedCredentials::default();
 
     // 1) prepare: handle with a populated pod_ref pointing at the Job.
@@ -290,11 +388,14 @@ async fn kind_smoke_runtime_lifecycle() {
 
     let client = kind_client().await;
 
+    let spec = sample_spec("task-kind-smoke-life");
+    let db = seeded_db(&spec.project_id).await;
+
     let config = test_config();
     let registry = std::sync::Arc::new(djinn_supervisor::ConnectionRegistry::new());
-    let runtime = KubernetesRuntime::from_client(client.clone(), config.clone(), registry);
+    let runtime =
+        KubernetesRuntime::from_client_with_db(client.clone(), config.clone(), registry, db);
 
-    let spec = sample_spec("task-kind-smoke-life");
     let credentials = ResolvedCredentials::default();
 
     // 1) prepare.

--- a/server/crates/djinn-k8s/tests/kind_smoke.rs
+++ b/server/crates/djinn-k8s/tests/kind_smoke.rs
@@ -19,6 +19,23 @@
 //! DJINN_TEST_KIND=1 cargo test -p djinn-k8s --test kind_smoke -- --ignored
 //! ```
 //!
+//! TWO THINGS THIS FILE HAS TO DO BEFORE IT MAY BUILD A `kube::Client`
+//!
+//! 1. Install a process-level rustls `CryptoProvider`. Until this was added
+//!    (task `d2ae`) both tests below panicked *before their first API call*
+//!    with "Could not automatically determine the process-level CryptoProvider
+//!    from Rustls crate features" — a `#[ignore]`d, `DJINN_TEST_KIND`-gated
+//!    file that no CI lane runs, so nothing ever noticed. See
+//!    [`support::install_crypto_provider`] for the mechanism and for why the
+//!    server binary is unaffected.
+//! 2. Refuse any API server that is not on loopback. These tests CREATE Jobs
+//!    and Secrets. `kube::Client::try_default()` resolves whatever context
+//!    happens to be current, and every context in a Djinn developer's
+//!    kubeconfig is EKS — so an unguarded `try_default()` plus a stray
+//!    `DJINN_TEST_KIND=1` writes into a managed cluster. kind always serves on
+//!    loopback; no managed control plane does. Same discipline as
+//!    `tests/kueue_cluster_harness.rs` and `tests/kueue_disruption/mod.rs`.
+//!
 //! The tests do NOT attempt to run a full task-run end-to-end — a real task
 //! lifecycle needs the djinn-server TCP listener + mirror volume + GitHub App
 //! token, all out of scope until PR 4 pt2. Here we assert:
@@ -45,6 +62,8 @@ use djinn_runtime::{ResolvedCredentials, SessionRuntime, SupervisorFlow, TaskRun
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::{Api, DeleteParams};
+
+mod support;
 
 /// Namespace the smoke tests write into. Assumed to exist — `make kind-up` in
 /// Phase 2 PR 4 creates it; otherwise we `kubectl create ns` it below.
@@ -102,6 +121,45 @@ fn kind_test_enabled() -> bool {
     true
 }
 
+/// Build the `kube::Client` these tests talk to.
+///
+/// Two things happen here that `kube::Client::try_default()` does not do.
+///
+/// First, [`support::install_crypto_provider`] runs — without it the very next
+/// line panics on "Could not automatically determine the process-level
+/// CryptoProvider from Rustls crate features", before any request is sent. It
+/// is safe to call once per test: the install itself happens exactly once per
+/// process and is loud if it ever loses a race.
+///
+/// Second, the resolved API-server URL is checked. These tests create real
+/// Jobs and Secrets, and a Djinn developer's kubeconfig contains nothing but
+/// EKS contexts, so "whatever context is current" is not an acceptable target.
+/// kind serves on loopback and no managed control plane does, which makes the
+/// host a sufficient guard. `DJINN_TEST_KIND_CONTEXT` selects a specific
+/// kubeconfig context; without it the current context is used, and still has
+/// to clear the loopback check.
+async fn kind_client() -> kube::Client {
+    support::install_crypto_provider();
+
+    let options = kube::config::KubeConfigOptions {
+        context: env::var("DJINN_TEST_KIND_CONTEXT").ok(),
+        ..Default::default()
+    };
+    let config = kube::Config::from_kubeconfig(&options)
+        .await
+        .expect("kind_smoke: resolve a kubeconfig for the kind cluster");
+
+    let host = config.cluster_url.host().unwrap_or_default().to_owned();
+    assert!(
+        matches!(host.as_str(), "127.0.0.1" | "localhost" | "::1" | "[::1]"),
+        "kind_smoke: refusing to run against non-loopback API server {host:?} — these tests \
+         CREATE Jobs and Secrets, and every context in a Djinn kubeconfig is EKS. Point \
+         KUBECONFIG (or DJINN_TEST_KIND_CONTEXT) at a local kind cluster.",
+    );
+
+    kube::Client::try_from(config).expect("kind_smoke: build a kube client for the kind cluster")
+}
+
 /// Build a `KubernetesConfig` scoped to the kind test namespace.
 ///
 /// `server_addr` is never actually dialed during these tests — the worker Pod
@@ -150,9 +208,7 @@ async fn kind_smoke_prepare_then_cancel() {
         return;
     }
 
-    let client = kube::Client::try_default()
-        .await
-        .expect("kind_smoke: kube::Client::try_default");
+    let client = kind_client().await;
 
     let config = test_config();
     let registry = std::sync::Arc::new(djinn_supervisor::ConnectionRegistry::new());
@@ -232,9 +288,7 @@ async fn kind_smoke_runtime_lifecycle() {
         return;
     }
 
-    let client = kube::Client::try_default()
-        .await
-        .expect("kind_smoke: kube::Client::try_default");
+    let client = kind_client().await;
 
     let config = test_config();
     let registry = std::sync::Arc::new(djinn_supervisor::ConnectionRegistry::new());

--- a/server/crates/djinn-k8s/tests/kueue_cluster_harness.rs
+++ b/server/crates/djinn-k8s/tests/kueue_cluster_harness.rs
@@ -36,13 +36,13 @@
 //!
 //! WHY THE LIVE HALF DRIVES `kubectl` AND NOT `kube::Client`
 //! ---------------------------------------------------------
-//! Because `kube::Client` does not currently work in this workspace's test
-//! binaries at all, and finding that out is itself one of this task's results.
+//! Originally, because `kube::Client` did not work in this workspace's test
+//! binaries at all — finding that out was one of this task's results.
 //!
 //! `workspace-hack` unifies `rustls` 0.23 with BOTH the `ring` and the
-//! `aws-lc-rs` providers enabled, and nothing in `server/crates` ever calls
-//! `CryptoProvider::install_default()`. The first TLS handshake therefore
-//! panics:
+//! `aws-lc-rs` providers enabled, and at the time nothing in a test binary
+//! called `CryptoProvider::install_default()`. The first TLS handshake
+//! therefore panicked:
 //!
 //! ```text
 //! Could not automatically determine the process-level CryptoProvider from
@@ -50,21 +50,26 @@
 //! ```
 //!
 //! MEASURED 2026-07-30: `DJINN_TEST_KIND=1 cargo test -p djinn-k8s --test
-//! kind_smoke -- --ignored` panics exactly there, against a live kind cluster,
-//! before its first API call. The file 6knv points at as the pattern to mirror
-//! is not merely un-run by CI — it is UNRUNNABLE, and has been silently so.
-//! That is the "harness that could not execute" failure class, found again.
+//! kind_smoke -- --ignored` panicked exactly there, against a live kind
+//! cluster, before its first API call. The file 6knv points at as the pattern
+//! to mirror was not merely un-run by CI — it was UNRUNNABLE, and had been
+//! silently so. That is the "harness that could not execute" failure class,
+//! found again.
 //!
-//! Fixing it means either installing a provider (a new dev-dependency, hence
-//! `cargo hakari generate`, hence editing `workspace-hack` — shared files this
-//! task must not touch while other agents are in the same crates) or narrowing
-//! the feature unification. Either is a real change with a real blast radius
-//! and belongs in its own PR. So this harness takes the route that needs
-//! neither: every live assertion below reads or writes through
-//! `kubectl --context kind-djinn-kueue-harness`, which is the same pinned-context
-//! discipline `deploy/kueue/zero-capture-gate.sh` and `deploy/kueue/preflight.sh`
-//! already use, and which cannot silently start targeting a cluster this
-//! harness did not create.
+//! RESOLVED 2026-07-31 by task `d2ae`: `tests/support/mod.rs` installs the
+//! `ring` provider explicitly, `kind_smoke.rs` uses it, and a `kube::Client`
+//! now builds in a djinn-k8s test binary. No dev-dependency was needed —
+//! `djinn-k8s` already carries a dev-only `rustls`, so `workspace-hack` and
+//! `cargo hakari generate` stayed untouched.
+//!
+//! This file still drives `kubectl` anyway, and deliberately: the reason that
+//! survives is pinned-context discipline, not the provider. Every live
+//! assertion below reads or writes through
+//! `kubectl --context kind-djinn-kueue-harness`, the same discipline
+//! `deploy/kueue/zero-capture-gate.sh` and `deploy/kueue/preflight.sh` already
+//! use, and which cannot silently start targeting a cluster this harness did
+//! not create. A future rewrite onto `kube::Client` is now possible but must
+//! carry an equivalent guard — see `kind_smoke.rs`'s loopback check.
 //!
 //! The objects still come from the REAL renderer: `build_task_run_job` produces
 //! the Job, it is serialized and handed to the API server unmodified, and what

--- a/server/crates/djinn-k8s/tests/kueue_disruption/mod.rs
+++ b/server/crates/djinn-k8s/tests/kueue_disruption/mod.rs
@@ -141,14 +141,21 @@ pub fn which(bin: &str) -> bool {
 /// construction — for an `http://` URL as readily as an `https://` one, so there
 /// is no TLS-free route around it.
 ///
-/// Re-exported from `tests/support/mod.rs` rather than reimplemented, so that
+/// Delegates to `tests/support/mod.rs` rather than reimplementing, so that
 /// every live-cluster test binary in this crate shares ONE installer. The
 /// previous body here was `let _ = …install_default();`, which discarded the
 /// `Err` arm — and that arm does not mean "already fine", it means some *other*
 /// provider won the install and this process is half-initialised. The shared
 /// helper installs exactly once under a `Once` and panics rather than hiding
 /// that. See task `d2ae`.
-pub use support::install_crypto_provider;
+///
+/// A wrapper and not a `pub use`: this module is private to each test binary,
+/// so a re-export the sibling binary never names would trip `unused_imports`
+/// under the lane's `-D warnings`. `#![allow(dead_code)]` at the top covers a
+/// function; it does not cover an import.
+pub fn install_crypto_provider() {
+    support::install_crypto_provider();
+}
 
 /// The context every live call is pinned to, after TWO independent refusals of
 /// anything else — the same discipline `tests/kueue_cluster_harness.rs` uses.

--- a/server/crates/djinn-k8s/tests/kueue_disruption/mod.rs
+++ b/server/crates/djinn-k8s/tests/kueue_disruption/mod.rs
@@ -27,6 +27,14 @@ use djinn_k8s::launcher::CgroupLauncherMode;
 use k8s_openapi::api::batch::v1::Job;
 use serde_json::Value;
 
+// `tests/support/` is shared by every test binary in this crate, but a binary
+// may only include it once — a second copy would mean a second `Once` and
+// exactly the half-initialised state the helper exists to prevent. The
+// `kueue_disruption_*` binaries reach it through this module, so they do NOT
+// declare `mod support;` themselves.
+#[path = "../support/mod.rs"]
+mod support;
+
 // ---------------------------------------------------------------------------
 // The one cluster this file may ever touch.
 // ---------------------------------------------------------------------------
@@ -131,12 +139,16 @@ pub fn which(bin: &str) -> bool {
 /// rustls 0.23 refuses to pick a provider when `workspace-hack` has unified both
 /// `ring` and `aws-lc-rs` into the build, and `kube::Client::try_from` panics on
 /// construction — for an `http://` URL as readily as an `https://` one, so there
-/// is no TLS-free route around it. Installing `ring` here is process-global,
-/// idempotent (the `Err` arm means somebody already installed one), and scoped
-/// to this test binary.
-pub fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
-}
+/// is no TLS-free route around it.
+///
+/// Re-exported from `tests/support/mod.rs` rather than reimplemented, so that
+/// every live-cluster test binary in this crate shares ONE installer. The
+/// previous body here was `let _ = …install_default();`, which discarded the
+/// `Err` arm — and that arm does not mean "already fine", it means some *other*
+/// provider won the install and this process is half-initialised. The shared
+/// helper installs exactly once under a `Once` and panics rather than hiding
+/// that. See task `d2ae`.
+pub use support::install_crypto_provider;
 
 /// The context every live call is pinned to, after TWO independent refusals of
 /// anything else — the same discipline `tests/kueue_cluster_harness.rs` uses.

--- a/server/crates/djinn-k8s/tests/support/mod.rs
+++ b/server/crates/djinn-k8s/tests/support/mod.rs
@@ -1,0 +1,69 @@
+//! Shared test-support helpers for `djinn-k8s`'s integration test binaries.
+//!
+//! This directory is a subdirectory of `tests/`, so cargo does NOT compile it
+//! as its own test binary. Pull it in with `mod support;` from a file directly
+//! under `tests/`.
+
+use std::sync::Once;
+
+/// Install the process-level rustls [`CryptoProvider`] that this test binary
+/// needs before it constructs its first `kube::Client`.
+///
+/// # Why this is needed at all
+///
+/// rustls 0.23 will only pick a provider by itself when exactly one of its
+/// `ring` / `aws_lc_rs` features is enabled. This workspace enables **both** on
+/// `x86_64-unknown-linux-gnu`: `workspace-hack`'s `[dependencies]` block asks
+/// for `rustls … features = ["ring", …]` and its
+/// `[target.x86_64-unknown-linux-gnu.dependencies]` block asks for
+/// `rustls … features = ["aws-lc-rs", "aws_lc_rs"]`, and cargo unions the two.
+/// `CryptoProvider::get_default_or_install_from_crate_features()` therefore
+/// finds an ambiguous build and panics with
+///
+/// ```text
+/// Could not automatically determine the process-level CryptoProvider from Rustls crate features
+/// ```
+///
+/// `kube::Client` construction is where that bites: it builds a TLS config
+/// eagerly, for an `http://` API-server URL as readily as an `https://` one, so
+/// there is no TLS-free route around it.
+///
+/// # Why production is not affected
+///
+/// `server/src/main.rs` calls `rustls::crypto::ring::default_provider()
+/// .install_default()` before it builds the tokio runtime. An explicit install
+/// short-circuits the crate-feature sniffing entirely, so the ambiguity above
+/// is never consulted in the server binary. Test binaries have no such `main`,
+/// which is the whole of the defect — nothing else installs one for them.
+///
+/// # Why this fails loudly
+///
+/// `install_default()` returns `Err` when a provider is already installed.
+/// Swallowing that (`let _ = …`) would paper over a half-initialised process in
+/// which some *other* provider — aws-lc-rs, say — is the live default and this
+/// call silently did nothing, which is a far more confusing failure than the
+/// one it replaces. So the install runs exactly once per process under a
+/// [`Once`] and `expect`s its result: a second *install* is never attempted, an
+/// install that loses a race against a foreign installer panics and names
+/// itself, and a poisoned `Once` re-panics on every later call. Calling this
+/// from every test in a binary is consequently both correct and cheap.
+///
+/// [`CryptoProvider`]: rustls::crypto::CryptoProvider
+pub fn install_crypto_provider() {
+    static INSTALL: Once = Once::new();
+
+    INSTALL.call_once(|| {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect(
+                "install the rustls `ring` CryptoProvider for this test binary: a provider was \
+                 already installed by something else in this process, so it is half-initialised \
+                 — find the other installer instead of ignoring this",
+            );
+    });
+
+    assert!(
+        rustls::crypto::CryptoProvider::get_default().is_some(),
+        "no process-level rustls CryptoProvider after install_crypto_provider()",
+    );
+}


### PR DESCRIPTION
## What was broken

`server/crates/djinn-k8s/tests/kind_smoke.rs` could not execute. Against a live
kind cluster both of its tests panicked **before their first API call**:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features
```

rustls 0.23 only picks a provider by itself when *exactly one* of its `ring` /
`aws_lc_rs` features is enabled. `server/src/main.rs:124-128` installs one
explicitly for the server binary, with a comment saying exactly that. Test
binaries have no such `main`, so nothing installs one and the first
`kube::Client` construction panics — `kube` builds a TLS config eagerly, for an
`http://` API-server URL as readily as an `https://` one, so there is no
TLS-free route around it.

The file is `#[ignore]` + `DJINN_TEST_KIND`-gated and no CI lane runs it
(`grep DJINN_TEST_KIND .github/workflows/` is empty), which is why this stayed
latent. Same "harness that cannot execute" class as `uoe7` and `uvb9`.

## Production is not affected — independently re-verified

Two claims were floating around and **one of them is wrong**, so both were
checked from the manifests rather than taken on trust.

**Wrong:** "workspace-hack pins rustls to `ring` rather than unifying `ring`
and `aws-lc-rs`." It unifies them. On `x86_64-unknown-linux-gnu`:

- `server/crates/workspace-hack/Cargo.toml:60`, `[dependencies]` —
  `rustls … features = ["logging", "ring", "std", "tls12"]`
- `server/crates/workspace-hack/Cargo.toml:154`,
  `[target.x86_64-unknown-linux-gnu.dependencies]` —
  `rustls … features = ["aws-lc-rs", "aws_lc_rs"]`

Cargo unions those. `cargo tree -p djinn-k8s -e features -i rustls --target
x86_64-unknown-linux-gnu` confirms `rustls feature "aws-lc-rs"` is live. rustls'
`provider_from_crate_features()` is `cfg(all(feature = "ring", not(feature =
"aws_lc_rs")))` / the mirror image, so with both on it returns `None` — which is
precisely the observed panic. The comment #2842 added to
`djinn-k8s/Cargo.toml` was right; the task description's version was not.

**Right, but for a different reason than stated:** production is unaffected.
Not because the feature set is unambiguous, but because `server/src/main.rs`
calls `rustls::crypto::ring::default_provider().install_default()` before it
builds the tokio runtime. An *explicit* install sets the process default and
`get_default_or_install_from_crate_features()` never consults the crate
features at all. The ambiguity is real and simply never reached in the server
binary.

Checked, and unchanged by this PR:

- `server/src/main.rs` — untouched.
- `server/crates/workspace-hack/Cargo.toml` — untouched. No dev-dependency was
  added, so no `cargo hakari generate`: `djinn-k8s` already carries a dev-only
  `rustls = { version = "0.23", default-features = false, features = ["ring",
  "std"] }` from #2842.
- The three `kube::Client::try_default()` call sites in production code
  (`djinn-k8s/src/lib.rs:96`, `src/runtime.rs:336`, `:356`,
  `src/token_review.rs:70`) are all reached only from `djinn-server`, i.e.
  downstream of that install.

## The audit (AC2)

Every `#[ignore]`d test binary in the workspace, and everything that builds a
`kube::Client` anywhere:

| Test binary | Builds a kube client? | Verdict |
| --- | --- | --- |
| `djinn-k8s/tests/kind_smoke.rs` | yes, `Client::try_default()` | **AFFECTED — fixed here.** Now installs the provider and pins to loopback. |
| `djinn-k8s/tests/kueue_disruption_conformance.rs` (+ `tests/kueue_disruption/mod.rs`) | yes, `Client::try_from(config)` | Already installed a provider (#2842) but via `let _ = …install_default()`, which discards the arm that means *another provider won*. **Hardened here** — routed through the shared helper. |
| `djinn-k8s/tests/kueue_disruption_governor.rs` | no — `kubectl`-driven only | Unaffected. Shares `tests/kueue_disruption/mod.rs`, so it inherits the helper it does not call. |
| `djinn-k8s/tests/kueue_cluster_harness.rs` | no — `kubectl --context` only | Unaffected. Its module doc claimed `kube::Client` "does not currently work in this workspace's test binaries"; that is now false, so the block is updated to record the fix while keeping the pinned-context rationale, which is independent of it. |
| `djinn-k8s/tests/kueue_admission_conformance.rs` | no — `kubectl --context` only | Unaffected, same shape. |
| `djinn-k8s/tests/launcher_authority_protocol_render.rs` | `kube::Client::new(service_fn(…))` | Unaffected. A mocked tower service: no `Config`, no TLS stack. Not `#[ignore]`d, and it is green in CI today, which proves it. |
| `djinn-k8s` unit tests (`src/*_tests.rs`, `pod_resize.rs`, `graph_warmer*.rs`, …) | `kube::Client::new(service_fn(…))` | Unaffected, same reason. Green in CI. |
| `djinn-image-controller/tests/{unit,protocol_catalog_and_preservation}.rs` | no | Unaffected — no `kube::Client` in either. |
| `djinn-cgroup-launcher/tests/{brokered_git_trust,brokered_lease_lift_boundary,delegated_cpu_lease_lifecycle,kernel_boundary_under_rendered_context}.rs` | no | Unaffected. `#[ignore]`d kernel/cgroup tests, no `kube` dependency at all. |
| `djinn-db/tests/{apply_migrations,setup_test_template}.rs` | no | Unaffected. `#[ignore]`d, Postgres only. sqlx links rustls, but these run green today, so no TLS handshake is reached. |

`grep -rn "Client::try_default\|Config::infer\|Config::from_kubeconfig"` over
`server/` returns nothing outside the rows above, and `server/Cargo.toml` is
the only cargo workspace in the repo — so the list is exhaustive rather than
representative.

**Not fixed, flagged only:** `djinn-agent-worker` is a production binary that
links rustls (via `sqlx-core`) and never installs a provider. It runs green in
production today, so no rustls TLS path is currently reached from it, and
touching `main`-equivalents there is out of this task's scope. Recording it so
the next person adding an HTTPS call to the worker knows where to look.

## The fix

`server/crates/djinn-k8s/tests/support/mod.rs` — one installer, shared by every
live-cluster test binary in the crate. `kind_smoke.rs` pulls it in with
`mod support;`; `tests/kueue_disruption/mod.rs` re-exports it via `#[path =
"../support/mod.rs"]` so the `kueue_disruption_*` binaries keep the same
`install_crypto_provider()` call and there is still exactly one `Once` per
binary.

**AC4 — loudness.** `install_default()` returns `Err` when a provider is
already installed, and that arm does not mean "already fine", it means some
*other* provider is the live default and this call silently did nothing. So the
install runs exactly once per process under a `Once` and `expect`s its result:

- a second *install* is never attempted, so calling the helper from every test
  is correct and cheap;
- an install that loses a race against a foreign installer panics and names
  itself;
- a poisoned `Once` re-panics on every later call;
- a post-condition `assert!(CryptoProvider::get_default().is_some())` runs on
  every call, not just the first.

**Secondary, and worth reviewing on its own merits:** `kind_smoke.rs` no longer
uses `kube::Client::try_default()`. These tests CREATE Jobs and Secrets, and
every context in a Djinn developer's kubeconfig is EKS, so "whatever context is
current" plus a stray `DJINN_TEST_KIND=1` writes into a managed cluster. The
resolved API server must now be on loopback — kind always is, no managed
control plane is — the same guard `tests/kueue_disruption/mod.rs` and
`tests/kueue_cluster_harness.rs` already carry. `DJINN_TEST_KIND_CONTEXT`
selects a context explicitly.

## A second, independent rot in the same file

Installing the provider got the tests to their first API call and immediately
exposed the next thing that had rotted while nothing ran the file:

```
kind_smoke: prepare() should succeed against a live kind cluster:
Prepare("KubernetesRuntime constructed without a database handle;
`with_db` / `from_client_with_db` is required to dispatch task-run Jobs")
```

`prepare()` has resolved the per-project devcontainer image out of the database
since Phase 3 PR 5, and hard-fails rather than falling back to `config.image`.
`kind_smoke.rs` still built its runtime with `KubernetesRuntime::from_client`,
which leaves `db: None`. AC1 asks for tests that *run to completion*, so this is
fixed too, with the fixture `tests/launcher_authority_protocol_render.rs`
already uses: isolated test Postgres, project, catalog image marked ready with a
well-formed digest (migration 164 refuses a protocol-declaring image without
one), project pointed at it, and the durable launcher-authority singleton
aligned with the declaration so migration 167's fence admits the dispatch. The
pull ref is deliberately unresolvable — neither test waits for a Pod.

This is worth calling out on its own: an unrun harness does not rot in one
place. Both defects were invisible for the same reason.

## Verification

Live cluster: `kind` v0.32.0, `kindest/node:v1.30.13`, cluster
`djinn-d2ae-smoke`, its own `--kubeconfig` file holding **only** that context so
no EKS entry was reachable, API server `https://127.0.0.1:40633`. No registry
was needed or created. Cluster and node deleted afterwards; `kind get clusters`
now lists only `djinn-kueue-b2`, which belongs to a concurrent agent and was not
touched.

**AC1 — both tests pass against a live cluster.**

```
$ KUBECONFIG=…/d2ae-kubeconfig DJINN_TEST_KIND=1 \
    cargo test -p djinn-k8s --test kind_smoke -- --ignored --test-threads=1
running 2 tests
test kind_smoke_prepare_then_cancel ... ok
test kind_smoke_runtime_lifecycle ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.68s
```

Real API calls, not just a green line — the kind API server's own event log
shows the Jobs the tests created, and the namespace is clean afterwards:

```
$ kubectl get events -n djinn-test
djinn-taskrun-019fb83b-4a3e-7463-82b3-22a0ca27a056  FailedCreate  Error creating: pods "…-" is forbidden: … serviceaccount "djinn-taskrun" not found
djinn-taskrun-019fb83b-51d3-75b0-8525-8f1a432da219  FailedCreate  Error creating: pods "…-" is forbidden: … serviceaccount "djinn-taskrun" not found
$ kubectl get jobs,secrets,pods -n djinn-test
No resources found in djinn-test namespace.
```

(The Job controller failing to make a Pod is expected: the smoke tests do not
install the `djinn-taskrun` ServiceAccount and never wait for a Pod. It is also
the proof — only a Job the API server actually accepted produces that event.)

**AC1 non-vacuity — remove the install, the panic returns.** Commenting out the
single `support::install_crypto_provider();` line:

```
thread 'kind_smoke_prepare_then_cancel' panicked at rustls-0.23.42/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually,
or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

Note rustls' own last clause — *"exactly one of the 'aws-lc-rs' and 'ring'
features"*. That is the unification, confirmed by the failing binary itself.
Mutation reverted; the run above is the post-revert state.

**AC4 non-vacuity — the helper is loud, demonstrated not asserted.** Temporarily
letting a foreign installer win first (`let _ =
rustls::crypto::ring::default_provider().install_default();` immediately before
the helper):

```
thread 'kind_smoke_prepare_then_cancel' panicked at crates/djinn-k8s/tests/support/mod.rs:58:14:
install the rustls `ring` CryptoProvider for this test binary: a provider was already
installed by something else in this process, so it is half-initialised — find the other
installer instead of ignoring this: CryptoProvider { … key_provider: Ring }

thread 'kind_smoke_runtime_lifecycle' panicked at crates/djinn-k8s/tests/support/mod.rs:55:13:
Once instance has previously been poisoned
```

The first test panics naming itself and the second cannot proceed either. The
old `let _ = …` swallowed exactly this. Mutation reverted.

**Regression.** `cargo test -p djinn-k8s` — 342 lib tests plus every integration
binary, **0 failed, 0 warnings**, including the `kueue_disruption_*` pair whose
installer now delegates. `cargo fmt --all -- --check` clean.

Clippy was not run locally: the box is at 99% disk and a clippy-driver rebuild
of this dep tree does not fit. `cargo test`'s rustc pass emitted zero warnings
across all djinn-k8s targets, and the workspace lint set adds only
`dbg_macro` / `print_stdout` / `print_stderr` / `disallowed_methods`, none of
which this diff touches — but CI's clippy lane is the real check.

## Out of scope

- `server/src/main.rs` and `server/crates/workspace-hack/Cargo.toml` are
  untouched; no `cargo hakari generate` was run.
- Narrowing the `ring` / `aws-lc-rs` unification in `workspace-hack` is the
  other possible fix and is deliberately *not* taken here: it is a real change
  with a real blast radius across every crate, and the test binaries do not
  need it.
- No CI lane is added for `kind_smoke.rs`. It is still `#[ignore]` +
  `DJINN_TEST_KIND`-gated and still runs nowhere by default; this PR makes it
  *possible* to run, which is what the task asked for. Wiring it into a lane
  (and deciding whether it should gate merges) is a separate decision with its
  own cost.
- Noticed while running: the local test Postgres holds 674 leftover
  `djinn_test_*` databases from previous suite runs. Pre-existing, unrelated to
  this diff, mentioned only so it is written down somewhere.

Closes `d2ae`.
