### PR TITLE
refactor(db): move credential/custom_provider repos into djinn-db

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1682,7 +1682,6 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "sha2 0.10.9",
- "sqlx",
  "thiserror 2.0.18",
  "time",
  "tokenizers",

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -117,6 +117,8 @@ pub use repositories::{
         derive_pair_events, derive_pair_events_into,
     },
     coordinator_incarnation::{CoordinatorIncarnation, CoordinatorIncarnationRepository},
+    credential::CredentialRepository,
+    custom_provider::CustomProviderRepository,
     dispatch_pause::{DispatchPauseMutation, DispatchPauseRepository, DispatchPauseTarget},
     dispatch_state::{DispatchStateRecord, DispatchStateRepository, DispatchStateUpsert},
     doctor_finding::{

--- a/server/crates/djinn-db/src/repositories/credential.rs
+++ b/server/crates/djinn-db/src/repositories/credential.rs
@@ -1,9 +1,9 @@
 use uuid::Uuid;
 
+use crate::crypto;
+use crate::{Database, Result, ensure_db};
 use djinn_core::events::{DjinnEventEnvelope, EventBus};
 use djinn_core::models::Credential;
-use djinn_db::crypto;
-use djinn_db::{Database, Result, ensure_db};
 
 #[derive(Clone)]
 pub struct CredentialRepository {
@@ -687,7 +687,7 @@ mod tests {
     /// Seed a real `users` row so the `credentials.owner_user_id` FK holds.
     async fn seed_user(db: &Database, github_id: i64, login: &str) -> String {
         db.ensure_initialized().await.unwrap();
-        djinn_db::UserRepository::new(db.clone())
+        crate::UserRepository::new(db.clone())
             .upsert_from_github(github_id, login, None, None)
             .await
             .unwrap()
@@ -952,63 +952,10 @@ mod tests {
         assert_eq!(none[0].key_name, "OPENAI_API_KEY");
     }
 
-    /// End-to-end replica of the coordinator's `resolve_user_model_priority`
-    /// body (real DB + repos + catalog), reproducing the exact staging setup:
-    /// a user who selected `openai/gpt-5.5` and connected Codex (`chatgpt_codex`
-    /// OAuth, which merges into `openai`) + an org-shared fireworks key. The
-    /// per-method `#[cfg(test)]` stub means the live suite never exercises this,
-    /// so we replicate it inline. The model MUST stay eligible.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn user_model_priority_keeps_openai_via_codex_merge() {
-        use crate::catalog::CatalogService;
-        use djinn_core::models::ModelLanes;
-        use djinn_db::UserSettingsRepository;
-
-        let db = Database::open_in_memory().unwrap();
-        let uid = seed_user(&db, 9001, "fern").await;
-        let repo = CredentialRepository::new(db.clone(), EventBus::noop());
-        repo.set_with_owner("chatgpt_codex", "__OAUTH_CHATGPT_CODEX", "tok", Some(&uid))
-            .await
-            .unwrap();
-        repo.set_with_owner("fireworks-ai", "FIREWORKS_API_KEY", "fk", None)
-            .await
-            .unwrap();
-        UserSettingsRepository::new(db.clone())
-            .upsert_lanes(
-                &uid,
-                &ModelLanes::from_flat(vec!["openai/gpt-5.5".to_string()]),
-            )
-            .await
-            .unwrap();
-
-        // ── replicate resolve_user_model_priority (implement lane = worker) ──
-        let models = UserSettingsRepository::new(db.clone())
-            .get(&uid)
-            .await
-            .unwrap()
-            .unwrap()
-            .lanes
-            .unwrap()
-            .for_role("worker")
-            .to_vec();
-        let creds = repo.list_for_user(Some(&uid)).await.unwrap();
-        let connected = CatalogService::new().connected_provider_ids(&creds);
-        let result: Vec<String> = models
-            .into_iter()
-            .filter(|m| {
-                let p = m.split_once('/').map(|(p, _)| p).unwrap_or(m.as_str());
-                connected.contains(p)
-            })
-            .collect();
-
-        assert!(
-            connected.contains("openai"),
-            "codex merge should connect openai; connected={connected:?}"
-        );
-        assert_eq!(
-            result,
-            vec!["openai/gpt-5.5".to_string()],
-            "openai/gpt-5.5 must remain eligible; connected={connected:?}"
-        );
-    }
+    // NOTE: `user_model_priority_keeps_openai_via_codex_merge` — the end-to-end
+    // replica of the coordinator's `resolve_user_model_priority` — cannot live
+    // here. It needs `djinn_provider::catalog::CatalogService`, and djinn-db
+    // must not depend on djinn-provider. It lives in
+    // `djinn-provider/tests/credential_user_model_priority.rs`, on the far side
+    // of the one dependency edge between the two crates.
 }

--- a/server/crates/djinn-db/src/repositories/custom_provider.rs
+++ b/server/crates/djinn-db/src/repositories/custom_provider.rs
@@ -1,6 +1,6 @@
+use crate::{Database, Result, ensure_db};
 use djinn_core::events::{DjinnEventEnvelope, EventBus};
 use djinn_core::models::{CustomProvider, SeedModel};
-use djinn_db::{Database, Result, ensure_db};
 
 pub struct CustomProviderRepository {
     db: Database,

--- a/server/crates/djinn-db/src/repositories/mod.rs
+++ b/server/crates/djinn-db/src/repositories/mod.rs
@@ -7,6 +7,8 @@ pub mod chat_interruption_notice;
 pub mod code_chunk;
 pub mod commit_file_changes;
 pub mod coordinator_incarnation;
+pub mod credential;
+pub mod custom_provider;
 pub mod dispatch_pause;
 pub mod dispatch_state;
 pub mod doctor_finding;

--- a/server/crates/djinn-db/src/repositories/test_support_fixtures.rs
+++ b/server/crates/djinn-db/src/repositories/test_support_fixtures.rs
@@ -465,7 +465,7 @@ pub async fn ensure_doctor_findings_schema(db: &Database) {
 /// or truncated ciphertext) without going through the encrypt/decrypt round-trip.
 ///
 /// This is a **test-only** escape hatch — all production writes MUST go through
-/// the `CredentialRepository` boundary in `djinn-provider`.
+/// the `CredentialRepository` boundary in `crate::repositories::credential`.
 pub async fn corrupt_credential_encrypted_value(db: &Database, key_name: &str, raw_bytes: Vec<u8>) {
     sqlx::query("UPDATE credentials SET encrypted_value = $1 WHERE key_name = $2")
         .bind(raw_bytes)

--- a/server/crates/djinn-provider/Cargo.toml
+++ b/server/crates/djinn-provider/Cargo.toml
@@ -35,7 +35,6 @@ serde_json = "1"
 serde_yaml = "0.9"
 serde_urlencoded = "0.7"
 sha2 = "0.10"
-sqlx = { version = "0.8", features = ["mysql", "runtime-tokio-rustls", "macros"] }
 thiserror = "2"
 tokenizers = "0.22.2"
 tokio = { version = "1", features = ["full"] }

--- a/server/crates/djinn-provider/src/repos/mod.rs
+++ b/server/crates/djinn-provider/src/repos/mod.rs
@@ -1,5 +1,14 @@
-pub mod credential;
-pub mod custom_provider;
-
-pub use credential::CredentialRepository;
-pub use custom_provider::CustomProviderRepository;
+//! Compatibility re-export.
+//!
+//! `CredentialRepository` and `CustomProviderRepository` live in `djinn-db`
+//! alongside every other repository — they issue Postgres queries and belong on
+//! the far side of the raw-SQL boundary that `scripts/check-raw-sql-boundary.sh`
+//! polices. They spent time in this crate only as the residue of a half-reverted
+//! move: `ef02b5104` moved them out of djinn-db, and `4c78658c4` moved the
+//! crypto half back the same day "so CredentialRepository can access crypto
+//! without depending on the provider crate" — leaving the repositories stranded.
+//!
+//! This shim keeps `djinn_provider::repos::*` working for existing call sites.
+//! New code should import from `djinn_db` directly.
+pub use djinn_db::repositories::{credential, custom_provider};
+pub use djinn_db::{CredentialRepository, CustomProviderRepository};

--- a/server/crates/djinn-provider/tests/credential_user_model_priority.rs
+++ b/server/crates/djinn-provider/tests/credential_user_model_priority.rs
@@ -1,0 +1,78 @@
+//! End-to-end replica of the coordinator's `resolve_user_model_priority` body
+//! (real DB + repos + catalog).
+//!
+//! This test used to live inside `CredentialRepository`'s own `mod tests`. When
+//! that repository moved to `djinn-db` it could not come along: it needs
+//! `djinn_provider::catalog::CatalogService`, and `djinn-db` must not depend on
+//! `djinn-provider`. It lives here instead — on the provider side of the single
+//! `djinn-provider -> djinn-db` edge, where both halves are in scope.
+
+use djinn_core::events::EventBus;
+use djinn_core::models::ModelLanes;
+use djinn_db::{CredentialRepository, Database, UserRepository, UserSettingsRepository};
+use djinn_provider::catalog::CatalogService;
+
+/// Seed a real `users` row so the `credentials.owner_user_id` FK holds.
+async fn seed_user(db: &Database, github_id: i64, login: &str) -> String {
+    db.ensure_initialized().await.unwrap();
+    UserRepository::new(db.clone())
+        .upsert_from_github(github_id, login, None, None)
+        .await
+        .unwrap()
+        .id
+}
+
+/// Reproduces the exact staging setup: a user who selected `openai/gpt-5.5` and
+/// connected Codex (`chatgpt_codex` OAuth, which merges into `openai`) plus an
+/// org-shared fireworks key. The per-method `#[cfg(test)]` stub means the live
+/// suite never exercises this, so we replicate it inline. The model MUST stay
+/// eligible.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_model_priority_keeps_openai_via_codex_merge() {
+    let db = Database::open_in_memory().unwrap();
+    let uid = seed_user(&db, 9001, "fern").await;
+    let repo = CredentialRepository::new(db.clone(), EventBus::noop());
+    repo.set_with_owner("chatgpt_codex", "__OAUTH_CHATGPT_CODEX", "tok", Some(&uid))
+        .await
+        .unwrap();
+    repo.set_with_owner("fireworks-ai", "FIREWORKS_API_KEY", "fk", None)
+        .await
+        .unwrap();
+    UserSettingsRepository::new(db.clone())
+        .upsert_lanes(
+            &uid,
+            &ModelLanes::from_flat(vec!["openai/gpt-5.5".to_string()]),
+        )
+        .await
+        .unwrap();
+
+    // ── replicate resolve_user_model_priority (implement lane = worker) ──
+    let models = UserSettingsRepository::new(db.clone())
+        .get(&uid)
+        .await
+        .unwrap()
+        .unwrap()
+        .lanes
+        .unwrap()
+        .for_role("worker")
+        .to_vec();
+    let creds = repo.list_for_user(Some(&uid)).await.unwrap();
+    let connected = CatalogService::new().connected_provider_ids(&creds);
+    let result: Vec<String> = models
+        .into_iter()
+        .filter(|m| {
+            let p = m.split_once('/').map(|(p, _)| p).unwrap_or(m.as_str());
+            connected.contains(p)
+        })
+        .collect();
+
+    assert!(
+        connected.contains("openai"),
+        "codex merge should connect openai; connected={connected:?}"
+    );
+    assert_eq!(
+        result,
+        vec!["openai/gpt-5.5".to_string()],
+        "openai/gpt-5.5 must remain eligible; connected={connected:?}"
+    );
+}


### PR DESCRIPTION
## What

Moves `credential.rs` and `custom_provider.rs` from `djinn-provider/src/repos/` into `djinn-db/src/repositories/`, and drops `djinn-provider`'s `sqlx` dependency.

These two files were the last standing violations of `scripts/check-raw-sql-boundary.sh` — "all direct sqlx query calls must go through the djinn-db repository layer" — with 24 and 4 raw sqlx calls respectively. They passed CI only because the guard is diff-scoped and neither file was being touched.

**The guard is untouched.** No exemption was added; in particular no `**/repos/*.rs` pattern, which would have turned a default-deny guard into a naming convention. After this move it passes honestly.

## Why this placement was accidental (git history)

This is the completion of a half-finished refactor, not a design change.

- **`ef02b5104`** ("Move crypto, credential/custom_provider repos, and OAuth to djinn-provider") deliberately moved crypto *and* these two repositories out of `djinn-db` into `djinn-provider`.
- **`4c78658c4`**, committed **73 minutes later the same day**, reverted half of it: it moved `crypto.rs` back to `djinn-db`, with the stated reason —
  > "Moves AES-256-GCM encryption utilities from djinn-provider to djinn-db **so CredentialRepository can access crypto without depending on the provider crate.**"

The crypto half went home. The repository half never followed, and has sat on the wrong side of the boundary since. No ADR defends the current placement, and `dispatch_pause.rs` — the identical shape (repository, `EventBus`, raw sqlx over Postgres) — has always lived in `djinn-db`.

Nothing blocked the move: `djinn-provider -> djinn-db` is the only edge between the crates and `djinn-db` has no path back, and the two files imported nothing from `djinn-provider` outside a single test (see below).

## The sqlx feature bug

`djinn-provider/Cargo.toml` declared:

```toml
sqlx = { version = "0.8", features = ["mysql", "runtime-tokio-rustls", "macros"] }
```

**`mysql`** — while every query in `repos/` is Postgres (`$1` placeholders, `RETURNING`, `ON CONFLICT`). The crate could never have built its own queries on its own declared feature set; it only compiled because `workspace-hack` unifies features workspace-wide.

**What I did:** rather than correct `mysql` -> `postgres`, I removed the dependency entirely. `sqlx` appears nowhere in `djinn-provider` outside `repos/`, so after the move the crate has no use for it at all. `Cargo.lock` shows a one-line change confirming this.

**Not fixed here (out of scope, flagging it):** the same bogus `mysql` feature is declared in `djinn-agent`, `djinn-core`, `djinn-memory`, and the workspace root `Cargo.toml`. So `sqlx-mysql` still gets built workspace-wide and `workspace-hack` is unchanged (`cargo hakari verify` passes). Removing it from `djinn-provider` alone does not drop `sqlx-mysql` from the build — that would need a separate sweep.

## Call sites do not churn

`djinn_provider::repos` is now a documented re-export shim, so all ~37 referencing files are untouched. Every call site uses the flat `repos::CredentialRepository` / `repos::CustomProviderRepository` form; the shim re-exports the module paths too, for completeness.

## One test moved the other way

`user_model_priority_keeps_openai_via_codex_merge` lived in `credential.rs`'s `mod tests` and uses `djinn_provider::catalog::CatalogService`. It could not follow the repository into `djinn-db` without creating the circular dependency that `4c78658c4` explicitly avoided.

It moved in the opposite direction instead, to `djinn-provider/tests/credential_user_model_priority.rs`, where both the repository and the catalog are in scope. Its `seed_user` helper goes through `djinn_db::UserRepository`, not raw SQL, so the relocated test is not a new boundary violation (confirmed by the whole-tree guard run).

**Test count is unchanged:** 18 before (15 in `credential.rs` + 3 in `custom_provider.rs`), 18 after (14 + 3 + 1 relocated).

## Verification

- **Guard, before:** on `origin/main`, `printf ... | sh scripts/check-raw-sql-boundary.sh --files-from-stdin` exits **1**, reporting 24 hits in `credential.rs` and 4 in `custom_provider.rs`.
- **Guard, after:** the moved files pass. Whole-tree run over all 1259 in-scope files: **exit 0**, no violations. CI diff-mode run (`BASE_SHA=origin/main`): exit 0.
- **`.sqlx` did NOT churn.** `git status server/.sqlx` is empty, and `make sqlx-verify` reports `server/.sqlx/ is up to date (408 entries)`. Query hashes are content-keyed, so relocating the source file leaves the cache untouched and no entry is orphaned.
- `cargo check --workspace --all-targets --all-features` clean (via `sqlx-verify`), covering every dependent crate.
- `cargo clippy -p djinn-db -p djinn-provider --all-targets --all-features -- -D warnings` clean.
- `cargo fmt --all --check` clean.
- `cargo hakari verify` — `workspace-hack works correctly`.
- `cargo nextest run -p djinn-db -p djinn-provider --all-features` — **2278 passed, 0 failed**, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
