### PR TITLE
feat(board-health): give the kueue_workload_admission projection a reader (ecrz)

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
+++ b/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
@@ -1066,10 +1066,9 @@ pub struct BoardHealthBuildLease {
 /// The Kueue cutover deleted the pre-create admission ledger, so this is the
 /// only occupancy authority **in this payload**. It is NOT the only gate that
 /// can stop a build: Kueue's ClusterQueue now decides admission, and a Job it
-/// has not admitted stays suspended with nothing recorded in any relation
-/// `board_health` reads. `at_capacity: false` therefore still does not mean a
-/// dispatch can proceed — see `kueue_clusterqueue_admission` in
-/// `BoardHealthDispatchGateCoverage::unevaluated_gates`.
+/// has not admitted stays suspended with nothing recorded in `build_leases`.
+/// `at_capacity: false` therefore still does not mean a dispatch can proceed —
+/// read `BoardHealthKueueAdmission` for what Kueue itself decided.
 #[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct BoardHealthBuildCapacity {
     /// Always `build_leases`, so the payload names its own authority.
@@ -1157,6 +1156,99 @@ pub struct BoardHealthBuildAdmissionDenial {
     pub note: String,
 }
 
+/// One row of the Kueue admission projection (migration 165) — Kueue's own
+/// decision about one build Workload, as the leader's Workload reflector
+/// observed it.
+#[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
+pub struct BoardHealthKueueWorkload {
+    /// The `task_runs.id` the Workload accounts for.
+    pub task_run_id: String,
+    /// `pending`, `admitted` or `finished`. Reversible between the first two:
+    /// Kueue preempts admitted Workloads for quota and re-admits them later.
+    pub admission: String,
+    /// Kueue's own word for the state (`Preempted`, `ClusterQueueStopped`,
+    /// `Deactivated`, ...). `null` is honest — Kueue offered no reason — never
+    /// a stand-in for one that was lost.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// The Workload object name, for `kubectl -n djinn describe workload <name>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workload_name: Option<String>,
+    /// Observed state CHANGES, not observations — a watch resync does not move
+    /// this. A high count on a `pending` row is quota thrash.
+    pub transitions: i64,
+    /// The owning task, when a `task_runs` row exists to tie it to one.
+    ///
+    /// `null` is the NORMAL state of a genuinely-pending Workload: under
+    /// create-then-admit the `task_runs` row is written by the in-pod
+    /// supervisor, which cannot run until Kueue admits the Job. An entry is
+    /// never attributed to a guessed task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_short_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_seen_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<String>,
+    /// Seconds since the Workload was first observed at all.
+    pub first_seen_age_seconds: i64,
+    /// Seconds since the last observation. Small while the reflector is alive.
+    pub observed_age_seconds: i64,
+}
+
+/// What Kueue decided, read from the `kueue_workload_admission` projection.
+///
+/// This is a **different authority** from `BoardHealthBuildCapacity`. Since the
+/// Kueue cutover the ClusterQueue decides build capacity, and a Job it has not
+/// admitted sits suspended with no `build_leases` row at all — so a healthy
+/// `build_capacity` used to be the last word available while the board was
+/// wedged behind a quota nothing recorded. Migration 165 records it; this block
+/// is where it surfaces.
+///
+/// **`projection_state` is the field to read first.** `no_workloads_observed`
+/// means the relation is EMPTY, which is what `kueue.armed=false` — the shipped
+/// default — looks like. It is explicitly not a stalled queue: nothing is
+/// pending. It is equally not proof that Kueue admitted anything, because a
+/// reflector that never started looks identical, which is why
+/// `kueue_clusterqueue_admission` stays in
+/// `BoardHealthDispatchGateCoverage::unevaluated_gates` in that state and moves
+/// to `evaluated_gates` only under `observing`.
+#[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
+pub struct BoardHealthKueueAdmission {
+    /// Always `kueue_workload_admission`, so the payload names its authority.
+    #[serde(default)]
+    pub authority: String,
+    /// `no_workloads_observed` (relation empty) or `observing` (has rows).
+    pub projection_state: String,
+    pub total: i64,
+    /// Build Workloads Kueue has NOT admitted: Jobs suspended behind
+    /// ClusterQueue quota.
+    pub pending: i64,
+    pub admitted: i64,
+    pub finished: i64,
+    /// Rows with no `task_runs` row. Normal rather than alarming — see
+    /// `BoardHealthKueueWorkload::task_id`.
+    pub without_task_run: i64,
+    /// Age of the stalest observation in the relation. A watch resync refreshes
+    /// every row it replays, so a large value means nobody is watching Kueue,
+    /// not that Kueue is idle. `null` when the relation is empty.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stalest_observation_age_seconds: Option<i64>,
+    /// How long the longest-waiting pending Workload has been known about.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oldest_pending_first_seen_age_seconds: Option<i64>,
+    /// Cap on `pending_task_runs`; the counts above it are exact regardless.
+    #[serde(default)]
+    pub pending_entry_limit: i64,
+    /// The head of the pending queue, oldest-known first.
+    #[serde(default)]
+    pub pending_task_runs: Vec<BoardHealthKueueWorkload>,
+    /// Human-readable restatement of the authority boundary.
+    #[serde(default)]
+    pub note: String,
+}
+
 /// What the dispatch-gate verdict actually covers.
 ///
 /// This block exists because an empty `reasons` used to be indistinguishable
@@ -1172,9 +1264,14 @@ pub struct BoardHealthDispatchGateCoverage {
     pub evaluated_gates: Vec<String>,
     /// Gates the dispatcher applies that this section did not consult. Every
     /// entry is a way a task can be left queued while `gate_verdict` is
-    /// `unexplained`. Includes `kueue_clusterqueue_admission`: since the Kueue
-    /// cutover, quota is enforced by a ClusterQueue that leaves no row in any
-    /// relation `board_health` can read.
+    /// `unexplained`.
+    ///
+    /// `kueue_clusterqueue_admission` moves between this list and
+    /// `evaluated_gates` per call. It is here whenever
+    /// `BoardHealthKueueAdmission::projection_state` is not `observing` — an
+    /// empty projection is what both an unarmed cluster and a stopped reflector
+    /// look like from Postgres — and moves to `evaluated_gates` once the
+    /// projection has rows.
     #[serde(default)]
     pub unevaluated_gates: Vec<String>,
     /// Human-readable restatement of the bound, carried in the payload so an
@@ -1225,6 +1322,17 @@ pub struct BoardHealthDispatchGate {
     /// permitted path deletes the row.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build_admission_denial: Option<BoardHealthBuildAdmissionDenial>,
+    /// What Kueue decided, pool-wide. Absent only when the projection could not
+    /// be read — an EMPTY projection is still reported, as
+    /// `projection_state: "no_workloads_observed"`, because "nothing is queued"
+    /// and "nobody looked" are different answers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kueue_admission: Option<BoardHealthKueueAdmission>,
+    /// This task's own Kueue Workload, when the projection has a row that ties
+    /// to a live `task_runs` row for it. A row that cannot be tied to one is
+    /// never attributed here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kueue_workload: Option<BoardHealthKueueWorkload>,
     /// Final gate verdict — `blocked` when an evaluated gate fired,
     /// `unexplained` when none did.
     ///
@@ -1238,7 +1346,8 @@ pub struct BoardHealthDispatchGate {
     pub gate_verdict: Option<String>,
     /// Machine-readable gate reasons (`no_eligible_model`,
     /// `image_not_ready`, `build_lease_queued`, `build_lease_terminal`,
-    /// `build_lease_occupied_without_session`, `build_pool_at_capacity`).
+    /// `build_lease_occupied_without_session`, `build_pool_at_capacity`,
+    /// `kueue_workload_pending`, `kueue_workload_admitted_without_session`).
     /// Always present in the serialized output (may be an empty array) so
     /// clients can rely on the key existing. Read it together with
     /// `coverage`: empty means "no EVALUATED gate fired".

--- a/server/crates/djinn-control-plane/tests/board_tools.rs
+++ b/server/crates/djinn-control-plane/tests/board_tools.rs
@@ -430,6 +430,33 @@ async fn board_health_mcp_legacy_and_additive_fields_coexist() {
     assert!(gate.get("rate_limited").is_some());
     assert!(gate.get("credential_available").is_some());
     assert!(gate.get("reasons").is_some());
+    // The Kueue admission projection must survive the TYPED round-trip — the
+    // DB builds this JSON, `BoardHealthResponse` parses it, and the tool
+    // re-serializes it. A field the type does not model is dropped here rather
+    // than at some later, quieter moment.
+    let kueue = gate
+        .get("kueue_admission")
+        .expect("kueue_admission must reach the MCP payload");
+    assert_eq!(
+        kueue.get("projection_state").and_then(|v| v.as_str()),
+        Some("no_workloads_observed"),
+        "an unarmed test cluster reports the INERT variant, never a pending queue"
+    );
+    assert_eq!(kueue.get("pending").and_then(|v| v.as_i64()), Some(0));
+    assert!(
+        gate.get("kueue_workload").is_none(),
+        "a task with no Workload carries no per-task Kueue block"
+    );
+    let unevaluated = gate
+        .get("coverage")
+        .and_then(|c| c.get("unevaluated_gates"))
+        .and_then(|v| v.as_array())
+        .expect("coverage.unevaluated_gates must be present");
+    assert!(
+        unevaluated.contains(&json!("kueue_clusterqueue_admission")),
+        "an empty projection cannot distinguish an unarmed cluster from a dead \
+         reflector, so the gate stays unevaluated; got {unevaluated:?}"
+    );
     // Threshold ladder.
     let threshold = stranded_finding
         .get("threshold")

--- a/server/crates/djinn-db/src/repositories/task/board_health.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health.rs
@@ -314,6 +314,12 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
     // report a lease/capacity fact instead of an independent guess.
     let lease_ledger = super::board_health_dispatch_gate::load_lease_ledger(pool).await;
 
+    // Kueue's OWN admission decision, from the migration-165 projection. Loaded
+    // once for the whole section for the same reason as the lease ledger, and
+    // cheap in the shipped default: an empty relation costs one aggregate and
+    // short-circuits before the detail queries run.
+    let kueue_projection = super::board_health_kueue_admission::load_kueue_projection(pool).await;
+
     let stranded_sql = r#"SELECT t.id, t.short_id, t.title, t.status, t.updated_at, t.owner,
                   t.epic_id, t.issue_type, t.project_id, t.created_by_user_id,
                   e.short_id AS epic_short_id,
@@ -514,6 +520,7 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
                 row.get::<Option<String>, _>("last_dispatched_role"),
                 cooldown_until,
                 super::board_health_dispatch_gate::lease_gate(&lease_ledger, &task_id),
+                super::board_health_kueue_admission::kueue_gate(&kueue_projection, &task_id),
                 reasons,
             );
 

--- a/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate.rs
@@ -111,12 +111,28 @@
 //! The blind spot the cutover OPENED is that Kueue's ClusterQueue now decides
 //! build capacity, and a Job it has not admitted is queued by Kueue with no row
 //! in any relation this section reads. That is why
-//! `kueue_clusterqueue_admission` is listed in [`UNEVALUATED_GATES`] rather
+//! `kueue_clusterqueue_admission` was listed in [`UNEVALUATED_GATES`] rather
 //! than left for an operator to infer from a healthy-looking `build_capacity`.
+//!
+//! # Closing that blind spot (ecrz)
+//!
+//! It is no longer true that Kueue's decision leaves no row. Migration 165's
+//! `kueue_workload_admission` is a durable projection of what Kueue decided,
+//! written by the leader's Workload reflector, and
+//! [`super::board_health_kueue_admission`] now reads it into a `kueue_admission`
+//! block beside `build_capacity`. `kueue_clusterqueue_admission` therefore moves
+//! between `evaluated_gates` and `unevaluated_gates` at runtime instead of
+//! sitting unconditionally in the latter — but ONLY when the projection holds
+//! rows. Read that module for why an empty relation is deliberately not treated
+//! as an evaluation: it is what a healthy unarmed cluster and a dead reflector
+//! both look like from Postgres, and this section does not emit verdicts it
+//! cannot justify.
 
 use std::collections::HashMap;
 
 use sqlx::Row;
+
+use super::board_health_kueue_admission::{KUEUE_GATE, KueueGateOutcome};
 
 /// Gates the stranded-ready section evaluates from durable state.
 ///
@@ -143,13 +159,11 @@ pub(super) const EVALUATED_GATES: &[&str] = &[
 /// ladder is not listed here because it is process-local state on the leader
 /// and leaves no durable row to enumerate against; when it refuses, the reason
 /// arrives on the persisted denial record instead (`build_admission_denial`).
+///
+/// `kueue_clusterqueue_admission` is deliberately NOT in this list any more: it
+/// is added to whichever list the projection read justifies, per call. See
+/// [`super::board_health_kueue_admission`].
 pub(super) const UNEVALUATED_GATES: &[&str] = &[
-    // The Kueue cutover moved build capacity to a ClusterQueue. A Job Kueue has
-    // not admitted is SUSPENDED by Kueue and leaves no row in any relation this
-    // section reads, so a healthy `build_capacity` block now says strictly less
-    // than it used to. Naming the gap is the only honest option available from
-    // a Postgres read.
-    "kueue_clusterqueue_admission",
     "per_user_lane_concurrency_cap",
     "per_user_model_concurrency_cap",
     "slot_pool_capacity",
@@ -769,9 +783,11 @@ pub(super) fn dispatch_gate_json(
     last_dispatched_role: Option<String>,
     cooldown_until: Option<String>,
     lease: LeaseGateOutcome,
+    kueue: KueueGateOutcome,
     mut reasons: Vec<&'static str>,
 ) -> serde_json::Value {
     reasons.extend(lease.reasons);
+    reasons.extend(kueue.reasons);
 
     let mut evaluated_gates: Vec<&'static str> = EVALUATED_GATES
         .iter()
@@ -779,6 +795,11 @@ pub(super) fn dispatch_gate_json(
         .filter(|gate| lease.evaluated || *gate != "build_lease_admission")
         .filter(|gate| lease.denial_evaluated || *gate != "build_admission_denial")
         .collect();
+    // The one gate whose evaluated/unevaluated status is decided per call: it
+    // depends on whether the projection had anything to say at all.
+    if kueue.evaluated {
+        evaluated_gates.push(KUEUE_GATE);
+    }
     evaluated_gates.sort_unstable();
 
     let mut unevaluated_gates: Vec<&'static str> = UNEVALUATED_GATES.to_vec();
@@ -787,6 +808,9 @@ pub(super) fn dispatch_gate_json(
     }
     if !lease.denial_evaluated {
         unevaluated_gates.push("build_admission_denial");
+    }
+    if !kueue.evaluated {
+        unevaluated_gates.push(KUEUE_GATE);
     }
     unevaluated_gates.sort_unstable();
 
@@ -808,6 +832,8 @@ pub(super) fn dispatch_gate_json(
         "build_lease":          lease.build_lease,
         "build_capacity":       lease.build_capacity,
         "build_admission_denial": lease.build_admission_denial,
+        "kueue_admission":      kueue.kueue_admission,
+        "kueue_workload":       kueue.kueue_workload,
         "gate_verdict":         gate_verdict,
         "reasons":              reasons,
         "coverage": serde_json::json!({
@@ -816,18 +842,22 @@ pub(super) fn dispatch_gate_json(
             "unevaluated_gates": unevaluated_gates,
             "build_lease_unevaluated_detail": lease.unevaluated_detail,
             "build_admission_denial_unevaluated_detail": lease.denial_unevaluated_detail,
+            "kueue_admission_unevaluated_detail": kueue.unevaluated_detail,
             "note": "`reasons` covers only `evaluated_gates`. An empty `reasons` \
                      yields `unexplained`, which means no evaluated gate fired — \
                      NOT that the dispatcher had no reason. `build_capacity` speaks \
-                     for the LEASE ledger alone, and since the Kueue cutover a Job \
-                     can sit suspended behind a ClusterQueue quota that leaves no \
-                     row in any relation read here, so a healthy `build_capacity` \
-                     is not evidence that dispatch is possible. \
+                     for the LEASE ledger alone; what Kueue decided is a separate \
+                     authority and is reported in `kueue_admission`, read from the \
+                     migration-165 projection. \
                      `build_admission_denial` is the dispatcher's OWN recorded \
                      `DenialCause` (#2661, migration 161) — the only field here \
                      that is a decision rather than a re-derivation of one — but \
                      the process that wrote it was deleted by the cutover, so a \
-                     `null` there is the steady state rather than an all-clear.",
+                     `null` there is the steady state rather than an all-clear. \
+                     `kueue_clusterqueue_admission` appears in `evaluated_gates` \
+                     only while the projection holds rows; while it is empty an \
+                     unarmed cluster and a stopped reflector are indistinguishable \
+                     from here, so the gate stays unevaluated.",
         }),
         // Retained for backward compatibility with the initial board_health
         // contract.

--- a/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate_tests.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate_tests.rs
@@ -99,7 +99,10 @@ fn an_empty_kueue_projection_leaves_the_gate_unevaluated() {
     let ledger = observed(Vec::new(), capacity(0, 3, true));
     let gate = gate(&ledger, "task-1");
     assert_eq!(gate["gate_verdict"], VERDICT_UNEXPLAINED);
-    assert_eq!(gate["kueue_admission"]["projection_state"], "no_workloads_observed");
+    assert_eq!(
+        gate["kueue_admission"]["projection_state"],
+        "no_workloads_observed"
+    );
     assert!(gate["kueue_workload"].is_null());
     let unevaluated = gate["coverage"]["unevaluated_gates"].as_array().unwrap();
     assert!(unevaluated.contains(&serde_json::json!("kueue_clusterqueue_admission")));

--- a/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate_tests.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate_tests.rs
@@ -64,6 +64,16 @@ fn denials(entries: Vec<(&str, DenialRow)>) -> Option<HashMap<String, DenialRow>
     )
 }
 
+/// The projection state production ships in: `kueue.armed=false`, no Workload
+/// ever observed. Every lease-focused test below runs against it so the Kueue
+/// block never silently changes what they assert.
+fn inert_kueue() -> KueueGateOutcome {
+    crate::repositories::task::board_health_kueue_admission::kueue_gate(
+        &crate::repositories::task::board_health_kueue_admission::KueueProjection::Inert,
+        "task-1",
+    )
+}
+
 fn gate(ledger: &LeaseLedger, task_id: &str) -> serde_json::Value {
     dispatch_gate_json(
         "worker",
@@ -77,8 +87,65 @@ fn gate(ledger: &LeaseLedger, task_id: &str) -> serde_json::Value {
         None,
         None,
         lease_gate(ledger, task_id),
+        inert_kueue(),
         Vec::new(),
     )
+}
+
+/// While the projection is empty the Kueue gate must be declared UNevaluated
+/// and must contribute no reason: an unarmed cluster is not a stalled one.
+#[test]
+fn an_empty_kueue_projection_leaves_the_gate_unevaluated() {
+    let ledger = observed(Vec::new(), capacity(0, 3, true));
+    let gate = gate(&ledger, "task-1");
+    assert_eq!(gate["gate_verdict"], VERDICT_UNEXPLAINED);
+    assert_eq!(gate["kueue_admission"]["projection_state"], "no_workloads_observed");
+    assert!(gate["kueue_workload"].is_null());
+    let unevaluated = gate["coverage"]["unevaluated_gates"].as_array().unwrap();
+    assert!(unevaluated.contains(&serde_json::json!("kueue_clusterqueue_admission")));
+    let evaluated = gate["coverage"]["evaluated_gates"].as_array().unwrap();
+    assert!(!evaluated.contains(&serde_json::json!("kueue_clusterqueue_admission")));
+}
+
+/// **The gate this reader was written to promote.** With rows in the
+/// projection, `kueue_clusterqueue_admission` moves from `unevaluated_gates` to
+/// `evaluated_gates` — it is no longer a permanent blind spot.
+#[test]
+fn an_observing_projection_promotes_the_kueue_gate_to_evaluated() {
+    let ledger = observed(Vec::new(), capacity(0, 3, true));
+    let kueue = KueueGateOutcome {
+        kueue_admission: serde_json::json!({ "projection_state": "observing" }),
+        kueue_workload: serde_json::json!({ "admission": "pending" }),
+        reasons: vec!["kueue_workload_pending"],
+        evaluated: true,
+        unevaluated_detail: None,
+    };
+    let gate = dispatch_gate_json(
+        "worker",
+        &["task_edit"],
+        None,
+        true,
+        false,
+        false,
+        false,
+        true,
+        None,
+        None,
+        lease_gate(&ledger, "task-1"),
+        kueue,
+        Vec::new(),
+    );
+    assert_eq!(gate["gate_verdict"], VERDICT_BLOCKED);
+    assert!(
+        gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("kueue_workload_pending"))
+    );
+    let evaluated = gate["coverage"]["evaluated_gates"].as_array().unwrap();
+    assert!(evaluated.contains(&serde_json::json!("kueue_clusterqueue_admission")));
+    let unevaluated = gate["coverage"]["unevaluated_gates"].as_array().unwrap();
+    assert!(!unevaluated.contains(&serde_json::json!("kueue_clusterqueue_admission")));
 }
 
 /// The regression this module exists for: a task denied for a capacity /
@@ -192,6 +259,7 @@ fn model_reasons_and_lease_reasons_compose() {
         None,
         None,
         lease_gate(&ledger, "task-1"),
+        inert_kueue(),
         vec!["no_eligible_model"],
     );
     let reasons = gate["reasons"].as_array().unwrap();

--- a/server/crates/djinn-db/src/repositories/task/board_health_kueue_admission.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_kueue_admission.rs
@@ -1,0 +1,421 @@
+//! The dispatch-gate reader for the Kueue admission projection (migration 165).
+//!
+//! # Why this exists
+//!
+//! `kueue_workload_admission` is written by `djinn-server`'s
+//! `kueue_workload_reconcile` Workload reflector and, until this module, was
+//! read by nothing. A written-but-unread projection is not a source of truth:
+//! it is a table that happens to have rows in it. Worse, the Kueue cutover moved
+//! build capacity onto a ClusterQueue, so the one question the board most needs
+//! answered once Kueue is armed — *is this board sitting still because Kueue has
+//! not admitted anything?* — had no durable answer anywhere. On 2026-07-30 the
+//! absence of exactly that surface turned a pod-permit wedge into a ninety
+//! minute diagnosis.
+//!
+//! # The distinction this module refuses to collapse
+//!
+//! Production today runs `kueue.armed=false`: no namespace is Kueue-managed, no
+//! Job is suspended, and there are **zero** Workloads. Reporting that as
+//! "pending" would describe a healthy unarmed cluster as a stalled one, which is
+//! strictly worse than reporting nothing — the operator who lost ninety minutes
+//! did so following a health surface that was confidently wrong, not one that
+//! was silent.
+//!
+//! So the projection has three outcomes here and they are never merged:
+//!
+//! * [`KueueProjection::Unobservable`] — the relation could not be read. Never
+//!   substituted with "no rows"; that substitution is the mistake
+//!   [`super::board_health_dispatch_gate`] exists to undo.
+//! * [`KueueProjection::Inert`] — the relation was read and holds **no rows at
+//!   all**. The reflector only runs when Kueue is armed, on the leader, against
+//!   a Kubernetes runtime, so an empty relation means no build Workload has been
+//!   observed by this deployment. Nothing is queued behind Kueue; this is the
+//!   shipped default and it is NOT a stall.
+//! * [`KueueProjection::Observing`] — the relation holds rows, so the reflector
+//!   has observed at least one Workload and Kueue is in the loop.
+//!
+//! `kueue_clusterqueue_admission` moves from `unevaluated_gates` to
+//! `evaluated_gates` **only** in the `Observing` case. Under `Inert` a dead
+//! reflector (leader failover, no Kubernetes client) is indistinguishable from
+//! an unarmed cluster from a Postgres read, and claiming to have evaluated a
+//! gate whose evidence source might simply not be running is precisely the
+//! "confidently wrong" failure this section was rewritten to remove.
+//!
+//! # Why a pending row usually has no task
+//!
+//! The projection is keyed by `task_runs.id`, but under create-then-admit the
+//! `task_runs` row is created by the **in-pod supervisor** — which does not run
+//! until Kueue admits the Job. So a genuinely-pending Workload structurally has
+//! no `task_runs` row and therefore no task to attribute it to. That is not a
+//! defect of this reader; it is the window the projection exists to make
+//! visible. Such rows are surfaced in `pending_task_runs` with an explicit
+//! `task_id: null`, never attached to a task.
+//!
+//! The consequence for a row whose task-run does not exist — whether it never
+//! did or was deleted underneath it — is that it can never become a phantom
+//! per-task entry: `by_task` is built from an INNER JOIN against `task_runs`, so
+//! an unattributable row contributes to the counts and to `pending_task_runs`
+//! (with a null task) and to nothing else.
+
+use std::collections::HashMap;
+
+use sqlx::Row;
+
+/// The dispatcher gate this reader answers for, named identically to the entry
+/// [`super::board_health_dispatch_gate::UNEVALUATED_GATES`] used to carry
+/// unconditionally.
+pub(super) const KUEUE_GATE: &str = "kueue_clusterqueue_admission";
+
+/// How many pending entries travel in the payload.
+///
+/// The block is emitted once per stranded finding, so an unbounded list would
+/// multiply. Ten is enough to name the head of a queue; the counts above it are
+/// exact regardless.
+const MAX_PENDING_ENTRIES: i64 = 10;
+
+/// Pool-wide counts over the whole projection.
+#[derive(Clone, Debug)]
+pub(super) struct KueueSummary {
+    pub total: i64,
+    pub pending: i64,
+    pub admitted: i64,
+    pub finished: i64,
+    /// Rows with no `task_runs` row. Under create-then-admit this is the normal
+    /// state of every genuinely-pending Workload, not an anomaly.
+    pub without_task_run: i64,
+    /// Age of the STALEST `observed_at` in the relation.
+    ///
+    /// A Kubernetes watch resync refreshes `observed_at` on every row it
+    /// replays, so this is small while the reflector is alive and grows without
+    /// bound once it stops. It is the only signal available from Postgres that
+    /// distinguishes "Kueue is watching and nothing changed" from "nobody has
+    /// looked at Kueue since the last leader died".
+    pub stalest_observation_age_seconds: Option<i64>,
+    /// Age of the oldest `first_seen_at` among PENDING rows: how long the
+    /// longest-waiting Workload has been known about at all.
+    pub oldest_pending_first_seen_age_seconds: Option<i64>,
+}
+
+/// One projection row, with its task attribution when one exists.
+#[derive(Clone, Debug)]
+pub(super) struct KueueAdmissionRow {
+    pub task_run_id: String,
+    /// `pending`, `admitted` or `finished`.
+    pub admission: String,
+    /// Kueue's own word for the state, when it gave one.
+    pub reason: Option<String>,
+    pub workload_name: Option<String>,
+    /// Observed state CHANGES, not observations — a watch resync does not move
+    /// this. A high count on a `pending` row is quota thrash.
+    pub transitions: i64,
+    /// `null` when no `task_runs` row exists for `task_run_id`.
+    pub task_id: Option<String>,
+    pub task_short_id: Option<String>,
+    pub first_seen_at: Option<String>,
+    pub observed_at: Option<String>,
+    pub first_seen_age_seconds: i64,
+    pub observed_age_seconds: i64,
+}
+
+impl KueueAdmissionRow {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "task_run_id":            self.task_run_id,
+            "admission":              self.admission,
+            "reason":                 self.reason,
+            "workload_name":          self.workload_name,
+            "transitions":            self.transitions,
+            "task_id":                self.task_id,
+            "task_short_id":          self.task_short_id,
+            "first_seen_at":          self.first_seen_at,
+            "observed_at":            self.observed_at,
+            "first_seen_age_seconds": self.first_seen_age_seconds,
+            "observed_age_seconds":   self.observed_age_seconds,
+        })
+    }
+}
+
+/// What this section managed to learn about `kueue_workload_admission`.
+#[derive(Clone, Debug)]
+pub(super) enum KueueProjection {
+    /// The relation could not be read. Deliberately not "no rows".
+    Unobservable { detail: &'static str },
+    /// Read, and empty. No Workload has ever been observed by this deployment.
+    Inert,
+    /// Read, and non-empty: the reflector has seen Kueue decide something.
+    Observing {
+        summary: KueueSummary,
+        /// The head of the pending queue, oldest first. Includes rows with no
+        /// task attribution, which is what a genuinely-pending Workload looks
+        /// like.
+        pending: Vec<KueueAdmissionRow>,
+        /// Newest projection row per task, for rows that join to a live
+        /// `task_runs` row. An unattributable row is absent by construction.
+        by_task: HashMap<String, KueueAdmissionRow>,
+    },
+}
+
+/// Read the projection once for the whole board-health section.
+///
+/// The empty case costs exactly one aggregate query — which is the case
+/// production is in today — and only a non-empty relation pays for the detail
+/// queries.
+pub(super) async fn load_kueue_projection(pool: &sqlx::PgPool) -> KueueProjection {
+    let summary_sql = r"SELECT
+             COUNT(*)::BIGINT AS total,
+             COUNT(*) FILTER (WHERE k.admission = 'pending')::BIGINT   AS pending,
+             COUNT(*) FILTER (WHERE k.admission = 'admitted')::BIGINT  AS admitted,
+             COUNT(*) FILTER (WHERE k.admission = 'finished')::BIGINT  AS finished,
+             COUNT(*) FILTER (
+                 WHERE NOT EXISTS (SELECT 1 FROM task_runs r WHERE r.id = k.task_run_id)
+             )::BIGINT AS without_task_run,
+             FLOOR(EXTRACT(EPOCH FROM (now() - MIN(k.observed_at))))::BIGINT
+                 AS stalest_observation_age_seconds,
+             FLOOR(EXTRACT(EPOCH FROM (
+                 now() - MIN(k.first_seen_at) FILTER (WHERE k.admission = 'pending')
+             )))::BIGINT AS oldest_pending_first_seen_age_seconds
+           FROM kueue_workload_admission k";
+
+    let Ok(summary_row) = sqlx::query(summary_sql).fetch_one(pool).await else {
+        return KueueProjection::Unobservable {
+            detail: "kueue_workload_admission could not be read",
+        };
+    };
+
+    let summary = KueueSummary {
+        total: summary_row.try_get("total").unwrap_or(0),
+        pending: summary_row.try_get("pending").unwrap_or(0),
+        admitted: summary_row.try_get("admitted").unwrap_or(0),
+        finished: summary_row.try_get("finished").unwrap_or(0),
+        without_task_run: summary_row.try_get("without_task_run").unwrap_or(0),
+        stalest_observation_age_seconds: summary_row
+            .try_get("stalest_observation_age_seconds")
+            .ok()
+            .flatten(),
+        oldest_pending_first_seen_age_seconds: summary_row
+            .try_get("oldest_pending_first_seen_age_seconds")
+            .ok()
+            .flatten(),
+    };
+
+    if summary.total == 0 {
+        return KueueProjection::Inert;
+    }
+
+    let Some(pending) = load_pending(pool).await else {
+        return KueueProjection::Unobservable {
+            detail: "kueue_workload_admission pending rows could not be read",
+        };
+    };
+    let Some(by_task) = load_by_task(pool).await else {
+        return KueueProjection::Unobservable {
+            detail: "kueue_workload_admission could not be joined to task_runs",
+        };
+    };
+
+    KueueProjection::Observing {
+        summary,
+        pending,
+        by_task,
+    }
+}
+
+/// Common projection columns, with the task attribution LEFT-joined on.
+const ROW_COLUMNS: &str = r#"k.task_run_id,
+        k.admission,
+        k.reason,
+        k.workload_name,
+        k.transitions::BIGINT AS transitions,
+        r.task_id,
+        t.short_id AS task_short_id,
+        to_char(k.first_seen_at AT TIME ZONE 'utc',
+                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS first_seen_at,
+        to_char(k.observed_at AT TIME ZONE 'utc',
+                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS observed_at,
+        FLOOR(EXTRACT(EPOCH FROM (now() - k.first_seen_at)))::BIGINT AS first_seen_age_seconds,
+        FLOOR(EXTRACT(EPOCH FROM (now() - k.observed_at)))::BIGINT   AS observed_age_seconds"#;
+
+fn row_from(row: &sqlx::postgres::PgRow) -> Option<KueueAdmissionRow> {
+    Some(KueueAdmissionRow {
+        task_run_id: row.try_get("task_run_id").ok()?,
+        admission: row.try_get("admission").ok()?,
+        reason: row.try_get("reason").ok().flatten(),
+        workload_name: row.try_get("workload_name").ok().flatten(),
+        transitions: row.try_get("transitions").unwrap_or(0),
+        task_id: row.try_get("task_id").ok().flatten(),
+        task_short_id: row.try_get("task_short_id").ok().flatten(),
+        first_seen_at: row.try_get("first_seen_at").ok().flatten(),
+        observed_at: row.try_get("observed_at").ok().flatten(),
+        first_seen_age_seconds: row.try_get("first_seen_age_seconds").unwrap_or(0),
+        observed_age_seconds: row.try_get("observed_age_seconds").unwrap_or(0),
+    })
+}
+
+/// The head of the pending queue, oldest-known first.
+///
+/// LEFT JOIN, deliberately: a pending Workload whose Job has never been admitted
+/// has no `task_runs` row and dropping it here would hide the exact population
+/// this projection exists to expose.
+async fn load_pending(pool: &sqlx::PgPool) -> Option<Vec<KueueAdmissionRow>> {
+    let sql = format!(
+        "SELECT {ROW_COLUMNS}
+           FROM kueue_workload_admission k
+           LEFT JOIN task_runs r ON r.id = k.task_run_id
+           LEFT JOIN tasks t     ON t.id = r.task_id
+          WHERE k.admission = 'pending'
+          ORDER BY k.first_seen_at ASC
+          LIMIT {MAX_PENDING_ENTRIES}"
+    );
+    let rows = sqlx::query(&sql).fetch_all(pool).await.ok()?;
+    Some(rows.iter().filter_map(row_from).collect())
+}
+
+/// Newest projection row per task.
+///
+/// INNER JOIN, equally deliberately: this map is what a task's `dispatch_gate`
+/// claims about ITS OWN Workload, so a row that cannot be tied to a live
+/// `task_runs` row must not reach it. That is the whole phantom-entry
+/// protection — an orphaned projection row is counted and listed, and attributed
+/// to nobody.
+async fn load_by_task(pool: &sqlx::PgPool) -> Option<HashMap<String, KueueAdmissionRow>> {
+    let sql = format!(
+        "SELECT DISTINCT ON (r.task_id) {ROW_COLUMNS}
+           FROM kueue_workload_admission k
+           JOIN task_runs r ON r.id = k.task_run_id
+           LEFT JOIN tasks t ON t.id = r.task_id
+          ORDER BY r.task_id, k.observed_at DESC"
+    );
+    let rows = sqlx::query(&sql).fetch_all(pool).await.ok()?;
+    Some(
+        rows.iter()
+            .filter_map(|row| {
+                let parsed = row_from(row)?;
+                let task_id = parsed.task_id.clone()?;
+                Some((task_id, parsed))
+            })
+            .collect(),
+    )
+}
+
+/// Result of applying the Kueue admission gate to one task.
+pub(super) struct KueueGateOutcome {
+    /// Pool-wide projection state as JSON, or `null` when it was unreadable.
+    pub kueue_admission: serde_json::Value,
+    /// This task's own projection row as JSON, or `null` when it has none.
+    pub kueue_workload: serde_json::Value,
+    /// Machine-readable reasons contributed by this gate.
+    pub reasons: Vec<&'static str>,
+    /// True only under [`KueueProjection::Observing`]. See the module docs for
+    /// why an empty relation does NOT count as an evaluation.
+    pub evaluated: bool,
+    /// Why the gate could not be evaluated, surfaced in `coverage`.
+    pub unevaluated_detail: Option<&'static str>,
+}
+
+/// Apply the Kueue admission gate to one task.
+pub(super) fn kueue_gate(projection: &KueueProjection, task_id: &str) -> KueueGateOutcome {
+    match projection {
+        KueueProjection::Unobservable { detail } => KueueGateOutcome {
+            kueue_admission: serde_json::Value::Null,
+            kueue_workload: serde_json::Value::Null,
+            reasons: Vec::new(),
+            evaluated: false,
+            unevaluated_detail: Some(detail),
+        },
+        KueueProjection::Inert => KueueGateOutcome {
+            kueue_admission: serde_json::json!({
+                "authority":        "kueue_workload_admission",
+                "projection_state": "no_workloads_observed",
+                "total":            0,
+                "pending":          0,
+                "admitted":         0,
+                "finished":         0,
+                "without_task_run": 0,
+                "stalest_observation_age_seconds": serde_json::Value::Null,
+                "oldest_pending_first_seen_age_seconds": serde_json::Value::Null,
+                "pending_task_runs": serde_json::Value::Array(Vec::new()),
+                "note": "The Kueue admission projection (migration 165) holds NO rows. Its \
+                         only writer is the leader's Workload reflector, which does not start \
+                         unless Kueue is armed against a Kubernetes runtime, so an empty \
+                         relation means this deployment has observed no build Workload at \
+                         all. That is the shipped default (`kueue.armed=false`) and it is \
+                         explicitly NOT a stalled queue: nothing is pending. It is also not \
+                         proof that Kueue admitted anything — a reflector that never started, \
+                         or stopped, looks identical from here, which is why \
+                         `kueue_clusterqueue_admission` stays in `unevaluated_gates` in this \
+                         state.",
+            }),
+            kueue_workload: serde_json::Value::Null,
+            reasons: Vec::new(),
+            evaluated: false,
+            unevaluated_detail: Some(
+                "kueue_workload_admission holds no rows: Kueue is unarmed, or armed and has \
+                 observed no Workload, and the two are indistinguishable from Postgres",
+            ),
+        },
+        KueueProjection::Observing {
+            summary,
+            pending,
+            by_task,
+        } => {
+            let mine = by_task.get(task_id);
+            let mut reasons: Vec<&'static str> = Vec::new();
+            if let Some(row) = mine {
+                match row.admission.as_str() {
+                    // Kueue has this task's Workload queued: the Job is
+                    // suspended behind ClusterQueue quota. This is the reason
+                    // that had no durable source at all before migration 165.
+                    "pending" => reasons.push("kueue_workload_pending"),
+                    // The Workload was admitted but the task is still stranded
+                    // with no running session, so the run behind it is gone.
+                    // Reported, because a projection that says "admitted" for a
+                    // task nothing is running is the tombstone shape of #2661.
+                    "admitted" => reasons.push("kueue_workload_admitted_without_session"),
+                    _ => {}
+                }
+            }
+
+            let kueue_admission = serde_json::json!({
+                "authority":        "kueue_workload_admission",
+                "projection_state": "observing",
+                "total":            summary.total,
+                "pending":          summary.pending,
+                "admitted":         summary.admitted,
+                "finished":         summary.finished,
+                "without_task_run": summary.without_task_run,
+                "stalest_observation_age_seconds": summary.stalest_observation_age_seconds,
+                "oldest_pending_first_seen_age_seconds":
+                    summary.oldest_pending_first_seen_age_seconds,
+                "pending_entry_limit": MAX_PENDING_ENTRIES,
+                "pending_task_runs": pending
+                    .iter()
+                    .map(KueueAdmissionRow::to_json)
+                    .collect::<Vec<_>>(),
+                "note": "Kueue's OWN admission decision as the leader's Workload reflector \
+                         observed it (migration 165). `pending` is the number of build \
+                         Workloads Kueue has NOT admitted — Jobs sitting suspended behind \
+                         ClusterQueue quota, which leave no row in `build_leases` and used to \
+                         leave no trace anywhere. `without_task_run` is normal rather than \
+                         alarming: under create-then-admit the `task_runs` row is written by \
+                         the in-pod supervisor, which cannot run until Kueue admits, so a \
+                         genuinely-pending Workload has no task to attribute it to and is \
+                         listed with `task_id: null`. `stalest_observation_age_seconds` is \
+                         the liveness check on the reflector itself: a watch resync refreshes \
+                         every row it replays, so a large value means nobody is watching \
+                         Kueue rather than that Kueue is idle.",
+            });
+
+            KueueGateOutcome {
+                kueue_admission,
+                kueue_workload: mine.map_or(serde_json::Value::Null, KueueAdmissionRow::to_json),
+                reasons,
+                evaluated: true,
+                unevaluated_detail: None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "board_health_kueue_admission_tests.rs"]
+mod tests;

--- a/server/crates/djinn-db/src/repositories/task/board_health_kueue_admission_tests.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_kueue_admission_tests.rs
@@ -1,0 +1,146 @@
+//! Pure unit coverage for the Kueue admission gate's decision logic.
+//!
+//! The database-backed non-vacuity proofs live in
+//! `djinn-db/tests/task_tests/board_health_kueue_admission.rs`; these pin the
+//! three-way outcome that must never collapse into two.
+
+use super::*;
+
+fn row(task_run_id: &str, admission: &str, task_id: Option<&str>) -> KueueAdmissionRow {
+    KueueAdmissionRow {
+        task_run_id: task_run_id.to_owned(),
+        admission: admission.to_owned(),
+        reason: Some("Preempted".to_owned()),
+        workload_name: Some(format!("job-{task_run_id}")),
+        transitions: 3,
+        task_id: task_id.map(ToOwned::to_owned),
+        task_short_id: task_id.map(|_| "ab12".to_owned()),
+        first_seen_at: Some("2026-07-30T00:00:00.000Z".to_owned()),
+        observed_at: Some("2026-07-30T00:10:00.000Z".to_owned()),
+        first_seen_age_seconds: 900,
+        observed_age_seconds: 4,
+    }
+}
+
+fn observing(rows: Vec<KueueAdmissionRow>) -> KueueProjection {
+    let summary = KueueSummary {
+        total: rows.len() as i64,
+        pending: rows.iter().filter(|r| r.admission == "pending").count() as i64,
+        admitted: rows.iter().filter(|r| r.admission == "admitted").count() as i64,
+        finished: rows.iter().filter(|r| r.admission == "finished").count() as i64,
+        without_task_run: rows.iter().filter(|r| r.task_id.is_none()).count() as i64,
+        stalest_observation_age_seconds: Some(4),
+        oldest_pending_first_seen_age_seconds: Some(900),
+    };
+    let pending = rows
+        .iter()
+        .filter(|r| r.admission == "pending")
+        .cloned()
+        .collect();
+    let by_task = rows
+        .into_iter()
+        .filter_map(|r| r.task_id.clone().map(|id| (id, r)))
+        .collect();
+    KueueProjection::Observing {
+        summary,
+        pending,
+        by_task,
+    }
+}
+
+/// **AC2, in isolation.** An empty projection is the shipped default and must
+/// never read as a queued Workload.
+#[test]
+fn an_empty_projection_is_inert_and_never_pending() {
+    let outcome = kueue_gate(&KueueProjection::Inert, "task-1");
+    assert_eq!(
+        outcome.kueue_admission["projection_state"],
+        "no_workloads_observed"
+    );
+    assert_eq!(outcome.kueue_admission["pending"], 0);
+    assert!(
+        outcome.reasons.is_empty(),
+        "an unarmed cluster must contribute no dispatch reason, got {:?}",
+        outcome.reasons
+    );
+    assert!(
+        !outcome.evaluated,
+        "an empty relation cannot distinguish an unarmed cluster from a dead reflector, so the \
+         gate is NOT evaluated"
+    );
+    assert!(outcome.unevaluated_detail.is_some());
+}
+
+/// An unreadable relation must not be laundered into "no rows".
+#[test]
+fn an_unreadable_projection_is_not_an_empty_one() {
+    let outcome = kueue_gate(
+        &KueueProjection::Unobservable { detail: "boom" },
+        "task-1",
+    );
+    assert!(outcome.kueue_admission.is_null());
+    assert!(!outcome.evaluated);
+    assert_eq!(outcome.unevaluated_detail, Some("boom"));
+}
+
+/// A pending Workload for THIS task is a blocking reason.
+#[test]
+fn a_pending_workload_for_this_task_blocks() {
+    let outcome = kueue_gate(&observing(vec![row("run-1", "pending", Some("task-1"))]), "task-1");
+    assert!(outcome.evaluated);
+    assert_eq!(outcome.reasons, vec!["kueue_workload_pending"]);
+    assert_eq!(outcome.kueue_workload["admission"], "pending");
+    assert_eq!(outcome.kueue_admission["projection_state"], "observing");
+}
+
+/// The same projection, the other direction: an admitted Workload does not
+/// contribute the pending reason.
+#[test]
+fn an_admitted_workload_does_not_report_pending() {
+    let outcome = kueue_gate(
+        &observing(vec![row("run-1", "admitted", Some("task-1"))]),
+        "task-1",
+    );
+    assert_eq!(outcome.kueue_workload["admission"], "admitted");
+    assert!(
+        !outcome.reasons.contains(&"kueue_workload_pending"),
+        "an admitted Workload is not queued, got {:?}",
+        outcome.reasons
+    );
+}
+
+/// **AC3, in isolation.** A row with no task attribution is counted and listed
+/// but never becomes another task's evidence.
+#[test]
+fn an_unattributed_row_never_becomes_a_task_entry() {
+    let projection = observing(vec![
+        row("orphan-run", "pending", None),
+        row("run-1", "admitted", Some("task-1")),
+    ]);
+    let outcome = kueue_gate(&projection, "task-1");
+    assert_eq!(
+        outcome.kueue_workload["task_run_id"], "run-1",
+        "task-1 must see its OWN row, never the unattributed one"
+    );
+    assert!(
+        !outcome.reasons.contains(&"kueue_workload_pending"),
+        "an unattributed pending row must not strand a different task"
+    );
+
+    // A task with no row of its own sees no per-task block at all.
+    let other = kueue_gate(&projection, "task-2");
+    assert!(
+        other.kueue_workload.is_null(),
+        "an unattributed row must not attach itself to an unrelated task"
+    );
+
+    let listed = outcome.kueue_admission["pending_task_runs"]
+        .as_array()
+        .expect("pending_task_runs is an array");
+    assert_eq!(listed.len(), 1);
+    assert!(
+        listed[0]["task_id"].is_null(),
+        "an unattributable pending Workload is listed with a null task, never invented one"
+    );
+    assert_eq!(outcome.kueue_admission["without_task_run"], 1);
+}

--- a/server/crates/djinn-db/src/repositories/task/board_health_kueue_admission_tests.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_kueue_admission_tests.rs
@@ -74,10 +74,7 @@ fn an_empty_projection_is_inert_and_never_pending() {
 /// An unreadable relation must not be laundered into "no rows".
 #[test]
 fn an_unreadable_projection_is_not_an_empty_one() {
-    let outcome = kueue_gate(
-        &KueueProjection::Unobservable { detail: "boom" },
-        "task-1",
-    );
+    let outcome = kueue_gate(&KueueProjection::Unobservable { detail: "boom" }, "task-1");
     assert!(outcome.kueue_admission.is_null());
     assert!(!outcome.evaluated);
     assert_eq!(outcome.unevaluated_detail, Some("boom"));
@@ -86,7 +83,10 @@ fn an_unreadable_projection_is_not_an_empty_one() {
 /// A pending Workload for THIS task is a blocking reason.
 #[test]
 fn a_pending_workload_for_this_task_blocks() {
-    let outcome = kueue_gate(&observing(vec![row("run-1", "pending", Some("task-1"))]), "task-1");
+    let outcome = kueue_gate(
+        &observing(vec![row("run-1", "pending", Some("task-1"))]),
+        "task-1",
+    );
     assert!(outcome.evaluated);
     assert_eq!(outcome.reasons, vec!["kueue_workload_pending"]);
     assert_eq!(outcome.kueue_workload["admission"], "pending");

--- a/server/crates/djinn-db/src/repositories/task/mod.rs
+++ b/server/crates/djinn-db/src/repositories/task/mod.rs
@@ -13,6 +13,7 @@ mod activity;
 mod blockers;
 mod board_health;
 mod board_health_dispatch_gate;
+mod board_health_kueue_admission;
 mod board_health_stalled_epics;
 mod ci;
 mod generation;

--- a/server/crates/djinn-db/tests/task_tests.rs
+++ b/server/crates/djinn-db/tests/task_tests.rs
@@ -18,6 +18,8 @@ pub(crate) use tokio::sync::broadcast;
 mod board_health;
 #[path = "task_tests/board_health_dispatch_gate.rs"]
 mod board_health_dispatch_gate;
+#[path = "task_tests/board_health_kueue_admission.rs"]
+mod board_health_kueue_admission;
 #[path = "task_tests/closed_task_sync.rs"]
 mod closed_task_sync;
 #[path = "task_tests/existing.rs"]

--- a/server/crates/djinn-db/tests/task_tests/board_health_kueue_admission.rs
+++ b/server/crates/djinn-db/tests/task_tests/board_health_kueue_admission.rs
@@ -1,0 +1,377 @@
+//! Database-backed proof that the `kueue_workload_admission` projection has a
+//! real reader.
+//!
+//! Every assertion here runs against a live Postgres and a real
+//! `board_health()` call. The failure mode being guarded is the one that made
+//! this task exist: a projection that is written and never read, or read by
+//! something that returns a constant and therefore cannot be wrong.
+
+use super::*;
+
+use djinn_db::KueueWorkloadAdmissionRepository;
+
+/// Seed a stranded open task in its own project, backdated past the threshold.
+async fn stranded_task(db: &Database, repo: &TaskRepository, title: &str) -> Task {
+    let project = create_test_project(db).await;
+    let epic = create_test_epic(db, &project.id).await;
+    let task = repo
+        .create_fixture_in_project(
+            &project.id,
+            Some(&epic.id),
+            title,
+            "desc",
+            "design",
+            "task",
+            1,
+            "worker",
+            Some("open"),
+            None,
+        )
+        .await
+        .unwrap();
+    backdate_task_updated_at(db, &task.id, "600 minutes").await;
+    task
+}
+
+/// Create the `task_runs` row the in-pod supervisor would write once Kueue
+/// admitted the Job, and return its id.
+async fn seed_task_run(db: &Database, task_id: &str) -> String {
+    let project_id: String = sqlx::query_scalar("SELECT project_id FROM tasks WHERE id = $1")
+        .bind(task_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    let task_run_id = uuid::Uuid::now_v7().to_string();
+    sqlx::query(
+        "INSERT INTO task_runs (id, project_id, task_id, trigger_type, status) \
+         VALUES ($1, $2, $3, 'dispatch', 'running')",
+    )
+    .bind(&task_run_id)
+    .bind(&project_id)
+    .bind(task_id)
+    .execute(db.pool())
+    .await
+    .unwrap();
+    task_run_id
+}
+
+/// Move a projection row's admission state with a direct database write, the
+/// way Kueue's reflector would, and the way an operator would to check whether
+/// anything is actually reading it.
+async fn set_admission(db: &Database, task_run_id: &str, admission: &str) {
+    let updated = sqlx::query(
+        "UPDATE kueue_workload_admission SET admission = $2, observed_at = now() \
+         WHERE task_run_id = $1",
+    )
+    .bind(task_run_id)
+    .bind(admission)
+    .execute(db.pool())
+    .await
+    .unwrap()
+    .rows_affected();
+    assert_eq!(updated, 1, "the projection row must exist to be flipped");
+}
+
+async fn gate_for(repo: &TaskRepository, task_id: &str) -> serde_json::Value {
+    let report = repo.board_health(24).await.unwrap();
+    report["stranded_ready"]["findings"]
+        .as_array()
+        .expect("stranded_ready.findings is an array")
+        .iter()
+        .find(|f| f["id"] == task_id)
+        .unwrap_or_else(|| panic!("task {task_id} must appear as stranded"))["dispatch_gate"]
+        .clone()
+}
+
+/// **AC1 — non-vacuity, both directions.**
+///
+/// A reader that returns a constant, or that always reports `null`, passes any
+/// single-state assertion. So the row is flipped `pending` → `admitted` →
+/// `pending` against a live database and the surfaced value is asserted to move
+/// with it every time, including the `reasons` list and the final verdict.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_surfaced_admission_state_follows_the_row_in_both_directions() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Waiting on Kueue").await;
+    let task_run_id = seed_task_run(&db, &task.id).await;
+
+    KueueWorkloadAdmissionRepository::new(db.clone())
+        .apply(&task_run_id, "pending", Some("Preempted"), Some("wl-1"))
+        .await
+        .unwrap();
+
+    // ── pending ────────────────────────────────────────────────────────────
+    let gate = gate_for(&repo, &task.id).await;
+    assert_eq!(
+        gate["kueue_workload"]["admission"], "pending",
+        "the gate must report the row's actual state, got {:?}",
+        gate["kueue_workload"]
+    );
+    assert_eq!(gate["kueue_workload"]["task_run_id"], task_run_id);
+    assert_eq!(gate["kueue_workload"]["reason"], "Preempted");
+    assert_eq!(gate["kueue_workload"]["workload_name"], "wl-1");
+    assert_eq!(gate["kueue_admission"]["projection_state"], "observing");
+    assert_eq!(gate["kueue_admission"]["pending"], 1);
+    assert_eq!(gate["kueue_admission"]["admitted"], 0);
+    assert!(
+        gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("kueue_workload_pending")),
+        "a Workload Kueue has not admitted is a named blocking reason, got {:?}",
+        gate["reasons"]
+    );
+    assert_eq!(gate["gate_verdict"], "blocked");
+
+    // ── admitted ───────────────────────────────────────────────────────────
+    set_admission(&db, &task_run_id, "admitted").await;
+    let gate = gate_for(&repo, &task.id).await;
+    assert_eq!(
+        gate["kueue_workload"]["admission"], "admitted",
+        "the surfaced value must move when the row moves"
+    );
+    assert_eq!(gate["kueue_admission"]["pending"], 0);
+    assert_eq!(gate["kueue_admission"]["admitted"], 1);
+    assert!(
+        gate["kueue_admission"]["pending_task_runs"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "nothing is pending once the Workload is admitted"
+    );
+    assert!(
+        !gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("kueue_workload_pending")),
+        "an admitted Workload must not keep reporting a queue"
+    );
+
+    // ── and back, because a one-way reader is still a broken one ───────────
+    set_admission(&db, &task_run_id, "pending").await;
+    let gate = gate_for(&repo, &task.id).await;
+    assert_eq!(gate["kueue_workload"]["admission"], "pending");
+    assert_eq!(gate["kueue_admission"]["pending"], 1);
+    assert_eq!(gate["kueue_admission"]["admitted"], 0);
+    assert!(
+        gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("kueue_workload_pending")),
+        "a re-queued Workload — Kueue preempting an admitted build — must reappear"
+    );
+}
+
+/// **AC2 — the inert case is not a stall.**
+///
+/// Production runs `kueue.armed=false`: no namespace is Kueue-managed, the
+/// reflector never starts, and the projection is empty. Reporting that as
+/// pending would describe a healthy cluster as a wedged one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unarmed_deployment_reports_the_inert_variant_not_pending() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Nothing to do with Kueue").await;
+
+    // No reflector has run, because `kueue.armed=false` is what production
+    // ships: the relation is empty exactly as it is today.
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM kueue_workload_admission")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(
+        rows, 0,
+        "the fixture must reproduce the unarmed steady state"
+    );
+
+    let gate = gate_for(&repo, &task.id).await;
+    assert_eq!(
+        gate["kueue_admission"]["projection_state"], "no_workloads_observed",
+        "an empty projection is the INERT variant"
+    );
+    assert_eq!(gate["kueue_admission"]["pending"], 0);
+    assert!(gate["kueue_workload"].is_null());
+    assert!(
+        !gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("kueue_workload_pending")),
+        "an unarmed cluster must never contribute a pending reason, got {:?}",
+        gate["reasons"]
+    );
+    assert_eq!(
+        gate["gate_verdict"], "unexplained",
+        "nothing about Kueue explains this task, and the gate must not pretend otherwise"
+    );
+
+    // And the gate is honestly declared unevaluated: a reflector that never
+    // started and an unarmed cluster are the same empty relation from here.
+    let unevaluated = gate["coverage"]["unevaluated_gates"].as_array().unwrap();
+    assert!(
+        unevaluated.contains(&serde_json::json!("kueue_clusterqueue_admission")),
+        "got {unevaluated:?}"
+    );
+    assert!(
+        gate["coverage"]["kueue_admission_unevaluated_detail"]
+            .as_str()
+            .is_some_and(|d| d.contains("no rows")),
+        "the reason the gate was not evaluated must travel with the payload"
+    );
+}
+
+/// **AC3 — no phantom entries.**
+///
+/// A projection row whose `task_runs` row does not exist must never be
+/// attributed to a task. The counts still see it — it is a real Workload — but
+/// no task's `dispatch_gate` may claim it, and the listed entry carries a null
+/// task rather than an invented one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_projection_row_with_no_task_run_is_attributed_to_nobody() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Innocent bystander").await;
+
+    // A task-run id that no `task_runs` row has ever had.
+    let orphan_run = uuid::Uuid::now_v7().to_string();
+    KueueWorkloadAdmissionRepository::new(db.clone())
+        .apply(&orphan_run, "pending", Some("Preempted"), Some("wl-orphan"))
+        .await
+        .unwrap();
+
+    let gate = gate_for(&repo, &task.id).await;
+    assert!(
+        gate["kueue_workload"].is_null(),
+        "an unattributable row must not attach itself to an unrelated task, got {:?}",
+        gate["kueue_workload"]
+    );
+    assert!(
+        !gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("kueue_workload_pending")),
+        "a task with no Workload of its own must not inherit somebody else's queue"
+    );
+    assert_eq!(
+        gate["gate_verdict"], "unexplained",
+        "an orphan row is not an explanation for this task"
+    );
+
+    // Not silently dropped either: it is a real pending Workload, counted and
+    // listed with an explicitly null task.
+    assert_eq!(gate["kueue_admission"]["pending"], 1);
+    assert_eq!(gate["kueue_admission"]["without_task_run"], 1);
+    let listed = gate["kueue_admission"]["pending_task_runs"]
+        .as_array()
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["task_run_id"], orphan_run);
+    assert!(
+        listed[0]["task_id"].is_null() && listed[0]["task_short_id"].is_null(),
+        "the entry must decline to name a task rather than guess one, got {:?}",
+        listed[0]
+    );
+}
+
+/// **AC4 — the surface depends on the projection and on nothing else.**
+///
+/// Everything else this task could be blocked on is explicitly clean: the lease
+/// authority is armed with spare capacity, there is no dispatch lease row, no
+/// recorded denial, a healthy credential and no chosen model. The ONLY thing
+/// that can produce a `blocked` verdict is the projection read. Delete the row
+/// and the same board-health call returns `unexplained`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_verdict_is_carried_by_the_projection_alone() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Only Kueue can explain this").await;
+    let task_run_id = seed_task_run(&db, &task.id).await;
+
+    // An armed, NOT-full lease pool: the other durable authority has nothing to
+    // say about this task.
+    sqlx::query("UPDATE admission_handoff SET v1_mode = 'enforce' WHERE name = 'build'")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query("UPDATE build_lease_caps SET cap = 8 WHERE singleton")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    let baseline = gate_for(&repo, &task.id).await;
+    assert_eq!(
+        baseline["gate_verdict"], "unexplained",
+        "with an empty projection nothing explains this task; got {:?}",
+        baseline["reasons"]
+    );
+    assert_eq!(baseline["build_capacity"]["at_capacity"], false);
+    assert!(baseline["build_lease"].is_null());
+    assert!(baseline["build_admission_denial"].is_null());
+
+    KueueWorkloadAdmissionRepository::new(db.clone())
+        .apply(&task_run_id, "pending", Some("Pending"), Some("wl-only"))
+        .await
+        .unwrap();
+
+    let blocked = gate_for(&repo, &task.id).await;
+    assert_eq!(
+        blocked["gate_verdict"], "blocked",
+        "the projection is the only thing that changed, so it must be what changed the verdict"
+    );
+    assert_eq!(
+        blocked["reasons"].as_array().unwrap(),
+        &vec![serde_json::json!("kueue_workload_pending")],
+        "and it must be the ONLY reason — no other gate is firing here"
+    );
+    let evaluated = blocked["coverage"]["evaluated_gates"].as_array().unwrap();
+    assert!(
+        evaluated.contains(&serde_json::json!("kueue_clusterqueue_admission")),
+        "with rows in the projection the gate is genuinely evaluated; got {evaluated:?}"
+    );
+
+    // Remove the read's only input and the surface collapses back — the answer
+    // is not derivable from anywhere else in the payload.
+    sqlx::query("DELETE FROM kueue_workload_admission WHERE task_run_id = $1")
+        .bind(&task_run_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    let after = gate_for(&repo, &task.id).await;
+    assert_eq!(after["gate_verdict"], "unexplained");
+    assert!(after["kueue_workload"].is_null());
+    assert_eq!(
+        after["kueue_admission"]["projection_state"],
+        "no_workloads_observed"
+    );
+}
+
+/// A `finished` Workload is neither a queue nor a live build, so it contributes
+/// no reason. Without this the reader could satisfy every test above by
+/// treating any row as blocking.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_finished_workload_contributes_no_reason() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Workload already finished").await;
+    let task_run_id = seed_task_run(&db, &task.id).await;
+
+    KueueWorkloadAdmissionRepository::new(db.clone())
+        .apply(&task_run_id, "finished", None, Some("wl-done"))
+        .await
+        .unwrap();
+
+    let gate = gate_for(&repo, &task.id).await;
+    assert_eq!(gate["kueue_workload"]["admission"], "finished");
+    assert_eq!(gate["kueue_admission"]["finished"], 1);
+    assert!(
+        gate["reasons"].as_array().unwrap().is_empty(),
+        "a finished Workload explains nothing, got {:?}",
+        gate["reasons"]
+    );
+    assert_eq!(gate["gate_verdict"], "unexplained");
+}


### PR DESCRIPTION
## What

`kueue_workload_admission` (migration 165, PR #2827) had **no reader**. This gives it one, at the surface an operator already looks at when nothing is dispatching: the stranded-ready `dispatch_gate` diagnostic in `board_health`.

New module `djinn-db/src/repositories/task/board_health_kueue_admission.rs`, loaded once per board-health call beside the lease ledger, emitting two new blocks on every stranded finding:

* **`kueue_admission`** — pool-wide: `projection_state`, `total` / `pending` / `admitted` / `finished`, `without_task_run`, `stalest_observation_age_seconds`, `oldest_pending_first_seen_age_seconds`, and the head of the pending queue (`pending_task_runs`, capped at 10).
* **`kueue_workload`** — this task's own projection row, when one ties to a live `task_runs` row.

Two new machine-readable reasons: `kueue_workload_pending` and `kueue_workload_admitted_without_session`.

Nothing on the write path changed. `build_admission_denials` still has no writer and still reports `null` — S3a's capitals stand.

## The distinction AC2 is about

Production is `kueue.armed=false`: no namespace labelled, reflector never starts, relation empty. Reporting that as *pending* would describe a healthy cluster as a wedged one, which is the same class of mistake that cost ninety minutes on 2026-07-30. So the reader has three outcomes and never merges them:

| state | meaning |
|---|---|
| `Unobservable` | the relation could not be read — never laundered into "no rows" |
| `Inert` → `projection_state: "no_workloads_observed"` | read, and **empty**. Nothing is queued behind Kueue. Explicitly not a stall |
| `Observing` → `projection_state: "observing"` | read, and non-empty: the reflector has seen Kueue decide something |

The arming flag itself is deliberately **not** consulted. `kueue_preflight.rs` says in as many words that `kueue_armed_from_env()` is the only correct way to ask, and it lives in `djinn-k8s`, which `djinn-db` does not depend on; re-parsing `DJINN_KUEUE_ARMED` here would be a second source of truth that skips the preflight latch. The empty relation is the honest Postgres-side proxy, and its ambiguity is disclosed rather than papered over (see below).

## Did `kueue_clusterqueue_admission` become evaluated?

**Partly, and conditionally — which is the honest answer.**

S4 put `kueue_clusterqueue_admission` in `UNEVALUATED_GATES` because a suspended Job left no row in any relation the section read. That is no longer true: migration 165 records exactly that. So the gate is no longer a constant in `UNEVALUATED_GATES`; it is placed per call:

* `projection_state == "observing"` → **`evaluated_gates`**. Rows exist, so the reflector is live and would have recorded this task's Workload; "this relation records no pending Workload for this task" is a claim the section can actually make.
* otherwise → stays in **`unevaluated_gates`**, with `coverage.kueue_admission_unevaluated_detail` saying why.

It does *not* become unconditionally evaluated, because an empty relation is what an unarmed cluster **and** a stopped reflector both look like from Postgres. Claiming to have evaluated a gate whose evidence source may simply not be running is the "confidently wrong" failure this whole module was rewritten to remove. Once Kueue is armed and the first Workload lands, the gate promotes itself.

## Phantom entries (AC3)

The projection is keyed by `task_runs.id`, but under create-then-admit the `task_runs` row is written by the **in-pod supervisor**, which cannot run until Kueue admits the Job. So a genuinely-pending Workload structurally has no task to attribute it to.

`by_task` is therefore built from an **INNER JOIN** against `task_runs`: a row that cannot be tied to a live run never becomes any task's `kueue_workload` and never contributes a reason to any task. It is still counted (`pending`, `without_task_run`) and still listed, with `task_id: null` — declining to name a task rather than inventing one. Dropping it entirely would hide the exact population the projection exists to expose.

## ACs, with the mutations actually run

**AC1 — both directions, real database.** `the_surfaced_admission_state_follows_the_row_in_both_directions` seeds a task-run + projection row, then flips `admission` with a direct `UPDATE`, calling real `board_health()` between each:

```
pending  → kueue_workload.admission="pending",  pending=1 admitted=0, reasons=[kueue_workload_pending], verdict=blocked
admitted → kueue_workload.admission="admitted", pending=0 admitted=1, pending_task_runs=[], no pending reason
pending  → kueue_workload.admission="pending",  pending=1 admitted=0, reason back
```

A constant-returning or always-null reader fails at step 1 or step 2.

**AC2** — `an_unarmed_deployment_reports_the_inert_variant_not_pending` asserts the relation is empty (the shipped default), then `projection_state == "no_workloads_observed"`, `pending == 0`, no `kueue_workload_pending` reason, verdict `unexplained`, and `kueue_clusterqueue_admission` present in `unevaluated_gates` with a detail string.

**AC3** — `a_projection_row_with_no_task_run_is_attributed_to_nobody` seeds an orphan pending row; the stranded task's `kueue_workload` is null, no reason is inherited, verdict stays `unexplained`, and the listed entry carries `task_id: null` / `task_short_id: null` while `pending == 1`, `without_task_run == 1`.

**AC4** — `the_verdict_is_carried_by_the_projection_alone` arms the lease authority with spare capacity, no lease row, no denial, healthy credential, no chosen model — baseline verdict `unexplained`. Inserting one projection row flips it to `blocked` with `reasons == ["kueue_workload_pending"]` and nothing else; deleting the row returns it to `unexplained`. The answer is not derivable from anywhere else in the payload.

Plus `a_finished_workload_contributes_no_reason` (a reader that blocked on any row would pass everything above), five unit tests on the three-way outcome, two on the gate promotion, and an MCP contract assertion in `board_tools.rs` that the block survives the typed `BoardHealthResponse` round-trip.

## Test output

```
cargo test -p djinn-db --test task_tests board_health_kueue_admission
  5 passed; 0 failed
cargo test -p djinn-db --test task_tests
  153 passed; 0 failed
cargo test -p djinn-db --lib board_health
  50 passed; 0 failed
cargo test -p djinn-control-plane --test board_tools
  7 passed; 0 failed
cargo clippy -p djinn-db -p djinn-control-plane --all-targets   # clean
cargo fmt --all -- --check                                      # clean
check-file-size.sh / check-raw-sql-boundary.sh                  # clean
```

All queries are runtime `sqlx::query` (matching the rest of the board-health sections), so no `server/.sqlx/` regeneration is needed.

## Cost

The empty case — production today — costs exactly one aggregate query and short-circuits before the two detail queries run.

Closes `ecrz` (epic `4c9q`, proposal `9oga`).
