### PR TITLE
ci: retire the Rust file-size gate, keep the measurement as a report

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -590,40 +590,71 @@ jobs:
           done
           echo "::error::cargo-deny check failed after 3 attempts"
           exit 1
-      - name: Check changed Rust file sizes
+      # REPORT, NOT A GATE. This step is structurally incapable of failing the
+      # run: every command is `|| true`-guarded and the block ends `exit 0`.
+      #
+      # It gated changed files from 2026-06-11 to 2026-07-30. Over those seven
+      # weeks it produced 108 `djinn:allow-oversize` markers and zero splits,
+      # while the oversized-file count went 22 -> 79 — every file that ever
+      # tripped it was marked, none was restructured. It also blocked two
+      # correctness fixes (#2815, #2839) on ~200 bytes of headroom each. See
+      # the rationale block at the top of scripts/check-file-size.sh.
+      #
+      # Retiring the veto deliberately leaves the measurement in place: the
+      # ranked report goes to the step summary and to `::notice` annotations,
+      # and the authorship-time nudge in djinn-agent carries the pressure that
+      # a merge-time gate could not.
+      #
+      # Note there is no `continue-on-error:` here. That would surface the step
+      # as a failure GitHub then ignores, which reads as "the size gate is
+      # broken" to every human scanning the run. A report that succeeds is not
+      # the same artifact as a failure that is tolerated.
+      - name: Self-test Rust file-size report
+        if: needs.preflight.outputs.size == 'true'
+        run: ./scripts/test-check-file-size.sh
+      - name: Report changed Rust file sizes
         if: needs.preflight.outputs.size == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          set -eu
+          # GitHub's default step shell is `bash -eo pipefail`. Both are turned
+          # off here on purpose: a report must not inherit gating semantics from
+          # its shell. `-u` is kept — an unset variable here is a bug in this
+          # block, not a finding about the tree.
+          set +e +o pipefail
+          set -u
 
           if [ -z "$BASE_SHA" ]; then
             # workflow_dispatch has no PR/merge context; fall back to origin/main
-            # so the guard still runs against changes since the main branch.
+            # so the report still covers changes since the main branch.
             git fetch --no-tags --depth=1 origin main >/dev/null 2>&1 || true
             BASE_SHA="$(git rev-parse --verify origin/main 2>/dev/null || true)"
           fi
 
           if [ -z "$BASE_SHA" ]; then
-            echo "::error::Could not determine a base SHA for changed-file detection (event=$EVENT_NAME)."
-            exit 1
+            echo "::warning::Could not determine a base SHA for changed-file detection (event=$EVENT_NAME); skipping the file-size report."
+            exit 0
           fi
 
           echo "Computing changed-file diff against base $BASE_SHA (event=$EVENT_NAME)..."
           # --diff-filter=AMR = Added, Modified, Renamed. D (Deleted) is
-          # intentionally excluded so deleted files are not re-checked.
+          # intentionally excluded so deleted files are not re-reported.
           # The three-dot form uses the merge base of $BASE_SHA and HEAD,
           # which tolerates a slightly stale PR base SHA after main advances.
           git diff --name-only --diff-filter=AMR "$BASE_SHA...HEAD" \
-            | ./scripts/check-file-size.sh --files-from-stdin
+            | ./scripts/check-file-size.sh --files-from-stdin \
+            || echo "::warning::The file-size report did not run to completion. It is report-only, so this does not block."
+          exit 0
       - name: Check applied migrations are immutable
         if: needs.preflight.outputs.migrations == 'true'
         run: ./scripts/check-migrations-immutable.sh
-      # Routed by the same output as the size guard: both police the shape of
-      # Rust source, and `size` is set for any server change. Unlike the size
-      # guard this one scans the whole tree rather than the diff — it is a
-      # grep over tracked *.rs with no build, and a whole-tree scan cannot be
-      # dodged by a base-SHA trick.
+      # Routed by the same output as the file-size report: both concern the
+      # shape of Rust source, and `size` is set for any server change. This
+      # one is still a GATE, deliberately — unlike a size limit it has no
+      # one-line escape, and the `_partN` fragmentation it forbids is exactly
+      # what the size gate's per-file line limit used to reward. It also scans
+      # the whole tree rather than the diff: a grep over tracked *.rs with no
+      # build, and a whole-tree scan cannot be dodged by a base-SHA trick.
       - name: Self-test include! guard
         if: needs.preflight.outputs.size == 'true'
         run: ./scripts/test-check-include-macro.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,19 +96,37 @@ Minimal local check:
 ./scripts/jit-pitfall-readout-bundle.sh --self-test
 ```
 
-## Rust size guard
+## Rust size report
 
-Lightweight guard for Rust source files under `server/crates/**` and `server/src/**`. A file fails when it exceeds either size threshold.
+Measures Rust source files under `server/crates/**` and `server/src/**` and ranks the largest worst-first. **It does not fail.** The only non-zero exit is a usage error.
 
-### CI gate
+### Why it is not a gate
 
-`.github/workflows/quality-gate.yml` runs the "Check changed Rust file sizes" step of the `server-guards` job for PR and merge-queue server changes. The step computes added, modified, and renamed files with `git diff --name-only --diff-filter=AMR` and pipes that list to changed-file mode:
+It was one, from 2026-06-11 to 2026-07-30. The outcome over those seven weeks:
+
+| | at landing | 2026-07-30 |
+| --- | --: | --: |
+| files carrying `// djinn:allow-oversize` | 0 | 108 |
+| oversized files (by line count) | 22 | 79 |
+| files split in response | — | 0 |
+
+101 of the 108 marker-carrying files were genuinely oversized and **no** oversized file lacked a marker. Every file that ever tripped the gate got a marker; none got restructured.
+
+That is an incentive gap, not a discipline problem: complying means restructuring a module, evading means adding one comment line. At roughly 100x cost asymmetry, evasion always wins. A per-file *line* limit is also satisfiable by cutting a file at any point, and the `_partN` fragments that produced hid 20.7k lines from rust-analyzer, rustfmt and three CI guards.
+
+On 2026-07-30 the gate blocked two correctness fixes on `MAX_BYTES`: PR #2815 (141 bytes of headroom, tipped over by its own explanatory comment) and PR #2839 (267 bytes, tipped over by the coverage fix itself). Both were resolved by adding a marker.
+
+Pressure toward workable file sizes now lives at authorship time instead, in `djinn-agent`'s `edit`/`write`/`apply_patch` tool results — the moment where there is nothing to satisfy and therefore nothing to game.
+
+### CI
+
+`.github/workflows/quality-gate.yml` runs the "Report changed Rust file sizes" step of the `server-guards` job for PR and merge-queue server changes. The step computes added, modified, and renamed files with `git diff --name-only --diff-filter=AMR` and pipes that list to changed-file mode:
 
 ```sh
 ./scripts/check-file-size.sh --files-from-stdin
 ```
 
-CI is a regression guard for new or edited Rust files; it does not full-tree scan every legacy file on each PR.
+The step is structurally incapable of failing the run. The ranked table lands in the job step summary and the worst offenders become `::notice` annotations (capped at 10, which is all GitHub renders per step). CI covers new or edited Rust files; it does not full-tree scan every legacy file on each PR.
 
 ### Run locally
 
@@ -124,19 +142,21 @@ Full-tree audit mode:
 ./scripts/check-file-size.sh --all
 ```
 
-A full-tree audit may still report legacy oversized files until future split work lands.
-
 ### Thresholds
 
-Defaults are `MAX_LINES=1500` and `MAX_BYTES=51200`; exceeding either limit fails the guard. Override either value with environment variables:
+Defaults are `MAX_LINES=1500` and `MAX_BYTES=51200`. These now decide only what appears in the report, not what is permitted. Override either value with environment variables:
 
 ```sh
 MAX_LINES=1200 MAX_BYTES=45000 ./scripts/check-file-size.sh --all
 ```
 
-### Escape hatch
+Rows are ranked by **bytes** descending, because bytes is the binding constraint on whether a reader can load a file at all — an agent's `read` returns at most 2000 lines and at most `output_stash::MAX_TOOL_RESULT_CHARS` (30 000) characters. Line count is shown alongside as the more legible number.
 
-Add `// djinn:allow-oversize` anywhere in a file to allow an intentional exception. Use this only when a Rust source file genuinely needs to exceed the guideline and should not block CI.
+### The marker
+
+`// djinn:allow-oversize` anywhere in a file no longer grants anything, because nothing is denied. It is still parsed: it is the author's on-the-record statement that the file's size is deliberate, and it splits the ranking into `acknowledged` and `unacknowledged` rows — the one axis on which the report is actionable.
+
+The 108 existing markers are deliberately left in place. Removing them would be 108 files of churn for zero behavioural change; if that cleanup is ever wanted it is its own piece of work.
 
 ### Skipped paths
 

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -1,5 +1,56 @@
 #!/bin/sh
-# Rust source-file size guard.
+# Rust source-file size REPORT.
+#
+# This script measures. It does not gate. It exits 0 whether or not the tree
+# contains oversized files; the only non-zero exits are usage errors (2).
+#
+# ## Why this stopped being a gate
+#
+# It landed 2026-06-11 as a hard failure on changed files. Measured 2026-07-30,
+# after seven weeks:
+#
+#   * files carrying `// djinn:allow-oversize`: 0 -> 108
+#   * oversized files (by line count):          22 -> 79
+#   * files split in response to the gate:       0
+#
+# 101 of the 108 marker-carrying files are genuinely oversized, and NO oversized
+# file lacks a marker. Every file that ever tripped the gate got a marker; none
+# got restructured. That is the whole distribution, not a sample.
+#
+# The mechanism is an incentive gap, not a discipline problem: complying means
+# restructuring a module (hours, a behaviour-bearing refactor, review risk)
+# while evading means adding one comment line (seconds, zero risk). At ~100x
+# cost asymmetry evasion always wins. Worse, a per-file line limit is
+# satisfiable by cutting a file at ANY point, and the `_partN` fragments that
+# produced hid 20.7k lines from rust-analyzer, rustfmt and three CI guards.
+#
+# On 2026-07-30 the gate blocked two correctness fixes on MAX_BYTES — PR #2815
+# (141 bytes of headroom, tipped over by its own explanatory comment) and PR
+# #2839 (267 bytes, tipped over by the coverage fix itself). Both were resolved
+# by adding a marker. That is the gate taxing correctness work and collecting
+# nothing.
+#
+# So: keep the measurement, drop the veto. Pressure toward workable file sizes
+# now lives at authorship time, in the agent's edit/write/apply_patch tool
+# results, where there is nothing to satisfy and therefore nothing to game.
+#
+# ## Why the marker is still parsed
+#
+# Nothing fails, so the marker no longer grants permission — but it still
+# carries information: it is the author's on-the-record statement that this
+# file's size is deliberate. The report uses it to separate `acknowledged` from
+# `unacknowledged` rows, which is the only axis on which the ranking is
+# actionable. The existing 108 markers are deliberately left in place; removing
+# them would be 108 files of churn for zero behavioural change.
+#
+# ## Ranking
+#
+# Rows are ordered by BYTES descending (lines descending, then path, as
+# tiebreaks). Bytes is the binding constraint on whether a reader can load a
+# file at all: an agent's `read` returns at most 2000 lines AND at most
+# `output_stash::MAX_TOOL_RESULT_CHARS` (30_000) characters, so byte size is
+# what decides how many calls it takes to see the file. Line count is reported
+# alongside because it is the more legible number to a human.
 #
 # Usage:
 #   ./scripts/check-file-size.sh --all
@@ -8,18 +59,19 @@
 #   SIZE_GUARD_MODE=all ./scripts/check-file-size.sh
 #   SIZE_GUARD_MODE=files-from-stdin ./scripts/check-file-size.sh < changed-files.txt
 #
-# Checks Rust files under server/crates/ and server/src/ relative to the
+# Reports on Rust files under server/crates/ and server/src/ relative to the
 # repository root. Full-tree mode audits every in-scope Rust file. Changed-file
 # mode evaluates only supplied paths that are in scope and still exist.
-# A file is oversized if it exceeds either threshold:
+# A file is listed as oversized if it exceeds either report threshold:
 #   MAX_LINES  maximum line count, default 1500
 #   MAX_BYTES  maximum byte count, default 51200
 #
 # Generated files are skipped defensively: paths containing /generated/ and
-# files with a .gen.* suffix are ignored. If a genuinely-large Rust source file
-# must exceed the thresholds, add this exact token anywhere in the file:
-#   // djinn:allow-oversize
-# Oversized files with that marker are reported as allowed and do not fail.
+# files with a .gen.* suffix are ignored.
+#
+# When $GITHUB_STEP_SUMMARY is set the ranked table is also appended there as
+# markdown, and the worst offenders are emitted as `::notice` annotations
+# (capped at ANNOTATION_LIMIT, because GitHub renders at most 10 per step).
 
 set -eu
 
@@ -27,6 +79,7 @@ MAX_LINES=${MAX_LINES:-1500}
 MAX_BYTES=${MAX_BYTES:-51200}
 ALLOW_MARKER='djinn:allow-oversize'
 MODE=${SIZE_GUARD_MODE:-all}
+ANNOTATION_LIMIT=${ANNOTATION_LIMIT:-10}
 
 SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/.." && pwd)
@@ -37,14 +90,17 @@ usage() {
     cat <<EOF
 Usage: $0 [--all|--files-from-stdin]
 
+Reports Rust source-file sizes. Never fails on an oversized file.
+
 Modes:
   --all               Audit all in-scope Rust files (default; also SIZE_GUARD_MODE=all).
   --files-from-stdin  Read changed file paths from stdin and audit only in-scope Rust files
                       that still exist (also SIZE_GUARD_MODE=files-from-stdin).
 
 Environment:
-  MAX_LINES           Maximum line count before a file is oversized (default: 1500).
-  MAX_BYTES           Maximum byte count before a file is oversized (default: 51200).
+  MAX_LINES           Line count above which a file is listed (default: 1500).
+  MAX_BYTES           Byte count above which a file is listed (default: 51200).
+  ANNOTATION_LIMIT    Max ::notice annotations emitted (default: 10).
 EOF
 }
 
@@ -102,10 +158,88 @@ is_in_scope_rs_file() {
     return 0
 }
 
+# Emit the ranked report from a tab-separated record file whose columns are:
+#   bytes<TAB>lines<TAB>status<TAB>path
+#
+# `checked` is the number of in-scope files measured. The function always
+# returns success; there is no failure path.
+emit_report() {
+    records=$1
+    checked=$2
+
+    oversized=$(wc -l < "$records" | tr -d '[:space:]')
+
+    if [ "$oversized" -eq 0 ]; then
+        printf 'Rust source-file size report (report-only; nothing here fails the build).\n'
+        printf 'Report thresholds: MAX_LINES=%s MAX_BYTES=%s.\n' "$MAX_LINES" "$MAX_BYTES"
+        printf 'Found 0 oversized file(s). Checked %s Rust source file(s).\n' "$checked"
+        return 0
+    fi
+
+    # Rank: bytes desc, then lines desc, then path asc for a stable order.
+    sorted="$records.sorted"
+    sort -t "$(printf '\t')" -k1,1nr -k2,2nr -k4,4 "$records" > "$sorted"
+
+    unacknowledged=$(cut -f3 "$sorted" | grep -c '^unacknowledged$' || true)
+    acknowledged=$((oversized - unacknowledged))
+
+    printf 'Rust source-file size report (report-only; nothing here fails the build).\n'
+    printf 'Report thresholds: MAX_LINES=%s MAX_BYTES=%s.\n' "$MAX_LINES" "$MAX_BYTES"
+    printf 'Ranked worst-first by bytes (a reader loads bytes, not lines).\n\n'
+    printf '  RANK      BYTES    LINES  STATUS          PATH\n'
+
+    rank=0
+    while IFS="$(printf '\t')" read -r bytes lines status path; do
+        rank=$((rank + 1))
+        printf '  %4d  %9s  %7s  %-14s  %s\n' "$rank" "$bytes" "$lines" "$status" "$path"
+    done < "$sorted"
+
+    printf '\nFound %s oversized file(s) (%s unacknowledged, %s acknowledged by %s). ' \
+        "$oversized" "$unacknowledged" "$acknowledged" "$ALLOW_MARKER"
+    printf 'Checked %s Rust source file(s).\n' "$checked"
+
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        {
+            printf '### Rust source-file size report\n\n'
+            printf 'Report only — this step cannot fail the build. '
+            printf '%s oversized (%s unacknowledged, %s acknowledged) of %s checked, ' \
+                "$oversized" "$unacknowledged" "$acknowledged" "$checked"
+            printf 'thresholds `MAX_LINES=%s` / `MAX_BYTES=%s`.\n\n' "$MAX_LINES" "$MAX_BYTES"
+            printf '| # | bytes | lines | status | path |\n'
+            printf '| --: | --: | --: | --- | --- |\n'
+            rank=0
+            while IFS="$(printf '\t')" read -r bytes lines status path; do
+                rank=$((rank + 1))
+                printf '| %d | %s | %s | %s | `%s` |\n' \
+                    "$rank" "$bytes" "$lines" "$status" "$path"
+            done < "$sorted"
+            printf '\n'
+        } >> "$GITHUB_STEP_SUMMARY"
+    fi
+
+    # Annotations, worst first. GitHub renders at most 10 per step, so asking
+    # for more just discards the tail silently — cap it explicitly instead.
+    rank=0
+    while IFS="$(printf '\t')" read -r bytes lines status path; do
+        rank=$((rank + 1))
+        if [ "$rank" -gt "$ANNOTATION_LIMIT" ]; then
+            break
+        fi
+        printf '::notice file=%s,line=1,title=Large Rust source (report only)::%s is %s bytes / %s lines (%s). Report only — nothing is blocked.\n' \
+            "$path" "$path" "$bytes" "$lines" "$status"
+    done < "$sorted"
+
+    rm -f "$sorted"
+    return 0
+}
+
 check_files() {
     checked=0
-    violations=0
-    allowed=0
+
+    records=$(mktemp "${TMPDIR:-/tmp}/djinn-size-report.XXXXXX")
+    # The report is best-effort measurement; never leave scratch behind, and
+    # never let a cleanup failure become the step's exit status.
+    trap 'rm -f "$records" "$records.sorted" 2>/dev/null || true' EXIT INT TERM
 
     while IFS= read -r file || [ -n "$file" ]; do
         [ -n "$file" ] || continue
@@ -123,38 +257,15 @@ check_files() {
 
         if [ "$lines" -gt "$MAX_LINES" ] || [ "$bytes" -gt "$MAX_BYTES" ]; then
             if grep -q "$ALLOW_MARKER" "$file"; then
-                printf 'OK    %s  (allowed: %s; %s lines, %s bytes)\n' \
-                    "$file" "$ALLOW_MARKER" "$lines" "$bytes"
-                allowed=$((allowed + 1))
+                status=acknowledged
             else
-                printf 'FAIL  %s  (%s lines, %s bytes)\n' "$file" "$lines" "$bytes"
-                violations=$((violations + 1))
+                status=unacknowledged
             fi
+            printf '%s\t%s\t%s\t%s\n' "$bytes" "$lines" "$status" "$file" >> "$records"
         fi
     done
 
-    if [ "$checked" -eq 0 ]; then
-        printf 'Checked 0 Rust source file(s); found 0 oversized file(s) under MAX_LINES=%s / MAX_BYTES=%s.\n' \
-            "$MAX_LINES" "$MAX_BYTES"
-        exit 0
-    fi
-
-    if [ "$violations" -gt 0 ]; then
-        printf 'Found %s oversized file(s) under MAX_LINES=%s / MAX_BYTES=%s. Checked %s Rust source file(s).' \
-            "$violations" "$MAX_LINES" "$MAX_BYTES" "$checked"
-        if [ "$allowed" -gt 0 ]; then
-            printf ' %s oversized file(s) allowed by marker.' "$allowed"
-        fi
-        printf '\n'
-        exit 1
-    fi
-
-    printf 'Found 0 oversized file(s) under MAX_LINES=%s / MAX_BYTES=%s. Checked %s Rust source file(s).' \
-        "$MAX_LINES" "$MAX_BYTES" "$checked"
-    if [ "$allowed" -gt 0 ]; then
-        printf ' %s oversized file(s) allowed by marker.' "$allowed"
-    fi
-    printf '\n'
+    emit_report "$records" "$checked"
     exit 0
 }
 

--- a/scripts/ci-file-size-report.test.mjs
+++ b/scripts/ci-file-size-report.test.mjs
@@ -1,0 +1,136 @@
+// Contract tests for the retired Rust file-size gate.
+//
+// scripts/test-check-file-size.sh proves the SCRIPT cannot fail on an
+// oversized file. It cannot see the workflow. These tests cover the other
+// half: that the step wiring in quality-gate.yml cannot turn a size
+// measurement back into a red build, and that retiring the veto did not
+// leave the `quality-gate` rollup expecting a result nobody produces.
+//
+// Run with:
+//   node --test scripts/ci-file-size-report.test.mjs
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+const WORKFLOW = resolve('.github/workflows/quality-gate.yml');
+const REPORT_STEP = 'Report changed Rust file sizes';
+const SELFTEST_STEP = 'Self-test Rust file-size report';
+
+function fail(message) {
+  throw new Error(`ci-file-size-report: ${message}`);
+}
+
+const source = readFileSync(WORKFLOW, 'utf8').replace(/\r\n/g, '\n');
+const lines = source.split('\n');
+
+/** Slice the YAML block of the step whose `- name:` matches `name`. */
+function stepBlock(name) {
+  const startsAt = lines.findIndex((line) => line.trim() === `- name: ${name}`);
+  if (startsAt < 0) fail(`workflow has no step named ${JSON.stringify(name)}`);
+  const indent = lines[startsAt].indexOf('-');
+  const block = [lines[startsAt]];
+  for (let i = startsAt + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    // A blank line belongs to the step; a `- ` or dedent at or above the
+    // step's own indent starts the next step or the next job key.
+    if (line.trim() === '') { block.push(line); continue; }
+    const lineIndent = line.search(/\S/);
+    if (lineIndent <= indent) break;
+    block.push(line);
+  }
+  return block.join('\n');
+}
+
+test('the file-size report step is routed, but cannot fail the run', () => {
+  const block = stepBlock(REPORT_STEP);
+
+  assert.match(
+    block,
+    /if:\s*needs\.preflight\.outputs\.size == 'true'/,
+    'the report must stay routed by the `size` preflight output — an unrouted report is a deleted one',
+  );
+
+  // The retirement itself. Three independent reasons the step exits 0:
+  // gating shell options are off, every script invocation is `||`-guarded,
+  // and the block ends on an unconditional `exit 0`.
+  assert.match(
+    block,
+    /set \+e \+o pipefail/,
+    "the step must clear bash's inherited `-e`/`pipefail`, or a non-zero script exit fails the run",
+  );
+  assert.match(
+    block,
+    /check-file-size\.sh --files-from-stdin\s*\\?\s*\n?\s*\|\| echo "::warning/,
+    'the script invocation must be `||`-guarded so a crash degrades to a warning',
+  );
+  assert.match(
+    block.trimEnd(),
+    /\n\s*exit 0$/,
+    'the run block must end on an unconditional `exit 0`',
+  );
+
+  // A size finding must never be raised at error severity again.
+  assert.doesNotMatch(
+    block,
+    /exit 1\b/,
+    'the report step must contain no failing exit path',
+  );
+  assert.doesNotMatch(
+    block,
+    /::error/,
+    'a large file is a notice, not an error annotation',
+  );
+
+  // `continue-on-error` would render the step as a failure GitHub then
+  // ignores. That reads as "the size gate is broken" to every human
+  // scanning the run; a report that succeeds is a different artifact from
+  // a failure that is tolerated.
+  assert.doesNotMatch(
+    block,
+    /continue-on-error/,
+    'the report must genuinely succeed, not be a tolerated failure',
+  );
+});
+
+test('the report script keeps its own self-test wired into the same lane', () => {
+  const block = stepBlock(SELFTEST_STEP);
+  assert.match(block, /if:\s*needs\.preflight\.outputs\.size == 'true'/);
+  assert.match(block, /run:\s*\.\/scripts\/test-check-file-size\.sh/);
+
+  // The self-test IS still a gate, deliberately: it fails when the reporter
+  // is broken, never when a file is large. Without it, "report-only" would
+  // be indistinguishable from "silently does nothing".
+  const step = stepBlock(SELFTEST_STEP);
+  assert.doesNotMatch(step, /continue-on-error/);
+  assert.doesNotMatch(step, /\|\| true/);
+});
+
+test('the quality-gate rollup still expects a server-guards result on size work', () => {
+  // Retiring the veto must not strand the rollup. `size` selects
+  // `server-guards`, so the job still RUNS and still reports `success` — the
+  // rollup's `selected=true result=success` arm. If the routing had been
+  // dropped instead, `size` work would leave `server-guards` skipped while
+  // some other output still selected it, and the rollup would fail closed on
+  // a lane nobody meant to remove.
+  const guardsJob = source.slice(source.indexOf('\n  server-guards:'));
+  const guardsIf = guardsJob.slice(0, guardsJob.indexOf('runs-on:'));
+  assert.match(
+    guardsIf,
+    /needs\.preflight\.outputs\.size == 'true'/,
+    'server-guards must still be selected by the `size` output',
+  );
+
+  const rollup = source.slice(source.indexOf('\n  quality-gate:'));
+  assert.match(
+    rollup,
+    /\|\| needs\.preflight\.outputs\.size == 'true'[\s\S]*?\}\}:\$\{\{ needs\.server-guards\.result \}\}/,
+    'the rollup must keep pairing the `size` selector with the server-guards result',
+  );
+  assert.match(
+    rollup,
+    /check server-guards "\$GUARDS"/,
+    'the rollup must still assert the server-guards lane',
+  );
+});

--- a/scripts/test-check-file-size.sh
+++ b/scripts/test-check-file-size.sh
@@ -1,9 +1,14 @@
 #!/bin/sh
 # Self-test harness for scripts/check-file-size.sh.
 #
-# Exercises the production guard end-to-end against synthetic fixture files
+# Exercises the production reporter end-to-end against synthetic fixture files
 # that this script creates (and tears down) under the repository's
 # server/crates/ tree. Pure POSIX shell; no cargo, no python, no network.
+#
+# The reporter is report-only: the central property asserted here is that an
+# oversized file with NO `djinn:allow-oversize` marker is still *named* in the
+# ranked report and still exits 0. It used to exit 1; see the rationale block
+# at the top of check-file-size.sh for why that stopped.
 #
 # Run from the repository root:
 #
@@ -85,6 +90,7 @@ run_guard() {
         MAX_LINES=2 \
         MAX_BYTES=64 \
         SIZE_GUARD_MODE="$mode" \
+        GITHUB_STEP_SUMMARY="$LOG_DIR/$label.summary.md" \
         sh "$GUARD" --files-from-stdin < "$log" > "$out" 2>&1
     return $?
 }
@@ -185,9 +191,21 @@ set +e
 run_guard t3_oversized files-from-stdin "$OVER_PATH"
 t3_actual=$?
 set -e
-assert_exit "T3 synthetic oversized file exits non-zero" 1 "$t3_actual" "$LOG_DIR/t3_oversized.log.out"
-assert_output_contains "T3 reports the failing fixture" \
-    "FAIL  $OVER_PATH" "$LOG_DIR/t3_oversized.log.out"
+# The retirement contract, stated twice: an oversized file with NO marker must
+# NOT fail (first assertion) and must still be named (second). Either one alone
+# is satisfiable by a broken script — a reporter that prints nothing passes the
+# first, and the pre-retirement gate passed the second.
+assert_exit "T3 unacknowledged oversized file exits 0" 0 "$t3_actual" "$LOG_DIR/t3_oversized.log.out"
+assert_output_contains "T3 ranks the unacknowledged fixture" \
+    "unacknowledged  $OVER_PATH" "$LOG_DIR/t3_oversized.log.out"
+assert_output_contains "T3 summary counts it as unacknowledged" \
+    "1 unacknowledged" "$LOG_DIR/t3_oversized.log.out"
+assert_output_contains "T3 emits a notice annotation, not an error" \
+    "::notice file=$OVER_PATH,line=1" "$LOG_DIR/t3_oversized.log.out"
+assert_output_lacks "T3 emits no error annotation" \
+    "::error" "$LOG_DIR/t3_oversized.log.out"
+assert_output_contains "T3 writes the ranked table to the step summary" \
+    "| \`$OVER_PATH\` |" "$LOG_DIR/t3_oversized.summary.md"
 
 # ── T4: generated paths and .gen.* files are skipped ─────────────────
 # Both **/generated/** directory paths and *.gen.* file suffixes must be
@@ -230,10 +248,11 @@ assert_output_lacks "T4 does not report the generated-dir file" \
 assert_output_lacks "T4 does not report the .gen.rs file" \
     "FAIL  $GEN_FILE_PATH" "$LOG_DIR/t4_generated.log.out"
 
-# ── T5: djinn:allow-oversize marker permits an oversized file ───────
-# The marker is the documented escape hatch: an oversized file that
-# includes the exact token "// djinn:allow-oversize" must be reported
-# as OK and not cause a failure.
+# ── T5: djinn:allow-oversize marker classifies, it no longer permits ──
+# Nothing fails, so the marker grants nothing. It is still parsed because
+# it is the author's on-the-record statement that the size is deliberate,
+# which is the one axis that makes the ranking actionable: it separates
+# `acknowledged` rows from `unacknowledged` ones.
 FIXTURE_ALLOW="$REPO_ROOT/$FIXTURE_BASE/src/allowed.rs"
 {
     printf '// djinn:allow-oversize\n'
@@ -251,35 +270,28 @@ run_guard t5_marker files-from-stdin "$ALLOW_PATH"
 t5_actual=$?
 set -e
 assert_exit "T5 marker file exits 0" 0 "$t5_actual" "$LOG_DIR/t5_marker.log.out"
-assert_output_contains "T5 reports the marker file as allowed" \
-    "OK    $ALLOW_PATH  (allowed: djinn:allow-oversize" \
+# Four leading spaces: the status column is left-padded to 14, so
+# "acknowledged" + 2 pad + 2 separator distinguishes it from the 14-char
+# "unacknowledged" + 2 separator that T3 asserts.
+assert_output_contains "T5 ranks the marker file as acknowledged" \
+    "acknowledged    $ALLOW_PATH" \
     "$LOG_DIR/t5_marker.log.out"
-assert_output_contains "T5 summary mentions 1 allowed file" \
-    "1 oversized file(s) allowed by marker" \
+assert_output_contains "T5 summary counts 1 acknowledged, 0 unacknowledged" \
+    "(0 unacknowledged, 1 acknowledged by djinn:allow-oversize)" \
     "$LOG_DIR/t5_marker.log.out"
 
-# ── T6: full-tree mode can be invoked explicitly ─────────────────────
-# Run --all with a generous threshold so the real tree passes; the
-# important property is that the mode flag is accepted, find walks the
-# server/ roots, and the guard reports a non-zero file count. We don't
-# need to enumerate every file — only assert the mode runs to
-# completion and reports it scanned at least one in-scope Rust file.
+# ── T6: full-tree mode over the REAL tree exits 0 ───────────────────
+# Deliberately run with thresholds low enough that the real repository is
+# saturated with oversized files. Under the pre-retirement gate this exited
+# 1; report-only means it must exit 0 while still naming what it found.
 set +e
 cd "$REPO_ROOT" && env \
-    MAX_LINES=9999999 \
-    MAX_BYTES=999999999 \
+    MAX_LINES=1 \
+    MAX_BYTES=1 \
     sh "$GUARD" --all > "$LOG_DIR/t6_all.log.out" 2>&1
 t6_actual=$?
 set -e
-
-if [ "$t6_actual" -eq 0 ] || [ "$t6_actual" -eq 1 ]; then
-    # exit 0 = no oversized; exit 1 = oversized; both prove --all ran.
-    pass "T6 --all mode runs to completion (exit=$t6_actual)"
-else
-    fail "T6 --all mode" "unexpected exit=$t6_actual
-output:
-$(cat "$LOG_DIR/t6_all.log.out")"
-fi
+assert_exit "T6 --all over a saturated tree exits 0" 0 "$t6_actual" "$LOG_DIR/t6_all.log.out"
 if grep -q "Checked [0-9][0-9]* Rust source file(s)" "$LOG_DIR/t6_all.log.out"; then
     pass "T6 --all mode scanned the server tree"
 else
@@ -287,6 +299,54 @@ else
         "no 'Checked N Rust source file(s)' line in:
 $(cat "$LOG_DIR/t6_all.log.out")"
 fi
+# Annotations are capped so GitHub's 10-per-step render limit does not
+# silently discard the tail of a 100+ row report.
+t6_notices=$(grep -c '^::notice ' "$LOG_DIR/t6_all.log.out" || true)
+if [ "$t6_notices" -le 10 ] && [ "$t6_notices" -gt 0 ]; then
+    pass "T6 --all caps annotations at 10 (emitted $t6_notices)"
+else
+    fail "T6 --all caps annotations at 10" "emitted $t6_notices"
+fi
+
+# ── T7: the report is ranked worst-first by bytes ────────────────────
+# A flat list of 100+ paths is not a report. The ordering is the product:
+# the biggest file must be rank 1 regardless of the input order.
+FIXTURE_BIG="$REPO_ROOT/$FIXTURE_BASE/src/bigger.rs"
+FIXTURE_SMALL="$REPO_ROOT/$FIXTURE_BASE/src/smaller.rs"
+{
+    printf '// synthetic BIG fixture\n'
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+        printf 'fn big_%02d() { /* %s */ }\n' "$i" \
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    done
+} > "$FIXTURE_BIG"
+{
+    printf '// synthetic SMALL-but-still-oversized fixture\n'
+    for i in 1 2 3; do
+        printf 'fn small_%02d() {}\n' "$i"
+    done
+} > "$FIXTURE_SMALL"
+
+BIG_PATH="$FIXTURE_BASE/src/bigger.rs"
+SMALL_PATH="$FIXTURE_BASE/src/smaller.rs"
+set +e
+# Feed the SMALLER file first: rank must come from measurement, not order.
+run_guard t7_rank files-from-stdin "$SMALL_PATH" "$BIG_PATH"
+t7_actual=$?
+set -e
+assert_exit "T7 ranked report exits 0" 0 "$t7_actual" "$LOG_DIR/t7_rank.log.out"
+t7_first=$(grep -E "^ +[0-9]+ +[0-9]+ +[0-9]+ +unacknowledged" "$LOG_DIR/t7_rank.log.out" \
+    | head -n 1 | awk '{print $NF}')
+if [ "$t7_first" = "$BIG_PATH" ]; then
+    pass "T7 the largest file ranks first despite input order"
+else
+    fail "T7 the largest file ranks first despite input order" \
+        "rank 1 was '$t7_first', expected '$BIG_PATH'
+output:
+$(cat "$LOG_DIR/t7_rank.log.out")"
+fi
+assert_output_contains "T7 still names the smaller offender" \
+    "unacknowledged  $SMALL_PATH" "$LOG_DIR/t7_rank.log.out"
 
 # ── summary ──────────────────────────────────────────────────────────
 printf -- '------------------------------------------\n'


### PR DESCRIPTION
## What this does

Stops `scripts/check-file-size.sh` failing the build. Keeps every byte of its measurement and turns it into a ranked report.

## Why

The gate landed 2026-06-11. It has been measured.

| | at landing | 2026-07-30 |
| --- | --: | --: |
| files carrying `// djinn:allow-oversize` | 0 | 108 |
| oversized files (by line count) | 22 | 79 |
| files split in response | — | 0 |

Right now 101 of the 108 marker-carrying files are genuinely oversized, and **zero oversized files lack a marker**. Every file that ever tripped the gate got a marker; none got restructured. That is the whole distribution, not a sample.

The mechanism is an incentive gap, not a discipline problem. Complying means restructuring a module — hours, a behaviour-bearing refactor, review risk. Evading means adding one comment line — seconds, zero risk. At roughly 100x cost asymmetry, evasion always wins, and merge time is where the asymmetry bites hardest: the author has already finished, and the cheapest path back to green is the marker.

A per-file **line** limit is additionally satisfiable by cutting a file at any point, and the `_partN` fragments that produced hid 20.7k lines from rust-analyzer, rustfmt and three CI guards.

On 2026-07-30 the gate blocked two correctness fixes, both on `MAX_BYTES`:

- **#2815** — `proposal_tools/create.rs`, 141 bytes of headroom, tipped over by its own explanatory comment.
- **#2839** — `handlers/workspace.rs`, 267 bytes of headroom, tipped over by the coverage fix itself.

Both were resolved by adding a marker. The gate was taxing correctness work and collecting nothing.

## What replaces it

The report, plus an authorship-time nudge in `djinn-agent` (separate PR — this one is independently valuable and should not wait on it).

### The report

Ranked worst-first by **bytes**, with lines alongside. Bytes leads because bytes is what decides whether a reader can load the file at all: a `read` returns at most 2000 lines and at most `output_stash::MAX_TOOL_RESULT_CHARS` (30 000) characters. Line count is shown because it is the more legible number to a human.

Output goes three places: stdout, `$GITHUB_STEP_SUMMARY` as a markdown table, and `::notice` annotations capped at 10 (all GitHub renders per step — asking for more silently discards the tail).

```
  RANK      BYTES    LINES  STATUS          PATH
     1     444870    10182  acknowledged    server/crates/djinn-supervisor/src/lib.rs
     2     379705     9382  acknowledged    server/crates/djinn-db/src/repositories/proposal.rs
     ...
Found 103 oversized file(s) (0 unacknowledged, 103 acknowledged by djinn:allow-oversize). Checked 1488 Rust source file(s).
```

### The marker still means something

It no longer grants permission, because nothing is denied. It stays parsed because it is the author's on-the-record statement that the size is deliberate, and it splits the ranking into `acknowledged` / `unacknowledged` — the one axis on which the report is actionable.

**The 108 existing markers are deliberately left alone.** Removing them is 108 files of churn for zero behavioural change, and its own piece of work if ever wanted.

### The step cannot fail

Three independent reasons: bash's inherited `-e`/`pipefail` are cleared, the script invocation is `||`-guarded, and the block ends `exit 0`. A missing base SHA now warns instead of erroring.

No `continue-on-error:`. That renders the step as a failure GitHub then ignores, which reads as "the size gate is broken" to every human scanning the run. A report that succeeds is not the same artifact as a failure that is tolerated.

### One thing added rather than removed

The script's self-test was documented in `scripts/README.md` but never run in CI. It is now wired in beside the include!-guard self-test, and it **is** still a gate — it fails when the reporter is broken, never when a file is large. Without it, "report-only" would be indistinguishable from "silently does nothing".

## Verification

- **The gate no longer blocks.** A 2401-line / 158 425-byte `.rs` file with no marker, at production thresholds: old script `exit 1`, new script `exit 0`.
- **The report still reports.** Same file, same run: ranked at position 1 as `unacknowledged`, plus a `::notice` annotation.
- **Non-vacuity.** 12 of the 23 self-test assertions fail against the pre-change script; 2 of the 3 new workflow-contract tests fail against the pre-change workflow. (The third asserts the rollup pairing is *preserved*, so it passes on both sides by design.)
- `scripts/test-check-file-size.sh` — 23 passed, 0 failed.
- `node --test scripts/ci-file-size-report.test.mjs` — 3 passed.
- `node --test scripts/ci-changed-scope.test.mjs scripts/ci-cache-policy.test.mjs scripts/ci-qa-smoke-workflow.test.mjs scripts/ci-nextest-plan.test.mjs` — 80 passed, 0 failed.
- `actionlint .github/workflows/quality-gate.yml` — clean.

### Rollup

Unchanged by construction. `size` still selects `server-guards`, so the job still runs and still succeeds — `quality-gate` never sees a missing result. `scripts/ci-file-size-report.test.mjs` asserts that pairing explicitly so a later edit cannot quietly strand the lane. The job is also not reduced to a no-op: the include! guard, whole-tree rustfmt, migrations, raw-SQL, capability and boundary steps all still gate.

The include! guard stays a gate on purpose, and its comment now says why: unlike a size limit it has no one-line escape, and the `_partN` fragmentation it forbids is exactly what the size gate's line limit used to reward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)