### PR TITLE
feat(agent): nudge at authorship time when a file outgrows a single read

### DIFF
--- a/server/crates/djinn-agent/src/extension/handlers.rs
+++ b/server/crates/djinn-agent/src/extension/handlers.rs
@@ -54,6 +54,7 @@ mod jit_pitfalls;
 #[allow(dead_code)]
 mod memory_agent;
 mod shell_exec;
+mod size_nudge;
 // Retained for test coverage; production dispatch goes through djinn-mcp-extension.
 #[allow(dead_code)]
 mod task_admin;

--- a/server/crates/djinn-agent/src/extension/handlers/size_nudge.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/size_nudge.rs
@@ -1,0 +1,258 @@
+//! Authorship-time file-size nudge.
+//!
+//! ## Why this exists, and why it is not a gate
+//!
+//! `scripts/check-file-size.sh` gated changed Rust files on 1500 lines /
+//! 51200 bytes from 2026-06-11. Measured seven weeks later: 108 files had
+//! acquired the `// djinn:allow-oversize` escape marker, the oversized-file
+//! count had gone 22 -> 79, and **zero** files had been split. Every file that
+//! ever tripped the gate was marked; none was restructured.
+//!
+//! The reason is an incentive gap, not a discipline problem. Complying means
+//! restructuring a module; evading means adding one comment line. At that cost
+//! asymmetry evasion always wins, and a merge-time gate is exactly where the
+//! asymmetry bites hardest — the author has already finished, and the cheapest
+//! path back to green is the marker.
+//!
+//! So the pressure moved to the moment of authorship. A nudge attached to a
+//! *successful* edit cannot be gamed, because there is nothing to satisfy: no
+//! exit code changes, no marker helps, and ignoring it costs nothing. What it
+//! can do is put a fact in front of the author at the only moment they are
+//! already holding the file's structure in mind.
+//!
+//! ## Advisory, and structurally so
+//!
+//! This module has no error path. Its entry point takes a response value and
+//! returns a response value; every failure mode (unreadable file, missing
+//! metadata, path outside the worktree) returns the response untouched. It is
+//! called *after* the mutation has been written and can never influence it.
+//!
+//! It deliberately does NOT live in `gate_guard`. PR #2821 and #2839 fixed a
+//! read-coverage deadlock in that deny path, which workers had been escaping by
+//! routing edits through the ungated `shell` tool. A size message that read as
+//! a denial would push them straight back off the instrumented path — the exact
+//! failure the coverage fix just undid. So it rides the success payload
+//! alongside `related_files` and `jit_pitfalls`, under its own `size_nudge`
+//! key, on a result that already says `"ok": true`.
+//!
+//! ## Choosing the threshold
+//!
+//! Not 1500 lines and not 51200 bytes — those numbers came from the retired
+//! gate and were never derived from anything. The nudge fires on exactly one
+//! condition, and it is a fact about the tool surface rather than a taste
+//! judgement: **a single `read` can no longer return the whole file.**
+//!
+//! Two clamps produce that, both already load-bearing in `workspace.rs`:
+//!
+//! * `read` returns at most [`super::workspace::READ_MAX_LINES`] (2000) lines
+//!   — `p.limit.unwrap_or(2000).min(2000)`.
+//! * The rendered result is clamped to
+//!   [`crate::output_stash::MAX_TOOL_RESULT_CHARS`] (30 000) characters, of
+//!   which `read` budgets [`super::workspace::read_content_budget`] for the
+//!   numbered listing itself.
+//!
+//! Both are read from the production constants, not copied, so the nudge
+//! tracks them if they ever move.
+//!
+//! The resulting message is specific in the way that matters: not "this file is
+//! large" (noise — large compared to what?) but "seeing this file in full costs
+//! N `read` calls", which is a number the reader is about to pay.
+//!
+//! ## Scope and frequency
+//!
+//! Language-agnostic: the read budget does not care what the file is, so
+//! neither does this. Generated paths and lockfiles are skipped — nobody splits
+//! a `Cargo.lock`, and a nudge nobody can act on is just noise.
+//!
+//! Fires at most once per (session, path), tracked process-wide by the same
+//! worktree-path session key `FileTime` and `jit_pitfalls` use. A worker
+//! editing one big file thirty times gets one nudge, not thirty.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+use super::workspace::{READ_MAX_LINES, read_content_budget};
+
+/// Characters a numbered listing spends per line *beyond* the line's own
+/// bytes: six columns of line number, a tab, and a newline.
+///
+/// The tab and the newline cost two characters each rather than one because
+/// `output_stash` clamps the *serialized* result, and JSON escapes them as
+/// `\t` and `\n`. `numbered_lines_within_budget` charges the same way.
+const LISTING_LINE_OVERHEAD: usize = 6 + 2 + 2;
+
+/// Response key carrying the nudge. Distinct from `jit_pitfalls` so a consumer
+/// can tell an advisory about *this file's shape* from an advisory about *what
+/// is known to go wrong here*.
+const RESPONSE_KEY: &str = "size_nudge";
+
+/// Sessions × paths already nudged. Same shape and same session key as the
+/// `jit_pitfalls` first-modification set.
+static NUDGED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn nudged_set() -> &'static Mutex<HashSet<String>> {
+    NUDGED.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Record the (session, path) pair and report whether this is the first time.
+fn claim_first_nudge(session_id: &str, path: &Path) -> bool {
+    let key = format!("{session_id}\u{0}{}", path.display());
+    match nudged_set().lock() {
+        Ok(mut set) => set.insert(key),
+        // A poisoned mutex must not cost the caller their tool result. Fail
+        // toward silence: an extra-quiet advisory beats a panic on a write.
+        Err(_) => false,
+    }
+}
+
+/// Number of `read` calls needed to see a file of `bytes`/`lines` in full.
+///
+/// Both clamps bind independently, so the answer is whichever is worse. The
+/// byte estimate assumes no JSON-escaped characters beyond the per-line tab and
+/// newline, which makes it a floor: a file full of quotes and backslashes costs
+/// more reads than this returns, never fewer.
+pub(crate) fn reads_required(bytes: usize, lines: usize) -> usize {
+    let by_lines = lines.div_ceil(READ_MAX_LINES.max(1));
+    let budget = read_content_budget().max(1);
+    let listing_chars = bytes.saturating_add(lines.saturating_mul(LISTING_LINE_OVERHEAD));
+    let by_chars = listing_chars.div_ceil(budget);
+    by_lines.max(by_chars).max(1)
+}
+
+/// Largest byte count that cannot possibly need a second `read`, whatever the
+/// line distribution turns out to be.
+///
+/// A file of `b` bytes has at most `b` lines, so its worst-case listing costs
+/// `b * (1 + LISTING_LINE_OVERHEAD)` characters. Below this bound the answer is
+/// "one read" without opening the file — which is what keeps the common case
+/// (small files, the overwhelming majority of edits) at a single `metadata`
+/// call.
+fn single_read_certain_bytes() -> usize {
+    let by_chars = read_content_budget() / (1 + LISTING_LINE_OVERHEAD);
+    by_chars.min(READ_MAX_LINES)
+}
+
+/// Paths whose size is not the author's to fix. A nudge that cannot be acted
+/// on is noise, and noise is what makes advisories get filtered out wholesale.
+fn is_exempt(path: &Path) -> bool {
+    let display = path.to_string_lossy();
+    if display.contains("/generated/") || display.contains("\\generated\\") {
+        return true;
+    }
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    name.contains(".gen.") || name.ends_with(".lock") || name.ends_with(".min.js")
+}
+
+/// Compose the advisory for a file that no longer fits in one `read`.
+///
+/// Shaped after the `gate_guard` prompts — a concrete measurement first, then
+/// one thing to consider — but deliberately inverted in mood. `gate_guard`
+/// returns `Err` and demands four facts before it will proceed. This returns
+/// text on a successful result and demands nothing, and it says so twice, in
+/// the first sentence and the last.
+fn compose(display_path: &str, bytes: usize, lines: usize, reads: usize) -> String {
+    format!(
+        "The edit succeeded; this is advisory and blocks nothing.\n\
+         {display_path} is now {lines} lines / {bytes} bytes. A single `read` \
+         returns at most {READ_MAX_LINES} lines and about {budget} characters \
+         of listing, so seeing this file in full now costs {reads} `read` \
+         calls — neither you nor the next reader can hold it in one.\n\
+         If there is a genuine seam here — a boundary that would still make \
+         sense if nobody were measuring — this is the cheapest moment you will \
+         ever get to split on it, because you already have the structure in \
+         mind. If there isn't one, carry on; a file cut in an arbitrary place \
+         is worse than a long one.",
+        budget = read_content_budget(),
+    )
+}
+
+/// Measure `path` and return the advisory, or `None` when there is nothing
+/// worth saying.
+///
+/// `None` covers every uninteresting and every degenerate case alike: the file
+/// fits in one `read`, the path is exempt, this (session, path) was already
+/// nudged, or the file could not be measured at all. There is no `Err`.
+async fn nudge_for(session_id: &str, path: &Path, display_path: &str) -> Option<String> {
+    if is_exempt(path) {
+        return None;
+    }
+
+    let bytes = tokio::fs::metadata(path).await.ok()?.len() as usize;
+    // Cheap exit for the overwhelming majority of edits: below this bound no
+    // line distribution can force a second read, so the file never has to be
+    // opened.
+    if bytes <= single_read_certain_bytes() {
+        return None;
+    }
+
+    let content = tokio::fs::read(path).await.ok()?;
+    let lines = content.iter().filter(|b| **b == b'\n').count()
+        + usize::from(!content.is_empty() && !content.ends_with(b"\n"));
+
+    let reads = reads_required(bytes, lines);
+    if reads <= 1 {
+        return None;
+    }
+
+    // Claimed last, so a file that never qualified does not burn its one
+    // nudge; the first time it actually crosses the line, it still fires.
+    if !claim_first_nudge(session_id, path) {
+        return None;
+    }
+
+    Some(compose(display_path, bytes, lines, reads))
+}
+
+/// Append the size advisory to a successful `write`/`edit`/`apply_patch`
+/// result, for whichever touched file most needs it.
+///
+/// Multi-file patches nudge about their single worst file rather than one entry
+/// per path: three advisories in one result is a wall of text the reader skips,
+/// which is the failure mode this is trying to avoid.
+///
+/// Returns `response` unchanged whenever there is nothing to say. It cannot
+/// fail and it cannot deny — by the time it runs, the bytes are already on
+/// disk.
+pub(crate) async fn maybe_append_size_nudge(
+    response: serde_json::Value,
+    worktree_path: &Path,
+    touched: &[std::path::PathBuf],
+) -> serde_json::Value {
+    let session_id = worktree_path.display().to_string();
+
+    let mut best: Option<(usize, String)> = None;
+    for path in touched {
+        let display_path = path
+            .strip_prefix(worktree_path)
+            .unwrap_or(path.as_path())
+            .display()
+            .to_string();
+        let Some(text) = nudge_for(&session_id, path, &display_path).await else {
+            continue;
+        };
+        // Rank by rendered length only to break ties deterministically; the
+        // meaningful ordering is done inside `nudge_for`, which already refuses
+        // anything that fits in one read.
+        let weight = text.len();
+        if best.as_ref().is_none_or(|(w, _)| weight > *w) {
+            best = Some((weight, text));
+        }
+    }
+
+    let Some((_, text)) = best else {
+        return response;
+    };
+
+    let mut response = response;
+    if let Some(obj) = response.as_object_mut() {
+        obj.insert(RESPONSE_KEY.to_string(), serde_json::Value::String(text));
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/crates/djinn-agent/src/extension/handlers/size_nudge/tests.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/size_nudge/tests.rs
@@ -1,0 +1,413 @@
+//! Tests for the authorship-time size nudge.
+//!
+//! The contract has three halves and every test here holds all of them at
+//! once, because two of the three are satisfiable by doing nothing:
+//!
+//!   1. the nudge appears when the file no longer fits in one `read`;
+//!   2. it does NOT appear when the file does fit;
+//!   3. **the edit succeeds either way.**
+//!
+//! (3) is the one that matters most. A "nudge" that could deny an edit would
+//! be the retired gate wearing a new name, and worse, it would land in the
+//! deny path that #2821/#2839 just unwedged — workers were escaping that
+//! deadlock onto the ungated `shell` tool, and anything reading as a denial
+//! sends them straight back.
+
+use super::*;
+use crate::extension::handlers::workspace::{call_apply_patch, call_edit, call_write};
+use crate::test_helpers::{agent_context_from_db, create_test_db, test_tempdir};
+use tokio_util::sync::CancellationToken;
+
+fn setup(prefix: &str) -> (tempfile::TempDir, crate::context::AgentContext) {
+    let dir = test_tempdir(prefix);
+    let db = create_test_db();
+    let state = agent_context_from_db(db, CancellationToken::new());
+    (dir, state)
+}
+
+/// A body large enough that no single `read` can return it: comfortably past
+/// both the 2000-line ceiling and the listing character budget.
+fn oversized_body(marker: &str) -> String {
+    let mut body = format!("// {marker}\n");
+    for i in 0..3_000 {
+        body.push_str(&format!(
+            "fn generated_{i:05}() {{ /* padding padding */ }}\n"
+        ));
+    }
+    body
+}
+
+fn args(value: serde_json::Value) -> Option<serde_json::Map<String, serde_json::Value>> {
+    Some(value.as_object().expect("object args").clone())
+}
+
+// ── the arithmetic, against the production clamps ────────────────────────
+
+#[test]
+fn a_file_inside_both_clamps_costs_exactly_one_read() {
+    // 500 lines of ~40 bytes is well inside 2000 lines and inside the
+    // listing budget once per-line overhead is charged.
+    assert_eq!(reads_required(20_000, 500), 1);
+    // Empty and single-line files are never interesting.
+    assert_eq!(reads_required(0, 0), 1);
+    assert_eq!(reads_required(12, 1), 1);
+}
+
+#[test]
+fn each_clamp_forces_a_second_read_on_its_own() {
+    // Line clamp alone: 2001 tiny lines are only ~4 kB, far inside the
+    // character budget, but `read` still refuses to return them in one call.
+    assert_eq!(reads_required(4_002, 2_001), 2);
+
+    // Character clamp alone: one enormous line is a single line, so the line
+    // clamp is satisfied, yet the listing cannot be rendered in one result.
+    let budget = read_content_budget();
+    assert!(reads_required(budget * 2, 1) >= 2);
+}
+
+#[test]
+fn the_estimate_charges_json_escaping_for_the_listing_gutter() {
+    // The clamp applies to the SERIALIZED result, so a tab and a newline cost
+    // two characters each. Under-charging here would let a file that really
+    // needs two reads report one. Pin the constant against that.
+    assert_eq!(LISTING_LINE_OVERHEAD, 10);
+    let budget = read_content_budget();
+    // A file whose raw bytes fit the budget but whose gutter does not.
+    let lines = 1_500;
+    let bytes = budget - 1;
+    assert_eq!(reads_required(bytes, lines), 2);
+}
+
+#[test]
+fn the_cheap_bound_never_hides_a_file_that_needs_two_reads() {
+    // The bound exists so small edits skip the file read entirely. It is only
+    // sound if EVERY line distribution at that size still costs one read —
+    // including the pathological all-newlines file.
+    let bound = single_read_certain_bytes();
+    assert!(bound > 0);
+    for lines in [0usize, 1, bound / 2, bound] {
+        assert_eq!(
+            reads_required(bound, lines),
+            1,
+            "cheap bound {bound} claimed a single read for {lines} lines, but the estimate disagrees",
+        );
+    }
+}
+
+#[test]
+fn generated_and_lock_paths_are_exempt() {
+    assert!(is_exempt(Path::new("/w/server/src/generated/api.rs")));
+    assert!(is_exempt(Path::new("/w/ui/src/mcp-tools.gen.ts")));
+    assert!(is_exempt(Path::new("/w/Cargo.lock")));
+    assert!(!is_exempt(Path::new("/w/server/src/lib.rs")));
+    assert!(!is_exempt(Path::new("/w/server/src/generated_report.rs")));
+}
+
+#[test]
+fn the_message_is_advisory_in_its_first_and_last_sentence() {
+    let text = compose("server/src/big.rs", 200_000, 5_000, 7);
+    // Specific, not generic: the actionable number is the read cost.
+    assert!(text.contains("5000 lines / 200000 bytes"), "{text}");
+    assert!(text.contains("7 `read` calls"), "{text}");
+    assert!(text.contains("2000 lines"), "{text}");
+
+    // It must not read as a denial. These are the words the gate_guard deny
+    // path uses, and the ones a worker learned to route around via `shell`.
+    assert!(text.starts_with("The edit succeeded"), "{text}");
+    for forbidden in ["FORCE-", "denied", "forbidden", "before you", "retry"] {
+        assert!(
+            !text.contains(forbidden),
+            "advisory must not read as a denial, found {forbidden:?} in: {text}",
+        );
+    }
+}
+
+// ── end to end, through the real tool handlers ───────────────────────────
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn write_of_an_oversized_file_succeeds_and_carries_the_nudge() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup("nudge-write-big-");
+
+    let result = call_write(
+        &state,
+        &args(serde_json::json!({
+            "path": "big.rs",
+            "content": oversized_body("oversized write fixture"),
+        })),
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect("an advisory must never fail a write");
+
+    assert_eq!(result["ok"], serde_json::json!(true));
+    // The write really happened — the nudge did not stand in for it.
+    let on_disk = tokio::fs::read_to_string(worktree.path().join("big.rs"))
+        .await
+        .expect("file written");
+    assert!(on_disk.contains("generated_02999"), "full body written");
+
+    let nudge = result["size_nudge"].as_str().expect("nudge present");
+    assert!(nudge.contains("big.rs"), "{nudge}");
+    assert!(nudge.contains("`read` calls"), "{nudge}");
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn write_of_a_small_file_succeeds_with_no_nudge() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup("nudge-write-small-");
+
+    let result = call_write(
+        &state,
+        &args(serde_json::json!({
+            "path": "small.rs",
+            "content": "fn small() {}\n",
+        })),
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect("small writes are unaffected");
+
+    assert_eq!(result["ok"], serde_json::json!(true));
+    assert!(
+        result.get("size_nudge").is_none(),
+        "a file that fits in one read must produce no advisory: {result}",
+    );
+    let on_disk = tokio::fs::read_to_string(worktree.path().join("small.rs"))
+        .await
+        .expect("file written");
+    assert_eq!(on_disk, "fn small() {}\n");
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn a_mid_size_file_past_the_cheap_bound_still_gets_no_nudge() {
+    // The small-file tests above exit through `single_read_certain_bytes`
+    // without ever consulting the estimate, so on their own they prove only
+    // that the short-circuit works. This one is deliberately sized past that
+    // bound — ~10 kB over 300 lines — so the "no nudge" verdict has to come
+    // out of `reads_required` itself. Without it, an estimate that claimed
+    // every file needs two reads would still pass the whole suite.
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup("nudge-midsize-");
+
+    let mut body = String::new();
+    for i in 0..300 {
+        body.push_str(&format!(
+            "fn mid_{i:03}() {{ /* thirty-odd bytes of padding here */ }}\n"
+        ));
+    }
+    assert!(
+        body.len() > single_read_certain_bytes(),
+        "fixture must clear the cheap bound to exercise the estimate",
+    );
+
+    let result = call_write(
+        &state,
+        &args(serde_json::json!({ "path": "mid.rs", "content": body })),
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect("mid-size writes are unaffected");
+
+    assert_eq!(result["ok"], serde_json::json!(true));
+    assert!(
+        result.get("size_nudge").is_none(),
+        "a 300-line file still fits in one read and must not be advised about: {result}",
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn edit_of_an_oversized_file_succeeds_and_carries_the_nudge() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup("nudge-edit-big-");
+    let file = worktree.path().join("big.rs");
+    tokio::fs::write(&file, oversized_body("oversized edit fixture"))
+        .await
+        .expect("seed");
+
+    let session_id = worktree.path().display().to_string();
+    // Non-worker role: this test is about the advisory, not about GateGuard's
+    // read-coverage ladder, which has its own suite.
+    state
+        .file_time
+        .read_with_coverage(
+            &session_id,
+            &file,
+            crate::file_time::ReadCoverage::Full,
+            false,
+        )
+        .await
+        .expect("record read");
+
+    let result = call_edit(
+        &state,
+        &args(serde_json::json!({
+            "path": "big.rs",
+            "old_text": "fn generated_00007",
+            "new_text": "fn renamed_00007",
+        })),
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("planner"),
+    )
+    .await
+    .expect("an advisory must never fail an edit");
+
+    assert_eq!(result["ok"], serde_json::json!(true));
+    let on_disk = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert!(on_disk.contains("fn renamed_00007"), "edit applied");
+
+    let nudge = result["size_nudge"].as_str().expect("nudge present");
+    assert!(nudge.contains("big.rs"), "{nudge}");
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn edit_of_a_small_file_succeeds_with_no_nudge() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup("nudge-edit-small-");
+    let file = worktree.path().join("small.rs");
+    tokio::fs::write(&file, "fn small() {}\n")
+        .await
+        .expect("seed");
+
+    let session_id = worktree.path().display().to_string();
+    state
+        .file_time
+        .read_with_coverage(
+            &session_id,
+            &file,
+            crate::file_time::ReadCoverage::Full,
+            false,
+        )
+        .await
+        .expect("record read");
+
+    let result = call_edit(
+        &state,
+        &args(serde_json::json!({
+            "path": "small.rs",
+            "old_text": "small",
+            "new_text": "tiny",
+        })),
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("planner"),
+    )
+    .await
+    .expect("small edits are unaffected");
+
+    assert_eq!(result["ok"], serde_json::json!(true));
+    assert!(
+        result.get("size_nudge").is_none(),
+        "a file that fits in one read must produce no advisory: {result}",
+    );
+    let on_disk = tokio::fs::read_to_string(&file).await.expect("read back");
+    assert_eq!(on_disk, "fn tiny() {}\n");
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn apply_patch_of_an_oversized_file_succeeds_and_carries_one_nudge() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup("nudge-patch-big-");
+
+    // Two Adds in one patch, one oversized and one tiny. The result must
+    // carry exactly one advisory, about the file that needs it.
+    let patch = format!(
+        "*** Begin Patch\n*** Add File: big.rs\n{}*** Add File: tiny.rs\n+fn tiny() {{}}\n*** End Patch\n",
+        oversized_body("oversized patch fixture")
+            .lines()
+            .map(|l| format!("+{l}\n"))
+            .collect::<String>(),
+    );
+
+    let result = call_apply_patch(
+        &state,
+        &args(serde_json::json!({ "patch": patch })),
+        worktree.path(),
+        None,
+        Some("task-1"),
+        Some("worker"),
+    )
+    .await
+    .expect("an advisory must never fail a patch");
+
+    assert_eq!(result["ok"], serde_json::json!(true));
+    assert!(
+        worktree.path().join("big.rs").exists() && worktree.path().join("tiny.rs").exists(),
+        "both files applied",
+    );
+
+    let nudge = result["size_nudge"].as_str().expect("nudge present");
+    assert!(nudge.contains("big.rs"), "{nudge}");
+    assert!(
+        !nudge.contains("tiny.rs"),
+        "the small file must not be advised about: {nudge}",
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn the_nudge_fires_once_per_file_per_session() {
+    let _jit_env = crate::test_helpers::jit_env_read_guard();
+    let (worktree, state) = setup("nudge-once-");
+    let file = worktree.path().join("big.rs");
+    let session_id = worktree.path().display().to_string();
+
+    let mut seen = Vec::new();
+    for pass in 0..3 {
+        tokio::fs::write(&file, oversized_body(&format!("pass {pass}")))
+            .await
+            .expect("seed");
+        state
+            .file_time
+            .read_with_coverage(
+                &session_id,
+                &file,
+                crate::file_time::ReadCoverage::Full,
+                false,
+            )
+            .await
+            .expect("record read");
+
+        let result = call_edit(
+            &state,
+            &args(serde_json::json!({
+                "path": "big.rs",
+                "old_text": format!("// pass {pass}"),
+                "new_text": format!("// touched {pass}"),
+            })),
+            worktree.path(),
+            None,
+            Some("task-1"),
+            Some("planner"),
+        )
+        .await
+        .expect("every edit succeeds");
+
+        assert_eq!(result["ok"], serde_json::json!(true));
+        seen.push(result.get("size_nudge").is_some());
+    }
+
+    assert_eq!(
+        seen,
+        vec![true, false, false],
+        "a worker editing one big file repeatedly gets one advisory, not one per edit",
+    );
+}

--- a/server/crates/djinn-agent/src/extension/handlers/workspace.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/workspace.rs
@@ -8,6 +8,7 @@
 
 use super::gate_guard::{gate_guard_edit_check, gate_guard_shell_check};
 use super::shell_exec::{effective_shell_timeout_ms, finish_shell};
+use super::size_nudge::maybe_append_size_nudge;
 use super::workspace_helpers::{
     cargo_check_denied, classify_cargo_command, emit_edit_match_telemetry,
 };
@@ -260,9 +261,17 @@ fn json_escaped_len(s: &str) -> usize {
 /// This does **not** widen the clamp: it makes the read handler stop at a line
 /// boundary the clamp will accept, so the window the model receives is the
 /// window the handler recorded coverage for.
-fn read_content_budget() -> usize {
+pub(crate) fn read_content_budget() -> usize {
     crate::output_stash::MAX_TOOL_RESULT_CHARS.saturating_sub(READ_RESULT_RESERVE_CHARS)
 }
+
+/// Hard ceiling on the number of lines one `read` will return, and the default
+/// when the caller does not ask for a window.
+///
+/// Named because it is a contract, not an implementation detail: `size_nudge`
+/// derives "how many reads does this file cost?" from this exact value, so a
+/// literal here and a literal there would be a drift bug waiting to happen.
+pub(crate) const READ_MAX_LINES: usize = 2000;
 
 /// The extension tool name whose results record read coverage.
 const READ_TOOL_NAME: &str = "read";
@@ -417,7 +426,7 @@ pub(crate) async fn call_read(
                     .unwrap_or_else(|| "HEAD".to_string());
                 let content = crate::repo_access::read_file(&pid, &git_ref, &p.file_path).await?;
                 let offset = p.offset.unwrap_or(0);
-                let limit = p.limit.unwrap_or(2000).min(2000);
+                let limit = p.limit.unwrap_or(READ_MAX_LINES).min(READ_MAX_LINES);
                 return Ok(numbered_window(&content, offset, limit, &p.file_path));
             }
             // Same as the task project (or unresolvable → fall through to the
@@ -454,7 +463,7 @@ pub(crate) async fn call_read(
     })?;
 
     let offset = p.offset.unwrap_or(0);
-    let limit = p.limit.unwrap_or(2000).min(2000);
+    let limit = p.limit.unwrap_or(READ_MAX_LINES).min(READ_MAX_LINES);
 
     // We only need the window [offset, offset+limit). Stream line by line and
     // stop once we've collected one line past the window — enough to know
@@ -713,6 +722,15 @@ pub(crate) async fn call_write(
             let response =
                 maybe_append_pitfall_hint(response, state, worktree_path, project_id, &touched)
                     .await;
+            // Authorship-time size advisory. Runs after the bytes are on disk
+            // and cannot affect them; see size_nudge's module docs for why it
+            // is here and not in gate_guard.
+            let response = maybe_append_size_nudge(
+                response,
+                worktree_path,
+                std::slice::from_ref(&path),
+            )
+            .await;
             Ok(response)
         })
         .await
@@ -862,6 +880,10 @@ pub(crate) async fn call_edit(
                         &touched,
                     )
                     .await;
+                    // Authorship-time size advisory; see `call_write`.
+                    let result =
+                        maybe_append_size_nudge(result, worktree_path, std::slice::from_ref(&path))
+                            .await;
                     Ok(result)
                 }
                 MatchOutcome::Ambiguous => {
@@ -1075,6 +1097,15 @@ pub(crate) async fn call_apply_patch(
     };
     let response =
         maybe_append_pitfall_hint(response, state, worktree_path, project_id, &touched_rel).await;
+    // Authorship-time size advisory; see `call_write`. A patch can touch many
+    // files, so the nudge picks the single worst rather than stacking one
+    // advisory per path. Deletes are excluded — nothing was authored.
+    let touched_abs: Vec<std::path::PathBuf> = results
+        .iter()
+        .filter(|(_, action)| *action != "deleted")
+        .map(|(file_path, _)| file_path.clone())
+        .collect();
+    let response = maybe_append_size_nudge(response, worktree_path, &touched_abs).await;
     Ok(response)
 }
 


### PR DESCRIPTION
## What this does

Attaches a short advisory to **successful** `write` / `edit` / `apply_patch` results when the edited file can no longer be returned by a single `read`. New `size_nudge` key on the result JSON, alongside `related_files` and `jit_pitfalls`.

Pairs with #2849, which retires the merge-time file-size gate. That PR stands alone; this one is the replacement pressure.

## Why authorship time

The gate failed because merge time is the worst possible moment to apply this pressure. The author has already finished, and the cheapest path back to green is a one-line escape marker — which is what happened 108 times, against zero splits.

A nudge at authorship time cannot be gamed, because **there is nothing to satisfy**. No exit code changes. No marker helps. Ignoring it costs nothing. What it can do is put a fact in front of the author at the only moment they are already holding the file's structure in mind.

## Where it is *not*: the deny path

Deliberately not in `gate_guard`. That is the path #2821 and #2839 just unwedged — workers had been escaping its read-coverage deadlock by routing edits through the ungated `shell` tool. A size message that read as a denial would send them straight back off the instrumented path, undoing that fix.

So the nudge runs *after* the bytes are on disk, has no error type at all, and opens with `The edit succeeded`. Its signature is `Value -> Value`; every failure mode (unreadable file, poisoned mutex, path outside the worktree) returns the response untouched.

## The threshold, and why it is not 1500/51200

Those numbers came from the retired gate and were never derived from anything. This fires on exactly one condition — a fact about the tool surface rather than a taste judgement:

> **a single `read` can no longer return the whole file.**

Two clamps produce that, both already load-bearing in `workspace.rs`, both *read from the production constants* rather than copied:

- `read` returns at most 2000 lines — now the named `READ_MAX_LINES`, previously a literal repeated in two places.
- The rendered result is clamped to `output_stash::MAX_TOOL_RESULT_CHARS` (30 000), of which `read_content_budget()` (28 976) is the numbered listing.

The per-line gutter is charged at 10 characters: six columns of line number, plus a tab and a newline at **two** characters each, because the clamp applies to the JSON-*serialized* result. Under-charging there would let a file that genuinely needs two reads report one.

That makes the message specific in the way that matters. Not "this file is 2400 lines" — noise, large compared to what? — but "seeing this file in full costs 3 `read` calls", a price the reader is about to pay. For `workspace.rs` today:

```
The edit succeeded; this is advisory and blocks nothing.
server/crates/djinn-agent/src/extension/handlers/workspace.rs is now 1312 lines / 54172 bytes.
A single `read` returns at most 2000 lines and about 28976 characters of listing, so seeing this
file in full now costs 3 `read` calls — neither you nor the next reader can hold it in one.
If there is a genuine seam here — a boundary that would still make sense if nobody were
measuring — this is the cheapest moment you will ever get to split on it, because you already
have the structure in mind. If there isn't one, carry on; a file cut in an arbitrary place is
worse than a long one.
```

That last clause is deliberate. The old **line** limit was satisfiable by cutting anywhere, and the `_partN` fragments it rewarded hid 20.7k lines from rust-analyzer, rustfmt and three CI guards. An advisory that produces the same fragmentation would be a regression, not a fix.

## Details

- **Language-agnostic.** The read budget does not care what the file is, so neither does this. Generated paths, `.gen.*` and lockfiles are exempt — a nudge nobody can act on is what teaches readers to filter advisories wholesale.
- **Once per (session, path).** Same process-wide set and same worktree-path session key as the `jit_pitfalls` first-modification hint. Thirty edits to one big file produce one advisory, not thirty.
- **Cheap path for small edits.** A byte bound skips opening the file entirely in the common case. It is *derived* so that no line distribution below it can need two reads, and a test asserts exactly that rather than trusting the arithmetic.
- **Multi-file patches** advise about their single worst file. Three advisories in one result is a wall of text the reader skips, which is the failure mode this is trying to avoid.

## Verification

Every test holds all three halves of the contract at once — nudge present, nudge absent, **and the edit succeeding in both cases** — because two of the three are satisfiable by doing nothing.

Non-vacuity by mutation, both run and both reverted:

- **Mutation A** — make `maybe_append_size_nudge` a no-op, i.e. as if never wired. The 4 positive tests fail; the negative tests pass.
- **Mutation B** — make `reads_required` always return 2, i.e. nudge everything. This initially passed the whole suite, which exposed a real gap: the small-file tests exit through the cheap byte bound and never consult the estimate at all. Added `a_mid_size_file_past_the_cheap_bound_still_gets_no_nudge` (~10 kB / 300 lines) so the "no nudge" verdict has to come out of `reads_required` itself. Mutation B then fails it, end to end.

Results:

- `cargo test -p djinn-agent` — 1464 lib tests + all integration binaries pass, 0 failed. 13 of those are new.
- `cargo clippy -p djinn-agent --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)