### PR TITLE
fix(coordinator): give each test actor its own doctor registry (de15)

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -79,7 +79,21 @@ where
 /// Giving each actor its own registry in tests makes a check's database the
 /// database of the actor that runs it, which is what the production invariant
 /// already says.
+/// Registering into the global as well under `cfg(test)` is not redundant. It
+/// is what keeps every *other* consequence of this change at zero: a
+/// registration owns an `Arc` of its source, which owns a `Database`, and
+/// `register` replacing by name is what drops the previous actor's sources —
+/// which is what runs `TestDbInit::drop`, i.e. `DROP DATABASE`, on the *next*
+/// actor's construction thread. Take that away and the test databases either
+/// accumulate until Postgres runs out of shared memory (a leaked registry) or
+/// get dropped from a task being torn down inside `Runtime::drop`, where
+/// `TestDbInit`'s blocking `std::thread::spawn(..).join()` wedged the suite
+/// past the 900 s cap. Both were observed. Keeping the global registration
+/// keeps object lifetimes byte-identical to before; only the *read* moves.
+#[cfg(not(test))]
 pub(super) type DoctorRegistryHandle = &'static djinn_core::doctor::DoctorRegistry;
+#[cfg(test)]
+pub(super) type DoctorRegistryHandle = Arc<djinn_core::doctor::DoctorRegistry>;
 
 /// Build the registry a freshly-constructed actor resolves its checks from.
 #[cfg(not(test))]
@@ -87,22 +101,9 @@ pub(super) fn new_doctor_registry_handle() -> DoctorRegistryHandle {
     djinn_core::doctor::registry()
 }
 
-/// A fresh per-actor registry, leaked so it is `&'static` like the production
-/// singleton.
-///
-/// The leak is deliberate and it is what the singleton already did: a check
-/// registered into the global registry holds an `Arc` of its source, which
-/// holds a `Database`, and nothing ever unregisters — so every test database
-/// in the binary was already kept alive for the whole process. An owned
-/// `Arc<DoctorRegistry>` would instead have dropped with its actor, and that
-/// changed something unrelated to check isolation: `TestDbInit::drop` issues
-/// `DROP DATABASE` from a `std::thread::spawn(..).join()`, and running that
-/// from a task being dropped during `Runtime::drop` wedged the suite (one
-/// observed run sat on a single wave test past the 900 s cap). Matching the
-/// production lifetime keeps this change to the one thing it is about.
 #[cfg(test)]
 pub(super) fn new_doctor_registry_handle() -> DoctorRegistryHandle {
-    Box::leak(Box::new(djinn_core::doctor::DoctorRegistry::new()))
+    Arc::new(djinn_core::doctor::DoctorRegistry::new())
 }
 
 /// Coordinator actor state.
@@ -620,57 +621,65 @@ impl CoordinatorActor {
                 events_tx.clone(),
             ),
         );
-        crate::doctor::register_doctor_checks(
-            &doctor_registry,
-            Arc::new(crate::doctor::live_mover::NoOpLiveMoverSource),
-            Arc::clone(&stranded_ready_source) as Arc<dyn crate::doctor::StrandedReadySource>,
-        );
         let retrieval_health_source =
             Arc::new(crate::doctor::retrieval_health::RetrievalHealthSource::new(
                 db.clone(),
                 djinn_core::models::KnowledgeInjectionConfig::default(),
             ));
-        crate::doctor::register_retrieval_health_checks(
-            &doctor_registry,
-            Arc::clone(&retrieval_health_source),
-        );
         let closed_parent_open_children_source = Arc::new(
             crate::doctor::TaskRepositoryClosedParentOpenChildrenSource::new(
                 db.clone(),
                 events_tx.clone(),
             ),
         );
-        crate::doctor::register_closed_parent_open_children_check_with_repair(
-            &doctor_registry,
-            Arc::clone(&closed_parent_open_children_source)
-                as Arc<dyn crate::doctor::ClosedParentOpenChildrenSource>,
-            Arc::clone(&closed_parent_open_children_source)
-                as Arc<dyn crate::doctor::ClosedParentOpenChildrenRepairSource>,
-        );
-        // Read-only cache-root manifest detector. On-demand cadence: it stats
-        // the cache PVC and walks candidates, which is too expensive for the
-        // cheap periodic subset. It has no fix path.
-        crate::doctor::register_stale_cache_roots_check(
-            &doctor_registry,
-            Arc::new(crate::doctor::ProjectRepositoryStaleCacheRootsSource::new(
-                db.clone(),
-            )),
-        );
-        crate::doctor::register_refinement_phantom_active_check(
-            &doctor_registry,
-            Arc::new(
-                crate::doctor::ProposalRepositoryRefinementPhantomActiveSource::new(
+        let register_checks_into = |registry: &djinn_core::doctor::DoctorRegistry| {
+            crate::doctor::register_doctor_checks(
+                registry,
+                Arc::new(crate::doctor::live_mover::NoOpLiveMoverSource),
+                Arc::clone(&stranded_ready_source) as Arc<dyn crate::doctor::StrandedReadySource>,
+            );
+            crate::doctor::register_retrieval_health_checks(
+                registry,
+                Arc::clone(&retrieval_health_source),
+            );
+            crate::doctor::register_closed_parent_open_children_check_with_repair(
+                registry,
+                Arc::clone(&closed_parent_open_children_source)
+                    as Arc<dyn crate::doctor::ClosedParentOpenChildrenSource>,
+                Arc::clone(&closed_parent_open_children_source)
+                    as Arc<dyn crate::doctor::ClosedParentOpenChildrenRepairSource>,
+            );
+            // Read-only cache-root manifest detector. On-demand cadence: it
+            // stats the cache PVC and walks candidates, which is too expensive
+            // for the cheap periodic subset. It has no fix path.
+            crate::doctor::register_stale_cache_roots_check(
+                registry,
+                Arc::new(crate::doctor::ProjectRepositoryStaleCacheRootsSource::new(
                     db.clone(),
-                    events_tx.clone(),
+                )),
+            );
+            crate::doctor::register_refinement_phantom_active_check(
+                registry,
+                Arc::new(
+                    crate::doctor::ProposalRepositoryRefinementPhantomActiveSource::new(
+                        db.clone(),
+                        events_tx.clone(),
+                    ),
                 ),
-            ),
-        );
-        crate::doctor::register_stalled_epic_check(
-            &doctor_registry,
-            Arc::new(crate::doctor::TaskRepositoryStalledEpicSource::new(
-                db.clone(),
-            )),
-        );
+            );
+            crate::doctor::register_stalled_epic_check(
+                registry,
+                Arc::new(crate::doctor::TaskRepositoryStalledEpicSource::new(
+                    db.clone(),
+                )),
+            );
+        };
+        register_checks_into(&doctor_registry);
+        // Under `cfg(test)` the line above filled a registry private to this
+        // actor, so the global still needs its (unread) registration to keep
+        // source lifetimes exactly as they were — see [`DoctorRegistryHandle`].
+        #[cfg(test)]
+        register_checks_into(djinn_core::doctor::registry());
         Self {
             receiver,
             events,

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -53,6 +53,48 @@ where
 
 // ─── Actor (≤20 fields — AGENT-11) ───────────────────────────────────────────
 
+/// Where a [`CoordinatorActor`] keeps its doctor checks.
+///
+/// Production is unchanged: the actor registers into, and reads back from, the
+/// process-global [`djinn_core::doctor::registry()`] singleton, which is the
+/// same registry the MCP `doctor_run` / `doctor_fix` surfaces resolve against
+/// (`McpState` defaults to it — PR #2820). One server process runs one
+/// coordinator, so "global" and "this actor's" are the same set of checks.
+///
+/// Under `cfg(test)` they are not the same thing, and that difference was a
+/// flake source. `DoctorRegistry::register` replaces by check *name*, and cargo
+/// runs every test in a binary as a thread of one process, so each of the
+/// ~1980 coordinator lib tests that builds an actor overwrote all seven
+/// coordinator checks with sources bound to *its own* ephemeral Postgres
+/// database (a 4-connection pool). Whichever test registered last served every
+/// concurrent actor's tick: sixteen actors piled onto one foreign pool, and
+/// once that owning test finished and its database was dropped the checks sat
+/// there until the pool acquire timed out. A single observed tick spent
+/// `elapsed_ms=15046` in `run_cheap_subset` on
+/// `pool timed out while waiting for an open connection`. The coordinator is a
+/// single-mailbox actor, so for those fifteen seconds it serviced neither its
+/// mailbox nor the event stream, and whichever sibling test was waiting on a
+/// rule to fire failed its bounded wait — a different one each run.
+///
+/// Giving each actor its own registry in tests makes a check's database the
+/// database of the actor that runs it, which is what the production invariant
+/// already says.
+#[cfg(not(test))]
+pub(super) type DoctorRegistryHandle = &'static djinn_core::doctor::DoctorRegistry;
+#[cfg(test)]
+pub(super) type DoctorRegistryHandle = Arc<djinn_core::doctor::DoctorRegistry>;
+
+/// Build the registry a freshly-constructed actor will own.
+#[cfg(not(test))]
+pub(super) fn new_doctor_registry_handle() -> DoctorRegistryHandle {
+    djinn_core::doctor::registry()
+}
+
+#[cfg(test)]
+pub(super) fn new_doctor_registry_handle() -> DoctorRegistryHandle {
+    Arc::new(djinn_core::doctor::DoctorRegistry::new())
+}
+
 /// Coordinator actor state.
 ///
 /// Durability boundary: `last_dispatched`, `inflight_dispatches`,
@@ -181,6 +223,9 @@ pub(super) struct CoordinatorActor {
     #[cfg(not(test))]
     pub(super) retrieval_health_source:
         Option<Arc<crate::doctor::retrieval_health::RetrievalHealthSource>>,
+    /// The doctor registry this actor registers its checks into and resolves
+    /// the cheap subset from. See [`DoctorRegistryHandle`].
+    pub(super) doctor_registry: DoctorRegistryHandle,
     /// Per-task state of the PR poller's offloaded clean-merge fast path. The
     /// heavy mechanical merge (fetch + ephemeral clone + merge + push) runs in a
     /// spawned background task instead of inline on this tick; the poller reads
@@ -552,10 +597,13 @@ impl CoordinatorActor {
         let mut tick = time::interval(STUCK_INTERVAL);
         tick.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
-        // Wire the coordinator-side doctor checks into the global registry. The
-        // stranded-ready source is cached here and refreshed each tick before the
-        // cheap subset runs; the live-mover source is a no-op until the production
+        // Wire the coordinator-side doctor checks into this actor's registry —
+        // the process-global one in production, a private one under
+        // `cfg(test)`; see [`DoctorRegistryHandle`]. The stranded-ready source
+        // is cached here and refreshed each tick before the cheap subset runs;
+        // the live-mover source is a no-op until the production
         // evidence-collector adapter (T5) is wired.
+        let doctor_registry = new_doctor_registry_handle();
         let stranded_ready_source = Arc::new(
             crate::doctor::stranded_ready::TaskRepositoryStrandedReadySource::new(
                 db.clone(),
@@ -563,7 +611,7 @@ impl CoordinatorActor {
             ),
         );
         crate::doctor::register_doctor_checks(
-            djinn_core::doctor::registry(),
+            &doctor_registry,
             Arc::new(crate::doctor::live_mover::NoOpLiveMoverSource),
             Arc::clone(&stranded_ready_source) as Arc<dyn crate::doctor::StrandedReadySource>,
         );
@@ -573,7 +621,7 @@ impl CoordinatorActor {
                 djinn_core::models::KnowledgeInjectionConfig::default(),
             ));
         crate::doctor::register_retrieval_health_checks(
-            djinn_core::doctor::registry(),
+            &doctor_registry,
             Arc::clone(&retrieval_health_source),
         );
         let closed_parent_open_children_source = Arc::new(
@@ -583,7 +631,7 @@ impl CoordinatorActor {
             ),
         );
         crate::doctor::register_closed_parent_open_children_check_with_repair(
-            djinn_core::doctor::registry(),
+            &doctor_registry,
             Arc::clone(&closed_parent_open_children_source)
                 as Arc<dyn crate::doctor::ClosedParentOpenChildrenSource>,
             Arc::clone(&closed_parent_open_children_source)
@@ -593,13 +641,13 @@ impl CoordinatorActor {
         // the cache PVC and walks candidates, which is too expensive for the
         // cheap periodic subset. It has no fix path.
         crate::doctor::register_stale_cache_roots_check(
-            djinn_core::doctor::registry(),
+            &doctor_registry,
             Arc::new(crate::doctor::ProjectRepositoryStaleCacheRootsSource::new(
                 db.clone(),
             )),
         );
         crate::doctor::register_refinement_phantom_active_check(
-            djinn_core::doctor::registry(),
+            &doctor_registry,
             Arc::new(
                 crate::doctor::ProposalRepositoryRefinementPhantomActiveSource::new(
                     db.clone(),
@@ -608,7 +656,7 @@ impl CoordinatorActor {
             ),
         );
         crate::doctor::register_stalled_epic_check(
-            djinn_core::doctor::registry(),
+            &doctor_registry,
             Arc::new(crate::doctor::TaskRepositoryStalledEpicSource::new(
                 db.clone(),
             )),
@@ -647,6 +695,7 @@ impl CoordinatorActor {
             )),
             #[cfg(not(test))]
             retrieval_health_source: Some(retrieval_health_source),
+            doctor_registry,
             auto_merge_tracker: Arc::new(std::sync::Mutex::new(HashMap::new())),
             consolidation_runner: consolidation_runner
                 .unwrap_or_else(|| Arc::new(DbConsolidationRunner::new(db.clone()))),
@@ -805,6 +854,11 @@ impl CoordinatorActor {
         }
 
         summary
+    }
+
+    /// The registry this actor's checks live in. See [`DoctorRegistryHandle`].
+    pub(super) fn doctor_registry(&self) -> &djinn_core::doctor::DoctorRegistry {
+        &self.doctor_registry
     }
 
     pub fn dispatch_state_snapshot(&self) -> CoordinatorDebugSnapshot {
@@ -1130,7 +1184,7 @@ impl CoordinatorActor {
         crate::doctor::leader_tick::run_elected_retrieval_refresh_and_cheap_checks(
             true,
             retrieval_health_source,
-            djinn_core::doctor::registry(),
+            self.doctor_registry(),
             &self.db,
             &self.events_tx,
             Some(&doctor_run_id),
@@ -1433,7 +1487,7 @@ impl CoordinatorActor {
                 #[cfg(not(test))]
                 let result = crate::doctor::leader_tick::run_manual_retrieval_refresh_and_checks(
                     self.retrieval_health_source.as_ref(),
-                    djinn_core::doctor::registry(),
+                    self.doctor_registry(),
                     &self.db,
                     &self.events_tx,
                     Some(&run_id),

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -79,20 +79,30 @@ where
 /// Giving each actor its own registry in tests makes a check's database the
 /// database of the actor that runs it, which is what the production invariant
 /// already says.
-#[cfg(not(test))]
 pub(super) type DoctorRegistryHandle = &'static djinn_core::doctor::DoctorRegistry;
-#[cfg(test)]
-pub(super) type DoctorRegistryHandle = Arc<djinn_core::doctor::DoctorRegistry>;
 
-/// Build the registry a freshly-constructed actor will own.
+/// Build the registry a freshly-constructed actor resolves its checks from.
 #[cfg(not(test))]
 pub(super) fn new_doctor_registry_handle() -> DoctorRegistryHandle {
     djinn_core::doctor::registry()
 }
 
+/// A fresh per-actor registry, leaked so it is `&'static` like the production
+/// singleton.
+///
+/// The leak is deliberate and it is what the singleton already did: a check
+/// registered into the global registry holds an `Arc` of its source, which
+/// holds a `Database`, and nothing ever unregisters — so every test database
+/// in the binary was already kept alive for the whole process. An owned
+/// `Arc<DoctorRegistry>` would instead have dropped with its actor, and that
+/// changed something unrelated to check isolation: `TestDbInit::drop` issues
+/// `DROP DATABASE` from a `std::thread::spawn(..).join()`, and running that
+/// from a task being dropped during `Runtime::drop` wedged the suite (one
+/// observed run sat on a single wave test past the 900 s cap). Matching the
+/// production lifetime keeps this change to the one thing it is about.
 #[cfg(test)]
 pub(super) fn new_doctor_registry_handle() -> DoctorRegistryHandle {
-    Arc::new(djinn_core::doctor::DoctorRegistry::new())
+    Box::leak(Box::new(djinn_core::doctor::DoctorRegistry::new()))
 }
 
 /// Coordinator actor state.

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -106,6 +106,15 @@ pub(super) fn new_doctor_registry_handle() -> DoctorRegistryHandle {
     Arc::new(djinn_core::doctor::DoctorRegistry::new())
 }
 
+/// Borrow a handle as a plain registry reference.
+///
+/// The deref coercion that gets there differs per `cfg` — `&&'static T` in
+/// production, `&Arc<T>` under test — so it happens here instead of at every
+/// call site, where the production spelling would be a `needless_borrow`.
+pub(super) fn registry_of(handle: &DoctorRegistryHandle) -> &djinn_core::doctor::DoctorRegistry {
+    handle
+}
+
 /// Coordinator actor state.
 ///
 /// Durability boundary: `last_dispatched`, `inflight_dispatches`,
@@ -674,7 +683,7 @@ impl CoordinatorActor {
                 )),
             );
         };
-        register_checks_into(&doctor_registry);
+        register_checks_into(registry_of(&doctor_registry));
         // Under `cfg(test)` the line above filled a registry private to this
         // actor, so the global still needs its (unread) registration to keep
         // source lifetimes exactly as they were — see [`DoctorRegistryHandle`].
@@ -877,7 +886,7 @@ impl CoordinatorActor {
 
     /// The registry this actor's checks live in. See [`DoctorRegistryHandle`].
     pub(super) fn doctor_registry(&self) -> &djinn_core::doctor::DoctorRegistry {
-        &self.doctor_registry
+        registry_of(&self.doctor_registry)
     }
 
     pub fn dispatch_state_snapshot(&self) -> CoordinatorDebugSnapshot {

--- a/server/crates/djinn-coordinator/src/consolidation.rs
+++ b/server/crates/djinn-coordinator/src/consolidation.rs
@@ -471,6 +471,7 @@ mod tests {
             breaker_open_backoff_streak: std::collections::HashMap::new(),
             background_work_tracker: BackgroundWorkTracker::default(),
             stranded_ready_source: None,
+            doctor_registry: crate::actor::new_doctor_registry_handle(),
             closed_parent_open_children_source: None,
             auto_merge_tracker: AutoMergeTracker::default(),
             consolidation_runner: runner,

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -3765,6 +3765,7 @@ mod inflight_ledger_tests {
             breaker_open_backoff_streak: HashMap::new(),
             background_work_tracker: BackgroundWorkTracker::default(),
             stranded_ready_source: None,
+            doctor_registry: crate::actor::new_doctor_registry_handle(),
             closed_parent_open_children_source: None,
             auto_merge_tracker: AutoMergeTracker::default(),
             consolidation_runner: std::sync::Arc::new(
@@ -5021,6 +5022,7 @@ mod failover_chain_tests {
             breaker_open_backoff_streak: HashMap::new(),
             background_work_tracker: BackgroundWorkTracker::default(),
             stranded_ready_source: None,
+            doctor_registry: crate::actor::new_doctor_registry_handle(),
             closed_parent_open_children_source: None,
             auto_merge_tracker: AutoMergeTracker::default(),
             consolidation_runner: std::sync::Arc::new(
@@ -7593,6 +7595,7 @@ mod monitored_reopen_no_eligible_model_tests {
             breaker_open_backoff_streak: HashMap::new(),
             background_work_tracker: BackgroundWorkTracker::default(),
             stranded_ready_source: None,
+            doctor_registry: crate::actor::new_doctor_registry_handle(),
             closed_parent_open_children_source: None,
             auto_merge_tracker: AutoMergeTracker::default(),
             consolidation_runner: std::sync::Arc::new(
@@ -8118,6 +8121,7 @@ mod build_admission_route_tests {
             breaker_open_backoff_streak: HashMap::new(),
             background_work_tracker: BackgroundWorkTracker::default(),
             stranded_ready_source: None,
+            doctor_registry: crate::actor::new_doctor_registry_handle(),
             closed_parent_open_children_source: None,
             auto_merge_tracker: AutoMergeTracker::default(),
             consolidation_runner: std::sync::Arc::new(

--- a/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
@@ -190,6 +190,7 @@ pub(crate) fn build_refinement_actor(
         active_refinements: HashMap::new(),
         refinement_sessions: HashMap::new(),
         stranded_ready_source: None,
+        doctor_registry: crate::actor::new_doctor_registry_handle(),
         closed_parent_open_children_source: None,
         dispatched: 0,
         recovered: 0,

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -498,6 +498,7 @@ fn coordinator_actor_for_tests(
         active_refinements: HashMap::new(),
         refinement_sessions: HashMap::new(),
         stranded_ready_source: None,
+        doctor_registry: crate::actor::new_doctor_registry_handle(),
         closed_parent_open_children_source: None,
         dispatched: 0,
         recovered: 0,


### PR DESCRIPTION
Closes the third `djinn-coordinator` flake cluster reported in `de15`, found
while fixing the first two in #2824.

**The theory recorded in the task is wrong**, and the real mechanism is worth
stating plainly, because it is the *same root shape* as both clusters #2824 and
#2820 fixed: a process-global singleton under cargo's one-process-many-threads
model.

## The theory that was in the task

> the test's own coordinator dispatches the fixture's second worker task into
> the live mock slot pool moments before the test closes it, then emits nothing
> for the remaining 10 seconds. The fixture races its own dispatch.

The first half is real and visible in the logs — the fixture's coordinator does
dispatch its own second task. It is not why the test fails. That dispatch
completes in ~80 ms and is fully logged. The coordinator then goes silent for a
reason that has nothing to do with the fixture's ordering, and no fixture change
was needed to fix it.

## What is actually happening

`djinn_core::doctor::registry()` is a process-wide `OnceLock` whose `register`
**replaces by check name**. `CoordinatorActor::new` registers seven coordinator
checks into it, each bound to that actor's `Database`. Cargo runs every test in
a binary as a thread of one process, so all ~1980 coordinator lib tests that
build an actor write into that one map, and **whichever registered last serves
every concurrent actor**. Each test's `Database::open_in_memory` is a separate
ephemeral Postgres database with a **4-connection pool**.

`tokio::time::interval` yields its first tick immediately, so every actor runs
the cheap doctor subset within milliseconds of starting — against that one
foreign pool. Sixteen actors at default concurrency exhaust four connections,
and once the owning test finishes and its database is dropped, the checks block
until the acquire times out.

From a captured baseline failure (`wave::tests::two_phased_p2_decomposes_after_p1_closes`):

```
12:49:44.045  DEBUG  CoordinatorActor: planning task already exists, skipping epic_id=yf5m
12:49:59.087  WARN   closed_parent_open_children doctor: failed to load board-health snapshot
                     error=database error: pool timed out while waiting for an open connection
12:49:59.132  INFO   CoordinatorActor: cheap doctor tick complete checks=7 elapsed_ms=15046
...
panicked at wave.rs:887: called `Result::unwrap()` on an `Err` value: Sqlx(PoolTimedOut)
```

**15,046 ms in one tick.** The coordinator is a single-mailbox actor — one
`select!` loop servicing each pass serially — so for those fifteen seconds it
serviced neither its mailbox nor the event stream. Whichever sibling test was
waiting on a rule to fire failed its bounded wait, and a different one is
unlucky each run.

That accounts for every reported symptom: the varying failure set, the "emits
nothing for the remaining 10 seconds", and the multi-minute hang — the same
exhaustion also times out the *test's own* queries, which is what the
`Sqlx(PoolTimedOut)` above is (that one is the test thread, not the actor). The
matching `rules::tests::batch_completion_creates_decomposition_task` trace shows
the same silence: dispatch finishes at `.426`, then nothing at all until the 10 s
poll gives up.

## The fix

Resolve the registry **per actor**:

```rust
#[cfg(not(test))] type DoctorRegistryHandle = &'static DoctorRegistry;  // the singleton
#[cfg(test)]      type DoctorRegistryHandle = Arc<DoctorRegistry>;      // one per actor
```

Production is unchanged: the `cfg(not(test))` alias resolves to the same
`djinn_core::doctor::registry()` singleton, with the same registration calls and
the same read in `run_tick` — the same instance `McpState` defaults to (#2820).
One server process runs one coordinator, so "global" and "this actor's" have
always been the same set of checks there. Under `cfg(test)` a check's database is
now the database of the actor that runs it, which is what the production
invariant already said. This is the coordinator half of #2820, which made the
same registry injectable on `McpState` for exactly this reason and left the
coordinator side on the singleton.

Under `cfg(test)` the actor **also** registers into the global, where nothing
reads it. That is not redundant, and the two intermediate commits are kept
because they document why. A registration owns an `Arc` of its source, which owns
a `Database`, and `register` replacing by name is what drops the previous actor's
sources — which is what runs `TestDbInit::drop`, i.e. `DROP DATABASE`, on the
*next* actor's construction thread. Moving the registration off the global takes
that over, and both ways of doing so broke:

* an owned `Arc<DoctorRegistry>` per actor moved the drop into `Runtime::drop`,
  where `TestDbInit`'s blocking `std::thread::spawn(..).join()` wedged one run
  on a single wave test past a 900 s cap;
* leaking the registry removed the drop entirely, and test databases accumulated
  until Postgres refused to resize a shared-memory segment — 1515 leaked
  `djinn_test_*` databases and 276 failures in one run.

Keeping the global registration keeps object lifetimes byte-identical to before;
only the *read* moves. Verified: a full run now leaves 15 test databases behind,
the same order as before, against 1515 with the leaked variant.

No poll timeout was extended and nothing was serialized. The race is *closed*,
not widened — the cross-test coupling is removed rather than out-waited.

## Verification — `cargo test -p djinn-coordinator --lib`, default (parallel) concurrency

Baseline on `main`, 4 runs (a 5th was consumed by a cold build):

| run | failures |
| --- | --- |
| 1 | `rules::tests::batch_completion_creates_decomposition_task` |
| 2 | `wave::tests::two_phased_p2_decomposes_after_p1_closes` (+ `pr_poller::…`) |
| 3 | `rules::tests::task_created_event_for_closed_linked_spike_records_evidence_received`, `wave::tests::epic_updated_does_not_recreate_planning_when_worker_tasks_exist` |
| 4 | `tests::status_and_stuck::reopened_twice_applies_failure_once_per_reopen_count` (+ `pr_poller::…`) |

4/4 runs failed, a different set each time — the reported signature.

After the fix, 8 consecutive runs:

```
RUN 1 rc=0 secs=28  1980 passed; 0 failed
RUN 2 rc=0 secs=27  1980 passed; 0 failed
RUN 3 rc=0 secs=43  1980 passed; 0 failed
RUN 4 rc=0 secs=58  1980 passed; 0 failed
RUN 5 rc=0 secs=48  1980 passed; 0 failed
RUN 6 rc=0 secs=38  1980 passed; 0 failed
RUN 7 rc=0 secs=29  1980 passed; 0 failed
RUN 8 rc=101        1979 passed; 1 failed  (context::tests::cache_cleanup_config_from_env_ignores_invalid_numbers)
TOTAL de15_cluster_failures=0  hangs=0  over 8 runs
```

Zero failures and zero hangs in `rules::tests`, `wave::tests` and
`tests::status_and_stuck` across all eight; seven of the eight are entirely
green. Run 8's single failure is a different cluster — see below.

### Teeth

The rule `rules::tests::batch_completion_creates_decomposition_task` covers is
`CoordinatorActor::on_task_closed` rule 2. Mutating its firing condition in
`rules.rs` —

```rust
-let all_closed = worker_tasks.iter().all(|t| t.status == "closed");
+let all_closed = false; // TEETH-CHECK MUTATION
```

— fails the test, and the shape of the failure is the point:

```
mutated:  FAILED  ... assertion `left == right` failed:
                      batch completion should create exactly one planning task
          test result: FAILED. 0 passed; 1 failed;  finished in 10.79s
restored: test result: ok. 1 passed; 0 failed;      finished in  0.81s
```

10.79 s mutated (the poll runs its full deadline, then asserts) versus 0.81 s
restored — the test still observes the production write, and it now observes it
immediately rather than after a fifteen-second stall.

## Two separate residuals, deliberately not fixed here

Both are the same *shape* as this bug (a process-global read under parallel
tests) but different mechanisms and different fixes:

* `pr_poller::tests::auto_merge_reopen_decision_records_merge_failure_after_lock_release`
  (2 baseline runs, `left: 0.0, right: 2.0`) reads the **process-global metrics
  registry** via `djinn_telemetry::render()` and asserts an absolute value on
  `djinn_pr_poller_tracked`, a gauge any concurrent sibling overwrites. A #2824
  leftover that was not converted to `IsolatedRecorder`.
* `context::tests::cache_cleanup_config_from_env_ignores_invalid_numbers`
  (run 8) mutates **process-global environment variables**
  (`DJINN_CACHE_CLEANUP_*`) with `std::env::set_var`, which every concurrent
  test in the binary sees.

Test-scoped change; the production binary is unchanged.
