### PR TITLE
fix(kueue): a routine eviction must not destroy a recoverable task-run (03z3)

### DIFF
--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -22,6 +22,7 @@ mod launcher_cpu;
 pub mod pod_resize;
 pub mod private_dep_config;
 pub mod runtime;
+mod runtime_eviction;
 pub mod scip_job;
 pub mod scip_schedule;
 pub mod secret;

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -60,6 +60,7 @@ use uuid::Uuid;
 
 use crate::config::KubernetesConfig;
 use crate::job::{build_task_run_job_with_read_sources, taskrun_job_ref_from_job};
+use crate::runtime_eviction::{PodAbsenceVerdict, classify_absent_pod};
 use crate::secret::{TaskRunSecretBuilder, job_owner_reference, task_run_resource_name};
 use crate::sidecar::ImageServiceResolution;
 
@@ -1157,13 +1158,21 @@ impl SessionRuntime for KubernetesRuntime {
     ///   gone (TTL-GC'd after finishing) → the run finished out-of-band and we
     ///   never saw a report; treat as a terminal disappearance.
     /// - The *fenced* Pod — the immutable UID this watch bound on its first
-    ///   observation — is gone while the Job is still NONTERMINAL. That is a
-    ///   force-delete / node loss / out-of-band eviction, and it is the one arm
-    ///   that also has to *act*: see [`Self::reap_lost_fenced_pod`].
+    ///   observation — is gone while the Job is still NONTERMINAL **and nothing
+    ///   in observable cluster state explains the absence**. That is a
+    ///   force-delete / node loss, and it is the one arm that also has to *act*:
+    ///   see [`Self::reap_lost_fenced_pod`].
     ///
     /// A `Succeeded` Job is NOT treated as death — a clean run delivers its
     /// terminal report over the stream, which the runner prefers; resolving
     /// here on success would race that and risk a spurious "interrupted".
+    ///
+    /// Neither is a Kueue EVICTION, which is bit-for-bit the same observation —
+    /// Kueue re-suspends the Job and its Pod is deleted — and is RECOVERABLE:
+    /// releasing the queue re-admits the Workload and a new Pod runs. Reaping
+    /// there would convert a run that was going to finish into one that never
+    /// can. [`crate::runtime_eviction::classify_absent_pod`] holds the two
+    /// fields that tell the two apart, and why they are those two.
     ///
     /// # The Pod fence
     ///
@@ -1194,6 +1203,10 @@ impl SessionRuntime for KubernetesRuntime {
         // The immutable Pod identity this run is fenced to. Bound once, on the
         // first observation that carries a UID; never re-bound.
         let mut bound_pod_uid: Option<String> = None;
+        // Whether the previous poll already reported holding on an explained
+        // Pod absence. Presentation only: a run parked in the queue for an hour
+        // must not write the same INFO line 240 times.
+        let mut held_absence = false;
 
         loop {
             // 1. Richest signal first: the Pod's container terminated state,
@@ -1258,18 +1271,35 @@ impl SessionRuntime for KubernetesRuntime {
                                     // A cleanly Complete Job whose Pod was
                                     // TTL-GC'd is NOT a death: the terminal
                                     // report rides the stream. Keep watching.
+                                    //
+                                    // Nor is a Kueue EVICTION, which produces
+                                    // this same state and is recoverable — see
+                                    // `crate::runtime_eviction`. Only an
+                                    // unexplained absence is A1's subject.
                                     if !job_completed_cleanly(&job) {
-                                        return self
-                                            .reap_lost_fenced_pod(
+                                        match classify_absent_pod(&self.client, ns, &job, job_name)
+                                            .await
+                                        {
+                                            PodAbsenceVerdict::Abandoned => {
+                                                return self
+                                                    .reap_lost_fenced_pod(
+                                                        handle,
+                                                        job_name,
+                                                        bound_pod_uid.as_deref(),
+                                                        &unadopted_pod_uids(
+                                                            &list.items,
+                                                            bound_pod_uid.as_deref(),
+                                                        ),
+                                                    )
+                                                    .await;
+                                            }
+                                            verdict => self.log_held_pod_absence(
                                                 handle,
                                                 job_name,
-                                                bound_pod_uid.as_deref(),
-                                                &unadopted_pod_uids(
-                                                    &list.items,
-                                                    bound_pod_uid.as_deref(),
-                                                ),
-                                            )
-                                            .await;
+                                                &verdict,
+                                                &mut held_absence,
+                                            ),
+                                        }
                                     }
                                 }
                                 Err(_) => {
@@ -1371,6 +1401,46 @@ impl KubernetesRuntime {
     /// A failed delete does not suppress the reason: the run is dead either
     /// way, and refusing to resolve would pin the dispatch slot on the very
     /// stall this watch exists to break. The next reconcile can retry the Job.
+    /// Report a fenced-Pod absence the watch is deliberately NOT acting on.
+    ///
+    /// The first observation is INFO — a run whose Pod vanished and was not
+    /// reaped is exactly the thing an operator wants in the log, once. Every
+    /// later poll is DEBUG, because a Workload can sit in the queue for as long
+    /// as the queue is full and 4 lines a minute of it is not information.
+    fn log_held_pod_absence(
+        &self,
+        handle: &RunHandle,
+        job_name: &str,
+        verdict: &PodAbsenceVerdict,
+        already_reported: &mut bool,
+    ) {
+        let (kind, evidence) = match verdict {
+            PodAbsenceVerdict::Recoverable(evidence) => ("recoverable", evidence.as_str()),
+            PodAbsenceVerdict::Inconclusive(error) => ("inconclusive", error.as_str()),
+            // Never reached: the caller reaps on `Abandoned` instead of holding.
+            PodAbsenceVerdict::Abandoned => ("abandoned", ""),
+        };
+        if std::mem::replace(already_reported, true) {
+            debug!(
+                task_run_id = %handle.task_run_id,
+                job = %job_name,
+                verdict = %kind,
+                %evidence,
+                "kubernetes_runtime: infra-death watch — still holding the fenced Pod's absence"
+            );
+            return;
+        }
+        info!(
+            task_run_id = %handle.task_run_id,
+            job = %job_name,
+            verdict = %kind,
+            %evidence,
+            "kubernetes_runtime: infra-death watch — the fenced worker Pod is gone but its \
+             absence is explained; NOT terminalising and NOT reaping the Job, so the run can \
+             still be re-admitted"
+        );
+    }
+
     async fn reap_lost_fenced_pod(
         &self,
         handle: &RunHandle,

--- a/server/crates/djinn-k8s/src/runtime_eviction.rs
+++ b/server/crates/djinn-k8s/src/runtime_eviction.rs
@@ -1,0 +1,187 @@
+//! Telling a RECOVERABLE Kueue eviction apart from a genuinely abandoned Job
+//! (task `03z3`, epic `fbiy`).
+//!
+//! # The defect this exists to close
+//!
+//! `fbiy-A1` (#2833) gave [`crate::runtime::KubernetesRuntime::watch_infra_death`]
+//! an arm that fires when the fenced worker Pod is absent while its Job is still
+//! nonterminal: it terminalises the task-run and foreground-deletes the Job so
+//! the Job stops holding Kueue quota. For an abandoned Pod that is right.
+//!
+//! A routine Kueue eviction produces *the same observable state* — Kueue
+//! re-suspends the Job and the Job controller deletes its Pod — and an eviction
+//! is RECOVERABLE: when capacity returns, the very same Workload is re-admitted
+//! and a new Pod runs. Deleting the Job there converts a run that was going to
+//! finish into one that never can.
+//!
+//! `fbiy-B2` (#2842) then measured, on a live armed cluster, that the renderer's
+//! `backoffLimit: 0` makes a force-deleted Pod an immediate Job *failure* (~5s),
+//! which resolves through the pre-existing `job_failed_reason` arm. So on a real
+//! cluster A1's arm is reached almost exclusively BY EVICTION — the one case
+//! where its action is wrong.
+//!
+//! The fix narrows the arm rather than removing it: an abandoned Job still has
+//! to be reaped, because a stale Job holding quota forever is why A1 exists.
+//!
+//! # The distinguisher, and why it is these two fields
+//!
+//! Measured on the disposable armed cluster (kind, Kubernetes 1.31, Kueue
+//! 0.19.0, 2026-07-31; full transcript in the PR body):
+//!
+//! | phase | `job.spec.suspend` | Workload `Evicted` condition |
+//! |---|---|---|
+//! | admitted, running | `false` | *absent* |
+//! | evicted (`stopPolicy: HoldAndDrain`) | `true` at t+0s, Pod gone at t+34s | `True`, reason `ClusterQueueStopped` |
+//! | re-admitted (~1s after release) | `false` | **still present**, `False`, reason `QuotaReserved`, message `Previously: The ClusterQueue is stopped` |
+//!
+//! Two fields, because one alone is not enough:
+//!
+//! * [`job_is_suspended`] — `spec.suspend` on the Job object the watch has
+//!   already fetched. Kueue writes it BEFORE the Pod goes away (t+0s versus
+//!   t+34s above), so there is no window in which the Pod is missing and the
+//!   suspension is not yet visible. It costs no extra API call and needs no
+//!   Kueue CRD, so it also answers for a plain `kubectl patch suspend=true`.
+//! * [`workload_eviction_record`] — the Workload's `Evicted` condition,
+//!   **whatever its status**. This is the one that survives re-admission: Kueue
+//!   flips the condition to `False` and keeps it, so a watch that samples after
+//!   the queue was released can still see that this Workload's quota was taken
+//!   back. `spec.suspend` alone cannot see that — the re-admitted Job reads
+//!   `suspend: false` with the fenced Pod still gone, which is bit-for-bit the
+//!   state A1 reaps on, and the release measured ~1s against a 15s poll.
+//!
+//! Neither is a timing heuristic: both are field reads, and no branch here
+//! consults a clock, a duration or a sleep. That is `03z3`'s AC3.
+//!
+//! # Failing toward "hold", except where Kueue does not exist
+//!
+//! [`classify_absent_pod`] answers `Abandoned` only on a definite negative: the
+//! Job is not suspended AND Kueue's own record says this Workload was never
+//! evicted, or the Workload API is not served at all (no Kueue in this cluster,
+//! so no eviction can have happened and A1's behaviour is the whole truth).
+//! Any other failure — RBAC, a 5xx, a timeout — is [`PodAbsenceVerdict::Inconclusive`]
+//! and holds, because the next poll is 15 seconds away while a wrong reap is
+//! permanent. An evicted Workload holds NO quota in the meantime (measured: the
+//! ClusterQueue's `pods` usage falls to 0 on eviction), so holding does not
+//! strand the capacity the reap exists to release.
+
+use k8s_openapi::api::batch::v1::Job;
+use kube::Api;
+use kube::api::ListParams;
+
+use crate::workload_inventory::{CONDITION_EVICTED, KueueWorkload};
+
+/// Why the fenced Pod is missing, as far as observable cluster state can say.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PodAbsenceVerdict {
+    /// Nothing explains it: the Job is unsuspended, therefore owed a Pod, and
+    /// Kueue has no record of ever taking its quota back. This is A1's subject —
+    /// terminalise and reap.
+    Abandoned,
+    /// The Job's Pod is gone because its admission was withdrawn, and the run
+    /// can still finish. Carries the evidence, for the log and the reason.
+    Recoverable(String),
+    /// The cluster could not be asked. Hold: a reap cannot be undone.
+    Inconclusive(String),
+}
+
+/// `spec.suspend` on the Job, defaulting to false exactly as the API server does.
+///
+/// A suspended Job is nonterminal but NOT owed a Pod — its controller deletes
+/// the Pods on purpose — so a missing Pod under it is expected rather than
+/// evidence of abandonment.
+pub(crate) fn job_is_suspended(job: &Job) -> bool {
+    job.spec
+        .as_ref()
+        .and_then(|spec| spec.suspend)
+        .unwrap_or(false)
+}
+
+/// The Workload Kueue keeps for `job_name`, resolved through the ownerReference
+/// Kueue itself writes.
+///
+/// Deliberately not by name: the Workload's name is `job-<job>-<hash>` and the
+/// hash is Kueue's business, while the owner link is part of its published
+/// contract (`crate::workload_inventory` resolves task-runs the same way).
+pub(crate) fn workload_of<'a>(
+    workloads: &'a [KueueWorkload],
+    job_name: &str,
+) -> Option<&'a KueueWorkload> {
+    workloads.iter().find(|workload| {
+        workload
+            .metadata
+            .owner_references
+            .as_ref()
+            .is_some_and(|owners| {
+                owners
+                    .iter()
+                    .any(|owner| owner.kind == "Job" && owner.name == job_name)
+            })
+    })
+}
+
+/// The Workload's record of having been evicted, if it carries one.
+///
+/// **Status-insensitive on purpose.** `classify_workload_admission` reads
+/// `Evicted=True` because it answers "where is this Workload NOW"; this answers
+/// "was this Workload's quota ever taken back", and the measured post-re-admission
+/// value is `Evicted=False` with `message: "Previously: …"`. Requiring `True`
+/// here would see nothing one second after the queue is released, which is the
+/// exact sample that destroys a recoverable run.
+pub(crate) fn workload_eviction_record(workload: &KueueWorkload) -> Option<String> {
+    let evicted = workload
+        .status
+        .conditions
+        .iter()
+        .find(|condition| condition.condition_type == CONDITION_EVICTED)?;
+    let name = workload.metadata.name.as_deref().unwrap_or("<unnamed>");
+    Some(format!(
+        "Kueue Workload {name} carries an Evicted condition (status {}{}{})",
+        evicted.status,
+        evicted
+            .reason
+            .as_deref()
+            .map(|reason| format!(", reason {reason}"))
+            .unwrap_or_default(),
+        evicted
+            .message
+            .as_deref()
+            .filter(|message| !message.is_empty())
+            .map(|message| format!(", message {message}"))
+            .unwrap_or_default(),
+    ))
+}
+
+/// Why the fenced Pod of `job` is absent, read from the live cluster.
+///
+/// The Job is passed in rather than re-fetched: it is the same object the watch
+/// just used to decide the Job is nonterminal, so the two halves of the decision
+/// cannot disagree with each other.
+pub(crate) async fn classify_absent_pod(
+    client: &kube::Client,
+    namespace: &str,
+    job: &Job,
+    job_name: &str,
+) -> PodAbsenceVerdict {
+    if job_is_suspended(job) {
+        return PodAbsenceVerdict::Recoverable(format!(
+            "Job {job_name} is suspended, so it is not owed a Pod (Kueue re-suspends an evicted \
+             Job before its Pod is deleted)"
+        ));
+    }
+    let workloads: Api<KueueWorkload> = Api::namespaced(client.clone(), namespace);
+    match workloads.list(&ListParams::default()).await {
+        Ok(list) => match workload_of(&list.items, job_name).and_then(workload_eviction_record) {
+            Some(record) => PodAbsenceVerdict::Recoverable(record),
+            None => PodAbsenceVerdict::Abandoned,
+        },
+        // The Workload API is not served here: this cluster has no Kueue, so no
+        // eviction can have taken the Pod, and A1's containment is the whole
+        // answer. Any OTHER error is an unanswered question, not a negative.
+        Err(kube::Error::Api(response)) if response.code == 404 => PodAbsenceVerdict::Abandoned,
+        Err(error) => PodAbsenceVerdict::Inconclusive(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+#[path = "runtime_eviction_tests.rs"]
+mod runtime_eviction_tests;

--- a/server/crates/djinn-k8s/src/runtime_eviction_tests.rs
+++ b/server/crates/djinn-k8s/src/runtime_eviction_tests.rs
@@ -1,0 +1,229 @@
+//! The distinguisher, exercised over the shapes MEASURED on the live armed
+//! cluster (kind, Kubernetes 1.31 / Kueue 0.19.0, 2026-07-31).
+//!
+//! Every Workload fixture below is a transcription of a real `kubectl get
+//! workloads -o json` from that run, not an invented shape — the whole reason
+//! `03z3` exists is that a fixture modelled behaviour the cluster does not have.
+//! The one that matters most is
+//! [`the_evicted_record_survives_re_admission_where_spec_suspend_does_not`]:
+//! after re-admission Kueue leaves `Evicted` behind with `status: "False"`, and
+//! a status-sensitive read of it would see nothing exactly when the run is most
+//! destructible.
+
+use k8s_openapi::api::batch::v1::{Job, JobSpec};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference};
+
+use super::*;
+use crate::workload_inventory::{KueueWorkloadCondition, KueueWorkloadStatus};
+
+fn condition(kind: &str, status: &str, reason: &str, message: &str) -> KueueWorkloadCondition {
+    KueueWorkloadCondition {
+        condition_type: kind.into(),
+        status: status.into(),
+        reason: Some(reason.into()),
+        message: Some(message.into()),
+    }
+}
+
+fn workload_for(job_name: &str, conditions: Vec<KueueWorkloadCondition>) -> KueueWorkload {
+    KueueWorkload {
+        metadata: ObjectMeta {
+            name: Some(format!("job-{job_name}-1aa22")),
+            owner_references: Some(vec![OwnerReference {
+                api_version: "batch/v1".into(),
+                kind: "Job".into(),
+                name: job_name.into(),
+                uid: "job-uid".into(),
+                controller: Some(true),
+                ..OwnerReference::default()
+            }]),
+            ..ObjectMeta::default()
+        },
+        status: KueueWorkloadStatus { conditions },
+    }
+}
+
+/// Measured: an admitted, running Workload — no `Evicted` condition at all.
+fn admitted_workload(job_name: &str) -> KueueWorkload {
+    workload_for(
+        job_name,
+        vec![
+            condition(
+                "QuotaReserved",
+                "True",
+                "QuotaReserved",
+                "Quota reserved in ClusterQueue djinn-kueue",
+            ),
+            condition("Admitted", "True", "Admitted", "The workload is admitted"),
+            condition(
+                "PodsReady",
+                "True",
+                "Started",
+                "All pods reached readiness and the workload is running",
+            ),
+        ],
+    )
+}
+
+/// Measured under `stopPolicy: HoldAndDrain`.
+fn evicted_workload(job_name: &str) -> KueueWorkload {
+    workload_for(
+        job_name,
+        vec![
+            condition(
+                "QuotaReserved",
+                "False",
+                "Inadmissible",
+                "ClusterQueue djinn-kueue is inactive",
+            ),
+            condition(
+                "Evicted",
+                "True",
+                "ClusterQueueStopped",
+                "The ClusterQueue is stopped",
+            ),
+            condition(
+                "Admitted",
+                "False",
+                "NoReservation",
+                "The workload has no reservation",
+            ),
+        ],
+    )
+}
+
+/// Measured ~1 second after the queue was released. `Evicted` is STILL THERE.
+fn re_admitted_workload(job_name: &str) -> KueueWorkload {
+    workload_for(
+        job_name,
+        vec![
+            condition(
+                "QuotaReserved",
+                "True",
+                "QuotaReserved",
+                "Quota reserved in ClusterQueue djinn-kueue",
+            ),
+            condition(
+                "Evicted",
+                "False",
+                "QuotaReserved",
+                "Previously: The ClusterQueue is stopped",
+            ),
+            condition("Admitted", "True", "Admitted", "The workload is admitted"),
+            condition(
+                "Requeued",
+                "True",
+                "ClusterQueueRestarted",
+                "The ClusterQueue was restarted after being stopped",
+            ),
+        ],
+    )
+}
+
+fn job_with_suspend(suspend: Option<bool>) -> Job {
+    Job {
+        spec: Some(JobSpec {
+            suspend,
+            ..JobSpec::default()
+        }),
+        ..Job::default()
+    }
+}
+
+#[test]
+fn spec_suspend_is_read_as_the_api_server_defaults_it() {
+    assert!(job_is_suspended(&job_with_suspend(Some(true))));
+    assert!(!job_is_suspended(&job_with_suspend(Some(false))));
+    assert!(
+        !job_is_suspended(&job_with_suspend(None)),
+        "an absent `suspend` is `false`: a disarmed cluster renders the key not at all, and \
+         reading that as suspended would disable the containment everywhere Kueue is not used",
+    );
+    assert!(!job_is_suspended(&Job::default()));
+}
+
+/// THE ONE THAT CLOSES THE DEFECT.
+///
+/// A status-sensitive read (`Evicted == True`, which is what
+/// `classify_workload_admission` correctly does for "where is this Workload
+/// NOW") answers `None` for the re-admitted Workload — and the re-admitted
+/// Workload's Job reads `suspend: false` with the fenced Pod still gone, which
+/// is exactly the state the containment reaps. Measured live: the release of
+/// the queue to a new Pod took ~1s against a 15s poll, so that IS the sample the
+/// watch takes.
+#[test]
+fn the_evicted_record_survives_re_admission_where_spec_suspend_does_not() {
+    let re_admitted = re_admitted_workload("job-x");
+    assert!(!job_is_suspended(&job_with_suspend(Some(false))));
+
+    let record = workload_eviction_record(&re_admitted)
+        .expect("Kueue leaves the Evicted condition behind after re-admission");
+    assert!(
+        record.contains("status False") && record.contains("Previously: The ClusterQueue is"),
+        "the record must carry Kueue's own words, so an operator can see WHICH eviction held \
+         the reap off; got {record}",
+    );
+
+    let status_sensitive = re_admitted
+        .status
+        .conditions
+        .iter()
+        .find(|c| c.condition_type == CONDITION_EVICTED && c.status == "True");
+    assert!(
+        status_sensitive.is_none(),
+        "fixture invariant: the re-admitted Workload's Evicted condition is False, which is why \
+         this distinguisher must be status-INSENSITIVE",
+    );
+}
+
+#[test]
+fn an_evicted_workload_records_kueue_s_own_reason() {
+    let record = workload_eviction_record(&evicted_workload("job-x"))
+        .expect("an evicted Workload carries the condition");
+    assert!(
+        record.contains("status True") && record.contains("reason ClusterQueueStopped"),
+        "got {record}",
+    );
+}
+
+#[test]
+fn a_workload_that_was_never_evicted_yields_no_record() {
+    assert_eq!(workload_eviction_record(&admitted_workload("job-x")), None);
+    assert_eq!(
+        workload_eviction_record(&KueueWorkload::default()),
+        None,
+        "a Workload with no conditions at all is not evidence of an eviction",
+    );
+}
+
+/// Resolution is by ownerReference, so ANOTHER run's eviction cannot hold this
+/// run's reap off.
+///
+/// Without this, one preempted build in a busy namespace would disarm the
+/// containment for every abandoned Job beside it.
+#[test]
+fn the_workload_is_resolved_through_its_owner_reference() {
+    let workloads = vec![evicted_workload("other-job"), admitted_workload("mine")];
+    assert_eq!(
+        workload_of(&workloads, "mine").and_then(|w| w.metadata.name.clone()),
+        Some("job-mine-1aa22".to_string()),
+    );
+    assert!(
+        workload_of(&workloads, "mine")
+            .and_then(workload_eviction_record)
+            .is_none(),
+        "the neighbouring Workload's eviction must not be read as this Job's",
+    );
+    assert!(
+        workload_of(&workloads, "absent").is_none(),
+        "a Job with no Workload has no eviction record, and is reaped as fbiy-A1 built it",
+    );
+}
+
+/// An ownerReference to a *Pod* named like the Job is not the Job's Workload.
+#[test]
+fn owner_kind_is_part_of_the_match() {
+    let mut workload = evicted_workload("mine");
+    workload.metadata.owner_references.as_mut().unwrap()[0].kind = "Pod".into();
+    assert!(workload_of(std::slice::from_ref(&workload), "mine").is_none());
+}

--- a/server/crates/djinn-k8s/src/runtime_kueue_create_tests.rs
+++ b/server/crates/djinn-k8s/src/runtime_kueue_create_tests.rs
@@ -10,7 +10,8 @@
 //!   so it cannot show that `suspend: true` is what holds the Pod back rather
 //!   than the renderer merely writing a key nobody reads.
 //!
-//! The fake models exactly two pieces of Kubernetes behaviour beyond storage:
+//! The fake models exactly three pieces of behaviour beyond storage — two of
+//! them the Job controller's, one of them Kueue's:
 //!
 //! 1. the Job controller's rule that a Job creates Pods only while it is *not*
 //!    suspended. That rule is the entire point of the Kueue cutover, so it is
@@ -19,7 +20,15 @@
 //!    gets a *replacement* Pod, with a fresh `metadata.uid`. That is what
 //!    `runtime_pod_fence_tests` fences against — and it is honest to model here
 //!    because it is Job-controller behaviour, not Kueue behaviour. It is not a
-//!    substitute for the live-cluster proof.
+//!    substitute for the live-cluster proof;
+//! 3. Kueue's eviction lifecycle — [`FakeCluster::evict`] and
+//!    [`FakeCluster::readmit`] — added by `03z3`. Every field and every ordering
+//!    in those two is a transcription of `kubectl -o json` against the live
+//!    armed cluster on 2026-07-31, precisely because `03z3` exists to fix a
+//!    defect that a *modelled* Kueue would have got wrong: the fake's Job
+//!    controller mints a replacement Pod, and a real cluster with
+//!    `backoffLimit: 0` does not. The live proof is still
+//!    `tests/kueue_disruption_conformance.rs`, not this.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -63,6 +72,11 @@ pub(super) struct ClusterState {
     /// Pod objects the modelled Job controller has materialised, each with its
     /// own immutable `metadata.uid`.
     pub(super) pods: Vec<Value>,
+    /// Kueue `Workload` objects, one per Job carrying a queue-name label. Only
+    /// `metadata.ownerReferences` and `status.conditions` are modelled: they are
+    /// what [`crate::runtime_eviction`] reads, and inventing the rest would be
+    /// inventing behaviour.
+    pub(super) workloads: Vec<Value>,
     pub(super) calls: Vec<ApiCall>,
 }
 
@@ -112,6 +126,23 @@ impl FakeCluster {
         let mut names: Vec<String> = self.state.lock().unwrap().secrets.keys().cloned().collect();
         names.sort();
         names
+    }
+
+    /// Every stored Workload's name, so a test can assert there is NO Workload
+    /// backing the behaviour it is measuring.
+    pub(super) fn workload_names(&self) -> Vec<String> {
+        self.state
+            .lock()
+            .unwrap()
+            .workloads
+            .iter()
+            .filter_map(|workload| {
+                workload
+                    .pointer("/metadata/name")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect()
     }
 
     pub(super) fn pod_count(&self) -> usize {
@@ -217,6 +248,144 @@ impl FakeCluster {
             spec.insert("suspend".into(), Value::Bool(false));
         }
         self.reconcile_job_controller(&mut state, job_name);
+    }
+
+    /// Kueue capturing a Job that carries a `queue-name` label: a `Workload`
+    /// appears, owned by the Job, with no `Evicted` condition on it.
+    ///
+    /// Shape transcribed from `kubectl get workloads.kueue.x-k8s.io -o json`
+    /// against the live armed cluster (Kubernetes 1.31 / Kueue 0.19.0,
+    /// 2026-07-31), including the `job-<name>-<hash>` naming.
+    fn capture_workload(&self, state: &mut ClusterState, job_name: &str, job: &Value) {
+        if job
+            .pointer("/metadata/labels")
+            .and_then(|labels| labels.get(crate::config::LABEL_KUEUE_QUEUE_NAME))
+            .is_none()
+        {
+            return;
+        }
+        let job_uid = job
+            .pointer("/metadata/uid")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        state.workloads.push(json!({
+            "apiVersion": "kueue.x-k8s.io/v1beta1",
+            "kind": "Workload",
+            "metadata": {
+                "name": format!("job-{job_name}-1aa22"),
+                "namespace": "djinn",
+                "uid": self.next_uid(),
+                "ownerReferences": [{
+                    "apiVersion": "batch/v1",
+                    "kind": "Job",
+                    "name": job_name,
+                    "uid": job_uid,
+                    "controller": true,
+                }],
+            },
+            "status": {"conditions": [
+                {"type": "QuotaReserved", "status": "True", "reason": "QuotaReserved",
+                 "message": "Quota reserved in ClusterQueue djinn-kueue"},
+                {"type": "Admitted", "status": "True", "reason": "Admitted",
+                 "message": "The workload is admitted"},
+            ]},
+        }));
+    }
+
+    fn workload_conditions_of<'a>(
+        state: &'a mut ClusterState,
+        job_name: &str,
+    ) -> Option<&'a mut Value> {
+        state
+            .workloads
+            .iter_mut()
+            .find(|workload| {
+                workload
+                    .pointer("/metadata/ownerReferences/0/name")
+                    .and_then(Value::as_str)
+                    == Some(job_name)
+            })
+            .map(|workload| &mut workload["status"]["conditions"])
+    }
+
+    /// A Kueue EVICTION, as measured on the live armed cluster: Kueue
+    /// re-suspends the Job, the Job controller deletes its Pod, and NOTHING
+    /// replaces it (a suspended Job pods nothing). The Workload keeps existing
+    /// and gains `Evicted: True`.
+    ///
+    /// Returns the evicted Pod's uid. The ORDER is the measured one — `suspend`
+    /// is true from t+0s while the Pod took 34s to go — so a watch that samples
+    /// mid-eviction sees a suspended Job, which is half of what
+    /// [`crate::runtime_eviction::classify_absent_pod`] reads.
+    pub(super) fn evict(&self, job_name: &str, reason: &str) -> String {
+        let mut state = self.state.lock().unwrap();
+        if let Some(job) = state.jobs.get_mut(job_name)
+            && let Some(spec) = job.get_mut("spec").and_then(Value::as_object_mut)
+        {
+            spec.insert("suspend".into(), Value::Bool(true));
+        }
+        let index = Self::owned_pod_index(&state, job_name).expect("the Job has a Pod to evict");
+        let evicted = state.pods.remove(index);
+        if let Some(conditions) = Self::workload_conditions_of(&mut state, job_name) {
+            *conditions = json!([
+                {"type": "QuotaReserved", "status": "False", "reason": "Inadmissible",
+                 "message": "ClusterQueue djinn-kueue is inactive"},
+                {"type": "Evicted", "status": "True", "reason": reason,
+                 "message": "The ClusterQueue is stopped"},
+                {"type": "Admitted", "status": "False", "reason": "NoReservation",
+                 "message": "The workload has no reservation"},
+            ]);
+        }
+        // The Job controller must NOT replace an evicted Pod, and this asserts
+        // the fixture keeps that property rather than assuming it.
+        self.reconcile_job_controller(&mut state, job_name);
+        assert!(
+            Self::owned_pod_index(&state, job_name).is_none(),
+            "fixture invariant: a SUSPENDED Job materialises no Pod, so an eviction leaves none",
+        );
+        evicted
+            .pointer("/metadata/uid")
+            .and_then(Value::as_str)
+            .expect("stored Pod has a uid")
+            .to_string()
+    }
+
+    /// Kueue RE-ADMITTING the evicted Workload once capacity returns: `suspend`
+    /// goes back to false, the Job controller makes a NEW Pod with a NEW uid,
+    /// and the `Evicted` condition stays behind flipped to `False`.
+    ///
+    /// That last part is the measured fact this whole task turns on: at
+    /// `2026-07-31T12:47:59Z`, ~1s after the queue was released, the re-admitted
+    /// Workload still carried `Evicted / False / QuotaReserved / "Previously:
+    /// The ClusterQueue is stopped"`.
+    ///
+    /// Returns the re-admitted Pod's uid.
+    pub(super) fn readmit(&self, job_name: &str) -> String {
+        {
+            let mut state = self.state.lock().unwrap();
+            if let Some(conditions) = Self::workload_conditions_of(&mut state, job_name) {
+                *conditions = json!([
+                    {"type": "QuotaReserved", "status": "True", "reason": "QuotaReserved",
+                     "message": "Quota reserved in ClusterQueue djinn-kueue"},
+                    {"type": "Evicted", "status": "False", "reason": "QuotaReserved",
+                     "message": "Previously: The ClusterQueue is stopped"},
+                    {"type": "Admitted", "status": "True", "reason": "Admitted",
+                     "message": "The workload is admitted"},
+                    {"type": "Requeued", "status": "True", "reason": "ClusterQueueRestarted",
+                     "message": "The ClusterQueue was restarted after being stopped"},
+                ]);
+            }
+        }
+        self.unsuspend(job_name);
+        let state = self.state.lock().unwrap();
+        let index =
+            Self::owned_pod_index(&state, job_name).expect("re-admission materialises a new Pod");
+        state.pods[index]
+            .pointer("/metadata/uid")
+            .and_then(Value::as_str)
+            .expect("stored Pod has a uid")
+            .to_string()
     }
 
     /// `kubectl delete pod --force --grace-period=0`: the Pod object vanishes
@@ -334,9 +503,28 @@ impl FakeCluster {
         let is_job = path.contains("/jobs");
         let is_secret = path.contains("/secrets");
         let is_pod = path.contains("/pods");
+        let is_workload = path.contains("/workloads");
         // `.../jobs` on a create, `.../jobs/<name>` on a get/patch.
         let trailing = path.rsplit('/').next().unwrap_or_default().to_string();
         let named = !(trailing == "jobs" || trailing == "secrets" || trailing == "pods");
+
+        // A cluster with no Kueue CRD 404s this path, which is the fixture's
+        // default: `workloads` is empty unless a Job was captured, but the LIST
+        // still answers 200 with no items, exactly as an armed cluster with no
+        // Workload for this Job does. The 404 case has its own coverage in
+        // `runtime_eviction_tests`, against the error value rather than a fake.
+        if is_workload && method == "GET" {
+            let state = self.state.lock().unwrap();
+            return (
+                200,
+                json!({
+                    "apiVersion": "kueue.x-k8s.io/v1beta1",
+                    "kind": "WorkloadList",
+                    "metadata": {"resourceVersion": "1"},
+                    "items": state.workloads.clone(),
+                }),
+            );
+        }
 
         if is_pod && method == "GET" && !named {
             let state = self.state.lock().unwrap();
@@ -379,6 +567,13 @@ impl FakeCluster {
                         != Some(trailing.as_str())
                 });
             }
+            // Kueue garbage-collects a Workload whose owning Job is gone.
+            state.workloads.retain(|workload| {
+                workload
+                    .pointer("/metadata/ownerReferences/0/name")
+                    .and_then(Value::as_str)
+                    != Some(trailing.as_str())
+            });
             return (200, job);
         }
 
@@ -409,6 +604,7 @@ impl FakeCluster {
                 }
                 job["metadata"]["uid"] = Value::String(self.next_uid());
                 state.jobs.insert(name.clone(), job.clone());
+                self.capture_workload(&mut state, &name, &job);
                 self.reconcile_job_controller(&mut state, &name);
                 (201, job)
             }

--- a/server/crates/djinn-k8s/src/runtime_pod_fence_tests.rs
+++ b/server/crates/djinn-k8s/src/runtime_pod_fence_tests.rs
@@ -64,6 +64,15 @@ fn fence_config() -> KubernetesConfig {
     config
 }
 
+/// Armed: the Job renders `suspend: true` plus the `queue-name` label, so the
+/// fake captures a Kueue `Workload` for it and there is an admission — and an
+/// EVICTION — to model at all. `03z3`'s subject.
+fn armed_fence_config() -> KubernetesConfig {
+    let mut config = KubernetesConfig::for_testing();
+    config.kueue_armed = true;
+    config
+}
+
 fn runtime_on(cluster: &Arc<FakeCluster>, config: KubernetesConfig) -> KubernetesRuntime {
     KubernetesRuntime {
         client: cluster.client(),
@@ -157,6 +166,29 @@ where
     tokio::time::timeout(WATCH_BUDGET, watch)
         .await
         .map(|joined| joined.expect("the infra-death watch task panicked"))
+}
+
+/// Let the running watch take `polls` more turns of its loop.
+///
+/// Time is paused, so this costs no wall clock. Each iteration sleeps slightly
+/// PAST [`INFRA_DEATH_POLL_INTERVAL`]: with the test task parked the runtime
+/// goes idle and tokio auto-advances the clock to the watch's own deadline
+/// first, which is the only way a paused test can make the watch observe
+/// anything after its initial binding poll. Yielding instead would keep a task
+/// runnable forever, the clock would never advance, and the watch would sit at
+/// its sleep for the whole test — passing every "did not resolve" assertion
+/// without ever having looked at the cluster.
+async fn let_the_watch_poll(cluster: &Arc<FakeCluster>, polls: usize) {
+    let before = pod_list_calls(cluster);
+    for _ in 0..polls {
+        tokio::time::sleep(INFRA_DEATH_POLL_INTERVAL + Duration::from_secs(1)).await;
+    }
+    assert!(
+        pod_list_calls(cluster) >= before + polls,
+        "the watch must have polled {polls} more times ({before} -> {}); a test that asserts \
+         'it did not resolve' while the watch is parked asserts nothing",
+        pod_list_calls(cluster),
+    );
 }
 
 /// Every DELETE the fake apiserver observed against `job_name`, with the body
@@ -455,6 +487,215 @@ async fn a_completed_job_whose_pod_was_ttl_gcd_is_neither_a_death_nor_reaped() {
 }
 
 // ---------------------------------------------------------------------------
+// `03z3` — a Kueue eviction is RECOVERABLE and must not be reaped
+// ---------------------------------------------------------------------------
+
+/// Seed an ARMED task-run and drive it to admitted-and-running: the Job is
+/// created suspended with a captured Workload, and only the modelled admission
+/// gives it a Pod. Returns the Job name.
+async fn seed_admitted_taskrun(cluster: &Arc<FakeCluster>, config: &KubernetesConfig) -> String {
+    let job_name = seed_running_taskrun(cluster, config).await;
+    assert_eq!(
+        cluster.pod_count(),
+        0,
+        "an armed task-run Job is created SUSPENDED, so Kueue owns whether it ever pods",
+    );
+    cluster.unsuspend(&job_name);
+    assert_eq!(
+        cluster.pod_count(),
+        1,
+        "admission must materialise exactly one worker Pod to fence on",
+    );
+    job_name
+}
+
+/// Start the watch and let it bind its fence to the admitted Pod.
+fn watch_of(runtime: KubernetesRuntime, job_name: &str) -> tokio::task::JoinHandle<String> {
+    let handle = run_handle(job_name);
+    tokio::spawn(async move { runtime.watch_infra_death(&handle).await })
+}
+
+/// AC1. A Kueue eviction followed by a re-admission leaves the run ALIVE.
+///
+/// The two load-bearing assertions are that the watch has NOT resolved (the
+/// dispatch runner terminalises the run the instant it does) and that the Job is
+/// still on the API server (a reaped Job can never be re-admitted, and a retry
+/// mints a fresh task-run id so nothing ever adopts the old one back).
+///
+/// Non-vacuity, both directions:
+/// * restore the unconditional foreground delete — drop the `classify_absent_pod`
+///   match and reap on every absence — and the watch resolves during the
+///   eviction, so `is_finished` fails and the Job is gone;
+/// * make the watch never poll (it sits parked at its sleep) and
+///   [`let_the_watch_poll`] fails instead, so "did not resolve" cannot pass by
+///   the watch not having looked.
+#[tokio::test(start_paused = true)]
+async fn a_kueue_eviction_then_re_admission_leaves_the_task_run_alive() {
+    let cluster = FakeCluster::new();
+    let config = armed_fence_config();
+    let job_name = seed_admitted_taskrun(&cluster, &config).await;
+    let watch = watch_of(runtime_on(&cluster, config), &job_name);
+    await_fence_binding(&cluster).await;
+
+    let evicted_uid = cluster.evict(&job_name, "ClusterQueueStopped");
+    let_the_watch_poll(&cluster, 2).await;
+    assert!(
+        !watch.is_finished(),
+        "an evicted run is recoverable: the watch must not terminalise it, and it resolved. \
+         Surviving Jobs: {:?}",
+        cluster.job_names(),
+    );
+    assert_eq!(
+        cluster.job_names(),
+        vec![job_name.clone()],
+        "the evicted Job must survive — deleting it is what makes the eviction unrecoverable",
+    );
+
+    let readmitted_uid = cluster.readmit(&job_name);
+    assert_ne!(
+        evicted_uid, readmitted_uid,
+        "fixture invariant: re-admission mints a Pod with a NEW immutable uid",
+    );
+    let_the_watch_poll(&cluster, 3).await;
+
+    assert!(
+        !watch.is_finished(),
+        "the re-admitted run must still be alive: its new Pod is running and its terminal report \
+         will ride the stream",
+    );
+    assert_eq!(cluster.job_names(), vec![job_name.clone()]);
+    assert!(
+        job_delete_calls(&cluster, &job_name).is_empty(),
+        "no Job DELETE may be issued across an eviction; observed {:?}",
+        job_delete_calls(&cluster, &job_name),
+    );
+    watch.abort();
+}
+
+/// AC3, and the sample that actually happens on a cluster.
+///
+/// Measured live on 2026-07-31: after the queue is released, `spec.suspend` is
+/// back to `false` and a new Pod exists within ~1 SECOND, against a 15 second
+/// poll. So the poll that matters usually lands *after* re-admission, where the
+/// Job is unsuspended and the fenced Pod is gone — bit-for-bit the state fbiy-A1
+/// reaps on. Here the watch never observes the suspension at all.
+///
+/// What holds the reap off is the Workload's `Evicted` condition, which Kueue
+/// leaves behind flipped to `False`. Make
+/// [`crate::runtime_eviction::workload_eviction_record`] status-sensitive — read
+/// only `Evicted == True`, as `classify_workload_admission` correctly does for a
+/// different question — and this test fails while the previous one still passes.
+#[tokio::test(start_paused = true)]
+async fn a_re_admission_the_watch_never_saw_suspended_still_leaves_the_run_alive() {
+    let cluster = FakeCluster::new();
+    let config = armed_fence_config();
+    let job_name = seed_admitted_taskrun(&cluster, &config).await;
+    let watch = watch_of(runtime_on(&cluster, config), &job_name);
+    await_fence_binding(&cluster).await;
+
+    // Both transitions between two polls: the watch sees only the end state.
+    let evicted_uid = cluster.evict(&job_name, "ClusterQueueStopped");
+    let readmitted_uid = cluster.readmit(&job_name);
+    assert_ne!(evicted_uid, readmitted_uid);
+    assert_eq!(
+        cluster
+            .job(&job_name)
+            .and_then(|job| job.pointer("/spec/suspend").and_then(Value::as_bool)),
+        Some(false),
+        "the case under test is the one where `spec.suspend` has ALREADY gone back to false, so \
+         the Job-level signal is exhausted before the watch ever looks",
+    );
+
+    let_the_watch_poll(&cluster, 3).await;
+
+    assert!(
+        !watch.is_finished(),
+        "the only evidence left is Kueue's own Evicted record, and it must be enough",
+    );
+    assert_eq!(cluster.job_names(), vec![job_name.clone()]);
+    assert!(job_delete_calls(&cluster, &job_name).is_empty());
+    watch.abort();
+}
+
+/// The Job-level half of the distinguisher, with no Workload in existence.
+///
+/// `spec.suspend` is not merely a faster path to the same answer: it is the only
+/// answer available when the Workload cannot be read (a cluster with no Kueue,
+/// an operator's own `kubectl patch suspend=true`, an RBAC gap). A suspended Job
+/// is nonterminal but NOT owed a Pod, so its missing Pod is not evidence of
+/// anything.
+///
+/// Non-vacuity: drop the `job_is_suspended` arm from `classify_absent_pod` and
+/// this test fails — there is no Workload here to fall back on, because the
+/// disarmed renderer stamps no `queue-name` label and the fake captures nothing.
+#[tokio::test(start_paused = true)]
+async fn a_suspended_job_with_no_workload_at_all_is_not_reaped() {
+    let cluster = FakeCluster::new();
+    let config = fence_config();
+    let job_name = seed_running_taskrun(&cluster, &config).await;
+    let watch = watch_of(runtime_on(&cluster, config), &job_name);
+    await_fence_binding(&cluster).await;
+
+    cluster.evict(&job_name, "ClusterQueueStopped");
+    assert!(
+        cluster.workload_names().is_empty(),
+        "fixture invariant: a disarmed Job carries no queue-name label, so Kueue captures no \
+         Workload and `spec.suspend` is the only evidence there is",
+    );
+
+    let_the_watch_poll(&cluster, 3).await;
+    assert!(!watch.is_finished(), "a suspended Job is not owed a Pod");
+    assert_eq!(cluster.job_names(), vec![job_name.clone()]);
+    assert!(job_delete_calls(&cluster, &job_name).is_empty());
+    watch.abort();
+}
+
+/// AC2 under Kueue. The narrowing must not disarm the containment for a Job
+/// whose Workload was never evicted.
+///
+/// Same armed topology as the eviction tests — a captured Workload, a real
+/// admission — but the Pod is force-deleted rather than evicted, so the Workload
+/// carries no `Evicted` condition and `spec.suspend` is false. That is an
+/// UNEXPLAINED absence, and it must still terminalise and reap.
+///
+/// Non-vacuity: hold on every absence (return `Recoverable` unconditionally from
+/// `classify_absent_pod`) and this test fails on the surviving Job, while
+/// `a_force_deleted_worker_pod_terminalises_the_run_and_reaps_its_job` covers
+/// the same claim with no Kueue in the picture at all.
+#[tokio::test(start_paused = true)]
+async fn a_force_delete_under_a_never_evicted_workload_still_reaps() {
+    let cluster = FakeCluster::new();
+    let config = armed_fence_config();
+    let job_name = seed_admitted_taskrun(&cluster, &config).await;
+    let runtime = runtime_on(&cluster, config);
+
+    let mut destroyed_uid = String::new();
+    let reason = watch_after_fence_binding(&cluster, runtime, &job_name, |cluster| {
+        let (destroyed, replacement) = cluster.force_delete_pod_of(&job_name);
+        assert!(
+            replacement.is_some_and(|uid| uid != destroyed),
+            "fixture invariant: an UNSUSPENDED Job's controller replaces a destroyed Pod",
+        );
+        destroyed_uid = destroyed;
+    })
+    .await
+    .expect(
+        "a force-deleted Pod under an admitted, never-evicted Workload is still an abandoned run",
+    );
+
+    assert!(
+        reason.contains(&destroyed_uid),
+        "the death reason must name the destroyed Pod; got {reason}",
+    );
+    assert!(
+        cluster.job_names().is_empty(),
+        "the abandoned Job must still be reaped, or it holds its Kueue quota forever; still \
+         present: {:?}",
+        cluster.job_names(),
+    );
+}
+
+// ---------------------------------------------------------------------------
 // AC3 — the build lease refuses the replacement UID, in real PostgreSQL
 // ---------------------------------------------------------------------------
 
@@ -564,5 +805,69 @@ async fn every_lift_presented_with_the_replacement_pod_uid_is_rejected() {
         row.bound_pod_uid.as_deref(),
         Some(original),
         "no rejected lift may have moved the durable Pod binding"
+    );
+}
+
+/// `03z3` AC4. Surviving an eviction must not buy recovery with containment.
+///
+/// The uid here is not a literal: it is the one the modelled re-admission
+/// actually minted, so this asserts about the same object the previous tests let
+/// the run keep living beside. A run that recovers is still a run whose build
+/// lease is bound to the Pod it launched, and the Pod that came back is not that
+/// Pod.
+///
+/// Non-vacuity: allow the new uid — drop the pod-uid comparison from `bind`, or
+/// present `readmitted` as the original — and the `expect_err` fails.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_lift_from_the_re_admitted_pod_is_still_rejected() {
+    let cluster = FakeCluster::new();
+    let config = armed_fence_config();
+    let job_name = seed_admitted_taskrun(&cluster, &config).await;
+    let original = cluster
+        .pod_uids()
+        .first()
+        .expect("the admitted run has a Pod")
+        .clone();
+    cluster.evict(&job_name, "ClusterQueueStopped");
+    let readmitted = cluster.readmit(&job_name);
+    assert_ne!(original, readmitted);
+
+    let db = Database::open_in_memory().expect("real Postgres test database");
+    let repository = BuildLeaseRepository::new(db);
+    let key = invocation_key();
+    repository
+        .queue(&queue_input())
+        .await
+        .expect("queue the invocation lease");
+    let token = match repository
+        .grant_next(1, "2026-07-30T00:00:00.000Z", None)
+        .await
+        .expect("grant the queued lease")
+    {
+        GrantNextBuildLeaseResult::Granted(row) => {
+            row.fencing_token.expect("a granted lease carries a token")
+        }
+        other => panic!("expected a grant, got {other:?}"),
+    };
+    repository
+        .bind(&key, token, &original, None)
+        .await
+        .expect("bind the lease to the Pod the run launched before the eviction");
+
+    let rejected = repository
+        .bind(&key, token, &readmitted, None)
+        .await
+        .expect_err("the Pod Kueue re-admitted is not the Pod this lease is bound to");
+    assert_pod_uid_mismatch(rejected, "lift from the re-admitted Pod");
+
+    let row = repository
+        .get(&key)
+        .await
+        .expect("read the durable lease row")
+        .expect("the lease row exists");
+    assert_eq!(
+        row.bound_pod_uid.as_deref(),
+        Some(original.as_str()),
+        "recovery must not move the durable Pod binding",
     );
 }

--- a/server/crates/djinn-k8s/tests/kueue_disruption/mod.rs
+++ b/server/crates/djinn-k8s/tests/kueue_disruption/mod.rs
@@ -859,6 +859,161 @@ pub async fn kube_client(context: &str) -> kube::Client {
     kube::Client::try_from(config).expect("build a kube client for the harness context")
 }
 
+/// What an eviction left observable, sampled WHILE it was happening and again
+/// after the queue was released (`03z3`).
+///
+/// The two halves exist because neither field answers on its own: `suspend` is
+/// the Job-level signal Kueue writes *before* the Pod goes away, and the
+/// Workload's `Evicted` condition is the one that SURVIVES re-admission. A fix
+/// that read only the first would be blind at exactly the sample a 15s poll
+/// takes, and this struct is what proves the second is still there to read.
+#[derive(Debug, Default)]
+pub struct EvictionObservation {
+    /// `job.spec.suspend` at some sample taken between the eviction and the
+    /// Pod's disappearance.
+    pub suspended_during: bool,
+    /// The Workload's `Evicted` condition during the eviction, as
+    /// `(status, reason)`.
+    pub evicted_during: Option<(String, String)>,
+    /// The same condition AFTER the queue was released and the Workload
+    /// re-admitted. Measured 2026-07-31: `("False", "QuotaReserved")`.
+    pub evicted_after_readmission: Option<(String, String)>,
+    /// `job.spec.suspend` after re-admission. Measured: `false`, which is why
+    /// the Job-level signal alone cannot carry this.
+    pub suspended_after_readmission: bool,
+    /// ClusterQueue `pods` usage while the run sat evicted. Measured: 0 — an
+    /// evicted Workload holds no quota, which is why holding the reap off does
+    /// not strand the capacity the reap exists to release.
+    pub pods_usage_during: u64,
+    pub seconds_to_pod_deletion: u64,
+    pub seconds_to_readmission: u64,
+}
+
+/// `job.spec.suspend`, or `None` when the Job is gone.
+pub fn job_suspend(context: &str, job_name: &str) -> Option<bool> {
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            context,
+            "-n",
+            NAMESPACE,
+            "get",
+            "job",
+            job_name,
+            "-o",
+            "jsonpath={.spec.suspend}",
+        ])
+        .output()
+        .expect("kubectl is on PATH");
+    if !output.status.success() {
+        return None;
+    }
+    match stdout(&output).trim() {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// The named condition on this Job's Workload as `(status, reason)`, WHATEVER
+/// its status.
+///
+/// [`workload_condition`] answers "is it true now", which is the right question
+/// for admission and the wrong one for "was this Workload ever evicted": Kueue
+/// keeps the `Evicted` condition after re-admission and flips it to `False`.
+pub fn workload_condition_entry(
+    context: &str,
+    job_name: &str,
+    kind: &str,
+) -> Option<(String, String)> {
+    let list = kubectl_json(
+        context,
+        &["-n", NAMESPACE, "get", "workloads.kueue.x-k8s.io"],
+    );
+    list["items"]
+        .as_array()
+        .expect("a List has items")
+        .iter()
+        .find(|workload| {
+            workload["metadata"]["ownerReferences"]
+                .as_array()
+                .is_some_and(|owners| {
+                    owners
+                        .iter()
+                        .any(|owner| owner["kind"] == "Job" && owner["name"] == job_name)
+                })
+        })
+        .and_then(|workload| workload["status"]["conditions"].as_array())
+        .and_then(|conditions| {
+            conditions
+                .iter()
+                .find(|condition| condition["type"] == kind)
+                .map(|condition| {
+                    (
+                        condition["status"].as_str().unwrap_or("?").to_owned(),
+                        condition["reason"].as_str().unwrap_or("?").to_owned(),
+                    )
+                })
+        })
+}
+
+/// Evict this run, SAMPLE the distinguisher while it is evicted, release the
+/// queue, and sample it again once the Workload is re-admitted.
+///
+/// The release is not on a timer, for the reason [`evict_and_release`] records:
+/// it waits on the fenced Pod's actual disappearance. Everything recorded here
+/// is a field read; nothing infers anything from how long a step took.
+pub fn evict_capturing_the_distinguisher(
+    context: &str,
+    task_run_id: &str,
+    job_name: &str,
+    fenced_uid: &str,
+) -> EvictionObservation {
+    let mut observed = EvictionObservation::default();
+    set_stop_policy(context, "HoldAndDrain");
+    let mut gone = false;
+    for tick in 0..AWAIT_TICKS {
+        // Sampled every tick, because the Job is re-suspended long before the
+        // Pod object goes: taking this only at the end would record a property
+        // of the drain rather than of the eviction.
+        observed.suspended_during |= job_suspend(context, job_name) == Some(true);
+        if observed.evicted_during.is_none() {
+            observed.evicted_during = workload_condition_entry(context, job_name, "Evicted");
+        }
+        observed.pods_usage_during = pods_usage(context);
+        if !pods_of(context, task_run_id)
+            .iter()
+            .any(|(_, uid, _)| uid == fenced_uid)
+        {
+            gone = true;
+            observed.seconds_to_pod_deletion = (tick as u64) * TICK.as_millis() as u64 / 1000;
+            break;
+        }
+        std::thread::sleep(TICK);
+    }
+    assert!(
+        gone,
+        "Kueue never evicted the fenced Pod {fenced_uid}; workloads: {}",
+        workload_summary(context),
+    );
+    observed.pods_usage_during = pods_usage(context);
+
+    set_stop_policy(context, "None");
+    for tick in 0..AWAIT_TICKS {
+        if pods_of(context, task_run_id)
+            .iter()
+            .any(|(_, uid, phase)| uid != fenced_uid && !uid.is_empty() && phase == "Running")
+        {
+            observed.seconds_to_readmission = (tick as u64) * TICK.as_millis() as u64 / 1000;
+            break;
+        }
+        std::thread::sleep(TICK);
+    }
+    observed.evicted_after_readmission = workload_condition_entry(context, job_name, "Evicted");
+    observed.suspended_after_readmission = job_suspend(context, job_name) == Some(true);
+    observed
+}
+
 /// Drive one full Kueue eviction of this run and then release the queue.
 ///
 /// The release is NOT on a timer. Measured 2026-07-30: after `HoldAndDrain` the

--- a/server/crates/djinn-k8s/tests/kueue_disruption_conformance.rs
+++ b/server/crates/djinn-k8s/tests/kueue_disruption_conformance.rs
@@ -38,8 +38,16 @@
 //!    no `Failed` condition, Workload `Evicted` but not `Finished` — exactly
 //!    `job_failed_reason() == None && !job_completed_cleanly()`. Releasing the
 //!    queue re-admits the same Workload with a NEW Pod UID, so the eviction is
-//!    recoverable, the Job is owed a Pod, and the containment deletes it. That
-//!    is the live subject AC2 needed.
+//!    RECOVERABLE — and the containment deleted the Job anyway. That was filed
+//!    as `03z3`, a P0 blocker on arming Kueue anywhere, and fixed by narrowing
+//!    the arm to an absence nothing in observable cluster state explains
+//!    (`crate::runtime_eviction`). The test that used to assert the reap here is
+//!    replaced by [`live_a_kueue_eviction_and_re_admission_leaves_the_task_run_alive`],
+//!    which asserts the opposite, plus the two fields it turns on. Measured
+//!    2026-07-31: the Job reads `suspend: true` from t+0s of the eviction while
+//!    the Pod took 34s to go, and the re-admitted Workload STILL carries its
+//!    `Evicted` condition, flipped to `False` with message
+//!    `Previously: The ClusterQueue is stopped`.
 //! 4. **`kube::Client` panics on construction here.** `workspace-hack` unifies
 //!    rustls with both `ring` and `aws-lc-rs`, and it panics for `http://` as
 //!    readily as `https://`, so there is no TLS-free route around it.
@@ -381,31 +389,36 @@ fn live_force_deleting_an_admitted_pod_records_the_permitted_disjunction() {
 }
 
 // ===========================================================================
-// AC2 — the replacement UID, and the REAL watch that refuses it
+// `03z3` — an eviction is RECOVERABLE, and the watch must let it recover
 // ===========================================================================
 
-/// The live subject AC2 needs, produced by the only thing that produces it.
+/// **This test replaces the one that codified the defect.**
 ///
-/// A force-deleted Pod mints no replacement (finding 2). A Kueue EVICTION does:
-/// it re-suspends the Job, deletes the Pod, and — when capacity returns —
-/// re-admits the same Workload and the Job controller creates a NEW Pod with a
-/// DIFFERENT `metadata.uid` under the very same labels. That is the object
-/// `fenced_worker_pod` must refuse to adopt, and this drives the REAL
-/// `SessionRuntime::watch_infra_death` at it rather than a copy of its logic.
+/// `fbiy-B2` measured that A1's containment arm is reached on a live cluster
+/// almost exclusively BY EVICTION (finding 3 above: a force-delete goes
+/// `Failed` in ~5s under `backoffLimit: 0` and resolves through the pre-existing
+/// arm, so it never reaches A1's at all). The test that used to live here
+/// asserted the consequence — the watch resolves, the Job is reaped — and that
+/// consequence is wrong: releasing the queue re-admits the same Workload and the
+/// run can still finish, so reaping there converts a recoverable task-run into a
+/// destroyed one. `03z3` is that defect; this is its live proof.
 ///
-/// Three assertions, each of which fails on a different removal:
+/// Four assertions, each failing on a different regression:
 ///
-/// 1. the watch RESOLVES — reverting A1's Pod-absent-plus-Job-nonterminal arm
-///    makes it hang until the timeout, because the evicted Job is neither
-///    `Failed` nor `Complete` and the pre-existing arms have nothing to say;
-/// 2. the reason names the ORIGINAL Pod UID — removing the UID comparison from
-///    `fenced_worker_pod` makes the watch adopt the re-admitted Pod, see it
-///    healthy, and never resolve at all;
-/// 3. the Job is GONE from the live API server — a reap that builds
-///    `DeleteParams` and never sends them leaves it there.
+/// 1. the watch does NOT resolve — restore the unconditional foreground delete
+///    and it resolves inside the eviction window, which is how the dispatch
+///    runner terminalises a run;
+/// 2. the Job is STILL on the API server — a reaped Job can never be re-admitted
+///    and no retry ever adopts it (a retry mints a fresh task-run id);
+/// 3. Kueue re-admitted it and a NEW Pod is Running — so this measured a
+///    recovery rather than a cluster that quietly stayed broken;
+/// 4. AC3's distinguisher is asserted as a FIELD READ, in both phases: the Job
+///    reads `suspend: true` during the eviction, and the Workload still carries
+///    its `Evicted` condition after re-admission — which is the one the watch
+///    can still see at the sample a 15s poll actually takes.
 #[test]
 #[ignore]
-fn live_a_kueue_eviction_produces_the_replacement_uid_the_watch_refuses() {
+fn live_a_kueue_eviction_and_re_admission_leaves_the_task_run_alive() {
     if !live_tests_enabled() {
         return;
     }
@@ -422,6 +435,12 @@ fn live_a_kueue_eviction_produces_the_replacement_uid_the_watch_refuses() {
         workload_condition(&context, &job_name, "Admitted"),
         "the run must be admitted before eviction can mean anything; workloads: {}",
         workload_summary(&context),
+    );
+    assert_eq!(
+        workload_condition_entry(&context, &job_name, "Evicted"),
+        None,
+        "an admitted Workload that was never evicted carries no Evicted condition at all — that \
+         is what makes its later presence evidence rather than decoration",
     );
 
     let handle = RunHandle {
@@ -440,9 +459,10 @@ fn live_a_kueue_eviction_produces_the_replacement_uid_the_watch_refuses() {
         .enable_all()
         .build()
         .expect("build a tokio runtime for the live watch");
-    let reason = tokio_runtime.block_on({
+    let (resolved, observed) = tokio_runtime.block_on({
         let context = context.clone();
         let task_run_id = task_run_id.clone();
+        let job_name = job_name.clone();
         let bound_uid = bound_uid.clone();
         let config = config.clone();
         async move {
@@ -456,71 +476,189 @@ fn live_a_kueue_eviction_produces_the_replacement_uid_the_watch_refuses() {
                 // NOW. A watch disrupted before it has ever observed a Pod has
                 // nothing to be fenced to and would pass trivially.
                 std::thread::sleep(Duration::from_secs(20));
-                evict_and_release(&context, &task_run_id, &bound_uid);
+                evict_capturing_the_distinguisher(&context, &task_run_id, &job_name, &bound_uid)
             });
-            let reason =
-                tokio::time::timeout(Duration::from_secs(300), runtime.watch_infra_death(&handle))
+            // The watch must still be RUNNING when this elapses. The budget is
+            // deliberately far past the whole eviction: measured 2026-07-31, the
+            // drain took ~34s and the re-admission ~1s after release, against a
+            // 15s poll — so this leaves the watch several polls on each side,
+            // including the post-re-admission samples that are the destructive
+            // ones.
+            let resolved =
+                tokio::time::timeout(Duration::from_secs(150), runtime.watch_infra_death(&handle))
                     .await;
-            let _ = evicting.await;
-            reason
+            let observed = evicting.await.expect("the eviction driver panicked");
+            (resolved, observed)
         }
     });
     // Whatever happened, do not leave the queue stopped for the next test.
     set_stop_policy(&context, "None");
 
-    let reason = reason.unwrap_or_else(|_| {
+    eprintln!("03z3 live eviction observation: {observed:?}");
+
+    // 1. The watch never resolved. `Elapsed` is the pass.
+    if let Ok(reason) = resolved {
         panic!(
-            "the infra-death watch never resolved across a Kueue eviction. The evicted Job is \
-             suspended, NOT Failed and NOT Complete, so only fbiy-A1's \
-             Pod-absent-plus-Job-nonterminal arm can resolve it. Job still present: {}; \
+            "a routine Kueue eviction terminalised a RECOVERABLE task-run: the infra-death watch \
+             resolved with {reason:?}. Job still present: {}; workloads: {}",
+            job_exists(&context, &job_name),
+            workload_summary(&context),
+        );
+    }
+
+    // 2. The Job survived, so the run is still the one Kueue re-admitted.
+    assert!(
+        job_exists(&context, &job_name),
+        "the evicted Job must survive: deleting it is precisely what makes a recoverable \
+         eviction unrecoverable. Workloads: {}",
+        workload_summary(&context),
+    );
+
+    // 3. The recovery is real, not a cluster that stayed broken quietly.
+    let recovered: BTreeSet<String> = pods_of(&context, &task_run_id)
+        .into_iter()
+        .filter(|(_, uid, phase)| !uid.is_empty() && *uid != bound_uid && phase == "Running")
+        .map(|(_, uid, _)| uid)
+        .collect();
+    assert!(
+        !recovered.is_empty(),
+        "Kueue must have re-admitted the Workload and the Job controller must have created a NEW \
+         Pod; pods now: {:?}, workloads: {}",
+        pods_of(&context, &task_run_id),
+        workload_summary(&context),
+    );
+    assert!(
+        workload_condition(&context, &job_name, "Admitted"),
+        "the re-admitted Workload must be Admitted again; workloads: {}",
+        workload_summary(&context),
+    );
+
+    // 4. AC3: the distinguisher, asserted as a field read in both phases.
+    assert!(
+        observed.suspended_during,
+        "Kueue re-suspends an evicted Job — `spec.suspend` is the Job-level half of the \
+         distinguisher and it was never observed true: {observed:?}",
+    );
+    let (during_status, during_reason) = observed
+        .evicted_during
+        .clone()
+        .expect("an evicted Workload carries an Evicted condition");
+    assert_eq!(
+        during_status, "True",
+        "during the eviction the Workload's Evicted condition is True (reason {during_reason})",
+    );
+    let (after_status, after_reason) = observed.evicted_after_readmission.clone().expect(
+        "THE FIELD THIS FIX TURNS ON: Kueue leaves the Evicted condition behind after \
+             re-admission. Without it, a poll landing after the release sees an unsuspended Job \
+             with its fenced Pod gone — bit for bit the state fbiy-A1 reaps on — and nothing to \
+             tell it apart from abandonment",
+    );
+    assert!(
+        !observed.suspended_after_readmission,
+        "the re-admitted Job is unsuspended ({observed:?}), which is exactly why `spec.suspend` \
+         alone cannot carry this and the Workload's record has to",
+    );
+    eprintln!(
+        "03z3 AC3 distinguisher: Evicted during = ({during_status}, {during_reason}); after \
+         re-admission = ({after_status}, {after_reason}); job suspend during = {}, after = {}",
+        observed.suspended_during, observed.suspended_after_readmission,
+    );
+    assert_eq!(
+        observed.pods_usage_during, 0,
+        "RECORDED and asserted: an evicted Workload holds NO ClusterQueue quota, which is why \
+         holding the reap off does not strand the capacity the reap exists to release",
+    );
+
+    delete_job(&context, &job_name);
+}
+
+/// AC2, live: the narrowing must not have disarmed a genuine Pod loss.
+///
+/// On this cluster a force-delete resolves through the PRE-EXISTING
+/// `job_failed_reason` arm rather than A1's (finding 2), and that is the point:
+/// whichever arm answers, the run must still terminalise rather than hang. A fix
+/// that held on every absence — the obvious way to make the eviction test pass —
+/// fails here, because nothing else would ever resolve this watch.
+#[test]
+#[ignore]
+fn live_a_force_deleted_pod_still_terminalises_the_run() {
+    if !live_tests_enabled() {
+        return;
+    }
+    install_crypto_provider();
+    let context = harness_context();
+    clear_task_run_jobs(&context);
+    repair_cluster_queue_for_admission(&context);
+    ensure_workload_image_on_the_node();
+    let config = config_for(&context, WORKLOAD_IMAGE);
+
+    let (task_run_id, job_name) = launch_task_run(&context, &config);
+    let (pod_name, bound_uid) = await_running_pod(&context, &task_run_id);
+    assert_eq!(
+        workload_condition_entry(&context, &job_name, "Evicted"),
+        None,
+        "this run is being force-deleted, not evicted: its Workload must carry no Evicted record",
+    );
+
+    let handle = RunHandle {
+        task_run_id: task_run_id.clone(),
+        container_id: None,
+        pod_ref: Some(job_name.clone()),
+        started_at: SystemClock::new().now(),
+    };
+    let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("build a tokio runtime for the live watch");
+    let resolved = tokio_runtime.block_on({
+        let context = context.clone();
+        let config = config.clone();
+        async move {
+            let runtime = KubernetesRuntime::from_client(
+                kube_client(&context).await,
+                config,
+                std::sync::Arc::new(ConnectionRegistry::new()),
+            );
+            let destroying = tokio::task::spawn_blocking(move || {
+                std::thread::sleep(Duration::from_secs(20));
+                let deleted = Command::new("kubectl")
+                    .args([
+                        "--context",
+                        &context,
+                        "-n",
+                        NAMESPACE,
+                        "delete",
+                        "pod",
+                        &pod_name,
+                        "--grace-period=0",
+                        "--force",
+                    ])
+                    .output()
+                    .expect("kubectl is on PATH");
+                assert!(
+                    deleted.status.success(),
+                    "force-deleting {pod_name} failed: {}",
+                    stderr(&deleted),
+                );
+            });
+            let resolved =
+                tokio::time::timeout(Duration::from_secs(180), runtime.watch_infra_death(&handle))
+                    .await;
+            let _ = destroying.await;
+            resolved
+        }
+    });
+
+    let reason = resolved.unwrap_or_else(|_| {
+        panic!(
+            "a force-deleted worker Pod must still terminalise its run. Job present: {}; \
              workloads: {}",
             job_exists(&context, &job_name),
             workload_summary(&context),
         )
     });
-    eprintln!("AC2 live death reason: {reason}");
-
-    assert!(
-        reason.contains(&bound_uid),
-        "the run stays bound to the Pod UID it launched — the watch must name it rather than \
-         adopt whatever Pod the re-admission created. bound_uid={bound_uid}, reason: {reason}",
-    );
-
-    // The replacement, when the re-admission got one in front of a poll. This is
-    // RECORDED rather than required, because the watch may legitimately resolve
-    // inside the eviction window before Kueue re-admits — both orderings are
-    // correct behaviour and asserting one produces a flaky test.
-    let observed_uids: BTreeSet<String> = pods_of(&context, &task_run_id)
-        .into_iter()
-        .map(|(_, uid, _)| uid)
-        .filter(|uid| !uid.is_empty() && *uid != bound_uid)
-        .collect();
-    let refused_by_name = reason.contains("refused to adopt replacement Pod UID(s)");
-    eprintln!(
-        "AC2 RECORDED: replacement Pod UIDs seen after re-admission = {observed_uids:?}; \
-         the watch reported them refused by name = {refused_by_name}"
-    );
-    for uid in &observed_uids {
-        assert_ne!(
-            uid, &bound_uid,
-            "a replacement Pod must carry a different immutable UID",
-        );
-    }
-
-    // The reap, observed on the API server rather than in a log line.
-    let mut reaped = false;
-    for _ in 0..AWAIT_TICKS {
-        if !job_exists(&context, &job_name) {
-            reaped = true;
-            break;
-        }
-        std::thread::sleep(TICK);
-    }
-    assert!(
-        reaped,
-        "reconciliation must foreground-delete the old Job so it stops holding quota before the \
-         task-run is retried; {job_name} is still on the API server",
-    );
+    eprintln!("03z3 AC2 live death reason (bound uid {bound_uid}): {reason}");
 
     delete_job(&context, &job_name);
 }


### PR DESCRIPTION
Fixes `03z3` (epic `fbiy`, proposal `9oga`). **P0 blocker on arming Kueue anywhere, including the production VPS.**

## The defect

`fbiy-A1` (#2833) built containment: when the fenced worker Pod is absent while its Job is still nonterminal, terminalise the task-run and foreground-delete the Job so it stops holding quota. Correct for an abandoned Pod.

A routine **Kueue eviction produces exactly that observable state** — Kueue re-suspends the Job, the Job controller deletes its Pod — and an eviction is **recoverable**: release the queue and the same Workload is re-admitted with a new Pod. Deleting the Job there converts a run that was going to finish into one that never can. A retry always mints a fresh `task_run_id`, so nothing ever adopts the old Job back.

`fbiy-B2` (#2842) then measured the sharp part on a live cluster: `backoffLimit: 0` makes a force-deleted Pod an immediate Job **failure** (~5s), which resolves through the pre-existing `job_failed_reason` arm — so **A1's arm is never reached by a force-delete at all**. On a real cluster it is reached almost exclusively by eviction, the one case where its action is wrong.

Not live today (Kueue is installed but inert: `kueue.armed=false`, no namespace labelled, zero Workloads). It becomes live the instant anything is armed.

## The distinguisher

Narrowed, not removed — an abandoned Job still has to be reaped, which is why A1 exists. `runtime_eviction::classify_absent_pod` answers `Abandoned` only on a definite negative, from **two observable fields**, both measured on a disposable armed kind cluster (Kubernetes 1.31 / Kueue 0.19.0, 2026-07-31):

| phase | `job.spec.suspend` | Workload `Evicted` condition |
|---|---|---|
| admitted, running | `false` | **absent** |
| evicted (`stopPolicy: HoldAndDrain`) | `true` at t+0s (Pod gone at t+34..48s) | `True` / `ClusterQueueStopped` |
| re-admitted (~1s after release) | `false` | **still present**: `False` / `QuotaReserved` / `"Previously: The ClusterQueue is stopped"` |

* **`spec.suspend`** — on the Job object the watch already fetched. Kueue writes it *before* the Pod goes away, so there is no window where the Pod is missing and the suspension is not yet visible. No extra API call, no Kueue CRD, so it also answers for a plain `kubectl patch suspend=true`. A suspended Job is nonterminal but **not owed a Pod**, so a missing Pod under it is expected.
* **The Workload's `Evicted` condition, read status-INsensitively** — the field this fix turns on. It is the only one that survives re-admission: Kueue flips it to `False` and keeps it. `spec.suspend` alone is blind at exactly the sample a 15s poll takes, because the release measured **~1 second** to an unsuspended Job with a new Pod — bit for bit the state A1 reaps on. (`classify_workload_admission` correctly requires `True`; it answers a different question — "where is this Workload *now*".)

Neither is a timing heuristic: both are field reads, and no branch consults a clock, a duration or a sleep (AC3).

**Failure direction.** `Abandoned` requires a definite answer: the Job is unsuspended *and* Kueue's own record says this Workload was never evicted, or the Workload API is not served at all (404 — no Kueue in this cluster, so no eviction can have happened and A1's behaviour is the whole truth). Anything else (RBAC, 5xx, timeout) is `Inconclusive` and **holds**: the next poll is 15s away while a wrong reap is permanent, and an evicted Workload holds **no quota** (measured: ClusterQueue `pods` usage falls to 0), so holding does not strand the capacity the reap exists to release.

## Live evidence

Disposable cluster only, isolated triple (`djinn-kueue-b2` / `djinn-kueue-b2-registry` / port 5053), `--context kind-djinn-kueue-b2` pinned on every call. Deleted on exit — cluster and registry both confirmed gone.

```
running 3 tests
test live_a_force_deleted_pod_still_terminalises_the_run ...
  03z3 AC2 live death reason: BackoffLimitExceeded: Job has reached the specified backoff limit
ok
test live_a_kueue_eviction_and_re_admission_leaves_the_task_run_alive ...
  EvictionObservation { suspended_during: true,
                        evicted_during: Some(("True", "ClusterQueueStopped")),
                        evicted_after_readmission: Some(("False", "QuotaReserved")),
                        suspended_after_readmission: false,
                        pods_usage_during: 0,
                        seconds_to_pod_deletion: 46, seconds_to_readmission: 1 }
ok
test live_force_deleting_an_admitted_pod_records_the_permitted_disjunction ... ok

test result: ok. 3 passed; 0 failed; finished in 277.58s
```

**Live non-vacuity (AC1).** Restore the unconditional foreground delete and re-run the same test against the same cluster:

```
a routine Kueue eviction terminalised a RECOVERABLE task-run: the infra-death watch resolved
with "worker Pod dfd9b211-… was deleted while its Job djinn-taskrun-019fb852-… was still active
(force delete / node loss); the Job was foreground-deleted; refused to adopt replacement Pod
UID(s) 75a9b465-…"
  … while the Workload read Evicted=False (Previously: The ClusterQueue is stopped),
    Admitted=True, Requeued=True, PodsReady=True — i.e. it had already recovered.
FAILED
```

## Mutation testing (fixture)

Each mutation applied alone against the shipped tree, then reverted:

| mutation | tests killed |
|---|---|
| M1 restore the unconditional foreground delete (**AC1**) | `a_kueue_eviction_then_re_admission_leaves_the_task_run_alive`, `a_re_admission_the_watch_never_saw_suspended_still_leaves_the_run_alive`, `a_suspended_job_with_no_workload_at_all_is_not_reaped` |
| M2 remove the containment entirely — hold on every absence (**AC2**) | `a_force_deleted_worker_pod_terminalises_the_run_and_reaps_its_job`, `a_force_delete_under_a_never_evicted_workload_still_reaps`, `a_replacement_pod_with_a_different_uid_is_observed_but_never_adopted`, `the_reaping_job_delete_carries_foreground_propagation_in_its_request_body` |
| M3 read `Evicted` status-sensitively (`== True`) (**AC3**) | `a_re_admission_the_watch_never_saw_suspended_still_leaves_the_run_alive`, `a_kueue_eviction_then_re_admission_leaves_the_task_run_alive` |
| M4 drop the `spec.suspend` arm (**AC3**) | `a_suspended_job_with_no_workload_at_all_is_not_reaped` |
| M5 answer `Recoverable` for a missing Workload | the four containment tests above |
| M6 allow the new UID (drop `bind`'s pod-uid comparison) (**AC4**) | `a_lift_from_the_re_admitted_pod_is_still_rejected`, `every_lift_presented_with_the_replacement_pod_uid_is_rejected` |

AC2's non-vacuity is proven at the fixture level rather than live, deliberately: live, a force-delete resolves through the pre-existing `job_failed_reason` arm (finding 2), so removing A1's arm does not change that outcome. `live_a_force_deleted_pod_still_terminalises_the_run` still asserts the run terminalises — whichever arm answers — because a fix that held on every absence would leave that watch hanging forever.

## The fixture now models Kueue, honestly

`FakeCluster` gains Workload capture, `evict` and `readmit`. Every field and every ordering in them is a transcription of `kubectl -o json` against the live cluster — including the fact that a suspended Job materialises **no** replacement Pod — precisely because this defect exists thanks to a fixture that modelled behaviour the cluster does not have. The live proof remains `tests/kueue_disruption_conformance.rs`.

`let_the_watch_poll` asserts the watch actually took the polls the test claims: under `start_paused`, yielding would keep a task runnable, the clock would never advance, and every "it did not resolve" assertion would pass with the watch parked at its sleep having looked at nothing.

## What was replaced

`live_a_kueue_eviction_produces_the_replacement_uid_the_watch_refuses` asserted the watch resolves and the Job is reaped on an eviction. That *is* the defect, so it is replaced by a test asserting the opposite, plus the field reads it turns on. The pod-UID fence itself is untouched: the run stays bound to the Pod it launched, and PostgreSQL still rejects a lift presenting the re-admitted Pod's uid (AC4).

## Checks

* `cargo test -p djinn-k8s` — 353 lib + all integration targets green.
* `cargo clippy -p djinn-k8s --all-targets` — clean; `cargo fmt` applied to the touched files only.
* `scripts/check-file-size.sh` — every touched file under MAX_LINES 1500 / MAX_BYTES 51200; the new logic went into a new module rather than growing `runtime.rs`.
* No `deploy/**` change. Nothing arms anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
