### PR TITLE
fix(slot): inject the turn-inline budget and isolate its trip counter

### DIFF
--- a/server/crates/djinn-slot/src/reply_loop/streaming_retry_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/streaming_retry_tests.rs
@@ -334,6 +334,7 @@ async fn drive_stream_directly(
         otel_session: None,
         phase_tracker: None,
         cancel: &cancel,
+        turn_inline_budget: None,
     };
     let activity_ts = Arc::new(AtomicU64::new(0));
     let last_rpc_touch = Arc::new(AtomicU64::new(0));

--- a/server/crates/djinn-slot/src/reply_loop/tool_dispatch.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tool_dispatch.rs
@@ -170,6 +170,14 @@ pub(super) struct ToolDispatchContext<'a> {
     pub otel_session: Option<&'a telemetry::SessionSpan>,
     pub phase_tracker: Option<&'a Arc<Mutex<SessionPhaseTracker>>>,
     pub cancel: &'a tokio_util::sync::CancellationToken,
+    /// Override for the per-turn inline-character budget policy.
+    ///
+    /// Production wiring leaves this `None`, which makes the turn-budget pass
+    /// read [`TurnInlineBudgetConfig::from_env`] exactly as before. Tests set it
+    /// so they can drive the policy deterministically instead of mutating the
+    /// `DJINN_TURN_INLINE_*` process environment, which is shared by every test
+    /// in the binary and races under parallel execution.
+    pub turn_inline_budget: Option<super::turn_budget::TurnInlineBudgetConfig>,
 }
 
 /// Per-call fields passed into [`dispatch_single_tool`].

--- a/server/crates/djinn-slot/src/reply_loop/tool_dispatch_budget_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tool_dispatch_budget_tests.rs
@@ -1,18 +1,20 @@
-// The telemetry guard mutex is intentionally held across awaits to serialize tests.
-#![allow(clippy::await_holding_lock)]
 // Turn-inline-budget and `collect_tool_results` coverage split out of
 // `tool_dispatch_tests` to keep each test module under the source-size guard.
 // Shared helpers (`test_tool_schema`, `test_cancel_token`) remain in the sibling
 // `tool_dispatch_tests` module and are imported here.
+//
+// Nothing in this module serializes on a mutex or mutates the process
+// environment. The two process-global resources it used to share with its
+// siblings — the `DJINN_TURN_INLINE_*` variables and the
+// `djinn_reply_loop_inline_char_budget_trips_total` counter — are now injected
+// per test (`ToolDispatchContext::turn_inline_budget`) and captured per test
+// (`djinn_telemetry::IsolatedRecorder`) respectively.
 use super::super::turn_budget::{
     DEFAULT_TURN_INLINE_CHAR_BUDGET, DEFAULT_TURN_INLINE_PREVIEW_FLOOR, TurnInlineBudgetConfig,
     apply_turn_inline_budget_pass_with_config, read_positive_env_usize,
 };
-use super::tool_dispatch_tests::{
-    test_cancel_token, test_tool_schema, turn_budget_telemetry_guard,
-};
+use super::tool_dispatch_tests::{test_cancel_token, test_tool_schema};
 use super::*;
-use djinn_telemetry::render;
 
 fn test_dispatch_context<'a>(
     ctx: &'a SlotContext,
@@ -29,6 +31,29 @@ fn test_dispatch_context<'a>(
         otel_session: None,
         phase_tracker: None,
         cancel: test_cancel_token(),
+        turn_inline_budget: None,
+    }
+}
+
+/// Dispatch context whose turn-budget policy is injected rather than read from
+/// the process environment.
+///
+/// `collect_tool_results` runs the turn-budget pass internally, so a test that
+/// wants a non-default budget for that whole path used to `set_var` the
+/// `DJINN_TURN_INLINE_*` names. The environment is process-global: every
+/// concurrently running test in this binary that reached
+/// `TurnInlineBudgetConfig::from_env` observed the override, tripped the budget,
+/// and moved the shared trip counter. Injecting the config keeps the override
+/// on this context alone.
+fn test_dispatch_context_with_budget<'a>(
+    ctx: &'a SlotContext,
+    tool_metadata: &'a ToolRuntimeMetadataMap,
+    worktree_path: &'a std::path::Path,
+    config: TurnInlineBudgetConfig,
+) -> ToolDispatchContext<'a> {
+    ToolDispatchContext {
+        turn_inline_budget: Some(config),
+        ..test_dispatch_context(ctx, tool_metadata, worktree_path)
     }
 }
 #[tokio::test]
@@ -198,10 +223,10 @@ async fn collect_tool_results_budget_pass_externalizes_largest_serial_parallel_s
     let dispatcher = Arc::new(ConfigurableToolDispatcher::new(Vec::new(), handlers));
     let ctx = agent_context_from_db_with_dispatcher(db, CancellationToken::new(), Some(dispatcher));
     let worktree_path = std::path::Path::new("/tmp");
-    unsafe {
-        std::env::set_var("DJINN_TURN_INLINE_CHAR_BUDGET", "5000");
-        std::env::set_var("DJINN_TURN_INLINE_PREVIEW_FLOOR", "500");
-    }
+    let budget = TurnInlineBudgetConfig {
+        budget: 5_000,
+        preview_floor: 500,
+    };
     let schemas = vec![
         test_tool_schema(
             "shell",
@@ -260,7 +285,8 @@ async fn collect_tool_results_budget_pass_externalizes_largest_serial_parallel_s
         },
     )];
     let streaming_dispatched = HashSet::from([3]);
-    let dispatch_ctx = test_dispatch_context(&ctx, &tool_metadata, worktree_path);
+    let dispatch_ctx =
+        test_dispatch_context_with_budget(&ctx, &tool_metadata, worktree_path, budget);
     let blocks = collect_tool_results(
         &turn_tool_calls,
         streaming_results,
@@ -627,11 +653,15 @@ async fn externalization_preserves_extension_mcp_and_native_resource_recovery_me
     let ctx = agent_context_from_db_with_dispatcher(db, CancellationToken::new(), Some(dispatcher));
     let worktree_path = std::path::Path::new("/tmp");
     let tool_metadata = ToolRuntimeMetadataMap::new();
-    let dispatch_ctx = test_dispatch_context(&ctx, &tool_metadata, worktree_path);
-    unsafe {
-        std::env::set_var("DJINN_TURN_INLINE_CHAR_BUDGET", "200");
-        std::env::set_var("DJINN_TURN_INLINE_PREVIEW_FLOOR", "10");
-    }
+    let dispatch_ctx = test_dispatch_context_with_budget(
+        &ctx,
+        &tool_metadata,
+        worktree_path,
+        TurnInlineBudgetConfig {
+            budget: 200,
+            preview_floor: 10,
+        },
+    );
     let turn_tool_calls = vec![
         ContentBlock::ToolUse {
             id: "call-ext".into(),
@@ -657,10 +687,6 @@ async fn externalization_preserves_extension_mcp_and_native_resource_recovery_me
         &dispatch_ctx,
     )
     .await;
-    unsafe {
-        std::env::remove_var("DJINN_TURN_INLINE_CHAR_BUDGET");
-        std::env::remove_var("DJINN_TURN_INLINE_PREVIEW_FLOOR");
-    }
     for (expected_id, expected_name) in [
         ("call-ext", "extension_compute"),
         ("call-mcp", "mcp_fetch"),
@@ -810,15 +836,16 @@ fn budget_trip_counter_value(rendered: &str) -> f64 {
 async fn under_budget_turn_does_not_increment_budget_trip_counter() {
     use crate::test_helpers::{agent_context_from_db, create_test_db};
     use tokio_util::sync::CancellationToken;
-    let _guard = turn_budget_telemetry_guard();
-    djinn_telemetry::init().expect("telemetry init");
     let db = create_test_db();
     let ctx = agent_context_from_db(db, CancellationToken::new());
     let worktree_path = std::path::Path::new("/tmp");
     let tool_metadata = ToolRuntimeMetadataMap::new();
     let dispatch_ctx = test_dispatch_context(&ctx, &tool_metadata, worktree_path);
-    let before = render().expect("render metrics");
-    let before_value = budget_trip_counter_value(&before);
+    let recorder = djinn_telemetry::IsolatedRecorder::new();
+    let _scope = recorder.scope();
+    // Seed the series once so the strict reader below still fails loudly if the
+    // counter is ever renamed: an untouched registry renders no sample at all.
+    djinn_telemetry::reply_loop::increment_inline_char_budget_trip();
     let config = TurnInlineBudgetConfig {
         budget: 100_000_000,
         preview_floor: 10_000,
@@ -826,10 +853,10 @@ async fn under_budget_turn_does_not_increment_budget_trip_counter() {
     let body = "x".repeat(1_000);
     let mut results = vec![collected_text(0, "call-0", "read", &body)];
     apply_turn_inline_budget_pass_with_config(&mut results, &dispatch_ctx, config).await;
-    let after = render().expect("render after pass");
-    let after_value = budget_trip_counter_value(&after);
+    let after = recorder.render();
     assert_eq!(
-        after_value, before_value,
+        budget_trip_counter_value(&after),
+        1.0,
         "under-budget turn must not increment the budget-trip counter:\n{after}"
     );
 }
@@ -837,15 +864,13 @@ async fn under_budget_turn_does_not_increment_budget_trip_counter() {
 async fn over_budget_turn_increments_budget_trip_counter_by_one_for_multiple_externalizations() {
     use crate::test_helpers::{agent_context_from_db, create_test_db};
     use tokio_util::sync::CancellationToken;
-    let _guard = turn_budget_telemetry_guard();
-    djinn_telemetry::init().expect("telemetry init");
     let db = create_test_db();
     let ctx = agent_context_from_db(db, CancellationToken::new());
     let worktree_path = std::path::Path::new("/tmp");
     let tool_metadata = ToolRuntimeMetadataMap::new();
     let dispatch_ctx = test_dispatch_context(&ctx, &tool_metadata, worktree_path);
-    let before = render().expect("render metrics");
-    let before_value = budget_trip_counter_value(&before);
+    let recorder = djinn_telemetry::IsolatedRecorder::new();
+    let _scope = recorder.scope();
     let config = TurnInlineBudgetConfig {
         budget: 200,
         preview_floor: 10,
@@ -867,23 +892,24 @@ async fn over_budget_turn_increments_budget_trip_counter_by_one_for_multiple_ext
         })
         .count();
     assert!(externalized >= 2, "missing externalization");
-    let after = render().expect("render after pass");
-    let after_value = budget_trip_counter_value(&after);
-    assert_eq!(after_value, before_value + 1.0, "bad counter increment");
+    let after = recorder.render();
+    assert_eq!(
+        budget_trip_counter_value(&after),
+        1.0,
+        "bad counter increment:\n{after}"
+    );
 }
 #[tokio::test]
 async fn over_budget_turn_increments_budget_trip_counter_by_one_when_residual_overflow_remains() {
     use crate::test_helpers::{agent_context_from_db, create_test_db};
     use tokio_util::sync::CancellationToken;
-    let _guard = turn_budget_telemetry_guard();
-    djinn_telemetry::init().expect("telemetry init");
     let db = create_test_db();
     let ctx = agent_context_from_db(db, CancellationToken::new());
     let worktree_path = std::path::Path::new("/tmp");
     let tool_metadata = ToolRuntimeMetadataMap::new();
     let dispatch_ctx = test_dispatch_context(&ctx, &tool_metadata, worktree_path);
-    let before = render().expect("render metrics");
-    let before_value = budget_trip_counter_value(&before);
+    let recorder = djinn_telemetry::IsolatedRecorder::new();
+    let _scope = recorder.scope();
     let config = TurnInlineBudgetConfig {
         budget: 100,
         preview_floor: 10_000,
@@ -905,9 +931,12 @@ async fn over_budget_turn_increments_budget_trip_counter_by_one_when_residual_ov
             "floor externalized"
         );
     }
-    let after = render().expect("render after pass with residual overflow");
-    let after_value = budget_trip_counter_value(&after);
-    assert_eq!(after_value, before_value + 1.0, "bad counter increment");
+    let after = recorder.render();
+    assert_eq!(
+        budget_trip_counter_value(&after),
+        1.0,
+        "bad counter increment:\n{after}"
+    );
 }
 #[tokio::test]
 async fn budget_trip_structured_event_retains_required_fields() {
@@ -954,14 +983,14 @@ async fn budget_trip_structured_event_retains_required_fields() {
 }
 #[test]
 fn budget_trip_counter_name_is_coupled_to_telemetry_constant() {
-    let _guard = turn_budget_telemetry_guard();
-    djinn_telemetry::init().expect("telemetry init");
-    let before = render().expect("render metrics");
-    let before_value = budget_trip_counter_value(&before);
-    djinn_telemetry::reply_loop::increment_inline_char_budget_trip();
-    let after = render().expect("render after increment");
-    let after_value = budget_trip_counter_value(&after);
-    assert_eq!(after_value, before_value + 1.0, "bad counter increment");
+    let ((), rendered) = djinn_telemetry::render_isolated(
+        djinn_telemetry::reply_loop::increment_inline_char_budget_trip,
+    );
+    assert_eq!(
+        budget_trip_counter_value(&rendered),
+        1.0,
+        "bad counter increment:\n{rendered}"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/server/crates/djinn-slot/src/reply_loop/tool_dispatch_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tool_dispatch_tests.rs
@@ -344,6 +344,7 @@ fn test_tracked_dispatch_context<'a>(
         otel_session: None,
         phase_tracker: Some(phase_tracker),
         cancel: test_cancel_token(),
+        turn_inline_budget: None,
     }
 }
 #[test]

--- a/server/crates/djinn-slot/src/reply_loop/turn.rs
+++ b/server/crates/djinn-slot/src/reply_loop/turn.rs
@@ -1014,6 +1014,7 @@ pub async fn run_reply_loop(
                 otel_session: otel_session.as_ref(),
                 phase_tracker: Some(&phase_tracker),
                 cancel,
+                turn_inline_budget: None,
             };
             let mut stream_state = match consume_provider_stream(StreamLoopContext {
                 provider,
@@ -2600,6 +2601,7 @@ mod tests {
             otel_session: None,
             phase_tracker: None,
             cancel: &cancel,
+            turn_inline_budget: None,
         };
 
         let state = consume_provider_stream(StreamLoopContext {
@@ -2703,6 +2705,7 @@ mod tests {
             otel_session: None,
             phase_tracker: None,
             cancel: &cancel,
+            turn_inline_budget: None,
         };
         let activity_ts = Arc::new(AtomicU64::new(0));
         let last_rpc_touch = Arc::new(AtomicU64::new(0));

--- a/server/crates/djinn-slot/src/reply_loop/turn_budget.rs
+++ b/server/crates/djinn-slot/src/reply_loop/turn_budget.rs
@@ -107,8 +107,12 @@ pub(super) async fn apply_turn_inline_budget_pass(
     results: &mut [CollectedToolResult],
     ctx: &ToolDispatchContext<'_>,
 ) {
-    apply_turn_inline_budget_pass_with_config(results, ctx, TurnInlineBudgetConfig::from_env())
-        .await;
+    // An injected config wins; production leaves it unset and reads the
+    // environment, so the deployed behaviour is unchanged.
+    let config = ctx
+        .turn_inline_budget
+        .unwrap_or_else(TurnInlineBudgetConfig::from_env);
+    apply_turn_inline_budget_pass_with_config(results, ctx, config).await;
 }
 
 /// Config-injectable core of [`apply_turn_inline_budget_pass`] so unit tests can


### PR DESCRIPTION
## The racing shared resources

`tool_dispatch_budget_tests` shared **two** process-global resources with every other test in the `djinn-slot` lib binary.

**1. `DJINN_TURN_INLINE_CHAR_BUDGET` / `DJINN_TURN_INLINE_PREVIEW_FLOOR`.** Two tests `set_var`'d them (`tool_dispatch_budget_tests.rs:201` and `:631`) because they exercise `collect_tool_results`, which runs the turn-budget pass internally, and the pass read `TurnInlineBudgetConfig::from_env()`. There is one environment per process, so the override was visible to every concurrently running test that reached `from_env()` — making siblings trip a budget they would never otherwise trip.

**2. `djinn_reply_loop_inline_char_budget_trips_total`.** A label-free, process-global Prometheus counter. Three tests asserted a before/after delta of exactly `+1`/`+0` around the pass while holding `turn_budget_telemetry_guard()` — but that mutex was taken by only *some* of the tests that can increment the counter. `budget_trip_structured_event_retains_required_fields`, the two env-mutating tests above, and the largest-first selection tests all trip the budget without it.

The two compose into the observed failure. An env override makes an unguarded sibling trip the budget, the counter moves inside a guarded reader's delta window, the delta assertion fails, and the resulting panic **poisons the mutex** — which is why the other two guarded tests die with `telemetry mutex poisoned` rather than a real assertion:

```
panicked at tool_dispatch_budget_tests.rs:872:
assertion `left == right` failed: bad counter increment
  left: 3.0
 right: 2.0

panicked at tool_dispatch_tests.rs:13:
telemetry mutex poisoned: PoisonError { .. }
```

## The fix

Following the shape of #2820 (a process-global registry made an injectable dependency with a fallback to the singleton, so production wiring was untouched):

- **`ToolDispatchContext` gains `turn_inline_budget: Option<TurnInlineBudgetConfig>`.** `apply_turn_inline_budget_pass` uses it when set and otherwise falls back to `TurnInlineBudgetConfig::from_env()`. The production site in `turn.rs` and the two `turn.rs`/`streaming_retry_tests.rs` harness sites pass `None`, so deployed behaviour and the `DJINN_TURN_INLINE_*` operator contract are **unchanged**.
- **The two env-mutating tests inject the config** through a new `test_dispatch_context_with_budget` helper. No `set_var`/`remove_var` remains anywhere in the module.
- **The counter tests use the existing `djinn_telemetry::IsolatedRecorder` / `render_isolated` seam** — a thread-local Prometheus registry no other test can reach, which is exactly what that type was added for. They now assert an **exact absolute value** instead of a delta, so there is no window for a concurrent writer at all. The under-budget test seeds the series once so the strict reader still fails loudly if the counter is ever renamed.
- `turn_budget_telemetry_guard()` and `#![allow(clippy::await_holding_lock)]` are gone from this module.

No `#[serial]`, no retries, no `#[ignore]`, no single-threading.

## Verification

All runs are `cargo test -p djinn-slot --lib reply_loop::tool_dispatch::tool_dispatch_budget_tests` with `DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres SQLX_OFFLINE=true`.

### Before — default parallelism, 8 runs

```
run 1: ok.     21 passed; 0 failed
run 2: ok.     21 passed; 0 failed
run 3: ok.     21 passed; 0 failed
run 4: FAILED. 18 passed; 3 failed | over_budget_..._for_multiple_externalizations, over_budget_..._when_residual_overflow_remains, under_budget_turn_does_not_increment_budget_trip_counter
run 5: FAILED. 18 passed; 3 failed | over_budget_..._for_multiple_externalizations, over_budget_..._when_residual_overflow_remains, under_budget_turn_does_not_increment_budget_trip_counter
run 6: ok.     21 passed; 0 failed
run 7: ok.     21 passed; 0 failed
run 8: ok.     21 passed; 0 failed
SUMMARY: 6 clean / 2 failed
```

A separate 12-run loop hunting for the panic text failed on run 1 with the `left: 3.0 / right: 2.0` counter mismatch plus two poisoned-mutex cascades quoted above.

### After — default parallelism, 20 runs

```
run 1..20: ok. 21 passed; 0 failed   (every run)
SUMMARY: 20 clean / 0 failed
```

### After — other thread counts

```
--test-threads=1    5 runs   SUMMARY: 5 clean / 0 failed
--test-threads=64  10 runs   SUMMARY: 10 clean / 0 failed
```

### After — both `tool_dispatch` test modules together

The sibling `tool_dispatch_tests` still uses the mutex for its own phase-metric deltas, so it was re-run alongside:

```
cargo test -p djinn-slot --lib reply_loop::tool_dispatch::
run 1..20: ok. 27 passed; 0 failed   (every run)
SUMMARY: 20 clean / 0 failed
```

### Out of scope

`reply_loop::tests::*` (compaction / wind-down / strike tests) is a large **pre-existing** flake in the same binary — confirmed on pristine `main` with these changes stashed:

```
run 1: FAILED. 62 passed;  3 failed
run 2: FAILED. 56 passed;  9 failed
run 3: FAILED. 55 passed; 10 failed
SUMMARY: 0 clean / 3 failed
```

Different tests, different mechanism, untouched here.

### Gates

`cargo fmt --all -- --check` clean; `cargo clippy -p djinn-slot --all-targets -- -D warnings` clean.
