### PR TITLE
fix(server): scope the codebase-header cache reset to the calling test's project

### DIFF
--- a/server/src/server/chat/prompt/codebase_header.rs
+++ b/server/src/server/chat/prompt/codebase_header.rs
@@ -238,10 +238,22 @@ fn insert_cache(key: (String, String), text: String) {
     }
 }
 
+/// Drop every cached header belonging to `project_id`, leaving the rest of the
+/// map untouched.
+///
+/// The cache is a process-global `OnceLock<RwLock<HashMap>>` and cargo runs the
+/// whole test binary in one process, so a test starting from a clean slate has
+/// to reach into state its siblings are concurrently using. Keying the map by
+/// `(project_id, head)` already isolates the tests from one another — every test
+/// builds under its own project id — so the reset must be scoped the same way.
+/// A whole-map `clear()` throws that isolation away: a sibling calling it
+/// between another test's [`insert_cache`] and the [`lookup_cache`] that is
+/// supposed to hit evicts the entry under the running test, which then observes
+/// a freshly rendered header instead of the cached one.
 #[cfg(test)]
-pub(in crate::server::chat) fn clear_cache_for_tests() {
+pub(in crate::server::chat) fn clear_cache_for_tests(project_id: &str) {
     if let Ok(mut guard) = header_cache().write() {
-        guard.clear();
+        guard.retain(|(cached_project, _), _| cached_project != project_id);
     }
 }
 
@@ -713,7 +725,7 @@ mod tests {
 
     #[tokio::test]
     async fn full_header_includes_status_hotspots_and_tree() {
-        clear_cache_for_tests();
+        clear_cache_for_tests("p1-uniq-full");
         let tmp = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(tmp.path().join("src/api")).unwrap();
         std::fs::create_dir_all(tmp.path().join("src/models")).unwrap();
@@ -756,7 +768,7 @@ mod tests {
 
     #[tokio::test]
     async fn header_renders_with_only_status_when_others_fail() {
-        clear_cache_for_tests();
+        clear_cache_for_tests("p1-uniq-only-status");
         let tmp = tempfile::tempdir().unwrap();
         // No subdirs → folder tree is None.
 
@@ -776,7 +788,7 @@ mod tests {
 
     #[tokio::test]
     async fn cold_graph_with_tree_still_emits_header() {
-        clear_cache_for_tests();
+        clear_cache_for_tests("p1-uniq-cold");
         let tmp = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(tmp.path().join("src")).unwrap();
 
@@ -802,7 +814,7 @@ mod tests {
 
     #[tokio::test]
     async fn returns_none_when_everything_fails() {
-        clear_cache_for_tests();
+        clear_cache_for_tests("p1-uniq-none");
         let tmp = tempfile::tempdir().unwrap();
         // Empty dir → folder_tree is None too.
 
@@ -818,7 +830,7 @@ mod tests {
 
     #[tokio::test]
     async fn cache_returns_same_header_within_ttl() {
-        clear_cache_for_tests();
+        clear_cache_for_tests("p1-uniq-cache");
         let tmp = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(tmp.path().join("src")).unwrap();
 
@@ -887,7 +899,7 @@ mod tests {
 
     #[tokio::test]
     async fn built_header_is_wrapped_in_system_reminder() {
-        clear_cache_for_tests();
+        clear_cache_for_tests("p1-uniq-wrapped");
         let tmp = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(tmp.path().join("src")).unwrap();
 

--- a/server/src/server/chat/tests/prompt.rs
+++ b/server/src/server/chat/tests/prompt.rs
@@ -467,7 +467,7 @@ async fn codebase_header_builder_renders_status_hotspots_and_tree() {
         }
     }
 
-    clear_cache_for_tests();
+    clear_cache_for_tests("p-system-prompt");
     let tmp = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(tmp.path().join("src/api")).unwrap();
     std::fs::create_dir_all(tmp.path().join("tests")).unwrap();


### PR DESCRIPTION
## The racing shared resource

**`server::chat::prompt::codebase_header::header_cache()`** — a process-wide `OnceLock<RwLock<HashMap<(project_id, head), CachedHeader>>>`.

The tests are already isolated from one another *by that key*: every one of them builds under its own project id (`p1-uniq-full`, `p1-uniq-only-status`, `p1-uniq-cold`, `p1-uniq-none`, `p1-uniq-cache`, `p1-uniq-wrapped`, `p-system-prompt`). That namespacing was the intended isolation.

`clear_cache_for_tests()` wiped the **whole map**, which threw it away. Seven tests across two modules — six in `server/chat/prompt/codebase_header.rs` and one in `server/chat/tests/prompt.rs` — call it as their first statement.

`cache_returns_same_header_within_ttl` is the only test with a two-phase body: build once to populate the cache, then build again with a *different* stub and assert the cached text comes back. `build_codebase_header` `tokio::join!`s a `spawn_blocking` folder walk before it consults the cache, so there is a real cross-thread window between the first call's `insert_cache` and the second call's `lookup_cache`. A sibling landing its global `clear()` in that window evicts this test's entry, and the second build re-renders from `ops2`:

```
panicked at src/server/chat/prompt/codebase_header.rs:843:
assertion `left == right` failed
  left:  "…**Top hotspots** (by PageRank):\n- `first_call` (0.90)…"
 right:  "…**Top hotspots** (by PageRank):\n- `second_call_should_not_appear` (0.99)…"
```

That is the cache miss, verbatim — not a stale value, a *re-render*.

## The fix

`clear_cache_for_tests` now takes the project id and `retain`s every entry that does not belong to it, so a reset touches only the keys the calling test owns. All seven call sites pass their own id.

Production code is untouched: the function is `#[cfg(test)]`, and `lookup_cache` / `insert_cache` / the TTL eviction are unchanged.

No `#[serial]`, no retries, no `#[ignore]`, no single-threading.

## Verification

All runs are `cargo test -p djinn-server --lib prompt` with `DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres SQLX_OFFLINE=true`.

The `prompt` filter (21 tests) is the reproducer, not `codebase_header` (11 tests). The narrower filter starts all six clearers within the same microsecond, before any of them has inserted anything — 15/15 clean. Adding `server::chat::tests::prompt::codebase_header_builder_renders_status_hotspots_and_tree` from the other module staggers a seventh clearer late enough to land inside the window.

### Before — default parallelism, 15 runs

```
run  1: FAILED. 20 passed; 1 failed | codebase_header::tests::cache_returns_same_header_within_ttl
run  2: ok.     21 passed; 0 failed
run  3: ok.     21 passed; 0 failed
run  4: ok.     21 passed; 0 failed
run  5: FAILED. 20 passed; 1 failed | codebase_header::tests::cache_returns_same_header_within_ttl
run  6: ok.     21 passed; 0 failed
run  7: ok.     21 passed; 0 failed
run  8: FAILED. 20 passed; 1 failed | codebase_header::tests::cache_returns_same_header_within_ttl
run  9: ok.     21 passed; 0 failed
run 10: ok.     21 passed; 0 failed
run 11: ok.     21 passed; 0 failed
run 12: FAILED. 20 passed; 1 failed | codebase_header::tests::cache_returns_same_header_within_ttl
run 13: ok.     21 passed; 0 failed
run 14: ok.     21 passed; 0 failed
run 15: ok.     21 passed; 0 failed
SUMMARY: 11 clean / 4 failed
```

A separate 20-run loop hunting for the panic text failed on run 9 with the assertion quoted above.

### After — default parallelism, 20 runs

```
run 1..20: ok. 21 passed; 0 failed   (every run)
SUMMARY: 20 clean / 0 failed
```

### After — other thread counts, and the wider filter

```
--test-threads=1                                5 runs   SUMMARY: 5 clean / 0 failed
--test-threads=64                              10 runs   SUMMARY: 10 clean / 0 failed
cargo test -p djinn-server --lib server::chat  (89 tests)
                                               10 runs   SUMMARY: 10 clean / 0 failed
```

### Note

The full `cargo test -p djinn-server --lib` suite (630 tests) aborts with `thread 'tokio-rt-worker' has overflowed its stack` on this machine, on pristine `main` as well. It is unrelated to this change and is why the runs above are filtered.

### Gates

`cargo fmt --all -- --check` clean; `cargo clippy -p djinn-server --all-targets -- -D warnings` clean.
