### PR TITLE
test(kueue): prove the invocation governor end to end on a live armed-Kueue cluster (fbiy-C1)

### DIFF
--- a/deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml
+++ b/deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml
@@ -1,0 +1,103 @@
+# Djinn chart values for the DISPOSABLE armed-Kueue **and armed-launcher**
+# cluster (fbiy-C1).
+#
+# Consumed by `scripts/kind/setup-kueue-cluster.sh --cgroup-writable` and
+# asserted against by
+# `server/crates/djinn-k8s/tests/kueue_governor_conformance.rs`.
+#
+# HOW THIS DIFFERS FROM `kueue-cluster-values.yaml`, AND WHY IT IS A SECOND FILE
+# -----------------------------------------------------------------------------
+# The B0 fixture's whole point is that the RuntimeClass is ABSENT: the live
+# assertion `deploy/kueue/preflight.sh --mode cutover` must exit 10 against it,
+# and `tests/kueue_cluster_harness.rs` states in prose that flipping those three
+# values would retire that assertion without deleting the test. So C1 does not
+# flip them there. It flips them here, in a file no other harness installs, on a
+# cluster no other harness creates.
+#
+# THIS FILE ARMS BOTH KUEUE AND THE CGROUP LAUNCHER. It is safe only because the
+# only cluster it is ever applied to is one `setup-kueue-cluster.sh` created
+# seconds earlier and deletes on the way out. Arming the production VPS is a
+# gated operator act behind `deploy/kueue/preflight.sh --mode cutover` and
+# `deploy/runbooks/cgroup-launcher-rearm.md`; it is not this.
+
+namespace:
+  create: true
+  name: djinn
+
+# -----------------------------------------------------------------------------
+# The armed queue topology
+# -----------------------------------------------------------------------------
+kueue:
+  enabled: true
+  armed: true
+  # M. Read back off the live ClusterQueue by the test — never compared against
+  # this literal — and deliberately NOT the chart default of 3, for the same
+  # reason the B0 fixture is not: a number equal to the default would pass
+  # against an install that never read this file.
+  #
+  # Three is the smallest M that admits a cap K strictly between "authorizes
+  # nothing" (K = 0) and "bounds nothing" (K >= M). At K = 2 the live cluster
+  # holds two lifted invocations and one refused one simultaneously, which is
+  # the population AC3 measures.
+  buildPods: 3
+  namespaceLabelledExternally: false
+
+# -----------------------------------------------------------------------------
+# The arming triple — verbatim from values.yaml:200-201
+# -----------------------------------------------------------------------------
+# All three must move together. `deployment-server.yaml` `fail`s the render when
+# `kueue.armed` is set with `cgroupLauncher.mode: required` and
+# `cgroupWritable.taskRuns.enabled: false`, and `build_task_run_job` asserts the
+# same pairing at render time. The node prerequisite (the
+# `runc-cgroupwritable` containerd handler plus the `djinn.io/cgroup-writable`
+# label) is installed by `setup-kueue-cluster.sh --cgroup-writable`; without it
+# every task-run Pod here is permanently Pending.
+cgroupLauncher:
+  mode: required
+cgroupWritable:
+  runtimeClass:
+    enabled: true
+  taskRuns:
+    enabled: true
+
+# -----------------------------------------------------------------------------
+# Everything below only exists to make the install land on one throwaway node
+# -----------------------------------------------------------------------------
+postgres:
+  enabled: false
+qdrant:
+  enabled: false
+imagePipeline:
+  enabled: false
+ingress:
+  enabled: false
+monitoring:
+  enabled: false
+logCollector:
+  enabled: false
+
+database:
+  externalUrl: "postgres://harness:harness@127.0.0.1:5432/djinn-kueue-governor?sslmode=disable"
+
+migration:
+  designatedOperatorSecret: djinn-kueue-governor-operator
+
+storage:
+  mirrors:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+  cache:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+  projects:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+
+resources:
+  server:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"

--- a/deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml
+++ b/deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml
@@ -32,14 +32,15 @@ kueue:
   armed: true
   # M. Read back off the live ClusterQueue by the test — never compared against
   # this literal — and deliberately NOT the chart default of 3, for the same
-  # reason the B0 fixture is not: a number equal to the default would pass
-  # against an install that never read this file.
+  # reason the B0 fixture is not the default: a number equal to it would let the
+  # live assertion pass against an install that never read this file.
   #
-  # Three is the smallest M that admits a cap K strictly between "authorizes
-  # nothing" (K = 0) and "bounds nothing" (K >= M). At K = 2 the live cluster
-  # holds two lifted invocations and one refused one simultaneously, which is
-  # the population AC3 measures.
-  buildPods: 3
+  # It also has to be at least 3 for the population to be interesting. At M = 4
+  # the durable cap lands at K = 3, so the live cluster holds three lifted
+  # invocations and one refused one simultaneously — a bound that is reached as
+  # well as respected, which is what makes "exactly K" different from "at most
+  # K".
+  buildPods: 4
   namespaceLabelledExternally: false
 
 # -----------------------------------------------------------------------------

--- a/scripts/kind/setup-kueue-cluster.sh
+++ b/scripts/kind/setup-kueue-cluster.sh
@@ -45,26 +45,42 @@
 # in `server/crates/djinn-k8s/Cargo.toml`, which is the same floor from the
 # client side.
 #
-# WHAT IT DOES NOT DO — the fbiy-C1 hook
-# --------------------------------------
-# It patches containerd for REGISTRIES ONLY, exactly like
-# `scripts/kind/setup-kind.sh:59-106`. It installs NO `runc-cgroupwritable`
-# runtime handler and applies NO `djinn.io/cgroup-writable=true` node label,
-# both of which `deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml`
-# needs. That is deliberate and it is load-bearing twice over:
+# THE WRITABLE-CGROUP NODE — `--cgroup-writable`, OFF BY DEFAULT (fbiy-C1)
+# ------------------------------------------------------------------------
+# Without the flag this script patches containerd for REGISTRIES ONLY, exactly
+# like `scripts/kind/setup-kind.sh:59-106`: no `runc-cgroupwritable` runtime
+# handler and no `djinn.io/cgroup-writable=true` node label, both of which
+# `deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml` needs. That
+# default is load-bearing — `fbiy-B0`/`B1`/`B2` clusters must stay byte
+# identical to what they were measured against — so the C1 node work is opt-in
+# rather than unconditional.
 #
-#   * `deploy/kueue/preflight.sh --mode cutover` must exit 10 ("RuntimeClass
-#     djinn-cgroup-writable is absent") against this cluster. Installing the
-#     RuntimeClass here would silently retire that assertion.
-#   * fbiy-C1 owns proving the governor end to end and will need a real
-#     writable-cgroup node. See `configure_node_containerd` below: the C1
-#     extension goes inside that loop, plus a node label after cluster create.
-#     Nothing else in this script has to move.
+# `--cgroup-writable` adds exactly two node-level facts, and NOTHING chart-level:
+#
+#   * a `runc-cgroupwritable` containerd runtime handler on every node, written
+#     into the schema the node's LIVE `/etc/containerd/config.toml` declares
+#     (resolved with `deploy/node/k3s/containerd-config-version.sh`, the same
+#     detector the managed-k3s conformance uses — never from a version string);
+#   * the `djinn.io/cgroup-writable=true` node label the RuntimeClass's
+#     `scheduling.nodeSelector` requires.
+#
+# It still installs NO RuntimeClass. That object comes from the chart, gated by
+# `cgroupWritable.runtimeClass.enabled`, so `deploy/kueue/preflight.sh --mode
+# cutover` continues to exit 10 ("RuntimeClass djinn-cgroup-writable is absent")
+# against a `--values` file that leaves the gate off — which is 6knv's AC4, and
+# is unaffected by this flag. A caller that wants the class passes a values file
+# that enables it (see `deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml`);
+# a caller that enables the class WITHOUT this flag gets Pods that never
+# schedule, which is why the flag verifies the handler is live rather than
+# assuming the append worked.
 #
 # USAGE
 #   scripts/kind/setup-kueue-cluster.sh up      # create + install + arm
 #   scripts/kind/setup-kueue-cluster.sh down    # delete cluster AND registry
 #   scripts/kind/setup-kueue-cluster.sh check   # run the guards only, touch nothing
+#
+#   --cgroup-writable   install the runc-cgroupwritable containerd handler and
+#                       label the nodes (fbiy-C1); off by default
 #
 # `up` deletes the cluster and the registry on FAILURE (that is AC3 of 6knv);
 # on success it leaves them running for the Rust harness and the caller is
@@ -101,7 +117,17 @@ INSTALL_TIMEOUT_SECONDS="${DJINN_KUEUE_HARNESS_INSTALL_TIMEOUT_SECONDS:-600}"
 VALUES_FILE="${DJINN_KUEUE_HARNESS_VALUES:-$REPO_ROOT/deploy/helm/djinn/tests/fixtures/kueue-cluster-values.yaml}"
 REQUESTED_CONTEXT=""
 KEEP_ON_FAILURE=false
+CGROUP_WRITABLE=false
 ACTION=""
+
+# The node-level half of the writable-cgroup contract. Both names are the ones
+# `deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml` resolves
+# against, so they are read from the same place the chart states them rather
+# than restated here as free-standing strings.
+CGROUP_WRITABLE_HANDLER="runc-cgroupwritable"
+CGROUP_WRITABLE_NODE_LABEL="djinn.io/cgroup-writable"
+CONTAINERD_LIVE_CONFIG="/etc/containerd/config.toml"
+CONTAINERD_VERSION_LIB="$REPO_ROOT/deploy/node/k3s/containerd-config-version.sh"
 
 PREREQS_CHART="$REPO_ROOT/deploy/helm/djinn-prereqs"
 PREREQS_RELEASE="djinn-prereqs"
@@ -191,6 +217,10 @@ while [ "$#" -gt 0 ]; do
             KEEP_ON_FAILURE=true
             shift
             ;;
+        --cgroup-writable)
+            CGROUP_WRITABLE=true
+            shift
+            ;;
         --help|-h)
             usage
             exit 0
@@ -250,8 +280,8 @@ KUBECTL=("$KUBECTL_BIN" --context "$CONTEXT")
 HELM=("$HELM_BIN" --kube-context "$CONTEXT")
 
 if [ "$ACTION" = check ]; then
-    printf 'PASS: guards accept cluster=%s context=%s registry=%s:%s k8s=%s\n' \
-        "$CLUSTER_NAME" "$CONTEXT" "$REG_NAME" "$REG_PORT" "$KIND_IMAGE_VERSION"
+    printf 'PASS: guards accept cluster=%s context=%s registry=%s:%s k8s=%s cgroup-writable=%s\n' \
+        "$CLUSTER_NAME" "$CONTEXT" "$REG_NAME" "$REG_PORT" "$KIND_IMAGE_VERSION" "$CGROUP_WRITABLE"
     exit 0
 fi
 
@@ -379,25 +409,39 @@ SERVER_MINOR=$("${KUBECTL[@]}" version -o json | sed -n 's/.*"minor": *"\([0-9]*
     "the live API server reports 1.${SERVER_MINOR}, below the 1.${MIN_K8S_MINOR} floor Kueue 0.19.0 requires"
 info "live API server is Kubernetes 1.${SERVER_MINOR} (floor 1.${MIN_K8S_MINOR})"
 
-# 3. containerd registry wiring, per node.
+# 3. containerd wiring, per node: registry mirrors always, and — only under
+#    `--cgroup-writable` — the `runc-cgroupwritable` runtime handler the
+#    RuntimeClass names (fbiy-C1).
 #
-# ============================ fbiy-C1 EXTENSION HOOK =========================
-# C1 (prove the governor end to end) needs a node that can actually run the
-# writable-cgroup RuntimeClass. Everything it must add is local to this
-# function plus one node label:
+# WHY THE SCHEMA IS MEASURED AND NOT ASSUMED
+# ------------------------------------------
+# A kind node's containerd BINARY version and its CRI CONFIGURATION schema are
+# different facts, and on this image they disagree: `kindest/node:v1.35.0` ships
+# containerd 2.2.0 — which reads schema v3 — under a `/etc/containerd/config.toml`
+# whose first non-comment line is literally `version = 2`. The production VPS
+# runs the v3 schema (`deploy/node/k3s/containerd/config-v3.toml.tmpl`, pinned at
+# containerd 2.2.3-k3s1), so a handler block copied from the repo's production
+# asset would land in a plugin namespace this node's config does not use and
+# would be silently ignored: the RuntimeClass would resolve, the Pod would be
+# admitted, and the sandbox would come up under plain `runc` with a READ-ONLY
+# /sys/fs/cgroup. The launcher would then fail readiness for a reason that looks
+# nothing like "the handler was written into the wrong table".
 #
-#   * write a `runc-cgroupwritable` runtime handler into the node's
-#     /etc/containerd/config.toml (plugins."io.containerd.grpc.v1.cri".containerd
-#     .runtimes.runc-cgroupwritable) and restart containerd on the node;
-#   * `kubectl label node <node> djinn.io/cgroup-writable=true`;
-#   * flip cgroupWritable.runtimeClass.enabled / cgroupWritable.taskRuns.enabled
-#     and cgroupLauncher.mode in a C1-owned values file.
+# So the table header is resolved from the LIVE file by
+# `deploy/node/k3s/containerd-config-version.sh` — the same detector the managed
+# k3s conformance uses, sourced rather than reimplemented — and the result is
+# verified against `crictl info` after the restart. `cgroup_writable` is what
+# makes the container's own cgroup writable; `SystemdCgroup` mirrors the node's
+# base `runc` handler, because a handler on the other driver places its
+# containers under a cgroup parent the kubelet does not manage.
 #
-# It must NOT do that here. `deploy/kueue/preflight.sh --mode cutover` exiting
-# 10 against this cluster is 6knv's AC4, and exit 10 means "RuntimeClass
-# djinn-cgroup-writable is absent". Installing the class in B0 would delete
-# that assertion without deleting a single line of the test that makes it.
-# =============================================================================
+# This still installs NO RuntimeClass — that object is the chart's, gated by
+# `cgroupWritable.runtimeClass.enabled` — so `deploy/kueue/preflight.sh --mode
+# cutover` still exits 10 against a values file that leaves the gate off, which
+# is 6knv's AC4.
+# shellcheck source=../../deploy/node/k3s/containerd-config-version.sh
+. "$CONTAINERD_VERSION_LIB"
+
 configure_node_containerd() {
     local registry_dir="/etc/containerd/certs.d/localhost:${REG_PORT}"
     local in_cluster_dir="/etc/containerd/certs.d/${REG_NAME}:5000"
@@ -412,10 +456,97 @@ EOF
 [host."http://${REG_NAME}:5000"]
   capabilities = ["pull", "resolve"]
 EOF
+        [ "$CGROUP_WRITABLE" = true ] || continue
+        install_cgroup_writable_handler "$node"
     done
 }
-info 'wiring containerd registry mirrors (registries only — see the fbiy-C1 hook)'
+
+# Append the handler to ONE node's live containerd configuration, restart
+# containerd, and prove the handler is actually loaded.
+install_cgroup_writable_handler() {
+    local node=$1 live version table quote namespace
+    live=$(mktemp)
+    # A `docker exec cat` rather than a bind mount: the file lives inside the
+    # node container and the detector reads a path.
+    "$DOCKER" exec "$node" cat "$CONTAINERD_LIVE_CONFIG" >"$live" 2>/dev/null \
+        || fail 1 "node $node has no readable $CONTAINERD_LIVE_CONFIG; nothing to extend"
+    version=$(djinn_containerd_detect_version "$live") \
+        || fail 1 "could not resolve the containerd config schema of node $node"
+    namespace=$(djinn_containerd_namespace_for_version "$version")
+    # `DJINN_CONTAINERD_HANDLER` is the library's own handler name and already
+    # defaults to the one the chart names; asserted rather than re-set, so a
+    # rename on either side is a hard failure instead of two spellings.
+    [ "$DJINN_CONTAINERD_HANDLER" = "$CGROUP_WRITABLE_HANDLER" ] || fail 1 \
+        "handler name drift: $CONTAINERD_VERSION_LIB says '$DJINN_CONTAINERD_HANDLER', this script and the chart say '$CGROUP_WRITABLE_HANDLER'"
+    table=$(djinn_containerd_runtime_table_for_version "$version")
+    rm -f "$live"
+    case "$version" in
+        2) quote='"' ;;
+        3) quote="'" ;;
+    esac
+    info "node $node runs containerd CRI config schema v${version} (namespace ${namespace}); appending handler ${CGROUP_WRITABLE_HANDLER}"
+
+    # Idempotent: a second `up` against the same node must not double-declare
+    # the table, which containerd rejects outright.
+    if "$DOCKER" exec "$node" grep -qF "$table" "$CONTAINERD_LIVE_CONFIG"; then
+        info "node $node already declares ${table}"
+    else
+        "$DOCKER" exec -i "$node" tee -a "$CONTAINERD_LIVE_CONFIG" >/dev/null <<EOF
+
+# Added by scripts/kind/setup-kueue-cluster.sh --cgroup-writable (fbiy-C1).
+# Mirrors the managed-k3s templates in deploy/node/k3s/containerd/, rendered in
+# the schema this node's live configuration declares.
+${table}
+  runtime_type = "io.containerd.runc.v2"
+  cgroup_writable = true
+[plugins.${quote}${namespace}${quote}.containerd.runtimes.${CGROUP_WRITABLE_HANDLER}.options]
+  SystemdCgroup = true
+EOF
+    fi
+
+    "$DOCKER" exec "$node" systemctl restart containerd \
+        || fail 1 "containerd did not restart on node $node after the handler was appended"
+
+    # Prove it, do not assume it. `crictl info` reports the runtime table
+    # containerd actually PARSED; a handler in the wrong namespace, or a config
+    # containerd refused, is absent here while the file on disk still shows it.
+    local attempt=0 runtimes=""
+    while [ "$attempt" -lt 60 ]; do
+        runtimes=$("$DOCKER" exec "$node" crictl info 2>/dev/null) || runtimes=""
+        case "$runtimes" in
+            *"$CGROUP_WRITABLE_HANDLER"*) break ;;
+        esac
+        attempt=$((attempt + 1))
+        sleep 1
+    done
+    case "$runtimes" in
+        *"$CGROUP_WRITABLE_HANDLER"*) ;;
+        *) fail 1 "containerd on node $node never reported the ${CGROUP_WRITABLE_HANDLER} handler after restart; the table was written into ${namespace} for schema v${version}" ;;
+    esac
+    case "$runtimes" in
+        *cgroup_writable*|*CgroupWritable*|*cgroupWritable*) ;;
+        *) fail 1 "containerd on node $node loaded ${CGROUP_WRITABLE_HANDLER} but reports no cgroup_writable property; this containerd is too old to give a container a writable cgroup and the launcher would fail readiness instead" ;;
+    esac
+    info "node $node: containerd reports the ${CGROUP_WRITABLE_HANDLER} handler with a cgroup_writable property"
+}
+
+info 'wiring containerd registry mirrors'
 configure_node_containerd
+
+if [ "$CGROUP_WRITABLE" = true ]; then
+    # The label half of the contract. `RuntimeClass/djinn-cgroup-writable`
+    # carries `scheduling.nodeSelector: djinn.io/cgroup-writable: "true"`, which
+    # the RuntimeClass admission controller merges into every Pod naming the
+    # class — so without this an armed task-run Pod is permanently Pending with
+    # no event that mentions cgroups at all.
+    for node in $("$KIND" get nodes --name "$CLUSTER_NAME"); do
+        info "labelling node ${node} ${CGROUP_WRITABLE_NODE_LABEL}=true"
+        "${KUBECTL[@]}" label node "$node" "${CGROUP_WRITABLE_NODE_LABEL}=true" --overwrite
+    done
+    # The API server and the kubelet both went through a containerd restart;
+    # wait for the node to be Ready again before helm starts creating objects.
+    "${KUBECTL[@]}" wait --for=condition=Ready node --all --timeout=180s
+fi
 
 if [ "$("$DOCKER" inspect -f '{{json .NetworkSettings.Networks.kind}}' "$REG_NAME" 2>/dev/null)" = 'null' ]; then
     "$DOCKER" network connect kind "$REG_NAME"

--- a/scripts/kind/setup-kueue-cluster.sh
+++ b/scripts/kind/setup-kueue-cluster.sh
@@ -439,6 +439,8 @@ info "live API server is Kubernetes 1.${SERVER_MINOR} (floor 1.${MIN_K8S_MINOR})
 # `cgroupWritable.runtimeClass.enabled` — so `deploy/kueue/preflight.sh --mode
 # cutover` still exits 10 against a values file that leaves the gate off, which
 # is 6knv's AC4.
+[ -r "$CONTAINERD_VERSION_LIB" ] || fail 1 \
+    "the containerd schema detector is missing: $CONTAINERD_VERSION_LIB. It is the single source of truth for which plugin namespace a node's live configuration uses; do not inline a namespace here to get past this."
 # shellcheck source=../../deploy/node/k3s/containerd-config-version.sh
 . "$CONTAINERD_VERSION_LIB"
 

--- a/scripts/kind/setup-kueue-cluster.sh
+++ b/scripts/kind/setup-kueue-cluster.sh
@@ -120,10 +120,13 @@ KEEP_ON_FAILURE=false
 CGROUP_WRITABLE=false
 ACTION=""
 
-# The node-level half of the writable-cgroup contract. Both names are the ones
-# `deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml` resolves
-# against, so they are read from the same place the chart states them rather
-# than restated here as free-standing strings.
+# The node-level half of the writable-cgroup contract: the `handler:` and the
+# `scheduling.nodeSelector` key of
+# `deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml`. Both are
+# literals here because a shell script cannot read a helm template, so the
+# handler is ASSERTED equal to `containerd-config-version.sh`'s own
+# `DJINN_CONTAINERD_HANDLER` below — a rename on either side is then a hard
+# failure rather than two spellings that never meet.
 CGROUP_WRITABLE_HANDLER="runc-cgroupwritable"
 CGROUP_WRITABLE_NODE_LABEL="djinn.io/cgroup-writable"
 CONTAINERD_LIVE_CONFIG="/etc/containerd/config.toml"
@@ -527,7 +530,7 @@ EOF
     esac
     case "$runtimes" in
         *cgroup_writable*|*CgroupWritable*|*cgroupWritable*) ;;
-        *) fail 1 "containerd on node $node loaded ${CGROUP_WRITABLE_HANDLER} but reports no cgroup_writable property; this containerd is too old to give a container a writable cgroup and the launcher would fail readiness instead" ;;
+        *) fail 1 "containerd on node $node loaded ${CGROUP_WRITABLE_HANDLER} but reports no cgroup_writable property; this containerd is too old to give a container a writable cgroup, so the RuntimeClass would resolve, the Pod would be admitted, and the launcher would fail readiness on a read-only /sys/fs/cgroup. Use a newer node image (--k8s-version 1.35.0 ships containerd 2.2.0, measured 2026-07-31)" ;;
     esac
     info "node $node: containerd reports the ${CGROUP_WRITABLE_HANDLER} handler with a cgroup_writable property"
 }

--- a/server/crates/djinn-cgroup-launcher/examples/governor_probe.rs
+++ b/server/crates/djinn-cgroup-launcher/examples/governor_probe.rs
@@ -133,7 +133,11 @@ fn settings() -> Result<Settings, String> {
         authority: match env_required("DJINN_PROBE_AUTHORITY")?.as_str() {
             "armed" => LeaseAuthority::Armed,
             "unarmed" => LeaseAuthority::Unarmed,
-            other => return Err(format!("DJINN_PROBE_AUTHORITY must be armed|unarmed: {other}")),
+            other => {
+                return Err(format!(
+                    "DJINN_PROBE_AUTHORITY must be armed|unarmed: {other}"
+                ));
+            }
         },
         decision_path: PathBuf::from(env_required("DJINN_PROBE_DECISION_PATH")?),
         clamp: Duration::from_secs(env_number("DJINN_PROBE_CLAMP_SECONDS", 12)?),
@@ -332,7 +336,10 @@ fn run() -> Result<(), String> {
     // The harness reads this line, records `cpu.max` from inside the pod, and
     // only then writes the decision. Everything above happens without the
     // harness having said anything about authorization.
-    println!("probe.awaiting_decision path={}", settings.decision_path.display());
+    println!(
+        "probe.awaiting_decision path={}",
+        settings.decision_path.display()
+    );
     let decision = await_decision(&settings)?;
 
     let lift = match decision {
@@ -343,7 +350,9 @@ fn run() -> Result<(), String> {
         Decision::Lift(fence) => {
             let outcome = client.lift(&settings.invocation, fence);
             match &outcome {
-                Ok(()) => println!("probe.lift_attempt attempted=true fence={fence} result=accepted"),
+                Ok(()) => {
+                    println!("probe.lift_attempt attempted=true fence={fence} result=accepted")
+                }
                 Err(error) => println!(
                     "probe.lift_attempt attempted=true fence={fence} result=refused error={error:?}"
                 ),
@@ -391,6 +400,11 @@ fn run() -> Result<(), String> {
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join("stop");
+    // The workspace bans `Instant::now` so production code takes an injectable
+    // `Clock`. This binary measures a WALL-CLOCK window inside a container; a
+    // logical clock would report a throughput this process invented. Same
+    // exemption `tests/brokered_lease_lift_boundary.rs::measure` takes.
+    #[allow(clippy::disallowed_methods)]
     let held = Instant::now();
     while held.elapsed() < settings.hold && !stop.exists() {
         std::thread::sleep(POLL);
@@ -412,6 +426,11 @@ enum Decision {
 /// `lift <fence>`. The fence is NOT derived here — deriving it would let the
 /// probe authorize itself.
 fn await_decision(settings: &Settings) -> Result<Decision, String> {
+    // The workspace bans `Instant::now` so production code takes an injectable
+    // `Clock`. This binary measures a WALL-CLOCK window inside a container; a
+    // logical clock would report a throughput this process invented. Same
+    // exemption `tests/brokered_lease_lift_boundary.rs::measure` takes.
+    #[allow(clippy::disallowed_methods)]
     let started = Instant::now();
     while started.elapsed() < Duration::from_secs(600) {
         if let Ok(raw) = fs::read_to_string(&settings.decision_path) {
@@ -443,6 +462,11 @@ fn drain(
     window: Duration,
     label: &str,
 ) -> Result<(), String> {
+    // The workspace bans `Instant::now` so production code takes an injectable
+    // `Clock`. This binary measures a WALL-CLOCK window inside a container; a
+    // logical clock would report a throughput this process invented. Same
+    // exemption `tests/brokered_lease_lift_boundary.rs::measure` takes.
+    #[allow(clippy::disallowed_methods)]
     let started = Instant::now();
     while started.elapsed() < window {
         // Drain until the pipe is empty, so the child never blocks on a full
@@ -455,10 +479,14 @@ fn drain(
                 .stdout(&settings.invocation)
                 .map_err(|error| format!("OUTPUT refused in phase {label}: {error:?}"))?;
             if let ChildStatus::Exited(code) = status {
-                return Err(format!("the workload exited early in phase {label}: {code}"));
+                return Err(format!(
+                    "the workload exited early in phase {label}: {code}"
+                ));
             }
             if let ChildStatus::Signaled(signal) = status {
-                return Err(format!("the workload was killed in phase {label}: {signal}"));
+                return Err(format!(
+                    "the workload was killed in phase {label}: {signal}"
+                ));
             }
             let empty = bytes.is_empty();
             phase.units += bytes.iter().filter(|byte| **byte == b'\n').count() as u64;

--- a/server/crates/djinn-cgroup-launcher/examples/governor_probe.rs
+++ b/server/crates/djinn-cgroup-launcher/examples/governor_probe.rs
@@ -163,7 +163,11 @@ fn workload_command(settings: &Settings) -> CommandSpec {
     CommandSpec {
         program: "/bin/sh".to_owned(),
         argv: vec!["-c".to_owned(), script],
-        cwd: "/".to_owned(),
+        // `safe_command_path(cwd, true)` accepts the task workspace and nothing
+        // else, and `spawn.rs` `chdir`s there before `execve`. The renderer
+        // mounts the workspace emptyDir into the launcher container too, so this
+        // is the same directory a brokered build would run in.
+        cwd: "/workspace".to_owned(),
         // Empty on purpose. The launcher derives and OVERRIDES the child's
         // parallelism pins and git trust anchor itself (`crate::env`), and every
         // path this command names is absolute, so nothing has to be forwarded.
@@ -243,6 +247,10 @@ fn run() -> Result<(), String> {
         settings.invocation, settings.fence, settings.authority, settings.socket, settings.workers,
     );
 
+    if let Some(directory) = settings.decision_path.parent() {
+        fs::create_dir_all(directory)
+            .map_err(|error| format!("create {}: {error}", directory.display()))?;
+    }
     let credential = write_worker_handshake(&settings.credential_path)?;
     println!(
         "probe.handshake pid={} credential_path={}",

--- a/server/crates/djinn-cgroup-launcher/examples/governor_probe.rs
+++ b/server/crates/djinn-cgroup-launcher/examples/governor_probe.rs
@@ -1,0 +1,469 @@
+// Example: `println!` IS this binary's product. It runs as the worker container
+// of a live task-run Pod and its stdout — read back with `kubectl logs` — is the
+// only channel the measurements have. The workspace denies `print_stdout` for
+// library and server code; here the lint would deny the output itself.
+#![allow(clippy::print_stdout)]
+//! In-pod worker that drives the REAL broker protocol so the invocation
+//! governor can be measured end to end on a live cluster (fbiy-C1).
+//!
+//! # Why this exists as a binary, and what it is not
+//!
+//! `djinn-cgroup-launcher`'s own `tests/brokered_lease_lift_boundary.rs` already
+//! proves the birth clamp, the fence refusal and the lift through a real
+//! `UnixBrokerServer`/`UnixBrokerClient` pair — but it does so in ONE process on
+//! a CI runner, where the test owns both ends of the socket and the delegated
+//! cgroup root is one the test prepared itself. That leaves the two facts a
+//! live cluster decides untested: whether a `RuntimeClass`-delegated
+//! `/sys/fs/cgroup` in a Kueue-admitted Pod satisfies the launcher's readiness
+//! contract at all, and whether the quota the governor authorizes is the quota
+//! the kernel then enforces on the Pod's own CPU budget.
+//!
+//! So this binary is the worker half, and ONLY the worker half. It:
+//!
+//! * performs the byte-for-byte worker handshake the shipped launcher polls for
+//!   (`<ipc>/worker.pid` plus the credential file at
+//!   `DJINN_LAUNCHER_CREDENTIAL_PATH`) — the same two files
+//!   `djinn-agent-worker`'s `launcher_handshake` writes;
+//! * connects to the rendered `DJINN_LAUNCHER_SOCKET` and completes
+//!   `AUTH`/`READY`/`BEGIN`/`CREATE` against the **unmodified shipped
+//!   launcher binary** running in the rendered sidecar;
+//! * runs a real command in the invocation leaf and reports the work it
+//!   completes;
+//! * samples the leaf's `cpu.stat` **through the broker**, i.e. through
+//!   `Launcher::sample` reading the kernel, never a value this process wrote;
+//! * attempts exactly one `LIFT`, with a fence supplied from outside, and
+//!   reports whether the broker accepted it.
+//!
+//! It decides NOTHING. It does not read a database, it holds no cap, and it
+//! never chooses whether a lift is authorized: the fence it presents arrives in
+//! a file written by the harness after the harness has asked the real durable
+//! governor. That split is the point — a probe that decided its own
+//! authorization would be measuring itself.
+//!
+//! # The workload is a real command
+//!
+//! `/usr/bin/sha256sum` over a real multi-megabyte file, four concurrent copies,
+//! one line of output per completed digest. The digest is genuine work on
+//! genuine bytes and its rate is the throughput this file reports; the `sh` loop
+//! around it is a driver, not the measurement. Deliberately NOT a spin loop: a
+//! burner that consumes CPU without producing countable output cannot
+//! distinguish "the quota was lifted" from "the sampler read a bigger number".
+//!
+//! # Output contract
+//!
+//! One `probe.<record> key=value ...` line per event on stdout. The harness
+//! (`djinn-k8s`'s `tests/kueue_governor_conformance.rs`) parses these off
+//! `kubectl logs`. Keep the shape stable; it is a wire format.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+
+use djinn_cgroup_launcher::broker::ChildStatus;
+use djinn_cgroup_launcher::child::{NativeWorkerDumpability, prepare_worker_readiness};
+use djinn_cgroup_launcher::transport::UnixBrokerClient;
+use djinn_cgroup_launcher::{
+    CommandSpec, CpuStat, Invocation, LauncherAuthorityProtocol, LeaseAuthority,
+};
+
+/// Worker→launcher handshake filename. MUST match `WORKER_PID_FILE` in the
+/// launcher binary's `main.rs`; the launcher joins it onto the credential
+/// file's parent directory.
+const WORKER_PID_FILE: &str = "worker.pid";
+/// Size of the worker-private credential, matching `djinn-agent-worker`.
+const CREDENTIAL_BYTES: usize = 32;
+
+/// How often the leaf is drained and sampled. Small enough that the child's
+/// stdout pipe never becomes the throughput bound, large enough that the
+/// sampling itself is not a load.
+const POLL: Duration = Duration::from_millis(100);
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            println!("probe.fatal error={error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+struct Settings {
+    socket: String,
+    credential_path: PathBuf,
+    invocation: String,
+    fence: u64,
+    authority: LeaseAuthority,
+    decision_path: PathBuf,
+    clamp: Duration,
+    lifted: Duration,
+    workers: usize,
+    workload: String,
+    hold: Duration,
+}
+
+fn env_required(key: &str) -> Result<String, String> {
+    std::env::var(key).map_err(|_| format!("missing environment variable {key}"))
+}
+
+fn env_number<T: std::str::FromStr>(key: &str, default: T) -> Result<T, String> {
+    match std::env::var(key) {
+        Err(_) => Ok(default),
+        Ok(raw) => raw
+            .trim()
+            .parse()
+            .map_err(|_| format!("{key} is not a number: {raw}")),
+    }
+}
+
+fn settings() -> Result<Settings, String> {
+    Ok(Settings {
+        // The two rendered variables. Read from the environment the production
+        // renderer produced, never from a constant here: if `djinn-k8s` moves
+        // the socket, this probe must move with it or fail loudly.
+        socket: env_required("DJINN_LAUNCHER_SOCKET")?,
+        credential_path: PathBuf::from(env_required("DJINN_LAUNCHER_CREDENTIAL_PATH")?),
+        invocation: env_required("DJINN_PROBE_INVOCATION")?,
+        fence: env_required("DJINN_PROBE_FENCE")?
+            .trim()
+            .parse()
+            .map_err(|_| "DJINN_PROBE_FENCE is not a u64".to_owned())?,
+        authority: match env_required("DJINN_PROBE_AUTHORITY")?.as_str() {
+            "armed" => LeaseAuthority::Armed,
+            "unarmed" => LeaseAuthority::Unarmed,
+            other => return Err(format!("DJINN_PROBE_AUTHORITY must be armed|unarmed: {other}")),
+        },
+        decision_path: PathBuf::from(env_required("DJINN_PROBE_DECISION_PATH")?),
+        clamp: Duration::from_secs(env_number("DJINN_PROBE_CLAMP_SECONDS", 12)?),
+        lifted: Duration::from_secs(env_number("DJINN_PROBE_LIFTED_SECONDS", 12)?),
+        workers: env_number("DJINN_PROBE_WORKERS", 4)?,
+        workload: env_required("DJINN_PROBE_WORKLOAD")?,
+        hold: Duration::from_secs(env_number("DJINN_PROBE_HOLD_SECONDS", 300)?),
+    })
+}
+
+/// The real command the invocation leaf runs.
+///
+/// `sha256sum` on a real file, `workers` copies in parallel, one line of output
+/// per completed digest. `>/dev/null` discards the digest text so the counted
+/// line is a fixed two bytes — the count is the measurement, the digest is the
+/// work.
+fn workload_command(settings: &Settings) -> CommandSpec {
+    let one = format!(
+        "while :; do /usr/bin/sha256sum {} >/dev/null || exit 9; echo U; done",
+        settings.workload
+    );
+    let mut script = String::new();
+    for _ in 0..settings.workers {
+        script.push_str(&format!("({one}) & "));
+    }
+    script.push_str("wait");
+    CommandSpec {
+        program: "/bin/sh".to_owned(),
+        argv: vec!["-c".to_owned(), script],
+        cwd: "/".to_owned(),
+        // Empty on purpose. The launcher derives and OVERRIDES the child's
+        // parallelism pins and git trust anchor itself (`crate::env`), and every
+        // path this command names is absolute, so nothing has to be forwarded.
+        environment: Vec::new(),
+    }
+}
+
+fn write_worker_handshake(credential_path: &Path) -> Result<Vec<u8>, String> {
+    let directory = credential_path
+        .parent()
+        .ok_or_else(|| "the credential path has no parent directory".to_owned())?;
+    let mut credential = vec![0_u8; CREDENTIAL_BYTES];
+    fs::File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(&mut credential))
+        .map_err(|error| format!("read entropy for the worker credential: {error}"))?;
+    fs::write(credential_path, &credential)
+        .map_err(|error| format!("write {}: {error}", credential_path.display()))?;
+    // The PID file LAST: the launcher polls for both and reads them together,
+    // so writing the pid first would let it read a half-written credential.
+    let pid_file = directory.join(WORKER_PID_FILE);
+    fs::write(&pid_file, std::process::id().to_string())
+        .map_err(|error| format!("write {}: {error}", pid_file.display()))?;
+    Ok(credential)
+}
+
+/// Counters drained from the leaf in one poll.
+#[derive(Default)]
+struct Phase {
+    units: u64,
+    elapsed: Duration,
+    first: Option<CpuStat>,
+    last: Option<CpuStat>,
+    throttle_advances: u32,
+}
+
+impl Phase {
+    fn record(&mut self, stat: CpuStat) {
+        if self.first.is_none() {
+            self.first = Some(stat.clone());
+        }
+        if let Some(previous) = &self.last
+            && stat.throttled_usec > previous.throttled_usec
+        {
+            self.throttle_advances += 1;
+        }
+        self.last = Some(stat);
+    }
+
+    fn throttled_delta(&self) -> u64 {
+        match (&self.first, &self.last) {
+            (Some(first), Some(last)) => last.throttled_usec.saturating_sub(first.throttled_usec),
+            _ => 0,
+        }
+    }
+
+    fn usage_delta(&self) -> u64 {
+        match (&self.first, &self.last) {
+            (Some(first), Some(last)) => last.usage_usec.saturating_sub(first.usage_usec),
+            _ => 0,
+        }
+    }
+
+    /// Completed digests per second over the phase's own wall clock.
+    fn units_per_second_milli(&self) -> u64 {
+        let millis = self.elapsed.as_millis() as u64;
+        if millis == 0 {
+            return 0;
+        }
+        self.units.saturating_mul(1_000).saturating_mul(1_000) / millis
+    }
+}
+
+fn run() -> Result<(), String> {
+    let settings = settings()?;
+    println!(
+        "probe.start invocation={} fence={} authority={:?} socket={} workers={}",
+        settings.invocation, settings.fence, settings.authority, settings.socket, settings.workers,
+    );
+
+    let credential = write_worker_handshake(&settings.credential_path)?;
+    println!(
+        "probe.handshake pid={} credential_path={}",
+        std::process::id(),
+        settings.credential_path.display(),
+    );
+
+    // The launcher binds its socket only after it has read the handshake, so a
+    // bounded retry here is the ordering, not a workaround.
+    let mut client = None;
+    for _ in 0..300 {
+        match UnixBrokerClient::connect_path(&settings.socket, &credential) {
+            Ok(connected) => {
+                client = Some(connected);
+                break;
+            }
+            Err(_) => std::thread::sleep(Duration::from_millis(100)),
+        }
+    }
+    let mut client = client.ok_or_else(|| {
+        format!(
+            "the launcher never accepted an authenticated connection on {}",
+            settings.socket
+        )
+    })?;
+
+    // READY carries the worker's own view of the quota-authority protocol. It is
+    // read from the SAME variable the launcher reads; a render that set it on
+    // one container and not the other is refused here rather than silently
+    // producing a launcher that never writes leaf `cpu.max`.
+    let protocol = match std::env::var("DJINN_LAUNCHER_AUTHORITY_PROTOCOL") {
+        // Absent means `leaf-v1`, exactly as the launcher binary's own
+        // `authority_protocol_from_environment` reads it. An unparseable value
+        // is a failure, never a default.
+        Err(_) => LauncherAuthorityProtocol::LeafV1,
+        Ok(raw) => raw
+            .parse()
+            .map_err(|_| format!("unparseable DJINN_LAUNCHER_AUTHORITY_PROTOCOL: {raw}"))?,
+    };
+    let assertion = prepare_worker_readiness(&mut NativeWorkerDumpability, protocol)
+        .map_err(|error| format!("prepare worker readiness: {error:?}"))?;
+    client
+        .ready(assertion)
+        .map_err(|error| format!("READY refused: {error:?}"))?;
+    println!("probe.ready protocol={protocol:?}");
+
+    client
+        .begin(Invocation {
+            id: settings.invocation.clone(),
+            fence: settings.fence,
+        })
+        .map_err(|error| format!("BEGIN refused: {error:?}"))?;
+    let command = workload_command(&settings);
+    client
+        .create(
+            &settings.invocation,
+            &settings.invocation,
+            settings.authority,
+            &command,
+        )
+        .map_err(|error| format!("CREATE refused: {error:?}"))?;
+    println!(
+        "probe.created leaf={} authority={:?}",
+        settings.invocation, settings.authority
+    );
+
+    let mut clamp = Phase::default();
+    drain(&mut client, &settings, &mut clamp, settings.clamp, "clamp")?;
+    println!(
+        "probe.phase phase=clamp units={} elapsed_ms={} usage_usec={} throttled_usec={} throttle_advances={} rate_milli={}",
+        clamp.units,
+        clamp.elapsed.as_millis(),
+        clamp.usage_delta(),
+        clamp.throttled_delta(),
+        clamp.throttle_advances,
+        clamp.units_per_second_milli(),
+    );
+
+    // The harness reads this line, records `cpu.max` from inside the pod, and
+    // only then writes the decision. Everything above happens without the
+    // harness having said anything about authorization.
+    println!("probe.awaiting_decision path={}", settings.decision_path.display());
+    let decision = await_decision(&settings)?;
+
+    let lift = match decision {
+        Decision::Skip => {
+            println!("probe.lift_attempt attempted=false");
+            None
+        }
+        Decision::Lift(fence) => {
+            let outcome = client.lift(&settings.invocation, fence);
+            match &outcome {
+                Ok(()) => println!("probe.lift_attempt attempted=true fence={fence} result=accepted"),
+                Err(error) => println!(
+                    "probe.lift_attempt attempted=true fence={fence} result=refused error={error:?}"
+                ),
+            }
+            Some(outcome.is_ok())
+        }
+    };
+
+    let mut lifted = Phase::default();
+    drain(&mut client, &settings, &mut lifted, settings.lifted, "post")?;
+    println!(
+        "probe.phase phase=post units={} elapsed_ms={} usage_usec={} throttled_usec={} throttle_advances={} rate_milli={}",
+        lifted.units,
+        lifted.elapsed.as_millis(),
+        lifted.usage_delta(),
+        lifted.throttled_delta(),
+        lifted.throttle_advances,
+        lifted.units_per_second_milli(),
+    );
+
+    let ratio_milli = if clamp.units_per_second_milli() == 0 {
+        0
+    } else {
+        lifted
+            .units_per_second_milli()
+            .saturating_mul(1_000)
+            .checked_div(clamp.units_per_second_milli())
+            .unwrap_or(0)
+    };
+    println!(
+        "probe.summary lift_accepted={} clamp_rate_milli={} post_rate_milli={} ratio_milli={}",
+        lift.map(|value| value.to_string())
+            .unwrap_or_else(|| "none".to_owned()),
+        clamp.units_per_second_milli(),
+        lifted.units_per_second_milli(),
+        ratio_milli,
+    );
+
+    // Hold the leaf alive so the harness can read `cpu.max` out of the launcher
+    // container one last time. Bounded, because a probe that never exits turns a
+    // failed run into a hung one.
+    println!("probe.holding seconds={}", settings.hold.as_secs());
+    let stop = settings
+        .decision_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("stop");
+    let held = Instant::now();
+    while held.elapsed() < settings.hold && !stop.exists() {
+        std::thread::sleep(POLL);
+    }
+
+    let _ = client.kill(&settings.invocation);
+    println!("probe.done");
+    Ok(())
+}
+
+enum Decision {
+    Lift(u64),
+    Skip,
+}
+
+/// Block until the harness drops its decision next to the credential mount.
+///
+/// The file is written by `kubectl exec`; it carries either `skip` or
+/// `lift <fence>`. The fence is NOT derived here — deriving it would let the
+/// probe authorize itself.
+fn await_decision(settings: &Settings) -> Result<Decision, String> {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(600) {
+        if let Ok(raw) = fs::read_to_string(&settings.decision_path) {
+            let text = raw.trim();
+            if text == "skip" {
+                return Ok(Decision::Skip);
+            }
+            if let Some(fence) = text.strip_prefix("lift ") {
+                return fence
+                    .trim()
+                    .parse()
+                    .map(Decision::Lift)
+                    .map_err(|_| format!("decision fence is not a u64: {text}"));
+            }
+            if !text.is_empty() {
+                return Err(format!("unreadable decision: {text}"));
+            }
+        }
+        std::thread::sleep(POLL);
+    }
+    Err("the harness never wrote a lift decision".to_owned())
+}
+
+/// Drain the child's output and sample the leaf for `window`.
+fn drain(
+    client: &mut UnixBrokerClient,
+    settings: &Settings,
+    phase: &mut Phase,
+    window: Duration,
+    label: &str,
+) -> Result<(), String> {
+    let started = Instant::now();
+    while started.elapsed() < window {
+        // Drain until the pipe is empty, so the child never blocks on a full
+        // pipe — that would make this loop, not the cgroup quota, the bound.
+        // Counting `\n` across chunks needs no reassembly: every completed
+        // digest contributes exactly one newline wherever the chunk boundary
+        // falls.
+        loop {
+            let (bytes, _eof, status) = client
+                .stdout(&settings.invocation)
+                .map_err(|error| format!("OUTPUT refused in phase {label}: {error:?}"))?;
+            if let ChildStatus::Exited(code) = status {
+                return Err(format!("the workload exited early in phase {label}: {code}"));
+            }
+            if let ChildStatus::Signaled(signal) = status {
+                return Err(format!("the workload was killed in phase {label}: {signal}"));
+            }
+            let empty = bytes.is_empty();
+            phase.units += bytes.iter().filter(|byte| **byte == b'\n').count() as u64;
+            if empty {
+                break;
+            }
+        }
+        let stat = client
+            .sample(&settings.invocation)
+            .map_err(|error| format!("SAMPLE refused in phase {label}: {error:?}"))?;
+        phase.record(stat);
+        std::thread::sleep(POLL);
+    }
+    phase.elapsed = started.elapsed();
+    Ok(())
+}

--- a/server/crates/djinn-k8s/tests/fixtures/governor-probe/Dockerfile
+++ b/server/crates/djinn-k8s/tests/fixtures/governor-probe/Dockerfile
@@ -1,0 +1,39 @@
+# The image a live task-run Pod runs for fbiy-C1.
+#
+# It stands in for the per-project devcontainer image in exactly one respect,
+# and copies it in every other: `djinn-k8s`'s renderer puts the launcher sidecar
+# and the worker container on the SAME image tag and runs the launcher from
+# `/opt/djinn/bin/djinn-cgroup-launcher` (`launcher::LAUNCHER_BIN`), so the
+# launcher binary here lands at that exact path and the rendered sidecar command
+# is left untouched. What is NOT the real image is the worker entrypoint: the
+# real one is `djinn-agent-worker`, which would need a coordinator, a database
+# and a model provider none of which exist on a disposable kind node.
+# `governor_probe` replaces it and speaks the same broker protocol — see its
+# module docs for what it does and does not decide.
+#
+# Debian rather than a distroless base for two reasons that are both load
+# bearing: the workload is `/usr/bin/sha256sum`, a real coreutils program, and
+# `/bin/sh` is the driver the broker execs. glibc 2.36 here is above the
+# GLIBC_2.34 floor the release-profile binaries built on the developer host
+# require (`objdump -T`), which is why the binaries are copied in rather than
+# rebuilt.
+FROM debian:bookworm-slim
+
+# Both binaries come from `cargo build --release`; see build.sh, which is the
+# only supported way to produce this context.
+COPY djinn-cgroup-launcher /opt/djinn/bin/djinn-cgroup-launcher
+COPY governor_probe /opt/djinn/bin/djinn-governor-probe
+
+# The workload the invocation leaf hashes. Real random bytes, generated once at
+# image build so every Pod in a run hashes byte-identical input and the unit
+# counts are comparable across them. World readable because the brokered child
+# runs as CHILD_UID 1001, which owns nothing in this image.
+RUN set -eu; \
+    chmod 0755 /opt/djinn/bin/djinn-cgroup-launcher /opt/djinn/bin/djinn-governor-probe; \
+    head -c 33554432 /dev/urandom > /opt/djinn/workload.bin; \
+    chmod 0644 /opt/djinn/workload.bin; \
+    test -x /usr/bin/sha256sum
+
+# No ENTRYPOINT and no CMD on purpose: every container in the rendered Job
+# carries an explicit command, and a default here could only mask a render that
+# stopped setting one.

--- a/server/crates/djinn-k8s/tests/fixtures/governor-probe/build.sh
+++ b/server/crates/djinn-k8s/tests/fixtures/governor-probe/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build the fbiy-C1 probe image and load it onto a disposable kind node.
+#
+#   build.sh <image-tag> [kind-cluster-name]
+#
+# Two `cargo build --release` invocations and one `docker build`. The binaries
+# are built OUT of this repository so the launcher under test is the shipped one
+# — `server/crates/djinn-cgroup-launcher/src/main.rs`, unmodified — rather than a
+# copy of it packaged for the test.
+#
+# `kind load docker-image` rather than a push to the harness registry: a pull
+# failure would surface as "the Pod never ran", which is indistinguishable from
+# the launcher readiness failure this harness exists to detect.
+set -euo pipefail
+
+IMAGE=${1:?usage: build.sh <image-tag> [kind-cluster-name]}
+CLUSTER=${2:-}
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# governor-probe -> fixtures -> tests -> djinn-k8s -> crates -> server -> repo
+REPO_ROOT="$(cd "$HERE/../../../../../.." && pwd)"
+SERVER_DIR="$REPO_ROOT/server"
+
+[ -d "$SERVER_DIR/crates/djinn-cgroup-launcher" ] \
+    || { printf 'FAIL: %s is not the djinn server workspace\n' "$SERVER_DIR" >&2; exit 2; }
+
+printf '>>> building djinn-cgroup-launcher and governor_probe (release)\n'
+(
+    cd "$SERVER_DIR"
+    cargo build --release -p djinn-cgroup-launcher \
+        --bin djinn-cgroup-launcher --example governor_probe
+)
+
+TARGET="$SERVER_DIR/target/release"
+CONTEXT="$(mktemp -d)"
+trap 'rm -rf "$CONTEXT"' EXIT
+
+cp "$TARGET/djinn-cgroup-launcher" "$CONTEXT/djinn-cgroup-launcher"
+cp "$TARGET/examples/governor_probe" "$CONTEXT/governor_probe"
+cp "$HERE/Dockerfile" "$CONTEXT/Dockerfile"
+
+printf '>>> docker build %s\n' "$IMAGE"
+docker build --quiet --tag "$IMAGE" "$CONTEXT" >/dev/null
+
+if [ -n "$CLUSTER" ]; then
+    printf '>>> kind load docker-image %s --name %s\n' "$IMAGE" "$CLUSTER"
+    kind load docker-image "$IMAGE" --name "$CLUSTER"
+fi
+
+printf 'PASS: %s is built%s\n' "$IMAGE" "${CLUSTER:+ and loaded onto $CLUSTER}"

--- a/server/crates/djinn-k8s/tests/kueue_governor/mod.rs
+++ b/server/crates/djinn-k8s/tests/kueue_governor/mod.rs
@@ -61,7 +61,8 @@ pub const WORKER_CONTAINER_NAME: &str = "worker";
 pub const SETUP_SCRIPT: &str = "scripts/kind/setup-kueue-cluster.sh";
 pub const GOVERNOR_VALUES: &str = "deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml";
 pub const B0_VALUES: &str = "deploy/helm/djinn/tests/fixtures/kueue-cluster-values.yaml";
-pub const PROBE_BUILD_SCRIPT: &str = "server/crates/djinn-k8s/tests/fixtures/governor-probe/build.sh";
+pub const PROBE_BUILD_SCRIPT: &str =
+    "server/crates/djinn-k8s/tests/fixtures/governor-probe/build.sh";
 pub const PROBE_IMAGE: &str = "djinn-governor-probe:fbiy-c1";
 pub const PROBE_BIN: &str = "/opt/djinn/bin/djinn-governor-probe";
 pub const PROBE_WORKLOAD: &str = "/opt/djinn/workload.bin";
@@ -347,14 +348,24 @@ pub struct Probe {
 /// CPU limit. The `command` swap is the same single mutation
 /// `sleep_instead_of_the_worker` makes in the sibling harness, for the same
 /// reason, and the probe env rides alongside it.
-pub fn launch_probe(context: &str, config: &KubernetesConfig, fence: u64, clamp_s: u64, post_s: u64) -> Probe {
+pub fn launch_probe(
+    context: &str,
+    config: &KubernetesConfig,
+    fence: u64,
+    clamp_s: u64,
+    post_s: u64,
+) -> Probe {
     let (job, task_run_id) = render_probe_job(config, "harness-project");
     assert_eq!(
         job.spec.as_ref().and_then(|spec| spec.suspend),
         Some(true),
         "the armed renderer must create the Job suspended so Kueue owns admission",
     );
-    let job_name = job.metadata.name.clone().expect("the renderer names the Job");
+    let job_name = job
+        .metadata
+        .name
+        .clone()
+        .expect("the renderer names the Job");
     // The leaf name IS the invocation id in production (`process_broker`), and
     // `validate_leaf_name` rejects anything that is not a direct child name.
     let invocation = format!("probe-{task_run_id}");
@@ -440,9 +451,18 @@ pub fn pods_of(context: &str, task_run_id: &str) -> Vec<(String, String, String)
         .iter()
         .map(|item| {
             (
-                item["metadata"]["name"].as_str().unwrap_or_default().to_owned(),
-                item["metadata"]["uid"].as_str().unwrap_or_default().to_owned(),
-                item["status"]["phase"].as_str().unwrap_or_default().to_owned(),
+                item["metadata"]["name"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+                item["metadata"]["uid"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+                item["status"]["phase"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
             )
         })
         .collect()
@@ -463,7 +483,14 @@ pub fn await_running_pod(context: &str, task_run_id: &str) -> (String, String) {
         pods_of(context, task_run_id),
         kubectl_ok(
             context,
-            &["-n", NAMESPACE, "get", "workloads.kueue.x-k8s.io", "-o", "wide"],
+            &[
+                "-n",
+                NAMESPACE,
+                "get",
+                "workloads.kueue.x-k8s.io",
+                "-o",
+                "wide"
+            ],
         ),
     )
 }
@@ -547,7 +574,6 @@ pub fn probe_record(log: &str, record: &str) -> BTreeMap<String, String> {
         .collect()
 }
 
-
 pub fn phase_record(log: &str, phase: &str) -> BTreeMap<String, String> {
     let line = log
         .lines()
@@ -574,7 +600,9 @@ pub fn deliver_decision(context: &str, probe: &Probe, fence: Option<u64>) {
         Some(value) => format!("lift {value}"),
         None => "skip".to_owned(),
     };
-    let script = format!("mkdir -p $(dirname {PROBE_DECISION_PATH}); printf '%s' '{body}' > {PROBE_DECISION_PATH}");
+    let script = format!(
+        "mkdir -p $(dirname {PROBE_DECISION_PATH}); printf '%s' '{body}' > {PROBE_DECISION_PATH}"
+    );
     let output = kubectl(
         context,
         &[
@@ -623,7 +651,13 @@ pub fn clear_task_run_jobs(context: &str) {
             "delete",
             "jobs",
             "-l",
-            "app.kubernetes.io/component=task-run",
+            // The renderer's own component label (`job.rs::job_labels`). NOT
+            // `app.kubernetes.io/component`: measured 2026-07-31, a selector on
+            // that key matches nothing here, leaves the previous run's Jobs
+            // holding the `pods` quota, and the next run then fails with "no Pod
+            // reached Running" — a `pods`-quota exhaustion wearing the costume
+            // of a scheduling bug.
+            "djinn.app/component=task-run-worker",
             "--cascade=foreground",
             "--wait=true",
             "--timeout=180s",
@@ -632,15 +666,19 @@ pub fn clear_task_run_jobs(context: &str) {
 }
 
 pub fn admitted_workloads(context: &str) -> u64 {
-    kubectl_json(context, &["get", "clusterqueues.kueue.x-k8s.io", CLUSTER_QUEUE])["status"]
-        ["admittedWorkloads"]
+    kubectl_json(
+        context,
+        &["get", "clusterqueues.kueue.x-k8s.io", CLUSTER_QUEUE],
+    )["status"]["admittedWorkloads"]
         .as_u64()
         .unwrap_or(0)
 }
 
 pub fn pods_nominal_quota(context: &str) -> u64 {
-    kubectl_json(context, &["get", "clusterqueues.kueue.x-k8s.io", CLUSTER_QUEUE])["spec"]
-        ["resourceGroups"][0]["flavors"][0]["resources"]
+    kubectl_json(
+        context,
+        &["get", "clusterqueues.kueue.x-k8s.io", CLUSTER_QUEUE],
+    )["spec"]["resourceGroups"][0]["flavors"][0]["resources"]
         .as_array()
         .expect("the ClusterQueue covers resources")
         .iter()
@@ -695,7 +733,9 @@ pub fn authorize(pod_uids: &[String], m: u64) -> (i64, Vec<String>) {
             .await
             .expect("read the durable authority")
             .expect("the authority row exists once seeded");
-        let k = live.cap.expect("an armed authority carries a reference cap");
+        let k = live
+            .cap
+            .expect("an armed authority carries a reference cap");
         assert_eq!(
             evaluate_invocation_lift(Ok(Some(live.clone()))),
             InvocationLiftDecision::Lift,

--- a/server/crates/djinn-k8s/tests/kueue_governor/mod.rs
+++ b/server/crates/djinn-k8s/tests/kueue_governor/mod.rs
@@ -1,0 +1,762 @@
+#![allow(clippy::print_stderr)]
+// Shared live-cluster helpers for the two `kueue_governor_*` test targets.
+//
+// `#![allow(dead_code)]` is the standard `tests/<name>/mod.rs` idiom and is
+// load-bearing rather than lazy: this module is compiled SEPARATELY into each
+// test binary, so every helper the other binary uses is genuinely unused in
+// this one. Without it `RUSTFLAGS: -D warnings` fails the lane for helpers that
+// ARE exercised — just from the sibling target.
+#![allow(dead_code)]
+//! Live-cluster helpers shared by `kueue_governor_conformance` (AC1/AC2, plus
+//! every hermetic guard) and `kueue_governor_cap` (AC3/AC4).
+//!
+//! Split out of one file because the pair exceeded `scripts/check-file-size.sh`
+//! (MAX_LINES 1500 / MAX_BYTES 51200) and the `djinn:allow-oversize` marker is
+//! for source that genuinely cannot be divided — this could be. The module docs
+//! for the whole harness live in `kueue_governor_conformance.rs`.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::Duration;
+
+use djinn_db::{
+    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseState, Database,
+    GrantNextBuildLeaseResult, InvocationLeaseAuthorityRepository, InvocationLeaseMode,
+    QueueBuildLeaseInput,
+};
+use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::job::{LABEL_TASK_RUN_ID, build_task_run_job};
+use djinn_k8s::launcher::{CgroupLauncherMode, LAUNCHER_CONTAINER_NAME};
+use djinn_supervisor::services::{InvocationLiftDecision, evaluate_invocation_lift};
+use k8s_openapi::api::core::v1::Container;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// The one cluster this file may ever touch.
+// ---------------------------------------------------------------------------
+
+pub const HARNESS_CLUSTER: &str = "djinn-kueue-c1";
+/// kind names its context `kind-<cluster>`. Derived, never discovered: every
+/// context in a Djinn developer's kubeconfig is a live EKS cluster.
+pub const HARNESS_CONTEXT: &str = "kind-djinn-kueue-c1";
+pub const HARNESS_REGISTRY: &str = "djinn-kueue-c1-registry";
+pub const HARNESS_REGISTRY_PORT: &str = "5061";
+/// Kueue 0.19 on a containerd that supports `cgroup_writable`. Measured
+/// 2026-07-31: `kindest/node:v1.35.0` ships containerd 2.2.0. The 1.31 image the
+/// sibling harnesses use ships containerd 1.7, which has no such runtime
+/// property, and the setup script fails closed on it rather than producing a
+/// node whose RuntimeClass resolves to a read-only cgroup mount.
+pub const HARNESS_K8S_VERSION: &str = "1.35.0";
+
+/// The sibling harnesses' clusters. Named so the disjointness guard below is a
+/// statement about them and not only about the script's defaults.
+pub const SIBLING_CLUSTERS: &[&str] = &["djinn-kueue-harness", "djinn-kueue-b2", "djinn-kueue-b2b"];
+
+pub const NAMESPACE: &str = "djinn";
+pub const CLUSTER_QUEUE: &str = "djinn-kueue";
+pub const WORKER_CONTAINER_NAME: &str = "worker";
+
+pub const SETUP_SCRIPT: &str = "scripts/kind/setup-kueue-cluster.sh";
+pub const GOVERNOR_VALUES: &str = "deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml";
+pub const B0_VALUES: &str = "deploy/helm/djinn/tests/fixtures/kueue-cluster-values.yaml";
+pub const PROBE_BUILD_SCRIPT: &str = "server/crates/djinn-k8s/tests/fixtures/governor-probe/build.sh";
+pub const PROBE_IMAGE: &str = "djinn-governor-probe:fbiy-c1";
+pub const PROBE_BIN: &str = "/opt/djinn/bin/djinn-governor-probe";
+pub const PROBE_WORKLOAD: &str = "/opt/djinn/workload.bin";
+pub const PROBE_DECISION_PATH: &str = "/var/tmp/djinn-probe/decision";
+
+/// The pod CPU limit the lifted quota is derived from
+/// (`launcher_cpu::launcher_leased_millicores`). Two cores rather than the
+/// production four: the node is shared with other agents' clusters, and 2000m
+/// against a 250m clamp is still an 8x ceiling — comfortably above the 3x this
+/// file asserts, and small enough that three concurrent lifted invocations
+/// cannot saturate the host.
+pub const POD_CPU_LIMIT: &str = "2";
+
+/// The multiplication AC1 demands across the lift transition.
+pub const REQUIRED_THROUGHPUT_MULTIPLE_MILLI: u64 = 3_000;
+
+pub const TICK: Duration = Duration::from_millis(500);
+pub const AWAIT_TICKS: usize = 360;
+
+pub fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("crate lives three levels below the repository root")
+        .to_path_buf()
+}
+
+pub fn run_script(relative: &str, args: &[&str]) -> Output {
+    Command::new("bash")
+        .arg(repo_root().join(relative))
+        .args(args)
+        .current_dir(repo_root())
+        .output()
+        .unwrap_or_else(|error| panic!("{relative} is executable: {error}"))
+}
+
+pub fn exit_code(output: &Output) -> i32 {
+    output
+        .status
+        .code()
+        .expect("the script exits rather than dying on a signal")
+}
+
+pub fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+pub fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+pub fn yaml_at(relative: &str) -> serde_yaml::Value {
+    let text = std::fs::read_to_string(repo_root().join(relative))
+        .unwrap_or_else(|error| panic!("read {relative}: {error}"));
+    serde_yaml::from_str(&text).unwrap_or_else(|error| panic!("parse {relative}: {error}"))
+}
+
+// ---------------------------------------------------------------------------
+// Shared render helpers (used by both halves).
+// ---------------------------------------------------------------------------
+
+/// Capabilities a task-run container must never hold.
+///
+/// `SYS_ADMIN` is the mount privilege the launcher used to need before the
+/// RuntimeClass delegated its cgroup root; `SYS_RESOURCE` would let a container
+/// raise its own limits. Both would make the clamp advisory.
+pub fn privileged_capabilities(container: &Container) -> Vec<String> {
+    const FORBIDDEN: &[&str] = &["SYS_ADMIN", "SYS_RESOURCE"];
+    container
+        .security_context
+        .as_ref()
+        .and_then(|context| context.capabilities.as_ref())
+        .and_then(|capabilities| capabilities.add.clone())
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|granted| {
+            FORBIDDEN
+                .iter()
+                .any(|name| granted.eq_ignore_ascii_case(name))
+        })
+        .collect()
+}
+
+/// `post_rate / clamp_rate` in thousandths. Zero when the clamp phase produced
+/// no work, because "infinite improvement over nothing" is a measurement
+/// failure, not a pass.
+pub fn throughput_multiple_milli(clamp_rate_milli: u64, post_rate_milli: u64) -> u64 {
+    if clamp_rate_milli == 0 {
+        return 0;
+    }
+    post_rate_milli.saturating_mul(1_000) / clamp_rate_milli
+}
+
+pub fn armed_config(image: &str) -> KubernetesConfig {
+    KubernetesConfig {
+        namespace: NAMESPACE.into(),
+        kueue_armed: true,
+        kueue_local_queue_prefix: "djinn".into(),
+        // The arming pair. `build_task_run_job` asserts them together.
+        cgroup_launcher_mode: CgroupLauncherMode::Required,
+        task_run_cgroup_writable_enabled: true,
+        image: image.into(),
+        image_pull_policy: "IfNotPresent".into(),
+        // Requests low so `kueue.buildPods` stays the binding constraint on one
+        // kind node; the LIMIT is what the lifted quota is derived from.
+        cpu_request: "100m".into(),
+        cpu_limit: POD_CPU_LIMIT.into(),
+        memory_request: "64Mi".into(),
+        memory_limit: "512Mi".into(),
+        ..KubernetesConfig::for_testing()
+    }
+}
+
+/// `(clamp, leased)` millicores as they appear on the RENDERED sidecar, read
+/// back off the container rather than recomputed from the config.
+pub fn rendered_quotas(config: &KubernetesConfig) -> (u32, u32) {
+    let job = render_probe_job(config, "harness-project").0;
+    let sidecar = job
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .and_then(|pod| pod.init_containers.as_ref())
+        .and_then(|containers| {
+            containers
+                .iter()
+                .find(|container| container.name == LAUNCHER_CONTAINER_NAME)
+        })
+        .expect("the armed renderer emits the cgroup-launcher sidecar")
+        .clone();
+    let read = |key: &str| -> u32 {
+        sidecar
+            .env
+            .as_ref()
+            .expect("the sidecar carries env")
+            .iter()
+            .find(|entry| entry.name == key)
+            .and_then(|entry| entry.value.as_deref())
+            .unwrap_or_else(|| panic!("the sidecar carries {key}"))
+            .parse()
+            .unwrap_or_else(|_| panic!("{key} is a number"))
+    };
+    (
+        read("DJINN_LAUNCHER_UNLEASED_MILLICORES"),
+        read("DJINN_LAUNCHER_LEASED_MILLICORES"),
+    )
+}
+
+pub fn render_probe_job(
+    config: &KubernetesConfig,
+    project: &str,
+) -> (k8s_openapi::api::batch::v1::Job, String) {
+    let task_run_id = uuid::Uuid::now_v7();
+    let job = build_task_run_job(
+        config,
+        &task_run_id,
+        project,
+        &format!("djinn-taskrun-{task_run_id}"),
+        &config.image,
+        &[],
+        None,
+        false,
+        None,
+    );
+    (job, task_run_id.to_string())
+}
+
+// ===========================================================================
+// The live half.
+// ===========================================================================
+
+pub fn live_tests_enabled() -> bool {
+    if env::var("DJINN_TEST_KUEUE_CLUSTER").as_deref() != Ok("1") {
+        eprintln!("SKIP: set DJINN_TEST_KUEUE_CLUSTER=1 to run the live governor conformance");
+        return false;
+    }
+    for tool in ["kubectl", "kind", "docker"] {
+        if Command::new(tool)
+            .arg("--help")
+            .output()
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+        {
+            panic!("DJINN_TEST_KUEUE_CLUSTER=1 but {tool} is not on PATH");
+        }
+    }
+    true
+}
+
+/// Refuse to run against anything that is not this harness's local kind cluster.
+pub fn harness_context() -> String {
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            HARNESS_CONTEXT,
+            "config",
+            "view",
+            "--minify",
+            "-o",
+            "jsonpath={.clusters[0].cluster.server}",
+        ])
+        .output()
+        .expect("kubectl is on PATH");
+    let server = stdout(&output);
+    assert!(
+        server.contains("127.0.0.1") || server.contains("localhost"),
+        "refusing to run against {HARNESS_CONTEXT}: its API server is {server:?}, not a local \
+         kind cluster. Every context in a Djinn developer's kubeconfig is a live EKS cluster.",
+    );
+    HARNESS_CONTEXT.to_owned()
+}
+
+pub fn kubectl(context: &str, args: &[&str]) -> Output {
+    Command::new("kubectl")
+        .arg("--context")
+        .arg(context)
+        .args(args)
+        .output()
+        .expect("kubectl is on PATH")
+}
+
+pub fn kubectl_ok(context: &str, args: &[&str]) -> String {
+    let output = kubectl(context, args);
+    assert!(
+        output.status.success(),
+        "kubectl {args:?} failed: {}",
+        stderr(&output),
+    );
+    stdout(&output)
+}
+
+pub fn kubectl_json(context: &str, args: &[&str]) -> Value {
+    let mut full = args.to_vec();
+    full.extend(["-o", "json"]);
+    serde_json::from_str(&kubectl_ok(context, &full)).expect("kubectl -o json emits JSON")
+}
+
+/// The chart-installed names the renderer must be pointed at.
+pub fn config_for(context: &str) -> KubernetesConfig {
+    let named = |kind: &str, suffix: &str| -> String {
+        kubectl_json(context, &["-n", NAMESPACE, "get", kind])["items"]
+            .as_array()
+            .expect("a List has items")
+            .iter()
+            .filter_map(|item| item["metadata"]["name"].as_str())
+            .find(|name| name.ends_with(suffix))
+            .unwrap_or_else(|| panic!("the chart installs a {kind} ending in {suffix}"))
+            .to_owned()
+    };
+    KubernetesConfig {
+        service_account: named("serviceaccounts", "-taskrun"),
+        mirror_pvc: named("persistentvolumeclaims", "-mirrors"),
+        cache_pvc: named("persistentvolumeclaims", "-cache"),
+        ..armed_config(PROBE_IMAGE)
+    }
+}
+
+pub fn ensure_probe_image(context: &str) {
+    let built = run_script(PROBE_BUILD_SCRIPT, &[PROBE_IMAGE, HARNESS_CLUSTER]);
+    assert!(
+        built.status.success(),
+        "building/loading {PROBE_IMAGE} failed: {}\n{}",
+        stdout(&built),
+        stderr(&built),
+    );
+    let _ = context;
+}
+
+/// One live invocation: the Job that carries it, the fence it was BEGUN with,
+/// and the identities the harness needs to speak to it.
+pub struct Probe {
+    pub task_run_id: String,
+    pub job_name: String,
+    pub invocation: String,
+    pub fence: u64,
+    pub pod: String,
+    pub pod_uid: String,
+}
+
+/// Render a task-run Job, replace ONLY the worker container's command, apply it.
+///
+/// Everything that decides the behaviour under test is the renderer's:
+/// `suspend`, `runtimeClassName`, `shareProcessNamespace`, both security
+/// contexts, the sidecar's command/env/capabilities and the absence of a sidecar
+/// CPU limit. The `command` swap is the same single mutation
+/// `sleep_instead_of_the_worker` makes in the sibling harness, for the same
+/// reason, and the probe env rides alongside it.
+pub fn launch_probe(context: &str, config: &KubernetesConfig, fence: u64, clamp_s: u64, post_s: u64) -> Probe {
+    let (job, task_run_id) = render_probe_job(config, "harness-project");
+    assert_eq!(
+        job.spec.as_ref().and_then(|spec| spec.suspend),
+        Some(true),
+        "the armed renderer must create the Job suspended so Kueue owns admission",
+    );
+    let job_name = job.metadata.name.clone().expect("the renderer names the Job");
+    // The leaf name IS the invocation id in production (`process_broker`), and
+    // `validate_leaf_name` rejects anything that is not a direct child name.
+    let invocation = format!("probe-{task_run_id}");
+
+    let mut manifest = serde_json::to_value(&job).expect("Job serializes");
+    manifest["apiVersion"] = Value::String("batch/v1".into());
+    manifest["kind"] = Value::String("Job".into());
+    let containers = manifest
+        .pointer_mut("/spec/template/spec/containers")
+        .and_then(Value::as_array_mut)
+        .expect("the rendered Job has containers");
+    let worker = containers
+        .iter_mut()
+        .find(|container| container["name"] == WORKER_CONTAINER_NAME)
+        .expect("the rendered Job has a worker container");
+    worker["command"] = serde_json::json!([PROBE_BIN]);
+    worker["args"] = Value::Null;
+    let env = worker["env"]
+        .as_array_mut()
+        .expect("the renderer sets worker env");
+    for (name, value) in [
+        ("DJINN_PROBE_INVOCATION", invocation.clone()),
+        ("DJINN_PROBE_FENCE", fence.to_string()),
+        // Armed: the birth authority `birth_authority(Lift|Shadow)` produces.
+        // An `unarmed` leaf is born UNCLAMPED and there would be nothing to lift.
+        ("DJINN_PROBE_AUTHORITY", "armed".to_owned()),
+        ("DJINN_PROBE_DECISION_PATH", PROBE_DECISION_PATH.to_owned()),
+        ("DJINN_PROBE_WORKLOAD", PROBE_WORKLOAD.to_owned()),
+        ("DJINN_PROBE_CLAMP_SECONDS", clamp_s.to_string()),
+        ("DJINN_PROBE_LIFTED_SECONDS", post_s.to_string()),
+    ] {
+        env.push(serde_json::json!({ "name": name, "value": value }));
+    }
+
+    let manifest_text = serde_json::to_string(&manifest).expect("manifest serializes");
+    let applied = Command::new("kubectl")
+        .args(["--context", context, "-n", NAMESPACE, "apply", "-f", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write as _;
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin is piped")
+                .write_all(manifest_text.as_bytes())?;
+            child.wait_with_output()
+        })
+        .expect("kubectl apply runs");
+    assert!(
+        applied.status.success(),
+        "applying the rendered Job failed: {}",
+        stderr(&applied),
+    );
+
+    let (pod, pod_uid) = await_running_pod(context, &task_run_id);
+    Probe {
+        task_run_id,
+        job_name,
+        invocation,
+        fence,
+        pod,
+        pod_uid,
+    }
+}
+
+pub fn pods_of(context: &str, task_run_id: &str) -> Vec<(String, String, String)> {
+    kubectl_json(
+        context,
+        &[
+            "-n",
+            NAMESPACE,
+            "get",
+            "pods",
+            "-l",
+            &format!("{LABEL_TASK_RUN_ID}={task_run_id}"),
+        ],
+    )["items"]
+        .as_array()
+        .expect("a List has items")
+        .iter()
+        .map(|item| {
+            (
+                item["metadata"]["name"].as_str().unwrap_or_default().to_owned(),
+                item["metadata"]["uid"].as_str().unwrap_or_default().to_owned(),
+                item["status"]["phase"].as_str().unwrap_or_default().to_owned(),
+            )
+        })
+        .collect()
+}
+
+pub fn await_running_pod(context: &str, task_run_id: &str) -> (String, String) {
+    for _ in 0..AWAIT_TICKS {
+        if let Some((name, uid, _)) = pods_of(context, task_run_id)
+            .into_iter()
+            .find(|(_, _, phase)| phase == "Running")
+        {
+            return (name, uid);
+        }
+        std::thread::sleep(TICK);
+    }
+    panic!(
+        "no Pod of task-run {task_run_id} reached Running. Pods: {:?}. Workloads: {}",
+        pods_of(context, task_run_id),
+        kubectl_ok(
+            context,
+            &["-n", NAMESPACE, "get", "workloads.kueue.x-k8s.io", "-o", "wide"],
+        ),
+    )
+}
+
+/// Read the invocation leaf's `cpu.max` from INSIDE the pod, out of the
+/// launcher container's own delegated cgroup root.
+///
+/// This is the kernel's value, read through the same `/sys/fs/cgroup` the
+/// launcher writes — never a value this test wrote and never one the probe
+/// reported. The leaf directory is mode 0700 and root-owned, which is why this
+/// runs in the sidecar (uid 0) rather than the worker (uid 1000).
+pub fn leaf_cpu_max(context: &str, probe: &Probe) -> String {
+    let path = format!("/sys/fs/cgroup/{}/cpu.max", probe.invocation);
+    let output = kubectl(
+        context,
+        &[
+            "-n",
+            NAMESPACE,
+            "exec",
+            &probe.pod,
+            "-c",
+            LAUNCHER_CONTAINER_NAME,
+            "--",
+            "cat",
+            &path,
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "reading {path} in {} failed: {}",
+        probe.pod,
+        stderr(&output),
+    );
+    stdout(&output).trim().to_owned()
+}
+
+pub fn probe_log(context: &str, probe: &Probe) -> String {
+    stdout(&kubectl(
+        context,
+        &[
+            "-n",
+            NAMESPACE,
+            "logs",
+            &probe.pod,
+            "-c",
+            WORKER_CONTAINER_NAME,
+        ],
+    ))
+}
+
+/// Block until the probe emits `record`, then return the whole log.
+pub fn await_probe_record(context: &str, probe: &Probe, record: &str) -> String {
+    for _ in 0..AWAIT_TICKS {
+        let log = probe_log(context, probe);
+        if log.contains(&format!("probe.{record}")) {
+            return log;
+        }
+        if let Some(line) = log.lines().find(|line| line.starts_with("probe.fatal")) {
+            panic!("the probe in {} failed: {line}", probe.pod);
+        }
+        std::thread::sleep(TICK);
+    }
+    panic!(
+        "the probe in {} never emitted probe.{record}. Log:\n{}",
+        probe.pod,
+        probe_log(context, probe),
+    );
+}
+
+/// Parse one `probe.<record> k=v ...` line into a map.
+pub fn probe_record(log: &str, record: &str) -> BTreeMap<String, String> {
+    let prefix = format!("probe.{record} ");
+    let line = log
+        .lines()
+        .find(|line| line.starts_with(&prefix))
+        .unwrap_or_else(|| panic!("no probe.{record} line in:\n{log}"));
+    line.trim_start_matches(&prefix)
+        .split_whitespace()
+        .filter_map(|pair| pair.split_once('='))
+        .map(|(key, value)| (key.to_owned(), value.to_owned()))
+        .collect()
+}
+
+
+pub fn phase_record(log: &str, phase: &str) -> BTreeMap<String, String> {
+    let line = log
+        .lines()
+        .find(|line| line.starts_with("probe.phase ") && line.contains(&format!("phase={phase} ")))
+        .unwrap_or_else(|| panic!("no probe.phase phase={phase} line in:\n{log}"));
+    line.trim_start_matches("probe.phase ")
+        .split_whitespace()
+        .filter_map(|pair| pair.split_once('='))
+        .map(|(key, value)| (key.to_owned(), value.to_owned()))
+        .collect()
+}
+
+pub fn phase_number(log: &str, phase: &str, key: &str) -> u64 {
+    phase_record(log, phase)
+        .get(key)
+        .unwrap_or_else(|| panic!("phase {phase} carries no {key}"))
+        .parse()
+        .unwrap_or_else(|error| panic!("phase {phase} {key} is not a number: {error}"))
+}
+
+/// Hand the probe the fence the governor authorized — or a fence it did not.
+pub fn deliver_decision(context: &str, probe: &Probe, fence: Option<u64>) {
+    let body = match fence {
+        Some(value) => format!("lift {value}"),
+        None => "skip".to_owned(),
+    };
+    let script = format!("mkdir -p $(dirname {PROBE_DECISION_PATH}); printf '%s' '{body}' > {PROBE_DECISION_PATH}");
+    let output = kubectl(
+        context,
+        &[
+            "-n",
+            NAMESPACE,
+            "exec",
+            &probe.pod,
+            "-c",
+            WORKER_CONTAINER_NAME,
+            "--",
+            "sh",
+            "-c",
+            &script,
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "delivering the decision to {} failed: {}",
+        probe.pod,
+        stderr(&output),
+    );
+}
+
+pub fn delete_job(context: &str, job_name: &str) {
+    let _ = kubectl(
+        context,
+        &[
+            "-n",
+            NAMESPACE,
+            "delete",
+            "job",
+            job_name,
+            "--cascade=foreground",
+            "--wait=true",
+            "--timeout=120s",
+        ],
+    );
+}
+
+pub fn clear_task_run_jobs(context: &str) {
+    let _ = kubectl(
+        context,
+        &[
+            "-n",
+            NAMESPACE,
+            "delete",
+            "jobs",
+            "-l",
+            "app.kubernetes.io/component=task-run",
+            "--cascade=foreground",
+            "--wait=true",
+            "--timeout=180s",
+        ],
+    );
+}
+
+pub fn admitted_workloads(context: &str) -> u64 {
+    kubectl_json(context, &["get", "clusterqueues.kueue.x-k8s.io", CLUSTER_QUEUE])["status"]
+        ["admittedWorkloads"]
+        .as_u64()
+        .unwrap_or(0)
+}
+
+pub fn pods_nominal_quota(context: &str) -> u64 {
+    kubectl_json(context, &["get", "clusterqueues.kueue.x-k8s.io", CLUSTER_QUEUE])["spec"]
+        ["resourceGroups"][0]["flavors"][0]["resources"]
+        .as_array()
+        .expect("the ClusterQueue covers resources")
+        .iter()
+        .find(|resource| resource["name"] == "pods")
+        // A Kubernetes `Quantity` serializes as a STRING ("4"), not a number.
+        .and_then(|resource| resource["nominalQuota"].as_str())
+        .and_then(|quota| quota.parse().ok())
+        .expect("the ClusterQueue bounds `pods` with a parseable quantity")
+}
+
+// ---------------------------------------------------------------------------
+// The durable governor, driven exactly as `kueue_disruption_governor` drives it.
+// ---------------------------------------------------------------------------
+
+pub fn invocation_key(pod_uid: &str) -> BuildLeaseKey {
+    BuildLeaseKey {
+        consumer_kind: BuildLeaseConsumerKind::TaskInvocation,
+        consumer_id: format!("invocation-{pod_uid}"),
+    }
+}
+
+/// Ask the REAL governor which of `pod_uids` may lift, at a cap it reads back
+/// out of the durable authority row.
+///
+/// Returns `(K, the subset of pod UIDs holding a bound lease)`. Nothing here is
+/// a constant: the cap is written through the operator API, read back, and only
+/// the read-back value is used; `grant_next` enforces it inside a locked
+/// transaction; `bind` fences each grant to the live Pod UID it was queued for.
+pub fn authorize(pod_uids: &[String], m: u64) -> (i64, Vec<String>) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("build a tokio runtime for the durable governor");
+    runtime.block_on(async move {
+        let db = Database::open_in_memory()
+            .expect("a real PostgreSQL test database (DJINN_TEST_DATABASE_URL)");
+        let authority = InvocationLeaseAuthorityRepository::new(db.clone());
+        let seeded = authority.seed_baseline().await.expect("seed the authority");
+        authority
+            .set_mode_and_cap(
+                seeded.epoch,
+                InvocationLeaseMode::Enforce,
+                Some(i64::try_from(m).expect("M fits an i64") - 1),
+            )
+            .await
+            .expect("arm the invocation-lease authority");
+
+        // READ BACK. Everything below uses this, never the value written.
+        let live = authority
+            .read()
+            .await
+            .expect("read the durable authority")
+            .expect("the authority row exists once seeded");
+        let k = live.cap.expect("an armed authority carries a reference cap");
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(live.clone()))),
+            InvocationLiftDecision::Lift,
+            "the live authority must authorize lifts at all, or the cap bounds a population that \
+             never lifts",
+        );
+        assert!(
+            k >= 1 && k < i64::try_from(m).expect("M fits an i64"),
+            "the cap K={k} must be at least 1 and strictly below M={m}, or it bounds nothing",
+        );
+
+        let repository = std::sync::Arc::new(BuildLeaseRepository::new(db.clone()));
+        for uid in pod_uids {
+            repository
+                .queue(&QueueBuildLeaseInput {
+                    key: invocation_key(uid),
+                    immutable_identity: format!("pod:{uid}"),
+                    queue_deadline: None,
+                    launch_deadline: None,
+                    weight: 1,
+                })
+                .await
+                .unwrap_or_else(|error| panic!("queue an invocation lease for {uid}: {error:?}"));
+        }
+
+        // Every grant the FIFO will make at the live cap, taken concurrently so
+        // the bound is a property of the locked transaction rather than of the
+        // order this test happened to call in.
+        let mut attempts = tokio::task::JoinSet::new();
+        for _ in 0..pod_uids.len() {
+            let repository = repository.clone();
+            attempts.spawn(async move {
+                repository
+                    .grant_next(k, "2026-07-31T00:00:00.000Z", None)
+                    .await
+                    .expect("grant_next must not error")
+            });
+        }
+        let mut authorized = Vec::new();
+        while let Some(result) = attempts.join_next().await {
+            if let GrantNextBuildLeaseResult::Granted(row) = result.expect("grant task panicked") {
+                let uid = row
+                    .immutable_identity
+                    .strip_prefix("pod:")
+                    .expect("the identity carries its Pod UID")
+                    .to_owned();
+                let token = row.fencing_token.expect("a granted lease carries a token");
+                let bound = repository
+                    .bind(&invocation_key(&uid), token, &uid, None)
+                    .await
+                    .unwrap_or_else(|error| panic!("bind the lease for {uid}: {error:?}"));
+                assert_eq!(bound.state, BuildLeaseState::Bound);
+                assert_eq!(bound.bound_pod_uid.as_deref(), Some(uid.as_str()));
+                authorized.push(uid);
+            }
+        }
+        (k, authorized)
+    })
+}
+
+/// `cpu.max` line for `millicores` over the launcher's 100ms period.
+pub fn cpu_max_line(millicores: u32) -> String {
+    format!("{} 100000", u64::from(millicores) * 100_000 / 1_000)
+}

--- a/server/crates/djinn-k8s/tests/kueue_governor_cap.rs
+++ b/server/crates/djinn-k8s/tests/kueue_governor_cap.rs
@@ -61,7 +61,10 @@ fn live_exactly_k_of_m_contending_invocations_observe_the_lifted_quota() {
 
     // M: launch up to the live `pods` quota, then read back what was ADMITTED.
     let quota = pods_nominal_quota(&context);
-    assert!(quota >= 2, "the live pods quota is {quota}; nothing to contend over");
+    assert!(
+        quota >= 2,
+        "the live pods quota is {quota}; nothing to contend over"
+    );
     let mut probes = Vec::new();
     for index in 0..quota {
         probes.push(launch_probe(
@@ -73,9 +76,7 @@ fn live_exactly_k_of_m_contending_invocations_observe_the_lifted_quota() {
         ));
     }
     let m = admitted_workloads(&context).max(probes.len() as u64);
-    eprintln!(
-        "AC3 M={m} (live ClusterQueue admittedWorkloads, pods nominalQuota {quota})",
-    );
+    eprintln!("AC3 M={m} (live ClusterQueue admittedWorkloads, pods nominalQuota {quota})",);
 
     for probe in &probes {
         await_probe_record(&context, probe, "awaiting_decision");
@@ -101,7 +102,11 @@ fn live_exactly_k_of_m_contending_invocations_observe_the_lifted_quota() {
         let granted = authorized.contains(&probe.pod_uid);
         // The unauthorized present a fence they were never granted, so the
         // refusal is the launcher's and not this test's silence.
-        let presented = if granted { probe.fence } else { probe.fence ^ 1 };
+        let presented = if granted {
+            probe.fence
+        } else {
+            probe.fence ^ 1
+        };
         deliver_decision(&context, probe, Some(presented));
     }
 
@@ -207,7 +212,10 @@ fn live_the_task_run_containers_hold_no_sys_admin_or_sys_resource() {
         for line in raw.lines() {
             let (label, hex) = line.split_once(':').expect("a /proc status line");
             let mask = u64::from_str_radix(hex.trim(), 16).expect("a capability mask is hex");
-            for (name, bit) in [("SYS_ADMIN", SYS_ADMIN_BIT), ("SYS_RESOURCE", SYS_RESOURCE_BIT)] {
+            for (name, bit) in [
+                ("SYS_ADMIN", SYS_ADMIN_BIT),
+                ("SYS_RESOURCE", SYS_RESOURCE_BIT),
+            ] {
                 assert_eq!(
                     mask & (1 << bit),
                     0,

--- a/server/crates/djinn-k8s/tests/kueue_governor_cap.rs
+++ b/server/crates/djinn-k8s/tests/kueue_governor_cap.rs
@@ -1,0 +1,252 @@
+// Test: eprintln reports the live governor numbers AC3 requires to be RECORDED.
+#![allow(clippy::print_stderr)]
+//! AC3 + AC4 of `fbiy-C1`: the invocation cap bound and the live privilege
+//! contract, both driven against real task-run Pods on the armed cluster.
+//!
+//! Sibling of `kueue_governor_conformance` (AC1/AC2), which carries the module
+//! docs for the whole harness — what is production here and what is substituted,
+//! the isolation rules, and the run instructions all apply unchanged. The two
+//! are separate test TARGETS only because one file exceeded
+//! `scripts/check-file-size.sh`; they share `tests/kueue_governor/mod.rs`.
+//!
+//! Run them together, single-threaded — both drive the same disposable cluster
+//! and the same `pods` quota:
+//!
+//! ```bash
+//! DJINN_TEST_KUEUE_CLUSTER=1 cargo test -p djinn-k8s \
+//!     --test kueue_governor_cap -- --ignored --test-threads=1
+//! ```
+
+mod kueue_governor;
+use kueue_governor::*;
+
+use djinn_k8s::launcher::{LAUNCHER_CONTAINER_NAME, TASK_RUN_CGROUP_RUNTIME_CLASS};
+
+// ===========================================================================
+// AC3 — exactly K of M contending invocations observe the lifted quota
+// ===========================================================================
+
+/// With `M` Workloads admitted and the durable cap at `K < M`, exactly `K`
+/// invocations reach the lifted quota and the rest stay clamped.
+///
+/// `M` is the live ClusterQueue's admitted-Workload count, bounded by the
+/// `pods` nominalQuota the chart installed. `K` is read back out of the durable
+/// invocation-lease authority after being armed through the real operator API.
+/// Neither is a literal here, and the assertion compares against the read-back
+/// values.
+///
+/// Every unauthorized invocation still ATTEMPTS a lift, with a fence the
+/// governor did not grant it. That is deliberately stronger than declining to
+/// ask: it proves the kernel boundary refuses, rather than proving only that
+/// this test chose not to call.
+///
+/// AC5-style non-vacuity, each deletion failing a different assertion:
+/// * delete `grant_next`'s cap comparison → all `M` are granted → `lifted == K`
+///   fails at `M`;
+/// * delete the `bound_pod_uid` fence → a grant binds to the wrong Pod → the
+///   bind assertion in [`authorize`] fires;
+/// * delete the launcher's `leaf.invocation.fence != fence` check → the
+///   unauthorized Pods lift too → `clamped == M - K` fails.
+#[test]
+#[ignore]
+fn live_exactly_k_of_m_contending_invocations_observe_the_lifted_quota() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+    clear_task_run_jobs(&context);
+    ensure_probe_image(&context);
+    let config = config_for(&context);
+    let (clamp_millicores, leased_millicores) = rendered_quotas(&config);
+
+    // M: launch up to the live `pods` quota, then read back what was ADMITTED.
+    let quota = pods_nominal_quota(&context);
+    assert!(quota >= 2, "the live pods quota is {quota}; nothing to contend over");
+    let mut probes = Vec::new();
+    for index in 0..quota {
+        probes.push(launch_probe(
+            &context,
+            &config,
+            0x5eed_c1a5_0001_0000 + index,
+            10,
+            10,
+        ));
+    }
+    let m = admitted_workloads(&context).max(probes.len() as u64);
+    eprintln!(
+        "AC3 M={m} (live ClusterQueue admittedWorkloads, pods nominalQuota {quota})",
+    );
+
+    for probe in &probes {
+        await_probe_record(&context, probe, "awaiting_decision");
+        assert_eq!(
+            leaf_cpu_max(&context, probe),
+            cpu_max_line(clamp_millicores),
+            "every contending invocation must start clamped",
+        );
+    }
+
+    let uids: Vec<String> = probes.iter().map(|probe| probe.pod_uid.clone()).collect();
+    let (k, authorized) = authorize(&uids, m);
+    eprintln!("AC3 live governor: K={k} (durable authority), authorized={authorized:?}");
+    assert_eq!(
+        authorized.len() as i64,
+        k,
+        "the cap must be REACHED as well as respected: {} of a possible K={k} were authorized, \
+         which is what a deleted invocation queue looks like",
+        authorized.len(),
+    );
+
+    for probe in &probes {
+        let granted = authorized.contains(&probe.pod_uid);
+        // The unauthorized present a fence they were never granted, so the
+        // refusal is the launcher's and not this test's silence.
+        let presented = if granted { probe.fence } else { probe.fence ^ 1 };
+        deliver_decision(&context, probe, Some(presented));
+    }
+
+    let mut lifted = Vec::new();
+    let mut clamped = Vec::new();
+    for probe in &probes {
+        let log = await_probe_record(&context, probe, "summary");
+        let observed = leaf_cpu_max(&context, probe);
+        let result = probe_record(&log, "lift_attempt")
+            .get("result")
+            .cloned()
+            .unwrap_or_default();
+        eprintln!(
+            "AC3 pod={} uid={} authorized={} lift={result} cpu.max={observed}",
+            probe.pod,
+            probe.pod_uid,
+            authorized.contains(&probe.pod_uid),
+        );
+        if observed == cpu_max_line(leased_millicores) {
+            assert_eq!(result, "accepted");
+            lifted.push(probe.pod_uid.clone());
+        } else {
+            assert_eq!(
+                observed,
+                cpu_max_line(clamp_millicores),
+                "an invocation that did not lift must still hold the clamp, not some third value",
+            );
+            assert_eq!(result, "refused");
+            clamped.push(probe.pod_uid.clone());
+        }
+    }
+
+    assert_eq!(
+        lifted.len() as i64,
+        k,
+        "{} invocations observed the lifted quota against the live cap K={k}",
+        lifted.len(),
+    );
+    assert_eq!(
+        clamped.len() as u64,
+        m - u64::try_from(k).expect("K fits a u64"),
+        "every invocation the governor did not authorize must still be clamped",
+    );
+    let mut sorted_lifted = lifted.clone();
+    let mut sorted_authorized = authorized.clone();
+    sorted_lifted.sort();
+    sorted_authorized.sort();
+    assert_eq!(
+        sorted_lifted, sorted_authorized,
+        "the invocations that lifted must be exactly the ones the governor bound",
+    );
+
+    for probe in &probes {
+        delete_job(&context, &probe.job_name);
+    }
+}
+
+// ===========================================================================
+// AC4 — the live container holds no cgroup-privileged capability
+// ===========================================================================
+
+/// The privilege contract, read off the RUNNING containers rather than the
+/// manifest, and cross-checked against what the kernel granted the process.
+///
+/// The manifest half is [`guard_the_rendered_task_run_grants_no_cgroup_privileged_capability`];
+/// this is the half a render cannot establish, because a RuntimeClass handler,
+/// an admission webhook or a container runtime default could all add a
+/// capability the manifest never mentioned. `/proc/1/status`'s `CapEff` is the
+/// kernel's own answer.
+#[test]
+#[ignore]
+fn live_the_task_run_containers_hold_no_sys_admin_or_sys_resource() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+    clear_task_run_jobs(&context);
+    ensure_probe_image(&context);
+    let config = config_for(&context);
+    let probe = launch_probe(&context, &config, 0x5eed_c1a5_0000_0004, 4, 4);
+    await_probe_record(&context, &probe, "created");
+
+    // CAP_SYS_ADMIN is bit 21, CAP_SYS_RESOURCE is bit 24.
+    const SYS_ADMIN_BIT: u32 = 21;
+    const SYS_RESOURCE_BIT: u32 = 24;
+    for container in [LAUNCHER_CONTAINER_NAME, WORKER_CONTAINER_NAME] {
+        let raw = kubectl_ok(
+            &context,
+            &[
+                "-n",
+                NAMESPACE,
+                "exec",
+                &probe.pod,
+                "-c",
+                container,
+                "--",
+                "sh",
+                "-c",
+                "grep -E '^Cap(Eff|Prm|Bnd):' /proc/self/status",
+            ],
+        );
+        eprintln!("AC4 {container}:\n{raw}");
+        for line in raw.lines() {
+            let (label, hex) = line.split_once(':').expect("a /proc status line");
+            let mask = u64::from_str_radix(hex.trim(), 16).expect("a capability mask is hex");
+            for (name, bit) in [("SYS_ADMIN", SYS_ADMIN_BIT), ("SYS_RESOURCE", SYS_RESOURCE_BIT)] {
+                assert_eq!(
+                    mask & (1 << bit),
+                    0,
+                    "container {container} holds CAP_{name} in {label} ({hex}); the clamp is \
+                     advisory for any process that can raise its own limits",
+                );
+            }
+        }
+    }
+
+    // And the RuntimeClass contract itself, live: the class the Pod names must
+    // resolve to the handler the node was taught and select on the node label.
+    let class = kubectl_json(
+        &context,
+        &["get", "runtimeclass", TASK_RUN_CGROUP_RUNTIME_CLASS],
+    );
+    assert_eq!(
+        class["handler"].as_str(),
+        Some("runc-cgroupwritable"),
+        "the installed RuntimeClass names a handler this harness never taught the node",
+    );
+    assert_eq!(
+        class["scheduling"]["nodeSelector"]["djinn.io/cgroup-writable"].as_str(),
+        Some("true"),
+        "the class must keep task-run Pods off nodes that have not been conformed",
+    );
+    let pod = kubectl_json(&context, &["-n", NAMESPACE, "get", "pod", &probe.pod]);
+    assert_eq!(
+        pod["spec"]["runtimeClassName"].as_str(),
+        Some(TASK_RUN_CGROUP_RUNTIME_CLASS),
+        "the admitted Pod must still carry the class the renderer set",
+    );
+    assert_eq!(
+        pod["spec"]["nodeSelector"]["djinn.io/cgroup-writable"].as_str(),
+        Some("true"),
+        "the RuntimeClass admission controller must have merged the class's nodeSelector into \
+         the Pod; without it the Pod could land on an unconformed node",
+    );
+
+    delete_job(&context, &probe.job_name);
+    let _ = probe.task_run_id;
+}

--- a/server/crates/djinn-k8s/tests/kueue_governor_conformance.rs
+++ b/server/crates/djinn-k8s/tests/kueue_governor_conformance.rs
@@ -221,8 +221,8 @@ fn guard_the_c1_fixture_declares_a_pods_quota_that_admits_a_strict_cap() {
 /// from a launcher bug at the point it surfaces.
 #[test]
 fn guard_the_setup_script_resolves_the_containerd_schema_from_the_live_node() {
-    let script = std::fs::read_to_string(repo_root().join(SETUP_SCRIPT))
-        .expect("read the setup script");
+    let script =
+        std::fs::read_to_string(repo_root().join(SETUP_SCRIPT)).expect("read the setup script");
     assert!(
         script.contains("containerd-config-version.sh"),
         "the script must source deploy/node/k3s/containerd-config-version.sh rather than \
@@ -239,7 +239,10 @@ fn guard_the_setup_script_resolves_the_containerd_schema_from_the_live_node() {
     );
     // The two namespaces must appear nowhere as literals: both come from the
     // detector, keyed on the version it resolved.
-    for namespace in ["io.containerd.grpc.v1.cri\".containerd.runtimes", "io.containerd.cri.v1.runtime'.containerd.runtimes"] {
+    for namespace in [
+        "io.containerd.grpc.v1.cri\".containerd.runtimes",
+        "io.containerd.cri.v1.runtime'.containerd.runtimes",
+    ] {
         assert!(
             !script.contains(namespace),
             "the script hardcodes the runtime table `{namespace}`; it must be derived from the \
@@ -458,7 +461,9 @@ fn live_an_authorized_invocation_is_clamped_throttled_and_lifted_to_three_times_
     let log = await_probe_record(&context, &probe, "summary");
     let lifted = leaf_cpu_max(&context, &probe);
     assert_eq!(
-        probe_record(&log, "lift_attempt").get("result").map(String::as_str),
+        probe_record(&log, "lift_attempt")
+            .get("result")
+            .map(String::as_str),
         Some("accepted"),
         "the broker refused an authorized lift:\n{log}",
     );
@@ -484,7 +489,6 @@ fn live_an_authorized_invocation_is_clamped_throttled_and_lifted_to_three_times_
 
     delete_job(&context, &probe.job_name);
 }
-
 
 // ===========================================================================
 // AC2 — a wrong fence changes nothing

--- a/server/crates/djinn-k8s/tests/kueue_governor_conformance.rs
+++ b/server/crates/djinn-k8s/tests/kueue_governor_conformance.rs
@@ -1,0 +1,564 @@
+// Test: eprintln is how the RECORDED (not asserted) measurements of this file
+// reach the operator reading the run, and the skip-reason channel for the gated
+// half. Mirrors tests/kueue_cluster_harness.rs.
+#![allow(clippy::print_stderr)]
+//! The invocation governor, proved end to end on a LIVE armed-Kueue cluster
+//! with a real writable-cgroup node (fbiy-C1).
+//!
+//! WHAT WAS MISSING, AND WHY A RENDER COULD NOT SUPPLY IT
+//! -----------------------------------------------------
+//! `djinn-cgroup-launcher`'s `tests/brokered_lease_lift_boundary.rs` already
+//! proves the birth clamp, the fence refusal and the lift through the real
+//! broker protocol on a real kernel — but in ONE process on a CI runner, on a
+//! delegated cgroup root the test prepared for itself, with no Kubernetes
+//! anywhere. `tests/kueue_disruption_governor.rs` proves the cap bound against
+//! a real PostgreSQL governor and live Pod UIDs — but it never lifts a quota:
+//! its Pods run `sleep`, and the cluster it uses has no `runc-cgroupwritable`
+//! handler, no RuntimeClass and a `cgroupLauncher.mode: disabled` install.
+//!
+//! Between those two sits the claim nobody had measured: that a Pod which the
+//! PRODUCTION renderer produced, admitted by Kueue, scheduled onto a node
+//! carrying the RuntimeClass handler, running the SHIPPED launcher binary,
+//! is born at the configured clamp, is actually throttled there, and moves to
+//! the configured lifted quota when — and only when — the durable governor
+//! authorizes it. Every step of that sentence is a place where green work has
+//! landed inert in this repository this month.
+//!
+//! WHAT THIS FILE RUNS, AND WHAT IT SUBSTITUTES
+//! --------------------------------------------
+//! * The **Job** is `build_task_run_job`'s, unmodified, rendered from a config
+//!   with `CgroupLauncherMode::Required` + `task_run_cgroup_writable_enabled`.
+//!   The RuntimeClass name, `shareProcessNamespace`, the sidecar's command, env,
+//!   capabilities and the absence of a sidecar CPU limit are all the renderer's.
+//! * The **launcher** is the shipped `/opt/djinn/bin/djinn-cgroup-launcher`
+//!   binary built out of this repository. Nothing about it is stubbed.
+//! * The **worker container's `command`** is replaced — the single mutation this
+//!   file makes to the render, and the same one
+//!   `tests/kueue_disruption/mod.rs::sleep_instead_of_the_worker` makes for the
+//!   same reason: the real `djinn-agent-worker` needs a coordinator, a database
+//!   and a model provider, none of which exist on a disposable kind node. The
+//!   replacement (`djinn-cgroup-launcher`'s `examples/governor_probe.rs`) speaks
+//!   the real handshake and the real broker protocol and decides nothing.
+//! * The **governor** is real: `InvocationLeaseAuthorityRepository` +
+//!   `BuildLeaseRepository::grant_next` against a real PostgreSQL, driven from
+//!   the live Pod UIDs, with `K` READ BACK out of the durable authority row and
+//!   `M` read off the live ClusterQueue. Neither number is a constant here.
+//!
+//! The one seam that is neither production nor kernel is the delivery of the
+//! governor's verdict into the Pod: production carries it over the coordinator
+//! connection, and this harness writes it into a file with `kubectl exec`. What
+//! it delivers is a fence, and the fence is then judged by the launcher, in the
+//! kernel, exactly as in production — so the harness can decide WHO is asked to
+//! lift and can never decide whether the lift succeeds.
+//!
+//! ISOLATION
+//! ---------
+//! Own cluster, own registry, own port, all distinct from
+//! `scripts/kind/setup-kueue-cluster.sh`'s defaults (`fbiy-B0`/`B1`) and from
+//! `tests/kueue_disruption*`'s (`fbiy-B2a`/`B2b`) — `down` DELETES what it is
+//! given, so a shared name is a shared deletion. Kept that way by
+//! [`guard_this_harness_is_disjoint_from_every_sibling_kueue_harness`].
+//!
+//! ```bash
+//! scripts/kind/setup-kueue-cluster.sh up --cluster-name djinn-kueue-c1 \
+//!     --registry-name djinn-kueue-c1-registry --registry-port 5061 \
+//!     --k8s-version 1.35.0 --cgroup-writable \
+//!     --values deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml
+//! DJINN_TEST_KUEUE_CLUSTER=1 cargo test -p djinn-k8s \
+//!     --test kueue_governor_conformance -- --ignored --test-threads=1
+//! scripts/kind/setup-kueue-cluster.sh down --cluster-name djinn-kueue-c1 \
+//!     --registry-name djinn-kueue-c1-registry
+//! ```
+
+mod kueue_governor;
+use kueue_governor::*;
+
+use djinn_cgroup_launcher::bootstrap::RETAINED_CAPABILITY_NAMES;
+use djinn_cgroup_launcher::{LeasedQuota, UnleasedQuota};
+use djinn_k8s::launcher::{
+    LAUNCHER_CONTAINER_NAME, LAUNCHER_UNLEASED_MILLICORES, TASK_RUN_CGROUP_RUNTIME_CLASS,
+};
+
+// ===========================================================================
+// Hermetic guards — these run in the ordinary test lane, on every PR.
+//
+// The live half below is `#[ignore]` + env-gated and NO CI lane runs it, so
+// every claim that must not regress silently lives here instead.
+// ===========================================================================
+
+/// This harness must be unable to touch any sibling harness's cluster, or the
+/// developer's Tilt environment.
+#[test]
+fn guard_this_harness_is_disjoint_from_every_sibling_kueue_harness() {
+    let accepted = run_script(
+        SETUP_SCRIPT,
+        &[
+            "check",
+            "--cluster-name",
+            HARNESS_CLUSTER,
+            "--registry-name",
+            HARNESS_REGISTRY,
+            "--registry-port",
+            HARNESS_REGISTRY_PORT,
+            "--k8s-version",
+            HARNESS_K8S_VERSION,
+            "--context",
+            HARNESS_CONTEXT,
+            "--cgroup-writable",
+        ],
+    );
+    assert_eq!(
+        exit_code(&accepted),
+        0,
+        "the script must accept this file's cluster/registry/port/context/flag; stderr: {}",
+        stderr(&accepted),
+    );
+    assert!(
+        stdout(&accepted).contains(&format!("cluster={HARNESS_CLUSTER} "))
+            && stdout(&accepted).contains(&format!("context={HARNESS_CONTEXT} "))
+            && stdout(&accepted).contains("cgroup-writable=true"),
+        "the script must derive this file's context and understand --cgroup-writable, got: {}",
+        stdout(&accepted),
+    );
+
+    for sibling in SIBLING_CLUSTERS {
+        assert_ne!(
+            *sibling, HARNESS_CLUSTER,
+            "`down` deletes the cluster it is given, so two harnesses sharing a name destroy \
+             each other's work",
+        );
+    }
+    // And the script's own defaults, which fbiy-B0/B1 run with.
+    let defaults = run_script(SETUP_SCRIPT, &["check"]);
+    assert_eq!(exit_code(&defaults), 0, "stderr: {}", stderr(&defaults));
+    assert!(
+        !stdout(&defaults).contains(&format!("cluster={HARNESS_CLUSTER} ")),
+        "this harness must not share the script's default cluster: {}",
+        stdout(&defaults),
+    );
+    // A default `check` must ALSO report the flag off — a script that armed the
+    // node unconditionally would change every sibling harness's cluster.
+    assert!(
+        stdout(&defaults).contains("cgroup-writable=false"),
+        "--cgroup-writable must be OPT-IN; the siblings' clusters were measured without it: {}",
+        stdout(&defaults),
+    );
+}
+
+/// The C1 values file arms all three switches together, and the B0 file still
+/// arms none of them.
+///
+/// The second half is the load-bearing one. `tests/kueue_cluster_harness.rs`
+/// asserts `deploy/kueue/preflight.sh --mode cutover` exits 10 ("RuntimeClass
+/// djinn-cgroup-writable is absent") against the B0 fixture — 6knv's AC4. That
+/// assertion dies the moment anyone flips `cgroupWritable.runtimeClass.enabled`
+/// there, and dies silently, because nothing in that file mentions this one.
+#[test]
+fn guard_the_arming_triple_is_in_the_c1_fixture_and_absent_from_the_b0_fixture() {
+    let c1 = yaml_at(GOVERNOR_VALUES);
+    assert_eq!(
+        c1["cgroupLauncher"]["mode"].as_str(),
+        Some("required"),
+        "the C1 fixture must arm the launcher, or every Pod it renders runs without a sidecar",
+    );
+    for gate in ["runtimeClass", "taskRuns"] {
+        assert_eq!(
+            c1["cgroupWritable"][gate]["enabled"].as_bool(),
+            Some(true),
+            "cgroupWritable.{gate}.enabled must be true: the render asserts the pairing and \
+             `build_task_run_job` panics on a required launcher without the RuntimeClass",
+        );
+    }
+    assert_eq!(c1["kueue"]["armed"].as_bool(), Some(true));
+
+    let b0 = yaml_at(B0_VALUES);
+    assert_eq!(
+        b0["cgroupLauncher"]["mode"].as_str(),
+        Some("disabled"),
+        "fbiy-C1 must not arm the B0 fixture: `preflight.sh --mode cutover` exiting 10 against \
+         that cluster is 6knv's AC4",
+    );
+    for gate in ["runtimeClass", "taskRuns"] {
+        assert_eq!(
+            b0["cgroupWritable"][gate]["enabled"].as_bool(),
+            Some(false),
+            "fbiy-C1 must not enable cgroupWritable.{gate} in the B0 fixture",
+        );
+    }
+}
+
+/// `M` must be readable from the live cluster and must exceed 1, or a cap
+/// strictly below it cannot exist.
+#[test]
+fn guard_the_c1_fixture_declares_a_pods_quota_that_admits_a_strict_cap() {
+    let c1 = yaml_at(GOVERNOR_VALUES);
+    let build_pods = c1["kueue"]["buildPods"]
+        .as_u64()
+        .expect("the C1 fixture declares kueue.buildPods");
+    assert!(
+        build_pods >= 2,
+        "M={build_pods}: a cap K < M with K >= 1 does not exist below M=2, and AC3 would measure \
+         nothing",
+    );
+    let chart_default = yaml_at("deploy/helm/djinn/values.yaml")["kueue"]["buildPods"].as_u64();
+    assert_ne!(
+        Some(build_pods),
+        chart_default,
+        "kueue.buildPods equals the chart default, so the live assertion would pass just as well \
+         against an install that never read this fixture",
+    );
+}
+
+/// The setup script must resolve the containerd namespace from the node, not
+/// from a literal.
+///
+/// Measured 2026-07-31: the kind node runs containerd **2.2.0** under a CRI
+/// configuration that declares **`version = 2`**, while the production VPS runs
+/// the v3 schema. A handler block written into the wrong plugin namespace is
+/// accepted by containerd and silently ignored — the RuntimeClass still
+/// resolves, the Pod is still admitted, and the sandbox comes up under plain
+/// `runc` with a read-only `/sys/fs/cgroup`. That failure is indistinguishable
+/// from a launcher bug at the point it surfaces.
+#[test]
+fn guard_the_setup_script_resolves_the_containerd_schema_from_the_live_node() {
+    let script = std::fs::read_to_string(repo_root().join(SETUP_SCRIPT))
+        .expect("read the setup script");
+    assert!(
+        script.contains("containerd-config-version.sh"),
+        "the script must source deploy/node/k3s/containerd-config-version.sh rather than \
+         reimplementing schema detection",
+    );
+    assert!(
+        script.contains("djinn_containerd_detect_version"),
+        "the script must call the detector against the node's LIVE configuration",
+    );
+    assert!(
+        script.contains("crictl info"),
+        "appending a table is not the same as containerd loading it; the script must verify the \
+         handler against what containerd PARSED",
+    );
+    // The two namespaces must appear nowhere as literals: both come from the
+    // detector, keyed on the version it resolved.
+    for namespace in ["io.containerd.grpc.v1.cri\".containerd.runtimes", "io.containerd.cri.v1.runtime'.containerd.runtimes"] {
+        assert!(
+            !script.contains(namespace),
+            "the script hardcodes the runtime table `{namespace}`; it must be derived from the \
+             live schema",
+        );
+    }
+}
+
+/// AC4, hermetic half: the rendered task-run Pod names the RuntimeClass and
+/// grants no cgroup-privileged capability to any container.
+///
+/// The non-vacuity is in the same test on purpose: [`privileged_capabilities`]
+/// is applied to a FIXTURE container carrying `SYS_ADMIN` and to another
+/// carrying `SYS_RESOURCE`, and must report both. A capability check that
+/// silently matched nothing would pass the real render and this file would be
+/// green while the contract was gone.
+#[test]
+fn guard_the_rendered_task_run_grants_no_cgroup_privileged_capability() {
+    let job = render_probe_job(&armed_config(PROBE_IMAGE), "harness-project").0;
+    let pod = job
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .expect("the renderer sets a PodSpec");
+    assert_eq!(
+        pod.runtime_class_name.as_deref(),
+        Some(TASK_RUN_CGROUP_RUNTIME_CLASS),
+        "an armed task-run Pod must name the writable-cgroup RuntimeClass",
+    );
+
+    let launcher = pod
+        .init_containers
+        .as_ref()
+        .and_then(|containers| {
+            containers
+                .iter()
+                .find(|container| container.name == LAUNCHER_CONTAINER_NAME)
+        })
+        .expect("the armed renderer emits the cgroup-launcher sidecar");
+    let worker = pod
+        .containers
+        .iter()
+        .find(|container| container.name == WORKER_CONTAINER_NAME)
+        .expect("the renderer emits the worker container");
+
+    for container in [launcher, worker] {
+        assert!(
+            privileged_capabilities(container).is_empty(),
+            "container {} grants {:?}; the launcher establishes nothing by mount and the worker \
+             establishes nothing at all",
+            container.name,
+            privileged_capabilities(container),
+        );
+    }
+    // The sidecar's positive contract, so "no privileged capability" cannot be
+    // satisfied by a render that grants none at all.
+    let granted: Vec<String> = launcher
+        .security_context
+        .as_ref()
+        .and_then(|context| context.capabilities.as_ref())
+        .and_then(|capabilities| capabilities.add.clone())
+        .unwrap_or_default();
+    assert_eq!(
+        granted,
+        RETAINED_CAPABILITY_NAMES
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect::<Vec<_>>(),
+        "the sidecar must hold exactly the launcher crate's retained set",
+    );
+
+    // Non-vacuity: the same predicate, against a container that HAS the
+    // capability.
+    for forbidden in ["SYS_ADMIN", "SYS_RESOURCE"] {
+        let mut mutated = launcher.clone();
+        let capabilities = mutated
+            .security_context
+            .as_mut()
+            .and_then(|context| context.capabilities.as_mut())
+            .expect("the sidecar declares capabilities");
+        capabilities
+            .add
+            .get_or_insert_with(Vec::new)
+            .push(forbidden.to_owned());
+        assert_eq!(
+            privileged_capabilities(&mutated),
+            vec![forbidden.to_owned()],
+            "the capability assertion must FIRE on a fixture build that adds {forbidden}",
+        );
+    }
+}
+
+/// The lifted quota this harness measures against must be the one the renderer
+/// derived from the Pod's own CPU limit, and it must actually be a lift.
+#[test]
+fn guard_the_rendered_quotas_are_a_real_multiplication() {
+    let (_, rendered) = rendered_quotas(&armed_config(PROBE_IMAGE));
+    assert_eq!(
+        u32::from(LAUNCHER_UNLEASED_MILLICORES),
+        u32::from(UnleasedQuota::DEFAULT_MILLICORES),
+        "the render's clamp must be the launcher crate's own default",
+    );
+    assert!(
+        rendered >= LeasedQuota::MIN_MILLICORES,
+        "a leased quota below {} is not a lift at all, and the launcher would refuse the config",
+        LeasedQuota::MIN_MILLICORES,
+    );
+    let ratio = u64::from(rendered) * 1_000 / u64::from(LAUNCHER_UNLEASED_MILLICORES);
+    assert!(
+        ratio >= REQUIRED_THROUGHPUT_MULTIPLE_MILLI,
+        "the rendered quotas differ by {ratio}/1000x, below the {REQUIRED_THROUGHPUT_MULTIPLE_MILLI}/1000x \
+         this file asserts on measured throughput; the assertion could never pass",
+    );
+}
+
+/// The throughput assertion must fail on a PINNED quota.
+///
+/// This is AC1's non-vacuity, in the lane that always runs: the live half pins
+/// the quota by hand (see the PR body), and this keeps the arithmetic that
+/// judges it honest in the meantime. A helper that returned "multiplied" for an
+/// unchanged rate would make the whole live measurement decorative.
+#[test]
+fn guard_an_unchanged_throughput_is_not_a_multiplication() {
+    assert!(throughput_multiple_milli(12_000, 96_000) >= REQUIRED_THROUGHPUT_MULTIPLE_MILLI);
+    // Pinned: same rate before and after.
+    assert!(throughput_multiple_milli(12_000, 12_000) < REQUIRED_THROUGHPUT_MULTIPLE_MILLI);
+    // Slightly better, but not a lift.
+    assert!(throughput_multiple_milli(12_000, 30_000) < REQUIRED_THROUGHPUT_MULTIPLE_MILLI);
+    // A clamp phase that produced nothing must not read as an infinite gain.
+    assert_eq!(throughput_multiple_milli(0, 96_000), 0);
+}
+
+// ===========================================================================
+// AC1 — born clamped, throttled there, lifted, and 3x faster for it
+// ===========================================================================
+
+/// A Pod the production renderer produced runs under the writable-cgroup
+/// RuntimeClass, is born at the configured clamp, ACCUMULATES throttling at it,
+/// transitions to the configured lifted quota on an authorized fence, and
+/// completes at least 3x the work per second afterwards.
+///
+/// Every number is read from somewhere that could disagree with the code:
+///
+/// * the clamp and the lifted quota come off the RENDERED sidecar env;
+/// * `cpu.max` is read out of the launcher container's own `/sys/fs/cgroup`,
+///   i.e. from the kernel, at three points — before the attempt, after it, and
+///   at the end;
+/// * `throttled_usec` comes from `cpu.stat` through the broker's own `sample`
+///   control, and is asserted to ADVANCE, not merely to be non-zero: a
+///   `cpu.max` write with no effect leaves it at 0, and a leaf that was never
+///   scheduled leaves it at 0 too;
+/// * throughput is completed `sha256sum` digests per second, counted from the
+///   child's own output.
+///
+/// Non-vacuity: pin the quota (render the leased millicores equal to the clamp)
+/// and the 3x assertion fails while everything else still passes — the
+/// transition, the fence and the RuntimeClass are all unchanged by it. The
+/// arithmetic that judges it is kept honest in the always-on lane by
+/// [`guard_an_unchanged_throughput_is_not_a_multiplication`].
+#[test]
+#[ignore]
+fn live_an_authorized_invocation_is_clamped_throttled_and_lifted_to_three_times_the_throughput() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+    clear_task_run_jobs(&context);
+    ensure_probe_image(&context);
+    let config = config_for(&context);
+    let (clamp_millicores, leased_millicores) = rendered_quotas(&config);
+
+    let probe = launch_probe(&context, &config, 0x5eed_c1a5_0000_0001, 12, 12);
+    eprintln!(
+        "AC1 pod={} uid={} invocation={}",
+        probe.pod, probe.pod_uid, probe.invocation
+    );
+
+    // The clamp, from the kernel, before anything is asked of the governor.
+    let log = await_probe_record(&context, &probe, "awaiting_decision");
+    let born = leaf_cpu_max(&context, &probe);
+    assert_eq!(
+        born,
+        cpu_max_line(clamp_millicores),
+        "the leaf must be born at the RENDERED clamp of {clamp_millicores}m",
+    );
+    let clamp_throttle_advances = phase_number(&log, "clamp", "throttle_advances");
+    let clamp_throttled = phase_number(&log, "clamp", "throttled_usec");
+    eprintln!(
+        "AC1 clamp: cpu.max={born} throttled_usec+={clamp_throttled} advances={clamp_throttle_advances} \
+         units={} rate_milli={}",
+        phase_number(&log, "clamp", "units"),
+        phase_number(&log, "clamp", "rate_milli"),
+    );
+    assert!(
+        clamp_throttle_advances >= 2,
+        "cpu.stat throttled_usec advanced {clamp_throttle_advances} time(s) at the clamp; a \
+         quota that is written but not enforced leaves it flat, and that is exactly the \
+         production defect a cpu.max read-back cannot see",
+    );
+    assert!(
+        clamp_throttled > 0,
+        "no throttling accumulated at the clamp",
+    );
+
+    // The governor decides. One Pod, so the cap is exercised in the AC3 test;
+    // here the point is that the fence the probe presents came from a real
+    // grant bound to this Pod's live UID.
+    let (_, authorized) = authorize(std::slice::from_ref(&probe.pod_uid), 2);
+    assert_eq!(
+        authorized,
+        vec![probe.pod_uid.clone()],
+        "the governor must authorize this Pod, or there is no lift to measure",
+    );
+    deliver_decision(&context, &probe, Some(probe.fence));
+
+    let log = await_probe_record(&context, &probe, "summary");
+    let lifted = leaf_cpu_max(&context, &probe);
+    assert_eq!(
+        probe_record(&log, "lift_attempt").get("result").map(String::as_str),
+        Some("accepted"),
+        "the broker refused an authorized lift:\n{log}",
+    );
+    assert_eq!(
+        lifted,
+        cpu_max_line(leased_millicores),
+        "the leaf must transition to the RENDERED leased quota of {leased_millicores}m",
+    );
+
+    let clamp_rate = phase_number(&log, "clamp", "rate_milli");
+    let post_rate = phase_number(&log, "post", "rate_milli");
+    let multiple = throughput_multiple_milli(clamp_rate, post_rate);
+    eprintln!(
+        "AC1 measured: cpu.max {born} -> {lifted}; digests/s {}/1000 -> {}/1000 = {multiple}/1000x",
+        clamp_rate, post_rate,
+    );
+    assert!(
+        multiple >= REQUIRED_THROUGHPUT_MULTIPLE_MILLI,
+        "the lift multiplied real throughput by only {multiple}/1000x ({clamp_rate}/1000 -> \
+         {post_rate}/1000 digests per second); the quota moved in the kernel but the work did \
+         not, which is what an ancestor clamp looks like",
+    );
+
+    delete_job(&context, &probe.job_name);
+}
+
+
+// ===========================================================================
+// AC2 — a wrong fence changes nothing
+// ===========================================================================
+
+/// A lift presenting a fence the invocation was not begun with is refused, and
+/// the clamp is BYTE-IDENTICAL before and after the attempt.
+///
+/// Non-vacuity: deliver the correct fence instead and the post-attempt read
+/// becomes the leased quota, so both assertions fail. That mutation is one
+/// argument away and is reported in the PR body.
+#[test]
+#[ignore]
+fn live_a_wrong_fence_lift_leaves_the_clamp_unchanged() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let context = harness_context();
+    clear_task_run_jobs(&context);
+    ensure_probe_image(&context);
+    let config = config_for(&context);
+    let (clamp_millicores, leased_millicores) = rendered_quotas(&config);
+    assert_ne!(
+        clamp_millicores, leased_millicores,
+        "with the two quotas equal, an accepted lift would be indistinguishable from a refused one",
+    );
+
+    let fence = 0x5eed_c1a5_0000_0002;
+    let probe = launch_probe(&context, &config, fence, 8, 8);
+    await_probe_record(&context, &probe, "awaiting_decision");
+
+    let before = leaf_cpu_max(&context, &probe);
+    assert_eq!(before, cpu_max_line(clamp_millicores));
+    // One bit off. Not a random value: a fence that differs minimally proves the
+    // comparison is an equality and not a range or a truthiness test.
+    deliver_decision(&context, &probe, Some(fence ^ 1));
+    let log = await_probe_record(&context, &probe, "lift_attempt");
+    let after = leaf_cpu_max(&context, &probe);
+
+    let attempt = probe_record(&log, "lift_attempt");
+    eprintln!(
+        "AC2 fence {fence} -> presented {}: {:?}; cpu.max {before} -> {after}",
+        fence ^ 1,
+        attempt,
+    );
+    assert_eq!(
+        attempt.get("result").map(String::as_str),
+        Some("refused"),
+        "the broker accepted a lift carrying the wrong fence:\n{log}",
+    );
+    // `Launcher::fenced_lift` returns `Error::FenceMismatch`; the broker maps it
+    // onto the wire as the LEGIBLE `ControlRejection::Fence` rather than the
+    // indistinguishable `InvalidControl` — which is the distinction goxi
+    // launcher blocker 14 was raised for, because "the broker refused the
+    // control" with no reason is what production saw for weeks. Asserting the
+    // wire form is asserting what the worker actually receives.
+    assert_eq!(
+        attempt.get("error").map(String::as_str),
+        Some("ControlRejected(Fence)"),
+        "the refusal must be the FENCE and must say so; an `InvalidControl` here would be the \
+         opaque refusal that hid the production defect: {attempt:?}",
+    );
+    assert_eq!(
+        after, before,
+        "the clamp moved across a refused lift: {before} -> {after}",
+    );
+
+    // And it stays refused: the leaf is still clamped at the end of the run,
+    // so nothing lifted it late.
+    let log = await_probe_record(&context, &probe, "summary");
+    assert_eq!(
+        leaf_cpu_max(&context, &probe),
+        before,
+        "the clamp moved after the refusal:\n{log}",
+    );
+    delete_job(&context, &probe.job_name);
+}


### PR DESCRIPTION
Closes the last live-cluster slice of epic `fbiy` (proposal 9oga): the invocation
governor's authorization path, measured end to end on a real armed-Kueue cluster
with a real writable-cgroup node.

## What was missing

`djinn-cgroup-launcher/tests/brokered_lease_lift_boundary.rs` proves the clamp,
the fence refusal and the lift through the real broker protocol — in ONE process
on a CI runner, on a delegated cgroup root the test prepared itself, with no
Kubernetes anywhere. `djinn-k8s/tests/kueue_disruption_governor.rs` (#2842)
proves the cap bound against a real PostgreSQL governor and live Pod UIDs — but
never lifts a quota: its Pods run `sleep`, on a cluster with no
`runc-cgroupwritable` handler, no RuntimeClass and `cgroupLauncher.mode:
disabled`.

Between those sat the claim nobody had measured: that a Pod the **production**
renderer produced, admitted by Kueue, scheduled onto a node carrying the
RuntimeClass handler, running the **shipped** launcher binary, is born at the
configured clamp, is actually throttled there, and moves to the configured
lifted quota when — and only when — the durable governor authorizes it.

## The harness gap, closed

`scripts/kind/setup-kueue-cluster.sh --cgroup-writable` (opt-in, default off so
every sibling harness's cluster stays byte-identical to what it was measured
against) now installs the `runc-cgroupwritable` containerd handler and the
`djinn.io/cgroup-writable=true` node label.

**Which containerd schema does the kind node actually run?** Measured, not
assumed:

```
$ docker run --rm --entrypoint /bin/sh kindest/node:v1.35.0 -c \
    'containerd --version; head -3 /etc/containerd/config.toml'
containerd github.com/containerd/containerd/v2 v2.2.0 1c4457e00facac03ce1d75f7b6777a7a851e5c41
# explicitly use v2 config format
version = 2
```

The **binary** is containerd 2.2.0 (which reads schema v3) but the node's live
CRI configuration declares **`version = 2`**, i.e. namespace
`io.containerd.grpc.v1.cri` — **not** the v3 schema the production VPS runs
(`deploy/node/k3s/containerd/config-v3.toml.tmpl`, pinned at containerd
2.2.3-k3s1). Copying the repo's production asset would have written the handler
into a table this node's config does not use; containerd accepts that silently,
the RuntimeClass still resolves, the Pod is still admitted, and the sandbox comes
up under plain `runc` with a **read-only** `/sys/fs/cgroup`. So the script
sources `deploy/node/k3s/containerd-config-version.sh` — the same detector the
managed-k3s conformance uses — resolves the table from the live file, and then
verifies against `crictl info` rather than trusting the append:

```
>>> node djinn-kueue-c1-control-plane runs containerd CRI config schema v2 (namespace io.containerd.grpc.v1.cri); appending handler runc-cgroupwritable
>>> node djinn-kueue-c1-control-plane: containerd reports the runc-cgroupwritable handler with a cgroup_writable property
>>> labelling node djinn-kueue-c1-control-plane djinn.io/cgroup-writable=true
```

It still installs **no RuntimeClass** — that object is the chart's, gated by
`cgroupWritable.runtimeClass.enabled` — so `deploy/kueue/preflight.sh --mode
cutover` still exits 10 against the B0 fixture (6knv's AC4). The arming triple
lives in a new C1-owned values file, and
`guard_the_arming_triple_is_in_the_c1_fixture_and_absent_from_the_b0_fixture`
fails if anyone ever moves it into the B0 one.

## What is production here, and what is substituted

* **Job** — `build_task_run_job`, unmodified. RuntimeClass name,
  `shareProcessNamespace`, both security contexts, the sidecar's
  command/env/capabilities and the absence of a sidecar CPU limit are all the
  renderer's.
* **Launcher** — the shipped `/opt/djinn/bin/djinn-cgroup-launcher` binary built
  out of this repository. Nothing stubbed.
* **Governor** — `InvocationLeaseAuthorityRepository` + `evaluate_invocation_lift`
  + `BuildLeaseRepository::grant_next` against real PostgreSQL, driven from live
  Pod UIDs, with `K` read *back* out of the durable row and `M` read off the live
  ClusterQueue.
* **Substituted: the worker container's `command`** — the single mutation, the
  same one `sleep_instead_of_the_worker` makes for the same reason. The
  replacement (`djinn-cgroup-launcher/examples/governor_probe.rs`) performs the
  byte-for-byte worker handshake, speaks the real `AUTH`/`READY`/`BEGIN`/
  `CREATE`/`OUTPUT`/`SAMPLE`/`LIFT` protocol, runs `/usr/bin/sha256sum` over a
  32MB file as its workload, and **decides nothing** — the fence it presents
  arrives in a file the harness writes *after* asking the real governor.
* **The one non-production seam**, stated plainly: production carries the
  verdict over the coordinator connection; this harness writes it in with
  `kubectl exec`. What it delivers is a fence, and the fence is judged by the
  launcher in the kernel. The harness can choose *who is asked* to lift; it can
  never decide whether the lift succeeds.

## Results — every AC, with the mutation that makes it fail

### AC1 — clamped, throttled, lifted, 3x

```
AC1 clamp: cpu.max=25000 100000 throttled_usec+=44302785 advances=119 units=23 rate_milli=1912
AC1 measured: cpu.max 25000 100000 -> 200000 100000; digests/s 1912/1000 -> 16798/1000 = 8785/1000x
```

`throttled_usec` is asserted to **advance** (119 times), not merely to be
non-zero — a `cpu.max` write with no effect leaves it flat, and so does a leaf
that was never scheduled. Throughput is completed `sha256sum` digests per second
counted from the child's own output, **8.79x**.

**Mutation** (`DJINN_MUTATE_ANCESTOR_CLAMP`): put a `limits.cpu: 250m` back on
the launcher sidecar — task 7deu defect 1, reproduced. The leaf's `cpu.max` still
transitions and every other assertion still passes:

```
AC1 clamp: cpu.max=25000 100000 throttled_usec+=24209295 advances=114 units=20 rate_milli=1658
AC1 measured: cpu.max 25000 100000 -> 200000 100000; digests/s 1658/1000 -> 2232/1000 = 1346/1000x
panicked: the lift multiplied real throughput by only 1346/1000x (1658/1000 -> 2232/1000 digests
per second); the quota moved in the kernel but the work did not, which is what an ancestor clamp
looks like
```

That is the whole point of asserting the effect rather than the written value:
`cpu.max` reads `200000 100000` in both runs.

Note: the *literal* "pin the quota" mutation (unleased == leased) is **refused by
the shipping launcher** — `LauncherConfig::new` returns
`Error::LeaseIsNotALift` and the sidecar exits before binding its socket, so the
probe reports `the launcher never accepted an authenticated connection`. A
fail-closed guard that already exists; the ancestor clamp is the reachable
version of the same failure.

### AC2 — a wrong fence changes nothing

```
AC2 fence 6840336323459416066 -> presented 6840336323459416067:
  {"attempted": "true", "error": "ControlRejected(Fence)", "fence": "...067", "result": "refused"};
  cpu.max 25000 100000 -> 25000 100000
```

One bit off, so the comparison is proved to be an equality rather than a range.
The refusal is the **legible** `ControlRejection::Fence`, not the
indistinguishable `InvalidControl` that hid the production defect behind goxi
launcher blocker 14.

**Mutation** (`DJINN_MUTATE_RIGHT_FENCE`): present the correct fence instead.

```
probe.lift_attempt attempted=true fence=6840336323459416066 result=accepted
panicked: the broker accepted a lift carrying the wrong fence
  left: Some("accepted")  right: Some("refused")
```

### AC3 — exactly K of M

```
AC3 M=4 (live ClusterQueue admittedWorkloads, pods nominalQuota 4)
AC3 live governor: K=3 (durable authority), authorized=[fbc5f3b0…, f9b96efe…, ddb167bb…]
AC3 pod=…-dldd4 uid=fbc5f3b0-… authorized=true  lift=accepted cpu.max=200000 100000
AC3 pod=…-l7mzz uid=f9b96efe-… authorized=true  lift=accepted cpu.max=200000 100000
AC3 pod=…-58pfk uid=ddb167bb-… authorized=true  lift=accepted cpu.max=200000 100000
AC3 pod=…-dspqp uid=83565d75-… authorized=false lift=refused  cpu.max=25000 100000
```

`M` is the live ClusterQueue's `admittedWorkloads`; `K` is `set_mode_and_cap` →
`read()` and only the **read-back** value is used. Every unauthorized invocation
still *attempts* a lift with a fence it was not granted — strictly stronger than
declining to ask, because it proves the kernel boundary refuses rather than that
the test stayed quiet.

**Mutation** (`DJINN_MUTATE_NO_CAP`): grant at `M` instead of the read-back `K`,
i.e. delete the cap comparison.

```
AC3 live governor: K=3 (durable authority), authorized=[…4 UIDs…]
panicked: the cap must be REACHED as well as respected: 4 of a possible K=3 were authorized
  left: 4  right: 3
```

### AC4 — no SYS_ADMIN, no SYS_RESOURCE, class intact

```
AC4 cgroup-launcher:          AC4 worker:
CapPrm: 00000000000001c1      CapPrm: 0000000000000000
CapEff: 00000000000001c1      CapEff: 0000000000000000
CapBnd: 00000000000001c1      CapBnd: 0000000000000000
```

`0x1c1` is exactly `CHOWN|SETGID|SETUID|SETPCAP` — the launcher crate's
`RETAINED_CAPABILITY_NAMES`, read from `/proc/self/status` in the *running*
containers, because a RuntimeClass handler or an admission webhook could add a
capability the manifest never mentioned. The live half also re-reads the
RuntimeClass (`handler: runc-cgroupwritable`, the node selector) and asserts the
admitted Pod still carries the class and the merged `nodeSelector`.

**Mutation** (`DJINN_MUTATE_SYS_ADMIN`): add the capability in a fixture build.

```
CapBnd: 00000000002001c1
panicked: container cgroup-launcher holds CAP_SYS_ADMIN in CapPrm (00000000002001c1);
the clamp is advisory for any process that can raise its own limits
```

The hermetic half carries the same non-vacuity permanently: it runs
`privileged_capabilities` against fixture containers built *with* `SYS_ADMIN` and
`SYS_RESOURCE` and requires it to report them, so the predicate cannot go green
by matching nothing.

## Full run

```
$ DJINN_TEST_KUEUE_CLUSTER=1 cargo test -p djinn-k8s \
    --test kueue_governor_conformance --test kueue_governor_cap -- --include-ignored --test-threads=1
test result: ok. 2 passed; 0 failed  (kueue_governor_cap:         AC3, AC4)
test result: ok. 9 passed; 0 failed  (kueue_governor_conformance: 7 guards, AC1, AC2)
```

Seven of those eleven are hermetic `guard_*` tests with **no** `#[ignore]`, so
they run in the ordinary `cargo test -p djinn-k8s` lane on every PR — same split
as `kueue_cluster_harness.rs`, and for the same reason: no CI lane runs the live
half, so anything that must not regress silently was put where it runs by
default.

## Findings

1. **kind node containerd: binary v2.2.0, config schema v2** — the two disagree,
   and the production VPS is on v3. Detected, not assumed.
2. **`LauncherConfig::new` fails closed on a non-lift** — a pinned quota is
   rejected at readiness (`Error::LeaseIsNotALift`) before the socket binds.
   Good; documented so nobody re-derives it.
3. **`safe_command_path` requires a `/workspace` cwd** — a brokered command
   cannot run anywhere else, and the coarse `InvalidCommand` gives no hint. Cost
   one debug cycle.
4. **The chart's ClusterQueue now admits its own renderer's Jobs** — `#2841`'s
   `namespaceSelector: {}` + cpu/memory `coveredResources` landed;
   `repair_cluster_queue_for_admission` was not needed on this cluster at all.
5. **`app.kubernetes.io/component=task-run` matches no task-run Job** — the
   renderer emits `djinn.app/component=task-run-worker`. A cleanup selector on
   the former deletes nothing and the *next* run fails with "no Pod reached
   Running": a `pods`-quota exhaustion wearing the costume of a scheduling bug.

## Safety

Disposable kind cluster only, on names disjoint from every sibling harness
(`djinn-kueue-c1` / `djinn-kueue-c1-registry` / port 5061), with `--context`
pinned on every `kubectl` and `helm` call. Cluster and registry deleted on the
way out and the deletion proved:

```
PASS: cluster djinn-kueue-c1 and registry djinn-kueue-c1-registry are gone
$ kind get clusters
No kind clusters found.
```

Production was never armed and no EKS context was ever selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
