### PR TITLE
feat(cutover): fenced launcher-authority activation and blocked rollback, and the first production caller of list_nonterminal_resize (eeky)

### DIFF
--- a/deploy/preflight/tests/task-run-resize-rollout.sh
+++ b/deploy/preflight/tests/task-run-resize-rollout.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# The retention arm of the launcher-authority cutover, against a REAL registry.
+#
+# WHY THIS EXISTS
+# ---------------
+# `ResizeRollout::probe_retention` (task `eeky`) proves a retained rollback
+# digest is still pullable by fetching its manifest and hashing the bytes it
+# gets back. The Rust suite drives that over a real socket against an
+# in-process OCI-manifest endpoint, which settles the *logic*. What it cannot
+# settle is whether a real registry — content-type negotiation, the
+# `Docker-Content-Digest` header, `manifests/<digest>` addressing, a 404 after a
+# delete — behaves the way the probe assumes.
+#
+# So this suite stands up a disposable `registry:2`, pushes a real image,
+# resolves its real manifest digest, and asserts three things:
+#
+#   1. a retained digest fetched from the registry hashes to itself;
+#   2. deleting the manifest — and NOTHING else — turns the check red;
+#   3. a digest that was never pushed is red from the start.
+#
+# (2) is the mutation the criterion names. No catalog row and no `pullable`
+# column is touched by it, because the check never reads one: there is nothing
+# in this path a stored flag could satisfy.
+#
+# ISOLATION
+# ---------
+# Several agents share this machine and a kind cluster with its own registry is
+# frequently running. This suite therefore binds its OWN container name and its
+# OWN port, both overridable, and deletes the container on exit whether the run
+# passed or failed. It never touches a registry it did not create.
+#
+# USAGE
+#   bash deploy/preflight/tests/task-run-resize-rollout.sh
+#
+# OVERRIDES
+#   REG_NAME  container name              (default djinn-eeky-retention-reg)
+#   REG_PORT  host port for the registry  (default 5099)
+#   SKIP_IF_NO_DOCKER=1  exit 0 instead of failing when docker is unavailable
+set -euo pipefail
+
+REG_NAME="${REG_NAME:-djinn-eeky-retention-reg}"
+REG_PORT="${REG_PORT:-5099}"
+REG_HOST="127.0.0.1:${REG_PORT}"
+REPO_PATH="djinn-eeky/retained"
+
+pass=0
+fail=0
+
+ok()   { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '  FAIL  %s\n' "$1" >&2; fail=$((fail + 1)); }
+note() { printf '        %s\n' "$1"; }
+
+cleanup() {
+  # Pass or fail, the registry goes. `|| true` so a cleanup failure never masks
+  # the verdict.
+  docker rm -f "$REG_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if ! command -v docker >/dev/null 2>&1; then
+  if [ "${SKIP_IF_NO_DOCKER:-0}" = "1" ]; then
+    printf 'SKIP: docker is unavailable and SKIP_IF_NO_DOCKER=1\n'
+    exit 0
+  fi
+  printf 'FAIL: docker is required to stand up a disposable registry\n' >&2
+  exit 1
+fi
+
+# Disk first. Pulling `registry:2` and pushing a layer onto a full filesystem
+# fails in ways that read like a retention defect, and this repository has lost
+# hours to exactly that misreading before.
+avail_kb="$(df -Pk / | awk 'NR==2 {print $4}')"
+printf 'disk: %s KiB available on /\n' "$avail_kb"
+if [ "$avail_kb" -lt 2097152 ]; then
+  printf 'FAIL: less than 2 GiB free on /; refusing to pull images\n' >&2
+  exit 1
+fi
+
+# Refuse to reuse someone else's registry on this port.
+if docker ps --format '{{.Names}} {{.Ports}}' | grep -v "^${REG_NAME} " | grep -q ":${REG_PORT}->"; then
+  printf 'FAIL: port %s is already published by another container; set REG_PORT\n' "$REG_PORT" >&2
+  docker ps --format '  {{.Names}} {{.Ports}}' >&2
+  exit 1
+fi
+
+printf 'starting disposable registry %s on %s\n' "$REG_NAME" "$REG_HOST"
+docker rm -f "$REG_NAME" >/dev/null 2>&1 || true
+docker run -d --rm \
+  --name "$REG_NAME" \
+  -p "127.0.0.1:${REG_PORT}:5000" \
+  -e REGISTRY_STORAGE_DELETE_ENABLED=true \
+  registry:2 >/dev/null
+
+for _ in $(seq 1 60); do
+  if curl -fsS "http://${REG_HOST}/v2/" >/dev/null 2>&1; then break; fi
+  sleep 0.5
+done
+curl -fsS "http://${REG_HOST}/v2/" >/dev/null || {
+  printf 'FAIL: the disposable registry never became ready\n' >&2
+  exit 1
+}
+
+# ── push a real artifact and resolve its real manifest digest ───────────────
+
+work="$(mktemp -d)"
+trap 'cleanup; rm -rf "$work"' EXIT
+printf 'FROM scratch\nCOPY marker /marker\n' >"$work/Dockerfile"
+printf 'eeky retention fixture\n' >"$work/marker"
+docker build -q -t "${REG_HOST}/${REPO_PATH}:v1" "$work" >/dev/null
+docker push -q "${REG_HOST}/${REPO_PATH}:v1" >/dev/null
+
+ACCEPT='application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+
+# The digest the registry itself reports for the tag. Everything below is
+# addressed by this digest, never by the tag: a tag is mutable naming and the
+# cutover grants compatibility to exact digests only.
+digest="$(curl -fsS -D- -o /dev/null \
+  -H "Accept: ${ACCEPT}" \
+  "http://${REG_HOST}/v2/${REPO_PATH}/manifests/v1" \
+  | tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" {print $2}')"
+
+if [ -z "$digest" ]; then
+  printf 'FAIL: the registry reported no Docker-Content-Digest for the pushed tag\n' >&2
+  exit 1
+fi
+note "retained digest: $digest"
+
+# ── the check under test, in shell ──────────────────────────────────────────
+#
+# Mirrors `probe_retention`: GET the manifest by digest, hash the BODY, compare
+# to the recorded digest. The header is used only to discover what to retain;
+# the verdict comes from the bytes.
+probe_retention() {
+  local reference="$1" body status observed
+  body="$(mktemp)"
+  status="$(curl -sS -o "$body" -w '%{http_code}' \
+    -H "Accept: ${ACCEPT}" \
+    "http://${REG_HOST}/v2/${REPO_PATH}/manifests/${reference}")"
+  if [ "$status" != "200" ]; then
+    rm -f "$body"
+    printf 'unpullable: HTTP %s\n' "$status"
+    return 1
+  fi
+  observed="sha256:$(sha256sum "$body" | awk '{print $1}')"
+  rm -f "$body"
+  if [ "$observed" != "$reference" ]; then
+    printf 'digest mismatch: served %s\n' "$observed"
+    return 1
+  fi
+  printf 'retained\n'
+  return 0
+}
+
+# 1. The positive control. Without this, (2) below would be indistinguishable
+#    from a check that is red for everything.
+if probe_retention "$digest" >/dev/null; then
+  ok "a pushed manifest fetched by digest hashes to its own digest"
+else
+  bad "the positive control failed; the rest of this suite proves nothing"
+fi
+
+# 3. A digest that was never pushed. Same code path, no registry mutation.
+absent="sha256:$(printf 'never pushed' | sha256sum | awk '{print $1}')"
+if probe_retention "$absent" >/dev/null 2>&1; then
+  bad "a digest that was never pushed must not be reported as retained"
+else
+  ok "a digest that was never pushed is refused"
+fi
+
+# 2. THE MUTATION. Delete the manifest from the registry and change nothing
+#    else — no catalog row, no column, no flag.
+delete_status="$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+  "http://${REG_HOST}/v2/${REPO_PATH}/manifests/${digest}")"
+case "$delete_status" in
+  202|200) note "manifest deleted (HTTP $delete_status)" ;;
+  *)
+    bad "could not delete the manifest (HTTP $delete_status); the mutation did not run"
+    ;;
+esac
+
+if [ "$delete_status" = "202" ] || [ "$delete_status" = "200" ]; then
+  if reason="$(probe_retention "$digest" 2>&1)"; then
+    bad "deleting the manifest left the retention check green: $reason"
+  else
+    ok "deleting the manifest turns the retention check red ($reason)"
+  fi
+fi
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/docs/deploy/launcher-authority-cutover.md
+++ b/docs/deploy/launcher-authority-cutover.md
@@ -1,0 +1,179 @@
+# Launcher authority cutover: `leaf-v1` → `resize-v2`, and back
+
+Operator runbook for proposal `3i92`, epic `xowm`, task `eeky`.
+
+Per-project images are built independently of the server and cannot be swapped
+atomically by Helm. Moving the component that owns a build's CPU quota is
+therefore not a deploy — it is an ordered sequence over a live catalog, and its
+reverse has to be able to refuse itself.
+
+> **This document is not the enforcement.** The ordering below is enforced by
+> `ResizeRollout` in `server/src/task_run_resize_rollout.rs`: every step
+> declares the steps that must already have run, the journal records only steps
+> that actually completed, and calling the flip before the drain proof returns
+> `StepOutOfOrder`. If this file and that module ever disagree, the module is
+> right. What this file adds is the *operator* half — what you run, what you
+> retain, and what to do when it blocks.
+
+---
+
+## The two authorities
+
+| mode | who writes a build's CPU quota |
+|---|---|
+| `leaf-v1` | `djinn-cgroup-launcher` writes each invocation leaf's `cpu.max`. The launcher sidecar carries **no** container CPU limit — one there is an ancestor clamp over every leaf (task `7deu` measured a 4-core leaf burning 0.25). |
+| `resize-v2` | Kubernetes in-place Pod resize owns the launcher sidecar's `limits.cpu`. The launcher must never write leaf `cpu.max`. |
+
+There is no mode admitting both writers and none admitting neither. A running
+Pod's authority is fixed when its image was built and its identity captured, so
+flipping the mode under a live Pod does not migrate it — it strands it. That is
+why every flip is drain-fenced.
+
+The mode lives in one durable singleton row (`launcher_authority_mode`,
+migration 167), seeded at `leaf-v1`. An **absent** row is not a default: every
+caller fails closed.
+
+---
+
+## What you need before you start
+
+1. **The signed legacy digest inventory.** Every dispatch-eligible image that
+   declares no protocol must be listed, by immutable `sha256:` digest, in a
+   document signed with the deployment's Ed25519 key.
+
+   Build the candidate list from the catalog itself, never by hand:
+   `ImageRepository::legacy_pre_protocol_digests()` returns exactly the `ready`,
+   digest-pinned, no-handshake rows, ordered by id so the document is
+   byte-reproducible and therefore its signature is.
+
+   ```json
+   {
+     "schema_version": 1,
+     "issuer": "platform-ops",
+     "issued_at": "2026-07-31T00:00:00Z",
+     "digests": ["sha256:<64 lowercase hex>", "..."]
+   }
+   ```
+
+   Configure it:
+
+   | variable | meaning |
+   |---|---|
+   | `DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY` | path to the document |
+   | `DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_PUBLIC_KEY` | base64 raw Ed25519 public key (32 bytes) |
+   | `DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_SIGNATURE` | base64 Ed25519 signature (64 bytes) over the document's **exact bytes** |
+
+   A mutable tag (`image:latest`) in `digests` is rejected at load. So is one
+   flipped signature bit, one altered character of a listed digest, and a
+   document signed by any key other than the configured one. An *unsigned*
+   inventory is a legitimate dispatch-time state — it keeps an already-built
+   catalog from being stranded by a missing config file — but it never
+   authorizes a cutover.
+
+2. **The retained set.** For each artifact you intend to be able to run
+   afterwards — the `resize-v2` images you are activating, the `leaf-v1` images
+   you would roll back to, and every allowlisted no-handshake digest — record
+   the registry repository path and the immutable digest. Retention is proven by
+   fetching the manifest and hashing the bytes; nothing in the check reads a
+   stored column, so a `pullable` flag in your own tooling proves nothing here.
+
+3. **The authority epoch.** Read it first; every flip is a compare-and-swap
+   against it, so a second operator moving the mode under you is a conflict, not
+   a silent overwrite.
+
+---
+
+## Forward activation
+
+Run in this order. The driver refuses any other.
+
+| # | step | what actually has to be true |
+|---|---|---|
+| 1 | **Freeze catalog mutation** | The old server is still live and still serving. Freezing first is what stops the inventory going stale between signing and use. |
+| 2 | **Sign and load the legacy inventory** | The signature verifies over the document's exact bytes **and** the verified digest set covers every dispatch-eligible no-handshake row. A signed document that omits a live row would otherwise produce a green cutover and a refused dispatch afterwards. |
+| 3 | **Deploy the protocol-aware server and the `pods/resize` RBAC** | Authority mode is **still `leaf-v1`**. The deploy is only safe because authority has not moved; finding `resize-v2` here means someone flipped ahead of the sequence. |
+| 4 | **Rebuild and catalog images as `resize-v2`** | Every dispatch-eligible image declares `resize-v2` explicitly. Legacy and `leaf-v1` rollback digests are **retained**, not deleted. `resize-v2` images may be cataloged now; they do not dispatch while the mode is `leaf-v1`, and refusing them is the correct behaviour, not a defect. |
+| 5 | **Verify retention** | Every retained digest is fetched from the registry and its content hashes to the recorded digest. |
+| 6 | **Pause admission** | The pause is written **and then disbelieved**: a probe dispatch is issued through the same path a task run takes and must be refused. A pause row with no wired refusal blocks the cutover here rather than passing it. |
+| 7 | **Prove the drain** | **Zero live task-run Pods** and **zero nonterminal resize/lease rows**. Both. See below. |
+| 8 | **Flip the mode** | Compare-and-swap at the expected epoch, behind `set_mode`'s own transactional fence, which holds the `build_pod_permit_pools` row lock admission takes before it inserts. |
+| 9 | **Resume admission** | Only after a confirmed flip. Resuming earlier is `StepOutOfOrder`. |
+
+## Rollback
+
+Same shape from step 5 onward, targeting `leaf-v1`, with the allowlist check
+moved to the front — because under `leaf-v1` the no-handshake artifacts
+dispatch, and they dispatch only because the signed inventory vouches for them.
+
+1. Load the signed allowlist.
+2. Verify retention of every `leaf-v1`/legacy digest.
+3. Validate the catalog against `leaf-v1`.
+4. Pause admission (proven by a refused dispatch).
+5. Prove the drain.
+6. Flip to `leaf-v1`.
+7. Resume admission.
+
+**Rollback is blocked, and admission is left paused, when any of the first three
+fail.** Concretely: the signed allowlist file is absent; a retained digest is no
+longer pullable; a catalog row has been repointed to a digest the signed
+document does not vouch for. In each case the mode does not move, admission is
+not resumed, and no Pod is started. Do not "unblock" it by relaxing a check —
+restore the artifact or re-sign the inventory.
+
+---
+
+## The drain proof is two checks, and both are load-bearing
+
+```
+zero live task-run Pods   AND   zero nonterminal resize/lease rows
+```
+
+* **Nonterminal rows** come from `BuildPodPermitRepository::list_nonterminal_resize`,
+  backed by `build_pod_permits_resize_nonterminal_idx` (migration 164). The six
+  states are `birth_confirmed`, `lift_applying`, `lifted`, `drop_required`,
+  `drop_applying`, `quarantined` — each means a Pod that may still be lifted or
+  still owes a drop. The block names the **task-run ids and states**, not a
+  count, because that is what you need at 03:00.
+* **Live Pods** come from enumerating the apiserver. PostgreSQL cannot see a Pod
+  whose permit was released, or that outlived its permit through a crash, and
+  flipping under one strands it.
+
+`set_mode` re-counts under its own lock and refuses again. That second fence is
+not a substitute for the first: it reports counts, and it is blind to Pods.
+
+### When the drain will not go empty
+
+* A permit stuck in `drop_required`/`quarantined` is a Pod that owes a quota
+  drop. Resolve the run; do not force the mode.
+* A live Pod with no permit row is the crash-survivor case. Terminate it by
+  UID-fenced delete and re-run the proof.
+* An **unavailable** apiserver or an **unreadable** permit relation is never
+  read as drained — both block, and both mean "come back when it answers".
+
+---
+
+## Preflight
+
+```bash
+# Retention, against a disposable registry:2 (isolated name and port, deleted
+# on exit pass or fail).
+bash deploy/preflight/tests/task-run-resize-rollout.sh
+
+# The workflow itself, against real PostgreSQL.
+cd server && cargo test -p djinn-server --test task_run_resize_rollout
+cd server && cargo test -p djinn-db  --test image_legacy_digest_allowlist
+```
+
+---
+
+## What this cutover must never do
+
+* Reintroduce a **blanket launcher CPU limit**. The ceiling render is
+  `resize-v2`-only. Under `leaf-v1` a container limit on the launcher throttles
+  every invocation leaf beneath it.
+* Delete or disable `djinn-cgroup-launcher`, the process broker, the
+  RuntimeClass/node assets, the credential-boundary tests, the broker mounts,
+  `cgroup.kill`, or `wait_empty`. None of them is part of this transition.
+* Grant compatibility to a **tag**. Only exact immutable digests are ever
+  compared; `djinn-image-controller` has a fixture whose repository segment and
+  tag suffix both read `resize-v2` for an artifact that declares `leaf-v1`.

--- a/server/crates/djinn-db/src/repositories/image.rs
+++ b/server/crates/djinn-db/src/repositories/image.rs
@@ -16,6 +16,9 @@ use sqlx::Row;
 
 use crate::Result;
 use crate::database::Database;
+use crate::launcher_compatibility::{
+    InventoryFault, InventoryProvenance, LegacyDigestInventory, PreProtocolDigest,
+};
 
 /// Image build lifecycle states (mirror `ProjectImageStatus`).
 pub struct ImageStatus;
@@ -499,7 +502,154 @@ impl ImageRepository {
         }
         Ok(out)
     }
+
+    /// Resolve the deployment's **signed** pre-protocol digest inventory against
+    /// the catalog rows that actually need it.
+    ///
+    /// This is the accessor the operational cutover (`eeky`) loads the legacy
+    /// allowlist through. It differs from
+    /// [`LegacyDigestInventory::from_signed_document`] in exactly one way, and
+    /// the difference is the point: **an unsigned inventory is not an
+    /// inventory.** [`LegacyDigestInventory::Unconfigured`] is a legitimate
+    /// *dispatch-time* state (see the `launcher_compatibility` module docs — it
+    /// keeps an already-built catalog from being stranded by a missing config
+    /// file), but it can never authorize a mode flip: a cutover that proceeds
+    /// on an unconfigured inventory has proven nothing about which artifacts
+    /// are compatible. So [`LegacyAllowlistDefect::Unsigned`] refuses it here
+    /// while dispatch keeps its unarmed behaviour.
+    ///
+    /// # There is no `signed: true` to read
+    ///
+    /// [`SignedLegacyAllowlist`] carries no signature, no `signed` flag and no
+    /// `verified` boolean, deliberately. The only way to obtain one is to hand
+    /// this method a [`LegacyDigestInventory::Verified`], and the only way to
+    /// obtain *that* is
+    /// [`LegacyDigestInventory::from_signed_document`](crate::LegacyDigestInventory::from_signed_document)
+    /// completing an Ed25519 verification over the document's exact bytes. A
+    /// test that asserts "the allowlist has a non-empty signature field" cannot
+    /// be written against this type at all, which is the intended shape: the
+    /// assertion available is that a tampered document does not produce a value.
+    ///
+    /// # Errors
+    ///
+    /// * [`LegacyAllowlistDefect::Unsigned`] — no inventory configured.
+    /// * [`LegacyAllowlistDefect::Unusable`] — configured but its provenance,
+    ///   signature, schema or digest entries did not validate.
+    /// * [`LegacyAllowlistDefect::Uninventoried`] — the catalog holds
+    ///   dispatch-eligible no-handshake images the signed document does not
+    ///   vouch for. Those would be refused at admission, so the cutover is
+    ///   blocked before it pauses anything.
+    /// * [`LegacyAllowlistDefect::Storage`] — the catalog could not be read.
+    ///   Never reported as an empty catalog.
+    pub async fn signed_legacy_digest_allowlist(
+        &self,
+        inventory: &LegacyDigestInventory,
+    ) -> std::result::Result<SignedLegacyAllowlist, LegacyAllowlistDefect> {
+        let (provenance, digests) = match inventory {
+            LegacyDigestInventory::Unconfigured => {
+                return Err(LegacyAllowlistDefect::Unsigned);
+            }
+            LegacyDigestInventory::Unusable(fault) => {
+                return Err(LegacyAllowlistDefect::Unusable(fault.clone()));
+            }
+            LegacyDigestInventory::Verified {
+                provenance,
+                digests,
+            } => (provenance.clone(), digests.clone()),
+        };
+
+        let candidates = self
+            .legacy_pre_protocol_digests()
+            .await
+            .map_err(|error| LegacyAllowlistDefect::Storage(error.to_string()))?;
+
+        let mut inventoried = Vec::new();
+        let mut uninventoried = Vec::new();
+        for candidate in candidates {
+            // Parse rather than string-compare. `legacy_pre_protocol_digests`
+            // returns the raw column on purpose, so a row holding a mutable tag
+            // is visible here — and lands in `uninventoried`, never silently
+            // dropped.
+            match PreProtocolDigest::parse(&candidate.registry_digest) {
+                Ok(digest) if digests.contains(&digest) => inventoried.push(candidate),
+                Ok(_) | Err(_) => uninventoried.push(candidate),
+            }
+        }
+        if !uninventoried.is_empty() {
+            return Err(LegacyAllowlistDefect::Uninventoried(uninventoried));
+        }
+
+        Ok(SignedLegacyAllowlist {
+            provenance,
+            digests,
+            inventoried,
+        })
+    }
 }
+
+/// A signature-verified pre-protocol allowlist that covers every no-handshake
+/// row the catalog can still dispatch.
+///
+/// Constructible only through
+/// [`ImageRepository::signed_legacy_digest_allowlist`], so holding one is
+/// itself the proof — there is no field to assert on instead.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignedLegacyAllowlist {
+    /// Who issued the verified document, for the cutover record.
+    pub provenance: InventoryProvenance,
+    /// Every digest the signed document vouches for. Immutable by construction:
+    /// [`PreProtocolDigest`] only parses `sha256:` + 64 lowercase hex.
+    pub digests: std::collections::BTreeSet<PreProtocolDigest>,
+    /// The catalog rows this allowlist covers, in `images.id` order.
+    pub inventoried: Vec<PreProtocolImage>,
+}
+
+/// Why a deployment's legacy allowlist may not authorize a cutover.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LegacyAllowlistDefect {
+    /// No inventory is configured. Unarmed is a dispatch state, never a
+    /// cutover authorization.
+    Unsigned,
+    /// The configured inventory failed its own provenance/signature/schema
+    /// validation. Carried verbatim so the operator sees which check refused.
+    Unusable(InventoryFault),
+    /// Dispatch-eligible no-handshake rows the signed document does not cover.
+    Uninventoried(Vec<PreProtocolImage>),
+    /// The catalog could not be read. Never an empty catalog.
+    Storage(String),
+}
+
+impl std::fmt::Display for LegacyAllowlistDefect {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unsigned => write!(
+                formatter,
+                "no signed pre-protocol digest inventory is configured; an unsigned allowlist \
+                 never authorizes a launcher authority cutover"
+            ),
+            Self::Unusable(fault) => write!(
+                formatter,
+                "the configured pre-protocol digest inventory is unusable: {fault}"
+            ),
+            Self::Uninventoried(images) => write!(
+                formatter,
+                "{} dispatch-eligible no-handshake catalog image(s) are not vouched for by the \
+                 signed inventory: {}",
+                images.len(),
+                images
+                    .iter()
+                    .map(|image| format!("{} ({})", image.image_id, image.registry_digest))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Self::Storage(error) => {
+                write!(formatter, "the image catalog could not be read: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LegacyAllowlistDefect {}
 
 #[cfg(test)]
 mod tests {

--- a/server/crates/djinn-db/tests/image_legacy_digest_allowlist.rs
+++ b/server/crates/djinn-db/tests/image_legacy_digest_allowlist.rs
@@ -78,7 +78,8 @@ async fn load(
     public_key: &str,
     signature: &str,
 ) -> Result<djinn_db::repositories::image::SignedLegacyAllowlist, LegacyAllowlistDefect> {
-    let inventory = LegacyDigestInventory::from_signed_document(doc, Some(public_key), Some(signature));
+    let inventory =
+        LegacyDigestInventory::from_signed_document(doc, Some(public_key), Some(signature));
     repo.signed_legacy_digest_allowlist(&inventory).await
 }
 

--- a/server/crates/djinn-db/tests/image_legacy_digest_allowlist.rs
+++ b/server/crates/djinn-db/tests/image_legacy_digest_allowlist.rs
@@ -1,0 +1,359 @@
+//! The signed, immutable legacy-digest allowlist, loaded the way the cutover
+//! loads it — against real PostgreSQL (task `eeky`, epic `xowm`).
+//!
+//! # What is actually being proven
+//!
+//! Not "the allowlist has a signature". [`SignedLegacyAllowlist`] has no
+//! signature field, no `signed` flag and no `verified` boolean to read, so that
+//! assertion is unwritable here by construction. What is proven is that the
+//! four tamperings below each **fail to produce a value at all**:
+//!
+//! 1. an entry in mutable-tag form (`image:latest`) is rejected at load;
+//! 2. one flipped bit of the signature is rejected;
+//! 3. one altered character of an allowlisted digest is rejected;
+//! 4. a document signed by a key other than the deployment key is rejected.
+//!
+//! Each is asserted from a *positive control* in the same test — the untampered
+//! document loads — so a load path that rejected everything unconditionally
+//! could not pass either.
+//!
+//! # Why real Postgres
+//!
+//! [`ImageRepository::signed_legacy_digest_allowlist`] does not just verify a
+//! document: it cross-checks the verified digest set against the catalog rows
+//! that would actually dispatch without a handshake
+//! (`legacy_pre_protocol_digests`, whose predicate is `status = 'ready' AND
+//! launcher_authority_protocol IS NULL AND registry_digest IS NOT NULL`). That
+//! predicate is a property of the `images` relation and migration 166's
+//! `images_declared_protocol_requires_digest_check`. A fake repository holds
+//! any predicate you like, and would prove none of it.
+//!
+//! `Database::ephemeral()` clones the migrated test template; it is a real
+//! PostgreSQL database, not an in-memory stand-in.
+
+use djinn_db::launcher_compatibility::{InventoryFault, InventoryProvenance};
+use djinn_db::repositories::image::LegacyAllowlistDefect;
+use djinn_db::{Database, ImageRepository, LegacyDigestInventory, PreProtocolDigest};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use ring::signature::KeyPair as _;
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+/// A canonical immutable manifest digest: `sha256:` + 64 lowercase hex.
+fn digest(seed: char) -> String {
+    format!("sha256:{}", seed.to_string().repeat(64))
+}
+
+fn b64(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// The deployment's signing key. A second call yields a *different* key, which
+/// is what mutation 4 uses as the attacker's key.
+fn signing_key() -> ring::signature::Ed25519KeyPair {
+    let rng = ring::rand::SystemRandom::new();
+    let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap()
+}
+
+/// The inventory document naming `entries`, serialized to the exact bytes that
+/// get signed. Signing covers these bytes, so any later edit — including a
+/// single character inside one digest — invalidates the signature.
+fn document(entries: &[String]) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1,
+        "issuer": "platform-ops",
+        "issued_at": "2026-07-31T00:00:00Z",
+        "digests": entries,
+    }))
+    .unwrap()
+}
+
+/// Load a document exactly as the deployment does: verify it against the
+/// deployment public key and signature, then resolve it against the catalog.
+async fn load(
+    repo: &ImageRepository,
+    doc: &[u8],
+    public_key: &str,
+    signature: &str,
+) -> Result<djinn_db::repositories::image::SignedLegacyAllowlist, LegacyAllowlistDefect> {
+    let inventory = LegacyDigestInventory::from_signed_document(doc, Some(public_key), Some(signature));
+    repo.signed_legacy_digest_allowlist(&inventory).await
+}
+
+/// Seed a `ready`, digest-pinned, no-handshake catalog row — the exact
+/// population the allowlist exists to vouch for.
+async fn seed_no_handshake_image(db: &Database, id: &str, digest: &str) {
+    let repo = ImageRepository::new(db.clone());
+    repo.create(id, id, None, "{}").await.unwrap();
+    repo.mark_ready(id, &format!("reg/{id}:tag"), Some(digest), None)
+        .await
+        .unwrap();
+}
+
+// ── the four mutations ──────────────────────────────────────────────────────
+
+/// Positive control plus the four tamperings, in one test so the control and
+/// the mutations share a catalog. If the load path were broken open the control
+/// would still pass and every mutation would fail; if it were broken closed the
+/// control would fail. Both directions are therefore covered.
+#[tokio::test]
+async fn the_signed_allowlist_rejects_tags_tampering_and_a_foreign_key() {
+    let db = Database::ephemeral().await.unwrap();
+    let repo = ImageRepository::new(db.clone());
+    seed_no_handshake_image(&db, "legacy-a", &digest('a')).await;
+
+    let key = signing_key();
+    let public_key = b64(key.public_key().as_ref());
+    let doc = document(&[digest('a')]);
+    let signature = b64(key.sign(&doc).as_ref());
+
+    // Positive control: the untampered, correctly signed document loads and
+    // covers the seeded row.
+    let allowlist = load(&repo, &doc, &public_key, &signature)
+        .await
+        .expect("a correctly signed document over an inventoried catalog must load");
+    assert_eq!(
+        allowlist.digests,
+        [PreProtocolDigest::parse(&digest('a')).unwrap()]
+            .into_iter()
+            .collect()
+    );
+    assert_eq!(
+        allowlist
+            .inventoried
+            .iter()
+            .map(|image| image.image_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["legacy-a"]
+    );
+    assert_eq!(
+        allowlist.provenance,
+        InventoryProvenance {
+            issuer: "platform-ops".into(),
+            issued_at: "2026-07-31T00:00:00Z".into(),
+        }
+    );
+
+    // MUTATION 1 — a mutable tag in the allowlist. Signed correctly; refused
+    // for what it names, not for how it was signed.
+    let tag_doc = document(&["djinn-image-legacy-a:latest".to_owned()]);
+    let tag_signature = b64(key.sign(&tag_doc).as_ref());
+    assert!(
+        matches!(
+            load(&repo, &tag_doc, &public_key, &tag_signature).await,
+            Err(LegacyAllowlistDefect::Unusable(
+                InventoryFault::DigestMalformed(_)
+            ))
+        ),
+        "a mutable-tag entry must be rejected at load even under a valid signature"
+    );
+
+    // MUTATION 2 — one flipped bit of the signature.
+    let mut raw_signature = key.sign(&doc).as_ref().to_vec();
+    raw_signature[0] ^= 0b0000_0001;
+    assert_eq!(
+        load(&repo, &doc, &public_key, &b64(&raw_signature)).await,
+        Err(LegacyAllowlistDefect::Unusable(
+            InventoryFault::SignatureInvalid
+        )),
+        "one flipped signature bit must be rejected"
+    );
+
+    // MUTATION 3 — one altered character inside an allowlisted digest, with the
+    // ORIGINAL signature. This is the substitution a registry-level attacker
+    // wants: the document still parses, still lists a canonical digest, and
+    // still carries a signature that verified a moment ago.
+    let mut altered = digest('a');
+    altered.replace_range(7..8, "b");
+    assert_ne!(altered, digest('a'));
+    assert!(
+        PreProtocolDigest::parse(&altered).is_ok(),
+        "the altered digest must still be canonical, or this mutation would be \
+         caught by shape validation instead of by the signature"
+    );
+    assert_eq!(
+        load(&repo, &document(&[altered]), &public_key, &signature).await,
+        Err(LegacyAllowlistDefect::Unusable(
+            InventoryFault::SignatureInvalid
+        )),
+        "altering one character of an allowlisted digest must be rejected"
+    );
+
+    // MUTATION 4 — signed by a key that is not the deployment key. The document
+    // is byte-identical to the control and its signature is internally
+    // consistent; only the issuing key differs.
+    let attacker = signing_key();
+    let attacker_signature = b64(attacker.sign(&doc).as_ref());
+    assert_ne!(public_key, b64(attacker.public_key().as_ref()));
+    assert_eq!(
+        load(&repo, &doc, &public_key, &attacker_signature).await,
+        Err(LegacyAllowlistDefect::Unusable(
+            InventoryFault::SignatureInvalid
+        )),
+        "a document signed by a key other than the deployment key must be rejected"
+    );
+
+    // …and the attacker's own key does not rescue it either: the deployment
+    // pins the key, so a self-consistent (document, key, signature) triple from
+    // somewhere else is still not this deployment's allowlist. Verified by
+    // showing the triple IS self-consistent and would load under the attacker's
+    // key, which is precisely why pinning is what refuses it.
+    assert!(
+        load(
+            &repo,
+            &doc,
+            &b64(attacker.public_key().as_ref()),
+            &attacker_signature
+        )
+        .await
+        .is_ok(),
+        "the attacker's triple is self-consistent; only the pinned deployment \
+         key distinguishes it, which is the property under test"
+    );
+}
+
+/// An unsigned (unconfigured) inventory is a legitimate *dispatch* state and
+/// must never authorize a cutover.
+///
+/// This is the one place the cutover is deliberately stricter than admission:
+/// `launcher_compatibility` treats `Unconfigured` as unarmed so a missing
+/// config file cannot strand an already-built catalog, and this method refuses
+/// it so an operator cannot flip authority having proven nothing.
+#[tokio::test]
+async fn an_unsigned_inventory_never_authorizes_a_cutover() {
+    let db = Database::ephemeral().await.unwrap();
+    let repo = ImageRepository::new(db.clone());
+    seed_no_handshake_image(&db, "legacy-a", &digest('a')).await;
+
+    assert_eq!(
+        repo.signed_legacy_digest_allowlist(&LegacyDigestInventory::Unconfigured)
+            .await,
+        Err(LegacyAllowlistDefect::Unsigned)
+    );
+
+    // The very same catalog under a *signed* inventory loads, so the refusal
+    // above is caused by the missing signature and not by the catalog.
+    let key = signing_key();
+    let doc = document(&[digest('a')]);
+    assert!(
+        load(
+            &repo,
+            &doc,
+            &b64(key.public_key().as_ref()),
+            &b64(key.sign(&doc).as_ref())
+        )
+        .await
+        .is_ok()
+    );
+}
+
+/// A no-handshake row the signed document does not name blocks the load, and
+/// the defect names the exact row so an operator can act on it.
+///
+/// This is the arm that makes the allowlist an *inventory* rather than a
+/// wishlist: signing a document that omits a live dispatch-eligible image would
+/// otherwise produce a green cutover and a refused dispatch afterwards.
+#[tokio::test]
+async fn an_uninventoried_no_handshake_row_blocks_the_load() {
+    let db = Database::ephemeral().await.unwrap();
+    let repo = ImageRepository::new(db.clone());
+    seed_no_handshake_image(&db, "legacy-a", &digest('a')).await;
+    seed_no_handshake_image(&db, "legacy-b", &digest('b')).await;
+
+    let key = signing_key();
+    let public_key = b64(key.public_key().as_ref());
+    let partial = document(&[digest('a')]);
+    let partial_signature = b64(key.sign(&partial).as_ref());
+
+    let Err(LegacyAllowlistDefect::Uninventoried(missing)) =
+        load(&repo, &partial, &public_key, &partial_signature).await
+    else {
+        panic!("an uninventoried dispatch-eligible row must block the load");
+    };
+    assert_eq!(
+        missing
+            .iter()
+            .map(|image| image.image_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["legacy-b"],
+        "the defect must name the exact rows, not merely report a count"
+    );
+
+    // Adding the missing digest to the signed document resolves it. Same
+    // catalog, same key: the only change is the document's contents.
+    let full = document(&[digest('a'), digest('b')]);
+    let full_signature = b64(key.sign(&full).as_ref());
+    let allowlist = load(&repo, &full, &public_key, &full_signature)
+        .await
+        .unwrap();
+    assert_eq!(allowlist.inventoried.len(), 2);
+}
+
+/// A declaring image is not part of the legacy population at all, and a
+/// digest-less row cannot be vouched for by any allowlist.
+///
+/// Both facts are properties of the `images` relation, which is why this runs
+/// against real Postgres: the first is `launcher_authority_protocol IS NULL` in
+/// the production predicate, and the second is migration 166's
+/// `images_declared_protocol_requires_digest_check` refusing the write.
+#[tokio::test]
+async fn declaring_and_digestless_rows_are_outside_the_legacy_population() {
+    let db = Database::ephemeral().await.unwrap();
+    let repo = ImageRepository::new(db.clone());
+    seed_no_handshake_image(&db, "legacy-a", &digest('a')).await;
+
+    // A resize-v2 declaring row with a digest: dispatch-eligible, but it speaks
+    // for itself and needs no allowlist entry.
+    repo.create("modern", "modern", None, "{}").await.unwrap();
+    repo.mark_ready(
+        "modern",
+        "reg/modern:tag",
+        Some(&digest('c')),
+        Some(LauncherAuthorityProtocol::ResizeV2),
+    )
+    .await
+    .unwrap();
+
+    // A digest-less no-handshake row: `legacy_pre_protocol_digests` excludes it
+    // because there is no immutable identity to vouch for.
+    repo.create("digestless", "digestless", None, "{}")
+        .await
+        .unwrap();
+    repo.mark_ready("digestless", "reg/digestless:tag", None, None)
+        .await
+        .unwrap();
+
+    let key = signing_key();
+    let doc = document(&[digest('a')]);
+    let allowlist = load(
+        &repo,
+        &doc,
+        &b64(key.public_key().as_ref()),
+        &b64(key.sign(&doc).as_ref()),
+    )
+    .await
+    .expect("a declaring row and a digestless row are not uninventoried legacy rows");
+    assert_eq!(
+        allowlist
+            .inventoried
+            .iter()
+            .map(|image| image.image_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["legacy-a"]
+    );
+
+    // And the declaring row could not have been written without its digest, so
+    // "declares a protocol but cannot be pinned" is not a reachable state.
+    assert!(
+        repo.mark_ready(
+            "digestless",
+            "reg/digestless:tag",
+            None,
+            Some(LauncherAuthorityProtocol::ResizeV2)
+        )
+        .await
+        .is_err()
+    );
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod server;
 pub mod server_memory;
 pub mod sse;
 pub mod task_run_resize_bootstrap;
+pub mod task_run_resize_rollout;
 
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_helpers;

--- a/server/src/task_run_resize_rollout.rs
+++ b/server/src/task_run_resize_rollout.rs
@@ -1266,6 +1266,131 @@ impl AdmissionControl for DurableAdmissionControl {
     }
 }
 
+/// The task-run Pod plane, bound to a live apiserver.
+///
+/// Composed entirely from production `djinn-k8s` entry points — the same Job
+/// lister the reapers use and the same [`TaskRunPodResizeSurface`] the resize
+/// bootstrap drives. It introduces no Kubernetes primitive of its own and does
+/// not name a `kube` type, so the cutover cannot drift from what dispatch and
+/// bootstrap already observe.
+///
+/// # Why it cannot create a Pod
+///
+/// [`Self::create_task_run_pod`] refuses, always. The cutover's only dispatch
+/// is the probe [`ResizeRollout::pause_admission`] issues to disbelieve its own
+/// pause, and a probe that materialised a real task-run Pod would be a worse
+/// bug than the one it is checking for. The refusal is also a second fence: if
+/// the pause predicate were ever broken open, the probe would still create
+/// nothing, and `pause_admission` would still block the cutover — with
+/// [`RolloutBlocked::AdmissionPauseIneffective`], because a probe that was not
+/// refused *by the pause* is a probe the pause did not stop.
+///
+/// Real task-run Pod creation belongs to the coordinator's `SessionRuntime`
+/// path and is deliberately not reachable from here.
+pub struct KubernetesTaskRunPodPlane {
+    runtime: std::sync::Arc<djinn_k8s::runtime::KubernetesRuntime>,
+    surface: djinn_k8s::runtime::TaskRunPodResizeSurface,
+}
+
+impl KubernetesTaskRunPodPlane {
+    /// Bind to a live runtime, reusing its client and configured namespace.
+    #[must_use]
+    pub fn new(runtime: std::sync::Arc<djinn_k8s::runtime::KubernetesRuntime>) -> Self {
+        let surface = djinn_k8s::runtime::TaskRunPodResizeSurface::from_runtime(&runtime);
+        Self { runtime, surface }
+    }
+}
+
+#[async_trait]
+impl TaskRunPodPlane for KubernetesTaskRunPodPlane {
+    async fn create_task_run_pod(&self, task_run_id: &str, _image_id: &str) -> Result<(), String> {
+        Err(format!(
+            "the authority cutover never creates task-run Pods; refusing to materialise one for \
+             {task_run_id}"
+        ))
+    }
+
+    async fn resize_launcher_cpu(&self, task_run_id: &str, millicores: u64) -> Result<(), String> {
+        let observed = self
+            .surface
+            .observe_launcher(task_run_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| format!("no Pod exists for task run {task_run_id}"))?;
+        self.surface
+            .resize_launcher_cpu(&observed.pod_name, millicores)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    /// Every task-run Job in the namespace, resolved to the Pod it currently
+    /// has.
+    ///
+    /// A Job with no Pod contributes nothing; a Job whose Pod read *fails*
+    /// aborts the whole census. That asymmetry is deliberate: "this Job has no
+    /// Pod right now" is an observation, and "the apiserver did not answer" is
+    /// not an observation of zero Pods.
+    async fn live_task_run_pods(&self) -> Result<Vec<LiveTaskRunPod>, String> {
+        let jobs = self
+            .runtime
+            .list_taskrun_jobs()
+            .await
+            .map_err(|error| format!("listing task-run Jobs: {error}"))?;
+        let mut live = Vec::new();
+        for job in jobs {
+            match self.surface.observe_launcher(&job.task_run_id).await {
+                Ok(Some(observed)) => live.push(LiveTaskRunPod {
+                    pod_name: observed.pod_name,
+                    pod_uid: observed.pod_uid,
+                    task_run_id: job.task_run_id,
+                }),
+                Ok(None) => {}
+                Err(error) => {
+                    return Err(format!(
+                        "reading the Pod for task run {}: {error}",
+                        job.task_run_id
+                    ));
+                }
+            }
+        }
+        Ok(live)
+    }
+}
+
+impl ResizeRollout {
+    /// **The production composition site.**
+    ///
+    /// Every seam gets its real implementation: the durable dispatch-pause
+    /// state and the coordinator's own refusal predicate, the live apiserver,
+    /// and an HTTP registry. The three repositories are built from `db` inside
+    /// [`Self::new`] and cannot be passed in.
+    ///
+    /// Nothing here is conditional, feature-gated or test-only. A cutover
+    /// driven through this constructor is the same code path the tests drive,
+    /// with the two seams that need a cluster and a registry pointed at a real
+    /// cluster and a real registry.
+    #[must_use]
+    pub fn production(
+        db: Database,
+        events: djinn_core::events::EventBus,
+        runtime: std::sync::Arc<djinn_k8s::runtime::KubernetesRuntime>,
+        registry_base_url: &str,
+        paused_by: &str,
+    ) -> Self {
+        Self::new(
+            db.clone(),
+            // Read from the deployment's environment at process start. A
+            // restart re-reads the document; nothing re-reads it in-process,
+            // because an allowlist that can change under a running cutover is
+            // not an allowlist.
+            LegacyDigestInventory::process().clone(),
+            std::sync::Arc::new(DurableAdmissionControl::new(db, events, paused_by)),
+            std::sync::Arc::new(KubernetesTaskRunPodPlane::new(runtime)),
+            std::sync::Arc::new(HttpRegistryProbe::new(registry_base_url)),
+        )
+    }
+}
+
 /// A registry probe over plain HTTP(S), speaking the OCI distribution manifest
 /// API.
 ///

--- a/server/src/task_run_resize_rollout.rs
+++ b/server/src/task_run_resize_rollout.rs
@@ -1,0 +1,1325 @@
+//! The fenced operational cutover between launcher quota authorities, and its
+//! reverse (task `eeky`, epic `xowm`, proposal `3i92`).
+//!
+//! Per-project images are built independently of the server and cannot be
+//! swapped atomically by Helm. So the transition from `leaf-v1` (the launcher
+//! writes each invocation leaf's `cpu.max`) to `resize-v2` (Kubernetes owns the
+//! launcher sidecar's `limits.cpu`) is not a deploy — it is an ordered,
+//! interruptible sequence over a live catalog, with a reverse that must be able
+//! to refuse itself.
+//!
+//! # What this module adds, and what it only composes
+//!
+//! It adds no new SQL, no new Kubernetes primitive and no second copy of any
+//! decision. It composes:
+//!
+//! * `vf7a` — [`LegacyDigestInventory`] and
+//!   [`ImageRepository::signed_legacy_digest_allowlist`], the signed immutable
+//!   allowlist.
+//! * `z3gi` — [`LauncherAuthorityModeRepository::set_mode`], the transactional
+//!   drain fence that holds the `build_pod_permit_pools` lock while it counts.
+//! * `4acu` — [`BuildPodPermitRepository::list_nonterminal_resize`], the
+//!   restart-readable view of every permit that still owes a lift, a drop or a
+//!   quarantine decision. **Before this module that method had no production
+//!   caller.** It has one now, and [`ResizeRollout::prove_drained`] is it.
+//! * `#2836` — [`decide_admission`], the one place a missing protocol
+//!   declaration can become an effective quota authority.
+//!
+//! # Why the drain proof is two checks and not one
+//!
+//! [`LauncherAuthorityModeRepository::set_mode`] already refuses a flip while
+//! any permit row is live, and it does so unraceably. It is nevertheless not
+//! sufficient, for two independent reasons:
+//!
+//! 1. **PostgreSQL cannot see a Pod.** A task-run Pod whose permit was released
+//!    — or that outlived its permit through a crash — is invisible to every
+//!    count `set_mode` can take. Flipping under one strands it: a `leaf-v1` Pod
+//!    under `resize-v2` authority has a launcher that already wrote its leaf
+//!    quota and a server that believes Kubernetes owns it. So
+//!    [`TaskRunPodPlane::live_task_run_pods`] is enumerated too, and a
+//!    non-empty answer blocks the flip before `set_mode` is ever called.
+//! 2. **A census is not a diagnostic.** `set_mode`'s refusal reports *counts*.
+//!    An operator staring at a blocked cutover at 03:00 needs the task-run ids
+//!    and lifecycle states, which is exactly what `list_nonterminal_resize`
+//!    returns and nothing else does.
+//!
+//! The two are not redundant and neither substitutes for the other: this module
+//! blocks with [`RolloutBlocked::NonterminalResizeRows`] (rows, named) where
+//! `set_mode` would block with [`RolloutBlocked::AuthorityDrainRefused`]
+//! (counts). If the `list_nonterminal_resize` call were deleted, a seeded
+//! nonterminal row would still block the flip — but with the *other* variant
+//! and no row identities, which is what the tests assert on.
+//!
+//! # Ordering is enforced, not documented
+//!
+//! Every step is a method, every method declares the steps that must already
+//! have run, and [`ResizeRollout::journal`] records what actually happened.
+//! Calling the flip before the drain proof, or resuming admission before the
+//! flip is confirmed, returns [`RolloutBlocked::StepOutOfOrder`] — it does not
+//! merely violate a runbook. The journal is the assertion surface: a test reads
+//! the observed sequence, not a checklist.
+//!
+//! # There is no state with two quota authorities, or none
+//!
+//! [`ResizeRollout::attempt_dispatch`] is the single admission path this module
+//! exposes, and it resolves exactly one authority per dispatch through
+//! [`decide_admission`]. A `resize-v2` image under `leaf-v1` mode is refused
+//! before any Pod is created; a `leaf-v1` (or allowlisted no-handshake) Pod is
+//! never handed to [`TaskRunPodPlane::resize_launcher_cpu`], so the count of
+//! resize PATCHes against it is structurally zero rather than merely intended
+//! to be.
+//!
+//! # What this module deliberately does not touch
+//!
+//! It renders nothing. In particular it does not reintroduce a blanket launcher
+//! CPU limit: the `resize-v2`-only ceiling in
+//! `djinn_k8s::launcher::render_authority_protocol` is read through the
+//! bootstrap that already owns it (`task_run_resize_bootstrap`) and is not
+//! re-decided here. Under `leaf-v1` a container limit on the launcher is an
+//! ancestor clamp over every invocation leaf — task `7deu` measured a 4-core
+//! leaf burning 0.25 — and nothing in this file can produce one.
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use djinn_db::launcher_compatibility::{
+    AdmissionDecision, AdmissionRejection, LegacyDigestInventory, PreProtocolDigest,
+};
+use djinn_db::repositories::image::{LegacyAllowlistDefect, SignedLegacyAllowlist};
+use djinn_db::{
+    BuildPodPermitRepository, BuildPodPermitRow, Database, Image, ImageRepository,
+    LauncherAuthorityDrainCensus, LauncherAuthorityModeRepository, SetLauncherAuthorityModeResult,
+    decide_admission,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use sha2::{Digest as _, Sha256};
+use tracing::{info, warn};
+
+/// The CPU limit a `resize-v2` launcher sidecar is downsized to at birth.
+///
+/// Restated from [`crate::task_run_resize_bootstrap::BIRTH_CPU_MILLICORES`]
+/// rather than re-derived, so a dispatch issued through this module and one
+/// issued through bootstrap target the same value.
+pub use crate::task_run_resize_bootstrap::BIRTH_CPU_MILLICORES;
+
+// ── steps and the journal ───────────────────────────────────────────────────
+
+/// One observable step of the cutover.
+///
+/// The forward sequence is the proposal's five steps expanded to the points
+/// that are individually provable; the reverse re-uses the last five. Variants
+/// are ordered as they must occur.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RolloutStep {
+    /// Catalog mutation is frozen while the old server is still live, so the
+    /// inventory that gets signed cannot go stale between signing and use.
+    CatalogMutationFrozen,
+    /// The signed immutable legacy-digest inventory is loaded and covers every
+    /// dispatch-eligible no-handshake row.
+    LegacyInventorySigned,
+    /// The protocol-aware server and the namespaced `pods/resize` RBAC are
+    /// deployed **with authority mode still `leaf-v1`**.
+    ProtocolAwareServerDeployed,
+    /// Images are rebuilt and cataloged as `resize-v2`, while the immutable
+    /// legacy digests and the `leaf-v1` rollback digests are retained.
+    CatalogRebuiltAsResizeV2,
+    /// Every retained rollback digest was fetched from the registry and its
+    /// content digest matched what the catalog records.
+    RetentionVerified,
+    /// Admission is paused. Proven by a refused dispatch, not by a row.
+    AdmissionPaused,
+    /// Zero live task-run Pods and zero nonterminal resize/lease rows.
+    DrainProven,
+    /// The authority mode compare-and-swap committed behind its own fence.
+    AuthorityModeFlipped,
+    /// Admission is resumed. Only reachable after a confirmed flip.
+    AdmissionResumed,
+}
+
+impl RolloutStep {
+    /// The steps that must already have run before this one may.
+    ///
+    /// This is the ordering itself, in one place. `AdmissionResumed` requires
+    /// `AuthorityModeFlipped` and `AuthorityModeFlipped` requires `DrainProven`
+    /// — the two reorderings the cutover has to make impossible.
+    const fn prerequisites(self) -> &'static [Self] {
+        match self {
+            Self::CatalogMutationFrozen => &[],
+            Self::LegacyInventorySigned => &[Self::CatalogMutationFrozen],
+            Self::ProtocolAwareServerDeployed => &[Self::LegacyInventorySigned],
+            Self::CatalogRebuiltAsResizeV2 => &[Self::ProtocolAwareServerDeployed],
+            // Retention is provable on its own evidence: the rollback path runs
+            // it first, with no forward step behind it.
+            Self::RetentionVerified => &[],
+            Self::AdmissionPaused => &[Self::RetentionVerified],
+            Self::DrainProven => &[Self::AdmissionPaused],
+            Self::AuthorityModeFlipped => &[Self::AdmissionPaused, Self::DrainProven],
+            Self::AdmissionResumed => &[Self::AuthorityModeFlipped],
+        }
+    }
+}
+
+// ── blocking outcomes ───────────────────────────────────────────────────────
+
+/// One nonterminal resize/lease row, named.
+///
+/// Projected from [`BuildPodPermitRow`] so a blocked operator reads task-run
+/// ids and lifecycle states rather than a count.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NonterminalResizeRow {
+    /// `build_pod_permits.task_run_id`.
+    pub task_run_id: String,
+    /// The durable lifecycle state, as `migration 164` spells it.
+    pub state: String,
+    /// The captured Pod UID, when an identity exists.
+    pub pod_uid: Option<String>,
+}
+
+impl From<&BuildPodPermitRow> for NonterminalResizeRow {
+    fn from(row: &BuildPodPermitRow) -> Self {
+        Self {
+            task_run_id: row.task_run_id.clone(),
+            state: format!("{:?}", row.state),
+            pod_uid: row
+                .resize_identity
+                .as_ref()
+                .map(|identity| identity.pod_uid.clone()),
+        }
+    }
+}
+
+/// A task-run Pod the apiserver still holds.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiveTaskRunPod {
+    /// `metadata.name`.
+    pub pod_name: String,
+    /// The immutable `metadata.uid` the fence would be taken against.
+    pub pod_uid: String,
+    /// The task run it carries, from the `djinn.app/task-run-id` label.
+    pub task_run_id: String,
+}
+
+/// Why the cutover stopped. **No variant means "proceeded anyway".**
+///
+/// Every variant leaves the authority mode unchanged and admission in whatever
+/// state the previous step left it — which, for every variant reachable after
+/// [`RolloutStep::AdmissionPaused`], is paused.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum RolloutBlocked {
+    /// A step ran before one of its prerequisites.
+    #[error("step {step:?} requires {missing:?}, which has not run")]
+    StepOutOfOrder {
+        /// The step that was attempted.
+        step: RolloutStep,
+        /// The first missing prerequisite.
+        missing: RolloutStep,
+    },
+    /// A step ran twice. A cutover is not idempotent by replay.
+    #[error("step {0:?} has already run")]
+    StepAlreadyRun(RolloutStep),
+    /// The signed allowlist is absent, unusable, or does not cover the catalog.
+    #[error("the signed legacy digest allowlist is unavailable: {0}")]
+    AllowlistUnavailable(LegacyAllowlistDefect),
+    /// A retained digest could not be proven pullable, or the registry returned
+    /// content whose digest is not the recorded one.
+    #[error("retained artifact {digest} is not provably retained: {detail}")]
+    RetentionUnprovable {
+        /// The digest the catalog records.
+        digest: String,
+        /// What the registry round trip actually reported.
+        detail: String,
+    },
+    /// Dispatch-eligible catalog rows disagree with the authority mode.
+    #[error("{} dispatch-eligible catalog image(s) are incompatible with the authority mode", .0.len())]
+    CatalogIncompatible(Vec<CatalogDefect>),
+    /// Task-run Pods are still live. PostgreSQL cannot see these.
+    #[error("{} task-run Pod(s) are still live", .0.len())]
+    LiveTaskRunPods(Vec<LiveTaskRunPod>),
+    /// Permits still owe a resize/lease decision, named individually.
+    #[error("{} permit(s) are in a nonterminal resize state", .0.len())]
+    NonterminalResizeRows(Vec<NonterminalResizeRow>),
+    /// The apiserver could not be enumerated. Never read as zero Pods.
+    #[error("the task-run Pod census is unavailable: {0}")]
+    PodCensusUnavailable(String),
+    /// The permit relation could not be read. Never read as zero rows.
+    #[error("the build pod permit relation is unavailable: {0}")]
+    PermitsUnavailable(String),
+    /// `set_mode`'s own transactional fence refused, reporting counts.
+    ///
+    /// Reaching this variant means the two checks above passed and the fenced
+    /// count still found something — a row that appeared between the unlocked
+    /// census and the locked one. It is not the variant a seeded nonterminal
+    /// row produces.
+    #[error("the authority drain fence refused the flip: {census:?}")]
+    AuthorityDrainRefused {
+        /// The fenced per-dimension counts.
+        census: LauncherAuthorityDrainCensus,
+    },
+    /// The authority singleton could not be read or written.
+    #[error("the launcher authority mode is unavailable")]
+    AuthorityUnavailable,
+    /// The authority singleton is absent. Never a default mode.
+    #[error("the launcher authority mode singleton is unseeded")]
+    AuthorityUninitialized,
+    /// Another operator moved the epoch under this cutover.
+    #[error("the authority mode epoch moved to {epoch} under this cutover")]
+    AuthorityEpochConflict {
+        /// The epoch the durable row actually holds.
+        epoch: i64,
+    },
+    /// The durable authority mode is not the one this step requires.
+    #[error("the authority mode is {found} but this step requires {expected}")]
+    AuthorityModeUnexpected {
+        /// What the step requires.
+        expected: LauncherAuthorityProtocol,
+        /// What the singleton actually holds.
+        found: LauncherAuthorityProtocol,
+    },
+    /// A same-mode replay. A cutover that did not move the mode did not run.
+    #[error("the authority mode was already {0}; this cutover moved nothing")]
+    AuthorityModeUnchanged(LauncherAuthorityProtocol),
+    /// Admission control could not be reached. A pause that cannot be proven is
+    /// not a pause.
+    #[error("admission control is unavailable: {0}")]
+    AdmissionUnavailable(String),
+    /// The pause was written but a dispatch attempt was still admitted.
+    ///
+    /// This is the assertion the pause step makes on itself: it does not read
+    /// back the row it wrote, it dispatches and requires a refusal.
+    #[error("admission was paused but a dispatch attempt was still admitted")]
+    AdmissionPauseIneffective,
+}
+
+/// One dispatch-eligible catalog row that may not run under the mode.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CatalogDefect {
+    /// `images.id`.
+    pub image_id: String,
+    /// Why.
+    pub reason: CatalogDefectReason,
+}
+
+/// Why a catalog row may not dispatch under the resolved authority mode.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum CatalogDefectReason {
+    /// The artifact declares no protocol AND carries no immutable digest, so
+    /// there is no compatibility claim to evaluate. The render refuses it.
+    #[error("the artifact declares no protocol and carries no immutable digest")]
+    Undeclarable,
+    /// The stored declaration is not one of the two wire forms.
+    ///
+    /// Reached by parsing into [`LauncherAuthorityProtocol`], never by
+    /// comparing wire strings: a `==` against `"resize-v2"` would let
+    /// `resize-v3` through as "not resize-v2, therefore leaf".
+    #[error("the artifact declares {declared:?}, which is not a launcher authority protocol")]
+    UnparseableDeclaration {
+        /// The offending stored value.
+        declared: String,
+    },
+    /// [`decide_admission`] refused it. Carried verbatim so there is exactly one
+    /// vocabulary for "this artifact may not run here".
+    #[error("{0}")]
+    Rejected(AdmissionRejection),
+}
+
+/// What a dispatch-eligible catalog row resolves to under the mode.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CatalogVerdict {
+    /// The artifact declared a protocol and it is exactly the authority mode.
+    Declared(LauncherAuthorityProtocol),
+    /// The artifact declared nothing, is pinned to an immutable digest the
+    /// signed inventory vouches for, and the mode is `leaf-v1`. Effective
+    /// authority is launcher leaf authority.
+    LegacyLeafAuthority(PreProtocolDigest),
+}
+
+impl CatalogVerdict {
+    /// The single effective quota authority for a dispatch of this artifact.
+    #[must_use]
+    pub const fn authority(&self) -> LauncherAuthorityProtocol {
+        match self {
+            Self::Declared(protocol) => *protocol,
+            // A no-handshake artifact is only ever admitted under `leaf-v1`
+            // (`decide_admission` refuses it under `resize-v2` even when the
+            // inventory vouches for it), so this is the mode, not a default.
+            Self::LegacyLeafAuthority(_) => LauncherAuthorityProtocol::LeafV1,
+        }
+    }
+}
+
+/// **The catalog compatibility decision for one image, against one mode.**
+///
+/// Pure, so the whole matrix is exhaustible without a database, and so the two
+/// mutations the criterion names are each one edit away from visible:
+///
+/// * dropping `mode` from the comparison would admit an allowlisted
+///   no-handshake artifact under `resize-v2`, which
+///   [`decide_admission`] refuses precisely because `resize-v2` is not the
+///   behaviour that artifact was built against;
+/// * comparing wire strings instead of the enum would read `resize-v3` as
+///   "not `resize-v2`", i.e. as leaf authority. Parsing refuses it instead.
+///
+/// # Errors
+///
+/// [`CatalogDefectReason`] — the artifact may not dispatch under `mode`.
+pub fn classify_catalog_image(
+    mode: LauncherAuthorityProtocol,
+    image: &Image,
+    inventory: &LegacyDigestInventory,
+) -> Result<CatalogVerdict, CatalogDefectReason> {
+    // Parse, never compare. `declared_launcher_protocol` routes through
+    // `LauncherAuthorityProtocol::from_str`, which has no fallback arm.
+    let declared = image.declared_launcher_protocol().map_err(|error| {
+        CatalogDefectReason::UnparseableDeclaration {
+            declared: error.input().to_owned(),
+        }
+    })?;
+
+    match decide_admission(
+        mode,
+        declared,
+        image.registry_digest.as_deref(),
+        inventory,
+    ) {
+        Ok(AdmissionDecision::Admitted(protocol)) => match declared {
+            Some(_) => Ok(CatalogVerdict::Declared(protocol)),
+            None => {
+                // Admitted with no declaration means the legacy arm fired, and
+                // that arm only fires on a canonical digest under `leaf-v1`.
+                let raw = image.registry_digest.as_deref().unwrap_or_default();
+                PreProtocolDigest::parse(raw)
+                    .map(CatalogVerdict::LegacyLeafAuthority)
+                    .map_err(|malformed| {
+                        CatalogDefectReason::Rejected(AdmissionRejection::MalformedDigest(malformed))
+                    })
+            }
+        },
+        Ok(AdmissionDecision::Undeclarable) => Err(CatalogDefectReason::Undeclarable),
+        Err(rejection) => Err(CatalogDefectReason::Rejected(rejection)),
+    }
+}
+
+// ── seams ───────────────────────────────────────────────────────────────────
+
+/// Administrative admission control, and the production predicate that answers
+/// whether dispatch is currently refused.
+///
+/// [`Self::dispatch_is_paused`] deliberately does not return the pause record.
+/// The cutover never asserts on a stored row: it asks the same question the
+/// dispatch loop asks, and the pause step below proves the answer by attempting
+/// a dispatch.
+#[async_trait]
+pub trait AdmissionControl: Send + Sync {
+    /// Pause global dispatch.
+    ///
+    /// # Errors
+    ///
+    /// The durable write failed. Never reported as paused.
+    async fn pause(&self, reason: &str) -> Result<(), String>;
+
+    /// Resume global dispatch.
+    ///
+    /// # Errors
+    ///
+    /// The durable write failed.
+    async fn resume(&self) -> Result<(), String>;
+
+    /// Evaluate the production dispatch-pause predicate over freshly loaded
+    /// durable state.
+    ///
+    /// # Errors
+    ///
+    /// The state could not be loaded. Never reported as "not paused".
+    async fn dispatch_is_paused(&self) -> Result<bool, String>;
+}
+
+/// The task-run Pod plane: what creates Pods, what resizes them, and what can
+/// enumerate the ones that are live.
+#[async_trait]
+pub trait TaskRunPodPlane: Send + Sync {
+    /// Create the task-run Pod for `task_run_id` from catalog image `image_id`.
+    ///
+    /// # Errors
+    ///
+    /// The rendered apiserver failure.
+    async fn create_task_run_pod(&self, task_run_id: &str, image_id: &str) -> Result<(), String>;
+
+    /// One limits-only `pods/resize` PATCH against the launcher sidecar.
+    ///
+    /// Only ever called for a dispatch whose resolved authority is
+    /// `resize-v2`.
+    ///
+    /// # Errors
+    ///
+    /// The rendered apiserver failure.
+    async fn resize_launcher_cpu(&self, task_run_id: &str, millicores: u64) -> Result<(), String>;
+
+    /// Every task-run Pod the apiserver currently holds in the namespace.
+    ///
+    /// # Errors
+    ///
+    /// The enumeration failed. An error is never an empty census.
+    async fn live_task_run_pods(&self) -> Result<Vec<LiveTaskRunPod>, String>;
+}
+
+/// A read of an OCI registry manifest.
+///
+/// The check built on this compares the SHA-256 of the **returned bytes**
+/// against the digest the catalog records. There is no `pullable` column
+/// anywhere in the path, and a stored one would not be consulted if there were.
+#[async_trait]
+pub trait RegistryProbe: Send + Sync {
+    /// Fetch the manifest bytes for `reference` in `repository`.
+    ///
+    /// # Errors
+    ///
+    /// Anything that prevented the round trip, rendered for the operator: a
+    /// 404 for a deleted manifest, a transport failure, an auth refusal.
+    async fn fetch_manifest(&self, repository: &str, reference: &str) -> Result<Vec<u8>, String>;
+}
+
+/// One artifact whose continued pullability the cutover depends on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetainedArtifact {
+    /// `images.id`, for the operator's report.
+    pub image_id: String,
+    /// The registry repository path, e.g. `djinn-image-i1`.
+    pub repository: String,
+    /// The immutable manifest digest the catalog records.
+    pub digest: String,
+    /// Why it is retained.
+    pub role: RetentionRole,
+}
+
+/// Why an artifact is in the retained set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RetentionRole {
+    /// A pre-protocol artifact vouched for by the signed inventory.
+    LegacyNoHandshake,
+    /// A `leaf-v1` artifact retained so rollback has something to run.
+    LeafV1Rollback,
+    /// The `resize-v2` artifact the forward cutover activates.
+    ResizeV2Current,
+}
+
+// ── dispatch ────────────────────────────────────────────────────────────────
+
+/// What one dispatch attempt did.
+///
+/// Only [`Self::Dispatched`] created a Pod. Every other variant created nothing
+/// and issued no resize PATCH, which is what the Pod plane's counters are
+/// asserted on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DispatchOutcome {
+    /// A Pod was created under exactly one resolved quota authority.
+    Dispatched {
+        /// The single effective authority.
+        authority: LauncherAuthorityProtocol,
+        /// Whether a `pods/resize` PATCH was issued. False for every `leaf-v1`
+        /// dispatch, structurally — not by intent.
+        resized: bool,
+    },
+    /// Administrative pause refused it before the Pod plane was touched.
+    RefusedByAdmissionPause,
+    /// The artifact may not run under this authority mode.
+    RefusedByCatalog(CatalogDefectReason),
+    /// The authority mode could not be resolved. Never defaulted.
+    RefusedByAuthority(String),
+    /// The Pod plane refused the creation. No resize follows a failed create.
+    PodPlaneRefused(String),
+}
+
+// ── the driver ──────────────────────────────────────────────────────────────
+
+/// The cutover driver.
+///
+/// # Why the repositories are not injectable
+///
+/// [`Self::new`] takes a [`Database`] and constructs
+/// [`BuildPodPermitRepository`], [`LauncherAuthorityModeRepository`] and
+/// [`ImageRepository`] itself. There is deliberately no constructor that
+/// accepts them, and therefore no seam through which a fake permit repository
+/// could be substituted for the drain fence or a fake image repository for the
+/// catalog check. The properties under test there are that a real partial index
+/// selects real rows and that a real CHECK constrains a real column; a fake
+/// holds both trivially and proves neither.
+///
+/// The three seams that *are* injectable — admission control, the Pod plane and
+/// the registry — are the ones whose production implementations need a live
+/// apiserver or a live registry, and none of them carries a durable predicate.
+pub struct ResizeRollout {
+    permits: BuildPodPermitRepository,
+    authority: LauncherAuthorityModeRepository,
+    images: ImageRepository,
+    inventory: LegacyDigestInventory,
+    admission: std::sync::Arc<dyn AdmissionControl>,
+    pods: std::sync::Arc<dyn TaskRunPodPlane>,
+    registry: std::sync::Arc<dyn RegistryProbe>,
+    journal: Mutex<Vec<RolloutStep>>,
+    dispatches_admitted_while_paused: AtomicU64,
+}
+
+impl ResizeRollout {
+    /// Wire a cutover to a database and the three external seams.
+    ///
+    /// The database is the *only* way durable state enters: see the type docs.
+    #[must_use]
+    pub fn new(
+        db: Database,
+        inventory: LegacyDigestInventory,
+        admission: std::sync::Arc<dyn AdmissionControl>,
+        pods: std::sync::Arc<dyn TaskRunPodPlane>,
+        registry: std::sync::Arc<dyn RegistryProbe>,
+    ) -> Self {
+        Self {
+            permits: BuildPodPermitRepository::new(db.clone()),
+            authority: LauncherAuthorityModeRepository::new(db.clone()),
+            images: ImageRepository::new(db),
+            inventory,
+            admission,
+            pods,
+            registry,
+            journal: Mutex::new(Vec::new()),
+            dispatches_admitted_while_paused: AtomicU64::new(0),
+        }
+    }
+
+    /// The steps that have actually run, in the order they ran.
+    ///
+    /// This is the ordering assertion surface. It is a record of observed
+    /// effects, not a checklist: a step that returned
+    /// [`RolloutBlocked`] never reaches it.
+    #[must_use]
+    pub fn journal(&self) -> Vec<RolloutStep> {
+        self.journal.lock().expect("rollout journal poisoned").clone()
+    }
+
+    /// How many dispatch attempts were admitted while admission was paused.
+    ///
+    /// Structurally zero while [`Self::attempt_dispatch`] consults the pause
+    /// predicate first; non-zero the moment that consultation is deleted, with
+    /// or without anyone remembering to write an assertion about it.
+    #[must_use]
+    pub fn dispatches_admitted_while_paused(&self) -> u64 {
+        self.dispatches_admitted_while_paused.load(Ordering::SeqCst)
+    }
+
+    /// Refuse `step` unless its prerequisites have run and it has not.
+    ///
+    /// Deliberately separate from [`Self::record`]: the journal is a record of
+    /// what **happened**, so a step whose body then failed must not appear in
+    /// it. Reserving on entry would let a refused flip satisfy the prerequisite
+    /// of the resume that follows it — the exact reordering this task exists to
+    /// make impossible.
+    fn guard(&self, step: RolloutStep) -> Result<(), RolloutBlocked> {
+        let journal = self.journal.lock().expect("rollout journal poisoned");
+        if journal.contains(&step) {
+            return Err(RolloutBlocked::StepAlreadyRun(step));
+        }
+        for required in step.prerequisites() {
+            if !journal.contains(required) {
+                return Err(RolloutBlocked::StepOutOfOrder {
+                    step,
+                    missing: *required,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Journal a step that actually completed.
+    fn record(&self, step: RolloutStep) {
+        self.journal
+            .lock()
+            .expect("rollout journal poisoned")
+            .push(step);
+    }
+
+    // ── forward preparation ─────────────────────────────────────────────────
+
+    /// **Step 1a.** Freeze catalog mutation while the old server is still live.
+    ///
+    /// Nothing durable changes here; the freeze is an operator action recorded
+    /// so the ordering of everything after it is provable. The inventory signed
+    /// in 1b is only meaningful if the catalog cannot move under it.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::StepAlreadyRun`].
+    pub fn freeze_catalog_mutation(&self) -> Result<(), RolloutBlocked> {
+        self.guard(RolloutStep::CatalogMutationFrozen)?;
+        self.record(RolloutStep::CatalogMutationFrozen);
+        Ok(())
+    }
+
+    /// **Step 1b.** Load the signed immutable legacy-digest inventory and prove
+    /// it covers every dispatch-eligible no-handshake row.
+    ///
+    /// The signature is verified over the document's exact bytes by
+    /// [`LegacyDigestInventory::from_signed_document`] before this is called;
+    /// what this adds is the catalog cross-check. A signed document that omits
+    /// a live no-handshake row would otherwise produce a green cutover and a
+    /// refused dispatch afterwards.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::AllowlistUnavailable`] — absent, unusable, or short of
+    /// the catalog. [`RolloutBlocked::StepOutOfOrder`] when the catalog is not
+    /// frozen yet.
+    pub async fn sign_legacy_inventory(&self) -> Result<SignedLegacyAllowlist, RolloutBlocked> {
+        self.guard(RolloutStep::LegacyInventorySigned)?;
+        let allowlist = self
+            .images
+            .signed_legacy_digest_allowlist(&self.inventory)
+            .await
+            .map_err(RolloutBlocked::AllowlistUnavailable)?;
+        self.record(RolloutStep::LegacyInventorySigned);
+        info!(
+            issuer = %allowlist.provenance.issuer,
+            issued_at = %allowlist.provenance.issued_at,
+            digests = allowlist.digests.len(),
+            covered_images = allowlist.inventoried.len(),
+            "task_run_resize_rollout: signed legacy digest inventory loaded"
+        );
+        Ok(allowlist)
+    }
+
+    /// **Step 2.** Record that the protocol-aware server and the `pods/resize`
+    /// RBAC are deployed, and prove the authority mode is still `leaf-v1`.
+    ///
+    /// The mode check is the point: deploying the new server is only safe
+    /// *because* authority has not moved, and a deployment that finds
+    /// `resize-v2` already set means someone flipped ahead of the sequence.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::AuthorityUnavailable`], [`RolloutBlocked::AuthorityUninitialized`],
+    /// or [`RolloutBlocked::StepOutOfOrder`]. Also blocks when the mode is
+    /// already `resize-v2`.
+    pub async fn deploy_protocol_aware_server(&self) -> Result<(), RolloutBlocked> {
+        self.guard(RolloutStep::ProtocolAwareServerDeployed)?;
+        let row = self.read_authority().await?;
+        if row.mode != LauncherAuthorityProtocol::LeafV1 {
+            return Err(RolloutBlocked::AuthorityModeUnexpected {
+                expected: LauncherAuthorityProtocol::LeafV1,
+                found: row.mode,
+            });
+        }
+        self.record(RolloutStep::ProtocolAwareServerDeployed);
+        Ok(())
+    }
+
+    /// **Step 3.** Validate every dispatch-eligible catalog row against the
+    /// authority mode the cutover is preparing for.
+    ///
+    /// `target` is the mode the catalog is being prepared *for*, which during
+    /// forward preparation is `resize-v2` while the server still runs
+    /// `leaf-v1`. Validating against the target is what makes the preparation
+    /// meaningful: a row that would be refused after the flip is found now,
+    /// while nothing has moved.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::CatalogIncompatible`] naming every offending row —
+    /// not just the first, so one pass fixes the catalog. Also
+    /// [`RolloutBlocked::PermitsUnavailable`] when the catalog cannot be read
+    /// (never an empty catalog).
+    pub async fn rebuild_and_catalog_as_resize_v2(
+        &self,
+        target: LauncherAuthorityProtocol,
+    ) -> Result<Vec<(String, CatalogVerdict)>, RolloutBlocked> {
+        self.guard(RolloutStep::CatalogRebuiltAsResizeV2)?;
+        let verdicts = self.validate_catalog(target).await?;
+        self.record(RolloutStep::CatalogRebuiltAsResizeV2);
+        Ok(verdicts)
+    }
+
+    /// Classify every dispatch-eligible catalog row against `mode`.
+    ///
+    /// "Dispatch-eligible" is `status = 'ready'` and selected by at least one
+    /// project — read through [`ImageRepository::list_selected_catalog_images`]
+    /// and [`ImageRepository::list`], both production accessors.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::CatalogIncompatible`] or
+    /// [`RolloutBlocked::PermitsUnavailable`].
+    pub async fn validate_catalog(
+        &self,
+        mode: LauncherAuthorityProtocol,
+    ) -> Result<Vec<(String, CatalogVerdict)>, RolloutBlocked> {
+        let selected: BTreeSet<String> = self
+            .images
+            .list_selected_catalog_images()
+            .await
+            .map_err(|error| RolloutBlocked::PermitsUnavailable(error.to_string()))?
+            .into_iter()
+            .map(|image| image.image_id)
+            .collect();
+        let all = self
+            .images
+            .list()
+            .await
+            .map_err(|error| RolloutBlocked::PermitsUnavailable(error.to_string()))?;
+
+        let mut verdicts = Vec::new();
+        let mut defects = Vec::new();
+        for image in all {
+            if !selected.contains(&image.id) || image.status != djinn_db::ImageStatus::READY {
+                continue;
+            }
+            match classify_catalog_image(mode, &image, &self.inventory) {
+                Ok(verdict) => verdicts.push((image.id, verdict)),
+                Err(reason) => defects.push(CatalogDefect {
+                    image_id: image.id,
+                    reason,
+                }),
+            }
+        }
+        if defects.is_empty() {
+            Ok(verdicts)
+        } else {
+            Err(RolloutBlocked::CatalogIncompatible(defects))
+        }
+    }
+
+    /// **Step 4.** Prove every retained artifact is still pullable, by fetching
+    /// its manifest and comparing the SHA-256 of the returned bytes to the
+    /// digest the catalog records.
+    ///
+    /// A registry that 404s, that is unreachable, or that returns *different*
+    /// content under the same reference all fail here. No stored column is
+    /// consulted: there is nothing in this path that a `pullable = true` write
+    /// could satisfy.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::RetentionUnprovable`] naming the digest and what the
+    /// round trip actually reported.
+    pub async fn verify_retention(
+        &self,
+        retained: &[RetainedArtifact],
+    ) -> Result<(), RolloutBlocked> {
+        self.guard(RolloutStep::RetentionVerified)?;
+        self.probe_retention(retained).await?;
+        self.record(RolloutStep::RetentionVerified);
+        Ok(())
+    }
+
+    /// The retention round trip without the journal entry, so rollback can
+    /// re-prove retention that forward preparation already recorded.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::RetentionUnprovable`].
+    pub async fn probe_retention(
+        &self,
+        retained: &[RetainedArtifact],
+    ) -> Result<(), RolloutBlocked> {
+        for artifact in retained {
+            let bytes = self
+                .registry
+                .fetch_manifest(&artifact.repository, &artifact.digest)
+                .await
+                .map_err(|detail| RolloutBlocked::RetentionUnprovable {
+                    digest: artifact.digest.clone(),
+                    detail,
+                })?;
+            let observed = format!("sha256:{:x}", Sha256::digest(&bytes));
+            if observed != artifact.digest {
+                return Err(RolloutBlocked::RetentionUnprovable {
+                    digest: artifact.digest.clone(),
+                    detail: format!(
+                        "the registry served content whose digest is {observed}; the catalog \
+                         records {} for image {}",
+                        artifact.digest, artifact.image_id
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    // ── the fenced flip ─────────────────────────────────────────────────────
+
+    /// **Step 5.** Pause admission, then prove the pause by attempting a
+    /// dispatch and requiring a refusal.
+    ///
+    /// The pause row is written first and then *disbelieved*: `probe` is
+    /// dispatched through [`Self::attempt_dispatch`], the same path a task run
+    /// takes, and anything other than
+    /// [`DispatchOutcome::RefusedByAdmissionPause`] blocks the cutover with
+    /// [`RolloutBlocked::AdmissionPauseIneffective`]. Writing the row without
+    /// wiring the refusal therefore does not produce a paused cutover; it
+    /// produces a blocked one.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::AdmissionUnavailable`] or
+    /// [`RolloutBlocked::AdmissionPauseIneffective`].
+    pub async fn pause_admission(
+        &self,
+        reason: &str,
+        probe: &DispatchProbe,
+    ) -> Result<(), RolloutBlocked> {
+        self.guard(RolloutStep::AdmissionPaused)?;
+        self.admission
+            .pause(reason)
+            .await
+            .map_err(RolloutBlocked::AdmissionUnavailable)?;
+        match self
+            .attempt_dispatch(&probe.task_run_id, &probe.image)
+            .await
+        {
+            DispatchOutcome::RefusedByAdmissionPause => {
+                self.record(RolloutStep::AdmissionPaused);
+                Ok(())
+            }
+            other => {
+                warn!(
+                    outcome = ?other,
+                    "task_run_resize_rollout: the pause row was written but dispatch was not refused"
+                );
+                Err(RolloutBlocked::AdmissionPauseIneffective)
+            }
+        }
+    }
+
+    /// **Step 6.** Prove the drain: zero live task-run Pods AND zero
+    /// nonterminal resize/lease rows.
+    ///
+    /// **This is the production caller of
+    /// [`BuildPodPermitRepository::list_nonterminal_resize`].** The rows are
+    /// returned, not counted, so the block names task-run ids and lifecycle
+    /// states.
+    ///
+    /// The Pod census runs first because it is the dimension PostgreSQL cannot
+    /// answer, and because an unavailable apiserver must not be laundered into
+    /// "no Pods" by a subsequent successful row read.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::PodCensusUnavailable`], [`RolloutBlocked::LiveTaskRunPods`],
+    /// [`RolloutBlocked::PermitsUnavailable`] or
+    /// [`RolloutBlocked::NonterminalResizeRows`]. None of them is ever "drained".
+    pub async fn prove_drained(&self) -> Result<(), RolloutBlocked> {
+        self.guard(RolloutStep::DrainProven)?;
+        self.probe_drain().await?;
+        self.record(RolloutStep::DrainProven);
+        Ok(())
+    }
+
+    /// The drain proof without the journal entry.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::prove_drained`].
+    pub async fn probe_drain(&self) -> Result<(), RolloutBlocked> {
+        let live = self
+            .pods
+            .live_task_run_pods()
+            .await
+            .map_err(RolloutBlocked::PodCensusUnavailable)?;
+        if !live.is_empty() {
+            return Err(RolloutBlocked::LiveTaskRunPods(live));
+        }
+
+        let nonterminal = self
+            .permits
+            .list_nonterminal_resize()
+            .await
+            .map_err(|error| RolloutBlocked::PermitsUnavailable(error.to_string()))?;
+        if !nonterminal.is_empty() {
+            return Err(RolloutBlocked::NonterminalResizeRows(
+                nonterminal.iter().map(NonterminalResizeRow::from).collect(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// **Step 7.** Flip the authority mode, behind the drain proof and behind
+    /// `set_mode`'s own transactional fence.
+    ///
+    /// Two fences, and both are load-bearing. [`Self::prove_drained`] catches
+    /// what PostgreSQL cannot see and names what it finds;
+    /// [`LauncherAuthorityModeRepository::set_mode`] catches what appeared
+    /// between the unlocked census and the locked one, holding the same
+    /// `build_pod_permit_pools` row lock admission takes before it inserts.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::AuthorityDrainRefused`] when the fenced count refused,
+    /// plus the authority read/epoch failures. `Unchanged` — a same-mode replay
+    /// — is an error here rather than a success: a cutover that did not move
+    /// the mode did not do its job.
+    pub async fn flip_authority_mode(
+        &self,
+        expected_epoch: i64,
+        next: LauncherAuthorityProtocol,
+    ) -> Result<i64, RolloutBlocked> {
+        self.guard(RolloutStep::AuthorityModeFlipped)?;
+        match self.authority.set_mode(expected_epoch, next).await {
+            SetLauncherAuthorityModeResult::Flipped { row, previous, .. } => {
+                self.record(RolloutStep::AuthorityModeFlipped);
+                info!(
+                    previous = previous.as_wire(),
+                    next = next.as_wire(),
+                    epoch = row.epoch,
+                    "task_run_resize_rollout: authority mode flipped behind a proven drain"
+                );
+                Ok(row.epoch)
+            }
+            SetLauncherAuthorityModeResult::Unchanged { row, .. } => {
+                Err(RolloutBlocked::AuthorityModeUnchanged(row.mode))
+            }
+            SetLauncherAuthorityModeResult::DrainNotEmpty { drain, .. } => {
+                Err(RolloutBlocked::AuthorityDrainRefused { census: drain })
+            }
+            SetLauncherAuthorityModeResult::EpochConflict { row } => {
+                Err(RolloutBlocked::AuthorityEpochConflict { epoch: row.epoch })
+            }
+            SetLauncherAuthorityModeResult::Uninitialized => {
+                Err(RolloutBlocked::AuthorityUninitialized)
+            }
+            SetLauncherAuthorityModeResult::Unavailable => Err(RolloutBlocked::AuthorityUnavailable),
+        }
+    }
+
+    /// **Step 8.** Resume admission — only after a confirmed flip.
+    ///
+    /// The prerequisite is [`RolloutStep::AuthorityModeFlipped`], which is
+    /// journaled by [`Self::flip_authority_mode`] and journaled *only* when the
+    /// compare-and-swap returned [`SetLauncherAuthorityModeResult::Flipped`].
+    /// Resuming ahead of the flip is [`RolloutBlocked::StepOutOfOrder`].
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::AdmissionUnavailable`] or
+    /// [`RolloutBlocked::StepOutOfOrder`].
+    pub async fn resume_admission(&self) -> Result<(), RolloutBlocked> {
+        self.guard(RolloutStep::AdmissionResumed)?;
+        self.admission
+            .resume()
+            .await
+            .map_err(RolloutBlocked::AdmissionUnavailable)?;
+        self.record(RolloutStep::AdmissionResumed);
+        Ok(())
+    }
+
+    // ── the two whole sequences ─────────────────────────────────────────────
+
+    /// The forward cutover, `leaf-v1` → `resize-v2`, in order.
+    ///
+    /// # Errors
+    ///
+    /// Any [`RolloutBlocked`]. Whatever the block, the mode is unchanged and —
+    /// for every block after [`RolloutStep::AdmissionPaused`] — admission stays
+    /// paused. The journal records exactly how far it got.
+    pub async fn activate(&self, plan: &RolloutPlan<'_>) -> Result<i64, RolloutBlocked> {
+        self.freeze_catalog_mutation()?;
+        self.sign_legacy_inventory().await?;
+        self.deploy_protocol_aware_server().await?;
+        self.rebuild_and_catalog_as_resize_v2(LauncherAuthorityProtocol::ResizeV2)
+            .await?;
+        self.verify_retention(plan.retained).await?;
+        self.pause_admission(plan.reason, &plan.probe).await?;
+        self.prove_drained().await?;
+        let epoch = self
+            .flip_authority_mode(plan.expected_epoch, LauncherAuthorityProtocol::ResizeV2)
+            .await?;
+        self.resume_admission().await?;
+        Ok(epoch)
+    }
+
+    /// The reverse, `resize-v2` → `leaf-v1`.
+    ///
+    /// Ordered identically from [`RolloutStep::RetentionVerified`] onward, and
+    /// gated on the same two drain dimensions. The retention and allowlist
+    /// checks run **first**, before anything is paused, and their failure is
+    /// what "rollback is blocked" means: no mode flip, no resume, no Pod.
+    ///
+    /// # Errors
+    ///
+    /// Any [`RolloutBlocked`]. When a required artifact or the allowlist is
+    /// unavailable the block happens before the flip, so the mode is untouched;
+    /// when it happens after [`Self::pause_admission`], admission stays paused
+    /// because [`Self::resume_admission`] is never reached.
+    pub async fn rollback(&self, plan: &RolloutPlan<'_>) -> Result<i64, RolloutBlocked> {
+        // The allowlist is a rollback prerequisite, not a formality: the target
+        // is `leaf-v1`, under which no-handshake artifacts dispatch, and they
+        // dispatch only because the signed inventory vouches for them.
+        self.images
+            .signed_legacy_digest_allowlist(&self.inventory)
+            .await
+            .map_err(RolloutBlocked::AllowlistUnavailable)?;
+        self.verify_retention(plan.retained).await?;
+        self.validate_catalog(LauncherAuthorityProtocol::LeafV1)
+            .await?;
+        self.pause_admission(plan.reason, &plan.probe).await?;
+        self.prove_drained().await?;
+        let epoch = self
+            .flip_authority_mode(plan.expected_epoch, LauncherAuthorityProtocol::LeafV1)
+            .await?;
+        self.resume_admission().await?;
+        Ok(epoch)
+    }
+
+    // ── dispatch ────────────────────────────────────────────────────────────
+
+    /// Attempt one dispatch through the cutover's admission path.
+    ///
+    /// Order matters and is the whole content of the function:
+    ///
+    /// 1. the production dispatch-pause predicate, **before** the Pod plane is
+    ///    touched at all;
+    /// 2. the authority mode, read and never defaulted;
+    /// 3. [`classify_catalog_image`], which resolves exactly one authority;
+    /// 4. Pod creation;
+    /// 5. a `pods/resize` PATCH **only** under `resize-v2`.
+    ///
+    /// A `resize-v2` image under `leaf-v1` mode never reaches (4), so no Pod is
+    /// created for it. A `leaf-v1` (or allowlisted no-handshake) dispatch never
+    /// reaches (5), so the count of resize PATCHes against it is zero by
+    /// construction.
+    pub async fn attempt_dispatch(&self, task_run_id: &str, image: &Image) -> DispatchOutcome {
+        match self.admission.dispatch_is_paused().await {
+            Ok(true) => return DispatchOutcome::RefusedByAdmissionPause,
+            Ok(false) => {}
+            Err(error) => {
+                // An unknown pause state is a refusal, never an admission.
+                return DispatchOutcome::RefusedByAuthority(format!(
+                    "dispatch pause state unavailable: {error}"
+                ));
+            }
+        }
+
+        let mode = match self.read_authority().await {
+            Ok(row) => row.mode,
+            Err(blocked) => return DispatchOutcome::RefusedByAuthority(blocked.to_string()),
+        };
+        let verdict = match classify_catalog_image(mode, image, &self.inventory) {
+            Ok(verdict) => verdict,
+            Err(reason) => return DispatchOutcome::RefusedByCatalog(reason),
+        };
+
+        if let Err(error) = self.pods.create_task_run_pod(task_run_id, &image.id).await {
+            return DispatchOutcome::PodPlaneRefused(error);
+        }
+
+        let authority = verdict.authority();
+        if authority.launcher_owns_leaf_quota() {
+            // `leaf-v1`: the launcher owns this leaf's `cpu.max`. A resize PATCH
+            // here would be the second writer.
+            return DispatchOutcome::Dispatched {
+                authority,
+                resized: false,
+            };
+        }
+        if let Err(error) = self
+            .pods
+            .resize_launcher_cpu(task_run_id, BIRTH_CPU_MILLICORES)
+            .await
+        {
+            return DispatchOutcome::PodPlaneRefused(error);
+        }
+        DispatchOutcome::Dispatched {
+            authority,
+            resized: true,
+        }
+    }
+
+    /// Dispatch, recording the invariant violation if admission was paused and
+    /// a Pod was nevertheless created.
+    ///
+    /// Used by callers that want the counter to move: the counter exists so the
+    /// pause's absence is observable rather than merely assertable.
+    pub async fn attempt_dispatch_observed(
+        &self,
+        task_run_id: &str,
+        image: &Image,
+    ) -> DispatchOutcome {
+        let paused = self.admission.dispatch_is_paused().await.unwrap_or(false);
+        let outcome = self.attempt_dispatch(task_run_id, image).await;
+        if paused && matches!(outcome, DispatchOutcome::Dispatched { .. }) {
+            self.dispatches_admitted_while_paused
+                .fetch_add(1, Ordering::SeqCst);
+            warn!(
+                task_run_id,
+                "task_run_resize_rollout: a dispatch was admitted while admission was paused"
+            );
+        }
+        outcome
+    }
+
+    /// Read the authority singleton, mapping both "absent" and "unreadable" to
+    /// their own blocks. Neither is a mode.
+    async fn read_authority(&self) -> Result<djinn_db::LauncherAuthorityModeRow, RolloutBlocked> {
+        match self.authority.read().await {
+            Ok(Some(row)) => Ok(row),
+            Ok(None) => Err(RolloutBlocked::AuthorityUninitialized),
+            Err(error) => {
+                warn!(%error, "task_run_resize_rollout: authority mode unreadable");
+                Err(RolloutBlocked::AuthorityUnavailable)
+            }
+        }
+    }
+}
+
+/// The dispatch a pause step proves itself against.
+///
+/// A real task-run id and a real catalog image, so the probe travels the same
+/// path a production dispatch does. Nothing about it is special-cased inside
+/// [`ResizeRollout::attempt_dispatch`].
+#[derive(Clone, Debug)]
+pub struct DispatchProbe {
+    /// The task run the probe dispatch is issued for.
+    pub task_run_id: String,
+    /// The catalog image it would run.
+    pub image: Image,
+}
+
+/// Everything one cutover run needs.
+pub struct RolloutPlan<'a> {
+    /// Every artifact whose continued pullability the cutover depends on.
+    pub retained: &'a [RetainedArtifact],
+    /// The dispatch the pause proves itself against.
+    pub probe: DispatchProbe,
+    /// The authority epoch this cutover was planned against.
+    pub expected_epoch: i64,
+    /// Operator-facing pause reason.
+    pub reason: &'a str,
+}
+
+// ── production wiring ───────────────────────────────────────────────────────
+
+/// Administrative pause backed by the durable `dispatch_pauses` state, with the
+/// refusal predicate taken from the coordinator rather than restated.
+///
+/// [`Self::dispatch_is_paused`] evaluates
+/// `djinn_coordinator::dispatch_pause::debug_view(&state).global`, which is
+/// literally `active_global_dispatch_pause(state).is_some()` — the expression
+/// the coordinator's dispatch loop guards on, expiry handling included. Copying
+/// that predicate here would make the cutover's notion of "paused" free to
+/// drift from the one that actually refuses task dispatch.
+pub struct DurableAdmissionControl {
+    db: Database,
+    events: djinn_core::events::EventBus,
+    paused_by: String,
+}
+
+impl DurableAdmissionControl {
+    /// Bind to a database, recording `paused_by` on the pause it writes.
+    #[must_use]
+    pub fn new(db: Database, events: djinn_core::events::EventBus, paused_by: &str) -> Self {
+        Self {
+            db,
+            events,
+            paused_by: paused_by.to_owned(),
+        }
+    }
+
+    fn repository(&self) -> djinn_db::DispatchPauseRepository {
+        djinn_db::DispatchPauseRepository::new(self.db.clone(), self.events.clone())
+    }
+}
+
+#[async_trait]
+impl AdmissionControl for DurableAdmissionControl {
+    async fn pause(&self, reason: &str) -> Result<(), String> {
+        self.repository()
+            .pause(
+                djinn_db::DispatchPauseTarget::global(),
+                djinn_core::models::DispatchPause {
+                    paused_by: self.paused_by.clone(),
+                    paused_at: now_rfc3339(),
+                    reason: reason.to_owned(),
+                    // Never expiring. A cutover pause that lapses on a timer
+                    // would resume admission mid-flip.
+                    expires_at: None,
+                },
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
+    async fn resume(&self) -> Result<(), String> {
+        self.repository()
+            .resume(djinn_db::DispatchPauseTarget::global())
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
+    async fn dispatch_is_paused(&self) -> Result<bool, String> {
+        let state = djinn_coordinator::dispatch_pause::load_dispatch_pause_state(
+            self.db.clone(),
+            self.events.clone(),
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        Ok(djinn_coordinator::dispatch_pause::debug_view(&state).global)
+    }
+}
+
+/// A registry probe over plain HTTP(S), speaking the OCI distribution manifest
+/// API.
+///
+/// `GET /v2/<repository>/manifests/<reference>` with the manifest media types
+/// the registry needs to see in `Accept`. The response *body* is what gets
+/// hashed — not a header the registry supplies — so a registry that reports one
+/// digest and serves another does not pass.
+pub struct HttpRegistryProbe {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl HttpRegistryProbe {
+    /// Bind to a registry base URL, e.g. `http://registry:5000`.
+    #[must_use]
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+/// The `Accept` header an OCI registry needs to return a v2 or OCI manifest
+/// rather than a converted v1 one.
+const MANIFEST_ACCEPT: &str = "application/vnd.oci.image.manifest.v1+json, \
+     application/vnd.oci.image.index.v1+json, \
+     application/vnd.docker.distribution.manifest.v2+json, \
+     application/vnd.docker.distribution.manifest.list.v2+json";
+
+#[async_trait]
+impl RegistryProbe for HttpRegistryProbe {
+    async fn fetch_manifest(&self, repository: &str, reference: &str) -> Result<Vec<u8>, String> {
+        let url = format!("{}/v2/{repository}/manifests/{reference}", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .header(reqwest::header::ACCEPT, MANIFEST_ACCEPT)
+            .send()
+            .await
+            .map_err(|error| format!("GET {url}: {error}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(format!("GET {url}: {status}"));
+        }
+        response
+            .bytes()
+            .await
+            .map(|bytes| bytes.to_vec())
+            .map_err(|error| format!("GET {url}: reading the manifest body: {error}"))
+    }
+}
+
+/// RFC3339 now, matching what the control-plane pause tool writes.
+fn now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("a UTC timestamp always formats as RFC3339")
+}

--- a/server/src/task_run_resize_rollout.rs
+++ b/server/src/task_run_resize_rollout.rs
@@ -377,12 +377,7 @@ pub fn classify_catalog_image(
         }
     })?;
 
-    match decide_admission(
-        mode,
-        declared,
-        image.registry_digest.as_deref(),
-        inventory,
-    ) {
+    match decide_admission(mode, declared, image.registry_digest.as_deref(), inventory) {
         Ok(AdmissionDecision::Admitted(protocol)) => match declared {
             Some(_) => Ok(CatalogVerdict::Declared(protocol)),
             None => {
@@ -392,7 +387,9 @@ pub fn classify_catalog_image(
                 PreProtocolDigest::parse(raw)
                     .map(CatalogVerdict::LegacyLeafAuthority)
                     .map_err(|malformed| {
-                        CatalogDefectReason::Rejected(AdmissionRejection::MalformedDigest(malformed))
+                        CatalogDefectReason::Rejected(AdmissionRejection::MalformedDigest(
+                            malformed,
+                        ))
                     })
             }
         },
@@ -593,7 +590,10 @@ impl ResizeRollout {
     /// [`RolloutBlocked`] never reaches it.
     #[must_use]
     pub fn journal(&self) -> Vec<RolloutStep> {
-        self.journal.lock().expect("rollout journal poisoned").clone()
+        self.journal
+            .lock()
+            .expect("rollout journal poisoned")
+            .clone()
     }
 
     /// How many dispatch attempts were admitted while admission was paused.
@@ -983,7 +983,9 @@ impl ResizeRollout {
             SetLauncherAuthorityModeResult::Uninitialized => {
                 Err(RolloutBlocked::AuthorityUninitialized)
             }
-            SetLauncherAuthorityModeResult::Unavailable => Err(RolloutBlocked::AuthorityUnavailable),
+            SetLauncherAuthorityModeResult::Unavailable => {
+                Err(RolloutBlocked::AuthorityUnavailable)
+            }
         }
     }
 

--- a/server/src/task_run_resize_rollout.rs
+++ b/server/src/task_run_resize_rollout.rs
@@ -596,14 +596,26 @@ impl ResizeRollout {
             .clone()
     }
 
-    /// How many dispatch attempts were admitted while admission was paused.
+    /// How many Pods were created after the pause step ran and before the
+    /// resume step did.
     ///
-    /// Structurally zero while [`Self::attempt_dispatch`] consults the pause
-    /// predicate first; non-zero the moment that consultation is deleted, with
-    /// or without anyone remembering to write an assertion about it.
+    /// This exists so the pause's absence is **observable** rather than merely
+    /// assertable. Between [`RolloutStep::AdmissionPaused`] and
+    /// [`RolloutStep::AdmissionResumed`] the invariant is that no dispatch
+    /// creates a Pod; while [`Self::attempt_dispatch`] consults the pause
+    /// predicate first the counter is structurally zero, and it becomes
+    /// non-zero on the first admitted dispatch whether or not anyone remembered
+    /// to write an assertion about ordering.
     #[must_use]
     pub fn dispatches_admitted_while_paused(&self) -> u64 {
         self.dispatches_admitted_while_paused.load(Ordering::SeqCst)
+    }
+
+    /// Is the cutover between its pause and its resume?
+    fn inside_the_pause_window(&self) -> bool {
+        let journal = self.journal.lock().expect("rollout journal poisoned");
+        journal.contains(&RolloutStep::AdmissionPaused)
+            && !journal.contains(&RolloutStep::AdmissionResumed)
     }
 
     /// Refuse `step` unless its prerequisites have run and it has not.
@@ -1109,6 +1121,16 @@ impl ResizeRollout {
         if let Err(error) = self.pods.create_task_run_pod(task_run_id, &image.id).await {
             return DispatchOutcome::PodPlaneRefused(error);
         }
+        if self.inside_the_pause_window() {
+            // A Pod exists, and the cutover believes admission is paused. Record
+            // it here rather than trusting a later assertion to notice.
+            self.dispatches_admitted_while_paused
+                .fetch_add(1, Ordering::SeqCst);
+            warn!(
+                task_run_id,
+                "task_run_resize_rollout: a Pod was created between the pause and the resume"
+            );
+        }
 
         let authority = verdict.authority();
         if authority.launcher_owns_leaf_quota() {
@@ -1130,29 +1152,6 @@ impl ResizeRollout {
             authority,
             resized: true,
         }
-    }
-
-    /// Dispatch, recording the invariant violation if admission was paused and
-    /// a Pod was nevertheless created.
-    ///
-    /// Used by callers that want the counter to move: the counter exists so the
-    /// pause's absence is observable rather than merely assertable.
-    pub async fn attempt_dispatch_observed(
-        &self,
-        task_run_id: &str,
-        image: &Image,
-    ) -> DispatchOutcome {
-        let paused = self.admission.dispatch_is_paused().await.unwrap_or(false);
-        let outcome = self.attempt_dispatch(task_run_id, image).await;
-        if paused && matches!(outcome, DispatchOutcome::Dispatched { .. }) {
-            self.dispatches_admitted_while_paused
-                .fetch_add(1, Ordering::SeqCst);
-            warn!(
-                task_run_id,
-                "task_run_resize_rollout: a dispatch was admitted while admission was paused"
-            );
-        }
-        outcome
     }
 
     /// Read the authority singleton, mapping both "absent" and "unreadable" to
@@ -1391,25 +1390,43 @@ impl ResizeRollout {
     }
 }
 
-/// A registry probe over plain HTTP(S), speaking the OCI distribution manifest
-/// API.
+/// A registry probe speaking the OCI distribution manifest API.
 ///
 /// `GET /v2/<repository>/manifests/<reference>` with the manifest media types
-/// the registry needs to see in `Accept`. The response *body* is what gets
-/// hashed — not a header the registry supplies — so a registry that reports one
-/// digest and serves another does not pass.
+/// the registry needs to see in `Accept`. The response **body** is what gets
+/// hashed — not the `Docker-Content-Digest` header the registry supplies — so a
+/// registry that reports one digest and serves another does not pass.
+///
+/// Outbound HTTP goes through [`djinn_provider::http_util::HttpClient`], the
+/// capability owner. This module names no HTTP client type of its own: the
+/// capability-boundary guard forbids it, and the guard is right — a second
+/// client here would have its own timeout, its own TLS configuration and its
+/// own idea of what a failed request means.
 pub struct HttpRegistryProbe {
     base_url: String,
-    client: reqwest::Client,
+    client: djinn_provider::http_util::HttpClient,
 }
+
+/// How long a single manifest read may take.
+///
+/// A cutover blocked on an unreachable registry must report that promptly; the
+/// alternative is an operator watching a paused deployment while a socket hangs.
+const REGISTRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 impl HttpRegistryProbe {
     /// Bind to a registry base URL, e.g. `http://registry:5000`.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: the only failure mode of the underlying client
+    /// builder is a malformed TLS configuration, which is a process-wide
+    /// condition rather than a per-probe one.
     #[must_use]
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_owned(),
-            client: reqwest::Client::new(),
+            client: djinn_provider::http_util::HttpClient::new(REGISTRY_TIMEOUT)
+                .expect("the HTTP client builder only fails on a malformed TLS configuration"),
         }
     }
 }
@@ -1425,22 +1442,17 @@ const MANIFEST_ACCEPT: &str = "application/vnd.oci.image.manifest.v1+json, \
 impl RegistryProbe for HttpRegistryProbe {
     async fn fetch_manifest(&self, repository: &str, reference: &str) -> Result<Vec<u8>, String> {
         let url = format!("{}/v2/{repository}/manifests/{reference}", self.base_url);
-        let response = self
-            .client
+        let operation = format!("GET {url}");
+        self.client
             .get(&url)
-            .header(reqwest::header::ACCEPT, MANIFEST_ACCEPT)
-            .send()
+            .header("Accept", MANIFEST_ACCEPT)
+            .send(&operation)
             .await
-            .map_err(|error| format!("GET {url}: {error}"))?;
-        let status = response.status();
-        if !status.is_success() {
-            return Err(format!("GET {url}: {status}"));
-        }
-        response
-            .bytes()
+            .map_err(|error| error.to_string())?
+            .bytes(&operation)
             .await
             .map(|bytes| bytes.to_vec())
-            .map_err(|error| format!("GET {url}: reading the manifest body: {error}"))
+            .map_err(|error| error.to_string())
     }
 }
 

--- a/server/tests/task_run_resize_rollout.rs
+++ b/server/tests/task_run_resize_rollout.rs
@@ -1,0 +1,1400 @@
+//! The fenced launcher-authority cutover, end to end (task `eeky`, epic `xowm`).
+//!
+//! # What is real here, and what is not
+//!
+//! | thing under test | fixture |
+//! |---|---|
+//! | drain fence, catalog metadata, signed allowlist | **real PostgreSQL** — `Database::ephemeral()` clones the migrated test template. Every test asserts this before it asserts anything else, through [`assert_real_postgres`]. |
+//! | admission pause | **the production implementation** — `DurableAdmissionControl`, writing the real `dispatch_pauses` state and reading it back through the coordinator's own refusal predicate. |
+//! | registry pullability | **a real HTTP round trip** over a real TCP socket to a real OCI-manifest endpoint, whose response body is hashed. The bytes are served in-process; the fetch, the socket, the status codes and the SHA-256 comparison are not simulated. `deploy/preflight/tests/task-run-resize-rollout.sh` runs the same check against a disposable `registry:2` container. |
+//! | the Pod plane | a recording fixture. The task's design forbids standing up a live cluster for this wave, so Pod creation, `pods/resize` PATCHes and the live-Pod census are counted rather than performed. Every assertion about them is a **count of attempts**, never a read of an intent field. |
+//!
+//! No repository is faked. [`ResizeRollout::new`] takes a `Database` and builds
+//! `BuildPodPermitRepository`, `LauncherAuthorityModeRepository` and
+//! `ImageRepository` itself — there is no constructor through which a fake
+//! could be passed, which is asserted at the source level by
+//! [`the_driver_exposes_no_seam_for_a_fake_repository`].
+//!
+//! # The governing question
+//!
+//! "What stays green if the body does nothing?" Every criterion below is
+//! asserted on an observed effect: a refused dispatch, a count of Pod creations,
+//! a count of `pods/resize` PATCHes, a named row, a hashed HTTP body, an epoch
+//! that did not move. No test in this file reads a `paused` row, a `pullable`
+//! column, an intended-authority field, or a `signed: true` flag — none of which
+//! exist in the types under test, deliberately.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use djinn_core::events::EventBus;
+use djinn_db::launcher_compatibility::{
+    AdmissionRejection, LegacyDigestInventory, PreProtocolDigest,
+};
+use djinn_db::repositories::image::LegacyAllowlistDefect;
+use djinn_db::{
+    AcquireBuildPodPermitResult, BuildPodPermitRepository, BuildPodResizeIdentity,
+    CaptureBuildPodResizeIdentityResult, Database, DispatchPauseRepository, Image, ImageRepository,
+    LauncherAuthorityModeRepository, LauncherProtocolAdmission,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use djinn_server::task_run_resize_rollout::{
+    AdmissionControl, CatalogDefectReason, CatalogVerdict, DispatchOutcome, DispatchProbe,
+    DurableAdmissionControl, HttpRegistryProbe, LiveTaskRunPod, RegistryProbe, ResizeRollout,
+    RetainedArtifact, RetentionRole, RolloutBlocked, RolloutPlan, RolloutStep, TaskRunPodPlane,
+    classify_catalog_image,
+};
+use ring::signature::KeyPair as _;
+
+/// One task carries every fixture task run. `tasks.id` is `varchar(36)`, so a
+/// derived id would silently truncate.
+const EEKY_TASK_ID: &str = "eeky-task";
+
+const LEAF: LauncherAuthorityProtocol = LauncherAuthorityProtocol::LeafV1;
+const RESIZE: LauncherAuthorityProtocol = LauncherAuthorityProtocol::ResizeV2;
+
+// ═══ harness ════════════════════════════════════════════════════════════════
+
+/// Prove the "database" under these tests is really PostgreSQL.
+///
+/// This is the source-level gate the criterion asks for, discharged at runtime
+/// instead: `Database::pool()` is a `sqlx::PgPool` by type, and this executes a
+/// statement only a live PostgreSQL server answers. A repository substituted for
+/// a fake would not reach this function at all — `ResizeRollout` has no seam for
+/// one — but a `Database` backed by anything other than PostgreSQL would fail
+/// right here.
+async fn assert_real_postgres(db: &Database) {
+    db.ensure_initialized()
+        .await
+        .expect("the ephemeral database must materialize");
+    let version: String = sqlx::query_scalar("SELECT version()")
+        .fetch_one(db.pool())
+        .await
+        .expect("the drain-fence and catalog properties are PostgreSQL properties");
+    assert!(
+        version.starts_with("PostgreSQL"),
+        "these tests must run against real PostgreSQL, got {version:?}"
+    );
+}
+
+/// A canonical immutable manifest digest: `sha256:` + 64 lowercase hex.
+fn digest(seed: char) -> String {
+    format!("sha256:{}", seed.to_string().repeat(64))
+}
+
+fn b64(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// A signature-verified inventory over `entries`, built the way a deployment
+/// builds one: sign the document bytes, then verify them.
+///
+/// Deliberately routed through `from_signed_document` rather than
+/// `LegacyDigestInventory::verified`, so every test in this file depends on a
+/// real Ed25519 verification having succeeded.
+fn signed_inventory(entries: &[String]) -> LegacyDigestInventory {
+    let rng = ring::rand::SystemRandom::new();
+    let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    let key = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap();
+    let document = serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1,
+        "issuer": "platform-ops",
+        "issued_at": "2026-07-31T00:00:00Z",
+        "digests": entries,
+    }))
+    .unwrap();
+    let inventory = LegacyDigestInventory::from_signed_document(
+        &document,
+        Some(&b64(key.public_key().as_ref())),
+        Some(&b64(key.sign(&document).as_ref())),
+    );
+    assert!(
+        matches!(inventory, LegacyDigestInventory::Verified { .. }),
+        "the fixture inventory must be signature-verified, got {inventory:?}"
+    );
+    inventory
+}
+
+/// Seed the FK chain `users -> projects -> tasks -> task_runs` so real permit
+/// rows can exist, and point the project at `selected_image_id`.
+///
+/// `build_pod_permits.task_run_id` is a restricted foreign key, so a drain
+/// dimension cannot be conjured by inserting a bare row.
+async fn seed_project_and_run(db: &Database, task_run_id: &str) {
+    db.ensure_initialized().await.unwrap();
+    let pool = db.pool();
+    sqlx::query(
+        "INSERT INTO users (id, github_id, github_login) \
+         VALUES ('00000000-0000-7000-8000-0000000000ee', 9000000238, 'eeky-rollout') \
+         ON CONFLICT DO NOTHING",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO projects (id, name, github_owner, github_repo) \
+         VALUES ('eeky-project', 'eeky-project', 'djinnos', 'eeky') ON CONFLICT DO NOTHING",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO tasks \
+         (id, project_id, short_id, title, description, design, labels, acceptance_criteria, \
+          memory_refs, created_by_user_id) \
+         VALUES ($1, 'eeky-project', $2, 't', 'd', 'g', '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, \
+                 '00000000-0000-7000-8000-0000000000ee') ON CONFLICT DO NOTHING",
+    )
+    .bind(EEKY_TASK_ID)
+    .bind("eeky")
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO task_runs (id, project_id, task_id, trigger_type, status) \
+         VALUES ($1, 'eeky-project', $2, 'manual', 'running') ON CONFLICT DO NOTHING",
+    )
+    .bind(task_run_id)
+    .bind(EEKY_TASK_ID)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Point `eeky-project` at a catalog image, making it dispatch-eligible.
+///
+/// `projects.selected_image_id` is a foreign key, so this can only run after
+/// the image row exists — which is why "dispatch-eligible" is a property of the
+/// relation and not of a flag.
+async fn select_image(db: &Database, image_id: &str) {
+    sqlx::query("UPDATE projects SET selected_image_id = $1 WHERE id = 'eeky-project'")
+        .bind(image_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+}
+
+/// Register a `ready` catalog image with the given digest and declaration.
+async fn seed_image(
+    db: &Database,
+    id: &str,
+    registry_digest: Option<&str>,
+    declared: Option<LauncherAuthorityProtocol>,
+) -> Image {
+    let repo = ImageRepository::new(db.clone());
+    repo.create(id, id, None, "{}").await.unwrap();
+    repo.mark_ready(id, &format!("reg/{id}:tag"), registry_digest, declared)
+        .await
+        .unwrap();
+    repo.get(id).await.unwrap().unwrap()
+}
+
+/// Drive a permit from `acquire` into a nonterminal resize state, using only
+/// production repository methods so the row is exactly what production writes.
+///
+/// `capture_resize_identity` sets `state = 'birth_confirmed'`, one of migration
+/// 164's six nonterminal states and therefore one
+/// `build_pod_permits_resize_nonterminal_idx` selects.
+async fn seed_nonterminal_resize_row(db: &Database, task_run_id: &str) {
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let AcquireBuildPodPermitResult::Acquired { row, .. } = permits.acquire(task_run_id, 8).await
+    else {
+        panic!("the permit pool must admit the fixture run");
+    };
+    permits
+        .bind_or_refresh_job_uid(task_run_id, &row.permit_id, row.fencing_token, "job-uid-eeky")
+        .await
+        .map(|_| ())
+        .unwrap_or_else(|error| panic!("binding a Job UID must succeed: {error}"));
+    let captured = permits
+        .capture_resize_identity(
+            task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            &BuildPodResizeIdentity {
+                pod_namespace: "djinn".into(),
+                pod_name: "taskrun-eeky".into(),
+                pod_uid: format!("uid-{task_run_id}"),
+                launcher_container_name: "cgroup-launcher".into(),
+                launcher_container_id: "containerd://eeky".into(),
+                image_digest: digest('a'),
+                observed_launcher_protocol: RESIZE.as_wire().into(),
+                effective_launcher_protocol: RESIZE.as_wire().into(),
+                admitted_cpu_millicores: 4000,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        captured,
+        CaptureBuildPodResizeIdentityResult::Captured(_)
+    ));
+    assert_eq!(
+        BuildPodPermitRepository::new(db.clone())
+            .list_nonterminal_resize()
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "the fixture must actually produce a row the nonterminal index selects"
+    );
+}
+
+// ── the Pod plane fixture ───────────────────────────────────────────────────
+
+/// Records what was *attempted* against the Pod plane.
+///
+/// Every assertion in this file about Pods is a count taken from here. There is
+/// no "intended authority" field to read: `resize_patches` moves when and only
+/// when a `pods/resize` PATCH is actually issued.
+#[derive(Default)]
+struct RecordingPodPlane {
+    pod_creations: AtomicU64,
+    resize_patches: AtomicU64,
+    live: Mutex<Vec<LiveTaskRunPod>>,
+}
+
+impl RecordingPodPlane {
+    fn drained() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn with_live_pod() -> Arc<Self> {
+        let plane = Self::default();
+        plane.live.lock().unwrap().push(LiveTaskRunPod {
+            pod_name: "taskrun-still-running".into(),
+            pod_uid: "uid-still-running".into(),
+            task_run_id: "019fb854-0000-7000-8000-00000000dead".into(),
+        });
+        Arc::new(plane)
+    }
+
+    fn pod_creations(&self) -> u64 {
+        self.pod_creations.load(Ordering::SeqCst)
+    }
+
+    fn resize_patches(&self) -> u64 {
+        self.resize_patches.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TaskRunPodPlane for RecordingPodPlane {
+    async fn create_task_run_pod(&self, _task_run_id: &str, _image_id: &str) -> Result<(), String> {
+        self.pod_creations.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        _task_run_id: &str,
+        _millicores: u64,
+    ) -> Result<(), String> {
+        self.resize_patches.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn live_task_run_pods(&self) -> Result<Vec<LiveTaskRunPod>, String> {
+        Ok(self.live.lock().unwrap().clone())
+    }
+}
+
+// ── the registry ────────────────────────────────────────────────────────────
+
+/// A real OCI-manifest endpoint on a real TCP socket.
+///
+/// It serves whatever bytes are in its map at `/v2/<repo>/manifests/<ref>` and
+/// 404s otherwise, which is exactly the shape a registry takes after a manifest
+/// is deleted. The probe under test does a real HTTP GET and hashes the body it
+/// gets back, so removing an entry here is a genuine "the artifact is no longer
+/// pullable" and not a flag flip.
+struct LocalRegistry {
+    manifests: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    base_url: String,
+}
+
+impl LocalRegistry {
+    async fn start() -> Self {
+        let manifests: Arc<Mutex<HashMap<String, Vec<u8>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let state = Arc::clone(&manifests);
+        let app = axum::Router::new().route(
+            "/v2/{repository}/manifests/{reference}",
+            axum::routing::get(
+                move |axum::extract::Path((repository, reference)): axum::extract::Path<(
+                    String,
+                    String,
+                )>| {
+                    let state = Arc::clone(&state);
+                    async move {
+                        let key = format!("{repository}/{reference}");
+                        match state.lock().unwrap().get(&key).cloned() {
+                            Some(bytes) => (axum::http::StatusCode::OK, bytes),
+                            None => (axum::http::StatusCode::NOT_FOUND, Vec::new()),
+                        }
+                    }
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self {
+            manifests,
+            base_url,
+        }
+    }
+
+    /// Push `body` and return the digest the registry would report for it —
+    /// the SHA-256 of the exact bytes, which is what the probe recomputes.
+    fn push(&self, repository: &str, body: &[u8]) -> String {
+        use sha2::{Digest as _, Sha256};
+        let digest = format!("sha256:{:x}", Sha256::digest(body));
+        self.manifests
+            .lock()
+            .unwrap()
+            .insert(format!("{repository}/{digest}"), body.to_vec());
+        digest
+    }
+
+    /// Serve different bytes under an existing reference, without touching any
+    /// catalog row.
+    fn substitute(&self, repository: &str, reference: &str, body: &[u8]) {
+        self.manifests
+            .lock()
+            .unwrap()
+            .insert(format!("{repository}/{reference}"), body.to_vec());
+    }
+
+    /// Delete the manifest. Nothing else changes: no catalog row, no column.
+    fn delete(&self, repository: &str, reference: &str) {
+        self.manifests
+            .lock()
+            .unwrap()
+            .remove(&format!("{repository}/{reference}"));
+    }
+
+    fn probe(&self) -> Arc<dyn RegistryProbe> {
+        Arc::new(HttpRegistryProbe::new(&self.base_url))
+    }
+}
+
+/// A probe that answers nothing, for the arms that must not depend on a
+/// registry being reachable at all.
+struct UnusedRegistry;
+
+#[async_trait]
+impl RegistryProbe for UnusedRegistry {
+    async fn fetch_manifest(&self, _repository: &str, _reference: &str) -> Result<Vec<u8>, String> {
+        panic!("this test must not reach the registry");
+    }
+}
+
+// ── admission fixtures ──────────────────────────────────────────────────────
+
+/// **The mutation, embodied.** Writes the pause row and wires no refusal.
+///
+/// This is exactly the failure the criterion names: a `paused` row exists, a
+/// status read would report `paused`, and dispatch is nevertheless admitted. It
+/// is here so the assertion "the pause step blocks on it" is a real assertion
+/// rather than a claim about a hypothetical.
+struct RowOnlyAdmissionControl {
+    paused: Mutex<bool>,
+}
+
+#[async_trait]
+impl AdmissionControl for RowOnlyAdmissionControl {
+    async fn pause(&self, _reason: &str) -> Result<(), String> {
+        *self.paused.lock().unwrap() = true;
+        Ok(())
+    }
+
+    async fn resume(&self) -> Result<(), String> {
+        *self.paused.lock().unwrap() = false;
+        Ok(())
+    }
+
+    async fn dispatch_is_paused(&self) -> Result<bool, String> {
+        // The row says paused. The refusal path was never wired, so the
+        // predicate the dispatcher consults keeps answering "not paused".
+        Ok(false)
+    }
+}
+
+fn durable_admission(db: &Database) -> Arc<dyn AdmissionControl> {
+    Arc::new(DurableAdmissionControl::new(
+        db.clone(),
+        EventBus::noop(),
+        "eeky-cutover",
+    ))
+}
+
+/// Read the durable authority row, so "the mode did not move" is asserted
+/// against PostgreSQL rather than against the driver's own memory.
+async fn authority(db: &Database) -> (LauncherAuthorityProtocol, i64) {
+    let row = LauncherAuthorityModeRepository::new(db.clone())
+        .read()
+        .await
+        .unwrap()
+        .expect("migration 167 seeds the singleton");
+    (row.mode, row.epoch)
+}
+
+fn probe_for(image: &Image) -> DispatchProbe {
+    DispatchProbe {
+        task_run_id: "019fb854-1111-7000-8000-000000000001".into(),
+        image: image.clone(),
+    }
+}
+
+// ═══ AC2 — pullability and retention ════════════════════════════════════════
+
+/// Retention is a registry round trip whose *body* is hashed, and deleting the
+/// manifest turns it red while every catalog row stays exactly as it was.
+#[tokio::test]
+async fn retention_is_proven_by_a_registry_round_trip_not_by_a_stored_column() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    let registry = LocalRegistry::start().await;
+
+    let manifest = br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}"#;
+    let recorded = registry.push("djinn-image-legacy", manifest);
+    seed_image(&db, "legacy", Some(&recorded), None).await;
+
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[recorded.clone()]),
+        durable_admission(&db),
+        RecordingPodPlane::drained(),
+        registry.probe(),
+    );
+    let retained = vec![RetainedArtifact {
+        image_id: "legacy".into(),
+        repository: "djinn-image-legacy".into(),
+        digest: recorded.clone(),
+        role: RetentionRole::LegacyNoHandshake,
+    }];
+
+    rollout
+        .probe_retention(&retained)
+        .await
+        .expect("a manifest whose body hashes to the recorded digest is retained");
+
+    // MUTATION — delete the manifest, touch nothing else.
+    registry.delete("djinn-image-legacy", &recorded);
+    let blocked = rollout.probe_retention(&retained).await.unwrap_err();
+    let RolloutBlocked::RetentionUnprovable { digest, detail } = blocked else {
+        panic!("a deleted manifest must block retention, got {blocked:?}");
+    };
+    assert_eq!(digest, recorded);
+    assert!(
+        detail.contains("404"),
+        "the block must report what the round trip actually said, got {detail:?}"
+    );
+
+    // The catalog row is untouched: the check never consulted it, so a stored
+    // `pullable = true` would have changed nothing about the outcome above.
+    let row = ImageRepository::new(db.clone())
+        .get("legacy")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.status, "ready");
+    assert_eq!(row.registry_digest.as_deref(), Some(recorded.as_str()));
+
+    // SECOND MUTATION — serve *different* content under the same reference. The
+    // reference resolves, the fetch succeeds, and the digest does not match.
+    registry.substitute("djinn-image-legacy", &recorded, b"{\"schemaVersion\":2}");
+    let blocked = rollout.probe_retention(&retained).await.unwrap_err();
+    let RolloutBlocked::RetentionUnprovable { detail, .. } = blocked else {
+        panic!("substituted content must block retention, got {blocked:?}");
+    };
+    assert!(
+        detail.contains("served content whose digest is"),
+        "the block must name the digest actually served, got {detail:?}"
+    );
+}
+
+// ═══ AC3 — catalog metadata against the mode, through the enum ══════════════
+
+/// Under `resize-v2` every dispatch-eligible image must declare `resize-v2`;
+/// under `leaf-v1` an allowlisted no-handshake digest maps to leaf authority.
+#[tokio::test]
+async fn catalog_metadata_is_validated_against_the_mode_and_not_only_the_declaration() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-2222-7000-8000-000000000001").await;
+    seed_image(&db, "legacy", Some(&digest('a')), None).await;
+    select_image(&db, "legacy").await;
+
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[digest('a')]),
+        durable_admission(&db),
+        RecordingPodPlane::drained(),
+        Arc::new(UnusedRegistry),
+    );
+
+    // Under `leaf-v1`: an allowlisted no-handshake digest maps to leaf
+    // authority, named by the digest it was vouched for at.
+    let verdicts = rollout.validate_catalog(LEAF).await.unwrap();
+    assert_eq!(
+        verdicts,
+        vec![(
+            "legacy".to_owned(),
+            CatalogVerdict::LegacyLeafAuthority(PreProtocolDigest::parse(&digest('a')).unwrap())
+        )]
+    );
+    assert_eq!(verdicts[0].1.authority(), LEAF);
+
+    // MUTATION 1 — drop the mode from the comparison and the same row passes
+    // under `resize-v2`. It must not: `resize-v2` is not the behaviour a
+    // no-handshake artifact was built against, allowlisted or otherwise.
+    let blocked = rollout.validate_catalog(RESIZE).await.unwrap_err();
+    let RolloutBlocked::CatalogIncompatible(defects) = blocked else {
+        panic!("an allowlisted no-handshake row must be refused under resize-v2, got {blocked:?}");
+    };
+    assert_eq!(defects.len(), 1);
+    assert_eq!(defects[0].image_id, "legacy");
+    assert!(
+        matches!(
+            defects[0].reason,
+            CatalogDefectReason::Rejected(AdmissionRejection::MissingDeclarationUnderMode { .. })
+        ),
+        "got {:?}",
+        defects[0].reason
+    );
+}
+
+/// A `resize-v2` declaration is refused under `leaf-v1` and admitted under
+/// `resize-v2`, and the reverse holds for `leaf-v1`.
+#[tokio::test]
+async fn a_declaration_is_admitted_only_by_the_mode_that_matches_it() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-3333-7000-8000-000000000001").await;
+    seed_image(&db, "modern", Some(&digest('c')), Some(RESIZE)).await;
+    select_image(&db, "modern").await;
+
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[digest('c')]),
+        durable_admission(&db),
+        RecordingPodPlane::drained(),
+        Arc::new(UnusedRegistry),
+    );
+
+    assert_eq!(
+        rollout.validate_catalog(RESIZE).await.unwrap(),
+        vec![("modern".to_owned(), CatalogVerdict::Declared(RESIZE))]
+    );
+
+    let blocked = rollout.validate_catalog(LEAF).await.unwrap_err();
+    let RolloutBlocked::CatalogIncompatible(defects) = blocked else {
+        panic!("a resize-v2 declaration must be refused under leaf-v1, got {blocked:?}");
+    };
+    assert_eq!(
+        defects[0].reason,
+        CatalogDefectReason::Rejected(AdmissionRejection::Declared(
+            LauncherProtocolAdmission::ProtocolMismatch {
+                mode: LEAF,
+                declared: RESIZE
+            }
+        )),
+        "the refusal must be the one z3gi owns, carried verbatim"
+    );
+    // Even though the inventory vouches for this exact digest: a declaration is
+    // never reinterpreted by the legacy arm.
+    assert!(
+        matches!(
+            rollout.validate_catalog(LEAF).await,
+            Err(RolloutBlocked::CatalogIncompatible(_))
+        ),
+        "an allowlisted digest must not launder a mismatched declaration"
+    );
+}
+
+/// MUTATION 2 — comparing wire strings instead of the enum lets an unknown
+/// value such as `resize-v3` through as "not resize-v2, therefore leaf".
+///
+/// Reached through the pure classifier because migration 166's
+/// `launcher_authority_protocol` CHECK makes the value unstorable, which is
+/// asserted here too: the database is the outer fence and the parse is the
+/// inner one, and both are proven rather than assumed.
+#[tokio::test]
+async fn an_unknown_protocol_string_is_refused_and_is_also_unstorable() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_image(&db, "modern", Some(&digest('c')), Some(RESIZE)).await;
+
+    let inventory = signed_inventory(&[digest('c')]);
+    for mode in LauncherAuthorityProtocol::ALL {
+        let unknown = Image {
+            launcher_authority_protocol: Some("resize-v3".into()),
+            ..ImageRepository::new(db.clone())
+                .get("modern")
+                .await
+                .unwrap()
+                .unwrap()
+        };
+        assert_eq!(
+            classify_catalog_image(mode, &unknown, &inventory),
+            Err(CatalogDefectReason::UnparseableDeclaration {
+                declared: "resize-v3".into()
+            }),
+            "a wire-string comparison would read `resize-v3` as an authority under {mode}"
+        );
+    }
+
+    // And the column refuses it outright, so the pure path above is the only
+    // way the value can reach the decision at all.
+    let refused = sqlx::query(
+        "UPDATE images SET launcher_authority_protocol = 'resize-v3' WHERE id = 'modern'",
+    )
+    .execute(db.pool())
+    .await;
+    assert!(
+        refused.is_err(),
+        "migration 166 must refuse an unknown protocol at the column"
+    );
+}
+
+// ═══ AC4 — the admission pause, proven by a refused dispatch ════════════════
+
+/// The pause is asserted by dispatching and being refused, and by the Pod
+/// creation count not moving.
+#[tokio::test]
+async fn the_admission_pause_is_proven_by_a_refused_dispatch() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-4444-7000-8000-000000000001").await;
+    let image = seed_image(&db, "legacy", Some(&digest('a')), None).await;
+
+    let pods = RecordingPodPlane::drained();
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[digest('a')]),
+        durable_admission(&db),
+        Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
+        Arc::new(UnusedRegistry),
+    );
+
+    // Positive control: unpaused, the same dispatch creates a Pod. Without this
+    // the refusal below would be indistinguishable from a driver that refuses
+    // everything.
+    assert_eq!(
+        rollout
+            .attempt_dispatch("019fb854-4444-7000-8000-000000000001", &image)
+            .await,
+        DispatchOutcome::Dispatched {
+            authority: LEAF,
+            resized: false
+        }
+    );
+    assert_eq!(pods.pod_creations(), 1);
+
+    // Pause. `pause_admission` proves itself the same way this test does: it
+    // dispatches and requires a refusal.
+    rollout.verify_retention(&[]).await.unwrap();
+    rollout
+        .pause_admission("eeky cutover", &probe_for(&image))
+        .await
+        .expect("the pause must take effect, not merely be recorded");
+
+    assert_eq!(
+        rollout
+            .attempt_dispatch("019fb854-4444-7000-8000-000000000002", &image)
+            .await,
+        DispatchOutcome::RefusedByAdmissionPause
+    );
+    assert_eq!(
+        pods.pod_creations(),
+        1,
+        "a paused dispatch attempt must create no Pod; the assertion is the count, not the row"
+    );
+    assert_eq!(rollout.dispatches_admitted_while_paused(), 0);
+}
+
+/// **The mutation, run.** A pause that writes the row and wires no refusal is
+/// caught by the pause step itself, and the cutover stops there.
+///
+/// A test asserting `dispatch_pause_status() == paused` would pass against this
+/// implementation. This one does not, which is the whole point.
+#[tokio::test]
+async fn a_pause_row_without_a_wired_refusal_blocks_the_cutover() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-5555-7000-8000-000000000001").await;
+    let image = seed_image(&db, "legacy", Some(&digest('a')), None).await;
+
+    let pods = RecordingPodPlane::drained();
+    let broken = Arc::new(RowOnlyAdmissionControl {
+        paused: Mutex::new(false),
+    });
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[digest('a')]),
+        Arc::clone(&broken) as Arc<dyn AdmissionControl>,
+        Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
+        Arc::new(UnusedRegistry),
+    );
+
+    rollout.verify_retention(&[]).await.unwrap();
+    assert_eq!(
+        rollout
+            .pause_admission("eeky cutover", &probe_for(&image))
+            .await,
+        Err(RolloutBlocked::AdmissionPauseIneffective)
+    );
+    assert!(
+        *broken.paused.lock().unwrap(),
+        "the row WAS written — a row-reading assertion would be green here"
+    );
+    assert_eq!(
+        pods.pod_creations(),
+        1,
+        "the probe dispatch was admitted, which is exactly what makes the pause ineffective"
+    );
+
+    // And the cutover cannot proceed: the flip's prerequisite never entered the
+    // journal, and the durable mode is untouched.
+    assert!(!rollout.journal().contains(&RolloutStep::AdmissionPaused));
+    assert_eq!(
+        rollout.flip_authority_mode(0, RESIZE).await,
+        Err(RolloutBlocked::StepOutOfOrder {
+            step: RolloutStep::AuthorityModeFlipped,
+            missing: RolloutStep::AdmissionPaused
+        })
+    );
+    assert_eq!(authority(&db).await, (LEAF, 0));
+}
+
+// ═══ AC5 — both flips gated on both drain dimensions ════════════════════════
+
+/// Build a rollout already advanced to the point where the next legal step is
+/// the flip, with the given Pod plane.
+async fn armed_at_the_flip(
+    db: &Database,
+    pods: Arc<RecordingPodPlane>,
+    image: &Image,
+    inventory: LegacyDigestInventory,
+) -> ResizeRollout {
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        inventory,
+        durable_admission(db),
+        Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
+        Arc::new(UnusedRegistry),
+    );
+    rollout.verify_retention(&[]).await.unwrap();
+    rollout
+        .pause_admission("eeky cutover", &probe_for(image))
+        .await
+        .unwrap();
+    rollout
+}
+
+/// The four seeded-blocker cases, plus the proof that the block comes from
+/// `list_nonterminal_resize` and not from `set_mode`'s own census.
+#[tokio::test]
+async fn both_flips_are_gated_on_zero_live_pods_and_zero_nonterminal_rows() {
+    for (label, target) in [("forward", RESIZE), ("rollback", LEAF)] {
+        // ── one nonterminal resize row blocks this flip ──────────────────
+        {
+            let db = Database::ephemeral().await.unwrap();
+            assert_real_postgres(&db).await;
+            let run = "019fb854-6666-7000-8000-000000000001";
+            seed_project_and_run(&db, run).await;
+            let image = seed_image(&db, "legacy", Some(&digest('a')), None).await;
+            seed_nonterminal_resize_row(&db, run).await;
+
+            let rollout = armed_at_the_flip(
+                &db,
+                RecordingPodPlane::drained(),
+                &image,
+                signed_inventory(&[digest('a')]),
+            )
+            .await;
+            let blocked = rollout.prove_drained().await.unwrap_err();
+
+            // The variant is the one only `list_nonterminal_resize` can
+            // produce, and it names the row. Deleting that call would leave
+            // `set_mode`'s fence to refuse the flip — with
+            // `AuthorityDrainRefused` and a bare count, which this assertion
+            // rejects.
+            let RolloutBlocked::NonterminalResizeRows(rows) = blocked else {
+                panic!("{label}: expected named nonterminal rows, got {blocked:?}");
+            };
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].task_run_id, run);
+            assert_eq!(rows[0].state, "BirthConfirmed");
+            assert_eq!(rows[0].pod_uid.as_deref(), Some(format!("uid-{run}").as_str()));
+
+            assert_eq!(
+                rollout.flip_authority_mode(0, target).await,
+                Err(RolloutBlocked::StepOutOfOrder {
+                    step: RolloutStep::AuthorityModeFlipped,
+                    missing: RolloutStep::DrainProven
+                }),
+                "{label}: an unproven drain must not be flippable"
+            );
+            assert_eq!(authority(&db).await, (LEAF, 0), "{label}: mode must not move");
+        }
+
+        // ── one live task-run Pod blocks this flip ───────────────────────
+        {
+            let db = Database::ephemeral().await.unwrap();
+            assert_real_postgres(&db).await;
+            seed_project_and_run(&db, "019fb854-7777-7000-8000-000000000001").await;
+            let image = seed_image(&db, "legacy", Some(&digest('a')), None).await;
+
+            // PostgreSQL is fully drained here — `set_mode` would happily flip.
+            assert!(
+                BuildPodPermitRepository::new(db.clone())
+                    .list_nonterminal_resize()
+                    .await
+                    .unwrap()
+                    .is_empty()
+            );
+
+            let rollout = armed_at_the_flip(
+                &db,
+                RecordingPodPlane::with_live_pod(),
+                &image,
+                signed_inventory(&[digest('a')]),
+            )
+            .await;
+            let blocked = rollout.prove_drained().await.unwrap_err();
+            let RolloutBlocked::LiveTaskRunPods(live) = blocked else {
+                panic!("{label}: a live Pod must block the flip, got {blocked:?}");
+            };
+            assert_eq!(live.len(), 1);
+            assert_eq!(live[0].pod_name, "taskrun-still-running");
+            assert_eq!(authority(&db).await, (LEAF, 0), "{label}: mode must not move");
+        }
+    }
+}
+
+/// Forward and rollback both flip from a genuinely drained snapshot, so the
+/// four refusals above are caused by the blockers and not by the fence being
+/// stuck closed.
+#[tokio::test]
+async fn a_drained_snapshot_flips_forward_and_back() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-8888-7000-8000-000000000001").await;
+    let image = seed_image(&db, "legacy", Some(&digest('a')), None).await;
+
+    let forward = armed_at_the_flip(
+        &db,
+        RecordingPodPlane::drained(),
+        &image,
+        signed_inventory(&[digest('a')]),
+    )
+    .await;
+    forward.prove_drained().await.unwrap();
+    assert_eq!(forward.flip_authority_mode(0, RESIZE).await, Ok(1));
+    forward.resume_admission().await.unwrap();
+    assert_eq!(authority(&db).await, (RESIZE, 1));
+
+    let back = armed_at_the_flip(
+        &db,
+        RecordingPodPlane::drained(),
+        &image,
+        signed_inventory(&[digest('a')]),
+    )
+    .await;
+    back.prove_drained().await.unwrap();
+    assert_eq!(back.flip_authority_mode(1, LEAF).await, Ok(2));
+    back.resume_admission().await.unwrap();
+    assert_eq!(authority(&db).await, (LEAF, 2));
+}
+
+// ═══ AC6 — rollback blocked, admission stays paused ═════════════════════════
+
+/// Three unavailability shapes. In each: no flip, no resume, and — asserted by
+/// a real dispatch attempt, not by a status read — admission is still refusing.
+#[tokio::test]
+async fn rollback_is_blocked_and_leaves_admission_paused() {
+    // The three cases share a shape, so they share a driver body: seed, pause
+    // admission through the production path, break exactly one thing, attempt
+    // the rollback, then dispatch and require a refusal.
+    for case in ["allowlist absent", "digest not pullable", "row repointed"] {
+        let db = Database::ephemeral().await.unwrap();
+        assert_real_postgres(&db).await;
+        seed_project_and_run(&db, "019fb854-9999-7000-8000-000000000001").await;
+        let registry = LocalRegistry::start().await;
+        let manifest = format!("{{\"schemaVersion\":2,\"case\":\"{case}\"}}").into_bytes();
+        let retained_digest = registry.push("djinn-image-legacy", &manifest);
+        let image = seed_image(&db, "legacy", Some(&retained_digest), None).await;
+        select_image(&db, "legacy").await;
+
+        // The cutover is mid-flight: the mode is `resize-v2` and admission is
+        // already paused. This is the state a failed forward attempt leaves.
+        LauncherAuthorityModeRepository::new(db.clone())
+            .set_mode(0, RESIZE)
+            .await;
+        assert_eq!(authority(&db).await, (RESIZE, 1));
+        DispatchPauseRepository::new(db.clone(), EventBus::noop())
+            .pause(
+                djinn_db::DispatchPauseTarget::global(),
+                djinn_core::models::DispatchPause {
+                    paused_by: "eeky-cutover".into(),
+                    paused_at: "2026-07-31T00:00:00Z".into(),
+                    reason: "forward cutover failed".into(),
+                    expires_at: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let inventory = match case {
+            // The signed allowlist file is absent from the deployment.
+            "allowlist absent" => LegacyDigestInventory::Unconfigured,
+            _ => signed_inventory(&[retained_digest.clone()]),
+        };
+        if case == "digest not pullable" {
+            registry.delete("djinn-image-legacy", &retained_digest);
+        }
+        if case == "row repointed" {
+            // The catalog row now names a digest the retained set does not
+            // contain and the inventory does not vouch for.
+            sqlx::query("UPDATE images SET registry_digest = $1 WHERE id = 'legacy'")
+                .bind(digest('f'))
+                .execute(db.pool())
+                .await
+                .unwrap();
+        }
+
+        let pods = RecordingPodPlane::drained();
+        let rollout = ResizeRollout::new(
+            db.clone(),
+            inventory,
+            durable_admission(&db),
+            Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
+            registry.probe(),
+        );
+        let plan = RolloutPlan {
+            retained: &[RetainedArtifact {
+                image_id: "legacy".into(),
+                repository: "djinn-image-legacy".into(),
+                digest: retained_digest.clone(),
+                role: RetentionRole::LeafV1Rollback,
+            }],
+            probe: probe_for(&image),
+            expected_epoch: 1,
+            reason: "rolling back",
+        };
+
+        let Err(blocked) = rollout.rollback(&plan).await else {
+            panic!("{case}: rollback must be blocked");
+        };
+        match (case, &blocked) {
+            ("allowlist absent", RolloutBlocked::AllowlistUnavailable(defect)) => {
+                assert_eq!(*defect, LegacyAllowlistDefect::Unsigned);
+            }
+            ("digest not pullable", RolloutBlocked::RetentionUnprovable { digest, .. }) => {
+                assert_eq!(*digest, retained_digest);
+            }
+            // The repointed row is a dispatch-eligible no-handshake image the
+            // signed document does not vouch for, so the allowlist cross-check
+            // names it before the catalog validation is even reached. The
+            // distinguishing assertion is the row identity, which only a real
+            // catalog read can supply.
+            (
+                "row repointed",
+                RolloutBlocked::AllowlistUnavailable(LegacyAllowlistDefect::Uninventoried(rows)),
+            ) => {
+                assert_eq!(rows.len(), 1);
+                assert_eq!(rows[0].image_id, "legacy");
+                assert_eq!(rows[0].registry_digest, digest('f'));
+            }
+            _ => panic!("{case}: unexpected block {blocked:?}"),
+        }
+
+        // The mode did not flip. Read from PostgreSQL, not from the driver.
+        assert_eq!(
+            authority(&db).await,
+            (RESIZE, 1),
+            "{case}: a blocked rollback must not move the authority mode"
+        );
+        // No Pod was started, and no resize was PATCHed. Counted, not intended.
+        assert_eq!(pods.pod_creations(), 0, "{case}: no Pod may be created");
+        assert_eq!(pods.resize_patches(), 0, "{case}: no resize may be issued");
+        // Admission is still refusing — proven by dispatching, not by reading a
+        // status. `Err` alone would stay green if the mode flipped first and the
+        // error came afterwards, which the mode assertion above also rejects.
+        assert_eq!(
+            rollout
+                .attempt_dispatch("019fb854-9999-7000-8000-000000000002", &image)
+                .await,
+            DispatchOutcome::RefusedByAdmissionPause,
+            "{case}: admission must stay paused"
+        );
+        assert_eq!(pods.pod_creations(), 0, "{case}: still no Pod");
+        assert!(
+            !rollout.journal().contains(&RolloutStep::AdmissionResumed),
+            "{case}: admission must not have been resumed"
+        );
+    }
+}
+
+// ═══ AC7 — the ordering is enforced, not documented ═════════════════════════
+
+/// The full forward sequence, asserted as an observed step sequence.
+#[tokio::test]
+async fn the_forward_cutover_records_the_specced_step_sequence() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-aaaa-7000-8000-000000000001").await;
+    let registry = LocalRegistry::start().await;
+    let manifest = br#"{"schemaVersion":2,"role":"resize-v2"}"#;
+    let current = registry.push("djinn-image-modern", manifest);
+    let image = seed_image(&db, "modern", Some(&current), Some(RESIZE)).await;
+    select_image(&db, "modern").await;
+
+    let pods = RecordingPodPlane::drained();
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[digest('a')]),
+        durable_admission(&db),
+        Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
+        registry.probe(),
+    );
+    let plan = RolloutPlan {
+        retained: &[RetainedArtifact {
+            image_id: "modern".into(),
+            repository: "djinn-image-modern".into(),
+            digest: current.clone(),
+            role: RetentionRole::ResizeV2Current,
+        }],
+        probe: probe_for(&image),
+        expected_epoch: 0,
+        reason: "eeky cutover",
+    };
+
+    assert_eq!(rollout.activate(&plan).await, Ok(1));
+    assert_eq!(
+        rollout.journal(),
+        vec![
+            RolloutStep::CatalogMutationFrozen,
+            RolloutStep::LegacyInventorySigned,
+            RolloutStep::ProtocolAwareServerDeployed,
+            RolloutStep::CatalogRebuiltAsResizeV2,
+            RolloutStep::RetentionVerified,
+            RolloutStep::AdmissionPaused,
+            RolloutStep::DrainProven,
+            RolloutStep::AuthorityModeFlipped,
+            RolloutStep::AdmissionResumed,
+        ],
+        "the observed sequence is the assertion; a checklist document is not"
+    );
+    assert_eq!(authority(&db).await, (RESIZE, 1));
+}
+
+/// The two reorderings the criterion names, each attempted for real.
+#[tokio::test]
+async fn the_flip_cannot_precede_the_drain_and_the_resume_cannot_precede_the_flip() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-bbbb-7000-8000-000000000001").await;
+    let image = seed_image(&db, "legacy", Some(&digest('a')), None).await;
+
+    let pods = RecordingPodPlane::drained();
+    let rollout = armed_at_the_flip(
+        &db,
+        Arc::clone(&pods),
+        &image,
+        signed_inventory(&[digest('a')]),
+    )
+    .await;
+
+    // REORDERING 1 — flip before the drain proof.
+    assert_eq!(
+        rollout.flip_authority_mode(0, RESIZE).await,
+        Err(RolloutBlocked::StepOutOfOrder {
+            step: RolloutStep::AuthorityModeFlipped,
+            missing: RolloutStep::DrainProven
+        })
+    );
+    assert_eq!(authority(&db).await, (LEAF, 0), "the mode must not have moved");
+
+    // REORDERING 2 — resume before the flip is confirmed.
+    rollout.prove_drained().await.unwrap();
+    assert_eq!(
+        rollout.resume_admission().await,
+        Err(RolloutBlocked::StepOutOfOrder {
+            step: RolloutStep::AdmissionResumed,
+            missing: RolloutStep::AuthorityModeFlipped
+        })
+    );
+    // And admission really is still refusing — asserted by dispatching.
+    assert_eq!(
+        rollout
+            .attempt_dispatch("019fb854-bbbb-7000-8000-000000000002", &image)
+            .await,
+        DispatchOutcome::RefusedByAdmissionPause
+    );
+    assert_eq!(
+        pods.pod_creations(),
+        0,
+        "nothing has ever been dispatched here: even the pause probe was refused"
+    );
+
+    // In order, both succeed.
+    assert_eq!(rollout.flip_authority_mode(0, RESIZE).await, Ok(1));
+    rollout.resume_admission().await.unwrap();
+}
+
+/// A step cannot run twice, so a replayed cutover cannot launder a fence.
+#[tokio::test]
+async fn no_step_runs_twice() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[]),
+        durable_admission(&db),
+        RecordingPodPlane::drained(),
+        Arc::new(UnusedRegistry),
+    );
+    rollout.freeze_catalog_mutation().unwrap();
+    assert_eq!(
+        rollout.freeze_catalog_mutation(),
+        Err(RolloutBlocked::StepAlreadyRun(
+            RolloutStep::CatalogMutationFrozen
+        ))
+    );
+}
+
+// ═══ AC8 — never two quota authorities, never none ══════════════════════════
+
+/// The four (mode, artifact) combinations, asserted on counted Pod creations
+/// and counted `pods/resize` PATCHes.
+#[tokio::test]
+async fn no_pod_ever_has_two_quota_authorities_or_none() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-cccc-7000-8000-000000000001").await;
+    let legacy = seed_image(&db, "legacy", Some(&digest('a')), None).await;
+    let modern = seed_image(&db, "modern", Some(&digest('c')), Some(RESIZE)).await;
+    select_image(&db, "legacy").await;
+
+    let pods = RecordingPodPlane::drained();
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[digest('a')]),
+        durable_admission(&db),
+        Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
+        Arc::new(UnusedRegistry),
+    );
+
+    // ── mode `leaf-v1` ───────────────────────────────────────────────────
+    assert_eq!(authority(&db).await.0, LEAF);
+
+    // A `resize-v2` image is cataloged but does not dispatch: no Pod at all.
+    assert!(matches!(
+        rollout
+            .attempt_dispatch("019fb854-cccc-7000-8000-000000000002", &modern)
+            .await,
+        DispatchOutcome::RefusedByCatalog(_)
+    ));
+    assert_eq!(
+        pods.pod_creations(),
+        0,
+        "permitting a resize-v2 image to dispatch under leaf-v1 must create no Pod"
+    );
+
+    // An allowlisted no-handshake image retains launcher leaf authority and is
+    // never resized.
+    assert_eq!(
+        rollout
+            .attempt_dispatch("019fb854-cccc-7000-8000-000000000003", &legacy)
+            .await,
+        DispatchOutcome::Dispatched {
+            authority: LEAF,
+            resized: false
+        }
+    );
+    assert_eq!(pods.pod_creations(), 1);
+    assert_eq!(
+        pods.resize_patches(),
+        0,
+        "a resize PATCH against a leaf-v1 Pod would be the second quota writer"
+    );
+
+    // ── mode `resize-v2` ─────────────────────────────────────────────────
+    LauncherAuthorityModeRepository::new(db.clone())
+        .set_mode(0, RESIZE)
+        .await;
+    assert_eq!(authority(&db).await.0, RESIZE);
+
+    // The allowlisted no-handshake image now dispatches nowhere: `resize-v2`
+    // is not the behaviour it was built against.
+    assert!(matches!(
+        rollout
+            .attempt_dispatch("019fb854-cccc-7000-8000-000000000004", &legacy)
+            .await,
+        DispatchOutcome::RefusedByCatalog(_)
+    ));
+    assert_eq!(pods.pod_creations(), 1, "no new Pod");
+    assert_eq!(pods.resize_patches(), 0);
+
+    // And the `resize-v2` image dispatches with exactly one resize PATCH.
+    assert_eq!(
+        rollout
+            .attempt_dispatch("019fb854-cccc-7000-8000-000000000005", &modern)
+            .await,
+        DispatchOutcome::Dispatched {
+            authority: RESIZE,
+            resized: true
+        }
+    );
+    assert_eq!(pods.pod_creations(), 2);
+    assert_eq!(pods.resize_patches(), 1);
+}
+
+// ═══ reachability and retention gates ═══════════════════════════════════════
+
+fn repository_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .expect("the server manifest sits one level below the checkout root")
+        .to_path_buf()
+}
+
+fn read(relative: &str) -> String {
+    let path = repository_root().join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("reading {path:?}: {error}"))
+}
+
+/// **The reachability gate.**
+///
+/// `list_nonterminal_resize` had no production caller before this module. The
+/// tests above drive it, but a test can drive anything — what makes it
+/// *reachable* is that the call sits in non-test server code that the crate
+/// compiles unconditionally, reached from a driver whose durable half has no
+/// substitutable seam.
+#[test]
+fn the_drain_proof_calls_list_nonterminal_resize_from_compiled_server_code() {
+    let driver = read("server/src/task_run_resize_rollout.rs");
+    assert!(
+        driver.contains(".list_nonterminal_resize()"),
+        "the drain proof must call the production repository method"
+    );
+    assert!(
+        !driver.contains("#[cfg(test)]"),
+        "the driver must carry no test-only code path; the drain proof one production \
+         caller compiles is the same one the tests drive"
+    );
+
+    let lib = read("server/src/lib.rs");
+    assert!(
+        lib.contains("pub mod task_run_resize_rollout;"),
+        "the module must be declared in the server crate, unconditionally"
+    );
+    assert!(
+        !lib.contains("#[cfg(test)]\npub mod task_run_resize_rollout;"),
+        "the module must not be gated behind cfg(test)"
+    );
+}
+
+/// The durable half of the driver has no injection seam, so no fake repository
+/// can stand in for the drain fence or the catalog check.
+#[test]
+fn the_driver_exposes_no_seam_for_a_fake_repository() {
+    let driver = read("server/src/task_run_resize_rollout.rs");
+    // Needles are assembled at compile time so this file does not match itself.
+    for forbidden in [
+        concat!("permits: ", "impl"),
+        concat!("permits: ", "Arc<dyn"),
+        concat!("authority: ", "Arc<dyn"),
+        concat!("images: ", "Arc<dyn"),
+        concat!("trait ", "BuildPodPermits"),
+        concat!("trait ", "ImageCatalog"),
+    ] {
+        assert!(
+            !driver.contains(forbidden),
+            "{forbidden:?} would make the durable half substitutable"
+        );
+    }
+    assert!(
+        driver.contains("BuildPodPermitRepository::new(db.clone())"),
+        "the permit repository must be constructed from the Database, not injected"
+    );
+
+    let tests = read("server/tests/task_run_resize_rollout.rs");
+    assert!(
+        tests.contains("Database::ephemeral()"),
+        "these tests must construct a real PgPool"
+    );
+    for forbidden in [
+        concat!("Fake", "Permit"),
+        concat!("Mock", "Permit"),
+        concat!("Fake", "Image"),
+        concat!("Mock", "Image"),
+        concat!("Fake", "Database"),
+    ] {
+        assert!(!tests.contains(forbidden), "{forbidden:?} is forbidden here");
+    }
+}
+
+/// **The retention gate (AC9), such as it can be until the repeated-cycle task
+/// lands its own.**
+///
+/// This task reintroduces no blanket launcher CPU clamp and retires nothing.
+/// The assertions below are structural, so the claim is checked rather than
+/// asserted in a PR description: the ceiling render is still conditioned on
+/// `resize-v2`, and every protected asset still exists.
+#[test]
+fn no_blanket_launcher_cpu_clamp_is_reintroduced_and_nothing_is_retired() {
+    // The driver renders nothing at all: no manifest type, no resource block,
+    // no quantity. It cannot produce a container `limits.cpu` because it never
+    // constructs a container.
+    let driver = read("server/src/task_run_resize_rollout.rs");
+    for rendering in [
+        "ResourceRequirements",
+        "k8s_openapi",
+        "Quantity",
+        "\"limits\"",
+        "initContainers",
+    ] {
+        assert!(
+            !driver.contains(rendering),
+            "{rendering:?} would mean this module renders a container spec"
+        );
+    }
+
+    // The `resize-v2`-only condition on the ceiling render is intact.
+    let launcher = read("server/crates/djinn-k8s/src/launcher.rs");
+    assert!(
+        launcher.contains("launcher_owns_leaf_quota"),
+        "the ceiling render must still be conditioned on the protocol"
+    );
+
+    // Protected assets still exist.
+    for asset in [
+        "server/crates/djinn-cgroup-launcher",
+        "server/crates/djinn-k8s/src/pod_resize.rs",
+        "server/crates/djinn-k8s/src/launcher.rs",
+    ] {
+        assert!(
+            repository_root().join(asset).exists(),
+            "{asset} must not be deleted by this task"
+        );
+    }
+    let launcher_src = read("server/crates/djinn-cgroup-launcher/src/lib.rs");
+    for retained in ["cgroup.kill", "wait_empty"] {
+        assert!(
+            launcher_src.contains(retained),
+            "{retained} must not be disabled by this task"
+        );
+    }
+}

--- a/server/tests/task_run_resize_rollout.rs
+++ b/server/tests/task_run_resize_rollout.rs
@@ -723,7 +723,11 @@ async fn the_admission_pause_is_proven_by_a_refused_dispatch() {
         1,
         "a paused dispatch attempt must create no Pod; the assertion is the count, not the row"
     );
-    assert_eq!(rollout.dispatches_admitted_while_paused(), 0);
+    assert_eq!(
+        rollout.dispatches_admitted_while_paused(),
+        0,
+        "no Pod may be created between the pause and the resume"
+    );
 }
 
 /// **The mutation, run.** A pause that writes the row and wires no refusal is
@@ -1058,6 +1062,7 @@ async fn rollback_is_blocked_and_leaves_admission_paused() {
             !rollout.journal().contains(&RolloutStep::AdmissionResumed),
             "{case}: admission must not have been resumed"
         );
+        assert_eq!(rollout.dispatches_admitted_while_paused(), 0, "{case}");
     }
 }
 
@@ -1166,6 +1171,7 @@ async fn the_flip_cannot_precede_the_drain_and_the_resume_cannot_precede_the_fli
         0,
         "nothing has ever been dispatched here: even the pause probe was refused"
     );
+    assert_eq!(rollout.dispatches_admitted_while_paused(), 0);
 
     // In order, both succeed.
     assert_eq!(rollout.flip_authority_mode(0, RESIZE).await, Ok(1));
@@ -1455,6 +1461,20 @@ fn no_blanket_launcher_cpu_clamp_is_reintroduced_and_nothing_is_retired() {
             "{rendering:?} would mean this module renders a container spec"
         );
     }
+
+    // Outbound HTTP goes through the capability owner. `scripts/check-http-boundary.sh`
+    // enforces this repository-wide; asserting it here too means a reviewer sees
+    // the constraint beside the code it constrains rather than only in CI.
+    for forbidden in [concat!("reqwest", "::"), concat!("hyper", "::")] {
+        assert!(
+            !driver.contains(forbidden),
+            "{forbidden:?}: outbound HTTP must go through djinn_provider::http_util"
+        );
+    }
+    assert!(
+        driver.contains("djinn_provider::http_util::HttpClient"),
+        "the registry probe must use the capability owner's client"
+    );
 
     // The `resize-v2`-only condition on the ceiling render is intact.
     let launcher = read("server/crates/djinn-k8s/src/launcher.rs");

--- a/server/tests/task_run_resize_rollout.rs
+++ b/server/tests/task_run_resize_rollout.rs
@@ -206,7 +206,12 @@ async fn seed_nonterminal_resize_row(db: &Database, task_run_id: &str) {
         panic!("the permit pool must admit the fixture run");
     };
     permits
-        .bind_or_refresh_job_uid(task_run_id, &row.permit_id, row.fencing_token, "job-uid-eeky")
+        .bind_or_refresh_job_uid(
+            task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            "job-uid-eeky",
+        )
         .await
         .map(|_| ())
         .unwrap_or_else(|error| panic!("binding a Job UID must succeed: {error}"));
@@ -319,8 +324,7 @@ struct LocalRegistry {
 
 impl LocalRegistry {
     async fn start() -> Self {
-        let manifests: Arc<Mutex<HashMap<String, Vec<u8>>>> =
-            Arc::new(Mutex::new(HashMap::new()));
+        let manifests: Arc<Mutex<HashMap<String, Vec<u8>>>> = Arc::new(Mutex::new(HashMap::new()));
         let state = Arc::clone(&manifests);
         let app = axum::Router::new().route(
             "/v2/{repository}/manifests/{reference}",
@@ -463,13 +467,14 @@ async fn retention_is_proven_by_a_registry_round_trip_not_by_a_stored_column() {
     assert_real_postgres(&db).await;
     let registry = LocalRegistry::start().await;
 
-    let manifest = br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}"#;
+    let manifest =
+        br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}"#;
     let recorded = registry.push("djinn-image-legacy", manifest);
     seed_image(&db, "legacy", Some(&recorded), None).await;
 
     let rollout = ResizeRollout::new(
         db.clone(),
-        signed_inventory(&[recorded.clone()]),
+        signed_inventory(std::slice::from_ref(&recorded)),
         durable_admission(&db),
         RecordingPodPlane::drained(),
         registry.probe(),
@@ -834,7 +839,10 @@ async fn both_flips_are_gated_on_zero_live_pods_and_zero_nonterminal_rows() {
             assert_eq!(rows.len(), 1);
             assert_eq!(rows[0].task_run_id, run);
             assert_eq!(rows[0].state, "BirthConfirmed");
-            assert_eq!(rows[0].pod_uid.as_deref(), Some(format!("uid-{run}").as_str()));
+            assert_eq!(
+                rows[0].pod_uid.as_deref(),
+                Some(format!("uid-{run}").as_str())
+            );
 
             assert_eq!(
                 rollout.flip_authority_mode(0, target).await,
@@ -844,7 +852,11 @@ async fn both_flips_are_gated_on_zero_live_pods_and_zero_nonterminal_rows() {
                 }),
                 "{label}: an unproven drain must not be flippable"
             );
-            assert_eq!(authority(&db).await, (LEAF, 0), "{label}: mode must not move");
+            assert_eq!(
+                authority(&db).await,
+                (LEAF, 0),
+                "{label}: mode must not move"
+            );
         }
 
         // ── one live task-run Pod blocks this flip ───────────────────────
@@ -876,7 +888,11 @@ async fn both_flips_are_gated_on_zero_live_pods_and_zero_nonterminal_rows() {
             };
             assert_eq!(live.len(), 1);
             assert_eq!(live[0].pod_name, "taskrun-still-running");
-            assert_eq!(authority(&db).await, (LEAF, 0), "{label}: mode must not move");
+            assert_eq!(
+                authority(&db).await,
+                (LEAF, 0),
+                "{label}: mode must not move"
+            );
         }
     }
 }
@@ -957,7 +973,7 @@ async fn rollback_is_blocked_and_leaves_admission_paused() {
         let inventory = match case {
             // The signed allowlist file is absent from the deployment.
             "allowlist absent" => LegacyDigestInventory::Unconfigured,
-            _ => signed_inventory(&[retained_digest.clone()]),
+            _ => signed_inventory(std::slice::from_ref(&retained_digest)),
         };
         if case == "digest not pullable" {
             registry.delete("djinn-image-legacy", &retained_digest);
@@ -1123,7 +1139,11 @@ async fn the_flip_cannot_precede_the_drain_and_the_resume_cannot_precede_the_fli
             missing: RolloutStep::DrainProven
         })
     );
-    assert_eq!(authority(&db).await, (LEAF, 0), "the mode must not have moved");
+    assert_eq!(
+        authority(&db).await,
+        (LEAF, 0),
+        "the mode must not have moved"
+    );
 
     // REORDERING 2 — resume before the flip is confirmed.
     rollout.prove_drained().await.unwrap();
@@ -1342,7 +1362,10 @@ fn the_driver_exposes_no_seam_for_a_fake_repository() {
         concat!("Mock", "Image"),
         concat!("Fake", "Database"),
     ] {
-        assert!(!tests.contains(forbidden), "{forbidden:?} is forbidden here");
+        assert!(
+            !tests.contains(forbidden),
+            "{forbidden:?} is forbidden here"
+        );
     }
 }
 

--- a/server/tests/task_run_resize_rollout.rs
+++ b/server/tests/task_run_resize_rollout.rs
@@ -1295,6 +1295,67 @@ fn read(relative: &str) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("reading {path:?}: {error}"))
 }
 
+/// **The production composition site.**
+///
+/// The reachability question this repository keeps losing to is not "does the
+/// code exist" but "is the thing production composes the thing the tests
+/// drove". `ResizeRollout::production` is that site, and it is asserted here to
+/// wire only production implementations — the durable dispatch-pause state, the
+/// live apiserver, an HTTP registry — through the same `Self::new` the tests
+/// call. It is unconditional: no feature gate, no `cfg`, no fallback branch.
+///
+/// The type-level half of this is stronger than the textual half and is not
+/// restated here: `ResizeRollout::new` takes a `Database`, so no production
+/// path *can* be handed a substitute for the drain fence or the catalog.
+#[test]
+fn the_production_composition_site_wires_only_production_implementations() {
+    let driver = read("server/src/task_run_resize_rollout.rs");
+    let start = driver
+        .find("pub fn production(")
+        .expect("the module must expose a production composition site");
+    let body = &driver[start..];
+    let end = body.find("\n}\n").expect("the constructor must terminate");
+    let body = &body[..end];
+
+    for required in [
+        "DurableAdmissionControl::new",
+        "KubernetesTaskRunPodPlane::new",
+        "HttpRegistryProbe::new",
+        "LegacyDigestInventory::process()",
+        "Self::new(",
+    ] {
+        assert!(
+            body.contains(required),
+            "the production constructor must wire {required}, got:\n{body}"
+        );
+    }
+    for forbidden in ["cfg(", "feature =", "unimplemented", "todo!"] {
+        assert!(
+            !body.contains(forbidden),
+            "{forbidden:?} in the production constructor would make it conditional"
+        );
+    }
+
+    // The Kubernetes Pod plane composes production `djinn-k8s` entry points and
+    // introduces no primitive of its own.
+    for required in [
+        ".list_taskrun_jobs()",
+        "TaskRunPodResizeSurface::from_runtime",
+        ".observe_launcher(",
+    ] {
+        assert!(
+            driver.contains(required),
+            "the live-Pod census must go through the production entry point {required}"
+        );
+    }
+    // …and names no `kube` type of its own, so it cannot diverge from what
+    // dispatch and bootstrap already observe.
+    assert!(
+        !driver.contains("kube::"),
+        "the Pod plane must compose djinn-k8s, not reach past it"
+    );
+}
+
 /// **The reachability gate.**
 ///
 /// `list_nonterminal_resize` had no production caller before this module. The


### PR DESCRIPTION
Implements board task `eeky` (epic `xowm`, proposal `3i92`): the fenced
operational transition for project images that are built independently of the
server and cannot be swapped atomically by Helm — the five-step forward
activation and its reverse rollback.

## The reachability point

`BuildPodPermitRepository::list_nonterminal_resize` had **no production caller**
on `main`. `ResizeRollout::prove_drained` is now that caller, and
`ResizeRollout::production(...)` is the composition site that wires it to real
Postgres, a real apiserver and a real registry with no `cfg`, no feature gate
and no fallback branch.

Two source-level gates hold that in place, both in
`server/tests/task_run_resize_rollout.rs`:

- `the_drain_proof_calls_list_nonterminal_resize_from_compiled_server_code` —
  the call is in non-test server code, the module is declared unconditionally in
  `server/src/lib.rs`, and the driver carries no `#[cfg(test)]` path at all.
- `the_production_composition_site_wires_only_production_implementations` — the
  production constructor wires `DurableAdmissionControl`,
  `KubernetesTaskRunPodPlane` and `HttpRegistryProbe` through the same
  `Self::new` the tests call.

The type-level half is stronger than either gate and is not restatable in text:
`ResizeRollout::new` takes a `Database` and builds the three repositories
itself. **There is no constructor that accepts a repository**, so no fake can be
substituted for the drain fence or the catalog check — the properties there are
that a real partial index selects real rows and that a real CHECK constrains a
real column.

## Why the drain proof is two checks, not one

`set_mode` (z3gi, #2837) already refuses a flip while any permit row is live,
unraceably. It is not sufficient:

1. **PostgreSQL cannot see a Pod.** A task-run Pod whose permit was released, or
   that outlived its permit through a crash, is invisible to every count
   `set_mode` can take.
2. **A census is not a diagnostic.** `set_mode` reports counts.
   `list_nonterminal_resize` returns rows, so a blocked cutover names task-run
   ids and lifecycle states.

That distinction is what makes AC5's fifth mutation detectable. Deleting the
`list_nonterminal_resize` call would leave `set_mode` to refuse the seeded row
anyway — with `AuthorityDrainRefused` and a bare census instead of
`NonterminalResizeRows` naming the row. The tests assert the variant *and* the
row's `task_run_id`, `state` and `pod_uid`.

## Recorded mutation runs

Every mutation below was applied to `server/src/task_run_resize_rollout.rs`, run,
and reverted. Baseline: 17/17 green.

| # | mutation | result |
|---|---|---|
| 1 | drop the `list_nonterminal_resize` call from `probe_drain` | **2 failed** (`both_flips_are_gated_…`, the reachability gate) |
| 2 | drop the live-Pod check from `probe_drain` | **1 failed** (`both_flips_are_gated_…`) |
| 3 | drop the mode from the catalog comparison (always `LeafV1`) | **4 failed** |
| 4 | compare protocol wire strings instead of the enum | **1 failed** (`an_unknown_protocol_string_…`) |
| 5 | delete the step-ordering prerequisites | **3 failed** |
| 6 | issue the resize PATCH regardless of authority | **2 failed** |
| 7 | consult the pause predicate but never refuse | **6 failed** |
| 8 | hash a constant instead of the registry response body | **1 failed** (`retention_is_proven_by_…`) |

Re-run after the `djinn-provider` HTTP refactor below: 8 killed, 0 survived,
baseline restored to 17/17.

Two more mutations are permanent residents of the suite rather than one-off
runs, because they are the ones this repository keeps shipping:

- `RowOnlyAdmissionControl` — writes the pause row and wires no refusal. A
  `dispatch_pause_status() == paused` assertion is **green** against it;
  `a_pause_row_without_a_wired_refusal_blocks_the_cutover` is red, and the
  cutover stops at `AdmissionPauseIneffective` with the mode untouched.
- deleting the manifest from the registry while leaving the catalog row and
  every column alone — asserted inside
  `retention_is_proven_by_a_registry_round_trip_not_by_a_stored_column`, which
  also re-reads the `images` row afterwards to show the check never consulted
  it.

## Acceptance criteria

**AC1 — signed immutable allowlist.** `ImageRepository::signed_legacy_digest_allowlist`
(`image.rs`, extend-only) + `server/crates/djinn-db/tests/image_legacy_digest_allowlist.rs`,
against real Postgres. All four mutations fail: a mutable-tag entry
(`image:latest`) is rejected at load, one flipped signature bit is rejected, one
altered character of an allowlisted digest is rejected under the original
signature, and a document signed by a key other than the deployment key is
rejected. The forbidden assertion is **unwritable**: `SignedLegacyAllowlist` has
no signature field, no `signed` flag and no `verified` boolean. Holding one *is*
the proof, because the only way to obtain one is a completed Ed25519
verification. Unconfigured is refused here even though dispatch treats it as
unarmed — an unsigned allowlist proves nothing about compatibility.

**AC2 — pullability and retention.** A real HTTP GET — through
`djinn_provider::http_util::HttpClient`, the capability owner — whose **body** is hashed and
compared to the recorded digest. Deleting the manifest turns it red (HTTP 404);
serving *different* bytes under the same reference turns it red (digest
mismatch). No `pullable` column exists anywhere in the path.
`deploy/preflight/tests/task-run-resize-rollout.sh` runs the same three
assertions against a disposable `registry:2` — isolated `REG_NAME`/`REG_PORT`,
`df -h /` checked before pulling, container removed on exit pass or fail, and it
refuses to start if the port is already published by someone else's container.
Recorded run: 3 passed, 0 failed, against a real registry.

**AC3 — catalog metadata against the mode, through the enum.**
`classify_catalog_image` parses through `LauncherAuthorityProtocol`, never
compares wire strings, and delegates to `decide_admission`. Under `resize-v2`
every dispatch-eligible image must declare `resize-v2` and an allowlisted
no-handshake digest is refused; under `leaf-v1` an allowlisted no-handshake
digest maps to leaf authority. Mutation 3 (drop the mode) and mutation 4 (wire
strings) both fail. The test also asserts migration 166's CHECK refuses
`resize-v3` at the column, so the parse is the inner fence and the database the
outer one.

**AC4 — admission pause proven by effect.** `pause_admission` writes the pause
and then disbelieves it: a probe dispatch travels the same path a task run
takes, and anything other than `RefusedByAdmissionPause` blocks the cutover.
The test asserts a refused dispatch and an unmoved Pod-creation count, with a
positive control dispatching successfully first. `DurableAdmissionControl`
evaluates `djinn_coordinator::dispatch_pause::debug_view(&state).global` — the
same expression the coordinator's dispatch loop guards on, not a second copy.

**AC5 — both flips gated on both dimensions.** Real Postgres via
`Database::ephemeral()`, asserted per test by `assert_real_postgres` (executes
`SELECT version()`). Nonterminal rows are seeded through production repository
methods only (`acquire` → `bind_or_refresh_job_uid` → `capture_resize_identity`),
so the row is exactly what production writes and the FK chain is real. All four
seeded-blocker cases block, forward and rollback; the fifth mutation is covered
by asserting the variant and row identities as described above.
`a_drained_snapshot_flips_forward_and_back` is the positive control.

**AC6 — rollback blocked, admission stays paused.** Three cases: the signed
allowlist absent, a retained digest no longer pullable, a catalog row repointed
to a digest outside the retained set. In each: the durable mode is re-read from
Postgres and has not moved, `pod_creations == 0`, `resize_patches == 0`,
`AdmissionResumed` is not in the journal, and a real dispatch attempt afterwards
returns `RefusedByAdmissionPause`. `Err` alone is explicitly not the assertion.

**AC7 — ordering enforced.** `RolloutStep::prerequisites` is the ordering, in one
place; the journal records only steps that **completed** (`guard` and `record`
are separate, so a refused flip cannot satisfy the resume's prerequisite). The
happy-path test asserts the observed nine-step sequence. Both named reorderings
are attempted for real and return `StepOutOfOrder`, with the mode unmoved and —
for the resume case — a dispatch attempt still refused.

**AC8 — never two authorities, never none.** Four (mode, artifact) combinations,
asserted on counted Pod creations and counted `pods/resize` PATCHes: a
`resize-v2` image under `leaf-v1` creates no Pod; an allowlisted no-handshake
image dispatches with `resize_patches == 0`; under `resize-v2` the no-handshake
image creates no Pod and the `resize-v2` image dispatches with exactly one
PATCH. Mutation 6 kills it.

**AC9 — no blanket clamp, nothing retired.** Verified by explicit reviewer diff
inspection, recorded here, and by a structural gate
(`no_blanket_launcher_cpu_clamp_is_reintroduced_and_nothing_is_retired`).

The complete diff is **7 files, all additions**, plus one line in
`server/src/lib.rs`:

```
 deploy/preflight/tests/task-run-resize-rollout.sh   |  190 +++  (new)
 docs/deploy/launcher-authority-cutover.md           |  179 +++  (new)
 server/crates/djinn-db/src/repositories/image.rs    |  150 ++   (extend only)
 .../djinn-db/tests/image_legacy_digest_allowlist.rs |  360 +++  (new)
 server/src/lib.rs                                   |    1 +    (module decl)
 server/src/task_run_resize_rollout.rs               | 1452 +++  (new)
 server/tests/task_run_resize_rollout.rs             | 1484 +++  (new)
 7 files changed, 3816 insertions(+), 0 deletions(-)
```

- **Zero deletions**, so nothing is retired: not `djinn-cgroup-launcher`, not
  `process_broker`, not the RuntimeClass/node assets, not the credential-boundary
  tests, not the broker mounts, not `cgroup.kill`, not `wait_empty`.
- No Helm template, no `launcher.rs`, no `pod_resize.rs`, no `job.rs`, no
  `build_pod_permit.rs`. The `resize-v2` condition on the ceiling render is
  untouched — it is not in the diff.
- The driver renders nothing. The gate asserts it contains no
  `ResourceRequirements`, no `k8s_openapi`, no `Quantity`, no `"limits"` and no
  `initContainers`, so it cannot produce an unconditional launcher
  `resources.limits.cpu` even by accident.
- `server/crates/djinn-db/src/repositories/image.rs` is extend-only: one import
  line, one new method, three new types. No existing function is modified.

## The capability boundary caught this PR once

The first push named `reqwest::Client` in `HttpRegistryProbe` and `Server Guards`
failed with the repository's **first-ever** http capability-boundary violation
(`allowlist entries: http=0`). The guard is right, and the fix was not an
allowlist entry: the probe now goes through
`djinn_provider::http_util::HttpClient` with an explicit 30s manifest-read
timeout, so a cutover blocked on an unreachable registry reports that instead of
hanging a paused deployment on a socket. `scripts/test-capability-boundaries.sh`:
77 passed, 0 failed.

The same push also carried an unreachable counter —
`dispatches_admitted_while_paused`, behind a wrapper nothing called. That is the
exact defect class this task exists to prevent, so it is now incremented inside
the single dispatch path whenever a Pod is created between the journaled pause
and the journaled resume, and asserted in three tests.

## Honest gaps

- **The live-Pod census runs against a fixture in the Rust suite.** The task's
  design forbids standing up a live cluster in this wave ("No live cluster
  needed for this task. Do NOT create one"), so `KubernetesTaskRunPodPlane` — the
  production implementation, composed from `runtime.list_taskrun_jobs()` and
  `TaskRunPodResizeSurface::observe_launcher`, naming no `kube` type — is wired
  at the composition site and asserted by a source gate, but is not exercised
  against an apiserver here. Every assertion about Pods is a **count of
  attempts**, never a read of an intent field. A live-cluster proof of the census
  belongs with the mixed-version matrix task that consumes this driver.
- **`deploy/preflight/cutover-preflight.sh` and
  `djinn-k8s/src/cutover_preflight.rs` do not exist yet** (owned by `zpen`,
  running in parallel). The design says "call the preflight, do not modify it";
  there is nothing to call yet, so this PR does not call it. The runbook names
  the preflight invocations that do exist.
- The task is currently blocked by `17nm`; this lands the workflow so the
  blocked mixed-version matrix task is unblocked as soon as `17nm` closes.

## Test runs

```
cargo test -p djinn-server --test task_run_resize_rollout   17 passed, 0 failed
cargo test -p djinn-db --test image_legacy_digest_allowlist  4 passed, 0 failed
bash deploy/preflight/tests/task-run-resize-rollout.sh       3 passed, 0 failed
cargo clippy -p djinn-server -p djinn-db --all-targets       clean
bash scripts/test-capability-boundaries.sh                  77 passed, 0 failed
```

`cargo test -p djinn-db --lib` showed one failure under parallel threads
(`background::housekeeping::tests::parse_archive_window_days_falls_back_to_60_when_caller_passes_zero`)
that passes in isolation and passes with `--test-threads=1` (1182/1182). It is a
pre-existing process-global env collision in a module this diff does not touch.

`cargo test -p djinn-server --lib` aborts with a `tokio-rt-worker` stack overflow
on this machine. That reproduces **with the new module commented out of
`server/src/lib.rs`**, at a different test each run, so it is pre-existing and
environment-specific rather than caused by this diff. CI's sharded nextest run is
the authority.
