### PR TITLE
test(3i92): 40 lift/drop cycle invariants and the no-retirement repository diff gate (1j64)

### DIFF
--- a/.github/workflows/resize-kind.yml
+++ b/.github/workflows/resize-kind.yml
@@ -105,3 +105,114 @@ jobs:
       - name: Tear the cluster down
         if: always() && github.event.inputs.keep_on_failure != 'true'
         run: scripts/kind/setup-resize-kind-cluster.sh down
+
+  # -------------------------------------------------------------------------
+  # Task 1j64: 40+ lift/drop cycles, and the no-retirement gate's fixture
+  # self-test.
+  #
+  # A SEPARATE cluster from the job above, with its own name, registry and
+  # port: the two jobs run concurrently on the same `workflow_dispatch`, and a
+  # shared name would mean one job's teardown deleting the other's cluster
+  # mid-run. It invokes the same setup script rather than forking it.
+  #
+  # The gate itself needs no cluster and is ALSO invoked, on every PR, by
+  # `the_no_retirement_gate_passes_and_its_self_test_is_green` in
+  # server/tests/task_run_resize_cycles.rs — that is the always-on lane AC11
+  # asks for. The step here is the fixture self-test's dedicated home.
+  # -------------------------------------------------------------------------
+  resize-cycles:
+    name: Repeated lift/drop cycle invariants
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    # 40 cycles is 80 status-confirmed resizes plus a cluster, an image build
+    # and a chart install. Budgeted long deliberately; the teardown step below
+    # runs even when this cap is hit.
+    timeout-minutes: 90
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: "0"
+      CARGO_BUILD_BUILD_DIR: target
+      RUSTC_WRAPPER: ""
+      RUSTFLAGS: "-D warnings"
+      SQLX_OFFLINE: "true"
+      DJINN_RESIZE_HARNESS_K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.35.0' }}
+      # Isolated from every sibling harness: djinn-resize-pcod/5067 above,
+      # djinn-kueue-c1/5061 and djinn-kueue-b2b/5055 elsewhere in this
+      # repository. `guard_the_harness_is_disjoint_and_reuses_the_shared_script`
+      # fails on any collision, on every PR.
+      CYCLES_CLUSTER: djinn-resize-1j64
+      CYCLES_REGISTRY: djinn-resize-1j64-registry
+      CYCLES_REG_PORT: "5071"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kind, helm and crictl-capable tooling
+        run: |
+          set -euo pipefail
+          curl -fsSLo /tmp/kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+          chmod +x /tmp/kind
+          sudo mv /tmp/kind /usr/local/bin/kind
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          kind version
+          kubectl version --client
+          helm version
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # `save-if: false` is mandatory: every cache family in this repository has
+      # exactly one writer, declared in quality-gate.yml and enforced by
+      # scripts/ci-cache-policy.test.mjs.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: server
+          save-if: false
+          shared-key: server-test
+          cache-on-failure: true
+          cache-all-crates: true
+
+      # The no-retirement gate's fixtures, through the gate's own shell entry
+      # point. Cheap, and a red gate makes the cluster pointless.
+      - name: No-retirement gate self-test
+        run: |
+          set -euo pipefail
+          node --test scripts/test-resize-cutover-retention.mjs
+          ./scripts/check-resize-cutover-retention.sh
+
+      # The hermetic half. A guard failure here is the same failure a PR sees,
+      # and there is no point paying for a cluster if the wiring is wrong.
+      - name: Hermetic guards
+        working-directory: server
+        run: cargo test -p djinn-server --test task_run_resize_cycles
+
+      - name: Free space before the cluster
+        run: df -h /
+
+      - name: Bring up the disposable cluster
+        run: |
+          scripts/kind/setup-resize-kind-cluster.sh up \
+            --cluster-name "${CYCLES_CLUSTER}" \
+            --registry-name "${CYCLES_REGISTRY}" \
+            --registry-port "${CYCLES_REG_PORT}" \
+            --context "kind-${CYCLES_CLUSTER}" \
+            --k8s-version "${DJINN_RESIZE_HARNESS_K8S_VERSION}" \
+            ${{ github.event.inputs.keep_on_failure == 'true' && '--keep-on-failure' || '' }}
+
+      - name: Forty lift/drop cycles
+        working-directory: server
+        env:
+          DJINN_TEST_RESIZE_CYCLES: "1"
+        run: |
+          cargo test -p djinn-server --test task_run_resize_cycles -- \
+            --ignored --test-threads=1 --nocapture
+
+      # Pass or fail, cluster AND registry. The script's own EXIT trap covers a
+      # failure inside `up`; this covers a failure inside the suite, which the
+      # script never sees.
+      - name: Tear the cluster down
+        if: always() && github.event.inputs.keep_on_failure != 'true'
+        run: |
+          scripts/kind/setup-resize-kind-cluster.sh down \
+            --cluster-name "${CYCLES_CLUSTER}" \
+            --registry-name "${CYCLES_REGISTRY}" \
+            --registry-port "${CYCLES_REG_PORT}" \
+            --context "kind-${CYCLES_CLUSTER}"

--- a/scripts/check-resize-cutover-retention.sh
+++ b/scripts/check-resize-cutover-retention.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# The no-retirement gate for proposal 3i92's in-place task-run resize cutover
+# (epic xowm, task 1j64).
+#
+# The cutover moves ONE container's CPU ceiling. It retires nothing. This gate
+# refuses any diff that deletes or DISABLES the launcher crate, the broker, the
+# writable-cgroup RuntimeClass and node assets, the credential-boundary chart
+# tests, the launcher child mount set, the `cgroup.kill` write, `wait_empty`, or
+# the resize-v2-only condition on the launcher CPU ceiling.
+#
+# It is NOT a byte-identity check and must never become one — see the header of
+# scripts/resize-cutover-retention-manifest.mjs for why that formulation is
+# unsatisfiable in this epic.
+#
+# The exit code IS the contract:
+#   0  every protected asset is retained
+#   1  a retirement was detected
+#   2  the gate could not run at all
+#
+# Usage:
+#   ./scripts/check-resize-cutover-retention.sh
+#   RESIZE_RETENTION_ROOT=/path/to/fixture ./scripts/check-resize-cutover-retention.sh
+#     (self-test hook; see scripts/test-resize-cutover-retention.mjs)
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+DEFAULT_REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+ROOT=${RESIZE_RETENTION_ROOT:-$DEFAULT_REPO_ROOT}
+ENGINE="$SCRIPT_DIR/resize-cutover-retention-manifest.mjs"
+
+if [ ! -s "$ENGINE" ]; then
+    printf 'FATAL: the retention engine is missing: %s\n' "$ENGINE" >&2
+    exit 2
+fi
+
+if [ ! -d "$ROOT" ]; then
+    printf 'FATAL: retention root is not a directory: %s\n' "$ROOT" >&2
+    exit 2
+fi
+
+NODE_BIN=$(command -v node 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] && [ -x /opt/node/bin/node ]; then
+    NODE_BIN=/opt/node/bin/node
+fi
+if [ -z "$NODE_BIN" ]; then
+    printf 'FATAL: node is required but was not found on PATH or /opt/node/bin\n' >&2
+    exit 2
+fi
+
+# `exec` deliberately: the engine's exit code is this script's exit code, with
+# nothing in between that could turn a 1 into a 0.
+exec "$NODE_BIN" "$ENGINE" --root "$ROOT"

--- a/scripts/fixtures/resize-cutover-retention/README.md
+++ b/scripts/fixtures/resize-cutover-retention/README.md
@@ -1,0 +1,26 @@
+# Retention gate fixtures
+
+One directory per mutation. `scripts/test-resize-cutover-retention.mjs`
+materialises a scratch root from the REAL repository (every path
+`scripts/resize-cutover-retention-manifest.mjs --list-inputs` names), applies
+the fixture's operations to it, and runs
+`scripts/check-resize-cutover-retention.sh` against that root.
+
+`fixture.json` fields:
+
+| field | meaning |
+| --- | --- |
+| `asset` | the protected asset id this mutation targets; must appear in the gate's failure output when `expect` is `reject` |
+| `expect` | `reject` (the gate must exit nonzero) or `accept` (the gate must exit 0) |
+| `why` | what real-world retirement this mutation stands in for |
+| `operations` | `delete` / `replace` / `append`, applied in order |
+
+`replace` uses LITERAL text and must match exactly once. That is deliberate: a
+fixture whose anchor drifted out of the source would otherwise mutate nothing
+and the gate would "reject" it for no reason, or "accept" it vacuously.
+
+The `accept-*` fixtures are not decoration. AC8 of task 1j64 requires a
+**passing refactor case**: an ordinary rename inside a protected file must stay
+green. That case is what makes a byte-identity formulation of this gate
+impossible, which is the entire point — source files in this epic are expected
+to change; what must not happen is retirement.

--- a/scripts/fixtures/resize-cutover-retention/accept-baseline/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/accept-baseline/fixture.json
@@ -1,0 +1,6 @@
+{
+  "asset": null,
+  "expect": "accept",
+  "why": "The unmutated materialised root. This is what stops the self-test from passing against a gate that is simply always red, and it proves the materialised root the other fixtures are built on is COMPLETE — a missing input would fail here rather than silently make every reject fixture pass for the wrong reason.",
+  "operations": []
+}

--- a/scripts/fixtures/resize-cutover-retention/accept-comment-rewrite/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/accept-comment-rewrite/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": null,
+  "expect": "accept",
+  "why": "A second required-passing case: the doc comment above `kill` rewritten. Comments are the one thing the gate deliberately does not read, so rewriting one must not move the exit code. Paired with disable-cgroup-kill-commented-out this pins the gate's actual rule: comments never SATISFY a check and never BREAK one.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
+      "find": "    /// Mark terminal intent before cgroup-wide kill so a concurrent/replayed\n    /// grant can never lift it afterwards.\n",
+      "with": "    /// Terminal intent is marked first: a lift that arrives (or is replayed)\n    /// after this point must be refused rather than raise a dying leaf's quota.\n"
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/accept-local-variable-rename/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/accept-local-variable-rename/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": null,
+  "expect": "accept",
+  "why": "AC8's REQUIRED-PASSING case. An ordinary refactor: a local variable renamed inside the most heavily protected function in the repository. Nothing was retired, so the gate must stay green. A gate formulated as byte-identity of protected source files turns THIS red, which is why byte-identity is rejected outright — source files in this epic are expected to change; what must not happen is retirement.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
+      "find": "        let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n        if populated_zero(&events)? {\n",
+      "with": "        let drained = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n        if populated_zero(&drained)? {\n"
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-broker-mounts/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-broker-mounts/fixture.json
@@ -1,0 +1,8 @@
+{
+  "asset": "broker-mounts",
+  "expect": "reject",
+  "why": "The launcher child mount set deleted. A brokered command executes in the LAUNCHER container's mount namespace, so without these mounts every child's chdir into the workspace is ENOENT — the failure this module exists to have already fixed.",
+  "operations": [
+    { "op": "delete", "path": "server/crates/djinn-k8s/src/launcher_child_fs.rs" }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-cgroup-kill-write/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-cgroup-kill-write/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "cgroup-kill",
+  "expect": "reject",
+  "why": "The cgroup-wide kill removed outright. `kill` still exists, still marks terminal intent, and still returns Ok — it just no longer reaches anything. This is the shape a 'simplification' takes when someone decides pod resize made containment somebody else's problem.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
+      "find": "        self.fs.write_leaf(leaf.fd, \"cgroup.kill\", \"1\")\n",
+      "with": "        Ok(())\n"
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-cgroup-launcher-crate-manifest/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-cgroup-launcher-crate-manifest/fixture.json
@@ -1,0 +1,8 @@
+{
+  "asset": "cgroup-launcher-crate",
+  "expect": "reject",
+  "why": "Retiring the launcher crate starts with dropping its manifest: without it the crate no longer builds, no longer ships in the release image, and its containment suites stop compiling. The file the gate loses first is the one that names the crate.",
+  "operations": [
+    { "op": "delete", "path": "server/crates/djinn-cgroup-launcher/Cargo.toml" }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-containment-test/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-containment-test/fixture.json
@@ -1,0 +1,8 @@
+{
+  "asset": "launcher-containment-tests",
+  "expect": "reject",
+  "why": "The launcher crate's own containment proof deleted. Retiring the test that proves containment is retiring containment on a delay.",
+  "operations": [
+    { "op": "delete", "path": "server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs" }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-credential-boundary-test/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-credential-boundary-test/fixture.json
@@ -1,0 +1,8 @@
+{
+  "asset": "credential-boundary-tests",
+  "expect": "reject",
+  "why": "The pods/resize RBAC contract deleted. That test is the only thing asserting which identities may hold the resize verb; the cutover ADDS a caller of that verb, which makes the boundary more load-bearing, not less.",
+  "operations": [
+    { "op": "delete", "path": "deploy/helm/djinn/tests/pods-resize-rbac.sh" }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-launcher-ceiling-test/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-launcher-ceiling-test/fixture.json
@@ -1,0 +1,8 @@
+{
+  "asset": "launcher-cpu-ceiling-stays-conditional",
+  "expect": "reject",
+  "why": "The test that pins the launcher CPU ceiling to resize-v2 ONLY, deleted. launcher.rs's own comment points at this test by name; losing it is how a blanket clamp gets back in without anyone noticing.",
+  "operations": [
+    { "op": "delete", "path": "server/crates/djinn-k8s/src/launcher_tests.rs" }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-process-broker/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-process-broker/fixture.json
@@ -1,0 +1,8 @@
+{
+  "asset": "process-broker",
+  "expect": "reject",
+  "why": "The worker-side broker deleted. Without `ProcessHandle`/`CgroupLauncherClient` there is no seam through which an unprivileged worker reaches the privileged launcher, and no fenced lift.",
+  "operations": [
+    { "op": "delete", "path": "server/crates/djinn-agent/src/process_broker.rs" }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-runtimeclass-template/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-runtimeclass-template/fixture.json
@@ -1,0 +1,8 @@
+{
+  "asset": "runtimeclass-and-node-assets",
+  "expect": "reject",
+  "why": "The RuntimeClass template deleted. Without it there is no containerd handler granting a writable /sys/fs/cgroup and no nodeSelector keeping task-run Pods off unconformed nodes.",
+  "operations": [
+    { "op": "delete", "path": "deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml" }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/delete-wait-empty/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-wait-empty/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "wait-empty",
+  "expect": "reject",
+  "why": "The drain observation deleted from the launcher. `cgroup.kill` is asynchronous; without `wait_empty` nothing ever observes that the leaf actually emptied, and `remove` races the kernel.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
+      "find": "    pub fn wait_empty(&mut self, leaf: &Leaf) -> Result<(), Error> {\n        let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n        if populated_zero(&events)? {\n            Ok(())\n        } else {\n            Err(Error::StillPopulated)\n        }\n    }\n",
+      "with": ""
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/disable-cgroup-kill-always-false-guard/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-cgroup-kill-always-false-guard/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "cgroup-kill",
+  "expect": "reject",
+  "why": "AC9, mutation two, second form. The `cgroup.kill` write guarded behind a condition that can never be true. Every symbol is present, the statement is uncommented, and it executes never.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
+      "find": "        leaf.terminal = true;\n        self.fs.write_leaf(leaf.fd, \"cgroup.kill\", \"1\")\n",
+      "with": "        leaf.terminal = true;\n        if false {\n            self.fs.write_leaf(leaf.fd, \"cgroup.kill\", \"1\")?;\n        }\n        Ok(())\n"
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/disable-cgroup-kill-commented-out/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-cgroup-kill-commented-out/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "cgroup-kill",
+  "expect": "reject",
+  "why": "AC9, mutation two, first form. The `cgroup.kill` write commented out. A grep over raw source still finds the string, which is exactly why the gate judges COMMENT-STRIPPED source: a commented statement is a deleted statement that greps green.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
+      "find": "        self.fs.write_leaf(leaf.fd, \"cgroup.kill\", \"1\")\n",
+      "with": "        // self.fs.write_leaf(leaf.fd, \"cgroup.kill\", \"1\")\n        Ok(())\n"
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/disable-containment-lane/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-containment-lane/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "launcher-containment-tests",
+  "expect": "reject",
+  "why": "AC9's last clause. The containment proofs are retained on disk and no CI lane runs them any more. A retained test nothing invokes is a retired test, and this is the cheapest possible way to retire one: delete a line from a workflow.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": ".github/workflows/quality-gate.yml",
+      "find": "            --test brokered_lease_lift_boundary \\\n",
+      "with": ""
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/disable-launcher-cpu-ceiling-unconditional/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-launcher-cpu-ceiling-unconditional/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "launcher-cpu-ceiling-stays-conditional",
+  "expect": "reject",
+  "why": "AC10. The leaf-v1 arm removed, so the launcher sidecar's `resources.limits.cpu` renders UNCONDITIONALLY. Under leaf-v1 the launcher owns the leaf's own `cpu.max`, so a container limit here is an ancestor clamp over every invocation leaf: 7deu measured a leaf whose `cpu.max` read four cores while the process burned a quarter of one, with the leaf's own `nr_throttled` at 0 throughout. A `cpu.max` read-back would have reported the ceiling and said nothing.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-k8s/src/launcher.rs",
+      "find": "    if protocol.launcher_owns_leaf_quota() {\n        return Ok(None);\n    }\n",
+      "with": ""
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/disable-runtimeclass-conditional/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-runtimeclass-conditional/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "runtimeclass-and-node-assets",
+  "expect": "reject",
+  "why": "AC9, mutation three. The RuntimeClass template rendered conditionally on a condition that is disabled by construction. The file is present, `helm template` still succeeds, and the class never appears in any release. The gate pins the guard to exactly the one operator-facing switch, so an extra always-false conjunct is a retirement.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml",
+      "find": "{{- if .Values.cgroupWritable.runtimeClass.enabled }}\n",
+      "with": "{{- if and .Values.cgroupWritable.runtimeClass.enabled .Values.cgroupWritable.runtimeClass.legacyOptIn }}\n"
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/disable-runtimeclass-conditional/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-runtimeclass-conditional/fixture.json
@@ -1,7 +1,7 @@
 {
   "asset": "runtimeclass-and-node-assets",
   "expect": "reject",
-  "why": "AC9, mutation three. The RuntimeClass template rendered conditionally on a condition that is disabled by construction. The file is present, `helm template` still succeeds, and the class never appears in any release. The gate pins the guard to exactly the one operator-facing switch, so an extra always-false conjunct is a retirement.",
+  "why": "AC9, mutation three: the RuntimeClass template rendered conditionally with a default of disabled. Stated precisely, because the naive reading of that phrase is already true of this chart and must not be broken. `cgroupWritable.runtimeClass.enabled` defaults to FALSE on purpose — arming the writable-cgroup class before the nodes pass conformance leaves task-run Pods unschedulable, so the chart ships it off and the operator turns it on. What must not happen is a SECOND condition the operator has no switch for: the class then never renders no matter what they set, and the file, the template and `helm template` all still look healthy. The gate pins the guard to exactly the one operator-facing condition, so any extra conjunct reads as a retirement.",
   "operations": [
     {
       "op": "replace",

--- a/scripts/fixtures/resize-cutover-retention/disable-wait-empty-call-site/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-wait-empty-call-site/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "wait-empty",
+  "expect": "reject",
+  "why": "Retirement by unreachability. `wait_empty` survives untouched in the launcher, the broker, the transport and the handle trait — and the one production caller that turns the asynchronous `cgroup.kill` into an OBSERVED drain is gone. Presence checks all pass. This is the failure mode the resize reachability guard was written for, applied to containment.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-agent/src/process.rs",
+      "find": "        child.wait_empty().map_err(LeaseInvocationError::Launcher)?;\n",
+      "with": ""
+    }
+  ]
+}

--- a/scripts/fixtures/resize-cutover-retention/disable-wait-empty-immediate-ok/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-wait-empty-immediate-ok/fixture.json
@@ -1,0 +1,13 @@
+{
+  "asset": "wait-empty",
+  "expect": "reject",
+  "why": "AC9, mutation one. `wait_empty` replaced with an immediate `Ok(())`. The symbol is still there, the call sites still compile, every existence check still passes — and the leaf is never observed to drain. A gate that only checks the file still exists stays green under this.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
+      "find": "        let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n        if populated_zero(&events)? {\n            Ok(())\n        } else {\n            Err(Error::StillPopulated)\n        }\n",
+      "with": "        Ok(())\n"
+    }
+  ]
+}

--- a/scripts/resize-cutover-retention-manifest.mjs
+++ b/scripts/resize-cutover-retention-manifest.mjs
@@ -1,0 +1,654 @@
+#!/usr/bin/env node
+// The no-retirement engine for proposal 3i92's epic `xowm` (task 1j64).
+//
+// WHY THIS EXISTS
+// ---------------
+// The in-place task-run resize cutover moves the CPU ceiling of one container.
+// It is NOT a licence to retire the containment and credential boundary that
+// the launcher, the broker and the writable-cgroup RuntimeClass make up. The
+// epic's retained boundary is explicit: no deletion and no DISABLING of the
+// launcher crate, the broker, the RuntimeClass and node assets, the
+// credential-boundary tests, the broker mounts, the `cgroup.kill` write, or
+// `wait_empty` belongs in this cutover.
+//
+// WHAT THIS IS NOT
+// ----------------
+// It is NOT a byte-identity check, and it must never become one. Source files
+// in this epic are EXPECTED to change: they are being refactored around the
+// resize path right now. A gate phrased as "file X must be byte-identical"
+// combined with "pattern P must have zero hits", where P occurs in X, is
+// unsatisfiable — that exact pair cost a full agent-run on 2026-07-30. So the
+// contract here is:
+//
+//   * PRESENCE   — the asset's files are still tracked and non-empty.
+//   * CONTENT    — the behaviour-bearing statement is still there, judged on
+//                  source with whole-line comments stripped, so commenting a
+//                  write out reads as deleting it.
+//   * REACHABILITY — something in PRODUCTION still calls it. A `wait_empty`
+//                  that exists and is called from nowhere is retired in every
+//                  sense that matters.
+//   * NO ALWAYS-FALSE GUARDS — `if false`, `#[cfg(any())]` and friends are
+//                  disablement wearing the costume of a conditional.
+//
+// A refactor that renames a local variable inside a protected file passes.
+// Deleting the `cgroup.kill` write, stubbing `wait_empty` to return
+// immediately, or wedging the RuntimeClass template behind an always-false
+// condition does not.
+//
+// Usage:
+//   node scripts/resize-cutover-retention-manifest.mjs [--root <dir>]
+//   node scripts/resize-cutover-retention-manifest.mjs --list-inputs
+//
+// Exit codes: 0 = every asset retained, 1 = a retirement was detected,
+// 2 = the gate could not run (its own subject is missing).
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Paths, spelled once.
+// ---------------------------------------------------------------------------
+
+const LAUNCHER_CRATE = 'server/crates/djinn-cgroup-launcher';
+const LAUNCHER_LIB = `${LAUNCHER_CRATE}/src/lib.rs`;
+const LAUNCHER_MAIN = `${LAUNCHER_CRATE}/src/main.rs`;
+const LAUNCHER_BROKER = `${LAUNCHER_CRATE}/src/broker.rs`;
+const LAUNCHER_TRANSPORT = `${LAUNCHER_CRATE}/src/transport.rs`;
+const LAUNCHER_CARGO = `${LAUNCHER_CRATE}/Cargo.toml`;
+const CONTAINMENT_TEST = `${LAUNCHER_CRATE}/tests/containment_and_escalation.rs`;
+const LIFT_BOUNDARY_TEST = `${LAUNCHER_CRATE}/tests/brokered_lease_lift_boundary.rs`;
+
+const PROCESS_BROKER = 'server/crates/djinn-agent/src/process_broker.rs';
+const PROCESS = 'server/crates/djinn-agent/src/process.rs';
+
+const CHILD_FS = 'server/crates/djinn-k8s/src/launcher_child_fs.rs';
+const K8S_LAUNCHER = 'server/crates/djinn-k8s/src/launcher.rs';
+const K8S_JOB = 'server/crates/djinn-k8s/src/job.rs';
+const K8S_LAUNCHER_TESTS = 'server/crates/djinn-k8s/src/launcher_tests.rs';
+
+const RUNTIMECLASS_TEMPLATE =
+    'deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml';
+const NODE_CONFORMANCE = 'deploy/node/k3s/djinn-cgroup-writable-conformance.sh';
+const CHART_VALUES = 'deploy/helm/djinn/values.yaml';
+const RBAC_TEST = 'deploy/helm/djinn/tests/pods-resize-rbac.sh';
+const CGROUP_RENDER_TEST = 'deploy/helm/djinn/tests/cgroup-writable-render.sh';
+const CHART_CONTRACT_RUNNER = 'scripts/test-helm-chart-contracts.sh';
+
+const WORKSPACE_MANIFEST = 'server/Cargo.toml';
+const QUALITY_GATE = '.github/workflows/quality-gate.yml';
+const RELEASE_WORKFLOW = '.github/workflows/release.yml';
+
+// ---------------------------------------------------------------------------
+// Always-false disablement signatures.
+//
+// None of these ever appears legitimately in the protected set. A conditional
+// that can never be true is a deletion that still passes `[ -f "$path" ]`, so
+// it is rejected wherever it shows up in a protected Rust or template file.
+// ---------------------------------------------------------------------------
+
+const ALWAYS_FALSE = [
+    { pattern: /\bif\s+false\b/, name: 'if false' },
+    { pattern: /\bif\s+!\s*true\b/, name: 'if !true' },
+    { pattern: /#\[cfg\(any\(\)\)\]/, name: '#[cfg(any())]' },
+    { pattern: /\bcfg!\(any\(\)\)/, name: 'cfg!(any())' },
+    { pattern: /\bif\s+0\s*==\s*1\b/, name: 'if 0 == 1' },
+    { pattern: /\{\{-?\s*if\s+false\s*-?\}\}/, name: '{{ if false }}' },
+];
+
+// ---------------------------------------------------------------------------
+// The protected assets.
+//
+// `content` entries are asserted against COMMENT-STRIPPED source, so a
+// commented-out write is an absent write. `reachability` entries are the same
+// assertion made about a PRODUCTION call site: presence without a caller is
+// retirement with extra steps.
+// ---------------------------------------------------------------------------
+
+const ASSETS = [
+    {
+        id: 'cgroup-launcher-crate',
+        title: 'the djinn-cgroup-launcher crate',
+        files: [LAUNCHER_CARGO, LAUNCHER_LIB, LAUNCHER_MAIN, LAUNCHER_BROKER, LAUNCHER_TRANSPORT],
+        content: [
+            {
+                path: LAUNCHER_CARGO,
+                pattern: /name\s*=\s*"djinn-cgroup-launcher"/,
+                why: 'the crate must still declare itself; a renamed crate is a retired one under a different name',
+            },
+            {
+                path: WORKSPACE_MANIFEST,
+                pattern: /crates\/djinn-cgroup-launcher/,
+                why: 'the crate must stay a workspace member, or `cargo test --workspace` stops compiling and running its containment suites',
+            },
+        ],
+        reachability: [
+            {
+                path: RELEASE_WORKFLOW,
+                pattern: /-p\s+djinn-cgroup-launcher/,
+                why: 'the release lane must still build the launcher binary, or the shipped image has no launcher to run',
+            },
+        ],
+        alwaysFalseScan: [LAUNCHER_LIB, LAUNCHER_BROKER, LAUNCHER_MAIN],
+    },
+    {
+        id: 'cgroup-kill',
+        title: 'the cgroup.kill write site',
+        files: [LAUNCHER_LIB, PROCESS_BROKER, PROCESS],
+        content: [
+            {
+                path: LAUNCHER_LIB,
+                pattern: /write_leaf\(\s*leaf\.fd\s*,\s*"cgroup\.kill"\s*,\s*"1"\s*\)/,
+                why: 'the whole-cgroup kill is what reaches EVERY descendant of the invocation leaf. A per-pid SIGKILL does not, and a commented-out write does not either',
+            },
+            {
+                path: LAUNCHER_LIB,
+                pattern: /leaf\.terminal\s*=\s*true/,
+                why: 'terminal intent must be marked BEFORE the kill, so a concurrent or replayed grant can never lift a leaf that is being torn down',
+            },
+            {
+                path: PROCESS_BROKER,
+                pattern: /fn\s+kill\s*\(\s*&mut\s+self\s*\)\s*->\s*io::Result<\(\)>\s*;/,
+                why: 'the broker-side handle must still expose kill',
+            },
+        ],
+        reachability: [
+            {
+                path: PROCESS,
+                pattern: /child\.kill\(\)/,
+                why: 'the invocation teardown path must still call kill; a kill nobody calls contains nothing',
+            },
+        ],
+        alwaysFalseScan: [LAUNCHER_LIB, PROCESS_BROKER],
+    },
+    {
+        id: 'wait-empty',
+        title: 'wait_empty, the drain observation',
+        files: [LAUNCHER_LIB, LAUNCHER_BROKER, LAUNCHER_TRANSPORT, PROCESS_BROKER, PROCESS],
+        content: [
+            {
+                path: LAUNCHER_LIB,
+                pattern: /pub\s+fn\s+wait_empty\s*\(/,
+                why: 'the launcher must still expose the drain observation',
+            },
+            {
+                path: LAUNCHER_LIB,
+                pattern: /read_leaf\(\s*leaf\.fd\s*,\s*"cgroup\.events"\s*\)/,
+                why: 'emptiness is READ from cgroup.events. A wait_empty that returns Ok(()) without reading the kernel is the disablement this gate exists to reject',
+            },
+            {
+                path: LAUNCHER_LIB,
+                pattern: /populated_zero\s*\(/,
+                why: 'the read must be interpreted: `populated 0` is the condition, not the mere fact that the file was readable',
+            },
+            {
+                path: LAUNCHER_LIB,
+                pattern: /Error::StillPopulated/,
+                why: 'a still-populated leaf must be able to FAIL. A wait_empty with no failure arm cannot observe anything',
+            },
+            {
+                path: LAUNCHER_LIB,
+                pattern: /self\.wait_empty\(\s*leaf\s*\)\s*\?/,
+                why: 'removal must be gated on the drain; removing a populated leaf is the leak this observation prevents',
+            },
+            {
+                path: LAUNCHER_BROKER,
+                pattern: /launcher\.wait_empty\(/,
+                why: 'the privileged broker must still drive the drain on behalf of the unprivileged worker',
+            },
+            {
+                path: LAUNCHER_TRANSPORT,
+                pattern: /pub\s+fn\s+wait_empty\s*\(/,
+                why: 'the control protocol must still carry the drain frame, or the worker cannot ask for it',
+            },
+            {
+                path: PROCESS_BROKER,
+                pattern: /fn\s+wait_empty\s*\(\s*&mut\s+self\s*\)\s*->\s*io::Result<\(\)>\s*;/,
+                why: 'the worker-side handle must still expose the drain',
+            },
+        ],
+        reachability: [
+            {
+                path: PROCESS,
+                pattern: /child\.wait_empty\(\)/,
+                why: 'the invocation teardown path must still WAIT for the drain. This is the one call that turns `cgroup.kill` from asynchronous into observed',
+            },
+        ],
+        alwaysFalseScan: [LAUNCHER_LIB, LAUNCHER_BROKER, LAUNCHER_TRANSPORT, PROCESS_BROKER],
+    },
+    {
+        id: 'process-broker',
+        title: 'the worker-side process broker',
+        files: [PROCESS_BROKER, PROCESS],
+        content: [
+            {
+                path: PROCESS_BROKER,
+                pattern: /trait\s+ProcessHandle\s*:/,
+                why: 'the handle trait is the seam every brokered invocation is torn down through',
+            },
+            {
+                path: PROCESS_BROKER,
+                pattern: /trait\s+CgroupLauncherClient\s*:/,
+                why: 'the client trait is how the worker reaches the privileged launcher at all',
+            },
+            {
+                path: PROCESS_BROKER,
+                pattern: /fn\s+fenced_lift\s*\(\s*&mut\s+self\s*\)/,
+                why: 'the fenced lift is the authority boundary; an unfenced lift is goxi blocker 14',
+            },
+        ],
+        reachability: [
+            {
+                path: PROCESS,
+                pattern: /\.map_err\(LeaseInvocationError::Launcher\)/,
+                why: 'the production invocation path must still surface launcher failures rather than swallow them',
+            },
+        ],
+        alwaysFalseScan: [PROCESS_BROKER],
+    },
+    {
+        id: 'broker-mounts',
+        title: 'the launcher child mount set',
+        files: [CHILD_FS],
+        content: [
+            {
+                path: CHILD_FS,
+                pattern: /pub\s+fn\s+launcher_volume_mounts\s*\(/,
+                why: 'a brokered command runs in the LAUNCHER container mount namespace; without these mounts every child chdir is ENOENT',
+            },
+            {
+                path: CHILD_FS,
+                pattern: /pub\s+fn\s+launcher_data_mounts\s*\(/,
+                why: 'the child surfaces (mirror, projects, cache, workspace) must still be re-rendered onto the sidecar',
+            },
+            {
+                path: CHILD_FS,
+                pattern: /pub\s+fn\s+launcher_scratch_volumes\s*\(/,
+                why: 'the scratch volumes backing /tmp, /var/tmp and the home dir must still be declared',
+            },
+            {
+                path: CHILD_FS,
+                pattern: /worker_launcher_ipc_mount\(\)/,
+                why: 'the IPC volume is the only path shared by the worker and the sidecar; the broker socket lives on it',
+            },
+        ],
+        reachability: [
+            {
+                path: K8S_LAUNCHER,
+                pattern: /launcher_child_fs::launcher_volume_mounts\(/,
+                why: 'the renderer must still attach the mount set to the sidecar it emits',
+            },
+            {
+                path: K8S_JOB,
+                pattern: /launcher_child_fs::launcher_scratch_volumes\(\)/,
+                why: 'the Job renderer must still declare the volumes those mounts resolve against',
+            },
+        ],
+        alwaysFalseScan: [CHILD_FS],
+    },
+    {
+        id: 'runtimeclass-and-node-assets',
+        title: 'the writable-cgroup RuntimeClass and node assets',
+        files: [RUNTIMECLASS_TEMPLATE, NODE_CONFORMANCE, CHART_VALUES],
+        content: [
+            {
+                path: RUNTIMECLASS_TEMPLATE,
+                pattern: /^\{\{-\s*if\s+\.Values\.cgroupWritable\.runtimeClass\.enabled\s*\}\}$/m,
+                why: 'the template must be guarded by exactly the one operator-facing switch. An extra conjunct, or a literal false, renders the class unreachable while leaving the file in place',
+            },
+            {
+                path: RUNTIMECLASS_TEMPLATE,
+                pattern: /name:\s*djinn-cgroup-writable$/m,
+                why: 'the task-run class is what keeps ordinary task-run Pods off unconformed nodes',
+            },
+            {
+                path: RUNTIMECLASS_TEMPLATE,
+                pattern: /name:\s*djinn-cgroup-writable-probe$/m,
+                why: 'the probe class is what breaks the marker/probe deadlock; without it node conformance cannot run',
+            },
+            {
+                path: RUNTIMECLASS_TEMPLATE,
+                pattern: /handler:\s*runc-cgroupwritable/,
+                why: 'the containerd handler is the whole point; a class without it grants a read-only /sys/fs/cgroup',
+            },
+            {
+                path: RUNTIMECLASS_TEMPLATE,
+                pattern: /djinn\.io\/cgroup-writable:\s*"true"/,
+                why: 'the node selector is the scheduling boundary the RuntimeClass admission controller merges in',
+            },
+            {
+                path: CHART_VALUES,
+                pattern: /^cgroupWritable:$/m,
+                why: 'the operator-facing switch must remain declared in values.yaml, or the template guard reads a value that does not exist',
+            },
+            {
+                path: NODE_CONFORMANCE,
+                pattern: /djinn\.io\/cgroup-writable/,
+                why: 'node conformance is what earns the marker the selector demands',
+            },
+        ],
+        reachability: [
+            {
+                path: K8S_LAUNCHER,
+                pattern: /TASK_RUN_CGROUP_RUNTIME_CLASS/,
+                why: 'the renderer must still name the class on the Pod it emits',
+            },
+        ],
+        alwaysFalseScan: [RUNTIMECLASS_TEMPLATE],
+    },
+    {
+        id: 'credential-boundary-tests',
+        title: 'the credential-boundary chart tests',
+        files: [RBAC_TEST, CGROUP_RENDER_TEST, CHART_CONTRACT_RUNNER],
+        content: [
+            {
+                path: RBAC_TEST,
+                pattern: /pods\/resize/,
+                why: 'the RBAC contract is what keeps the resize verb off every identity that must not hold it',
+            },
+            {
+                path: CGROUP_RENDER_TEST,
+                pattern: /runtimeClass|runtimeClassName/,
+                why: 'the render contract is what proves the class actually lands on the Pod',
+            },
+            {
+                path: CHART_CONTRACT_RUNNER,
+                pattern: /\$\{?TESTS_DIR\}?"?\/\*\.sh/,
+                why: 'the runner must still glob the whole contract directory. A runner that names scripts one by one silently drops the one nobody remembered to add',
+            },
+        ],
+        reachability: [
+            {
+                path: CHART_CONTRACT_RUNNER,
+                pattern: /deploy\/helm\/djinn\/tests/,
+                why: 'the runner must still point at the directory these tests live in',
+            },
+        ],
+        alwaysFalseScan: [],
+    },
+    {
+        id: 'launcher-containment-tests',
+        title: "the launcher crate's own containment proofs",
+        files: [CONTAINMENT_TEST, LIFT_BOUNDARY_TEST],
+        content: [
+            {
+                path: CONTAINMENT_TEST,
+                pattern: /wait_empty\(/,
+                why: 'the containment proof must still exercise the drain',
+            },
+            {
+                path: LIFT_BOUNDARY_TEST,
+                pattern: /wait_empty\(/,
+                why: 'the brokered lift-boundary proof must still exercise the drain through the real broker protocol',
+            },
+        ],
+        reachability: [
+            {
+                path: QUALITY_GATE,
+                pattern: /--test\s+brokered_lease_lift_boundary/,
+                why: 'a CI lane must still RUN the privileged boundary proof. A retained test file that no lane invokes is a retired test',
+            },
+            {
+                path: QUALITY_GATE,
+                pattern: /BROKERED_LIFT_EXPECTED_PROOFS/,
+                why: 'the lane must still assert how many #[ignore]d proofs it expects, or a suite that executes zero of them looks green',
+            },
+            {
+                path: QUALITY_GATE,
+                pattern: /-p\s+djinn-cgroup-launcher/,
+                why: 'the lane must still build the launcher crate under test',
+            },
+        ],
+        alwaysFalseScan: [],
+    },
+    {
+        id: 'launcher-cpu-ceiling-stays-conditional',
+        title: 'the resize-v2-only launcher CPU ceiling',
+        files: [K8S_LAUNCHER, K8S_LAUNCHER_TESTS],
+        content: [
+            {
+                path: K8S_LAUNCHER,
+                pattern: /fn\s+resolve_launcher_cpu_ceiling\s*\(/,
+                why: 'the ceiling must stay a decision, not a constant',
+            },
+            {
+                path: K8S_LAUNCHER,
+                pattern: /if\s+protocol\.launcher_owns_leaf_quota\(\)\s*\{\s*return\s+Ok\(None\)\s*;/,
+                why: 'under leaf-v1 the launcher owns the leaf cpu.max, so a container limit here becomes an ancestor clamp over EVERY invocation leaf. 7deu measured a leaf whose cpu.max read four cores while the process burned a quarter of one, with the leaf nr_throttled at 0. Removing this arm renders the limit unconditionally and reintroduces that clamp',
+            },
+            {
+                path: K8S_LAUNCHER_TESTS,
+                pattern: /fn\s+the_launcher_cpu_ceiling_is_rendered_only_under_resize_v2\s*\(/,
+                why: 'the conditionality must stay under test by name; the source comment in launcher.rs points at this test',
+            },
+        ],
+        reachability: [
+            {
+                path: K8S_LAUNCHER,
+                pattern: /resolve_launcher_cpu_ceiling\(/,
+                why: 'the resolver must still be called from the render path',
+            },
+        ],
+        alwaysFalseScan: [K8S_LAUNCHER],
+    },
+];
+
+/// A gate whose asset table shrank is a gate that stopped guarding things.
+const MINIMUM_ASSETS = 9;
+
+// ---------------------------------------------------------------------------
+// Comment stripping.
+//
+// Whole-line comments only, deliberately. The mutation this defends against is
+// "comment the write out", which always produces a line whose first non-space
+// characters are `//` (or `#` in YAML/shell). Stripping trailing comments as
+// well would mean parsing string literals, and a `//` inside a URL in a string
+// would corrupt the very line being asserted on.
+// ---------------------------------------------------------------------------
+
+export function stripComments(source, path) {
+    const ext = extname(path);
+    const hashStyle = ext === '.yaml' || ext === '.yml' || ext === '.sh' || ext === '.toml';
+    const out = [];
+    let inBlock = false;
+    for (const line of source.split('\n')) {
+        const trimmed = line.trim();
+        if (inBlock) {
+            if (trimmed.includes('*/')) {
+                inBlock = false;
+            }
+            out.push('');
+            continue;
+        }
+        if (!hashStyle && trimmed.startsWith('/*')) {
+            if (!trimmed.includes('*/')) {
+                inBlock = true;
+            }
+            out.push('');
+            continue;
+        }
+        if (!hashStyle && (trimmed.startsWith('//') || trimmed.startsWith('*'))) {
+            out.push('');
+            continue;
+        }
+        if (hashStyle && trimmed.startsWith('#')) {
+            out.push('');
+            continue;
+        }
+        out.push(line);
+    }
+    return out.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation.
+// ---------------------------------------------------------------------------
+
+function everyInput() {
+    const paths = new Set();
+    for (const asset of ASSETS) {
+        for (const path of asset.files) {
+            paths.add(path);
+        }
+        for (const check of [...asset.content, ...asset.reachability]) {
+            paths.add(check.path);
+        }
+        for (const path of asset.alwaysFalseScan) {
+            paths.add(path);
+        }
+    }
+    return [...paths].sort();
+}
+
+function readSource(root, path) {
+    const full = join(root, path);
+    if (!existsSync(full)) {
+        return { missing: true };
+    }
+    const info = statSync(full);
+    if (!info.isFile() || info.size === 0) {
+        return { empty: true };
+    }
+    const raw = readFileSync(full, 'utf8');
+    return { raw, code: stripComments(raw, path) };
+}
+
+export function evaluate(root) {
+    const failures = [];
+    const passed = [];
+
+    if (ASSETS.length < MINIMUM_ASSETS) {
+        return {
+            fatal: `the asset table holds ${ASSETS.length} assets but at least ${MINIMUM_ASSETS} are protected. Someone deleted an asset from the gate instead of from the repository.`,
+        };
+    }
+
+    for (const asset of ASSETS) {
+        const problems = [];
+
+        for (const path of asset.files) {
+            const source = readSource(root, path);
+            if (source.missing) {
+                problems.push(`DELETED: ${path} is gone.`);
+            } else if (source.empty) {
+                problems.push(`EMPTIED: ${path} exists but holds no content.`);
+            }
+        }
+
+        for (const check of asset.content) {
+            const source = readSource(root, check.path);
+            if (source.missing || source.empty) {
+                problems.push(`DELETED: ${check.path} is gone, so /${check.pattern.source}/ cannot be there.`);
+                continue;
+            }
+            if (!check.pattern.test(source.code)) {
+                const commentedOut = check.pattern.test(source.raw);
+                problems.push(
+                    commentedOut
+                        ? `DISABLED: ${check.path} still contains /${check.pattern.source}/, but only inside a comment. Commenting a statement out retires it. Why it is guarded: ${check.why}.`
+                        : `RETIRED: ${check.path} no longer matches /${check.pattern.source}/. Why it is guarded: ${check.why}.`,
+                );
+            }
+        }
+
+        for (const check of asset.reachability) {
+            const source = readSource(root, check.path);
+            if (source.missing || source.empty) {
+                problems.push(`UNREACHABLE: ${check.path} is gone, so nothing calls into this asset from there.`);
+                continue;
+            }
+            if (!check.pattern.test(source.code)) {
+                problems.push(
+                    `UNREACHABLE: ${check.path} no longer matches /${check.pattern.source}/. Presence without a caller is retirement with extra steps. Why it is guarded: ${check.why}.`,
+                );
+            }
+        }
+
+        for (const path of asset.alwaysFalseScan) {
+            const source = readSource(root, path);
+            if (source.missing || source.empty) {
+                continue; // already reported above
+            }
+            for (const guard of ALWAYS_FALSE) {
+                if (guard.pattern.test(source.code)) {
+                    problems.push(
+                        `DISABLED: ${path} carries an always-false guard (${guard.name}). A conditional that can never be true is a deletion that still passes an existence check.`,
+                    );
+                }
+            }
+        }
+
+        if (problems.length > 0) {
+            failures.push({ asset, problems });
+        } else {
+            passed.push(asset);
+        }
+    }
+
+    return { failures, passed };
+}
+
+// ---------------------------------------------------------------------------
+// CLI.
+// ---------------------------------------------------------------------------
+
+function main(argv) {
+    let root = process.env.RESIZE_RETENTION_ROOT ?? process.cwd();
+    for (let index = 0; index < argv.length; index += 1) {
+        if (argv[index] === '--root') {
+            root = argv[index + 1];
+            index += 1;
+            if (!root) {
+                process.stderr.write('FATAL: --root requires a value\n');
+                return 2;
+            }
+        } else if (argv[index] === '--list-inputs') {
+            process.stdout.write(`${everyInput().join('\n')}\n`);
+            return 0;
+        } else {
+            process.stderr.write(`FATAL: unknown argument ${argv[index]}\n`);
+            return 2;
+        }
+    }
+
+    if (!existsSync(root)) {
+        process.stderr.write(`FATAL: root does not exist: ${root}\n`);
+        return 2;
+    }
+
+    const result = evaluate(root);
+    if (result.fatal) {
+        process.stderr.write(`FATAL: ${result.fatal}\n`);
+        return 2;
+    }
+
+    for (const asset of result.passed) {
+        process.stdout.write(`ok: ${asset.id} — ${asset.title} is retained.\n`);
+    }
+
+    if (result.failures.length === 0) {
+        process.stdout.write(
+            `check-resize-cutover-retention: OK (${result.passed.length} protected assets retained)\n`,
+        );
+        return 0;
+    }
+
+    for (const failure of result.failures) {
+        process.stderr.write(`\nFAIL: ${failure.asset.id} — ${failure.asset.title}\n`);
+        for (const problem of failure.problems) {
+            process.stderr.write(`      ${problem}\n`);
+        }
+    }
+    process.stderr.write(
+        '\nThe in-place resize cutover retires NOTHING in the containment and\n' +
+        'credential boundary. If one of these assets legitimately moved, update\n' +
+        'scripts/resize-cutover-retention-manifest.mjs to point at its new home —\n' +
+        'do not delete the entry.\n',
+    );
+    return 1;
+}
+
+export { ASSETS, everyInput, MINIMUM_ASSETS };
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/test-resize-cutover-retention.mjs
+++ b/scripts/test-resize-cutover-retention.mjs
@@ -1,0 +1,284 @@
+// Self-test for the no-retirement gate (proposal 3i92, epic xowm, task 1j64).
+//
+// Every case here runs the SHELL ENTRY POINT
+// `scripts/check-resize-cutover-retention.sh` and judges it by its EXIT CODE.
+// That is deliberate and is the whole of AC11: making the shell script exit 0
+// unconditionally has to turn this file red, so this file may never reach past
+// it into the engine module for the pass/fail verdict.
+//
+// How a fixture is evaluated:
+//
+//   1. Ask the engine which paths it reads (`--list-inputs`).
+//   2. Materialise exactly those paths from the REAL repository into a scratch
+//      root. Copying only the gate's own inputs keeps this fast and, more
+//      importantly, means a fixture cannot accidentally pass because some
+//      unrelated file happened to satisfy a check.
+//   3. Apply the fixture's operations.
+//   4. Run the shell gate against the scratch root and assert the exit code —
+//      and, for a rejection, that the failure output NAMES the asset the
+//      fixture targeted. "It failed" is not evidence; "it failed for this
+//      reason" is.
+//
+// Run it: node --test scripts/test-resize-cutover-retention.mjs
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+    copyFileSync,
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+
+import { ASSETS, MINIMUM_ASSETS, everyInput, stripComments } from './resize-cutover-retention-manifest.mjs';
+
+const SCRIPT_DIR = dirname(new URL(import.meta.url).pathname);
+const REPO_ROOT = resolve(SCRIPT_DIR, '..');
+const GATE = join(SCRIPT_DIR, 'check-resize-cutover-retention.sh');
+const ENGINE = join(SCRIPT_DIR, 'resize-cutover-retention-manifest.mjs');
+const FIXTURE_DIR = join(SCRIPT_DIR, 'fixtures', 'resize-cutover-retention');
+
+// ---------------------------------------------------------------------------
+// Fixture loading.
+// ---------------------------------------------------------------------------
+
+function loadFixtures() {
+    const entries = readdirSync(FIXTURE_DIR, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort();
+    return entries.map((name) => {
+        const path = join(FIXTURE_DIR, name, 'fixture.json');
+        assert.ok(existsSync(path), `fixture ${name} has no fixture.json`);
+        const fixture = JSON.parse(readFileSync(path, 'utf8'));
+        assert.ok(
+            fixture.expect === 'reject' || fixture.expect === 'accept',
+            `fixture ${name}: expect must be "reject" or "accept", got ${fixture.expect}`,
+        );
+        assert.ok(
+            typeof fixture.why === 'string' && fixture.why.length > 40,
+            `fixture ${name}: "why" must explain the retirement it stands in for`,
+        );
+        assert.ok(Array.isArray(fixture.operations), `fixture ${name}: operations must be an array`);
+        return { name, ...fixture };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Scratch-root materialisation.
+// ---------------------------------------------------------------------------
+
+function gateInputs() {
+    const listed = spawnSync(process.execPath, [ENGINE, '--list-inputs'], { encoding: 'utf8' });
+    assert.equal(listed.status, 0, `--list-inputs failed: ${listed.stderr}`);
+    const paths = listed.stdout.trim().split('\n').filter(Boolean);
+    assert.ok(paths.length >= 15, `the gate reads only ${paths.length} paths; that is too few to be guarding nine assets`);
+    return paths;
+}
+
+function materialise(paths) {
+    const root = mkdtempSync(join(tmpdir(), 'resize-retention-'));
+    for (const relative of paths) {
+        const source = join(REPO_ROOT, relative);
+        assert.ok(
+            existsSync(source),
+            `the gate names ${relative} but the repository does not have it. Either the asset moved (update the manifest) or the gate is pointing at nothing.`,
+        );
+        const destination = join(root, relative);
+        mkdirSync(dirname(destination), { recursive: true });
+        copyFileSync(source, destination);
+    }
+    return root;
+}
+
+function apply(root, fixture) {
+    for (const operation of fixture.operations) {
+        const target = join(root, operation.path);
+        switch (operation.op) {
+            case 'delete': {
+                assert.ok(
+                    existsSync(target),
+                    `fixture ${fixture.name}: cannot delete ${operation.path}, it is not in the materialised root. The gate does not read it, so deleting it would prove nothing.`,
+                );
+                rmSync(target);
+                break;
+            }
+            case 'replace': {
+                const before = readFileSync(target, 'utf8');
+                const occurrences = before.split(operation.find).length - 1;
+                assert.equal(
+                    occurrences,
+                    1,
+                    `fixture ${fixture.name}: its anchor in ${operation.path} matched ${occurrences} times, not exactly once. An anchor that drifted out of the source mutates nothing and the fixture then proves nothing.`,
+                );
+                writeFileSync(target, before.replace(operation.find, operation.with));
+                break;
+            }
+            case 'append': {
+                writeFileSync(target, `${readFileSync(target, 'utf8')}${operation.text}`);
+                break;
+            }
+            default:
+                assert.fail(`fixture ${fixture.name}: unknown operation ${operation.op}`);
+        }
+    }
+}
+
+/// Run the SHELL gate. Never the engine module: AC11 makes the shell script's
+/// exit code the contract.
+function runGate(root) {
+    const result = spawnSync('sh', [GATE], {
+        encoding: 'utf8',
+        env: { ...process.env, RESIZE_RETENTION_ROOT: root },
+    });
+    return {
+        status: result.status,
+        stdout: result.stdout ?? '',
+        stderr: result.stderr ?? '',
+    };
+}
+
+const FIXTURES = loadFixtures();
+
+// ---------------------------------------------------------------------------
+// The gate's subject must be real.
+// ---------------------------------------------------------------------------
+
+test('the gate passes against the real repository', () => {
+    const result = runGate(REPO_ROOT);
+    assert.equal(
+        result.status,
+        0,
+        `the gate rejects HEAD. Nothing in this task retires anything, so this is the gate being wrong:\n${result.stdout}\n${result.stderr}`,
+    );
+    assert.match(result.stdout, /check-resize-cutover-retention: OK/);
+});
+
+test('the gate guards at least every asset the epic named', () => {
+    assert.ok(
+        ASSETS.length >= MINIMUM_ASSETS,
+        `the asset table holds ${ASSETS.length}, below the ${MINIMUM_ASSETS} floor`,
+    );
+    const ids = new Set(ASSETS.map((asset) => asset.id));
+    for (const required of [
+        'cgroup-launcher-crate',
+        'process-broker',
+        'runtimeclass-and-node-assets',
+        'credential-boundary-tests',
+        'broker-mounts',
+        'cgroup-kill',
+        'wait-empty',
+    ]) {
+        assert.ok(ids.has(required), `the epic's retained boundary names ${required} and the gate does not guard it`);
+    }
+});
+
+test('every asset carries its own deletion or disablement fixture', () => {
+    const covered = new Set(
+        FIXTURES.filter((fixture) => fixture.expect === 'reject').map((fixture) => fixture.asset),
+    );
+    for (const asset of ASSETS) {
+        assert.ok(
+            covered.has(asset.id),
+            `asset ${asset.id} has no rejecting fixture. A gate that enumerates protected paths and is never PROVEN to reject their removal is a gate that can always exit 0.`,
+        );
+    }
+});
+
+test('the fixture set carries a required-passing refactor case', () => {
+    const accepting = FIXTURES.filter(
+        (fixture) => fixture.expect === 'accept' && fixture.operations.length > 0,
+    );
+    assert.ok(
+        accepting.length >= 1,
+        'AC8 requires a passing refactor case. Without one the gate could be a byte-identity check and nothing here would notice.',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Every fixture, through the shell entry point.
+// ---------------------------------------------------------------------------
+
+for (const fixture of FIXTURES) {
+    test(`fixture ${fixture.name} is ${fixture.expect}ed`, () => {
+        const paths = gateInputs();
+        const root = materialise(paths);
+        try {
+            apply(root, fixture);
+            const result = runGate(root);
+            if (fixture.expect === 'accept') {
+                assert.equal(
+                    result.status,
+                    0,
+                    `${fixture.name} must PASS — ${fixture.why}\n${result.stdout}\n${result.stderr}`,
+                );
+                return;
+            }
+            assert.equal(
+                result.status,
+                1,
+                `${fixture.name} must be REJECTED with exit 1 — ${fixture.why}\n${result.stdout}\n${result.stderr}`,
+            );
+            assert.ok(
+                result.stderr.includes(fixture.asset),
+                `${fixture.name} was rejected, but not for the asset it targets (${fixture.asset}). A rejection for an unrelated reason proves nothing about this asset:\n${result.stderr}`,
+            );
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// The two mechanisms the fixtures rest on, unit-tested directly.
+// ---------------------------------------------------------------------------
+
+test('comment stripping removes whole-line comments and leaves code alone', () => {
+    const rust = [
+        '    // self.fs.write_leaf(leaf.fd, "cgroup.kill", "1")',
+        '    self.fs.write_leaf(leaf.fd, "cgroup.kill", "1")',
+        '    /*',
+        '    self.fs.write_leaf(leaf.fd, "cgroup.other", "1")',
+        '    */',
+    ].join('\n');
+    const stripped = stripComments(rust, 'x.rs');
+    assert.equal(
+        stripped.split('cgroup.kill').length - 1,
+        1,
+        'exactly the uncommented write must survive',
+    );
+    assert.ok(!stripped.includes('cgroup.other'), 'a block-commented statement must not survive');
+    const yaml = ['# name: djinn-cgroup-writable', 'name: djinn-cgroup-writable'].join('\n');
+    assert.equal(stripComments(yaml, 'x.yaml').split('name:').length - 1, 1);
+});
+
+test('the gate refuses a root it cannot read', () => {
+    const result = spawnSync('sh', [GATE], {
+        encoding: 'utf8',
+        env: { ...process.env, RESIZE_RETENTION_ROOT: '/nonexistent/resize-retention-root' },
+    });
+    assert.equal(
+        result.status,
+        2,
+        'a gate that cannot find its subject must say so with a distinct code rather than pass',
+    );
+});
+
+test('an emptied protected file reads as a deletion', () => {
+    const root = materialise(gateInputs());
+    try {
+        writeFileSync(join(root, 'server/crates/djinn-cgroup-launcher/src/lib.rs'), '');
+        const result = runGate(root);
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /EMPTIED|DELETED/);
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});

--- a/server/tests/task_run_resize_cycles.rs
+++ b/server/tests/task_run_resize_cycles.rs
@@ -1,0 +1,1365 @@
+// `kubectl`, `docker` and the setup script all report through stderr, and the
+// skip lines below are the only channel a `--ignored` run has for saying why it
+// did nothing. The workspace denies `print_stderr` for library and server code.
+#![allow(clippy::print_stderr)]
+//! Repeated lift/drop cycle invariants for in-place task-run resize (proposal
+//! 3i92, epic `xowm`, task `1j64`), plus the always-on wiring of the epic's
+//! no-retirement gate.
+//!
+//! # The property
+//!
+//! A limits-only resize moves ONE number: the launcher sidecar's
+//! `resources.limits.cpu`. It must leave everything that scheduling, Kueue
+//! accounting and CPU shares are computed from exactly where it found it. Over
+//! [`CYCLES`] lift/drop cycles against one live Pod, five things must not move:
+//!
+//! 1. `resources.requests` on every container and init container,
+//! 2. `status.*.allocatedResources`,
+//! 3. the Pod's QoS class,
+//! 4. the NODE's allocated CPU **requests**,
+//! 5. the cgroup `cpu.weight` at the pod slice and at the launcher container,
+//!
+//! while the status-confirmed limit moves correctly on every single cycle.
+//!
+//! # What this file refuses to accept as evidence
+//!
+//! * **A written value.** `cpu.weight` is read from the cgroup FILE, on the node
+//!   and inside the launcher container. Deriving it from `resources.requests`
+//!   would assert that the number we asked for equals the number we asked for.
+//!   That is the `cpu.max` versus `cpu.stat` distinction that cost task 7deu a
+//!   week: a leaf whose `cpu.max` read four cores while the process burned a
+//!   quarter of one, `nr_throttled` at 0 throughout.
+//! * **A Pod spec standing in for node accounting.** The Node's allocated
+//!   requests are read from the Node's own allocated-resources view. The Pod
+//!   spec is the INPUT to that accounting, not the accounting.
+//! * **`status.containerStatuses` as confirmation.** The launcher is a native
+//!   sidecar: `spec.initContainers[name=cgroup-launcher]`. Confirmation comes
+//!   from `status.initContainerStatuses[name=cgroup-launcher]` through the
+//!   PRODUCTION reader [`confirm_launcher_cpu`] and from nowhere else. The
+//!   source gate below holds that line.
+//! * **A loop that reports 40 without running 40.** The completion counter is
+//!   incremented only after a cycle's DROP is status-confirmed, and the final
+//!   assertion is on the counter, not on the loop bound. A `break` after the
+//!   first cycle leaves it at 1.
+//! * **An invariant that holds because nothing moved.** Every "did not move"
+//!   assertion is paired with a "DID move" witness: the per-cycle confirmations
+//!   and the node's allocated LIMITS, which do change under a resize.
+//!
+//! # Running it
+//!
+//! ```text
+//! scripts/kind/setup-resize-kind-cluster.sh up --cluster-name djinn-resize-1j64 \
+//!     --registry-name djinn-resize-1j64-registry --registry-port 5071
+//! cd server && DJINN_TEST_RESIZE_CYCLES=1 \
+//!     cargo test -p djinn-server --test task_run_resize_cycles -- --ignored --nocapture
+//! scripts/kind/setup-resize-kind-cluster.sh down --cluster-name djinn-resize-1j64 \
+//!     --registry-name djinn-resize-1j64-registry --registry-port 5071
+//! ```
+//!
+//! The hermetic guards run on every PR with no cluster at all, and they are
+//! where the no-retirement gate is invoked by an always-on lane.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::Duration;
+
+use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::job::{
+    COMPONENT_TASK_RUN_WORKER, LABEL_COMPONENT, LABEL_TASK_RUN_ID, build_task_run_job,
+};
+use djinn_k8s::launcher::{
+    CgroupLauncherMode, LAUNCHER_CONTAINER_NAME, TASK_RUN_CGROUP_RUNTIME_CLASS,
+    apply_launcher_authority_protocol, render_authority_protocol,
+};
+use djinn_k8s::pod_resize::{
+    CpuLimit, RESIZE_SUBRESOURCE, build_resize_patch, confirm_launcher_cpu,
+    has_resize_pending_condition,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// The one cluster this file may ever touch.
+//
+// Isolated from every sibling harness. `djinn-resize-pcod`/5067 belongs to task
+// pcod, `djinn-kueue-c1`/5061 and `djinn-kueue-b2b`/5055 to the Kueue harnesses,
+// and a sibling agent may be running any of them right now.
+// ---------------------------------------------------------------------------
+
+const HARNESS_CLUSTER: &str = "djinn-resize-1j64";
+/// kind names its context `kind-<cluster>`. DERIVED, never discovered: every
+/// context in a Djinn developer's kubeconfig is a live EKS cluster.
+const HARNESS_CONTEXT: &str = "kind-djinn-resize-1j64";
+const HARNESS_REGISTRY: &str = "djinn-resize-1j64-registry";
+const HARNESS_REGISTRY_PORT: &str = "5071";
+/// `pods/resize` needs 1.33; the cgroup-writable RuntimeClass needs containerd
+/// 2.2, which `kindest/node:v1.35.0` ships.
+const HARNESS_K8S_VERSION: &str = "1.35.0";
+
+/// Every OTHER live-cluster harness in this repository, spelled out rather than
+/// imported. A disjointness guard that imported the sibling's constant would
+/// pass by construction.
+const SIBLING_CLUSTERS: &[&str] = &[
+    "djinn",
+    "djinn-resize-pcod",
+    "djinn-kueue-harness",
+    "djinn-kueue-b1",
+    "djinn-kueue-b2",
+    "djinn-kueue-b2b",
+    "djinn-kueue-c1",
+];
+const SIBLING_REGISTRY_PORTS: &[&str] = &["5000", "5001", "5051", "5053", "5055", "5061", "5067"];
+
+const SETUP_SCRIPT: &str = "scripts/kind/setup-resize-kind-cluster.sh";
+const WORKFLOW: &str = ".github/workflows/resize-kind.yml";
+const THIS_FILE: &str = "server/tests/task_run_resize_cycles.rs";
+const RETENTION_GATE: &str = "scripts/check-resize-cutover-retention.sh";
+const RETENTION_SELFTEST: &str = "scripts/test-resize-cutover-retention.mjs";
+const PROBE_BUILD_SCRIPT: &str = "server/crates/djinn-k8s/tests/fixtures/governor-probe/build.sh";
+const PROBE_IMAGE: &str = "djinn-resize-probe:1j64";
+
+const NAMESPACE: &str = "djinn";
+const WORKER_CONTAINER_NAME: &str = "worker";
+
+/// The number of complete lift/drop cycles the live proof performs. The task
+/// floor is 40; this is a named constant so the floor is asserted against a
+/// number rather than against a loop that happens to be written `0..40`.
+const CYCLES: usize = 40;
+/// The floor itself, separate from the count, so raising `CYCLES` never
+/// silently lowers what is being PROVEN.
+const MIN_CYCLES: usize = 40;
+const _: () = assert!(CYCLES >= MIN_CYCLES);
+
+/// The container CPU limit a `resize-v2` sidecar is born at, taken from the
+/// production constant rather than spelled again.
+const BIRTH_MILLICORES: u64 = djinn_server::task_run_resize_bootstrap::BIRTH_CPU_MILLICORES;
+
+/// The pod CPU limit the render derives its launcher ceiling from. Two cores
+/// rather than the production four: this node is shared with other agents'
+/// clusters.
+const STOCK_CPU_LIMIT: &str = "2";
+
+/// `Instant::now` is workspace-disallowed, so every wait here is
+/// iteration-counted.
+const TICK: Duration = Duration::from_millis(400);
+const READY_TICKS: usize = 300;
+const CONFIRM_TICKS: usize = 150;
+
+/// The two status lists AC3's `allocatedResources` snapshot covers.
+///
+/// This array is the ONLY place in this file that spells the regular
+/// container-status list, and `guard_confirmation_never_reads_container_statuses`
+/// enforces that. Limit CONFIRMATION comes from
+/// `status.initContainerStatuses[name=cgroup-launcher]` through the production
+/// reader and from nowhere else; this snapshot is a byte-identity witness over
+/// both lists, which is a different question with a different answer.
+const STATUS_LISTS: [&str; 2] = ["initContainerStatuses", "containerStatuses"];
+
+// ---------------------------------------------------------------------------
+// Repository helpers.
+// ---------------------------------------------------------------------------
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .expect("the server package lives one level below the repository root")
+        .to_path_buf()
+}
+
+fn read_repo_file(relative: &str) -> String {
+    std::fs::read_to_string(repo_root().join(relative))
+        .unwrap_or_else(|error| panic!("read {relative}: {error}"))
+}
+
+fn run_setup_script(args: &[&str]) -> Output {
+    Command::new("bash")
+        .arg(repo_root().join(SETUP_SCRIPT))
+        .args(args)
+        .current_dir(repo_root())
+        .output()
+        .unwrap_or_else(|error| panic!("{SETUP_SCRIPT} is executable: {error}"))
+}
+
+fn exit_code(output: &Output) -> i32 {
+    output
+        .status
+        .code()
+        .expect("the script exits rather than dying on a signal")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// The isolated-name arguments every invocation of the shared harness carries.
+fn harness_args() -> Vec<&'static str> {
+    vec![
+        "--cluster-name",
+        HARNESS_CLUSTER,
+        "--registry-name",
+        HARNESS_REGISTRY,
+        "--registry-port",
+        HARNESS_REGISTRY_PORT,
+        "--context",
+        HARNESS_CONTEXT,
+    ]
+}
+
+// ===========================================================================
+// Hermetic guards. No cluster, no `#[ignore]`; these run on every PR.
+// ===========================================================================
+
+/// AC1's first half. The floor is a named constant and it is at least 40.
+#[test]
+fn guard_the_cycle_count_is_a_named_constant_of_at_least_forty() {
+    // Constant, so it is a COMPILE error rather than a test failure: lowering
+    // the floor below 40 must not be something a run can get past.
+    const { assert!(MIN_CYCLES >= 40) };
+    const { assert!(CYCLES >= MIN_CYCLES) };
+
+    let source = read_repo_file(THIS_FILE);
+    // The completion counter, not the loop bound, is what the final assertion
+    // rests on. Exactly one increment site, and it is asserted against
+    // MIN_CYCLES.
+    //
+    // Every needle is built by concatenation so this guard's OWN text cannot
+    // satisfy it. A guard whose subject is the file it lives in and which
+    // spells its needle literally passes because of itself.
+    let increment = concat!("completed_cycles", " += 1");
+    assert_eq!(
+        source.matches(increment).count(),
+        1,
+        "there must be exactly ONE place a cycle is counted as complete. Two increment sites is how a loop reports 40 having run 20."
+    );
+    assert!(
+        source.contains(concat!("completed_cycles", ", CYCLES,")),
+        "the completion counter must be compared against the cycle count itself, so a `break` after the first cycle is red rather than merely quieter"
+    );
+    assert!(
+        source.contains(concat!("completed_cycles", " >= MIN_CYCLES")),
+        "the completion counter must also be asserted against the task floor, so lowering CYCLES below 40 cannot make the suite pass"
+    );
+}
+
+/// AC12. The harness cannot touch the Tilt cluster, any sibling harness, or any
+/// context it did not derive itself — and it is not a fork of the shared script,
+/// it INVOKES it.
+#[test]
+fn guard_the_harness_is_disjoint_and_reuses_the_shared_script() {
+    assert!(
+        repo_root().join(SETUP_SCRIPT).is_file(),
+        "{SETUP_SCRIPT} must exist; this suite invokes it rather than forking it"
+    );
+    let source = read_repo_file(THIS_FILE);
+    assert!(
+        source.contains(SETUP_SCRIPT),
+        "this suite must name the shared setup script"
+    );
+    assert!(
+        !repo_root()
+            .join("scripts/kind/setup-resize-cycles-cluster.sh")
+            .exists(),
+        "a second copy of the harness is exactly what this task was told not to create"
+    );
+
+    for sibling in SIBLING_CLUSTERS {
+        assert_ne!(
+            HARNESS_CLUSTER, *sibling,
+            "this harness DELETES its cluster on teardown; sharing a name with {sibling} would delete a sibling agent's live cluster"
+        );
+        assert_ne!(HARNESS_REGISTRY, format!("{sibling}-registry"));
+    }
+    for port in SIBLING_REGISTRY_PORTS {
+        assert_ne!(
+            HARNESS_REGISTRY_PORT, *port,
+            "registry port {port} is published by a sibling harness that may be running right now"
+        );
+    }
+    assert_eq!(
+        HARNESS_CONTEXT,
+        format!("kind-{HARNESS_CLUSTER}"),
+        "the context is DERIVED from the cluster name. A discovered context is an EKS cluster."
+    );
+
+    // The shared script accepts this harness's own names ...
+    let accepted = run_setup_script(&[&["check"], harness_args().as_slice()].concat());
+    assert_eq!(
+        exit_code(&accepted),
+        0,
+        "the shared harness refused this suite's isolated names:\n{}",
+        stderr_of(&accepted)
+    );
+
+    // ... and refuses a sibling's, so the disjointness above is enforced by the
+    // script and not merely asserted by this test.
+    let refused = run_setup_script(&[
+        "check",
+        "--cluster-name",
+        "djinn-kueue-c1",
+        "--registry-name",
+        HARNESS_REGISTRY,
+        "--registry-port",
+        HARNESS_REGISTRY_PORT,
+    ]);
+    assert_eq!(
+        exit_code(&refused),
+        3,
+        "the shared harness accepted a sibling's cluster name:\n{}",
+        stdout_of(&refused)
+    );
+
+    // And it refuses a context this suite did not derive. Every context in a
+    // Djinn developer's kubeconfig is a live EKS cluster.
+    let foreign = run_setup_script(
+        &[
+            &["check"],
+            harness_args().as_slice(),
+            &["--context", "arn:aws:eks:eu-west-3:1:cluster/djinn-prod"],
+        ]
+        .concat(),
+    );
+    assert_eq!(
+        exit_code(&foreign),
+        3,
+        "the shared harness accepted an externally supplied context:\n{}",
+        stdout_of(&foreign)
+    );
+}
+
+/// AC12. The 1.30 repository floor is enforced, and the "1.29" older docs
+/// carried was measured false and corrected in #2818.
+#[test]
+fn guard_the_kubernetes_floor_is_enforced() {
+    let below = run_setup_script(
+        &[
+            &["check"],
+            harness_args().as_slice(),
+            &["--k8s-version", "1.29.0"],
+        ]
+        .concat(),
+    );
+    assert_eq!(
+        exit_code(&below),
+        7,
+        "1.29 was accepted; the repository floor is 1.30 (Kueue 0.19 / k8s-openapi v1_30)"
+    );
+    assert!(
+        stderr_of(&below).contains("2818"),
+        "the refusal must name the correction so nobody restores the measured-false 1.29 floor:\n{}",
+        stderr_of(&below)
+    );
+
+    let accepted = run_setup_script(
+        &[
+            &["check"],
+            harness_args().as_slice(),
+            &["--k8s-version", HARNESS_K8S_VERSION],
+        ]
+        .concat(),
+    );
+    assert_eq!(
+        exit_code(&accepted),
+        0,
+        "this suite's own Kubernetes version was refused:\n{}",
+        stderr_of(&accepted)
+    );
+}
+
+/// AC6's second mutation, source half. Confirmation may never read
+/// `status.containerStatuses`: the launcher is a native sidecar and has no entry
+/// there, so anything found under that name is a different container or a
+/// fabrication.
+#[test]
+fn guard_confirmation_never_reads_container_statuses() {
+    let source = read_repo_file(THIS_FILE);
+    // Built by concatenation so this guard's own text is not a hit.
+    let needle = concat!("container", "Statuses");
+    let hits: Vec<&str> = source
+        .lines()
+        .filter(|line| line.contains(needle))
+        .filter(|line| !line.trim_start().starts_with("//!"))
+        .filter(|line| !line.trim_start().starts_with("///"))
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "the regular container-status list may be named exactly once, in STATUS_LISTS, and only for the allocatedResources byte-identity snapshot. Found:\n{hits:#?}"
+    );
+    assert!(
+        hits[0].contains("STATUS_LISTS"),
+        "the one permitted mention must be the STATUS_LISTS constant, not a confirmation read: {}",
+        hits[0]
+    );
+    assert!(
+        source.contains("confirm_launcher_cpu("),
+        "confirmation must go through the PRODUCTION reader, which reads status.initContainerStatuses[name=cgroup-launcher] and nothing else"
+    );
+}
+
+/// AC4's mutation, source half. `cpu.weight` is a cgroup FILE. Deriving it from
+/// `resources.requests` asserts that what we asked for equals what we asked for,
+/// and stays green even when the kernel applied something else.
+#[test]
+fn guard_cpu_weight_is_read_from_the_cgroup_file() {
+    let source = read_repo_file(THIS_FILE);
+    assert!(
+        source.contains("/cpu.weight"),
+        "cpu.weight must be read as a PATH under a cgroup directory"
+    );
+    for line in source.lines() {
+        if !line.contains("cpu.weight") {
+            continue;
+        }
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        assert!(
+            !line.contains("requests"),
+            "cpu.weight must never be derived from a request value: {line}"
+        );
+    }
+    assert!(
+        source.contains("node_read(") && source.contains("launcher_read("),
+        "the weight must be read at BOTH the pod slice (on the node) and the launcher container"
+    );
+}
+
+/// AC5's mutation, source half. Node allocation is read from the Node, not from
+/// a Pod spec.
+#[test]
+fn guard_node_allocation_is_read_from_the_node() {
+    let source = read_repo_file(THIS_FILE);
+    assert!(
+        source.contains("\"describe\", \"node\""),
+        "the Node's own allocated-resources view is what must be read; a sum over Pod specs is the INPUT to that accounting, not the accounting"
+    );
+    assert!(
+        source.contains("Allocated resources"),
+        "the parser must be anchored on the Node's Allocated resources section"
+    );
+}
+
+/// AC2's mutation, hermetic half. The production resize body touches ONLY the
+/// launcher's `limits.cpu`. A body that also moved `requests` — by as little as
+/// 1m — would change scheduling and Kueue accounting, and the live snapshot
+/// comparison would catch it; this catches it without a cluster.
+#[test]
+fn guard_the_resize_patch_touches_only_the_launcher_cpu_limit() {
+    let body = build_resize_patch(CpuLimit::from_millis(1_234));
+    let document = serde_json::to_value(&body).expect("the resize patch serialises");
+    let rendered = serde_json::to_string(&document).expect("serialise");
+
+    assert!(
+        !rendered.contains("requests"),
+        "the resize body names `requests`. A limits-only resize must not: {rendered}"
+    );
+    assert!(
+        !rendered.contains("\"containers\""),
+        "the resize body names the regular container list. The launcher is an init container: {rendered}"
+    );
+    let init = document["spec"]["initContainers"]
+        .as_array()
+        .expect("the resize body targets the initContainers array");
+    assert_eq!(
+        init.len(),
+        1,
+        "the body must name exactly the launcher, so the strategic merge on `patchMergeKey: name` leaves every other container untouched"
+    );
+    assert_eq!(init[0]["name"], LAUNCHER_CONTAINER_NAME);
+    assert_eq!(init[0]["resources"]["limits"]["cpu"], json!("1234m"));
+    assert!(
+        init[0]["resources"]["requests"].is_null(),
+        "the body carries requests for the launcher: {rendered}"
+    );
+
+    // Strategic, not merge: `Patch::Merge` on this shape answers
+    // `limits: Forbidden: resource limits cannot be removed`.
+    let source = read_repo_file(THIS_FILE);
+    assert!(
+        source.contains("\"strategic\""),
+        "the PATCH must be strategic; the initContainers array carries patchMergeKey: name and a JSON-merge body would replace the whole array"
+    );
+}
+
+/// AC11. The no-retirement gate is INVOKED by an always-on lane — this one — and
+/// its exit code is the contract.
+#[test]
+fn the_no_retirement_gate_passes_and_its_self_test_is_green() {
+    let gate = repo_root().join(RETENTION_GATE);
+    assert!(gate.is_file(), "{RETENTION_GATE} is missing");
+    let selftest = repo_root().join(RETENTION_SELFTEST);
+    assert!(selftest.is_file(), "{RETENTION_SELFTEST} is missing");
+
+    let checked = Command::new("sh")
+        .arg(&gate)
+        .current_dir(repo_root())
+        .output()
+        .expect("the retention gate is executable");
+    assert_eq!(
+        exit_code(&checked),
+        0,
+        "the no-retirement gate rejects this tree. Nothing in the resize cutover retires the containment or credential boundary:\n{}\n{}",
+        stdout_of(&checked),
+        stderr_of(&checked)
+    );
+
+    // The gate's own fixtures, through the gate's own shell entry point. This is
+    // what makes "stub the script to exit 0" red rather than quietly fine.
+    let tested = Command::new("node")
+        .args(["--test", RETENTION_SELFTEST])
+        .current_dir(repo_root())
+        .output()
+        .expect("node is required to run the retention gate's self-test");
+    assert!(
+        tested.status.success(),
+        "the retention gate's fixture self-test failed:\n{}\n{}",
+        stdout_of(&tested),
+        stderr_of(&tested)
+    );
+}
+
+/// A live proof that never runs is not a proof. The workflow must carry this
+/// suite's job, its isolated names, an `--ignored` invocation, and an
+/// unconditional teardown.
+#[test]
+fn guard_the_live_lane_is_wired() {
+    let workflow = read_repo_file(WORKFLOW);
+    for needle in [
+        "resize-cycles",
+        HARNESS_CLUSTER,
+        HARNESS_REGISTRY,
+        HARNESS_REGISTRY_PORT,
+        "task_run_resize_cycles",
+        "--ignored",
+        SETUP_SCRIPT,
+        RETENTION_SELFTEST,
+    ] {
+        assert!(
+            workflow.contains(needle),
+            "{WORKFLOW} does not mention `{needle}`; the live lane is not wired"
+        );
+    }
+    assert!(
+        workflow.contains("DJINN_TEST_RESIZE_CYCLES"),
+        "without the enabling variable the `--ignored` run skips every live proof and reports success"
+    );
+    assert!(
+        workflow.contains("if: always()"),
+        "teardown must run pass or fail; a cluster left standing holds this node's disk and the next run's quota"
+    );
+
+    // The suite's own count of live proofs, so deleting one fails the ordinary
+    // PR lane rather than silently shrinking the dispatch lane.
+    let source = read_repo_file(THIS_FILE);
+    let live_proofs = source.matches("#[ignore = \"live:").count();
+    assert_eq!(
+        live_proofs, 1,
+        "this suite declares {live_proofs} live proofs; the workflow and this guard both expect 1"
+    );
+}
+
+// ===========================================================================
+// The live half.
+// ===========================================================================
+
+fn live_tests_enabled() -> bool {
+    if std::env::var("DJINN_TEST_RESIZE_CYCLES").as_deref() != Ok("1") {
+        eprintln!(
+            "SKIP: DJINN_TEST_RESIZE_CYCLES=1 is not set. Bring the cluster up with `{SETUP_SCRIPT} up --cluster-name {HARNESS_CLUSTER} --registry-name {HARNESS_REGISTRY} --registry-port {HARNESS_REGISTRY_PORT}` first."
+        );
+        return false;
+    }
+    for tool in ["kubectl", "kind", "docker"] {
+        assert!(
+            Command::new("which")
+                .arg(tool)
+                .output()
+                .is_ok_and(|output| output.status.success()),
+            "{tool} must be on PATH for the live lane"
+        );
+    }
+    true
+}
+
+/// Two independent refusals: the context name must be the one this harness
+/// derives, and the API server it resolves to must be loopback.
+fn assert_harness_context() {
+    let server = kubectl_ok(&[
+        "config",
+        "view",
+        "--minify",
+        "-o",
+        "jsonpath={.clusters[0].cluster.server}",
+    ]);
+    assert!(
+        server.starts_with("https://127.0.0.1:")
+            || server.starts_with("https://localhost:")
+            || server.starts_with("https://[::1]:"),
+        "context {HARNESS_CONTEXT} resolves to {server}, which is not a loopback API server. This suite creates and deletes Jobs; it may only run against the disposable kind cluster."
+    );
+}
+
+fn kubectl(args: &[&str]) -> Output {
+    Command::new("kubectl")
+        .arg("--context")
+        .arg(HARNESS_CONTEXT)
+        .args(args)
+        .output()
+        .expect("kubectl is executable")
+}
+
+fn kubectl_ok(args: &[&str]) -> String {
+    let output = kubectl(args);
+    assert!(
+        output.status.success(),
+        "kubectl {args:?} failed: {}",
+        stderr_of(&output)
+    );
+    stdout_of(&output).trim().to_owned()
+}
+
+fn kubectl_json(args: &[&str]) -> Value {
+    let mut full = args.to_vec();
+    full.extend_from_slice(&["-o", "json"]);
+    serde_json::from_str(&kubectl_ok(&full)).expect("kubectl -o json returns JSON")
+}
+
+fn kubectl_apply(document: &Value) {
+    let mut child = Command::new("kubectl")
+        .arg("--context")
+        .arg(HARNESS_CONTEXT)
+        .args(["-n", NAMESPACE, "apply", "-f", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("kubectl apply spawns");
+    {
+        use std::io::Write;
+        let stdin = child.stdin.as_mut().expect("apply has a stdin");
+        stdin
+            .write_all(
+                serde_json::to_string(document)
+                    .expect("serialise")
+                    .as_bytes(),
+            )
+            .expect("write the manifest");
+    }
+    let output = child.wait_with_output().expect("kubectl apply completes");
+    assert!(
+        output.status.success(),
+        "kubectl apply failed: {}",
+        stderr_of(&output)
+    );
+}
+
+fn launcher_read(pod: &str, path: &str) -> String {
+    let output = kubectl(&[
+        "-n",
+        NAMESPACE,
+        "exec",
+        pod,
+        "-c",
+        LAUNCHER_CONTAINER_NAME,
+        "--",
+        "cat",
+        path,
+    ]);
+    assert!(
+        output.status.success(),
+        "reading {path} in {pod} failed: {}",
+        stderr_of(&output)
+    );
+    stdout_of(&output).trim_end().to_owned()
+}
+
+fn node_name() -> String {
+    let output = Command::new("kind")
+        .args(["get", "nodes", "--name", HARNESS_CLUSTER])
+        .output()
+        .expect("kind is executable");
+    assert!(
+        output.status.success(),
+        "kind get nodes: {}",
+        stderr_of(&output)
+    );
+    stdout_of(&output)
+        .lines()
+        .next()
+        .expect("the harness cluster has a node")
+        .trim()
+        .to_owned()
+}
+
+fn node_exec(node: &str, argv: &[&str]) -> Output {
+    let mut args = vec!["exec", node];
+    args.extend_from_slice(argv);
+    Command::new("docker")
+        .args(&args)
+        .output()
+        .expect("docker is executable")
+}
+
+fn node_read(node: &str, path: &str) -> String {
+    let output = node_exec(node, &["cat", path]);
+    assert!(
+        output.status.success(),
+        "reading {path} on node {node} failed: {}",
+        stderr_of(&output)
+    );
+    stdout_of(&output).trim_end().to_owned()
+}
+
+/// The apiserver canonicalises `2000m` to `2`, so every comparison here goes
+/// through the production parser rather than through strings. A string
+/// comparison reports `never reported 2000m; last observed Some(2000)`.
+fn millicores(raw: impl AsRef<str>) -> u64 {
+    CpuLimit::parse(raw.as_ref())
+        .unwrap_or_else(|error| panic!("parse cpu quantity {}: {error:?}", raw.as_ref()))
+        .millis()
+}
+
+/// Canonical serialized bytes: object keys sorted at every depth, so the
+/// comparison is over the whole subtree rather than over the fields somebody
+/// remembered to name. A field-by-field comparison stays green under a change
+/// to the field it omits.
+fn canonical(value: &Value) -> String {
+    fn walk(value: &Value) -> Value {
+        match value {
+            Value::Object(map) => {
+                let sorted: BTreeMap<String, Value> = map
+                    .iter()
+                    .map(|(key, inner)| (key.clone(), walk(inner)))
+                    .collect();
+                Value::Object(sorted.into_iter().collect())
+            }
+            Value::Array(items) => Value::Array(items.iter().map(walk).collect()),
+            other => other.clone(),
+        }
+    }
+    serde_json::to_string(&walk(value)).expect("canonical serialisation")
+}
+
+// ---------------------------------------------------------------------------
+// The five invariants, each read from the place that would actually drift.
+// ---------------------------------------------------------------------------
+
+/// AC2. Every container's and init container's `resources.requests`, keyed by
+/// list and name, as canonical bytes.
+fn requests_snapshot(pod: &Value) -> String {
+    let mut map = BTreeMap::new();
+    for list in ["initContainers", "containers"] {
+        for entry in pod["spec"][list].as_array().into_iter().flatten() {
+            let name = entry["name"].as_str().expect("a container name");
+            map.insert(
+                format!("{list}/{name}"),
+                entry["resources"]["requests"].clone(),
+            );
+        }
+    }
+    assert!(
+        map.len() >= 2,
+        "a rendered task-run Pod has a worker and a launcher; snapshotting {} containers means the traversal found nothing",
+        map.len()
+    );
+    canonical(&json!(map))
+}
+
+/// AC3, first half. `status.*.allocatedResources` over BOTH status lists.
+fn allocated_resources_snapshot(pod: &Value) -> String {
+    let mut map = BTreeMap::new();
+    for list in STATUS_LISTS {
+        for entry in pod["status"][list].as_array().into_iter().flatten() {
+            let name = entry["name"].as_str().expect("a container name");
+            map.insert(
+                format!("{list}/{name}"),
+                entry["allocatedResources"].clone(),
+            );
+        }
+    }
+    assert!(
+        !map.is_empty(),
+        "no container status carried allocatedResources; the traversal found nothing and the comparison would be vacuous"
+    );
+    canonical(&json!(map))
+}
+
+/// AC3, second half. Read from the LIVE Pod status, never inferred from the
+/// spec.
+fn qos_class(pod: &Value) -> String {
+    pod["status"]["qosClass"]
+        .as_str()
+        .expect("a running Pod reports a QoS class in its status")
+        .to_owned()
+}
+
+/// AC5. The NODE's own allocated-resources view, in millicores.
+///
+/// `kubectl describe node` renders the node's allocation table:
+///
+/// ```text
+///   Resource   Requests     Limits
+///   --------   --------     ------
+///   cpu        1050m (13%)  2350m (29%)
+/// ```
+///
+/// Returned as `(requests, limits)`. The LIMITS half is not decoration: it is
+/// the witness that something moved at all, so the requests half cannot pass
+/// vacuously on a Pod that never resized.
+fn node_allocated_cpu(node: &str) -> (u64, u64) {
+    let described = kubectl_ok(&["describe", "node", node]);
+    let mut in_section = false;
+    for line in described.lines() {
+        if line.starts_with("Allocated resources") {
+            in_section = true;
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        let trimmed = line.trim();
+        if trimmed.starts_with("cpu ") || trimmed == "cpu" {
+            let fields: Vec<&str> = trimmed.split_whitespace().collect();
+            // `cpu <requests> (<pct>) <limits> (<pct>)`
+            assert!(
+                fields.len() >= 4,
+                "unparsed node allocation row: {trimmed}\n{described}"
+            );
+            return (millicores(fields[1]), millicores(fields[3]));
+        }
+        if trimmed.starts_with("Events") {
+            break;
+        }
+    }
+    panic!("no `cpu` row in the node's Allocated resources section:\n{described}");
+}
+
+/// AC4. `cpu.weight` from the kernel's own files: the pod slice on the node and
+/// the launcher container's own cgroup root.
+struct Weights {
+    pod_slice: String,
+    launcher: String,
+}
+
+fn cpu_weights(node: &str, node_slice: &str, pod: &str) -> Weights {
+    Weights {
+        pod_slice: node_read(node, &format!("{node_slice}/cpu.weight")),
+        launcher: launcher_read(pod, "/sys/fs/cgroup/cpu.weight"),
+    }
+}
+
+/// The launcher's own view, from `status.initContainerStatuses` and NOWHERE
+/// else. The launcher is a native sidecar; it has no regular container status.
+struct LauncherStatus {
+    container_id: String,
+    restart_count: u64,
+    limit_millis: Option<u64>,
+}
+
+fn launcher_status(pod: &Value) -> LauncherStatus {
+    let entry = pod["status"]["initContainerStatuses"]
+        .as_array()
+        .expect("the launcher is a native sidecar; its status lives in the init-container statuses")
+        .iter()
+        .find(|entry| entry["name"] == LAUNCHER_CONTAINER_NAME)
+        .unwrap_or_else(|| panic!("no init-container status named {LAUNCHER_CONTAINER_NAME}"));
+    LauncherStatus {
+        container_id: entry["containerID"]
+            .as_str()
+            .expect("a running sidecar has a container id")
+            .to_owned(),
+        restart_count: entry["restartCount"].as_u64().expect("a restart count"),
+        limit_millis: entry["resources"]["limits"]["cpu"].as_str().map(millicores),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch helpers.
+// ---------------------------------------------------------------------------
+
+/// The renderer emits `djinn.app/component=task-run-worker`. A cleanup selector
+/// on `app.kubernetes.io/component=task-run` matches NOTHING, and the previous
+/// run's Jobs then keep holding the `pods` quota — which surfaces on the next
+/// run as "no Pod reached Running", quota exhaustion wearing the costume of a
+/// scheduling bug.
+fn cleanup_previous_runs() {
+    let selector = format!("{LABEL_COMPONENT}={COMPONENT_TASK_RUN_WORKER}");
+    for kind in ["job", "pod"] {
+        let _ = kubectl(&[
+            "-n",
+            NAMESPACE,
+            "delete",
+            kind,
+            "-l",
+            &selector,
+            "--ignore-not-found",
+            "--wait=true",
+            "--timeout=120s",
+        ]);
+    }
+}
+
+/// The chart-installed object names a live render must be pointed at, found by
+/// SUFFIX: the release prefix is the helm release name, so hardcoding either
+/// spelling breaks the moment the release is renamed.
+struct ChartNames {
+    service_account: String,
+    mirror_pvc: String,
+    projects_pvc: String,
+    cache_pvc: String,
+}
+
+fn chart_names() -> ChartNames {
+    let named = |kind: &str, suffix: &str| -> String {
+        kubectl_json(&["-n", NAMESPACE, "get", kind])["items"]
+            .as_array()
+            .expect("a List has items")
+            .iter()
+            .filter_map(|item| item["metadata"]["name"].as_str())
+            .find(|name| name.ends_with(suffix))
+            .unwrap_or_else(|| panic!("the chart installs a {kind} ending in {suffix}"))
+            .to_owned()
+    };
+    ChartNames {
+        service_account: named("serviceaccounts", "-taskrun"),
+        mirror_pvc: named("persistentvolumeclaims", "-mirrors"),
+        projects_pvc: named("persistentvolumeclaims", "-projects"),
+        cache_pvc: named("persistentvolumeclaims", "-cache"),
+    }
+}
+
+struct Rendered {
+    task_run_id: String,
+    launcher_ceiling_millis: u64,
+    document: Value,
+}
+
+/// Render a task-run Job exactly the way production does — `build_task_run_job`
+/// then `apply_launcher_authority_protocol` under `resize-v2` — and read the
+/// ceiling back OUT of the render rather than recomputing it from the config.
+fn render_task_run_job(chart: &ChartNames) -> Rendered {
+    let mut config = KubernetesConfig::for_testing();
+    config.cgroup_launcher_mode = CgroupLauncherMode::Required;
+    config.task_run_cgroup_writable_enabled = true;
+    config.namespace = NAMESPACE.to_owned();
+    config.service_account = chart.service_account.clone();
+    config.mirror_pvc = chart.mirror_pvc.clone();
+    config.projects_pvc = chart.projects_pvc.clone();
+    config.cache_pvc = chart.cache_pvc.clone();
+    config.cpu_limit = STOCK_CPU_LIMIT.to_owned();
+
+    let task_run_id = Uuid::now_v7();
+    let mut job = build_task_run_job(
+        &config,
+        &task_run_id,
+        "cycles-project",
+        "cycles-secret",
+        PROBE_IMAGE,
+        &[],
+        None,
+        false,
+        None,
+    );
+    let protocol = render_authority_protocol(
+        Some(LauncherAuthorityProtocol::ResizeV2),
+        Some("sha256:1j64"),
+    )
+    .expect("resize-v2 is declarable");
+    apply_launcher_authority_protocol(&mut job, config.cgroup_launcher_mode, protocol)
+        .expect("the rendered sidecar accepts the resize-v2 ceiling");
+
+    let document = serde_json::to_value(&job).expect("the rendered Job serialises");
+    let launcher_ceiling_millis = millicores(
+        document["spec"]["template"]["spec"]["initContainers"]
+            .as_array()
+            .expect("initContainers")
+            .iter()
+            .find(|entry| entry["name"] == LAUNCHER_CONTAINER_NAME)
+            .expect("the rendered sidecar")["resources"]["limits"]["cpu"]
+            .as_str()
+            .expect("the rendered sidecar carries a resize-v2 cpu ceiling"),
+    );
+    let task_run_id = document["metadata"]["labels"][LABEL_TASK_RUN_ID]
+        .as_str()
+        .expect("the renderer stamps the task-run id onto the Job")
+        .to_owned();
+
+    Rendered {
+        task_run_id,
+        launcher_ceiling_millis,
+        document,
+    }
+}
+
+/// The image the sidecar runs is the SHIPPED launcher binary at the path the
+/// renderer expects; only the worker's entrypoint is replaced, with a hold. This
+/// suite proves resource-accounting invariants, not brokered execution — pcod's
+/// suite proves the latter against the same image.
+fn ensure_probe_image() {
+    let output = Command::new("bash")
+        .arg(repo_root().join(PROBE_BUILD_SCRIPT))
+        .args([PROBE_IMAGE, HARNESS_CLUSTER])
+        .current_dir(repo_root())
+        .output()
+        .expect("the probe build script is executable");
+    assert!(
+        output.status.success(),
+        "building {PROBE_IMAGE} failed:\n{}",
+        stderr_of(&output)
+    );
+}
+
+fn prepare_holding_job(document: &mut Value) {
+    document["spec"]["backoffLimit"] = json!(0);
+    document["spec"]["ttlSecondsAfterFinished"] = json!(600);
+    let spec = &mut document["spec"]["template"]["spec"];
+    assert_eq!(
+        spec["runtimeClassName"], TASK_RUN_CGROUP_RUNTIME_CLASS,
+        "the render did not name the writable-cgroup RuntimeClass; the launcher would come up on a read-only /sys/fs/cgroup"
+    );
+    let worker = spec["containers"]
+        .as_array_mut()
+        .expect("containers")
+        .iter_mut()
+        .find(|entry| entry["name"] == WORKER_CONTAINER_NAME)
+        .expect("the render carries a worker container");
+    worker["image"] = json!(PROBE_IMAGE);
+    worker["imagePullPolicy"] = json!("IfNotPresent");
+    worker["command"] = json!(["/bin/sh", "-c", "sleep 5400"]);
+    worker["args"] = json!([]);
+
+    // The birth downsize `TaskRunResizeBootstrap` performs before dispatch, so
+    // cycle 1 lifts from the same place every later cycle does.
+    let launcher = document["spec"]["template"]["spec"]["initContainers"]
+        .as_array_mut()
+        .expect("the render carries the launcher as an init container")
+        .iter_mut()
+        .find(|entry| entry["name"] == LAUNCHER_CONTAINER_NAME)
+        .expect("exactly one cgroup-launcher init container");
+    launcher["resources"]["limits"]["cpu"] = json!(format!("{BIRTH_MILLICORES}m"));
+
+    document["metadata"]["labels"][LABEL_COMPONENT] = json!(COMPONENT_TASK_RUN_WORKER);
+}
+
+fn await_running_pod(task_run_id: &str) -> String {
+    let selector = format!("{LABEL_TASK_RUN_ID}={task_run_id}");
+    for _ in 0..READY_TICKS {
+        let names = kubectl_ok(&[
+            "-n",
+            NAMESPACE,
+            "get",
+            "pods",
+            "-l",
+            &selector,
+            "-o",
+            "jsonpath={range .items[*]}{.metadata.name}{\" \"}{.status.phase}{\"\\n\"}{end}",
+        ]);
+        for line in names.lines() {
+            let mut parts = line.split_whitespace();
+            if let (Some(name), Some("Running")) = (parts.next(), parts.next()) {
+                return name.to_owned();
+            }
+        }
+        std::thread::sleep(TICK);
+    }
+    panic!(
+        "no Pod reached Running for {selector}. If a previous run's Jobs were left behind they hold the `pods` quota and this is quota exhaustion, not scheduling:\n{}",
+        kubectl_ok(&["-n", NAMESPACE, "get", "pods,jobs"])
+    );
+}
+
+/// The pod's own cgroup slice on the NODE, located by the Pod uid rather than by
+/// guessing the kubelet's naming scheme.
+fn pod_slice_path(node: &str, pod: &str) -> String {
+    let uid = kubectl_ok(&[
+        "-n",
+        NAMESPACE,
+        "get",
+        "pod",
+        pod,
+        "-o",
+        "jsonpath={.metadata.uid}",
+    ]);
+    let underscored = uid.replace('-', "_");
+    let output = node_exec(
+        node,
+        &[
+            "sh",
+            "-c",
+            &format!(
+                "find /sys/fs/cgroup -maxdepth 4 -type d \\( -name '*{uid}*' -o -name '*{underscored}*' \\) | head -1"
+            ),
+        ],
+    );
+    let path = stdout_of(&output).trim().to_owned();
+    assert!(
+        !path.is_empty(),
+        "could not locate the cgroup slice of pod {pod} (uid {uid}) on node {node}"
+    );
+    path
+}
+
+/// `Patch::Strategic` is mandatory: the initContainers array carries
+/// `patchMergeKey: name`, and `Patch::Merge` answers
+/// `limits: Forbidden: resource limits cannot be removed`.
+fn resize_launcher(pod: &str, target_millis: u64) {
+    let body = build_resize_patch(CpuLimit::from_millis(target_millis));
+    let body = serde_json::to_string(&body).expect("serialise the resize patch");
+    let output = kubectl(&[
+        "-n",
+        NAMESPACE,
+        "patch",
+        "pod",
+        pod,
+        "--subresource",
+        RESIZE_SUBRESOURCE,
+        "--type",
+        "strategic",
+        "--patch",
+        &body,
+    ]);
+    assert!(
+        output.status.success(),
+        "the resize PATCH failed. A 404 here means this cluster has no pods/resize subresource:\n{}",
+        stderr_of(&output)
+    );
+}
+
+/// Confirmation from `status.initContainerStatuses[name=cgroup-launcher]` in
+/// PARSED MILLICORES — never from the PATCH response, never from the mutable
+/// `spec`, never from an HTTP 200 — and cross-checked against the PRODUCTION
+/// reader on the object the apiserver returned.
+fn await_confirmed_limit(pod: &str, target_millis: u64, cycle: usize, phase: &str) -> Value {
+    let mut last = Value::Null;
+    for _ in 0..CONFIRM_TICKS {
+        let document = kubectl_json(&["-n", NAMESPACE, "get", "pod", pod]);
+        let observed = launcher_status(&document).limit_millis;
+        // The type is inferred from `has_resize_pending_condition`, which takes
+        // the production `Pod`. Deserialising into it is itself part of the
+        // check: a status shape the production reader cannot parse is not a
+        // confirmation.
+        let settled = serde_json::from_value(document.clone())
+            .ok()
+            .filter(|parsed| !has_resize_pending_condition(parsed));
+        if observed == Some(target_millis)
+            && let Some(parsed) = &settled
+        {
+            confirm_launcher_cpu(parsed, CpuLimit::from_millis(target_millis)).unwrap_or_else(
+                |error| {
+                    panic!(
+                        "cycle {cycle} {phase}: the production reader refused a limit this suite read as confirmed: {error:?}"
+                    )
+                },
+            );
+            return document;
+        }
+        last = document;
+        std::thread::sleep(TICK);
+    }
+    panic!(
+        "cycle {cycle} {phase}: the launcher's init-container status never reported {target_millis}m; last observed {:?}. Millicores, not strings: the apiserver canonicalises 2000m to 2.",
+        launcher_status(&last).limit_millis
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The proof.
+// ---------------------------------------------------------------------------
+
+/// AC1 through AC6, on one Pod, over [`CYCLES`] complete lift/drop cycles.
+#[test]
+#[ignore = "live: needs the disposable kind cluster from scripts/kind/setup-resize-kind-cluster.sh"]
+fn live_repeated_cycles_move_only_the_launcher_limit() {
+    if !live_tests_enabled() {
+        return;
+    }
+    assert_harness_context();
+    let node = node_name();
+    cleanup_previous_runs();
+    ensure_probe_image();
+
+    let chart = chart_names();
+    let rendered = render_task_run_job(&chart);
+    let ceiling = rendered.launcher_ceiling_millis;
+    assert!(
+        ceiling > BIRTH_MILLICORES,
+        "the rendered ceiling ({ceiling}m) is not above the birth limit ({BIRTH_MILLICORES}m); every cycle would be a no-op and every invariant would hold vacuously"
+    );
+
+    let mut document = rendered.document.clone();
+    prepare_holding_job(&mut document);
+    kubectl_apply(&document);
+
+    let pod = await_running_pod(&rendered.task_run_id);
+    let node_slice = pod_slice_path(&node, &pod);
+
+    // ---- The BEFORE snapshot, taken once, before cycle 1. ----
+    let born = kubectl_json(&["-n", NAMESPACE, "get", "pod", &pod]);
+    assert_eq!(
+        launcher_status(&born).limit_millis,
+        Some(BIRTH_MILLICORES),
+        "the sidecar was not born at the {BIRTH_MILLICORES}m birth limit"
+    );
+    let container_id = launcher_status(&born).container_id;
+    let restart_count = launcher_status(&born).restart_count;
+
+    let requests_before = requests_snapshot(&born);
+    let allocated_before = allocated_resources_snapshot(&born);
+    let qos_before = qos_class(&born);
+    let (node_requests_before, node_limits_at_rest) = node_allocated_cpu(&node);
+    let weights_before = cpu_weights(&node, &node_slice, &pod);
+
+    eprintln!(">>> before: qos={qos_before} node allocated cpu={node_requests_before}m");
+    eprintln!(
+        ">>> before: pod slice cpu.weight={} launcher cpu.weight={}",
+        weights_before.pod_slice, weights_before.launcher
+    );
+
+    // ---- The cycles. ----
+    let mut completed_cycles = 0usize;
+    let mut lift_confirmations = 0usize;
+    let mut drop_confirmations = 0usize;
+    let mut node_limits_saw_a_lift = false;
+
+    for cycle in 1..=CYCLES {
+        // Lift.
+        resize_launcher(&pod, ceiling);
+        let lifted = await_confirmed_limit(&pod, ceiling, cycle, "lift");
+        lift_confirmations += 1;
+
+        assert_eq!(
+            launcher_status(&lifted).container_id,
+            container_id,
+            "cycle {cycle}: the container id changed, so this was a RESTART, not an in-place resize"
+        );
+        assert_eq!(
+            launcher_status(&lifted).restart_count,
+            restart_count,
+            "cycle {cycle}: the restart count moved"
+        );
+        assert_eq!(
+            qos_class(&lifted),
+            qos_before,
+            "cycle {cycle}: the Pod left its starting QoS class mid-lift"
+        );
+        assert_eq!(
+            requests_snapshot(&lifted),
+            requests_before,
+            "cycle {cycle}: a lift moved `resources.requests`"
+        );
+
+        // The witness that this cycle actually did something: the node's
+        // allocated LIMITS reflect the lift while its allocated REQUESTS do not.
+        let (node_requests_lifted, node_limits_lifted) = node_allocated_cpu(&node);
+        assert_eq!(
+            node_requests_lifted, node_requests_before,
+            "cycle {cycle}: the Node's allocated CPU REQUESTS moved on a limits-only resize. This is the assertion that protects Kueue accounting."
+        );
+        if node_limits_lifted != node_limits_at_rest {
+            node_limits_saw_a_lift = true;
+        }
+
+        // Drop.
+        resize_launcher(&pod, BIRTH_MILLICORES);
+        let dropped = await_confirmed_limit(&pod, BIRTH_MILLICORES, cycle, "drop");
+        drop_confirmations += 1;
+
+        assert_eq!(
+            launcher_status(&dropped).container_id,
+            container_id,
+            "cycle {cycle}: the container id changed on the way down"
+        );
+        assert_eq!(
+            launcher_status(&dropped).restart_count,
+            restart_count,
+            "cycle {cycle}: the restart count moved on the way down"
+        );
+
+        // Counted ONLY here: after this cycle's drop was status-confirmed.
+        completed_cycles += 1;
+
+        if cycle % 10 == 0 {
+            eprintln!(">>> {completed_cycles} cycles complete");
+        }
+    }
+
+    // ---- AC1. The counter, not the loop bound. ----
+    assert_eq!(
+        completed_cycles, CYCLES,
+        "the loop ran {CYCLES} times but only {completed_cycles} cycles completed a status-confirmed drop"
+    );
+    assert!(
+        completed_cycles >= MIN_CYCLES,
+        "only {completed_cycles} complete lift/drop cycles; the floor is {MIN_CYCLES}"
+    );
+    // ---- AC6. Every cycle confirmed individually, both ends. ----
+    assert_eq!(lift_confirmations, completed_cycles);
+    assert_eq!(drop_confirmations, completed_cycles);
+    assert!(
+        node_limits_saw_a_lift,
+        "the Node's allocated CPU LIMITS never moved across {completed_cycles} cycles. Nothing resized, so every invariant below would hold vacuously."
+    );
+
+    // ---- The AFTER snapshot. ----
+    let settled = kubectl_json(&["-n", NAMESPACE, "get", "pod", &pod]);
+    let (node_requests_after, _) = node_allocated_cpu(&node);
+    let weights_after = cpu_weights(&node, &node_slice, &pod);
+
+    // AC2, canonical bytes over the whole subtree.
+    assert_eq!(
+        requests_snapshot(&settled),
+        requests_before,
+        "`resources.requests` moved across {completed_cycles} lift/drop cycles"
+    );
+    // AC3.
+    assert_eq!(
+        allocated_resources_snapshot(&settled),
+        allocated_before,
+        "`status.*.allocatedResources` moved across {completed_cycles} lift/drop cycles"
+    );
+    assert_eq!(
+        qos_class(&settled),
+        qos_before,
+        "the Pod's QoS class moved across {completed_cycles} lift/drop cycles"
+    );
+    // AC4, from the cgroup FILES.
+    assert_eq!(
+        weights_after.pod_slice, weights_before.pod_slice,
+        "the pod slice's cpu.weight moved. This is read from the kernel's file, not derived from a request."
+    );
+    assert_eq!(
+        weights_after.launcher, weights_before.launcher,
+        "the launcher container's cpu.weight moved"
+    );
+    // AC5, from the Node.
+    assert_eq!(
+        node_requests_after, node_requests_before,
+        "the Node's allocated CPU requests moved across {completed_cycles} lift/drop cycles"
+    );
+
+    // The Pod ends where it started, and the launcher never restarted.
+    assert_eq!(
+        launcher_status(&settled).limit_millis,
+        Some(BIRTH_MILLICORES)
+    );
+    assert_eq!(launcher_status(&settled).container_id, container_id);
+    assert_eq!(launcher_status(&settled).restart_count, restart_count);
+
+    eprintln!(
+        ">>> {completed_cycles} complete cycles: {BIRTH_MILLICORES}m <-> {ceiling}m, {lift_confirmations} lift and {drop_confirmations} drop confirmations"
+    );
+    eprintln!(
+        ">>> unmoved across all of them: requests, allocatedResources, QoS class, node allocated cpu, and both cgroup weight files"
+    );
+
+    cleanup_previous_runs();
+}

--- a/server/tests/task_run_resize_cycles.rs
+++ b/server/tests/task_run_resize_cycles.rs
@@ -69,7 +69,7 @@ use djinn_k8s::job::{
     COMPONENT_TASK_RUN_WORKER, LABEL_COMPONENT, LABEL_TASK_RUN_ID, build_task_run_job,
 };
 use djinn_k8s::launcher::{
-    CgroupLauncherMode, LAUNCHER_CONTAINER_NAME, TASK_RUN_CGROUP_RUNTIME_CLASS,
+    CgroupLauncherMode, LAUNCHER_CONTAINER_NAME, LAUNCHER_IPC_DIR, TASK_RUN_CGROUP_RUNTIME_CLASS,
     apply_launcher_authority_protocol, render_authority_protocol,
 };
 use djinn_k8s::pod_resize::{
@@ -119,6 +119,11 @@ const RETENTION_GATE: &str = "scripts/check-resize-cutover-retention.sh";
 const RETENTION_SELFTEST: &str = "scripts/test-resize-cutover-retention.mjs";
 const PROBE_BUILD_SCRIPT: &str = "server/crates/djinn-k8s/tests/fixtures/governor-probe/build.sh";
 const PROBE_IMAGE: &str = "djinn-resize-probe:1j64";
+const PROBE_WORKLOAD: &str = "/opt/djinn/workload.bin";
+/// How long the probe holds its broker connection open. Comfortably longer than
+/// [`CYCLES`] cycles take, and bounded, because a probe that never exits turns a
+/// failed run into a hung one.
+const PROBE_HOLD_SECONDS: &str = "2400";
 
 const NAMESPACE: &str = "djinn";
 const WORKER_CONTAINER_NAME: &str = "worker";
@@ -1001,9 +1006,9 @@ fn render_task_run_job(chart: &ChartNames) -> Rendered {
 }
 
 /// The image the sidecar runs is the SHIPPED launcher binary at the path the
-/// renderer expects; only the worker's entrypoint is replaced, with a hold. This
-/// suite proves resource-accounting invariants, not brokered execution — pcod's
-/// suite proves the latter against the same image.
+/// renderer expects; only the worker's entrypoint is replaced. This suite proves
+/// resource-accounting invariants, not brokered execution — pcod's suite proves
+/// the latter against the same image.
 fn ensure_probe_image() {
     let output = Command::new("bash")
         .arg(repo_root().join(PROBE_BUILD_SCRIPT))
@@ -1018,7 +1023,7 @@ fn ensure_probe_image() {
     );
 }
 
-fn prepare_holding_job(document: &mut Value) {
+fn prepare_holding_job(document: &mut Value, invocation: &str) {
     document["spec"]["backoffLimit"] = json!(0);
     document["spec"]["ttlSecondsAfterFinished"] = json!(600);
     let spec = &mut document["spec"]["template"]["spec"];
@@ -1034,8 +1039,51 @@ fn prepare_holding_job(document: &mut Value) {
         .expect("the render carries a worker container");
     worker["image"] = json!(PROBE_IMAGE);
     worker["imagePullPolicy"] = json!("IfNotPresent");
-    worker["command"] = json!(["/bin/sh", "-c", "sleep 5400"]);
+    // The worker must complete the broker HANDSHAKE, not merely exist. The
+    // launcher's startup readiness contract gives the worker a bounded window to
+    // connect and then exits 1 — measured on the first live run of this suite,
+    // where a `sleep` stand-in produced `worker handshake did not complete in
+    // time` and a launcher restart mid-cycle-16. That restart is real evidence
+    // (the container-id assertion caught it), but it is evidence about the
+    // stand-in, not about resize. So the worker is the SHIPPED probe, speaking
+    // the real protocol to the unmodified launcher binary in the rendered
+    // sidecar.
+    //
+    // `skip` is written before the probe starts: this suite proves
+    // resource-accounting invariants across repeated resizes, so the probe
+    // creates its leaf, runs a short workload, declines the lift and holds the
+    // connection open for the whole cycle run. pcod's suite is where the lift
+    // itself is judged.
+    worker["command"] = json!([
+        "/bin/sh",
+        "-c",
+        format!(
+            "set -eu; mkdir -p {LAUNCHER_IPC_DIR}; printf 'skip' > {LAUNCHER_IPC_DIR}/decision; exec /opt/djinn/bin/djinn-governor-probe"
+        )
+    ]);
     worker["args"] = json!([]);
+
+    let environment = worker["env"].as_array_mut().expect("the worker has env");
+    for (name, value) in [
+        ("DJINN_PROBE_INVOCATION", invocation.to_owned()),
+        // Unused on the `skip` arm, but the probe requires it to be declarable.
+        ("DJINN_PROBE_FENCE", "0".to_owned()),
+        ("DJINN_PROBE_AUTHORITY", "armed".to_owned()),
+        (
+            "DJINN_PROBE_DECISION_PATH",
+            format!("{LAUNCHER_IPC_DIR}/decision"),
+        ),
+        ("DJINN_PROBE_WORKLOAD", PROBE_WORKLOAD.to_owned()),
+        ("DJINN_PROBE_CLAMP_SECONDS", "2".to_owned()),
+        ("DJINN_PROBE_LIFTED_SECONDS", "2".to_owned()),
+        ("DJINN_PROBE_WORKERS", "1".to_owned()),
+        // Longer than 40 cycles can take. The probe's own hold is bounded so a
+        // failed run is a failed run rather than a hung one.
+        ("DJINN_PROBE_HOLD_SECONDS", PROBE_HOLD_SECONDS.to_owned()),
+    ] {
+        environment.retain(|entry| entry["name"] != name);
+        environment.push(json!({ "name": name, "value": value }));
+    }
 
     // The birth downsize `TaskRunResizeBootstrap` performs before dispatch, so
     // cycle 1 lifts from the same place every later cycle does.
@@ -1048,6 +1096,41 @@ fn prepare_holding_job(document: &mut Value) {
     launcher["resources"]["limits"]["cpu"] = json!(format!("{BIRTH_MILLICORES}m"));
 
     document["metadata"]["labels"][LABEL_COMPONENT] = json!(COMPONENT_TASK_RUN_WORKER);
+}
+
+/// Wait for a line on the worker's stdout. `probe.fatal` is a hard stop: a probe
+/// that failed will never print the line being waited for, and a timeout would
+/// report that as "the cluster was slow".
+fn await_probe_line(pod: &str, needle: &str) {
+    for _ in 0..READY_TICKS {
+        let log = stdout_of(&kubectl(&[
+            "-n",
+            NAMESPACE,
+            "logs",
+            pod,
+            "-c",
+            WORKER_CONTAINER_NAME,
+        ]));
+        assert!(
+            !log.contains("probe.fatal"),
+            "the brokered probe failed before reaching `{needle}`:\n{log}"
+        );
+        if log.contains(needle) {
+            return;
+        }
+        std::thread::sleep(TICK);
+    }
+    panic!(
+        "the worker never printed `{needle}`:\n{}",
+        stdout_of(&kubectl(&[
+            "-n",
+            NAMESPACE,
+            "logs",
+            pod,
+            "-c",
+            WORKER_CONTAINER_NAME
+        ]))
+    );
 }
 
 fn await_running_pod(task_run_id: &str) -> String {
@@ -1195,11 +1278,17 @@ fn live_repeated_cycles_move_only_the_launcher_limit() {
         "the rendered ceiling ({ceiling}m) is not above the birth limit ({BIRTH_MILLICORES}m); every cycle would be a no-op and every invariant would hold vacuously"
     );
 
+    let invocation_id = Uuid::now_v7().to_string();
     let mut document = rendered.document.clone();
-    prepare_holding_job(&mut document);
+    prepare_holding_job(&mut document, &invocation_id);
     kubectl_apply(&document);
 
     let pod = await_running_pod(&rendered.task_run_id);
+    // The worker must have completed the broker handshake and created its leaf
+    // before the cycles start. Otherwise the launcher's startup readiness
+    // contract expires mid-run and the sidecar RESTARTS, which the container-id
+    // assertion would report as a failed resize.
+    await_probe_line(&pod, "probe.holding");
     let node_slice = pod_slice_path(&node, &pod);
 
     // ---- The BEFORE snapshot, taken once, before cycle 1. ----

--- a/server/tests/task_run_resize_cycles.rs
+++ b/server/tests/task_run_resize_cycles.rs
@@ -1,3 +1,8 @@
+// djinn:allow-oversize — task 1j64's design names `server/tests/task_run_resize_cycles.rs`
+// as the single exclusive path for this proof, so the live helpers cannot move
+// into a `tests/<name>/mod.rs` sibling without leaving that set. The size is
+// deliberate and recorded here rather than left unacknowledged in the report.
+//
 // `kubectl`, `docker` and the setup script all report through stderr, and the
 // skip lines below are the only channel a `--ignored` run has for saying why it
 // did nothing. The workspace denies `print_stderr` for library and server code.

--- a/server/tests/task_run_resize_cycles.rs
+++ b/server/tests/task_run_resize_cycles.rs
@@ -120,6 +120,9 @@ const SIBLING_REGISTRY_PORTS: &[&str] = &["5000", "5001", "5051", "5053", "5055"
 const SETUP_SCRIPT: &str = "scripts/kind/setup-resize-kind-cluster.sh";
 const WORKFLOW: &str = ".github/workflows/resize-kind.yml";
 const THIS_FILE: &str = "server/tests/task_run_resize_cycles.rs";
+/// pcod's suite. Read, never edited: it owns the production-path proof and the
+/// misleading-status fixture this suite defers to for the live half of AC6.
+const PCOD_SUITE: &str = "server/tests/task_run_resize_kind.rs";
 const RETENTION_GATE: &str = "scripts/check-resize-cutover-retention.sh";
 const RETENTION_SELFTEST: &str = "scripts/test-resize-cutover-retention.mjs";
 const PROBE_BUILD_SCRIPT: &str = "server/crates/djinn-k8s/tests/fixtures/governor-probe/build.sh";
@@ -411,6 +414,33 @@ fn guard_confirmation_never_reads_container_statuses() {
     assert!(
         source.contains("confirm_launcher_cpu("),
         "confirmation must go through the PRODUCTION reader, which reads status.initContainerStatuses[name=cgroup-launcher] and nothing else"
+    );
+}
+
+/// AC6's second mutation, live half — asserted here rather than duplicated.
+///
+/// The misleading-status fixture already exists in `pcod`'s suite: a hermetic
+/// proof that the production reader refuses a Pod whose only `cgroup-launcher`
+/// entry is a REGULAR container, and a live one that applies exactly that Pod to
+/// the cluster. Rebuilding either here would be a second copy of the same
+/// evidence, so this suite DEFERS to them — and a deferral to a proof nobody
+/// checks still exists is an assumption. This guard checks.
+#[test]
+fn guard_the_misleading_status_fixture_still_exists_and_is_run() {
+    let sibling = read_repo_file(PCOD_SUITE);
+    for proof in [
+        "the_misleading_container_status_is_not_confirmation",
+        "live_the_absent_init_status_is_not_confirmed",
+    ] {
+        assert!(
+            sibling.contains(proof),
+            "{PCOD_SUITE} no longer carries `{proof}`. This suite's confirmation reads defer to it for the live half of AC6; if it moved, point this guard at its new home rather than deleting the guard."
+        );
+    }
+    let workflow = read_repo_file(WORKFLOW);
+    assert!(
+        workflow.contains("task_run_resize_kind"),
+        "the live misleading-status fixture is no longer invoked by any lane"
     );
 }
 


### PR DESCRIPTION
Closes task `1j64` of epic `xowm` (proposal 3i92). Two deliverables.

> **Reuses pcod's harness (#2861, merged).** This branch is rebased on that
> merge: it **invokes** `scripts/kind/setup-resize-kind-cluster.sh` rather than
> forking it, with its own isolated `djinn-resize-1j64` / `5071` names, and
> appends one job to the `resize-kind.yml` pcod created.

## 1. Forty lift/drop cycles — `server/tests/task_run_resize_cycles.rs`

Nine hermetic guards that run on every PR with no cluster, and one live proof
over 40 complete lift/drop cycles against a production-rendered task-run Pod.

**Measured on a disposable kind 1.35.0 cluster (`djinn-resize-1j64`, torn down
and confirmed gone):**

```
>>> before: qos=Burstable node allocated cpu=2550m
>>> before: pod slice cpu.weight=41 launcher cpu.weight=11
>>> 40 complete cycles: 250m <-> 2000m, 40 lift and 40 drop confirmations
>>> unmoved across all of them: requests, allocatedResources, QoS class,
    node allocated cpu, and both cgroup weight files
test result: ok. 1 passed; finished in 170.23s
```

Each of the five invariants is read from the place that would actually drift:

| invariant | read from |
| --- | --- |
| `resources.requests` | canonical serialized bytes over the whole subtree, keys sorted at every depth — not named fields |
| `status.*.allocatedResources` | both status lists, same canonical form |
| QoS class | `status.qosClass` on the live Pod, never inferred from the spec |
| node allocated CPU **requests** | the Node's own allocated-resources view, never a Pod spec |
| `cpu.weight` | the cgroup **files**, at the pod slice on the node and inside the launcher container |

`cpu.weight` read **11** against a **50m** launcher request. That number is what
makes the file read visibly not a request derivation — it is what the kernel
applied, not what was asked for.

### Non-vacuity is asserted, not assumed

* `completed_cycles` is incremented **only** after that cycle's drop is
  status-confirmed, and is asserted against both `CYCLES` and a separate
  `MIN_CYCLES` floor. A `break` after cycle 1 leaves it at 1.
* The Node's allocated **limits** are asserted to have moved at least once, so
  the requests invariant cannot hold because nothing resized.
* Both ends of **every** cycle are confirmed individually, through the
  production reader `confirm_launcher_cpu` on
  `status.initContainerStatuses[name=cgroup-launcher]`, in parsed millicores
  (the apiserver canonicalises `2000m` to `2`).
* A source gate holds `containerStatuses` to its **single** permitted mention —
  the `allocatedResources` snapshot constant — so no confirmation can reach it.
* Every source-gate needle is built with `concat!` so the guard's own text
  cannot satisfy the guard.

### The first live run failed, and that is the point

A `sleep` worker stand-in never completes the broker handshake, so the
launcher's startup readiness contract expired and the sidecar restarted
**mid-cycle-16** — caught by the container-id assertion. The worker is now the
shipped `governor_probe` speaking the real protocol to the unmodified launcher
binary in the rendered sidecar.

## 2. The no-retirement gate

`scripts/check-resize-cutover-retention.sh` +
`scripts/resize-cutover-retention-manifest.mjs` +
`scripts/fixtures/resize-cutover-retention/` +
`scripts/test-resize-cutover-retention.mjs`.

Nine protected assets: the launcher crate, the `cgroup.kill` write, `wait_empty`,
the process broker, the launcher child mount set, the writable-cgroup
RuntimeClass and node assets, the credential-boundary chart tests, the launcher
containment proofs, and the **resize-v2-only** condition on the launcher CPU
ceiling.

Four rules per asset: **presence**, **behaviour-bearing content** (judged on
comment-stripped source, so commenting a write out reads as deleting it),
**production reachability**, and **rejection of always-false guards**.

**Deliberately not a byte-identity check.** Two `accept-*` fixtures pin that: a
local-variable rename inside `Launcher::wait_empty`, and a doc-comment rewrite.
Both go red under any byte-identity formulation. Source files in this epic are
expected to change; what must not happen is retirement.

Fourteen rejecting fixtures, at least one per asset, each asserted to fail **for
the asset it targets** rather than merely to fail:

* `wait_empty` stubbed to an immediate `Ok(())`
* the `cgroup.kill` write commented out
* the `cgroup.kill` write behind `if false`
* the RuntimeClass template behind an extra always-false conjunct
* the launcher CPU ceiling rendered **unconditionally** (7deu's ancestor clamp)
* the one production `wait_empty` caller deleted (retirement by unreachability)
* the containment proof's CI lane line deleted (a test no lane runs is retired)
* per-asset deletions for the remaining assets

The self-test drives the **shell** entry point, so its exit code is the
contract. Verified: stubbing the script to `exit 0` turns the suite red.

```
node --test scripts/test-resize-cutover-retention.mjs   # 26 pass, 0 fail
```

## Acceptance criteria

| AC | where |
| --- | --- |
| 1 — 40 cycles actually complete | `completed_cycles`, asserted vs `CYCLES` and `MIN_CYCLES`; `guard_the_cycle_count_is_a_named_constant_of_at_least_forty` |
| 2 — `requests` byte-identical | `requests_snapshot` (canonical bytes) + `guard_the_resize_patch_touches_only_the_launcher_cpu_limit` |
| 3 — `allocatedResources` + QoS | `allocated_resources_snapshot`, `qos_class` (from `status`), asserted per cycle and end to end |
| 4 — `cpu.weight` from the file | `cpu_weights` via `node_read`/`launcher_read`; `guard_cpu_weight_is_read_from_the_cgroup_file` |
| 5 — Node allocated requests | `node_allocated_cpu`; `guard_node_allocation_is_read_from_the_node` |
| 6 — per-cycle confirmation | `await_confirmed_limit`, 40 lift + 40 drop; `guard_confirmation_never_reads_container_statuses`; live misleading-status half deferred to pcod and held in place by `guard_the_misleading_status_fixture_still_exists_and_is_run` |
| 7 — per-asset fixtures | 14 rejecting fixtures + a coverage assertion over the asset table |
| 8 — presence/reachability, not byte-identity | `accept-local-variable-rename`, `accept-comment-rewrite` |
| 9 — disabling counts | `disable-wait-empty-immediate-ok`, `disable-cgroup-kill-*`, `disable-runtimeclass-conditional`, `disable-containment-lane` |
| 10 — no blanket launcher clamp | asset `launcher-cpu-ceiling-stays-conditional` + `disable-launcher-cpu-ceiling-unconditional` |
| 11 — gate runs in CI | `the_no_retirement_gate_passes_and_its_self_test_is_green` (always-on Rust lane) + the `resize-cycles` workflow job |
| 12 — disposable harness | `guard_the_harness_is_disjoint_and_reuses_the_shared_script`, `guard_the_kubernetes_floor_is_enforced`, isolated `djinn-resize-1j64` / `5071`, `--context` pinned everywhere, teardown `if: always()` |

## Honest reporting

* **AC11 wiring.** `quality-gate.yml` is outside this task's exclusive file set,
  so the gate reaches the always-on lane through a Rust `#[test]` in
  `task_run_resize_cycles.rs` that shells out to
  `check-resize-cutover-retention.sh` and to `node --test` on the self-test.
  That test requires `node` on the runner. A follow-up could move the
  invocation into `quality-gate.yml` alongside the sibling gates.
* **AC5's source.** The Node exposes no `status` field for allocated requests;
  the machine-readable equivalent is `kubectl describe node`'s allocation table,
  which is what is parsed. It aggregates every Pod on the node — 2550m, not this
  Pod's 1050m — so it is demonstrably not a Pod-spec read.
* **AC2's mutation** (a resize body that also touches `requests`) is proven
  hermetically rather than live: the apiserver will not accept a requests change
  through `pods/resize` on this path, so the assertion that catches it is
  `guard_the_resize_patch_touches_only_the_launcher_cpu_limit` over the real
  `build_resize_patch` output.
* **AC6's live misleading-status fixture is not rebuilt here.** pcod's suite
  already carries both halves — hermetic
  (`the_misleading_container_status_is_not_confirmation`) and live
  (`live_the_absent_init_status_is_not_confirmed`) — and a second copy of that
  evidence is worth less than one copy nobody can silently delete. So this suite
  defers, and `guard_the_misleading_status_fixture_still_exists_and_is_run` goes
  red if either proof or the lane that runs it disappears.
* **AC9's RuntimeClass wording, stated precisely.**
  `cgroupWritable.runtimeClass.enabled` already defaults to `false`, on purpose:
  arming the class before the nodes pass conformance leaves task-run Pods
  unschedulable. The retirement the fixture stands in for is therefore a
  *second* condition the operator has no switch for, which leaves the file, the
  template and `helm template` all looking healthy while the class never
  renders. See `disable-runtimeclass-conditional/fixture.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
