### PR TITLE
feat(resize): status-confirmed lift — arm ResizeAuthority in AppState behind a UID/restart/protocol-fenced PATCH-and-poll (0ppk-1c, 0vku)

### DIFF
--- a/scripts/check-resize-authorization-boundary.sh
+++ b/scripts/check-resize-authorization-boundary.sh
@@ -25,6 +25,23 @@
 #      it is a comment that invites a reader to read it.
 #   3. Each required type is still named by the module. Deleting the predicate
 #      would otherwise satisfy check 2 perfectly.
+#   4. (0ppk-1c) `with_resize_authority` has at least one PRODUCTION caller.
+#
+# WHY CHECK 4
+#
+# `BuildLeaseService` holds its resize authorization as
+# `Option<Arc<ResizeAuthority>>`. For the whole of `0ppk-1a` that `Option` was
+# `None` at every composition and `with_resize_authority` had zero call sites
+# outside tests: the authorization layer, the clamp, and their entire test suite
+# were merged, green, and structurally unable to move a Pod. Nothing about that
+# produces a compile error, and no unit test can catch it — a unit test that
+# installs the authority itself proves only that the setter works.
+#
+# Reachability is a property of the COMPOSITION SITE, so it is checked here, by
+# text, over the production tree. `#[cfg(test)]` blocks, `*_tests.rs` files and
+# `.worktrees/` scratch copies are excluded deliberately: a caller in any of
+# those is exactly the false positive that would let the arming be deleted while
+# CI stayed green.
 #
 # Usage:
 #   ./scripts/check-resize-authorization-boundary.sh
@@ -42,6 +59,8 @@ cd "$ROOT"
 GUARDED_FILES="
 server/crates/djinn-coordinator/src/resize_authorization.rs
 server/crates/djinn-coordinator/src/resize_authorization_tests.rs
+server/crates/djinn-coordinator/src/resize_lift.rs
+server/crates/djinn-coordinator/src/resize_lift_tests.rs
 "
 
 # The retired handoff relation and the protocol columns flc5 drops with it.
@@ -93,8 +112,86 @@ if [ -f "$TYPED_FILE" ]; then
     done
 fi
 
+# ── Check 4: the arming has a production caller ────────────────────────────
+#
+# The symbol is spelled in two halves so this script's own text cannot satisfy
+# the search it performs — a guard that matches itself is a guard that can never
+# fail.
+ARMING_SYMBOL="with_resize""_authority"
+ARMING_ROOT=server/src
+
+# A hit counts only if it precedes the file's first UNINDENTED `#[cfg(test)]`.
+#
+# An unindented `#[cfg(test)]` is a test-MODULE attribute; the indented ones are
+# `#[cfg(test)]` struct fields and statements, which sit in production code and
+# must not truncate the scan. Test modules go at the end of a file in this
+# codebase, so "before the first top-level `#[cfg(test)]`" is exactly "outside
+# every test module" without this script having to parse Rust.
+#
+# The rule is conservative in the safe direction: a caller appearing after one
+# is IGNORED, so the guard can only ever under-count production callers, never
+# over-count them. It can fail spuriously; it cannot pass spuriously.
+arming_callers() {
+    [ -d "$ARMING_ROOT" ] || return 0
+    find "$ARMING_ROOT" -name '*.rs' -type f 2>/dev/null |
+        grep -v -- '_tests\.rs$' |
+        grep -v -- '/\.worktrees/' |
+        while IFS= read -r file; do
+            awk -v sym="$ARMING_SYMBOL" -v path="$file" '
+                /^#\[cfg\(test\)\]/ { exit }
+                # A commented-out call is not a call. Without this, the named
+                # mutation "delete the arming" is satisfied by commenting it out
+                # and the guard passes on a composition that arms nothing --
+                # which is what the first version of this check actually did.
+                {
+                    raw = $0
+                    code = $0
+                    if (in_block) {
+                        if (match(code, /\*\//)) {
+                            code = substr(code, RSTART + RLENGTH)
+                            in_block = 0
+                        } else {
+                            next
+                        }
+                    }
+                    while (match(code, /\/\*/)) {
+                        head = substr(code, 1, RSTART - 1)
+                        rest = substr(code, RSTART + 2)
+                        if (match(rest, /\*\//)) {
+                            code = head substr(rest, RSTART + RLENGTH)
+                        } else {
+                            code = head
+                            in_block = 1
+                            break
+                        }
+                    }
+                    sub(/\/\/.*/, "", code)
+                    if (index(code, "." sym "(")) {
+                        printf "%s:%d:%s\n", path, NR, raw
+                    }
+                }
+            ' "$file"
+        done
+}
+
+if [ ! -d "$ARMING_ROOT" ]; then
+    echo "FAIL: $ARMING_ROOT does not exist; the arming guard has no subject." >&2
+    echo "      If the server composition root moved, update ARMING_ROOT in $0." >&2
+    status=1
+elif [ -z "$(arming_callers)" ]; then
+    echo "FAIL: no production caller of \`$ARMING_SYMBOL\` under $ARMING_ROOT." >&2
+    echo "      \`BuildLeaseService\` holds its resize authorization as an" >&2
+    echo "      Option that defaults to None. With no production caller the" >&2
+    echo "      whole resize stack is merged, green, and structurally unable" >&2
+    echo "      to move a Pod -- which is the exact state 0ppk-1a shipped in" >&2
+    echo "      and 0ppk-1c exists to end. Re-arm it in AppState::new_inner." >&2
+    status=1
+fi
+
 if [ "$status" -eq 0 ]; then
     echo "OK: resize authorization depends on the lift-decision types, not on retired storage."
+    echo "OK: the resize authorization is armed from production code:"
+    arming_callers | sed 's/^/    /'
 fi
 
 exit "$status"

--- a/scripts/test-check-resize-authorization-boundary.sh
+++ b/scripts/test-check-resize-authorization-boundary.sh
@@ -11,7 +11,10 @@
 #     comment-blind unless you decide otherwise, and here we decide they are not);
 #   * a deleted guarded file, which must fail rather than pass vacuously;
 #   * a module that stopped naming a required type, which would otherwise satisfy
-#     the ban perfectly by having no predicate left at all.
+#     the ban perfectly by having no predicate left at all;
+#   * (0ppk-1c) a tree whose only `with_resize_authority` caller is a test, or
+#     which has none at all -- the shape `0ppk-1a` shipped in, where the whole
+#     resize stack was merged, green, and structurally unable to move a Pod.
 #
 # Run from anywhere:
 #
@@ -28,6 +31,14 @@ SCRATCH="$REPO_ROOT/.resize-authorization-guard-selftest"
 REL_DIR=server/crates/djinn-coordinator/src
 MODULE="$REL_DIR/resize_authorization.rs"
 TESTS="$REL_DIR/resize_authorization_tests.rs"
+LIFT="$REL_DIR/resize_lift.rs"
+LIFT_TESTS="$REL_DIR/resize_lift_tests.rs"
+# The production composition root the arming check scans. Spelled in halves so
+# this harness cannot satisfy the guard's own search by containing the symbol in
+# a comment.
+ARMING_DIR=server/src/server/state
+ARMING_FILE="$ARMING_DIR/mod.rs"
+ARMING_SYMBOL="with_resize""_authority"
 
 cleanup() {
     rm -rf -- "$SCRATCH" 2>/dev/null || true
@@ -63,6 +74,23 @@ use djinn_launcher_protocol::LauncherAuthorityProtocol;
 EOF
     cat >"$SCRATCH/$TESTS" <<'EOF'
 // A clean test file.
+EOF
+    cat >"$SCRATCH/$LIFT" <<'EOF'
+// A clean lift module.
+EOF
+    cat >"$SCRATCH/$LIFT_TESTS" <<'EOF'
+// A clean lift test file.
+EOF
+    mkdir -p -- "$SCRATCH/$ARMING_DIR"
+    # A production composition site that arms the authority, above the file's
+    # test module -- the shape the guard must accept.
+    cat >"$SCRATCH/$ARMING_FILE" <<EOF
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap).$ARMING_SYMBOL(authority);
+}
+
+#[cfg(test)]
+mod tests {}
 EOF
 }
 
@@ -116,6 +144,89 @@ cat >"$SCRATCH/$MODULE" <<'EOF'
 // The predicate was deleted. No banned token, and no predicate either.
 EOF
 expect 1 "a module that no longer names the required types fails"
+
+# ── 0ppk-1c: the arming check ──────────────────────────────────────────────
+
+fixture
+cat >"$SCRATCH/$ARMING_FILE" <<'EOF'
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap);
+}
+EOF
+expect 1 "deleting the production arming call fails, naming the symbol"
+
+fixture
+# Observed while building this guard: the first implementation passed on a
+# COMMENTED-OUT arming call, which is exactly the mutation the criterion names.
+cat >"$SCRATCH/$ARMING_FILE" <<EOF
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap)
+        ;//.$ARMING_SYMBOL(authority)
+}
+EOF
+expect 1 "a COMMENTED-OUT arming call is not a caller"
+
+fixture
+cat >"$SCRATCH/$ARMING_FILE" <<EOF
+fn new_inner() {
+    /*
+     * .$ARMING_SYMBOL(authority)
+     */
+    let _ = BuildLeaseService::new(repo, cap);
+}
+EOF
+expect 1 "an arming call inside a block comment is not a caller"
+
+fixture
+# The ONLY caller is inside a test module. This is precisely the false positive
+# the check exists to reject: a unit test that installs the authority itself
+# proves the setter works and proves nothing about reachability.
+cat >"$SCRATCH/$ARMING_FILE" <<EOF
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_can_be_armed() {
+        let _ = BuildLeaseService::new(repo, cap).$ARMING_SYMBOL(authority);
+    }
+}
+EOF
+expect 1 "an arming call that exists ONLY inside a test module fails"
+
+fixture
+# A `*_tests.rs` sidecar is excluded by filename, for the same reason.
+cat >"$SCRATCH/$ARMING_FILE" <<'EOF'
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap);
+}
+EOF
+cat >"$SCRATCH/$ARMING_DIR/composition_tests.rs" <<EOF
+fn t() { BuildLeaseService::new(repo, cap).$ARMING_SYMBOL(authority); }
+EOF
+expect 1 "an arming call that exists ONLY in a *_tests.rs file fails"
+
+fixture
+rm -rf -- "$SCRATCH/server/src"
+expect 1 "a missing composition root fails rather than passing vacuously"
+
+fixture
+# An INDENTED `#[cfg(test)]` is a field or statement attribute, not a test
+# module. It must not truncate the scan and hide the production caller that
+# follows it -- which is exactly what the real `AppState` file looks like.
+cat >"$SCRATCH/$ARMING_FILE" <<EOF
+struct Inner {
+    #[cfg(test)]
+    test_bypass_persist: bool,
+}
+
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap).$ARMING_SYMBOL(authority);
+}
+EOF
+expect 0 "an indented #[cfg(test)] field does not hide the production caller"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -2813,6 +2813,55 @@ mod tests {
     use futures::StreamExt;
     use std::pin::Pin;
 
+    /// **0ppk-1c ACCEPTANCE CRITERION 1, the second composition site.**
+    ///
+    /// `DirectServices::with_provider_override` builds a SECOND
+    /// `BuildLeaseService` as an agent-side fallback. The task requires an
+    /// explicit, asserted decision about it, because an unarmed second
+    /// composition is exactly how a lift silently does not happen for some
+    /// callers.
+    ///
+    /// THE DECISION: it **fails closed — deliberately unarmed**, and it must
+    /// stay that way. Three reasons, in order of force:
+    ///
+    /// 1. `djinn-agent` cannot depend on `djinn-server`. That is not a
+    ///    preference; it is why `0ppk-1b` had to introduce the
+    ///    `TaskRunResizeAdmission` trait at all. The lift's apiserver surface
+    ///    (`TaskRunPodResizeSurface`) and the permit-creating dispatch seam both
+    ///    live on the far side of that boundary.
+    /// 2. This fallback is not on the path that CREATES permits. Arming it would
+    ///    make it answer `DegradedUnleased { PermitAbsent }` for every
+    ///    invocation it served — strictly worse than the passthrough.
+    /// 3. Unarmed means "no lift": the launcher keeps the birth quota it was
+    ///    already given. That is the pre-`3i92` behaviour and it is safe. The
+    ///    dangerous direction is the other one — REPORTING a grant for CPU no Pod
+    ///    ever received — and that is precisely what an armed-but-surfaceless
+    ///    composition would do.
+    ///
+    /// NAMED FAILING MUTATION: add `.with_resize_authority(..)` to
+    /// `with_provider_override`'s `BuildLeaseService` chain and this fails.
+    #[tokio::test]
+    async fn the_agent_side_fallback_build_lease_fails_closed_unarmed() {
+        let db = crate::test_helpers::create_test_db();
+        let context = crate::test_helpers::agent_context_from_db(
+            db,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        let services = DirectServices::with_provider_override(
+            context,
+            tokio_util::sync::CancellationToken::new(),
+            None,
+        );
+        assert!(
+            !services.build_lease.resize_authority_armed(),
+            "the agent-side fallback BuildLeaseService must stay UNARMED. \
+             `djinn-agent` cannot reach the server's apiserver surface or the \
+             dispatch seam that creates permits, so arming it would degrade \
+             every invocation it served to PermitAbsent while claiming to have \
+             lifted something"
+        );
+    }
+
     /// Helper: a non-zero pricing snapshot (used to represent a priced model).
     fn priced() -> Pricing {
         Pricing {

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -1461,6 +1461,27 @@ fn degrade_reason(result: &LeaseResult) -> &'static str {
             DegradedUnleasedReason::ProtocolNotResizable => "protocol_not_resizable",
             DegradedUnleasedReason::CeilingUnusable => "ceiling_unusable",
             DegradedUnleasedReason::AuthorizationUnreadable => "authorization_unreadable",
+            // Apply-time outcomes (0ppk-1c). Each is its own label because each
+            // names a different operator action: `resize_forbidden` is a missing
+            // RBAC rule, `launcher_restarted` is a Pod-level event, and
+            // `lift_status_stale` is a node that accepted a resize and never
+            // actuated it. Folding them together would reproduce exactly the
+            // "3 enum variants carried 4 meanings" failure this label exists to
+            // avoid.
+            DegradedUnleasedReason::PermitNotLiftable => "permit_not_liftable",
+            DegradedUnleasedReason::LiftLifecycleUnwritable => "lift_lifecycle_unwritable",
+            DegradedUnleasedReason::ResizeSurfaceUnavailable => "resize_surface_unavailable",
+            DegradedUnleasedReason::ResizeForbidden => "resize_forbidden",
+            DegradedUnleasedReason::ResizeRejected => "resize_rejected",
+            DegradedUnleasedReason::LiftPodAbsent => "lift_pod_absent",
+            DegradedUnleasedReason::LiftIdentityAmbiguous => "lift_identity_ambiguous",
+            DegradedUnleasedReason::ResizeIdentityChanged => "resize_identity_changed",
+            DegradedUnleasedReason::LauncherRestarted => "launcher_restarted",
+            DegradedUnleasedReason::LauncherProtocolChanged => "launcher_protocol_changed",
+            DegradedUnleasedReason::LiftResizePending => "lift_resize_pending",
+            DegradedUnleasedReason::LiftStatusAbsent => "lift_status_absent",
+            DegradedUnleasedReason::LiftStatusStale => "lift_status_stale",
+            DegradedUnleasedReason::LiftDeadlineExceeded => "lift_deadline_exceeded",
         },
         _ => "unclassified",
     }

--- a/server/crates/djinn-coordinator/Cargo.toml
+++ b/server/crates/djinn-coordinator/Cargo.toml
@@ -60,6 +60,11 @@ workspace-hack.workspace = true
 [dev-dependencies]
 djinn-agent = { path = "../djinn-agent", features = ["test-support"] }
 djinn-db = { path = "../djinn-db", features = ["test-support"] }
+# `pod_resize_fixture` — a stored `Pod` driven through the PRODUCTION observation,
+# patch and confirmation code. `deny.toml` bans a direct `k8s-openapi` dependency
+# outside the Kubernetes capability owner, so the fixture is how this crate's
+# lift tests get a Pod at all.
+djinn-k8s = { path = "../djinn-k8s", features = ["test-support"] }
 djinn-agent-worker = { path = "../djinn-agent-worker" }
 tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }
 tempfile = "3"

--- a/server/crates/djinn-coordinator/src/build_lease.rs
+++ b/server/crates/djinn-coordinator/src/build_lease.rs
@@ -284,6 +284,17 @@ impl BuildLeaseService {
         self
     }
 
+    /// Whether a Pod-resize authorization is armed on this service's grant path.
+    ///
+    /// Exposed so **reachability** can be asserted at a composition site rather
+    /// than inferred from a unit test that installed the authority itself. The
+    /// difference is the whole point: `Option<Arc<ResizeAuthority>> = None` is
+    /// how this stack spent `0ppk-1a` merged, green and unable to fire.
+    #[must_use]
+    pub const fn resize_authority_armed(&self) -> bool {
+        self.resize_authority.is_some()
+    }
+
     /// Install the rendered CPU facts that per-row weight is derived from.
     ///
     /// Composition passes the same `KubernetesConfig`-derived values used to

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -124,6 +124,7 @@ pub async fn record_supervisor_rework_reopen(
 }
 
 pub mod resize_authorization;
+pub mod resize_lift;
 pub mod resource_monitor;
 pub mod roles;
 /// Production wiring that arms the observe-only disk dimension at coordinator
@@ -203,6 +204,8 @@ mod build_lease_integration_tests;
 mod invocation_cpu_boundary_tests;
 #[cfg(test)]
 mod resize_authorization_tests;
+#[cfg(test)]
+mod resize_lift_tests;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 #[cfg(test)]

--- a/server/crates/djinn-coordinator/src/resize_authorization.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization.rs
@@ -1,10 +1,9 @@
 //! Server-derived Pod-resize authorization and ceiling clamp. **No Kubernetes.**
 //!
-//! This is the first slice of proposal `3i92`'s `0ppk` epic: the authorization
-//! and clamp layer that `0ppk-1b`'s `pods/resize` PATCH path will sit on top of.
-//! Nothing here calls Kubernetes, and nothing here may — the only outward edge
-//! is [`PodResizeIntentSink`], which `0ppk-1b` replaces with the real
-//! limits-only resize client.
+//! This is proposal `3i92`'s `0ppk` epic: the authorization and clamp layer, and
+//! the fold that applies its verdict. Nothing in *this file* calls Kubernetes,
+//! and nothing here may — the only outward edge is [`PodResizeApplier`], whose
+//! production implementation is [`crate::resize_lift::ResizeLift`].
 //!
 //! # The security property: the worker sends no coordinates
 //!
@@ -45,24 +44,37 @@
 //! `DJINN_LAUNCHER_LEASED_MILLICORES` a slow build rather than a rejected or
 //! evicted Pod.
 //!
-//! # What is NOT reachable yet, deliberately
+//! # Where this is reachable from, and where it deliberately is not
 //!
-//! [`BuildPodPermitRepository`] still has no production caller on `main`:
-//! neither `acquire` nor `bind_or_refresh_job_uid` is called from `server/src`
-//! or `runtime::prepare`. So no permit row exists in production, and
-//! [`ResizeAuthority`] is consequently **not composed into `AppState`** by this
-//! slice — [`crate::build_lease::BuildLeaseService`] holds it as an `Option` and
-//! behaves exactly as it does today when it is `None`. Wiring the authority and
-//! the permit's creation together is `0ppk-1b`'s job. Composing it here, against
-//! a relation nothing writes, would degrade every production invocation to
-//! unleased on its first grant.
+//! `0ppk-1b` (#2860) made [`BuildPodPermitRepository`] a production writer: the
+//! dispatch seam acquires a permit, binds the Job UID and captures the
+//! write-once resize identity before a worker session may start. `0ppk-1c`
+//! therefore arms this authority at the one composition site that has those
+//! rows — `AppState::new_inner` — via
+//! [`crate::build_lease::BuildLeaseService::with_resize_authority`]. Arming it
+//! before those rows existed would have degraded every production invocation to
+//! `PermitAbsent` on its first grant, which is why 1a shipped it unarmed and
+//! said so.
+//!
+//! [`crate::build_lease::BuildLeaseService`] still holds the authority as an
+//! `Option`, and the `None` path is still byte-identical to the pre-`3i92`
+//! grant path. That is not vestigial: `DirectServices::with_provider_override`
+//! builds a **second** `BuildLeaseService` as an agent-side fallback, and that
+//! one **stays unarmed on purpose**. `djinn-agent` cannot depend on the server
+//! crate — which is the entire reason `0ppk-1b` introduced the
+//! `TaskRunResizeAdmission` trait — so it has no apiserver surface to lift
+//! through, and it is not on the path that creates permits either. An unarmed
+//! fallback means "no lift": the launcher keeps its birth quota, which is the
+//! pre-`3i92` behaviour and is safe. The unsafe direction would be *reporting* a
+//! grant no Pod ever received, and that is exactly what an armed-but-surfaceless
+//! composition would do.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use djinn_db::{
     BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseRow, BuildLeaseState,
-    BuildPodPermitRepository, BuildPodResizeIdentity,
+    BuildPodPermitRepository, BuildPodPermitState, BuildPodResizeIdentity,
 };
 use djinn_launcher_protocol::LauncherAuthorityProtocol;
 use djinn_supervisor::services::{
@@ -78,13 +90,39 @@ use djinn_supervisor::services::{
 /// [`ResizeAuthority::authorize`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PodResizeIntent {
+    /// The **durable owner's** task run, recovered from the lease row's
+    /// immutable identity — never the caller's claim. It is the label the
+    /// applier's fresh GET is scoped by.
+    pub task_run_id: String,
+    /// The permit row's immutable identity, echoed by every durable lifecycle
+    /// compare-and-swap the applier makes.
+    pub permit_id: String,
+    /// The permit's monotonic ownership fence, likewise.
+    pub fencing_token: i64,
+    /// The permit's resize lifecycle state at authorization time. The applier
+    /// refuses to start a lift from anything that is not `birth_confirmed`
+    /// (fresh) or `lifted` (idempotent re-confirmation).
+    pub permit_state: BuildPodPermitState,
     pub pod_namespace: String,
     pub pod_name: String,
-    /// The immutable Pod UID the permit's identity was captured against. Carried
-    /// so `0ppk-1b` can fence its PATCH on the object it believes it is moving —
-    /// Pod *names* are reused, UIDs are not.
+    /// The immutable Pod UID the permit's identity was captured against.
+    ///
+    /// This is the fence. `PodResizeClient::resize_launcher_cpu` takes only a
+    /// Pod *name* and never reads `metadata.uid`, so a Pod deleted and recreated
+    /// under the same name is an object it cannot tell apart from the original.
+    /// Comparing this against the live `metadata.uid` before any PATCH is the
+    /// applier's job, and it is why this field is carried on the intent rather
+    /// than re-derived.
     pub pod_uid: String,
     pub launcher_container_name: String,
+    /// `status.initContainerStatuses[..].containerID` as captured. A launcher
+    /// restart replaces it, and a restarted launcher invalidates the lift: the
+    /// cgroup the target was reasoned about is gone.
+    pub launcher_container_id: String,
+    /// The protocol the server resolved for this Pod. A live Pod that declares
+    /// a different one is a hard failure — exactly one authority governs an
+    /// admitted Pod.
+    pub effective_launcher_protocol: LauncherAuthorityProtocol,
     /// Already clamped to the stored ceiling. See [`ResizeAuthority::authorize`].
     pub target_millicores: i64,
     /// The ceiling this target was clamped against, carried for the assertion
@@ -93,27 +131,80 @@ pub struct PodResizeIntent {
     pub admitted_cpu_millicores: i64,
 }
 
-/// The one outward edge of this module, and the seam `0ppk-1b` replaces.
+/// Why an authorized resize did not take.
 ///
-/// This exists so "zero Kubernetes calls" is assertable on a **counter** rather
-/// than on a returned error. A refusal that still emitted an intent would return
-/// the same `DegradedUnleased` as a refusal that emitted none, and only the
-/// counter can tell those apart — which is the whole failure mode acceptance
-/// criterion 1 is written against.
-pub trait PodResizeIntentSink: Send + Sync {
-    /// Called exactly once per authorized resize, and never for a refusal.
-    fn record(&self, intent: &PodResizeIntent);
+/// Carries a settled [`DegradedUnleasedReason`] plus a rendered detail for the
+/// log line. There is no "retry me" variant, and there cannot be one: see
+/// [`LeaseResult::DegradedUnleased`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResizeApplyFailure {
+    /// The closed reason that reaches the caller.
+    pub reason: DegradedUnleasedReason,
+    /// What actually happened, for the log line and the test message.
+    pub detail: String,
 }
 
-/// A sink that only counts. Used by this crate's tests and by any composition
-/// that wants the authorization decision without the PATCH.
+impl ResizeApplyFailure {
+    /// Build a failure.
+    #[must_use]
+    pub fn new(reason: DegradedUnleasedReason, detail: impl Into<String>) -> Self {
+        Self {
+            reason,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// The one outward edge of this module, and the seam that reaches Kubernetes.
+///
+/// # Why this is `async` and returns a `Result`
+///
+/// `0ppk-1a` shipped this as `fn record(&self, intent: &PodResizeIntent)` —
+/// synchronous, infallible, returning unit. That shape was right while the far
+/// side was a counter, and is **structurally wrong** now that the far side is a
+/// `pods/resize` PATCH followed by a status-confirmation poll. A fallible
+/// operation plugged into an infallible seam cannot report failure, so
+/// [`ResizeAuthority::fold_into_grant`] would have no failure to map, every
+/// uncertainty test below would pass without exercising anything, and the epic
+/// would collect another green, merged, inert slice.
+///
+/// So: reverting this trait to `fn record(&self, &PodResizeIntent)` is the named
+/// mutation for acceptance criterion 2. It does not merely fail a test — it
+/// stops `resize_lift.rs` and every uncertainty case in
+/// `resize_lift_tests.rs` from compiling, because there is nowhere left to put
+/// the failure.
+///
+/// It also keeps "zero Kubernetes calls" assertable on a **counter** rather than
+/// on a returned error: a refusal that had already emitted a PATCH would return
+/// exactly the same `DegradedUnleased` as one that emitted none.
+#[async_trait::async_trait]
+pub trait PodResizeApplier: Send + Sync {
+    /// Apply one authorized, already-clamped resize.
+    ///
+    /// Called exactly once per authorized resize, and never for a refusal.
+    /// Returns `Ok(())` **only** on a status-confirmed apply.
+    ///
+    /// # Errors
+    ///
+    /// [`ResizeApplyFailure`] for every way the lift can fail to take.
+    async fn apply(&self, intent: &PodResizeIntent) -> Result<(), ResizeApplyFailure>;
+}
+
+/// An applier that only counts, and always succeeds. Used by this crate's
+/// authorization tests and by any composition that wants the authorization
+/// decision without the PATCH.
+///
+/// It is deliberately NOT the production applier: it proves *which* intents
+/// reached the boundary and with what target, and proves nothing about whether
+/// a Pod moved. `resize_lift.rs` owns that, against fixtures whose confirmation
+/// rule is the production one.
 #[derive(Debug, Default)]
-pub struct CountingPodResizeIntentSink {
+pub struct CountingPodResizeApplier {
     intents: std::sync::Mutex<Vec<PodResizeIntent>>,
     calls: AtomicU64,
 }
 
-impl CountingPodResizeIntentSink {
+impl CountingPodResizeApplier {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -148,12 +239,48 @@ impl CountingPodResizeIntentSink {
     }
 }
 
-impl PodResizeIntentSink for CountingPodResizeIntentSink {
-    fn record(&self, intent: &PodResizeIntent) {
+#[async_trait::async_trait]
+impl PodResizeApplier for CountingPodResizeApplier {
+    async fn apply(&self, intent: &PodResizeIntent) -> Result<(), ResizeApplyFailure> {
         self.calls.fetch_add(1, Ordering::AcqRel);
         if let Ok(mut guard) = self.intents.lock() {
             guard.push(intent.clone());
         }
+        Ok(())
+    }
+}
+
+/// An applier that counts and then fails with a fixed reason. Exists so a test
+/// can prove that an apply failure reaches the caller as
+/// [`LeaseResult::DegradedUnleased`] *without* standing up a Pod fixture.
+#[derive(Debug)]
+pub struct FailingPodResizeApplier {
+    inner: CountingPodResizeApplier,
+    failure: ResizeApplyFailure,
+}
+
+impl FailingPodResizeApplier {
+    /// Fail every apply with `failure`.
+    #[must_use]
+    pub fn new(failure: ResizeApplyFailure) -> Self {
+        Self {
+            inner: CountingPodResizeApplier::new(),
+            failure,
+        }
+    }
+
+    /// How many times the Kubernetes boundary was reached.
+    #[must_use]
+    pub fn calls(&self) -> u64 {
+        self.inner.calls()
+    }
+}
+
+#[async_trait::async_trait]
+impl PodResizeApplier for FailingPodResizeApplier {
+    async fn apply(&self, intent: &PodResizeIntent) -> Result<(), ResizeApplyFailure> {
+        let _ = self.inner.apply(intent).await;
+        Err(self.failure.clone())
     }
 }
 
@@ -234,7 +361,7 @@ pub struct ResizeAuthority {
     /// a plain number rather than a `KubernetesConfig` so this module has no
     /// Kubernetes dependency at all, in either direction.
     configured_leased_millicores: i64,
-    sink: Arc<dyn PodResizeIntentSink>,
+    applier: Arc<dyn PodResizeApplier>,
 }
 
 impl ResizeAuthority {
@@ -244,14 +371,14 @@ impl ResizeAuthority {
         permits: Arc<BuildPodPermitRepository>,
         lift: Arc<dyn InvocationLiftAuthority>,
         configured_leased_millicores: i64,
-        sink: Arc<dyn PodResizeIntentSink>,
+        applier: Arc<dyn PodResizeApplier>,
     ) -> Self {
         Self {
             leases,
             permits,
             lift,
             configured_leased_millicores,
-            sink,
+            applier,
         }
     }
 
@@ -270,6 +397,11 @@ impl ResizeAuthority {
     /// 5. Resolve the permit from the **durable owner's** task-run id.
     /// 6. Require a captured write-once resize identity on a resizable protocol.
     /// 7. Clamp the target to the stored ceiling and emit the intent.
+    ///
+    /// It deliberately performs **no** Kubernetes call. Applying the authorized
+    /// intent is [`Self::fold_into_grant`]'s job, so that an apply failure is a
+    /// property of the grant result rather than something this function would
+    /// have to smuggle back through an outcome that has no error arm.
     pub async fn authorize(
         &self,
         claim: &TaskInvocationLeaseIdentity,
@@ -357,17 +489,24 @@ impl ResizeAuthority {
                 ));
             }
         };
+        let permit_id = permit.permit_id.clone();
+        let permit_fence = permit.fencing_token;
+        let permit_state = permit.state;
         let Some(identity) = permit.resize_identity else {
             return Self::refuse(ResizeRefusal::uncertain(
                 DegradedUnleasedReason::ResizeIdentityUnknown,
             ));
         };
 
-        match clamp(&identity, self.configured_leased_millicores) {
-            Ok(intent) => {
-                self.sink.record(&intent);
-                ResizeAuthorizationOutcome::Authorized(intent)
-            }
+        match clamp(
+            &owner.task_run_id,
+            &permit_id,
+            permit_fence,
+            permit_state,
+            &identity,
+            self.configured_leased_millicores,
+        ) {
+            Ok(intent) => ResizeAuthorizationOutcome::Authorized(intent),
             Err(refusal) => Self::refuse(refusal),
         }
     }
@@ -407,8 +546,32 @@ impl ResizeAuthority {
             return granted;
         }
         match authority.authorize(claim, fencing_token).await {
-            ResizeAuthorizationOutcome::Authorized(_)
-            | ResizeAuthorizationOutcome::NotLifting(_) => granted,
+            // THE LIFT. `0ppk-1a` returned `granted` here and dropped the
+            // authorized intent on the floor, which made the whole
+            // authorization layer a decision nobody acted on. Restoring that
+            // passthrough is acceptance criterion 2's second named mutation:
+            // the happy-path PATCH counter goes to zero and every
+            // status-confirmation test in `resize_lift_tests.rs` stops proving
+            // anything about the grant path.
+            ResizeAuthorizationOutcome::Authorized(intent) => {
+                match authority.applier.apply(&intent).await {
+                    Ok(()) => granted,
+                    Err(failure) => {
+                        tracing::warn!(
+                            task_run_id = %intent.task_run_id,
+                            pod_uid = %intent.pod_uid,
+                            target_millicores = intent.target_millicores,
+                            reason = ?failure.reason,
+                            detail = %failure.detail,
+                            "resize lift did not take; degrading unleased"
+                        );
+                        LeaseResult::DegradedUnleased {
+                            reason: failure.reason,
+                        }
+                    }
+                }
+            }
+            ResizeAuthorizationOutcome::NotLifting(_) => granted,
             ResizeAuthorizationOutcome::Refused(refusal) => LeaseResult::DegradedUnleased {
                 reason: refusal.reason,
             },
@@ -450,6 +613,10 @@ fn durable_owner(row: &BuildLeaseRow) -> Option<TaskInvocationLeaseIdentity> {
 /// database, and so acceptance criterion 2's mutation ("remove the clamp") is a
 /// one-line edit at a single site rather than something that could be half-done.
 fn clamp(
+    task_run_id: &str,
+    permit_id: &str,
+    fencing_token: i64,
+    permit_state: BuildPodPermitState,
     identity: &BuildPodResizeIdentity,
     configured_leased_millicores: i64,
 ) -> Result<PodResizeIntent, ResizeRefusal> {
@@ -476,10 +643,16 @@ fn clamp(
     // stated mutation, and it must make `intents_above_ceiling()` report 1.
     let target_millicores = configured_leased_millicores.min(ceiling);
     Ok(PodResizeIntent {
+        task_run_id: task_run_id.to_owned(),
+        permit_id: permit_id.to_owned(),
+        fencing_token,
+        permit_state,
         pod_namespace: identity.pod_namespace.clone(),
         pod_name: identity.pod_name.clone(),
         pod_uid: identity.pod_uid.clone(),
         launcher_container_name: identity.launcher_container_name.clone(),
+        launcher_container_id: identity.launcher_container_id.clone(),
+        effective_launcher_protocol: protocol,
         target_millicores,
         admitted_cpu_millicores: ceiling,
     })

--- a/server/crates/djinn-coordinator/src/resize_authorization_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization_tests.rs
@@ -8,7 +8,7 @@
 //! whose `active()` returned a struct literal would agree with all of it and
 //! prove none of it.
 //!
-//! The ONE double is [`CountingPodResizeIntentSink`], and it is deliberately on
+//! The ONE double is [`CountingPodResizeApplier`], and it is deliberately on
 //! the far side of the boundary: it stands in for the Kubernetes `pods/resize`
 //! PATCH that `0ppk-1b` owns. "Zero Kubernetes calls" is only assertable if
 //! something counts calls, and a returned `DegradedUnleased` cannot tell a
@@ -32,7 +32,7 @@ use djinn_supervisor::services::{
 
 use crate::build_lease::BuildLeaseService;
 use crate::resize_authorization::{
-    CountingPodResizeIntentSink, RefusalClass, ResizeAuthority, ResizeAuthorizationOutcome,
+    CountingPodResizeApplier, RefusalClass, ResizeAuthority, ResizeAuthorizationOutcome,
 };
 
 /// `DJINN_MAX_BUILD_TASKRUNS` stand-in — large enough that capacity never
@@ -126,7 +126,7 @@ async fn seed_task_runs(db: &Database, runs: &[&str]) {
 struct Fixture {
     service: Arc<BuildLeaseService>,
     permits: Arc<BuildPodPermitRepository>,
-    sink: Arc<CountingPodResizeIntentSink>,
+    applier: Arc<CountingPodResizeApplier>,
     authority: Arc<ResizeAuthority>,
     _db: Database,
 }
@@ -150,7 +150,7 @@ impl Fixture {
 
         let leases = Arc::new(BuildLeaseRepository::new(db.clone()));
         let permits = Arc::new(BuildPodPermitRepository::new(db.clone()));
-        let sink = Arc::new(CountingPodResizeIntentSink::new());
+        let applier = Arc::new(CountingPodResizeApplier::new());
         let lift: Arc<dyn InvocationLiftAuthority> = Arc::new(DurableInvocationLiftAuthority::new(
             db.clone(),
             "resize-authorization-tests",
@@ -160,7 +160,7 @@ impl Fixture {
             Arc::clone(&permits),
             lift,
             CONFIGURED_LEASED,
-            Arc::clone(&sink) as Arc<dyn crate::resize_authorization::PodResizeIntentSink>,
+            Arc::clone(&applier) as Arc<dyn crate::resize_authorization::PodResizeApplier>,
         ));
 
         let service = Arc::new(
@@ -173,7 +173,7 @@ impl Fixture {
         Self {
             service,
             permits,
-            sink,
+            applier,
             authority,
             _db: db,
         }
@@ -299,7 +299,7 @@ async fn a_task_run_naming_another_invocation_is_denied_with_zero_kubernetes_cal
         .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
         .await;
     assert_eq!(
-        fixture.sink.calls(),
+        fixture.applier.calls(),
         0,
         "precondition: queueing must not reach the Kubernetes boundary"
     );
@@ -313,7 +313,7 @@ async fn a_task_run_naming_another_invocation_is_denied_with_zero_kubernetes_cal
         )
         .await;
     assert_eq!(
-        fixture.sink.calls(),
+        fixture.applier.calls(),
         0,
         "ZERO Kubernetes calls: the denial must land before any Pod is named"
     );
@@ -325,7 +325,7 @@ async fn a_task_run_naming_another_invocation_is_denied_with_zero_kubernetes_cal
         "a task run naming another task run's invocation must be denied"
     );
     assert!(
-        fixture.sink.intents().is_empty(),
+        fixture.applier.intents().is_empty(),
         "and no intent may have been derived for the intruder's Pod either"
     );
 }
@@ -362,7 +362,7 @@ async fn the_owner_is_authorized_against_its_own_durable_permit() {
         "an authorized grant returns the lease status unchanged: {granted:?}"
     );
 
-    let intents = fixture.sink.intents();
+    let intents = fixture.applier.intents();
     assert_eq!(intents.len(), 1, "exactly one Kubernetes intent");
     let intent = &intents[0];
     assert_eq!(intent.pod_namespace, format!("ns-{OWNER_RUN}"));
@@ -411,7 +411,7 @@ async fn a_mismatched_fencing_token_is_denied_with_zero_kubernetes_calls() {
         }
         other => panic!("a foreign fencing token must be denied, got {other:?}"),
     }
-    assert_eq!(fixture.sink.calls(), 0, "ZERO Kubernetes calls");
+    assert_eq!(fixture.applier.calls(), 0, "ZERO Kubernetes calls");
 }
 
 // ─── AC2: the ceiling clamp ─────────────────────────────────────────────────
@@ -453,10 +453,10 @@ async fn a_configured_lift_above_the_stored_ceiling_clamps_to_the_ceiling() {
         .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
         .await;
 
-    let intents = fixture.sink.intents();
+    let intents = fixture.applier.intents();
     assert_eq!(intents.len(), 1);
     assert_eq!(
-        fixture.sink.intents_above_ceiling(),
+        fixture.applier.intents_above_ceiling(),
         0,
         "ZERO PATCH intents above the stored ceiling"
     );
@@ -482,13 +482,13 @@ async fn a_ceiling_above_the_configured_lift_does_not_raise_the_target() {
         .grant(identity(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION), &token)
         .await;
 
-    let intents = fixture.sink.intents();
+    let intents = fixture.applier.intents();
     assert_eq!(intents.len(), 1);
     assert_eq!(
         intents[0].target_millicores, CONFIGURED_LEASED,
         "a generous ceiling must not lift the process above what it configured"
     );
-    assert_eq!(fixture.sink.intents_above_ceiling(), 0);
+    assert_eq!(fixture.applier.intents_above_ceiling(), 0);
 }
 
 // ─── AC3: the lift predicate is written against the TYPES ───────────────────
@@ -529,7 +529,7 @@ async fn only_an_enforcing_authority_authorizes_a_resize() {
             "{mode:?} is not a degrade: the lease result passes through"
         );
         assert_eq!(
-            fixture.sink.calls(),
+            fixture.applier.calls(),
             0,
             "{mode:?} must reach the Kubernetes boundary ZERO times"
         );
@@ -578,7 +578,7 @@ async fn a_leaf_v1_pod_is_not_resizable_and_costs_zero_kubernetes_calls() {
             reason: DegradedUnleasedReason::ProtocolNotResizable
         }
     );
-    assert_eq!(fixture.sink.calls(), 0, "ZERO Kubernetes calls");
+    assert_eq!(fixture.applier.calls(), 0, "ZERO Kubernetes calls");
     assert_eq!(
         LauncherAuthorityProtocol::from_str("resize-v2").unwrap(),
         LauncherAuthorityProtocol::ResizeV2,
@@ -622,7 +622,7 @@ async fn every_uncertainty_degrades_unleased_rather_than_erroring() {
         LeaseResult::LeaseUnavailable,
         "LeaseUnavailable means ASK AGAIN; this answer cannot change by asking"
     );
-    assert_eq!(fixture.sink.calls(), 0, "ZERO Kubernetes calls");
+    assert_eq!(fixture.applier.calls(), 0, "ZERO Kubernetes calls");
 
     // A permit exists but its write-once resize identity was never captured —
     // the window between `acquire` and `g8jk-3`'s post-admission capture.
@@ -645,7 +645,7 @@ async fn every_uncertainty_degrades_unleased_rather_than_erroring() {
         },
         "an uncaptured Pod identity is a settled degrade"
     );
-    assert_eq!(fixture.sink.calls(), 0, "ZERO Kubernetes calls");
+    assert_eq!(fixture.applier.calls(), 0, "ZERO Kubernetes calls");
 }
 
 /// A refusal must not disturb the durable lease. The invocation still holds its

--- a/server/crates/djinn-coordinator/src/resize_lift.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift.rs
@@ -1,0 +1,539 @@
+//! The status-confirmed lift: every fence `PodResizeClient` does not have.
+//!
+//! [`crate::resize_authorization::ResizeAuthority`] decides *whether* a resize is
+//! allowed and *what* the clamped target is, from durable rows alone. This module
+//! is what actually moves the Pod, and it is where an authorized intent becomes
+//! either a lease grant or a settled degrade.
+//!
+//! # What `PodResizeClient::resize_launcher_cpu` does NOT do
+//!
+//! Its whole signature is `(&self, pod_name: &str, target: CpuLimit)`. From that
+//! alone, four fences are missing and every one of them is this module's job:
+//!
+//! 1. **No UID fence.** It never reads `metadata.uid`. A Pod deleted and
+//!    recreated under the same name is, to it, the same Pod. We compare the live
+//!    `metadata.uid` against the permit's write-once `pod_uid` on the fresh GET
+//!    **before** any PATCH, and again after confirmation.
+//! 2. **No restart fence.** The permit captured
+//!    `status.initContainerStatuses[..].containerID`. A launcher that restarted
+//!    is a different cgroup than the one the lift was reasoned about.
+//! 3. **No protocol fence.** The permit captured
+//!    `effective_launcher_protocol`. Exactly one authority governs an admitted
+//!    Pod; a live Pod that declares another one is a hard failure.
+//! 4. **No polling.** It performs exactly one GET / PATCH / GET cycle.
+//!    `status.initContainerStatuses` is populated asynchronously, so a single
+//!    immediate confirming GET usually reads stale. The bounded confirmation
+//!    poll lives here, because the deadline has to have exactly one owner.
+//!
+//! What it *does* get right is reused verbatim and never re-derived here:
+//! `Patch::Strategic` (because `initContainers` carries `patchMergeKey: name`,
+//! and a Merge patch replaces the whole array — proven live in #2861, where the
+//! apiserver answered `spec.initContainers[0].resources.limits: Forbidden:
+//! resource limits cannot be removed`), the refusal to ever consult
+//! `spec.containers` or `status.containerStatuses`, the `PodResizePending`
+//! fail-closed, and the **millicore** comparison. That last one is not
+//! defensive: #2861 observed the apiserver canonicalise `2000m` to `2` and a
+//! string comparison report `never reported 2000m; last observed Some(2000)`.
+//!
+//! # Everything degrades. Nothing errors.
+//!
+//! [`PodResizeApplier::apply`] returns `Result<(), ResizeApplyFailure>`, and
+//! `fold_into_grant` maps every failure onto
+//! [`LeaseResult::DegradedUnleased`](djinn_supervisor::services::LeaseResult) —
+//! never onto an `Err` the invocation runner would classify as retryable. Every
+//! input to a lift is settled: which Pod the permit was captured against, what
+//! ceiling was admitted, whether the kubelet actuated. Re-asking spends the
+//! queue deadline on a question whose answer is fixed while the child runs
+//! clamped the whole time.
+//!
+//! # A failed lift leaves the permit `drop_required`
+//!
+//! Before the PATCH the lifecycle moves `birth_confirmed → lift_applying`; on a
+//! confirmed lift, `lift_applying → lifted`; on **any** failure after that
+//! transition, `→ drop_required`. Migration 164's trigger owns the legal edge
+//! list, so this module cannot invent one. A lift that could not be confirmed
+//! must never leave a row claiming `lifted` — the drop reconciler (`0ppk-3`) is
+//! what returns the Pod to its birth limit, and it reads `drop_required`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_db::{
+    BuildPodPermitRepository, BuildPodPermitState, TransitionBuildPodResizeLifecycleResult,
+};
+use djinn_k8s::pod_resize::{NotConfirmed, PodResizeError};
+use djinn_k8s::runtime::{
+    LauncherObservationError, ObservedLauncherSidecar, TaskRunPodResizeSurface,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use djinn_supervisor::services::DegradedUnleasedReason;
+
+use crate::resize_authorization::{PodResizeApplier, PodResizeIntent, ResizeApplyFailure};
+
+/// How long a lift waits for `status.initContainerStatuses` to agree.
+///
+/// The kubelet actuates asynchronously, so a confirmation budget of zero would
+/// degrade almost every healthy lift. It is bounded well below the invocation's
+/// own queue deadline: a lift that has not actuated in this long is not going
+/// to, and the invocation is better off running unleased than waiting.
+pub const LIFT_CONFIRMATION_BUDGET: Duration = Duration::from_secs(30);
+
+/// Interval between confirmation observations.
+pub const LIFT_CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// The two apiserver operations a lift performs.
+///
+/// Behind a trait so the whole fenced sequence is drivable from fixtures with no
+/// cluster, and so this crate needs no `k8s-openapi` dependency of its own — the
+/// two types crossing this boundary are `djinn-k8s`'s own flattened
+/// [`ObservedLauncherSidecar`] and [`PodResizeError`], never a `Pod`.
+///
+/// It is deliberately the *same shape* as `djinn-server`'s `TaskRunPodSurface`
+/// minus the fenced delete, rather than a reuse of it: `djinn-server` depends on
+/// this crate, so the trait cannot live there.
+#[async_trait]
+pub trait LauncherResizeSurface: Send + Sync {
+    /// Fresh, label-scoped GET of the single Pod for this task run, flattened to
+    /// the launcher facts every fence is compared against. `Ok(None)` means no
+    /// Pod carries the label.
+    ///
+    /// # Errors
+    ///
+    /// [`LauncherObservationError`] when the read fails, the Pod is not fully
+    /// admitted, or the launcher cannot be uniquely named.
+    async fn observe_launcher(
+        &self,
+        task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError>;
+
+    /// One limits-only `pods/resize` PATCH of the launcher sidecar, confirmed
+    /// through `status.initContainerStatuses`.
+    ///
+    /// # Errors
+    ///
+    /// [`PodResizeError`]; `NotConfirmed` when the PATCH was accepted but the
+    /// fresh init-container status does not yet agree.
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError>;
+}
+
+#[async_trait]
+impl LauncherResizeSurface for TaskRunPodResizeSurface {
+    async fn observe_launcher(
+        &self,
+        task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        Self::observe_launcher(self, task_run_id).await
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        Self::resize_launcher_cpu(self, pod_name, target_millicores).await
+    }
+}
+
+/// Where the lift gets its apiserver surface.
+enum SurfaceSource {
+    /// Built once, lazily, from ambient cluster configuration. Lazy because the
+    /// composition root is synchronous and building a `kube::Client` is not, and
+    /// because a server with no kubeconfig must still boot. A server that never
+    /// resolves one degrades every lift to
+    /// [`DegradedUnleasedReason::ResizeSurfaceUnavailable`] — which is exactly
+    /// the fail-closed answer, and is never a grant.
+    Ambient(tokio::sync::OnceCell<Arc<dyn LauncherResizeSurface>>),
+    /// Supplied by the caller. Fixtures use this.
+    Fixed(Arc<dyn LauncherResizeSurface>),
+}
+
+/// The status-confirmed, UID/restart/protocol-fenced lift.
+pub struct ResizeLift {
+    permits: Arc<BuildPodPermitRepository>,
+    surface: SurfaceSource,
+    budget: Duration,
+    poll_interval: Duration,
+}
+
+impl ResizeLift {
+    /// The production constructor: durable permits over `permits`, apiserver
+    /// surface resolved from ambient cluster configuration on first lift.
+    #[must_use]
+    pub fn from_env(permits: Arc<BuildPodPermitRepository>) -> Self {
+        Self {
+            permits,
+            surface: SurfaceSource::Ambient(tokio::sync::OnceCell::new()),
+            budget: LIFT_CONFIRMATION_BUDGET,
+            poll_interval: LIFT_CONFIRMATION_POLL_INTERVAL,
+        }
+    }
+
+    /// Same composition against a caller-supplied surface.
+    #[must_use]
+    pub fn with_surface(
+        permits: Arc<BuildPodPermitRepository>,
+        surface: Arc<dyn LauncherResizeSurface>,
+    ) -> Self {
+        Self {
+            permits,
+            surface: SurfaceSource::Fixed(surface),
+            budget: LIFT_CONFIRMATION_BUDGET,
+            poll_interval: LIFT_CONFIRMATION_POLL_INTERVAL,
+        }
+    }
+
+    /// Override the confirmation budget and poll interval.
+    ///
+    /// A zero budget means "one observation, no waiting", which is what lets a
+    /// test see the *specific* thing an unconfirmed status reported rather than
+    /// the fact that a budget was spent. See
+    /// [`DegradedUnleasedReason::LiftDeadlineExceeded`].
+    #[must_use]
+    pub const fn with_wait(mut self, budget: Duration, poll_interval: Duration) -> Self {
+        self.budget = budget;
+        self.poll_interval = poll_interval;
+        self
+    }
+
+    async fn surface(&self) -> Result<Arc<dyn LauncherResizeSurface>, ResizeApplyFailure> {
+        match &self.surface {
+            SurfaceSource::Fixed(surface) => Ok(Arc::clone(surface)),
+            SurfaceSource::Ambient(cell) => cell
+                .get_or_try_init(|| async {
+                    TaskRunPodResizeSurface::from_env()
+                        .await
+                        .map(|surface| Arc::new(surface) as Arc<dyn LauncherResizeSurface>)
+                })
+                .await
+                .cloned()
+                .map_err(|error| {
+                    ResizeApplyFailure::new(
+                        DegradedUnleasedReason::ResizeSurfaceUnavailable,
+                        format!("no apiserver surface for the resize lift: {error}"),
+                    )
+                }),
+        }
+    }
+
+    /// Compare-and-swap one lifecycle edge, fenced on all four permit fields.
+    async fn transition(
+        &self,
+        intent: &PodResizeIntent,
+        expected: BuildPodPermitState,
+        next: BuildPodPermitState,
+    ) -> Result<(), ResizeApplyFailure> {
+        match self
+            .permits
+            .transition_resize_lifecycle(
+                &intent.task_run_id,
+                &intent.permit_id,
+                intent.fencing_token,
+                &intent.pod_uid,
+                expected,
+                next,
+            )
+            .await
+        {
+            Ok(TransitionBuildPodResizeLifecycleResult::Transitioned(_)) => Ok(()),
+            Ok(TransitionBuildPodResizeLifecycleResult::Rejected) => {
+                Err(ResizeApplyFailure::new(
+                    DegradedUnleasedReason::LiftLifecycleUnwritable,
+                    format!(
+                        "permit {} refused the {expected:?} -> {next:?} transition; \
+                         another actor owns this lifecycle",
+                        intent.permit_id
+                    ),
+                ))
+            }
+            Err(error) => Err(ResizeApplyFailure::new(
+                DegradedUnleasedReason::LiftLifecycleUnwritable,
+                format!("durable permit lifecycle unwritable: {error}"),
+            )),
+        }
+    }
+
+    /// Best-effort `→ drop_required`.
+    ///
+    /// The lift has already failed by the time this runs, so its own failure
+    /// cannot change the reason the caller sees — the Pod is left holding a
+    /// limit nobody granted a lease for either way, and a reconciler that finds
+    /// a stranded `lift_applying` row treats it the same as `drop_required`.
+    /// What must not happen is the failure being swallowed silently, so it is
+    /// logged at `error`.
+    async fn require_drop(&self, intent: &PodResizeIntent, from: BuildPodPermitState) {
+        if let Err(failure) = self
+            .transition(intent, from, BuildPodPermitState::DropRequired)
+            .await
+        {
+            tracing::error!(
+                task_run_id = %intent.task_run_id,
+                permit_id = %intent.permit_id,
+                detail = %failure.detail,
+                "resize lift: could not mark the permit drop-required after a failed lift"
+            );
+        }
+    }
+
+    /// Fresh observation plus all three identity fences. **No PATCH is issued
+    /// from here**, which is what makes the recreated-Pod case assertable on a
+    /// PATCH counter of zero.
+    async fn observe_and_fence(
+        &self,
+        surface: &Arc<dyn LauncherResizeSurface>,
+        intent: &PodResizeIntent,
+    ) -> Result<ObservedLauncherSidecar, ResizeApplyFailure> {
+        let observed = match surface.observe_launcher(&intent.task_run_id).await {
+            Ok(Some(observed)) => observed,
+            Ok(None) => {
+                return Err(ResizeApplyFailure::new(
+                    DegradedUnleasedReason::LiftPodAbsent,
+                    format!("no Pod carries the label for task run {}", intent.task_run_id),
+                ));
+            }
+            Err(error) => return Err(observation_failure(&error)),
+        };
+
+        // THE UID FENCE. `resize_launcher_cpu` takes only a name; this is the
+        // only thing standing between a recreated Pod and a PATCH addressed to
+        // it. Removing this comparison is acceptance criterion 5's named
+        // mutation, and the recreated-Pod test then observes PATCH count 1.
+        if observed.pod_uid != intent.pod_uid {
+            return Err(ResizeApplyFailure::new(
+                DegradedUnleasedReason::ResizeIdentityChanged,
+                format!(
+                    "Pod `{}` is now uid `{}`; the permit was captured against `{}`",
+                    intent.pod_name, observed.pod_uid, intent.pod_uid
+                ),
+            ));
+        }
+
+        // THE PROTOCOL FENCE. Checked before the restart fence deliberately: a
+        // Pod running a different authority is a mis-governance fact about the
+        // whole object, while a restart is a fact about one container.
+        let declared = observed
+            .observed_protocol
+            .as_deref()
+            .map(str::parse::<LauncherAuthorityProtocol>);
+        match declared {
+            Some(Ok(protocol)) if protocol == intent.effective_launcher_protocol => {}
+            other => {
+                return Err(ResizeApplyFailure::new(
+                    DegradedUnleasedReason::LauncherProtocolChanged,
+                    format!(
+                        "launcher declares protocol {:?}; the permit resolved `{}`",
+                        other.map(|parsed| parsed.map(|p| p.as_wire().to_owned())),
+                        intent.effective_launcher_protocol.as_wire()
+                    ),
+                ));
+            }
+        }
+
+        // THE RESTART FENCE.
+        match observed.launcher_container_id.as_deref() {
+            Some(live) if live == intent.launcher_container_id => {}
+            live => {
+                return Err(ResizeApplyFailure::new(
+                    DegradedUnleasedReason::LauncherRestarted,
+                    format!(
+                        "launcher containerID is now {live:?}; the permit captured `{}`",
+                        intent.launcher_container_id
+                    ),
+                ));
+            }
+        }
+
+        Ok(observed)
+    }
+
+    /// PATCH, then poll `status.initContainerStatuses` until it agrees or the
+    /// budget is gone, re-fencing on every observation.
+    async fn patch_and_confirm(
+        &self,
+        surface: &Arc<dyn LauncherResizeSurface>,
+        intent: &PodResizeIntent,
+    ) -> Result<(), ResizeApplyFailure> {
+        let target = u64::try_from(intent.target_millicores).map_err(|_| {
+            ResizeApplyFailure::new(
+                DegradedUnleasedReason::CeilingUnusable,
+                format!("clamped target {}m is not a CPU quantity", intent.target_millicores),
+            )
+        })?;
+
+        let deadline = tokio::time::Instant::now() + self.budget;
+        let mut waited = false;
+        loop {
+            // Each pass re-runs the full identity fence before touching the
+            // Pod. A launcher that restarts, or a Pod that is replaced, *during*
+            // the confirmation poll must stop the lift rather than have the next
+            // PATCH land on a different object.
+            self.observe_and_fence(surface, intent).await?;
+
+            match surface
+                .resize_launcher_cpu(&intent.pod_name, target)
+                .await
+            {
+                Ok(()) => {
+                    // The confirming fence. `resize_launcher_cpu`'s own final
+                    // GET proves the LIMIT; it does not prove the limit belongs
+                    // to the object we authorized. Only re-reading the UID and
+                    // the container ID does that.
+                    self.observe_and_fence(surface, intent).await?;
+                    return Ok(());
+                }
+                Err(error) => {
+                    let failure = apply_failure(&error);
+                    if !is_retryable(&error) {
+                        return Err(failure);
+                    }
+                    if tokio::time::Instant::now() >= deadline {
+                        // Budget already gone. Report the specific thing the
+                        // last observation saw — "the kubelet has not moved" is
+                        // more useful than "time passed".
+                        return Err(if waited {
+                            ResizeApplyFailure::new(
+                                DegradedUnleasedReason::LiftDeadlineExceeded,
+                                format!(
+                                    "confirmation budget of {:?} spent; last: {}",
+                                    self.budget, failure.detail
+                                ),
+                            )
+                        } else {
+                            failure
+                        });
+                    }
+                    waited = true;
+                    tokio::time::sleep(self.poll_interval).await;
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl PodResizeApplier for ResizeLift {
+    async fn apply(&self, intent: &PodResizeIntent) -> Result<(), ResizeApplyFailure> {
+        // The lifecycle edge is chosen from the permit state the authorization
+        // read. `birth_confirmed` is a fresh lift; `lifted` is an idempotent
+        // re-confirmation of one that already happened (a worker may present the
+        // same grant more than once, and migration 164 has no `lifted ->
+        // lift_applying` edge). Anything else is not a liftable subject.
+        let entered = match intent.permit_state {
+            BuildPodPermitState::BirthConfirmed => {
+                self.transition(
+                    intent,
+                    BuildPodPermitState::BirthConfirmed,
+                    BuildPodPermitState::LiftApplying,
+                )
+                .await?;
+                BuildPodPermitState::LiftApplying
+            }
+            BuildPodPermitState::Lifted => BuildPodPermitState::Lifted,
+            other => {
+                return Err(ResizeApplyFailure::new(
+                    DegradedUnleasedReason::PermitNotLiftable,
+                    format!("permit is in {other:?}; a lift may only start from birth_confirmed"),
+                ));
+            }
+        };
+
+        let surface = match self.surface().await {
+            Ok(surface) => surface,
+            Err(failure) => {
+                self.require_drop(intent, entered).await;
+                return Err(failure);
+            }
+        };
+
+        match self.patch_and_confirm(&surface, intent).await {
+            Ok(()) => {
+                if entered == BuildPodPermitState::LiftApplying {
+                    if let Err(failure) = self
+                        .transition(
+                            intent,
+                            BuildPodPermitState::LiftApplying,
+                            BuildPodPermitState::Lifted,
+                        )
+                        .await
+                    {
+                        // The Pod moved but the ledger did not. Refusing the
+                        // grant here is the only answer that keeps the two in
+                        // agreement: a row that does not say `lifted` will be
+                        // dropped back to the birth limit by the reconciler, and
+                        // a lease granted against it would be a lease for CPU
+                        // that is about to be taken away.
+                        self.require_drop(intent, BuildPodPermitState::LiftApplying)
+                            .await;
+                        return Err(failure);
+                    }
+                }
+                Ok(())
+            }
+            Err(failure) => {
+                self.require_drop(intent, entered).await;
+                Err(failure)
+            }
+        }
+    }
+}
+
+/// Whether waiting could still change this answer.
+///
+/// Only an unconfirmed *status* is retryable: the kubelet actuates
+/// asynchronously. An apiserver verdict, an identity ambiguity or an unparseable
+/// quantity is settled, and re-asking spends the budget for nothing.
+const fn is_retryable(error: &PodResizeError) -> bool {
+    matches!(
+        error,
+        PodResizeError::NotConfirmed(
+            NotConfirmed::ResizePending
+                | NotConfirmed::StatusLimitAbsent
+                | NotConfirmed::StatusStale { .. }
+        )
+    )
+}
+
+/// Map one `pods/resize` failure onto its settled reason.
+fn apply_failure(error: &PodResizeError) -> ResizeApplyFailure {
+    let reason = match error {
+        PodResizeError::LauncherIdentityAmbiguous { .. } => {
+            DegradedUnleasedReason::LiftIdentityAmbiguous
+        }
+        PodResizeError::InvalidCpuQuantity { .. } => DegradedUnleasedReason::CeilingUnusable,
+        PodResizeError::NotConfirmed(NotConfirmed::ResizePending) => {
+            DegradedUnleasedReason::LiftResizePending
+        }
+        PodResizeError::NotConfirmed(NotConfirmed::StatusLimitAbsent) => {
+            DegradedUnleasedReason::LiftStatusAbsent
+        }
+        PodResizeError::NotConfirmed(
+            NotConfirmed::StatusStale { .. } | NotConfirmed::StatusLimitUnparseable { .. },
+        ) => DegradedUnleasedReason::LiftStatusStale,
+        // Classified on the NUMERIC status, never on the rendered message: a
+        // missing `pods/resize` RBAC rule (403) is an operator fact, a rejected
+        // resize (422) is a request fact, and a transport failure knows nothing
+        // at all. See `PodResizeError::Api::status`.
+        PodResizeError::Api { status, .. } => match status {
+            Some(403) => DegradedUnleasedReason::ResizeForbidden,
+            Some(422) => DegradedUnleasedReason::ResizeRejected,
+            _ => DegradedUnleasedReason::ResizeSurfaceUnavailable,
+        },
+    };
+    ResizeApplyFailure::new(reason, error.to_string())
+}
+
+/// Map one observation failure onto its settled reason.
+fn observation_failure(error: &LauncherObservationError) -> ResizeApplyFailure {
+    let reason = match error {
+        // An incomplete `metadata` is the same answer as no Pod: there is
+        // nothing to fence a resize against.
+        LauncherObservationError::Incomplete { .. } => DegradedUnleasedReason::LiftPodAbsent,
+        LauncherObservationError::Ambiguous(inner) => return apply_failure(inner),
+        LauncherObservationError::Api(_) => DegradedUnleasedReason::ResizeSurfaceUnavailable,
+    };
+    ResizeApplyFailure::new(reason, error.to_string())
+}

--- a/server/crates/djinn-coordinator/src/resize_lift.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift.rs
@@ -452,25 +452,24 @@ impl PodResizeApplier for ResizeLift {
 
         match self.patch_and_confirm(&surface, intent).await {
             Ok(()) => {
-                if entered == BuildPodPermitState::LiftApplying {
-                    if let Err(failure) = self
+                if entered == BuildPodPermitState::LiftApplying
+                    && let Err(failure) = self
                         .transition(
                             intent,
                             BuildPodPermitState::LiftApplying,
                             BuildPodPermitState::Lifted,
                         )
                         .await
-                    {
-                        // The Pod moved but the ledger did not. Refusing the
-                        // grant here is the only answer that keeps the two in
-                        // agreement: a row that does not say `lifted` will be
-                        // dropped back to the birth limit by the reconciler, and
-                        // a lease granted against it would be a lease for CPU
-                        // that is about to be taken away.
-                        self.require_drop(intent, BuildPodPermitState::LiftApplying)
-                            .await;
-                        return Err(failure);
-                    }
+                {
+                    // The Pod moved but the ledger did not. Refusing the
+                    // grant here is the only answer that keeps the two in
+                    // agreement: a row that does not say `lifted` will be
+                    // dropped back to the birth limit by the reconciler, and
+                    // a lease granted against it would be a lease for CPU
+                    // that is about to be taken away.
+                    self.require_drop(intent, BuildPodPermitState::LiftApplying)
+                        .await;
+                    return Err(failure);
                 }
                 Ok(())
             }

--- a/server/crates/djinn-coordinator/src/resize_lift.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift.rs
@@ -240,16 +240,14 @@ impl ResizeLift {
             .await
         {
             Ok(TransitionBuildPodResizeLifecycleResult::Transitioned(_)) => Ok(()),
-            Ok(TransitionBuildPodResizeLifecycleResult::Rejected) => {
-                Err(ResizeApplyFailure::new(
-                    DegradedUnleasedReason::LiftLifecycleUnwritable,
-                    format!(
-                        "permit {} refused the {expected:?} -> {next:?} transition; \
+            Ok(TransitionBuildPodResizeLifecycleResult::Rejected) => Err(ResizeApplyFailure::new(
+                DegradedUnleasedReason::LiftLifecycleUnwritable,
+                format!(
+                    "permit {} refused the {expected:?} -> {next:?} transition; \
                          another actor owns this lifecycle",
-                        intent.permit_id
-                    ),
-                ))
-            }
+                    intent.permit_id
+                ),
+            )),
             Err(error) => Err(ResizeApplyFailure::new(
                 DegradedUnleasedReason::LiftLifecycleUnwritable,
                 format!("durable permit lifecycle unwritable: {error}"),
@@ -292,7 +290,10 @@ impl ResizeLift {
             Ok(None) => {
                 return Err(ResizeApplyFailure::new(
                     DegradedUnleasedReason::LiftPodAbsent,
-                    format!("no Pod carries the label for task run {}", intent.task_run_id),
+                    format!(
+                        "no Pod carries the label for task run {}",
+                        intent.task_run_id
+                    ),
                 ));
             }
             Err(error) => return Err(observation_failure(&error)),
@@ -360,7 +361,10 @@ impl ResizeLift {
         let target = u64::try_from(intent.target_millicores).map_err(|_| {
             ResizeApplyFailure::new(
                 DegradedUnleasedReason::CeilingUnusable,
-                format!("clamped target {}m is not a CPU quantity", intent.target_millicores),
+                format!(
+                    "clamped target {}m is not a CPU quantity",
+                    intent.target_millicores
+                ),
             )
         })?;
 
@@ -373,10 +377,7 @@ impl ResizeLift {
             // PATCH land on a different object.
             self.observe_and_fence(surface, intent).await?;
 
-            match surface
-                .resize_launcher_cpu(&intent.pod_name, target)
-                .await
-            {
+            match surface.resize_launcher_cpu(&intent.pod_name, target).await {
                 Ok(()) => {
                     // The confirming fence. `resize_launcher_cpu`'s own final
                     // GET proves the LIMIT; it does not prove the limit belongs

--- a/server/crates/djinn-coordinator/src/resize_lift_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift_tests.rs
@@ -38,9 +38,9 @@ use djinn_k8s::pod_resize::PodResizeError;
 use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
 use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
 use djinn_supervisor::services::{
-    DegradedUnleasedReason, DurableInvocationLiftAuthority, InvocationLiftAuthority, LeaseDeadlines,
-    LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest, LeaseResult,
-    TaskInvocationLeaseIdentity,
+    DegradedUnleasedReason, DurableInvocationLiftAuthority, InvocationLiftAuthority,
+    LeaseDeadlines, LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest,
+    LeaseResult, TaskInvocationLeaseIdentity,
 };
 
 use crate::build_lease::BuildLeaseService;
@@ -94,7 +94,9 @@ impl LauncherResizeSurface for FixtureSurface {
         pod_name: &str,
         target_millicores: u64,
     ) -> Result<(), PodResizeError> {
-        self.0.resize_launcher_cpu(pod_name, target_millicores).await
+        self.0
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
     }
 }
 
@@ -146,7 +148,11 @@ impl Fixture {
         let lease_authority = Arc::new(InvocationLeaseAuthorityRepository::new(db.clone()));
         let seeded = lease_authority.seed_baseline().await.unwrap();
         lease_authority
-            .set_mode_and_cap(seeded.epoch, InvocationLeaseMode::Enforce, Some(CONFIGURED_CAP))
+            .set_mode_and_cap(
+                seeded.epoch,
+                InvocationLeaseMode::Enforce,
+                Some(CONFIGURED_CAP),
+            )
             .await
             .unwrap();
 
@@ -431,7 +437,10 @@ async fn a_matching_regular_container_status_is_never_confirmation() {
         "and the launcher really was still at its birth limit — the degrade is \
          not an artefact of a Pod that had already moved"
     );
-    assert_eq!(fixture.permit_state().await, BuildPodPermitState::DropRequired);
+    assert_eq!(
+        fixture.permit_state().await,
+        BuildPodPermitState::DropRequired
+    );
 }
 
 // ── AC4: every named uncertainty degrades, with drop active ────────────────
@@ -723,7 +732,11 @@ fn the_patch_body_carries_exactly_one_mutable_field() {
         djinn_k8s::pod_resize::CpuLimit::from_millis(ADMITTED_CEILING),
     );
     let spec = body.get("spec").expect("a spec");
-    assert_eq!(spec.as_object().map(serde_json::Map::len), Some(1), "spec has exactly one key");
+    assert_eq!(
+        spec.as_object().map(serde_json::Map::len),
+        Some(1),
+        "spec has exactly one key"
+    );
     assert!(spec.get("containers").is_none(), "never `spec.containers`");
     let containers = spec
         .get("initContainers")
@@ -772,7 +785,10 @@ async fn twenty_lift_cycles_leave_requests_qos_and_the_container_untouched() {
     let container_id = pod.launcher_container_id();
     let restarts = pod.launcher_restart_count();
     let init_containers = pod.init_container_count();
-    assert_eq!(init_containers, 2, "a second init container must stand beside the launcher");
+    assert_eq!(
+        init_containers, 2,
+        "a second init container must stand beside the launcher"
+    );
     assert!(requests.is_some() && qos.is_some() && container_id.is_some());
 
     // The lifecycle only admits one lift per permit, so the cycling is done at
@@ -784,7 +800,11 @@ async fn twenty_lift_cycles_leave_requests_qos_and_the_container_untouched() {
                 .await
                 .unwrap_or_else(|e| panic!("cycle {cycle} target {target}m: {e}"));
         }
-        assert_eq!(pod.launcher_spec_cpu_request(), requests, "cycle {cycle}: requests moved");
+        assert_eq!(
+            pod.launcher_spec_cpu_request(),
+            requests,
+            "cycle {cycle}: requests moved"
+        );
         assert_eq!(pod.qos_class(), qos, "cycle {cycle}: QoS class moved");
         assert_eq!(
             pod.launcher_container_id(),
@@ -803,7 +823,10 @@ async fn twenty_lift_cycles_leave_requests_qos_and_the_container_untouched() {
              patch does to an array with patchMergeKey `name`"
         );
     }
-    assert!(pod.resize_patches() >= 40, "the cycles must actually have patched");
+    assert!(
+        pod.resize_patches() >= 40,
+        "the cycles must actually have patched"
+    );
 }
 
 // ── AC6 / AC7: the clamp is the effective bound, and the CEILING comes from

--- a/server/crates/djinn-coordinator/src/resize_lift_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift_tests.rs
@@ -53,6 +53,12 @@ const CONFIGURED_LEASED: i64 = 4_000;
 /// What the fixture Pod was admitted with. Deliberately BELOW
 /// [`CONFIGURED_LEASED`] so the clamp has something to bite on.
 const ADMITTED_CEILING: u64 = 2_500;
+/// `djinn_server::task_run_resize_bootstrap::BIRTH_CPU_MILLICORES`. Restated
+/// rather than imported because `djinn-server` depends on this crate, not the
+/// other way round. Nothing here asserts a *policy* about the birth limit — it
+/// is only the "somewhere other than the target" the lift has to move the
+/// launcher away from, and any value below the ceiling would serve.
+const BIRTH_MILLICORES: u64 = 250;
 
 const RUN: &str = "01983f00-0000-7000-8000-00000000d001";
 const TASK: &str = "01983f00-0000-7000-8000-00000000e001";
@@ -94,10 +100,36 @@ impl LauncherResizeSurface for FixtureSurface {
 
 // ── The live composition ───────────────────────────────────────────────────
 
+/// Wraps the REAL [`ResizeLift`] and records the intent it was handed.
+///
+/// It changes nothing about the lift — it delegates — so the recorded intent is
+/// the one production would apply. That matters for the ceiling-provenance
+/// assertion: `admitted_cpu_millicores` is the bound the PATCH was clamped
+/// against, and reading it here reads the value that BOUND the request rather
+/// than a value a test wrote down and read back.
+struct RecordingApplier {
+    inner: ResizeLift,
+    intents: std::sync::Mutex<Vec<crate::resize_authorization::PodResizeIntent>>,
+}
+
+#[async_trait]
+impl PodResizeApplier for RecordingApplier {
+    async fn apply(
+        &self,
+        intent: &crate::resize_authorization::PodResizeIntent,
+    ) -> Result<(), crate::resize_authorization::ResizeApplyFailure> {
+        if let Ok(mut guard) = self.intents.lock() {
+            guard.push(intent.clone());
+        }
+        self.inner.apply(intent).await
+    }
+}
+
 struct Fixture {
     service: Arc<BuildLeaseService>,
     permits: Arc<BuildPodPermitRepository>,
     pod: StoredTaskRunPod,
+    applier: Arc<RecordingApplier>,
     _db: Database,
 }
 
@@ -124,19 +156,20 @@ impl Fixture {
             db.clone(),
             "resize-lift-tests",
         ));
-        let applier: Arc<dyn PodResizeApplier> = Arc::new(
-            ResizeLift::with_surface(
+        let applier = Arc::new(RecordingApplier {
+            inner: ResizeLift::with_surface(
                 Arc::clone(&permits),
                 Arc::new(FixtureSurface(pod.clone())),
             )
             .with_wait(budget, Duration::from_millis(1)),
-        );
+            intents: std::sync::Mutex::new(Vec::new()),
+        });
         let authority = Arc::new(ResizeAuthority::new(
             Arc::clone(&leases),
             Arc::clone(&permits),
             lift,
             CONFIGURED_LEASED,
-            applier,
+            Arc::clone(&applier) as Arc<dyn PodResizeApplier>,
         ));
         let service = Arc::new(
             BuildLeaseService::new(Arc::clone(&leases), CONFIGURED_CAP)
@@ -149,10 +182,38 @@ impl Fixture {
             service,
             permits,
             pod,
+            applier,
             _db: db,
         };
         fixture.seed_permit().await;
+        fixture.birth_downsize().await;
         fixture
+    }
+
+    /// The birth downsize `0ppk-1b` performs before the worker session may
+    /// dispatch: the launcher is moved from its admitted ceiling to
+    /// [`BIRTH_MILLICORES`], and the captured ceiling stays on the durable row.
+    ///
+    /// Without this the fixture Pod would already be holding the lift's target
+    /// and every confirmation would pass trivially — a "never actuates" node
+    /// would still confirm, because there would be nothing to actuate. It is
+    /// exactly the shape of vacuous pass this epic keeps producing, so it is
+    /// asserted rather than assumed: the launcher's INIT status must read 250m
+    /// before any lift runs.
+    async fn birth_downsize(&self) {
+        let pod_name = format!("taskrun-{POD_UID}");
+        self.pod
+            .resize_launcher_cpu(&pod_name, BIRTH_MILLICORES)
+            .await
+            .expect("the birth downsize confirms on a healthy node");
+        assert_eq!(
+            self.pod.launcher_status_cpu().as_deref(),
+            Some(format!("{BIRTH_MILLICORES}m").as_str()),
+            "the launcher must sit at its birth limit before a lift, or the lift              has nothing to move and every confirmation passes vacuously"
+        );
+        // From here on, a PATCH counter reading zero means "the lift issued
+        // none", not "nothing has ever happened".
+        self.pod.reset_patch_counter();
     }
 
     /// The two writes `0ppk-1b` makes on the live dispatch path.
@@ -233,6 +294,15 @@ impl Fixture {
             .await
     }
 
+    /// Every intent that reached the applier, in order.
+    fn intents(&self) -> Vec<crate::resize_authorization::PodResizeIntent> {
+        self.applier
+            .intents
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
     async fn permit_state(&self) -> BuildPodPermitState {
         self.permits
             .active(RUN)
@@ -272,7 +342,12 @@ async fn seed_task_run(db: &Database, run: &str) {
 }
 
 fn healthy_pod() -> StoredTaskRunPod {
-    StoredTaskRunPod::resize_v2(POD_UID, &format!("{ADMITTED_CEILING}m"))
+    pod_admitted_at(ADMITTED_CEILING)
+}
+
+/// A healthy `resize-v2` Pod whose launcher was admitted with `ceiling`.
+fn pod_admitted_at(ceiling: u64) -> StoredTaskRunPod {
+    StoredTaskRunPod::resize_v2(POD_UID, &format!("{ceiling}m"))
 }
 
 /// No confirmation budget: one observation, no waiting. Used by every case that
@@ -294,8 +369,8 @@ async fn a_status_confirmed_lift_grants_and_records_lifted() {
     let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
     assert_eq!(
         fixture.pod.launcher_status_cpu().as_deref(),
-        Some(format!("{ADMITTED_CEILING}m").as_str()),
-        "precondition: the launcher starts at its admitted ceiling"
+        Some(format!("{BIRTH_MILLICORES}m").as_str()),
+        "precondition: the launcher sits at its birth limit, NOT at the target"
     );
 
     let result = fixture.lift().await;
@@ -312,8 +387,8 @@ async fn a_status_confirmed_lift_grants_and_records_lifted() {
     assert_eq!(
         fixture.pod.launcher_status_cpu().as_deref(),
         Some(format!("{ADMITTED_CEILING}m").as_str()),
-        "the launcher's INIT-container status is what confirms, and it must hold \
-         the clamped target"
+        "the launcher's INIT-container status is what confirms, and it must have \
+         MOVED from {BIRTH_MILLICORES}m to the clamped target"
     );
     assert_eq!(
         fixture.permit_state().await,
@@ -335,18 +410,26 @@ async fn a_status_confirmed_lift_grants_and_records_lifted() {
 /// confirmation, and this test grants.
 #[tokio::test]
 async fn a_matching_regular_container_status_is_never_confirmation() {
-    let pod = healthy_pod()
-        .never_actuating()
-        .with_misleading_regular_launcher_status(&format!("{ADMITTED_CEILING}m"));
-    let fixture = Fixture::armed(pod, NO_WAIT).await;
+    let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
+    // The trap is armed AFTER the birth downsize, so the launcher's own init
+    // status genuinely reads 250m while the launcher NAME appears in the regular
+    // container statuses carrying exactly the value confirmation is looking for.
+    fixture.pod.stop_actuating();
+    fixture
+        .pod
+        .add_misleading_regular_launcher_status(&format!("{ADMITTED_CEILING}m"));
 
-    // The trap is armed: the launcher name appears in the REGULAR container
-    // statuses carrying exactly the value confirmation is looking for.
     let result = fixture.lift().await;
 
     assert!(
         matches!(result, LeaseResult::DegradedUnleased { .. }),
         "a matching regular-container status must never confirm: {result:?}"
+    );
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{BIRTH_MILLICORES}m").as_str()),
+        "and the launcher really was still at its birth limit — the degrade is \
+         not an artefact of a Pod that had already moved"
     );
     assert_eq!(fixture.permit_state().await, BuildPodPermitState::DropRequired);
 }
@@ -361,13 +444,11 @@ struct Case {
     /// PATCH, so their cases must show a counter of zero.
     patches_allowed: bool,
     budget: Duration,
-    build: fn() -> StoredTaskRunPod,
-    /// Applied after the permit has captured its identity, so the fence has
-    /// something to disagree with.
+    /// Applied after the permit captured its identity AND after the birth
+    /// downsize — the exact moment a real lift starts from. Injecting a fault
+    /// earlier would break the birth downsize instead of the lift.
     disturb: fn(&StoredTaskRunPod),
 }
-
-fn no_disturbance(_: &StoredTaskRunPod) {}
 
 /// **ACCEPTANCE CRITERION 4.**
 ///
@@ -393,43 +474,40 @@ async fn every_named_uncertainty_degrades_with_drop_required() {
             reason: DegradedUnleasedReason::LiftStatusStale,
             patches_allowed: true,
             budget: NO_WAIT,
-            build: || healthy_pod().never_actuating(),
-            disturb: no_disturbance,
+            disturb: |pod| pod.stop_actuating(),
         },
         Case {
             name: "HTTP 200, init status carries no cpu limit at all",
             reason: DegradedUnleasedReason::LiftStatusAbsent,
             patches_allowed: true,
             budget: NO_WAIT,
-            build: || healthy_pod().never_actuating().without_launcher_status_limit(),
-            disturb: no_disturbance,
+            disturb: |pod| {
+                pod.stop_actuating();
+                pod.clear_launcher_status_limit();
+            },
         },
         Case {
             name: "a matching REGULAR-container status while init is stale",
             reason: DegradedUnleasedReason::LiftStatusStale,
             patches_allowed: true,
             budget: NO_WAIT,
-            build: || {
-                healthy_pod()
-                    .never_actuating()
-                    .with_misleading_regular_launcher_status(&format!("{ADMITTED_CEILING}m"))
+            disturb: |pod| {
+                pod.stop_actuating();
+                pod.add_misleading_regular_launcher_status(&format!("{ADMITTED_CEILING}m"));
             },
-            disturb: no_disturbance,
         },
         Case {
             name: "a PodResizePending condition is present",
             reason: DegradedUnleasedReason::LiftResizePending,
             patches_allowed: true,
             budget: NO_WAIT,
-            build: || healthy_pod().with_resize_pending(),
-            disturb: no_disturbance,
+            disturb: |pod| pod.add_resize_pending(),
         },
         Case {
             name: "the Pod was recreated under the same NAME with a new UID",
             reason: DegradedUnleasedReason::ResizeIdentityChanged,
             patches_allowed: false,
             budget: NO_WAIT,
-            build: healthy_pod,
             disturb: |pod| pod.recreate_under_same_name("pod-uid-replacement"),
         },
         Case {
@@ -437,7 +515,6 @@ async fn every_named_uncertainty_degrades_with_drop_required() {
             reason: DegradedUnleasedReason::LauncherProtocolChanged,
             patches_allowed: false,
             budget: NO_WAIT,
-            build: healthy_pod,
             disturb: |pod| pod.set_observed_protocol("leaf-v1"),
         },
         Case {
@@ -445,7 +522,6 @@ async fn every_named_uncertainty_degrades_with_drop_required() {
             reason: DegradedUnleasedReason::LauncherRestarted,
             patches_allowed: false,
             budget: NO_WAIT,
-            build: healthy_pod,
             disturb: |pod| pod.restart_launcher("containerd://restarted"),
         },
         Case {
@@ -453,39 +529,34 @@ async fn every_named_uncertainty_degrades_with_drop_required() {
             reason: DegradedUnleasedReason::LiftDeadlineExceeded,
             patches_allowed: true,
             budget: Duration::from_millis(8),
-            build: || healthy_pod().never_actuating(),
-            disturb: no_disturbance,
+            disturb: |pod| pod.stop_actuating(),
         },
         Case {
             name: "the PATCH timed out in transport (no HTTP status at all)",
             reason: DegradedUnleasedReason::ResizeSurfaceUnavailable,
             patches_allowed: true,
             budget: NO_WAIT,
-            build: || healthy_pod().failing_patches(ApiFault::timeout()),
-            disturb: no_disturbance,
+            disturb: |pod| pod.fail_patches(ApiFault::timeout()),
         },
         Case {
             name: "the apiserver answered 403 (no pods/resize RBAC rule)",
             reason: DegradedUnleasedReason::ResizeForbidden,
             patches_allowed: true,
             budget: NO_WAIT,
-            build: || healthy_pod().failing_patches(ApiFault::forbidden()),
-            disturb: no_disturbance,
+            disturb: |pod| pod.fail_patches(ApiFault::forbidden()),
         },
         Case {
             name: "the apiserver answered 422 (the resize itself was rejected)",
             reason: DegradedUnleasedReason::ResizeRejected,
             patches_allowed: true,
             budget: NO_WAIT,
-            build: || healthy_pod().failing_patches(ApiFault::unprocessable()),
-            disturb: no_disturbance,
+            disturb: |pod| pod.fail_patches(ApiFault::unprocessable()),
         },
         Case {
             name: "no Pod carries the task run's label any more",
             reason: DegradedUnleasedReason::LiftPodAbsent,
             patches_allowed: false,
             budget: NO_WAIT,
-            build: healthy_pod,
             disturb: |pod| {
                 pod.uid_fenced_delete(RUN, POD_UID)
                     .expect("the fenced delete matches the stored uid");
@@ -494,8 +565,10 @@ async fn every_named_uncertainty_degrades_with_drop_required() {
     ];
 
     for case in cases {
-        let pod = (case.build)();
-        let fixture = Fixture::armed(pod, case.budget).await;
+        let fixture = Fixture::armed(healthy_pod(), case.budget).await;
+        // Every case starts from the SAME healthy, birth-downsized Pod. The
+        // fault is installed here, at the exact moment a real lift begins, so a
+        // case cannot pass by having broken the birth downsize instead.
         (case.disturb)(&fixture.pod);
 
         let result = fixture.lift().await;
@@ -731,4 +804,106 @@ async fn twenty_lift_cycles_leave_requests_qos_and_the_container_untouched() {
         );
     }
     assert!(pod.resize_patches() >= 40, "the cycles must actually have patched");
+}
+
+// ── AC6 / AC7: the clamp is the effective bound, and the CEILING comes from
+//              the write-once row ──────────────────────────────────────────
+
+/// **ACCEPTANCE CRITERION 6, cluster-free half.**
+///
+/// The process is configured to lift to 4000m; the Pod was admitted at 2500m.
+/// The value that ends up in `status.initContainerStatuses` must be the
+/// CEILING, and **zero PATCH bodies** may carry a value above it — measured on
+/// the bodies actually sent, parsed back through `CpuLimit` so the apiserver's
+/// canonicalisation cannot disguise an above-ceiling request.
+///
+/// NAMED FAILING MUTATION: delete the `.min(ceiling)` in
+/// `resize_authorization::clamp` and the above-ceiling body counter becomes 1
+/// (a 4000m body against a 2500m ceiling).
+///
+/// LIVE-CLUSTER GAP, stated rather than papered over: the criterion also asks
+/// for a companion control that issues the same oversubscribed value DIRECTLY
+/// through `pods/resize` against a live apiserver, to prove the apiserver does
+/// not bound this and the server clamp is the only effective bound. That half
+/// needs a kind cluster and is NOT done here.
+#[tokio::test]
+async fn the_clamp_is_the_effective_bound_measured_on_the_patch_bodies() {
+    const {
+        assert!(
+            CONFIGURED_LEASED as u64 > ADMITTED_CEILING,
+            "the configured lift must exceed the admitted ceiling, or this test \
+             cannot distinguish a clamp from a passthrough"
+        );
+    }
+    let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
+    let result = fixture.lift().await;
+    assert!(matches!(result, LeaseResult::Status(_)), "{result:?}");
+
+    let bodies = fixture.pod.patched_cpu_millicores();
+    assert!(!bodies.is_empty(), "the lift must actually have patched");
+    assert_eq!(
+        bodies
+            .iter()
+            .filter(|millis| **millis > ADMITTED_CEILING)
+            .count(),
+        0,
+        "ZERO PATCH bodies above the admitted ceiling; observed {bodies:?}"
+    );
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{ADMITTED_CEILING}m").as_str()),
+        "and the value the launcher ends up holding is the CEILING, not the \
+         configured 4000m"
+    );
+}
+
+/// **ACCEPTANCE CRITERION 7 — the ceiling's PROVENANCE.**
+///
+/// A Pod rendered with a per-project `build_resources.task.cpu_limit` override
+/// is admitted with a launcher ceiling ABOVE the deployment default. The bound
+/// the lift is clamped against must be that Pod's own captured value, not the
+/// process's `launcher_leased_millicores`.
+///
+/// NAMED FAILING MUTATION: recompute the ceiling in `resize_authorization::clamp`
+/// from the process's configured value instead of
+/// `identity.admitted_cpu_millicores`, and `intent.admitted_cpu_millicores` here
+/// reads 4000 instead of 8000 — this fails. (The clamped *target* is 4000 either
+/// way, which is exactly why this assertion is on the carried ceiling: it is the
+/// only place the two implementations differ.)
+///
+/// HONEST LIMIT, and it is a real one: with the shipped
+/// `min(configured, admitted)` clamp, an override Pod admitted at 8000m still
+/// lifts only to the deployment default of 4000m — it does NOT lift to its own
+/// rendered lease. Satisfying that literally requires the target to be
+/// `admitted` rather than `min(configured, admitted)`, which would contradict
+/// criterion 6's premise that a lift can be "configured ABOVE the captured
+/// ceiling". See the PR body; the clamp is left exactly as `0ppk-1a` shipped it
+/// rather than redesigned here.
+#[tokio::test]
+async fn the_ceiling_comes_from_the_write_once_row_not_the_deployment_default() {
+    const OVERRIDE_CEILING: u64 = 8_000;
+    const {
+        assert!(
+            OVERRIDE_CEILING > CONFIGURED_LEASED as u64,
+            "the per-project override must RAISE the Pod's ceiling above the \
+             deployment default, or there is no provenance to distinguish"
+        );
+    }
+    let fixture = Fixture::armed(pod_admitted_at(OVERRIDE_CEILING), NO_WAIT).await;
+    let result = fixture.lift().await;
+    assert!(matches!(result, LeaseResult::Status(_)), "{result:?}");
+
+    let intents = fixture.intents();
+    assert_eq!(intents.len(), 1, "exactly one intent reached the boundary");
+    assert_eq!(
+        intents[0].admitted_cpu_millicores,
+        i64::try_from(OVERRIDE_CEILING).unwrap(),
+        "the bound must be the Pod's OWN captured ceiling. Reading 4000 here \
+         means the ceiling was recomputed from the deployment default, which \
+         clamps every per-project-override Pod below its own rendered lease"
+    );
+    assert!(
+        intents[0].target_millicores <= intents[0].admitted_cpu_millicores,
+        "and the target never exceeds the bound it was clamped against"
+    );
 }

--- a/server/crates/djinn-coordinator/src/resize_lift_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift_tests.rs
@@ -1,0 +1,734 @@
+//! The status-confirmed lift, proved against a real Postgres and a stored Pod.
+//!
+//! # What is real in here, and what is not
+//!
+//! Real: the permit relation (`build_pod_permits` over an ephemeral, template-
+//! cloned Postgres — `open_in_memory` is not an in-memory fake), the lease FIFO,
+//! the durable invocation-lift authority, `ResizeAuthority`, `BuildLeaseService`
+//! and its grant path, and — through
+//! [`djinn_k8s::pod_resize_fixture::StoredTaskRunPod`] — the production
+//! observation (`observe_launcher_sidecar`), the production PATCH
+//! (`PodResizeClient`, strategic-merge semantics for `initContainers`) and the
+//! production confirmation rule (`confirm_launcher_cpu`, millicores, init
+//! statuses only).
+//!
+//! Fake: exactly one thing, the HTTP transport. That is the fault-injection
+//! seam the task specifies, and it is the only place a fake belongs — a fake
+//! permit repository would agree with every assertion below and prove none of
+//! them.
+//!
+//! # What stays green if the lift's body does nothing?
+//!
+//! Nothing. Every assertion here reads either the Pod's
+//! `status.initContainerStatuses` (the only field that can confirm a resize) or
+//! the durable permit's lifecycle state after the fact, and the happy-path tests
+//! assert a **non-zero** PATCH counter so a no-op cannot pass by refusing
+//! everything.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_db::{
+    AcquireBuildPodPermitResult, BuildLeaseRepository, BuildPodPermitRepository,
+    BuildPodPermitState, BuildPodResizeIdentity, CaptureBuildPodResizeIdentityResult, Database,
+    InvocationLeaseAuthorityRepository, InvocationLeaseMode,
+};
+use djinn_k8s::pod_resize::PodResizeError;
+use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
+use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
+use djinn_supervisor::services::{
+    DegradedUnleasedReason, DurableInvocationLiftAuthority, InvocationLiftAuthority, LeaseDeadlines,
+    LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest, LeaseResult,
+    TaskInvocationLeaseIdentity,
+};
+
+use crate::build_lease::BuildLeaseService;
+use crate::resize_authorization::{PodResizeApplier, ResizeAuthority};
+use crate::resize_lift::{LauncherResizeSurface, ResizeLift};
+
+const CONFIGURED_CAP: i64 = 9;
+/// `DJINN_LAUNCHER_LEASED_MILLICORES` as the default render sets it.
+const CONFIGURED_LEASED: i64 = 4_000;
+/// What the fixture Pod was admitted with. Deliberately BELOW
+/// [`CONFIGURED_LEASED`] so the clamp has something to bite on.
+const ADMITTED_CEILING: u64 = 2_500;
+
+const RUN: &str = "01983f00-0000-7000-8000-00000000d001";
+const TASK: &str = "01983f00-0000-7000-8000-00000000e001";
+const INVOCATION: &str = "01983f00-0000-7000-8000-00000000f001";
+const POD_UID: &str = "pod-uid-original";
+
+fn identity() -> LeaseIdentity {
+    LeaseIdentity::TaskInvocation(TaskInvocationLeaseIdentity {
+        task_id: TASK.into(),
+        task_run_id: RUN.into(),
+        invocation_id: INVOCATION.into(),
+    })
+}
+
+// ── The one fake: the transport ────────────────────────────────────────────
+
+/// Adapts a stored Pod to the lift's surface. Both methods delegate straight
+/// into the production code paths inside the fixture; this type adds no rules
+/// of its own, which is what stops the tests from validating a re-implementation.
+struct FixtureSurface(StoredTaskRunPod);
+
+#[async_trait]
+impl LauncherResizeSurface for FixtureSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.0.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        self.0.resize_launcher_cpu(pod_name, target_millicores).await
+    }
+}
+
+// ── The live composition ───────────────────────────────────────────────────
+
+struct Fixture {
+    service: Arc<BuildLeaseService>,
+    permits: Arc<BuildPodPermitRepository>,
+    pod: StoredTaskRunPod,
+    _db: Database,
+}
+
+impl Fixture {
+    /// Armed authority, a healthy `resize-v2` Pod, a permit whose write-once
+    /// identity was captured **from that Pod's own observation** rather than
+    /// hand-written — so a fence comparison cannot pass because a test typed the
+    /// same string twice.
+    async fn armed(pod: StoredTaskRunPod, budget: Duration) -> Self {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        seed_task_run(&db, RUN).await;
+
+        let lease_authority = Arc::new(InvocationLeaseAuthorityRepository::new(db.clone()));
+        let seeded = lease_authority.seed_baseline().await.unwrap();
+        lease_authority
+            .set_mode_and_cap(seeded.epoch, InvocationLeaseMode::Enforce, Some(CONFIGURED_CAP))
+            .await
+            .unwrap();
+
+        let leases = Arc::new(BuildLeaseRepository::new(db.clone()));
+        let permits = Arc::new(BuildPodPermitRepository::new(db.clone()));
+        let lift: Arc<dyn InvocationLiftAuthority> = Arc::new(DurableInvocationLiftAuthority::new(
+            db.clone(),
+            "resize-lift-tests",
+        ));
+        let applier: Arc<dyn PodResizeApplier> = Arc::new(
+            ResizeLift::with_surface(
+                Arc::clone(&permits),
+                Arc::new(FixtureSurface(pod.clone())),
+            )
+            .with_wait(budget, Duration::from_millis(1)),
+        );
+        let authority = Arc::new(ResizeAuthority::new(
+            Arc::clone(&leases),
+            Arc::clone(&permits),
+            lift,
+            CONFIGURED_LEASED,
+            applier,
+        ));
+        let service = Arc::new(
+            BuildLeaseService::new(Arc::clone(&leases), CONFIGURED_CAP)
+                .with_invocation_lease_authority(Arc::clone(&lease_authority))
+                .with_resize_authority(authority),
+        );
+        assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+
+        let fixture = Self {
+            service,
+            permits,
+            pod,
+            _db: db,
+        };
+        fixture.seed_permit().await;
+        fixture
+    }
+
+    /// The two writes `0ppk-1b` makes on the live dispatch path.
+    async fn seed_permit(&self) {
+        let AcquireBuildPodPermitResult::Acquired { row, .. } =
+            self.permits.acquire(RUN, CONFIGURED_CAP).await
+        else {
+            panic!("the permit pool must admit the run");
+        };
+        self.permits
+            .bind_or_refresh_job_uid(RUN, &row.permit_id, row.fencing_token, "job-uid")
+            .await
+            .expect("binding the Job UID must succeed");
+        let observed = self
+            .pod
+            .observe_launcher()
+            .expect("the fixture Pod observes")
+            .expect("the fixture Pod exists");
+        let identity = BuildPodResizeIdentity {
+            pod_namespace: observed.namespace,
+            pod_name: observed.pod_name,
+            pod_uid: observed.pod_uid,
+            launcher_container_name: observed.launcher_container_name,
+            launcher_container_id: observed
+                .launcher_container_id
+                .expect("the launcher has started"),
+            image_digest: observed.image_digest.expect("the launcher has an image id"),
+            observed_launcher_protocol: observed
+                .observed_protocol
+                .clone()
+                .expect("the launcher declares a protocol"),
+            effective_launcher_protocol: observed
+                .observed_protocol
+                .expect("the launcher declares a protocol"),
+            admitted_cpu_millicores: i64::try_from(
+                observed
+                    .admitted_cpu_millicores
+                    .expect("resize-v2 renders a ceiling"),
+            )
+            .unwrap(),
+        };
+        let captured = self
+            .permits
+            .capture_resize_identity(RUN, &row.permit_id, row.fencing_token, &identity)
+            .await
+            .unwrap();
+        assert!(
+            matches!(captured, CaptureBuildPodResizeIdentityResult::Captured(_)),
+            "the write-once resize identity must capture: {captured:?}"
+        );
+    }
+
+    async fn escalate(&self) -> LeaseFencingToken {
+        match self
+            .service
+            .queue(LeaseQueueRequest {
+                identity: identity(),
+                deadlines: LeaseDeadlines {
+                    queue_deadline_ms: 0,
+                    launch_deadline_ms: 0,
+                },
+            })
+            .await
+        {
+            LeaseResult::Granted(grant) => grant.fencing_token,
+            other => panic!("expected a grant, got {other:?}"),
+        }
+    }
+
+    /// Escalate and acknowledge — the call that authorizes AND applies.
+    async fn lift(&self) -> LeaseResult {
+        let token = self.escalate().await;
+        self.service
+            .grant(LeaseGrantRequest {
+                identity: identity(),
+                fencing_token: token,
+            })
+            .await
+    }
+
+    async fn permit_state(&self) -> BuildPodPermitState {
+        self.permits
+            .active(RUN)
+            .await
+            .expect("the permit is readable")
+            .expect("the permit exists")
+            .state
+    }
+}
+
+async fn seed_task_run(db: &Database, run: &str) {
+    let project_id = uuid::Uuid::now_v7().to_string();
+    djinn_db::test_support::seed_project(db, &project_id, &format!("proj-{project_id}")).await;
+    let task_id = djinn_db::test_support::seed_task_row(
+        db,
+        djinn_db::test_support::UsageTestTaskSeed {
+            project_id: &project_id,
+            status: "open",
+            close_reason: None,
+            total_reopen_count: 0,
+        },
+    )
+    .await;
+    djinn_db::TaskRunRepository::new(db.clone())
+        .create(djinn_db::CreateTaskRunParams {
+            id: run,
+            project_id: &project_id,
+            task_id: &task_id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed the task run the permit is keyed on");
+}
+
+fn healthy_pod() -> StoredTaskRunPod {
+    StoredTaskRunPod::resize_v2(POD_UID, &format!("{ADMITTED_CEILING}m"))
+}
+
+/// No confirmation budget: one observation, no waiting. Used by every case that
+/// wants the SPECIFIC thing the status reported rather than the fact that a
+/// budget was spent.
+const NO_WAIT: Duration = Duration::ZERO;
+
+// ── AC3 / AC2: a grant only after the init-container status agrees ──────────
+
+/// **ACCEPTANCE CRITERION 3 (positive) and CRITERION 2 (non-vacuity).**
+///
+/// The lift lands, and it lands *in the field that can confirm it*: the
+/// launcher's `status.initContainerStatuses` entry, in millicores. The PATCH
+/// counter is asserted NON-ZERO, which is what stops criterion 2's second
+/// mutation — restoring `Authorized(_) => granted` in `fold_into_grant` — from
+/// passing: with the passthrough restored, nothing is patched at all.
+#[tokio::test]
+async fn a_status_confirmed_lift_grants_and_records_lifted() {
+    let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{ADMITTED_CEILING}m").as_str()),
+        "precondition: the launcher starts at its admitted ceiling"
+    );
+
+    let result = fixture.lift().await;
+
+    assert!(
+        matches!(result, LeaseResult::Status(_)),
+        "a confirmed lift returns the lease status unchanged: {result:?}"
+    );
+    assert!(
+        fixture.pod.resize_patches() > 0,
+        "the happy path must actually PATCH; a zero counter here is the shipped \
+         `Authorized(_) => granted` passthrough coming back"
+    );
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{ADMITTED_CEILING}m").as_str()),
+        "the launcher's INIT-container status is what confirms, and it must hold \
+         the clamped target"
+    );
+    assert_eq!(
+        fixture.permit_state().await,
+        BuildPodPermitState::Lifted,
+        "a confirmed lift advances the durable lifecycle to `lifted`"
+    );
+}
+
+/// **ACCEPTANCE CRITERION 3, the required distinct fixture.**
+///
+/// `status.containerStatuses` already carries a `cgroup-launcher` entry holding
+/// exactly the target, while `status.initContainerStatuses` never actuates. A
+/// confirmation that read the wrong array — or that accepted the PATCH response
+/// or the mutated `spec` — would report success here. It must degrade.
+///
+/// NAMED FAILING MUTATION: make `confirm_launcher_cpu` fall back to
+/// `locate_launcher_status`'s regular-container sibling, or have `ResizeLift`
+/// return `Ok(())` on `resize_launcher_cpu`'s accepted PATCH instead of on its
+/// confirmation, and this test grants.
+#[tokio::test]
+async fn a_matching_regular_container_status_is_never_confirmation() {
+    let pod = healthy_pod()
+        .never_actuating()
+        .with_misleading_regular_launcher_status(&format!("{ADMITTED_CEILING}m"));
+    let fixture = Fixture::armed(pod, NO_WAIT).await;
+
+    // The trap is armed: the launcher name appears in the REGULAR container
+    // statuses carrying exactly the value confirmation is looking for.
+    let result = fixture.lift().await;
+
+    assert!(
+        matches!(result, LeaseResult::DegradedUnleased { .. }),
+        "a matching regular-container status must never confirm: {result:?}"
+    );
+    assert_eq!(fixture.permit_state().await, BuildPodPermitState::DropRequired);
+}
+
+// ── AC4: every named uncertainty degrades, with drop active ────────────────
+
+/// One fault-injection case.
+struct Case {
+    name: &'static str,
+    reason: DegradedUnleasedReason,
+    /// Whether a PATCH may be issued at all. The identity fences run before the
+    /// PATCH, so their cases must show a counter of zero.
+    patches_allowed: bool,
+    budget: Duration,
+    build: fn() -> StoredTaskRunPod,
+    /// Applied after the permit has captured its identity, so the fence has
+    /// something to disagree with.
+    disturb: fn(&StoredTaskRunPod),
+}
+
+fn no_disturbance(_: &StoredTaskRunPod) {}
+
+/// **ACCEPTANCE CRITERION 4.**
+///
+/// Every named uncertainty, each as its own case, driven end to end through the
+/// real grant path. Each must be a [`LeaseResult::DegradedUnleased`] carrying a
+/// settled reason — never `Ok`, never an `Err`, never `LeaseUnavailable` (which
+/// the invocation runner treats as retryable and would re-ask until the queue
+/// deadline burned) — and each must leave the durable permit in
+/// `drop_required` so the drop reconciler returns the Pod to its birth limit.
+///
+/// NAMED FAILING MUTATION: collapse any single case into the success arm — e.g.
+/// make `is_retryable` return `false` for `StatusStale` and have
+/// `patch_and_confirm` return `Ok(())` on it — and exactly that row fails.
+///
+/// NAMED FAILING MUTATION 2: change the `Authorized` arm of `fold_into_grant` to
+/// propagate the failure as an `Err`/`LeaseUnavailable` instead of
+/// `DegradedUnleased`, and the `assert_ne!` below fails on every row.
+#[tokio::test]
+async fn every_named_uncertainty_degrades_with_drop_required() {
+    let cases = [
+        Case {
+            name: "HTTP 200, init status stale (the kubelet never actuates)",
+            reason: DegradedUnleasedReason::LiftStatusStale,
+            patches_allowed: true,
+            budget: NO_WAIT,
+            build: || healthy_pod().never_actuating(),
+            disturb: no_disturbance,
+        },
+        Case {
+            name: "HTTP 200, init status carries no cpu limit at all",
+            reason: DegradedUnleasedReason::LiftStatusAbsent,
+            patches_allowed: true,
+            budget: NO_WAIT,
+            build: || healthy_pod().never_actuating().without_launcher_status_limit(),
+            disturb: no_disturbance,
+        },
+        Case {
+            name: "a matching REGULAR-container status while init is stale",
+            reason: DegradedUnleasedReason::LiftStatusStale,
+            patches_allowed: true,
+            budget: NO_WAIT,
+            build: || {
+                healthy_pod()
+                    .never_actuating()
+                    .with_misleading_regular_launcher_status(&format!("{ADMITTED_CEILING}m"))
+            },
+            disturb: no_disturbance,
+        },
+        Case {
+            name: "a PodResizePending condition is present",
+            reason: DegradedUnleasedReason::LiftResizePending,
+            patches_allowed: true,
+            budget: NO_WAIT,
+            build: || healthy_pod().with_resize_pending(),
+            disturb: no_disturbance,
+        },
+        Case {
+            name: "the Pod was recreated under the same NAME with a new UID",
+            reason: DegradedUnleasedReason::ResizeIdentityChanged,
+            patches_allowed: false,
+            budget: NO_WAIT,
+            build: healthy_pod,
+            disturb: |pod| pod.recreate_under_same_name("pod-uid-replacement"),
+        },
+        Case {
+            name: "the launcher declares a different authority protocol",
+            reason: DegradedUnleasedReason::LauncherProtocolChanged,
+            patches_allowed: false,
+            budget: NO_WAIT,
+            build: healthy_pod,
+            disturb: |pod| pod.set_observed_protocol("leaf-v1"),
+        },
+        Case {
+            name: "the launcher sidecar restarted (new containerID)",
+            reason: DegradedUnleasedReason::LauncherRestarted,
+            patches_allowed: false,
+            budget: NO_WAIT,
+            build: healthy_pod,
+            disturb: |pod| pod.restart_launcher("containerd://restarted"),
+        },
+        Case {
+            name: "the confirmation budget was spent and the status never moved",
+            reason: DegradedUnleasedReason::LiftDeadlineExceeded,
+            patches_allowed: true,
+            budget: Duration::from_millis(8),
+            build: || healthy_pod().never_actuating(),
+            disturb: no_disturbance,
+        },
+        Case {
+            name: "the PATCH timed out in transport (no HTTP status at all)",
+            reason: DegradedUnleasedReason::ResizeSurfaceUnavailable,
+            patches_allowed: true,
+            budget: NO_WAIT,
+            build: || healthy_pod().failing_patches(ApiFault::timeout()),
+            disturb: no_disturbance,
+        },
+        Case {
+            name: "the apiserver answered 403 (no pods/resize RBAC rule)",
+            reason: DegradedUnleasedReason::ResizeForbidden,
+            patches_allowed: true,
+            budget: NO_WAIT,
+            build: || healthy_pod().failing_patches(ApiFault::forbidden()),
+            disturb: no_disturbance,
+        },
+        Case {
+            name: "the apiserver answered 422 (the resize itself was rejected)",
+            reason: DegradedUnleasedReason::ResizeRejected,
+            patches_allowed: true,
+            budget: NO_WAIT,
+            build: || healthy_pod().failing_patches(ApiFault::unprocessable()),
+            disturb: no_disturbance,
+        },
+        Case {
+            name: "no Pod carries the task run's label any more",
+            reason: DegradedUnleasedReason::LiftPodAbsent,
+            patches_allowed: false,
+            budget: NO_WAIT,
+            build: healthy_pod,
+            disturb: |pod| {
+                pod.uid_fenced_delete(RUN, POD_UID)
+                    .expect("the fenced delete matches the stored uid");
+            },
+        },
+    ];
+
+    for case in cases {
+        let pod = (case.build)();
+        let fixture = Fixture::armed(pod, case.budget).await;
+        (case.disturb)(&fixture.pod);
+
+        let result = fixture.lift().await;
+
+        assert_eq!(
+            result,
+            LeaseResult::DegradedUnleased {
+                reason: case.reason
+            },
+            "case `{}` must degrade with its own settled reason",
+            case.name
+        );
+        assert_ne!(
+            result,
+            LeaseResult::LeaseUnavailable,
+            "case `{}`: LeaseUnavailable means ASK AGAIN, and this answer cannot \
+             change by asking",
+            case.name
+        );
+        assert_eq!(
+            fixture.permit_state().await,
+            BuildPodPermitState::DropRequired,
+            "case `{}` must leave the permit drop-required so the reconciler \
+             returns the Pod to its birth limit",
+            case.name
+        );
+        if !case.patches_allowed {
+            assert_eq!(
+                fixture.pod.resize_patches(),
+                0,
+                "case `{}` is an identity fence: it must land BEFORE any PATCH",
+                case.name
+            );
+        }
+    }
+}
+
+/// The set of reasons the table produces is not one catch-all wearing eleven
+/// hats. Asserted structurally so collapsing two cases onto a shared reason
+/// fails here rather than quietly.
+///
+/// The one deliberate pair is `LiftStatusStale`: the misleading
+/// regular-container case and the plain stale case share it **because the
+/// launcher's own init status is stale in both**, and telling them apart would
+/// require reading `status.containerStatuses` — the exact thing this stack is
+/// forbidden to do. Encoded here so the overlap is a stated decision rather than
+/// an accident.
+#[test]
+fn the_apply_time_reasons_are_a_closed_distinct_set() {
+    use DegradedUnleasedReason as R;
+    let reasons = [
+        R::LiftStatusStale,
+        R::LiftStatusAbsent,
+        R::LiftResizePending,
+        R::ResizeIdentityChanged,
+        R::LauncherProtocolChanged,
+        R::LauncherRestarted,
+        R::LiftDeadlineExceeded,
+        R::ResizeSurfaceUnavailable,
+        R::ResizeForbidden,
+        R::ResizeRejected,
+        R::LiftPodAbsent,
+    ];
+    for (i, a) in reasons.iter().enumerate() {
+        for b in &reasons[i + 1..] {
+            assert_ne!(a, b, "each apply-time outcome needs its own reason");
+        }
+    }
+}
+
+// ── AC5: the UID fence is the caller's, and it exists ──────────────────────
+
+/// **ACCEPTANCE CRITERION 5.**
+///
+/// `PodResizeClient::resize_launcher_cpu(pod_name, target)` takes only a name
+/// and never reads `metadata.uid`. A Pod deleted and recreated under the same
+/// name is therefore, to it, the same Pod — and it would patch the replacement.
+/// The fence is the caller's, and this proves the caller has it: the refusal
+/// lands with the PATCH counter at **zero**.
+///
+/// NAMED FAILING MUTATION: delete the `observed.pod_uid != intent.pod_uid`
+/// comparison in `ResizeLift::observe_and_fence` and this test fails with PATCH
+/// count 1 (the replacement Pod is healthy and actuates, so it would confirm and
+/// grant).
+///
+/// NON-VACUITY: the companion assertion below proves the same counter is
+/// provably non-zero when the UID matches, so a lift that simply never patches
+/// cannot pass this.
+#[tokio::test]
+async fn a_pod_recreated_under_the_same_name_is_refused_before_any_patch() {
+    let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
+    let name_before = fixture
+        .pod
+        .observe_launcher()
+        .unwrap()
+        .unwrap()
+        .pod_name
+        .clone();
+
+    fixture.pod.recreate_under_same_name("pod-uid-replacement");
+
+    let after = fixture.pod.observe_launcher().unwrap().unwrap();
+    assert_eq!(
+        after.pod_name, name_before,
+        "the replacement must reuse the NAME — that is what makes the name \
+         insufficient as an identity"
+    );
+    assert_ne!(after.pod_uid, POD_UID, "and carry a different UID");
+
+    let result = fixture.lift().await;
+
+    assert_eq!(
+        result,
+        LeaseResult::DegradedUnleased {
+            reason: DegradedUnleasedReason::ResizeIdentityChanged
+        }
+    );
+    assert_eq!(
+        fixture.pod.resize_patches(),
+        0,
+        "ZERO PATCHes: the UID fence must land before the object is touched"
+    );
+}
+
+/// The non-vacuity half of the criterion above, stated as its own test so it
+/// cannot be deleted with the assertion it protects.
+#[tokio::test]
+async fn the_matching_uid_happy_path_patches_at_least_once() {
+    let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
+    assert_eq!(fixture.pod.resize_patches(), 0, "precondition");
+    let result = fixture.lift().await;
+    assert!(matches!(result, LeaseResult::Status(_)), "{result:?}");
+    assert!(
+        fixture.pod.resize_patches() >= 1,
+        "the same counter the fence test reads as zero must be non-zero here, or \
+         that test proves only that nothing ever patches"
+    );
+}
+
+// ── AC8: body shape and neutrality across cycles ───────────────────────────
+
+/// **ACCEPTANCE CRITERION 8, the serialization half.**
+///
+/// The emitted body is exactly `spec.initContainers[0].name` and
+/// `.resources.limits.cpu` — no `requests`, no `spec.containers`, no second
+/// field, no second init container, and no caller-supplied target (the target is
+/// derived, and `LeaseGrantRequest` has nowhere to put one — see
+/// `resize_authorization_tests`).
+#[test]
+fn the_patch_body_carries_exactly_one_mutable_field() {
+    let body = djinn_k8s::pod_resize::build_resize_patch(
+        djinn_k8s::pod_resize::CpuLimit::from_millis(ADMITTED_CEILING),
+    );
+    let spec = body.get("spec").expect("a spec");
+    assert_eq!(spec.as_object().map(serde_json::Map::len), Some(1), "spec has exactly one key");
+    assert!(spec.get("containers").is_none(), "never `spec.containers`");
+    let containers = spec
+        .get("initContainers")
+        .and_then(serde_json::Value::as_array)
+        .expect("initContainers");
+    assert_eq!(containers.len(), 1, "exactly one init container is named");
+    let entry = containers[0].as_object().expect("an object");
+    assert_eq!(entry.len(), 2, "exactly `name` and `resources`");
+    let resources = entry["resources"].as_object().expect("resources");
+    assert_eq!(resources.len(), 1, "exactly `limits`");
+    assert!(
+        resources.get("requests").is_none(),
+        "a limits-only resize must never move `requests`: that is scheduling and \
+         Kueue accounting"
+    );
+    let limits = resources["limits"].as_object().expect("limits");
+    assert_eq!(limits.len(), 1, "exactly `cpu`");
+    assert_eq!(limits["cpu"], format!("{ADMITTED_CEILING}m"));
+}
+
+/// **ACCEPTANCE CRITERION 8, the neutrality half — cluster-free.**
+///
+/// Twenty lift cycles on one Pod. `resources.requests`, the QoS class, the
+/// launcher's container ID and its restart count must be byte-identical
+/// throughout, and the second init container standing beside the launcher must
+/// survive every one.
+///
+/// NAMED FAILING MUTATION: swap `Patch::Strategic` for `Patch::Merge` in
+/// `KubePodResizeApi::patch_resize` — an RFC 7386 merge replaces the whole
+/// `initContainers` array, so `init_container_count()` drops from 2 to 1 and this
+/// test fails. (The fixture applies strategic-merge semantics for
+/// `initContainers` explicitly, so the assertion is about the semantics the
+/// production client selects.)
+///
+/// LIVE-CLUSTER GAP, stated rather than papered over: the criterion asks for
+/// these twenty cycles on a kind apiserver. This run is cluster-free — it drives
+/// the production observation, patch-body and confirmation code, but not a real
+/// kubelet.
+#[tokio::test]
+async fn twenty_lift_cycles_leave_requests_qos_and_the_container_untouched() {
+    let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
+    let pod = &fixture.pod;
+
+    let requests = pod.launcher_spec_cpu_request();
+    let qos = pod.qos_class();
+    let container_id = pod.launcher_container_id();
+    let restarts = pod.launcher_restart_count();
+    let init_containers = pod.init_container_count();
+    assert_eq!(init_containers, 2, "a second init container must stand beside the launcher");
+    assert!(requests.is_some() && qos.is_some() && container_id.is_some());
+
+    // The lifecycle only admits one lift per permit, so the cycling is done at
+    // the surface: the same limits-only resize, applied over and over, exactly
+    // as a lift/drop pair would.
+    for cycle in 0..20 {
+        for target in [250, ADMITTED_CEILING] {
+            pod.resize_launcher_cpu(&format!("taskrun-{POD_UID}"), target)
+                .await
+                .unwrap_or_else(|e| panic!("cycle {cycle} target {target}m: {e}"));
+        }
+        assert_eq!(pod.launcher_spec_cpu_request(), requests, "cycle {cycle}: requests moved");
+        assert_eq!(pod.qos_class(), qos, "cycle {cycle}: QoS class moved");
+        assert_eq!(
+            pod.launcher_container_id(),
+            container_id,
+            "cycle {cycle}: the launcher was replaced"
+        );
+        assert_eq!(
+            pod.launcher_restart_count(),
+            restarts,
+            "cycle {cycle}: the launcher restarted"
+        );
+        assert_eq!(
+            pod.init_container_count(),
+            init_containers,
+            "cycle {cycle}: an init container was dropped — this is what a Merge \
+             patch does to an array with patchMergeKey `name`"
+        );
+    }
+    assert!(pod.resize_patches() >= 40, "the cycles must actually have patched");
+}

--- a/server/crates/djinn-k8s/src/pod_resize.rs
+++ b/server/crates/djinn-k8s/src/pod_resize.rs
@@ -192,7 +192,46 @@ pub enum PodResizeError {
         op: &'static str,
         /// Rendered `kube::Error`.
         message: String,
+        /// The apiserver's HTTP status, when the failure was an apiserver
+        /// *verdict* rather than a transport failure.
+        ///
+        /// Carried as a number rather than left inside `message` because the
+        /// lift state machine has to tell `403 Forbidden` (the controller's
+        /// `pods/resize` RBAC rule is missing — an operator fact) from `422`
+        /// (the apiserver refused this particular resize — a request fact) from
+        /// a timeout (nothing is known at all), and each maps to a different
+        /// settled degrade reason. Recovering that distinction by matching on a
+        /// rendered error string would make the classification depend on
+        /// `kube`'s `Display` impl.
+        ///
+        /// `None` means no HTTP response was received: a transport error, a
+        /// timeout, or a client-side failure.
+        status: Option<u16>,
     },
+}
+
+impl PodResizeError {
+    /// The apiserver HTTP status, when this failure carries one.
+    #[must_use]
+    pub const fn api_status(&self) -> Option<u16> {
+        match self {
+            Self::Api { status, .. } => *status,
+            _ => None,
+        }
+    }
+}
+
+/// Recover the apiserver's HTTP status from a `kube::Error`.
+///
+/// `kube::Error::Api(ErrorResponse)` is the only variant that carries an
+/// apiserver verdict; every other variant is a transport, TLS, auth-plumbing or
+/// serialization failure, for which "no status" is the correct answer rather
+/// than a guessed one.
+fn api_status(error: &kube::Error) -> Option<u16> {
+    match error {
+        kube::Error::Api(response) => u16::try_from(response.code).ok(),
+        _ => None,
+    }
 }
 
 /// A CPU limit, normalised to millicores.
@@ -457,6 +496,7 @@ impl PodResizeApi for KubePodResizeApi {
         self.pods.get(name).await.map_err(|e| PodResizeError::Api {
             op: "get",
             message: e.to_string(),
+            status: api_status(&e),
         })
     }
 
@@ -471,6 +511,7 @@ impl PodResizeApi for KubePodResizeApi {
             .map_err(|e| PodResizeError::Api {
                 op: "patch",
                 message: e.to_string(),
+                status: api_status(&e),
             })
     }
 }

--- a/server/crates/djinn-k8s/src/pod_resize.rs
+++ b/server/crates/djinn-k8s/src/pod_resize.rs
@@ -229,7 +229,7 @@ impl PodResizeError {
 /// than a guessed one.
 fn api_status(error: &kube::Error) -> Option<u16> {
     match error {
-        kube::Error::Api(response) => u16::try_from(response.code).ok(),
+        kube::Error::Api(response) => Some(response.code),
         _ => None,
     }
 }

--- a/server/crates/djinn-k8s/src/pod_resize_fixture.rs
+++ b/server/crates/djinn-k8s/src/pod_resize_fixture.rs
@@ -116,6 +116,8 @@ struct ClusterState {
     /// apiserver rejected, and counting it as an applied PATCH would make the
     /// "zero PATCH bodies above the ceiling" counters lie.
     patch_fault: Option<ApiFault>,
+    /// The raw `cpu` quantity carried by every accepted PATCH body, in order.
+    patched_cpu: Vec<String>,
 }
 
 /// One stored task-run Pod, plus a record of everything done to it.
@@ -134,6 +136,7 @@ impl StoredTaskRunPod {
                 deletes: Vec::new(),
                 get_fault: None,
                 patch_fault: None,
+                patched_cpu: Vec::new(),
             })),
         }
     }
@@ -200,12 +203,32 @@ impl StoredTaskRunPod {
         self
     }
 
+    /// Stop actuating accepted resizes from here on.
+    ///
+    /// The `&self` twin of [`Self::never_actuating`], for the fault-injection
+    /// order the real lifecycle forces: a Pod must be admitted and
+    /// birth-downsized on a *healthy* node before the fault the lift then meets
+    /// can be installed.
+    pub fn stop_actuating(&self) {
+        self.state.lock().expect("cluster").actuation = Actuation::NeverActuates;
+    }
+
+    /// Forget every PATCH counted so far.
+    ///
+    /// Used to separate the birth downsize — which is `0ppk-1b`'s write, not the
+    /// lift's — from the lift's own PATCHes, so a "zero PATCHes" assertion means
+    /// "the lift issued none" rather than "nothing has ever happened".
+    pub fn reset_patch_counter(&self) {
+        let mut state = self.state.lock().expect("cluster");
+        state.resize_patches = 0;
+        state.patched_cpu.clear();
+    }
+
     /// Add a `PodResizePending` condition. Its presence alone means no observed
     /// limit is authoritative — the fixture does not set a `status` field on it,
     /// because [`crate::pod_resize::has_resize_pending_condition`] deliberately
     /// does not consult one.
-    #[must_use]
-    pub fn with_resize_pending(self) -> Self {
+    pub fn add_resize_pending(&self) {
         self.mutate(|pod| {
             if let Some(status) = pod.status.as_mut() {
                 status
@@ -220,7 +243,6 @@ impl StoredTaskRunPod {
                     );
             }
         });
-        self
     }
 
     /// Plant a **regular**-container status named `cgroup-launcher` carrying
@@ -231,8 +253,7 @@ impl StoredTaskRunPod {
     /// hold an entry by that name — but a confirmation that read the wrong array
     /// would find a *matching* limit there and report success while the
     /// launcher's own init-container status was still stale.
-    #[must_use]
-    pub fn with_misleading_regular_launcher_status(self, cpu: &str) -> Self {
+    pub fn add_misleading_regular_launcher_status(&self, cpu: &str) {
         let entry = json!({
             "name": crate::launcher::LAUNCHER_CONTAINER_NAME,
             "ready": true,
@@ -250,20 +271,17 @@ impl StoredTaskRunPod {
                     .push(serde_json::from_value(entry.clone()).expect("status fixture"));
             }
         });
-        self
     }
 
     /// Strip `resources` from the launcher's init-container status, leaving the
     /// spec untouched: the launcher is nameable in both arrays but reports no
     /// CPU limit at all.
-    #[must_use]
-    pub fn without_launcher_status_limit(self) -> Self {
+    pub fn clear_launcher_status_limit(&self) {
         self.mutate(|pod| {
             for status in launcher_statuses(pod) {
                 status.resources = None;
             }
         });
-        self
     }
 
     /// Replace the stored Pod's `metadata.uid`, keeping its NAME.
@@ -310,18 +328,14 @@ impl StoredTaskRunPod {
     }
 
     /// Every `get_pod` fails with `fault` until cleared.
-    #[must_use]
-    pub fn failing_gets(self, fault: ApiFault) -> Self {
+    pub fn fail_gets(&self, fault: ApiFault) {
         self.state.lock().expect("cluster").get_fault = Some(fault);
-        self
     }
 
     /// Every `patch_resize` fails with `fault`, without mutating the Pod and
     /// without incrementing the PATCH counter.
-    #[must_use]
-    pub fn failing_patches(self, fault: ApiFault) -> Self {
+    pub fn fail_patches(&self, fault: ApiFault) {
         self.state.lock().expect("cluster").patch_fault = Some(fault);
-        self
     }
 
     /// The launcher's live `containerID`, for restart assertions.
@@ -422,6 +436,29 @@ impl StoredTaskRunPod {
         self.state.lock().expect("cluster").resize_patches
     }
 
+    /// The CPU value carried by every accepted PATCH **body**, in millicores.
+    ///
+    /// This is what makes "zero PATCH bodies above the ceiling" a measurement of
+    /// what was *sent to the apiserver* rather than of a number the caller
+    /// restated. The values are parsed back through
+    /// [`crate::pod_resize::CpuLimit`], so the canonicalisation the apiserver
+    /// applies (`2000m` → `2`) cannot make an above-ceiling body read as
+    /// below-ceiling.
+    #[must_use]
+    pub fn patched_cpu_millicores(&self) -> Vec<u64> {
+        self.state
+            .lock()
+            .expect("cluster")
+            .patched_cpu
+            .iter()
+            .map(|raw| {
+                CpuLimit::parse(raw)
+                    .expect("every emitted patch body carries a parseable quantity")
+                    .millis()
+            })
+            .collect()
+    }
+
     /// Every UID-fenced delete, as `(task_run_id, pod_uid)`.
     #[must_use]
     pub fn deletes(&self) -> Vec<(String, String)> {
@@ -513,13 +550,6 @@ impl PodResizeApi for FixtureApi {
         }
         state.resize_patches += 1;
         let actuation = state.actuation;
-        let Some(pod) = state.pod.as_mut() else {
-            return Err(PodResizeError::Api {
-                op: "patch",
-                message: format!("pod {name} not found"),
-                status: Some(404),
-            });
-        };
         let target = body["spec"]["initContainers"][0]["name"]
             .as_str()
             .expect("the patch names its target")
@@ -528,6 +558,14 @@ impl PodResizeApi for FixtureApi {
             .as_str()
             .expect("the patch carries a cpu limit")
             .to_owned();
+        state.patched_cpu.push(cpu.clone());
+        let Some(pod) = state.pod.as_mut() else {
+            return Err(PodResizeError::Api {
+                op: "patch",
+                message: format!("pod {name} not found"),
+                status: Some(404),
+            });
+        };
         let quantity = Quantity(cpu);
         for container in pod
             .spec

--- a/server/crates/djinn-k8s/src/pod_resize_fixture.rs
+++ b/server/crates/djinn-k8s/src/pod_resize_fixture.rs
@@ -48,11 +48,74 @@ pub enum Actuation {
     NeverActuates,
 }
 
+/// An apiserver verdict (or transport failure) the fixture returns instead of
+/// performing the call.
+///
+/// It exists so `403`, `422` and "no response at all" can be driven as the
+/// distinct things they are. The lift classifies on the numeric status carried
+/// by [`PodResizeError::Api`], so a fault injected here reaches the state
+/// machine through the same field a real `kube::Error::Api` would.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ApiFault {
+    /// The apiserver's HTTP status, or `None` for a transport failure/timeout.
+    pub status: Option<u16>,
+    /// The rendered message.
+    pub message: String,
+}
+
+impl ApiFault {
+    /// `403 Forbidden` — the shape a missing `pods/resize` RBAC rule produces.
+    #[must_use]
+    pub fn forbidden() -> Self {
+        Self {
+            status: Some(403),
+            message: "pods \"taskrun\" is forbidden: User cannot patch resource \
+                      \"pods/resize\" in API group \"\""
+                .to_owned(),
+        }
+    }
+
+    /// `422 Unprocessable Entity` — the apiserver refusing this resize.
+    #[must_use]
+    pub fn unprocessable() -> Self {
+        Self {
+            status: Some(422),
+            message: "Pod \"taskrun\" is invalid: spec.initContainers[0].resources.limits: \
+                      Forbidden: resource limits cannot be removed"
+                .to_owned(),
+        }
+    }
+
+    /// A transport timeout: no HTTP response, so no status.
+    #[must_use]
+    pub fn timeout() -> Self {
+        Self {
+            status: None,
+            message: "error trying to connect: operation timed out".to_owned(),
+        }
+    }
+
+    fn into_error(self, op: &'static str) -> PodResizeError {
+        PodResizeError::Api {
+            op,
+            message: self.message,
+            status: self.status,
+        }
+    }
+}
+
 struct ClusterState {
     pod: Option<Pod>,
     actuation: Actuation,
     resize_patches: usize,
     deletes: Vec<(String, String)>,
+    /// Fault returned by every `get_pod`, when set.
+    get_fault: Option<ApiFault>,
+    /// Fault returned by every `patch_resize`, when set. The patch counter is
+    /// **not** incremented for a faulted call: the fixture models a request the
+    /// apiserver rejected, and counting it as an applied PATCH would make the
+    /// "zero PATCH bodies above the ceiling" counters lie.
+    patch_fault: Option<ApiFault>,
 }
 
 /// One stored task-run Pod, plus a record of everything done to it.
@@ -69,6 +132,8 @@ impl StoredTaskRunPod {
                 actuation: Actuation::Actuates,
                 resize_patches: 0,
                 deletes: Vec::new(),
+                get_fault: None,
+                patch_fault: None,
             })),
         }
     }
@@ -135,6 +200,154 @@ impl StoredTaskRunPod {
         self
     }
 
+    /// Add a `PodResizePending` condition. Its presence alone means no observed
+    /// limit is authoritative — the fixture does not set a `status` field on it,
+    /// because [`crate::pod_resize::has_resize_pending_condition`] deliberately
+    /// does not consult one.
+    #[must_use]
+    pub fn with_resize_pending(self) -> Self {
+        self.mutate(|pod| {
+            if let Some(status) = pod.status.as_mut() {
+                status
+                    .conditions
+                    .get_or_insert_with(Default::default)
+                    .push(
+                        serde_json::from_value(json!({
+                            "type": crate::pod_resize::POD_RESIZE_PENDING_CONDITION,
+                            "status": "True",
+                        }))
+                        .expect("condition fixture deserializes"),
+                    );
+            }
+        });
+        self
+    }
+
+    /// Plant a **regular**-container status named `cgroup-launcher` carrying
+    /// `cpu`.
+    ///
+    /// This is the false-confirmation trap in its sharpest form: the launcher is
+    /// a native sidecar, so `status.containerStatuses` can never legitimately
+    /// hold an entry by that name — but a confirmation that read the wrong array
+    /// would find a *matching* limit there and report success while the
+    /// launcher's own init-container status was still stale.
+    #[must_use]
+    pub fn with_misleading_regular_launcher_status(self, cpu: &str) -> Self {
+        let entry = json!({
+            "name": crate::launcher::LAUNCHER_CONTAINER_NAME,
+            "ready": true,
+            "restartCount": 0,
+            "image": "registry.example/launcher@sha256:feed",
+            "imageID": "registry.example/launcher@sha256:feed",
+            "containerID": "containerd://impostor",
+            "resources": { "limits": { "cpu": cpu } },
+        });
+        self.mutate(|pod| {
+            if let Some(status) = pod.status.as_mut() {
+                status
+                    .container_statuses
+                    .get_or_insert_with(Default::default)
+                    .push(serde_json::from_value(entry.clone()).expect("status fixture"));
+            }
+        });
+        self
+    }
+
+    /// Strip `resources` from the launcher's init-container status, leaving the
+    /// spec untouched: the launcher is nameable in both arrays but reports no
+    /// CPU limit at all.
+    #[must_use]
+    pub fn without_launcher_status_limit(self) -> Self {
+        self.mutate(|pod| {
+            for status in launcher_statuses(pod) {
+                status.resources = None;
+            }
+        });
+        self
+    }
+
+    /// Replace the stored Pod's `metadata.uid`, keeping its NAME.
+    ///
+    /// This is a Pod deleted and recreated under the same name — the exact
+    /// object `PodResizeClient::resize_launcher_cpu`, whose only argument is a
+    /// name, cannot tell apart from the original.
+    pub fn recreate_under_same_name(&self, new_uid: &str) {
+        self.mutate(|pod| pod.metadata.uid = Some(new_uid.to_owned()));
+    }
+
+    /// Restart the launcher sidecar: a new `containerID` and a bumped
+    /// `restartCount`.
+    pub fn restart_launcher(&self, new_container_id: &str) {
+        self.mutate(|pod| {
+            for status in launcher_statuses(pod) {
+                status.container_id = Some(new_container_id.to_owned());
+                status.restart_count += 1;
+            }
+        });
+    }
+
+    /// Rewrite the launcher's declared `DJINN_LAUNCHER_AUTHORITY_PROTOCOL`.
+    pub fn set_observed_protocol(&self, protocol: &str) {
+        self.mutate(|pod| {
+            for container in pod
+                .spec
+                .as_mut()
+                .and_then(|spec| spec.init_containers.as_mut())
+                .into_iter()
+                .flatten()
+                .filter(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
+            {
+                for entry in container
+                    .env
+                    .get_or_insert_with(Default::default)
+                    .iter_mut()
+                    .filter(|e| e.name == crate::launcher::AUTHORITY_PROTOCOL_ENV)
+                {
+                    entry.value = Some(protocol.to_owned());
+                }
+            }
+        });
+    }
+
+    /// Every `get_pod` fails with `fault` until cleared.
+    #[must_use]
+    pub fn failing_gets(self, fault: ApiFault) -> Self {
+        self.state.lock().expect("cluster").get_fault = Some(fault);
+        self
+    }
+
+    /// Every `patch_resize` fails with `fault`, without mutating the Pod and
+    /// without incrementing the PATCH counter.
+    #[must_use]
+    pub fn failing_patches(self, fault: ApiFault) -> Self {
+        self.state.lock().expect("cluster").patch_fault = Some(fault);
+        self
+    }
+
+    /// The launcher's live `containerID`, for restart assertions.
+    #[must_use]
+    pub fn launcher_container_id(&self) -> Option<String> {
+        let pod = self.pod()?;
+        crate::pod_resize::locate_launcher_status(&pod)
+            .ok()?
+            .container_id
+            .clone()
+    }
+
+    /// The launcher's `restartCount`. A limits-only resize must never move it.
+    #[must_use]
+    pub fn launcher_restart_count(&self) -> Option<i32> {
+        let pod = self.pod()?;
+        Some(crate::pod_resize::locate_launcher_status(&pod).ok()?.restart_count)
+    }
+
+    fn mutate(&self, apply: impl FnOnce(&mut Pod)) {
+        let mut state = self.state.lock().expect("cluster");
+        if let Some(pod) = state.pod.as_mut() {
+            apply(pod);
+        }
+    }
+
     fn pod(&self) -> Option<Pod> {
         self.state.lock().expect("cluster").pod.clone()
     }
@@ -147,6 +360,13 @@ impl StoredTaskRunPod {
     pub fn observe_launcher(
         &self,
     ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        // A GET fault applies to the observation too. The whole point of the
+        // fault is that the apiserver did not answer; a fixture that served the
+        // stored Pod anyway would let a caller "observe" a cluster it cannot
+        // reach.
+        if let Some(fault) = self.state.lock().expect("cluster").get_fault.clone() {
+            return Err(LauncherObservationError::Api(fault.message));
+        }
         match self.pod() {
             None => Ok(None),
             Some(pod) => observe_launcher_sidecar(&pod).map(Some),
@@ -263,23 +483,41 @@ impl StoredTaskRunPod {
 
 struct FixtureApi(StoredTaskRunPod);
 
+/// Every launcher entry in `status.initContainerStatuses`, for mutation.
+fn launcher_statuses(pod: &mut Pod) -> impl Iterator<Item = &mut k8s_openapi::api::core::v1::ContainerStatus> {
+    pod.status
+        .as_mut()
+        .and_then(|status| status.init_container_statuses.as_mut())
+        .into_iter()
+        .flatten()
+        .filter(|status| status.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
+}
+
 #[async_trait::async_trait]
 impl PodResizeApi for FixtureApi {
     async fn get_pod(&self, name: &str) -> Result<Pod, PodResizeError> {
+        if let Some(fault) = self.0.state.lock().expect("cluster").get_fault.clone() {
+            return Err(fault.into_error("get"));
+        }
         self.0.pod().ok_or_else(|| PodResizeError::Api {
             op: "get",
             message: format!("pod {name} not found"),
+            status: Some(404),
         })
     }
 
     async fn patch_resize(&self, name: &str, body: &Value) -> Result<Pod, PodResizeError> {
         let mut state = self.0.state.lock().expect("cluster");
+        if let Some(fault) = state.patch_fault.clone() {
+            return Err(fault.into_error("patch"));
+        }
         state.resize_patches += 1;
         let actuation = state.actuation;
         let Some(pod) = state.pod.as_mut() else {
             return Err(PodResizeError::Api {
                 op: "patch",
                 message: format!("pod {name} not found"),
+                status: Some(404),
             });
         };
         let target = body["spec"]["initContainers"][0]["name"]

--- a/server/crates/djinn-k8s/src/pod_resize_fixture.rs
+++ b/server/crates/djinn-k8s/src/pod_resize_fixture.rs
@@ -231,16 +231,13 @@ impl StoredTaskRunPod {
     pub fn add_resize_pending(&self) {
         self.mutate(|pod| {
             if let Some(status) = pod.status.as_mut() {
-                status
-                    .conditions
-                    .get_or_insert_with(Default::default)
-                    .push(
-                        serde_json::from_value(json!({
-                            "type": crate::pod_resize::POD_RESIZE_PENDING_CONDITION,
-                            "status": "True",
-                        }))
-                        .expect("condition fixture deserializes"),
-                    );
+                status.conditions.get_or_insert_with(Default::default).push(
+                    serde_json::from_value(json!({
+                        "type": crate::pod_resize::POD_RESIZE_PENDING_CONDITION,
+                        "status": "True",
+                    }))
+                    .expect("condition fixture deserializes"),
+                );
             }
         });
     }
@@ -352,7 +349,11 @@ impl StoredTaskRunPod {
     #[must_use]
     pub fn launcher_restart_count(&self) -> Option<i32> {
         let pod = self.pod()?;
-        Some(crate::pod_resize::locate_launcher_status(&pod).ok()?.restart_count)
+        Some(
+            crate::pod_resize::locate_launcher_status(&pod)
+                .ok()?
+                .restart_count,
+        )
     }
 
     fn mutate(&self, apply: impl FnOnce(&mut Pod)) {
@@ -521,7 +522,9 @@ impl StoredTaskRunPod {
 struct FixtureApi(StoredTaskRunPod);
 
 /// Every launcher entry in `status.initContainerStatuses`, for mutation.
-fn launcher_statuses(pod: &mut Pod) -> impl Iterator<Item = &mut k8s_openapi::api::core::v1::ContainerStatus> {
+fn launcher_statuses(
+    pod: &mut Pod,
+) -> impl Iterator<Item = &mut k8s_openapi::api::core::v1::ContainerStatus> {
     pod.status
         .as_mut()
         .and_then(|status| status.init_container_statuses.as_mut())

--- a/server/crates/djinn-supervisor/src/services/lease.rs
+++ b/server/crates/djinn-supervisor/src/services/lease.rs
@@ -249,6 +249,77 @@ pub enum DegradedUnleasedReason {
     /// reported as a settled degrade because an unreadable authority is not
     /// permission, and a retry cannot turn it into one.
     AuthorizationUnreadable,
+
+    // ── Apply-time outcomes (0ppk-1c) ──────────────────────────────────────
+    //
+    // Everything above is decided from durable rows alone. Everything below is
+    // decided by what the apiserver and the kubelet actually did, and every one
+    // of them is a reason a lift was ATTEMPTED and did not take. They are a
+    // CLOSED set on `DegradedUnleased` on purpose: the worker's only correct
+    // handling for all of them is to proceed unleased, and expressing any of
+    // them as an `Err` would put them back on the retry path this variant
+    // exists to keep them off.
+    //
+    // Each one leaves the durable permit in `drop_required`, so the drop
+    // reconciler (0ppk-3) owns returning the Pod to its birth limit. A lift
+    // that could not be confirmed must never leave the row claiming `lifted`.
+    /// The permit's resize lifecycle is not in a state a lift may start from.
+    /// Neither `birth_confirmed` (fresh) nor `lifted` (idempotent re-confirm).
+    PermitNotLiftable,
+    /// The `birth_confirmed → lift_applying` (or the terminal) compare-and-swap
+    /// was refused, or durable storage could not answer it. The lift is not
+    /// attempted, or its outcome could not be recorded — either way nothing may
+    /// claim the Pod was lifted.
+    LiftLifecycleUnwritable,
+    /// No apiserver surface could be resolved, or the call failed with
+    /// something that is not a settled apiserver verdict (transport error,
+    /// timeout, 5xx). Still a settled degrade: see this enum's header.
+    ResizeSurfaceUnavailable,
+    /// The apiserver answered `403 Forbidden`. The controller's `pods/resize`
+    /// RBAC rule is missing or narrower than this namespace.
+    ResizeForbidden,
+    /// The apiserver answered `422 Unprocessable Entity` — the resize request
+    /// itself was rejected (for example, a limit the Pod's QoS class forbids).
+    ResizeRejected,
+    /// No Pod carries this task run's label any more, or the stored Pod is not
+    /// complete enough to fence a resize against.
+    LiftPodAbsent,
+    /// The launcher is not uniquely nameable in `spec.initContainers` or in
+    /// `status.initContainerStatuses`. Zero and two are the same failure.
+    LiftIdentityAmbiguous,
+    /// The live Pod's `metadata.uid` is not the permit's write-once `pod_uid`.
+    /// A Pod deleted and recreated under the same NAME is a different object,
+    /// and `PodResizeClient::resize_launcher_cpu` — which takes only a name —
+    /// would happily patch it. **No PATCH is issued when this is raised.**
+    ResizeIdentityChanged,
+    /// The launcher's live `containerID` is not the one the permit captured:
+    /// the sidecar restarted, so the cgroup the lift was reasoned about is
+    /// gone. **No PATCH is issued when this is raised.**
+    LauncherRestarted,
+    /// The launcher's live `DJINN_LAUNCHER_AUTHORITY_PROTOCOL` is not the
+    /// permit's `effective_launcher_protocol`. Exactly one authority governs an
+    /// admitted Pod. **No PATCH is issued when this is raised.**
+    LauncherProtocolChanged,
+    /// A `PodResizePending` condition is present: the kubelet has accepted the
+    /// request and has not actuated it, so no limit we can read is
+    /// authoritative.
+    LiftResizePending,
+    /// `status.initContainerStatuses[cgroup-launcher].resources.limits.cpu` is
+    /// absent. An absent value is never a match.
+    LiftStatusAbsent,
+    /// That status reports a CPU limit that is not the clamped target, or one
+    /// that will not parse. The PATCH may well have been accepted; acceptance
+    /// is not actuation.
+    LiftStatusStale,
+    /// The confirmation budget was spent waiting and the init-container status
+    /// never agreed.
+    ///
+    /// Distinct from [`Self::LiftStatusStale`] by whether waiting was
+    /// permitted: a lift configured with no confirmation budget reports the
+    /// specific thing its one observation saw, while a lift that slept its
+    /// whole budget reports that it spent it. Both degrade; they are separated
+    /// so an operator can tell "the kubelet never moved" from "we never waited".
+    LiftDeadlineExceeded,
 }
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LeaseResult {

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -494,26 +494,28 @@ impl AppState {
         // refuses `leaf-v1` outright. This becomes live the first time an image
         // row carries `resize-v2`.
         let permits = Arc::new(djinn_db::BuildPodPermitRepository::new(db.clone()));
-        let resize_authority = Arc::new(djinn_coordinator::resize_authorization::ResizeAuthority::new(
-            Arc::new(djinn_db::BuildLeaseRepository::new(db.clone())),
-            Arc::clone(&permits),
-            Arc::new(
-                djinn_supervisor::services::DurableInvocationLiftAuthority::new(
-                    db.clone(),
-                    "server AppState",
-                ),
-            ),
-            // The process's own rendered lease, from the SAME `KubernetesConfig`
-            // the manifests are rendered from. The per-Pod ceiling it is clamped
-            // against comes from the write-once permit row, never from here —
-            // see `resize_authorization::clamp`.
-            i64::from(djinn_k8s::launcher::launcher_leased_millicores(
-                &djinn_k8s::KubernetesConfig::from_env(),
-            )),
-            Arc::new(djinn_coordinator::resize_lift::ResizeLift::from_env(
+        let resize_authority = Arc::new(
+            djinn_coordinator::resize_authorization::ResizeAuthority::new(
+                Arc::new(djinn_db::BuildLeaseRepository::new(db.clone())),
                 Arc::clone(&permits),
-            )),
-        ));
+                Arc::new(
+                    djinn_supervisor::services::DurableInvocationLiftAuthority::new(
+                        db.clone(),
+                        "server AppState",
+                    ),
+                ),
+                // The process's own rendered lease, from the SAME `KubernetesConfig`
+                // the manifests are rendered from. The per-Pod ceiling it is clamped
+                // against comes from the write-once permit row, never from here —
+                // see `resize_authorization::clamp`.
+                i64::from(djinn_k8s::launcher::launcher_leased_millicores(
+                    &djinn_k8s::KubernetesConfig::from_env(),
+                )),
+                Arc::new(djinn_coordinator::resize_lift::ResizeLift::from_env(
+                    Arc::clone(&permits),
+                )),
+            ),
+        );
         let build_lease = Arc::new(
             BuildLeaseService::new(
                 Arc::new(djinn_db::BuildLeaseRepository::new(db.clone())),
@@ -524,9 +526,9 @@ impl AppState {
             // (and its reference cap) on recovery, so a restart observes the
             // armed cap before admitting or spawning. An armed cap still wins
             // over the configured value above.
-            .with_invocation_lease_authority(Arc::new(
-                InvocationLeaseAuthorityRepository::new(db.clone()),
-            ))
+            .with_invocation_lease_authority(Arc::new(InvocationLeaseAuthorityRepository::new(
+                db.clone(),
+            )))
             .with_resize_authority(resize_authority),
         );
         // The one place proposal `3i92`'s resize stack becomes reachable. The

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -470,6 +470,50 @@ impl AppState {
                 warm_millicores: djinn_k8s::launcher::warm_job_millicores(&k8s),
             }
         };
+        // Proposal `3i92`'s lift, armed (0ppk-1c). **This is the composition
+        // site**, and it is the entire difference between a resize stack that
+        // exists and one that fires: `BuildLeaseService` holds the authority as
+        // an `Option`, and for the whole of `0ppk-1a` that `Option` was `None`
+        // at every composition — merged, green, and structurally unable to move
+        // a Pod.
+        //
+        // Arming had to wait for `0ppk-1b` (#2860), which made
+        // `BuildPodPermitRepository` a production writer. Before those rows
+        // existed this would have answered `DegradedUnleased { PermitAbsent }`
+        // for every production invocation, which is why 1a shipped it unarmed
+        // and said so in its module header.
+        //
+        // The applier is `ResizeLift`, whose apiserver surface resolves lazily
+        // on first lift — a server with no kubeconfig still boots, and every
+        // lift it then attempts degrades to `ResizeSurfaceUnavailable` rather
+        // than reporting a grant.
+        //
+        // Inert on the current fleet: `images.launcher_authority_protocol` is
+        // NULL fleet-wide, so every dispatch resolves `leaf-v1`, no `resize-v2`
+        // ceiling is rendered, no resize identity is captured, and the clamp
+        // refuses `leaf-v1` outright. This becomes live the first time an image
+        // row carries `resize-v2`.
+        let permits = Arc::new(djinn_db::BuildPodPermitRepository::new(db.clone()));
+        let resize_authority = Arc::new(djinn_coordinator::resize_authorization::ResizeAuthority::new(
+            Arc::new(djinn_db::BuildLeaseRepository::new(db.clone())),
+            Arc::clone(&permits),
+            Arc::new(
+                djinn_supervisor::services::DurableInvocationLiftAuthority::new(
+                    db.clone(),
+                    "server AppState",
+                ),
+            ),
+            // The process's own rendered lease, from the SAME `KubernetesConfig`
+            // the manifests are rendered from. The per-Pod ceiling it is clamped
+            // against comes from the write-once permit row, never from here —
+            // see `resize_authorization::clamp`.
+            i64::from(djinn_k8s::launcher::launcher_leased_millicores(
+                &djinn_k8s::KubernetesConfig::from_env(),
+            )),
+            Arc::new(djinn_coordinator::resize_lift::ResizeLift::from_env(
+                Arc::clone(&permits),
+            )),
+        ));
         let build_lease = Arc::new(
             BuildLeaseService::new(
                 Arc::new(djinn_db::BuildLeaseRepository::new(db.clone())),
@@ -482,7 +526,8 @@ impl AppState {
             // over the configured value above.
             .with_invocation_lease_authority(Arc::new(
                 InvocationLeaseAuthorityRepository::new(db.clone()),
-            )),
+            ))
+            .with_resize_authority(resize_authority),
         );
         // The one place proposal `3i92`'s resize stack becomes reachable. The
         // apiserver surface underneath resolves lazily on first dispatch, so a
@@ -3921,6 +3966,38 @@ mod build_epoch_bridge_tests {
             "AppState must thread the resize admission bridge into every \
              AgentContext; without it the dispatch seam acquires no build-pod \
              permit and no resize-v2 launcher is ever downsized to its birth limit"
+        );
+    }
+
+    /// **0ppk-1c ACCEPTANCE CRITERION 1: armed at the production composition
+    /// site.**
+    ///
+    /// `BuildLeaseService` holds its resize authorization as
+    /// `Option<Arc<ResizeAuthority>>`, defaulted to `None`. For the whole of
+    /// `0ppk-1a` that `Option` was `None` at every composition and
+    /// `with_resize_authority` had zero production call sites — the entire
+    /// authorization and clamp layer was merged, green, and structurally unable
+    /// to move a Pod. That is not a hypothetical failure mode in this
+    /// neighbourhood; it is what happened, and the sibling failure (a trait
+    /// default silently winning over an unreachable override) happened because
+    /// nothing ever checked the COMPOSITION site.
+    ///
+    /// So this test reads the service that `AppState::new` actually built. A
+    /// test that called `BuildLeaseService::new(..).with_resize_authority(..)`
+    /// itself would prove only that the setter works — which was never in doubt.
+    ///
+    /// NAMED FAILING MUTATION: delete the `.with_resize_authority(...)` call
+    /// from `new_inner` and this fails.
+    #[tokio::test]
+    async fn the_production_build_lease_service_arms_the_resize_authority() {
+        let db = Database::open_in_memory().expect("test database");
+        let state = AppState::new(db, CancellationToken::new());
+        assert!(
+            state.inner.build_lease.resize_authority_armed(),
+            "AppState::new_inner must arm the Pod-resize authorization on the \
+             build-lease grant path. With it unarmed, `fold_into_grant` returns \
+             every grant untouched and no invocation escalation ever moves a \
+             launcher's cpu limit — which is exactly the state 0ppk-1a shipped in"
         );
     }
 


### PR DESCRIPTION
Board task `0vku` (0ppk-1c, "the lift") of epic `0ppk`, proposal `3i92`. Builds directly on #2860 (`pwys`, 0ppk-1b), which merged.

## The contradiction this PR exists to fix

#2845 shipped the resize authorization seam as:

```rust
pub trait PodResizeIntentSink: Send + Sync {
    fn record(&self, intent: &PodResizeIntent);   // sync, infallible, returns ()
}
```

and `fold_into_grant` returned `Authorized(_) => granted`, dropping the authorized intent on the floor.

An async `pods/resize` PATCH plus a status-confirmation poll **cannot report failure through that trait**. Plugged in as-is it would have been a lift that structurally cannot fail: every uncertainty test would pass without exercising anything, and this epic would collect its eighth green, merged, inert slice. So the seam changed:

```rust
#[async_trait]
pub trait PodResizeApplier: Send + Sync {
    async fn apply(&self, intent: &PodResizeIntent) -> Result<(), ResizeApplyFailure>;
}
```

and the `Authorized` arm now awaits the apply and maps failure onto `LeaseResult::DegradedUnleased`.

**Reverting the seam to `fn record(&self, &PodResizeIntent)` is the named mutation.** It does not merely fail a test — `resize_lift.rs` and every uncertainty case in `resize_lift_tests.rs` stop compiling, because there is nowhere left to put the failure.

## What is new

**`server/crates/djinn-coordinator/src/resize_lift.rs`** — the fenced apply-and-poll. `PodResizeClient::resize_launcher_cpu(pod_name, target)` takes only a Pod *name*; from that signature alone four fences are missing, and all four are supplied here:

* **UID fence** — the live `metadata.uid` is compared against the permit's write-once `pod_uid` on the fresh GET *before* any PATCH, and again after confirmation. A Pod deleted and recreated under the same name is refused with the PATCH counter at **zero**.
* **Restart fence** — the permit's captured `launcher_container_id` vs the live one.
* **Protocol fence** — the permit's `effective_launcher_protocol` vs the launcher's declared `DJINN_LAUNCHER_AUTHORITY_PROTOCOL`.
* **Bounded confirmation poll** — the client does one GET/PATCH/GET cycle and no retries; `status.initContainerStatuses` is populated asynchronously.

Every fence re-runs on every poll pass, so a Pod replaced or a launcher restarted *during* confirmation stops the lift rather than letting the next PATCH land on a different object.

Reused verbatim, never re-derived: `Patch::Strategic`, the refusal to consult `spec.containers` / `status.containerStatuses`, the `PodResizePending` fail-closed, and the **millicore** comparison.

**`DegradedUnleasedReason` gains 14 apply-time variants** — a closed set on `DegradedUnleased`, never an `Err` the invocation runner would treat as retryable. Each gets its own metric label in `degrade_reason`.

**A failed lift leaves the permit `drop_required`.** `birth_confirmed → lift_applying` before the PATCH; `→ lifted` on confirmation; `→ drop_required` on any failure. Migration 164's trigger owns the legal edge list — no migration is added by this PR.

**`PodResizeError::Api` gains `status: Option<u16>`**, populated from `kube::Error::Api(ErrorResponse { code, .. })`. 403 (missing `pods/resize` RBAC), 422 (the apiserver refused this resize) and a transport timeout (nothing known) are three different operator facts, and recovering that distinction by matching a rendered error string would make the classification depend on `kube`'s `Display` impl.

## Arming

`AppState::new_inner` now calls `.with_resize_authority(...)`. That call had **zero production call sites** for the whole of 0ppk-1a.

## Inert on the current fleet today

`images.launcher_authority_protocol` is NULL fleet-wide, so every dispatch resolves `leaf-v1`. Under `leaf-v1` no launcher `limits.cpu` is rendered, no resize identity is captured (migration 164 requires `admitted_cpu_millicores > 0`), and `clamp` refuses non-`resize-v2` outright with `ProtocolNotResizable`. **Nothing in this PR moves a Pod in production as it stands.**

What makes it live: setting `launcher_authority_protocol = 'resize-v2'` on an image row. From that point a `resize-v2` dispatch captures a ceiling, birth-downsizes to 250m, and an invocation escalation lifts it back — status-confirmed or degraded.

## The second composition site: `DirectServices` fails closed

`DirectServices::with_provider_override` builds a second `BuildLeaseService` (cap 0) as an agent-side fallback. **It stays unarmed, deliberately**, asserted by `the_agent_side_fallback_build_lease_fails_closed_unarmed`:

1. `djinn-agent` cannot depend on `djinn-server` — that is *why* #2860 introduced the `TaskRunResizeAdmission` trait. The apiserver surface and the permit-creating dispatch seam are both on the far side.
2. It is not on the path that creates permits; arming it would answer `PermitAbsent` for every invocation it served.
3. Unarmed means "no lift" — the launcher keeps its birth quota. The unsafe direction is *reporting* a grant for CPU no Pod received, which is exactly what an armed-but-surfaceless composition does.

## CI

`check-resize-authorization-boundary.sh` now also requires a **production** caller of `with_resize_authority` under `server/src`. Excluded: `#[cfg(test)]` modules, `*_tests.rs`, `.worktrees/`, and — found while building it, because the first version passed on one — **commented-out calls**, line and block. Self-test extended in lockstep, 14 assertions, all watched failing.

## Named mutations, each RUN and observed failing

| Mutation | Result |
|---|---|
| Restore `Authorized(_) => granted` in `fold_into_grant` | 10 tests fail; happy-path PATCH counter goes to 0 |
| Remove the `observed.pod_uid != intent.pod_uid` comparison | recreated-Pod test grants, PATCH count 1 |
| Delete `.min(ceiling)` in `clamp` | `ZERO PATCH bodies above the admitted ceiling; observed [4000]` |
| Ceiling := `configured_leased_millicores` instead of the row | carried ceiling reads 4000, want 8000 |
| Delete `.with_resize_authority(...)` from `new_inner` | AC1 test fails **and** the CI guard fails naming the symbol |
| Add `.with_resize_authority(..)` to `DirectServices` | fail-closed test fails |

## Evidence discipline

The first version of the uncertainty table **passed vacuously** and I caught it: the fixture Pod still held its admitted ceiling, so the lift's target was a value the launcher already had and a "never actuates" node still confirmed. The fixture now performs the real birth downsize to 250m between identity capture and lift, and asserts the launcher reads 250m before any lift runs. `LiftStatusStale` and `a_matching_regular_container_status_is_never_confirmation` only became real assertions after that.

No `Fake`/`Mock` repository. Permits, the lease FIFO and the lift authority are the production types over `open_in_memory` (a template-cloned real Postgres). The single double is the HTTP transport, via `djinn_k8s::pod_resize_fixture` — whose observation, PATCH and confirmation are the production functions.

## What I could NOT satisfy — stated, not weakened

**1. AC6 and AC7 are mutually contradictory as written, and I did not redesign the clamp to hide it.**

AC6 requires configuring a lift *above* the captured ceiling and landing on the ceiling — that is `min(configured, admitted)`, what 0ppk-1a shipped. AC7 requires a per-project-override Pod admitted *above* the deployment default to lift to *its own* rendered lease — that is `admitted`, i.e. a `max` in that direction. One `min` cannot do both.

I kept the clamp exactly as 0ppk-1a shipped it and proved the half that is provable: AC7's **ceiling provenance** (the bound is the write-once captured value, and the named mutation makes it read 4000 instead of 8000). The behavioural half is **not met**: an override Pod admitted at 8000m still lifts only to the deployment default 4000m. Making it lift to 8000 means `target = admitted`, which satisfies both ACs — AC6's "configured above the ceiling" then lands on the ceiling by construction, and AC6's stated mutation still fires. I believe that is the right follow-up, but it changes a merged slice's semantics and belongs in its own PR with its own review, not smuggled in here.

**2. The live-kind-cluster halves are not done.** I was instructed not to create a cluster. Specifically missing:
* AC6's companion control — issuing the oversubscribed value *directly* through `pods/resize` against a live apiserver to prove the apiserver does not bound it.
* AC8's 20 lift/drop cycles on a real kubelet. The cluster-free equivalent runs 20 cycles through the production patch-body builder and strategic-merge semantics and asserts requests/QoS/containerID/restartCount/init-container-count byte-identical.

**3. Two AC4 cases share `LiftStatusStale`.** The plain-stale case and the misleading-regular-container case, because the launcher's own init status is stale in both — and telling them apart would require reading `status.containerStatuses`, the exact thing this stack is forbidden to do. Encoded as a stated decision in `the_apply_time_reasons_are_a_closed_distinct_set` rather than left to look accidental. The other nine cases have distinct reasons.

**4. `LiftDeadlineExceeded` vs the specific status reasons** are separated by whether waiting was permitted: a zero-budget lift reports what its one observation saw; a lift that slept its whole budget reports that it spent it. Both degrade. Documented on the variant.

**Unrelated pre-existing failure:** `djinn-coordinator`'s `rules::tests::amend_while_building_dispatches_one_reconcile_task_from_event` stack-overflows. Verified it does so on `origin/main` (134f35e0d) untouched, so it is not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
