### PR TITLE
test(3i92): mixed-version matrix — three real image classes against four server modes, one quota authority per Pod (omp4)

### DIFF
--- a/.github/workflows/resize-matrix.yml
+++ b/.github/workflows/resize-matrix.yml
@@ -1,0 +1,170 @@
+name: Mixed-Version Resize Matrix
+
+# OPT-IN, NON-REQUIRED lane for the mixed-version launcher-authority matrix
+# (epic xowm, task omp4, proposal 3i92).
+#
+# DOES THIS RUN ANYWHERE BY DEFAULT? NO — stated here rather than left to be
+# discovered. There is exactly one trigger, `workflow_dispatch`. This lane never
+# runs on a pull request, never runs on a push to main, never runs in the merge
+# queue and is on no schedule. It is not a required check and cannot block a
+# merge. Nothing here runs unless a human presses "Run workflow".
+#
+# WHY IT IS NOT REQUIRED
+# It compiles a launcher from a pre-protocol revision, builds three container
+# images, creates a kind cluster and dispatches Pods it expects to be refused.
+# That is tens of minutes of runner time and a class of infrastructure flake
+# (image pulls, containerd restarts, kubelet actuation) that must never be able
+# to wedge the merge queue.
+#
+# WHAT STILL RUNS ON EVERY PR
+# A gated harness nobody runs decays silently, so everything in
+# `server/tests/task_run_resize_mixed_version.rs` that can be decided without an
+# API server is NOT `#[ignore]`d: the matrix's completeness, every admission
+# decision for all twelve cells against real PostgreSQL, the signed-inventory
+# fences, the resize body's shape, the millicore rule, the confirmation-site
+# source gate and the harness's production-safety refusals. Those run inside the
+# ordinary `djinn-server` test lane. What needs this workflow is only the half
+# that genuinely needs a kubelet.
+#
+# IT CANNOT TOUCH PRODUCTION. The runner's kubeconfig contains exactly one
+# context: the kind cluster the setup script creates. Every kubectl call in the
+# script and in the test binary is `--context`-pinned to a name DERIVED from the
+# cluster this lane creates, and both refuse a context whose API server is not
+# on loopback.
+
+on:
+  workflow_dispatch:
+    inputs:
+      k8s_version:
+        description: "kind node Kubernetes version (>= 1.33: pods/resize actuation and a containerd with cgroup_writable)"
+        required: false
+        default: "1.35.0"
+      keep_on_failure:
+        description: "If 'true', leave the cluster running on failure for debugging"
+        required: false
+        default: "false"
+
+concurrency:
+  group: resize-matrix-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_BUILD_BUILD_DIR: target
+  RUSTC_WRAPPER: ""
+  RUSTFLAGS: "-D warnings"
+  SQLX_OFFLINE: "true"
+  DJINN_RESIZE_MATRIX_K8S_VERSION: ${{ github.event.inputs.k8s_version || '1.35.0' }}
+  DJINN_TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/postgres
+
+jobs:
+  resize-matrix:
+    name: Three real image classes against four server modes
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    # Belt and braces: the only trigger is workflow_dispatch, and this makes a
+    # future edit that adds `pull_request` fail to turn this into a PR check by
+    # accident.
+    if: github.event_name == 'workflow_dispatch'
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: djinn
+        ports:
+          - "5433:5432"
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
+
+    steps:
+      # `fetch-depth: 0`: the legacy image is compiled from a pinned commit in a
+      # detached worktree, and a shallow clone does not contain it. Without this
+      # the build fails with "invalid reference", which reads like a bad pin.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install kind, kubectl and helm
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+          chmod +x /usr/local/bin/kind
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          kind version
+          kubectl version --client=true
+          helm version --short
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: server
+          # save-if MUST stay false. rust-cache SAVES by default, and every cache
+          # family in this repository has exactly one writer, declared in
+          # quality-gate.yml (`scripts/ci-cache-policy.test.mjs`). Without this
+          # line an opt-in lane quietly becomes a second writer to a family it
+          # does not own.
+          save-if: false
+          # server-test (codegen), not server-quality: this job builds and RUNS
+          # the djinn-server test binary.
+          shared-key: server-test
+          cache-on-failure: true
+          cache-all-crates: true
+
+      - name: Build the test database template
+        run: |
+          set -euo pipefail
+          psql "$DJINN_TEST_DATABASE_URL" -c 'CREATE DATABASE djinn_test_template'
+          (cd server && cargo test -p djinn-db --test setup_test_template -- --ignored)
+          psql "$DJINN_TEST_DATABASE_URL" \
+            -c "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'"
+        env:
+          PGPASSWORD: postgres
+
+      # The hermetic half needs no cluster and no Docker. Running it first means
+      # a broken production-safety guard or a drifted expectation fails in
+      # seconds instead of after a cluster bring-up and three image builds. This
+      # is also exactly what runs on every PR — if the two ever diverge, that is
+      # the bug.
+      - name: Hermetic half (the part that also runs on every PR)
+        working-directory: server
+        run: cargo test -p djinn-server --test task_run_resize_mixed_version
+
+      - name: Create the disposable matrix cluster
+        run: |
+          scripts/kind/setup-resize-matrix-cluster.sh up \
+            --k8s-version "$DJINN_RESIZE_MATRIX_K8S_VERSION" \
+            ${{ github.event.inputs.keep_on_failure == 'true' && '--keep-on-failure' || '' }}
+
+      - name: Build the three image classes and load them onto the node
+        run: tests/fixtures/resize-matrix/build.sh djinn-resize-omp4
+
+      - name: The live matrix
+        working-directory: server
+        env:
+          DJINN_TEST_RESIZE_MATRIX: "1"
+        # --test-threads=1 because the cells share one node, one sentinel
+        # directory and one server-wide authority mode: concurrent cells would
+        # contend for the very state one of them is measuring.
+        run: cargo test -p djinn-server --test task_run_resize_mixed_version -- --ignored --test-threads=1
+
+      # `if: always()` is the point of this step. The setup script tears its own
+      # cluster down when `up` fails, but a failure in a test step happens after
+      # `up` has already succeeded, and a cancelled run skips everything. Pass or
+      # fail, the cluster AND its registry go — and `selfcheck` PROVES they did,
+      # because a teardown that reported success while the cluster survived is
+      # how a disposable harness becomes a permanent one.
+      - name: Tear down the cluster and its registry
+        if: always() && github.event.inputs.keep_on_failure != 'true'
+        run: |
+          scripts/kind/setup-resize-matrix-cluster.sh down
+          scripts/kind/setup-resize-matrix-cluster.sh selfcheck

--- a/scripts/kind/setup-resize-matrix-cluster.sh
+++ b/scripts/kind/setup-resize-matrix-cluster.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+# Disposable kind cluster for the mixed-version launcher-authority matrix (omp4).
+#
+# This script CREATES AND DELETES its target. Nothing about that target is
+# discovered: the cluster name, the registry name, the registry port and the
+# context are all derived from the constants below and never read out of the
+# ambient kubeconfig. On a Djinn developer's machine every context in the
+# kubeconfig is a live EKS cluster, so "use the current context" is not a
+# convenience here — it is a production outage.
+#
+# WHY IT DELEGATES INSTEAD OF REBUILDING
+#
+# scripts/kind/setup-kueue-cluster.sh already knows how to stand up a node whose
+# containerd carries the `runc-cgroupwritable` handler and whose kubelet is
+# labelled for it (#2857), and how to install the djinn chart's ServiceAccount,
+# PVCs and RuntimeClass. Re-deriving any of that here would give the matrix a
+# SECOND opinion about how a cgroup-writable node is built, and the two would
+# drift. So `up` runs the guards this harness owns, then hands the creation to
+# that script with THIS harness's names, and adds only what the matrix itself
+# needs on top. Teardown is NOT delegated: a disposable harness must be able to
+# prove its own target is gone without depending on another script's exit path.
+#
+# WHY A SEPARATE CLUSTER FROM EVERY SIBLING
+#
+# The matrix flips a server-wide launcher authority mode and dispatches Pods it
+# expects to be REFUSED. Both are cluster-visible side effects that would
+# corrupt a concurrent harness's accounting, and the reserved lists below name
+# every sibling so the two can never fight over a cluster or a port.
+#
+# Usage:
+#   scripts/kind/setup-resize-matrix-cluster.sh up         # create (default)
+#   scripts/kind/setup-resize-matrix-cluster.sh down       # delete cluster AND registry
+#   scripts/kind/setup-resize-matrix-cluster.sh check      # every guard, create nothing
+#   scripts/kind/setup-resize-matrix-cluster.sh selfcheck  # prove teardown really tears down
+#
+# Options:
+#   --context NAME         must equal the derived context; any other value is refused
+#   --cluster-name NAME    default djinn-resize-omp4
+#   --registry-name NAME   default djinn-resize-omp4-registry
+#   --registry-port PORT   default 5071
+#   --k8s-version VER      default 1.35.0
+#   --min-free-gib N       default 30
+#   --keep-on-failure      skip the failure-path teardown (debugging only)
+#
+# Exit codes:
+#   2   usage error
+#   3   refused target (reserved name, a non-derived context, or a non-kind server)
+#   4   not enough free disk
+#   5   a required tool is missing
+#   6   refused to adopt a pre-existing cluster
+#   7   Kubernetes version below the floor
+#   1   anything else
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+KIND="${KIND:-kind}"
+KUBECTL_BIN="${KUBECTL:-kubectl}"
+DOCKER="${DOCKER:-docker}"
+
+CLUSTER_NAME="${DJINN_RESIZE_MATRIX_CLUSTER:-djinn-resize-omp4}"
+REG_NAME="${DJINN_RESIZE_MATRIX_REGISTRY:-djinn-resize-omp4-registry}"
+REG_PORT="${DJINN_RESIZE_MATRIX_REG_PORT:-5071}"
+KIND_IMAGE_VERSION="${DJINN_RESIZE_MATRIX_K8S_VERSION:-1.35.0}"
+MIN_FREE_GIB="${DJINN_RESIZE_MATRIX_MIN_FREE_GIB:-30}"
+REQUESTED_CONTEXT=""
+KEEP_ON_FAILURE=false
+ACTION=""
+
+# The delegate. Named as a constant so the Rust suite's guard can assert this
+# harness reuses it rather than growing a second cgroup-writable installer.
+UPSTREAM_SETUP="$REPO_ROOT/scripts/kind/setup-kueue-cluster.sh"
+
+# Everything this script must never touch, whatever it is asked to do.
+#
+# `djinn` / `kind-registry` / 5001 are scripts/kind/setup-kind.sh's defaults —
+# the developer's live Tilt environment. The rest are the OTHER disposable
+# harnesses; this script deletes what it is given, and a `down` aimed at one of
+# them would destroy a run in progress.
+RESERVED_CLUSTER_NAMES=(
+    djinn
+    kind
+    djinn-kueue-harness
+    djinn-kueue-b2
+    djinn-kueue-b2b
+    djinn-kueue-c1
+    djinn-resize-harness
+    djinn-resize-pcod
+)
+RESERVED_REGISTRY_NAMES=(
+    kind-registry
+    djinn-kueue-harness-registry
+    djinn-kueue-c1-registry
+    djinn-resize-harness-registry
+    djinn-resize-pcod-registry
+)
+RESERVED_REG_PORTS=(5000 5001 5051 5052 5055 5061 5067)
+
+EXIT_USAGE=2
+EXIT_REFUSED_TARGET=3
+EXIT_LOW_DISK=4
+EXIT_MISSING_TOOL=5
+EXIT_CLUSTER_EXISTS=6
+EXIT_VERSION_FLOOR=7
+
+# The floor.
+#
+# The EPIC's floor is Kubernetes 1.30 — Kueue 0.19 requires it, and the "1.29"
+# that appeared in older docs was MEASURED FALSE and corrected in #2818. Do not
+# restore 1.29 here or anywhere.
+#
+# This harness's own floor is higher, and both bounds are enforced: `pods/resize`
+# must exist and must actuate (`InPlacePodVerticalScaling`, beta and default-on
+# from 1.33), and `--cgroup-writable` needs a containerd that carries the
+# `cgroup_writable` runtime property, which the 1.31 node image does not ship.
+# A harness that silently ran without either would report "not confirmed" for a
+# reason that has nothing to do with the code under test.
+EPIC_MIN_K8S_MINOR=30
+MIN_K8S_MINOR=33
+
+# A floor below the epic's is a regression whatever the local reason. Asserted
+# here so an edit to MIN_K8S_MINOR cannot quietly undo #2818.
+[ "$MIN_K8S_MINOR" -ge "$EPIC_MIN_K8S_MINOR" ] || {
+    printf 'FAIL: MIN_K8S_MINOR=%s is below the epic floor 1.%s (see #2818)\n' \
+        "$MIN_K8S_MINOR" "$EPIC_MIN_K8S_MINOR" >&2
+    exit 1
+}
+
+# The chart-installed pieces the matrix renders against, and the node-side
+# directory the AC4 sentinel lands in.
+NAMESPACE="${DJINN_RESIZE_MATRIX_NAMESPACE:-djinn}"
+SENTINEL_DIR="/var/tmp/djinn-resize-matrix-sentinels"
+CGROUP_WRITABLE_RUNTIME_CLASS="djinn-cgroup-writable"
+
+# The header comment above IS the help text.
+usage() {
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' \
+        "${BASH_SOURCE[0]}" >&2
+}
+
+fail() {
+    local code=$1
+    shift
+    printf 'FAIL: %s\n' "$*" >&2
+    exit "$code"
+}
+
+info() { printf '>>> %s\n' "$*"; }
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || fail "$EXIT_MISSING_TOOL" "$1 is not on PATH"
+}
+
+# --- Argument parsing -------------------------------------------------------
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        up|down|check|selfcheck)
+            [ -z "$ACTION" ] || fail "$EXIT_USAGE" "two actions given: $ACTION and $1"
+            ACTION=$1
+            shift
+            ;;
+        --context)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--context requires a value'
+            REQUESTED_CONTEXT=$2
+            shift 2
+            ;;
+        --cluster-name)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--cluster-name requires a value'
+            CLUSTER_NAME=$2
+            shift 2
+            ;;
+        --registry-name)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--registry-name requires a value'
+            REG_NAME=$2
+            shift 2
+            ;;
+        --registry-port)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--registry-port requires a value'
+            REG_PORT=$2
+            shift 2
+            ;;
+        --k8s-version)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--k8s-version requires a value'
+            KIND_IMAGE_VERSION=$2
+            shift 2
+            ;;
+        --min-free-gib)
+            [ "$#" -ge 2 ] || fail "$EXIT_USAGE" '--min-free-gib requires a value'
+            MIN_FREE_GIB=$2
+            shift 2
+            ;;
+        --keep-on-failure)
+            KEEP_ON_FAILURE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            fail "$EXIT_USAGE" "unknown argument: $1"
+            ;;
+    esac
+done
+ACTION="${ACTION:-up}"
+
+# --- Guard 1: shapes --------------------------------------------------------
+[[ "$CLUSTER_NAME" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] \
+    || fail "$EXIT_USAGE" "--cluster-name must be a DNS label, got: $CLUSTER_NAME"
+[[ "$REG_NAME" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] \
+    || fail "$EXIT_USAGE" "--registry-name must be a DNS label, got: $REG_NAME"
+[[ "$REG_PORT" =~ ^[1-9][0-9]{2,4}$ ]] \
+    || fail "$EXIT_USAGE" "--registry-port must be a port number, got: $REG_PORT"
+[[ "$MIN_FREE_GIB" =~ ^[0-9]+$ ]] \
+    || fail "$EXIT_USAGE" "--min-free-gib must be an integer, got: $MIN_FREE_GIB"
+
+# --- Guard 2: reserved targets ----------------------------------------------
+for reserved in "${RESERVED_CLUSTER_NAMES[@]}"; do
+    [ "$CLUSTER_NAME" != "$reserved" ] || fail "$EXIT_REFUSED_TARGET" \
+        "refusing to operate on kind cluster '$CLUSTER_NAME': it belongs to the developer's Tilt environment or to a sibling harness, and this script deletes what it is given"
+done
+for reserved in "${RESERVED_REGISTRY_NAMES[@]}"; do
+    [ "$REG_NAME" != "$reserved" ] || fail "$EXIT_REFUSED_TARGET" \
+        "refusing to operate on registry '$REG_NAME': it belongs to another harness"
+done
+for reserved in "${RESERVED_REG_PORTS[@]}"; do
+    [ "$REG_PORT" != "$reserved" ] || fail "$EXIT_REFUSED_TARGET" \
+        "refusing to publish on port $REG_PORT: another harness's registry already claims it"
+done
+
+# --- Guard 3: the version floor ---------------------------------------------
+K8S_MAJOR=${KIND_IMAGE_VERSION%%.*}
+K8S_REST=${KIND_IMAGE_VERSION#*.}
+K8S_MINOR=${K8S_REST%%.*}
+[[ "$K8S_MAJOR" =~ ^[0-9]+$ && "$K8S_MINOR" =~ ^[0-9]+$ ]] \
+    || fail "$EXIT_USAGE" "--k8s-version must look like 1.35.0, got: $KIND_IMAGE_VERSION"
+if [ "$K8S_MAJOR" -lt 1 ] || { [ "$K8S_MAJOR" -eq 1 ] && [ "$K8S_MINOR" -lt "$MIN_K8S_MINOR" ]; }; then
+    fail "$EXIT_VERSION_FLOOR" \
+        "Kubernetes $KIND_IMAGE_VERSION is below the 1.$MIN_K8S_MINOR floor this harness needs (pods/resize actuation and a containerd with cgroup_writable). The epic floor is 1.$EPIC_MIN_K8S_MINOR; the 1.29 in older docs was measured false and corrected in #2818."
+fi
+
+# --- Guard 4: the context is DERIVED, never discovered ----------------------
+CONTEXT="kind-${CLUSTER_NAME}"
+if [ -n "$REQUESTED_CONTEXT" ] && [ "$REQUESTED_CONTEXT" != "$CONTEXT" ]; then
+    fail "$EXIT_REFUSED_TARGET" \
+        "refusing --context '$REQUESTED_CONTEXT': this harness only ever targets '$CONTEXT', the context of the cluster it creates and deletes"
+fi
+KUBECTL=("$KUBECTL_BIN" --context "$CONTEXT")
+
+# --- Guard 5: the resolved API server must be a local kind server -----------
+#
+# Guard 4 checks the NAME. This checks where that name points, which is what
+# catches a kubeconfig entry called `kind-djinn-resize-omp4` aimed at EKS. Host
+# anchored: `https://127.0.0.1.evil.example` starts with the loopback address
+# and is a remote host. Skipped when the context does not exist yet, which is
+# the normal state before `up`.
+refuse_non_kind_server() {
+    local server
+    server=$("$KUBECTL_BIN" --context "$CONTEXT" config view --minify \
+        -o 'jsonpath={.clusters[0].cluster.server}' 2>/dev/null || true)
+    [ -n "$server" ] || return 0
+    local host=${server#https://}
+    host=${host%%/*}
+    host=${host%:*}
+    case "$host" in
+        127.0.0.1|localhost|'[::1]') return 0 ;;
+        *)
+            fail "$EXIT_REFUSED_TARGET" \
+                "refusing to operate on context '$CONTEXT': its API server is $server, not a local kind server. Every context in a Djinn developer's kubeconfig is a live EKS cluster."
+            ;;
+    esac
+}
+refuse_non_kind_server
+
+if [ "$ACTION" = check ]; then
+    printf 'PASS: guards accept cluster=%s context=%s registry=%s:%s k8s=%s namespace=%s sentinels=%s\n' \
+        "$CLUSTER_NAME" "$CONTEXT" "$REG_NAME" "$REG_PORT" "$KIND_IMAGE_VERSION" \
+        "$NAMESPACE" "$SENTINEL_DIR"
+    exit 0
+fi
+
+# --- Teardown ---------------------------------------------------------------
+teardown() {
+    info "deleting kind cluster $CLUSTER_NAME"
+    "$KIND" delete cluster --name "$CLUSTER_NAME" || true
+    if "$DOCKER" inspect "$REG_NAME" >/dev/null 2>&1; then
+        info "removing registry container $REG_NAME"
+        "$DOCKER" rm -f "$REG_NAME" >/dev/null || true
+    fi
+    # Prove the deletion rather than asserting it. A teardown that reported
+    # success while the cluster survived is how a "disposable" harness becomes a
+    # permanent one on a host that is already at 85% disk.
+    local surviving
+    surviving=$("$KIND" get clusters 2>/dev/null | grep -Fx "$CLUSTER_NAME" || true)
+    if [ -n "$surviving" ]; then
+        printf 'FAIL: kind cluster %s survived teardown\n' "$CLUSTER_NAME" >&2
+        return 1
+    fi
+    if "$DOCKER" inspect "$REG_NAME" >/dev/null 2>&1; then
+        printf 'FAIL: registry container %s survived teardown\n' "$REG_NAME" >&2
+        return 1
+    fi
+    printf 'PASS: cluster %s and registry %s are gone\n' "$CLUSTER_NAME" "$REG_NAME"
+}
+
+if [ "$ACTION" = down ]; then
+    require_tool "$KIND"
+    require_tool "$DOCKER"
+    teardown
+    exit 0
+fi
+
+if [ "$ACTION" = selfcheck ]; then
+    # The harness self-test AC10 names: after a teardown, neither the cluster nor
+    # the registry may exist. Run it after `down`, or after a failed `up` — it is
+    # the check that catches a REMOVED teardown trap, which otherwise leaves a
+    # cluster behind and is invisible until the host fills up.
+    require_tool "$KIND"
+    require_tool "$DOCKER"
+    surviving=$("$KIND" get clusters 2>/dev/null | grep -Fx "$CLUSTER_NAME" || true)
+    [ -z "$surviving" ] || fail 1 \
+        "selfcheck: kind cluster $CLUSTER_NAME still exists; the teardown path did not run"
+    ! "$DOCKER" inspect "$REG_NAME" >/dev/null 2>&1 || fail 1 \
+        "selfcheck: registry container $REG_NAME still exists; the teardown path did not run"
+    printf 'PASS: no %s cluster and no %s registry survive\n' "$CLUSTER_NAME" "$REG_NAME"
+    exit 0
+fi
+
+# --- up ---------------------------------------------------------------------
+require_tool "$KIND"
+require_tool "$KUBECTL_BIN"
+require_tool "$DOCKER"
+require_tool helm
+[ -x "$UPSTREAM_SETUP" ] || fail "$EXIT_MISSING_TOOL" \
+    "$UPSTREAM_SETUP is missing or not executable; this harness delegates cluster creation to it rather than growing a second cgroup-writable installer"
+
+# Guard 6: disk, before anything is pulled. A full disk here evicts the control
+# plane and looks exactly like a flaky test.
+FREE_GIB=$(df -Pk / | awk 'NR == 2 { printf "%d", $4 / 1048576 }')
+[ -n "$FREE_GIB" ] || fail 1 "could not read free space on /"
+[ "$FREE_GIB" -ge "$MIN_FREE_GIB" ] || fail "$EXIT_LOW_DISK" \
+    "only ${FREE_GIB}GiB free on /; this harness needs at least ${MIN_FREE_GIB}GiB for three image classes plus a node image. Prune cargo-target-runs and docker images before retrying."
+
+# Guard 7: never adopt. A pre-existing cluster under this name was created by
+# something else, and this script's failure path deletes what it created.
+if "$KIND" get clusters 2>/dev/null | grep -Fxq "$CLUSTER_NAME"; then
+    fail "$EXIT_CLUSTER_EXISTS" \
+        "kind cluster '$CLUSTER_NAME' already exists. This harness refuses to adopt a cluster it did not create — run 'scripts/kind/setup-resize-matrix-cluster.sh down' first."
+fi
+
+cleanup_on_failure() {
+    local status=$?
+    if [ "$status" -ne 0 ] && [ "$KEEP_ON_FAILURE" = false ]; then
+        info "run failed (exit $status); tearing the disposable cluster down"
+        teardown || true
+    fi
+    exit "$status"
+}
+trap cleanup_on_failure EXIT
+
+info "delegating cluster creation to $(basename "$UPSTREAM_SETUP") --cgroup-writable"
+"$UPSTREAM_SETUP" up \
+    --cluster-name "$CLUSTER_NAME" \
+    --registry-name "$REG_NAME" \
+    --registry-port "$REG_PORT" \
+    --k8s-version "$KIND_IMAGE_VERSION" \
+    --min-free-gib "$MIN_FREE_GIB" \
+    --context "$CONTEXT" \
+    --cgroup-writable
+
+# Guard 8: re-check the floor against the LIVE API server. A tag can lie; the
+# server cannot.
+LIVE_MINOR=$("${KUBECTL[@]}" version -o json | awk -F'"' '/"minor"/ { gsub(/[^0-9]/, "", $4); print $4; exit }')
+[ -n "$LIVE_MINOR" ] || fail 1 "could not read the live API server minor version"
+[ "$LIVE_MINOR" -ge "$MIN_K8S_MINOR" ] || fail "$EXIT_VERSION_FLOOR" \
+    "the created cluster reports Kubernetes 1.${LIVE_MINOR}, below the 1.${MIN_K8S_MINOR} floor"
+
+# The two capabilities the matrix cannot fake. Checked here so a missing one
+# fails during setup with a name, rather than during a live cell as "the leaf
+# quota never appeared".
+info "verifying the cgroup-writable RuntimeClass is installed"
+"${KUBECTL[@]}" get runtimeclass "$CGROUP_WRITABLE_RUNTIME_CLASS" >/dev/null 2>&1 \
+    || fail 1 "RuntimeClass $CGROUP_WRITABLE_RUNTIME_CLASS is absent; the launcher cannot obtain a writable cgroup root and every leaf-authority cell would fail for the wrong reason"
+
+info "verifying the pods/resize subresource is served"
+"${KUBECTL[@]}" get --raw '/api/v1' \
+    | grep -q '"name":"pods/resize"' \
+    || fail "$EXIT_VERSION_FLOOR" "this API server does not serve pods/resize"
+
+# The AC4 sentinel lands on the node, outside any Pod, so its absence survives
+# the Pod that would have written it never existing.
+info "preparing the sentinel directory $SENTINEL_DIR on every node"
+for node in $("$KIND" get nodes --name "$CLUSTER_NAME"); do
+    "$DOCKER" exec "$node" sh -c "rm -rf '$SENTINEL_DIR' && mkdir -p '$SENTINEL_DIR' && chmod 0777 '$SENTINEL_DIR'"
+done
+
+trap - EXIT
+
+cat <<EOF
+
+PASS: mixed-version matrix harness is up.
+  context:    ${CONTEXT}
+  registry:   localhost:${REG_PORT} (${REG_NAME})
+  namespace:  ${NAMESPACE}
+  k8s:        1.${LIVE_MINOR}
+  sentinels:  ${SENTINEL_DIR}
+
+Build the three image classes and load them:
+  tests/fixtures/resize-matrix/build.sh ${CLUSTER_NAME}
+
+Run the live matrix:
+  DJINN_TEST_RESIZE_MATRIX=1 cargo test -p djinn-server --test task_run_resize_mixed_version -- --ignored --test-threads=1
+
+Tear it down (do this whether the tests passed or failed):
+  scripts/kind/setup-resize-matrix-cluster.sh down
+  scripts/kind/setup-resize-matrix-cluster.sh selfcheck
+EOF

--- a/scripts/kind/setup-resize-matrix-cluster.sh
+++ b/scripts/kind/setup-resize-matrix-cluster.sh
@@ -37,7 +37,7 @@
 #   --context NAME         must equal the derived context; any other value is refused
 #   --cluster-name NAME    default djinn-resize-omp4
 #   --registry-name NAME   default djinn-resize-omp4-registry
-#   --registry-port PORT   default 5071
+#   --registry-port PORT   default 5079
 #   --k8s-version VER      default 1.35.0
 #   --min-free-gib N       default 30
 #   --keep-on-failure      skip the failure-path teardown (debugging only)
@@ -61,7 +61,7 @@ DOCKER="${DOCKER:-docker}"
 
 CLUSTER_NAME="${DJINN_RESIZE_MATRIX_CLUSTER:-djinn-resize-omp4}"
 REG_NAME="${DJINN_RESIZE_MATRIX_REGISTRY:-djinn-resize-omp4-registry}"
-REG_PORT="${DJINN_RESIZE_MATRIX_REG_PORT:-5071}"
+REG_PORT="${DJINN_RESIZE_MATRIX_REG_PORT:-5079}"
 KIND_IMAGE_VERSION="${DJINN_RESIZE_MATRIX_K8S_VERSION:-1.35.0}"
 MIN_FREE_GIB="${DJINN_RESIZE_MATRIX_MIN_FREE_GIB:-30}"
 REQUESTED_CONTEXT=""
@@ -87,6 +87,7 @@ RESERVED_CLUSTER_NAMES=(
     djinn-kueue-c1
     djinn-resize-harness
     djinn-resize-pcod
+    djinn-resize-1j64
 )
 RESERVED_REGISTRY_NAMES=(
     kind-registry
@@ -94,8 +95,9 @@ RESERVED_REGISTRY_NAMES=(
     djinn-kueue-c1-registry
     djinn-resize-harness-registry
     djinn-resize-pcod-registry
+    djinn-resize-1j64-registry
 )
-RESERVED_REG_PORTS=(5000 5001 5051 5052 5055 5061 5067)
+RESERVED_REG_PORTS=(5000 5001 5051 5052 5055 5061 5067 5071)
 
 EXIT_USAGE=2
 EXIT_REFUSED_TARGET=3
@@ -360,15 +362,47 @@ cleanup_on_failure() {
 }
 trap cleanup_on_failure EXIT
 
+delegate_up() {
+    "$UPSTREAM_SETUP" up \
+        --cluster-name "$CLUSTER_NAME" \
+        --registry-name "$REG_NAME" \
+        --registry-port "$REG_PORT" \
+        --k8s-version "$KIND_IMAGE_VERSION" \
+        --min-free-gib "$MIN_FREE_GIB" \
+        --context "$CONTEXT" \
+        --cgroup-writable
+}
+
 info "delegating cluster creation to $(basename "$UPSTREAM_SETUP") --cgroup-writable"
-"$UPSTREAM_SETUP" up \
-    --cluster-name "$CLUSTER_NAME" \
-    --registry-name "$REG_NAME" \
-    --registry-port "$REG_PORT" \
-    --k8s-version "$KIND_IMAGE_VERSION" \
-    --min-free-gib "$MIN_FREE_GIB" \
-    --context "$CONTEXT" \
-    --cgroup-writable
+# ONE retry, for one measured race and no other.
+#
+# The delegate installs the pinned Kueue prerequisite with `helm --wait`, which
+# waits for the controller Deployment to become Available — not for its
+# conversion/mutating webhook Service to have endpoints. The djinn chart is
+# applied immediately afterwards and its ClusterQueue goes through that webhook,
+# so a cold node loses the race and the apply fails with `connection refused`
+# against `djinn-prereqs-kueue-webhook-service`. Measured on 2026-07-31: it
+# failed on the first attempt and succeeded on the second, on the same host.
+#
+# The retry tears the half-built cluster down first: the delegate refuses to
+# adopt an existing cluster, and adopting one is exactly the behaviour these
+# harnesses must never learn. If the second attempt fails too, that is a real
+# failure and it propagates.
+if ! delegate_up; then
+    info "delegated bring-up failed; tearing down and retrying once (kueue webhook race)"
+    teardown || true
+    delegate_up
+fi
+
+# The RuntimeClass is chart-gated and the delegate's values file does not enable
+# it. Turned on through the CHART rather than by applying a copy of the object,
+# so the handler name and the scheduling nodeSelector keep coming from the single
+# source of truth in `deploy/helm/djinn/templates/runtimeclass-cgroup-writable.yaml`.
+info "enabling the cgroup-writable RuntimeClass on the djinn release"
+helm --kube-context "$CONTEXT" upgrade djinn "$REPO_ROOT/deploy/helm/djinn" \
+    --namespace "$NAMESPACE" \
+    --reuse-values \
+    --set cgroupWritable.runtimeClass.enabled=true >/dev/null
 
 # Guard 8: re-check the floor against the LIVE API server. A tag can lie; the
 # server cannot.

--- a/server/tests/task_run_resize_mixed_version.rs
+++ b/server/tests/task_run_resize_mixed_version.rs
@@ -1156,7 +1156,7 @@ fn the_image_pins_are_immutable() {
 const HARNESS_CLUSTER: &str = "djinn-resize-omp4";
 const HARNESS_CONTEXT: &str = "kind-djinn-resize-omp4";
 const HARNESS_REGISTRY: &str = "djinn-resize-omp4-registry";
-const HARNESS_REG_PORT: u16 = 5071;
+const HARNESS_REG_PORT: u16 = 5079;
 const NAMESPACE: &str = "djinn";
 const SENTINEL_DIR: &str = "/var/tmp/djinn-resize-matrix-sentinels";
 const SENTINEL_MOUNT: &str = "/sentinel";
@@ -1176,8 +1176,9 @@ const SIBLING_CLUSTERS: &[&str] = &[
     "djinn-kueue-c1",
     "djinn-resize-harness",
     "djinn-resize-pcod",
+    "djinn-resize-1j64",
 ];
-const SIBLING_REG_PORTS: &[u16] = &[5051, 5052, 5055, 5061, 5067];
+const SIBLING_REG_PORTS: &[u16] = &[5051, 5052, 5055, 5061, 5067, 5071];
 
 const TICK: Duration = Duration::from_millis(500);
 const AWAIT_TICKS: usize = 360;
@@ -1675,6 +1676,27 @@ fn leaf_cpu_max(pod: &str, invocation: &str) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_owned()
 }
 
+/// The quota half of a cgroup v2 `cpu.max` line, in millicores, or `None` when
+/// the leaf carries no quota at all.
+///
+/// `cpu.max` is `"<quota|max> <period>"` — TWO fields. Comparing the whole line
+/// against `"max"` never matches, and comparing it against `"max 100000"` would
+/// bind this test to the kernel's default period. Only the first field is a
+/// statement about who wrote quota.
+fn leaf_quota_millicores(raw: &str) -> Option<u64> {
+    let mut fields = raw.split_whitespace();
+    let quota = fields.next()?;
+    let period: u64 = fields.next()?.parse().ok()?;
+    if quota == "max" {
+        return None;
+    }
+    let quota: u64 = quota.parse().ok()?;
+    if period == 0 {
+        return None;
+    }
+    Some(quota.saturating_mul(1_000) / period)
+}
+
 /// The launcher's CPU limit as the kubelet has ACTUATED it, from the ONLY
 /// confirmation site: `status.initContainerStatuses[name=cgroup-launcher]`.
 fn actuated_launcher_cpu(pod_json: &Value) -> Option<CpuLimit> {
@@ -1704,8 +1726,14 @@ fn resize_patches_recorded(pod_json: &Value) -> usize {
         .unwrap_or(0)
 }
 
+/// One Pod, WITH its `metadata.managedFields`.
+///
+/// `--show-managed-fields` is not optional decoration. kubectl strips
+/// managedFields from `-o json` by default, and without this flag the whole
+/// block reads `null` — which made "zero resize PATCHes landed" pass for a Pod
+/// that had been resized. Measured on this branch before the flag was added.
 fn pod_json(pod: &str) -> Value {
-    kubectl_json(&["-n", NAMESPACE, "get", "pod", pod])
+    kubectl_json(&["-n", NAMESPACE, "get", "pod", pod, "--show-managed-fields"])
 }
 
 fn sentinel_exists(name: &str) -> bool {
@@ -1751,8 +1779,35 @@ fn dispatch(images: &BuiltImages, cell: Cell) -> LiveCell {
     dispatch_as(images, cell, uuid::Uuid::now_v7().to_string())
 }
 
+/// [`harness_config`] with the ServiceAccount and PVC names the CHART actually
+/// installed on this cluster.
+///
+/// Resolved from the live cluster rather than hard-coded: the chart's release
+/// name prefixes them (`djinn-djinn-taskrun`, not `djinn-taskrun`), and a
+/// hard-coded guess fails as `FailedCreate: error looking up service account`
+/// minutes into a cell, which reads exactly like a scheduling problem.
+fn live_config(image: &str) -> KubernetesConfig {
+    let named = |kind: &str, suffix: &str| -> String {
+        kubectl_json(&["-n", NAMESPACE, "get", kind])["items"]
+            .as_array()
+            .expect("a List has items")
+            .iter()
+            .filter_map(|item| item["metadata"]["name"].as_str())
+            .find(|name| name.ends_with(suffix))
+            .unwrap_or_else(|| panic!("the chart installs a {kind} ending in {suffix}"))
+            .to_owned()
+    };
+    KubernetesConfig {
+        service_account: named("serviceaccounts", "-taskrun"),
+        mirror_pvc: named("persistentvolumeclaims", "-mirrors"),
+        cache_pvc: named("persistentvolumeclaims", "-cache"),
+        projects_pvc: named("persistentvolumeclaims", "-projects"),
+        ..harness_config(image)
+    }
+}
+
 fn dispatch_as(images: &BuiltImages, cell: Cell, task_run_id: String) -> LiveCell {
-    let config = harness_config(&images.tag(cell.image));
+    let config = live_config(&images.tag(cell.image));
     let (mut manifest, task_run_id) = render_cell_job_as(&config, cell, task_run_id);
     let invocation = attach_probe_and_sentinel(&mut manifest, cell, &task_run_id);
     let job_name = manifest["metadata"]["name"]
@@ -1886,9 +1941,8 @@ fn the_live_matrix_has_exactly_one_quota_authority_per_admitted_pod() {
         match cell.expected {
             Outcome::Admitted(Authority::Leaf) => {
                 leaf_cells += 1;
-                assert_ne!(
-                    leaf,
-                    "max",
+                assert!(
+                    leaf_quota_millicores(&leaf).is_some(),
                     "cell {}: LEAF authority means the launcher wrote a numeric quota into the \
                      invocation leaf; cpu.max reads {leaf:?}, so NOBODY wrote one",
                     cell.name(),
@@ -1918,8 +1972,8 @@ fn the_live_matrix_has_exactly_one_quota_authority_per_admitted_pod() {
                     )
                 });
                 assert_eq!(
-                    leaf,
-                    "max",
+                    leaf_quota_millicores(&leaf),
+                    None,
                     "cell {}: RESIZE authority means the launcher wrote NOTHING into the leaf, \
                      not even `max` as a rewrite; cpu.max reads {leaf:?}",
                     cell.name(),
@@ -1947,12 +2001,13 @@ fn the_live_matrix_has_exactly_one_quota_authority_per_admitted_pod() {
                 assert!(
                     resize_patches_recorded(&resized) >= 1,
                     "cell {}: the apiserver recorded no pods/resize PATCH, so the resize \
-                     authority never acted",
+                     authority never acted. managedFields: {}",
                     cell.name(),
+                    resized["metadata"]["managedFields"],
                 );
                 assert_eq!(
-                    leaf_cpu_max(&live.pod, &live.invocation),
-                    "max",
+                    leaf_quota_millicores(&leaf_cpu_max(&live.pod, &live.invocation)),
+                    None,
                     "cell {}: the launcher wrote leaf quota AFTER the resize; that is a second \
                      authority on the same Pod",
                     cell.name(),

--- a/server/tests/task_run_resize_mixed_version.rs
+++ b/server/tests/task_run_resize_mixed_version.rs
@@ -1,0 +1,2463 @@
+// Test: `eprintln!` is the skip-reason and measurement channel for the gated
+// half, mirroring `djinn-k8s`'s live harnesses.
+#![allow(clippy::print_stderr)]
+//! The mixed-version launcher-authority matrix (omp4, proposal 3i92).
+//!
+//! Three REAL image classes against four server modes, with two properties to
+//! prove across the cross product:
+//!
+//! 1. **Exactly one quota authority for every admitted Pod** — never two, never
+//!    zero.
+//! 2. **Rejection before shell execution** for every incompatible combination.
+//!
+//! # The matrix is derived, never listed
+//!
+//! [`matrix`] is `ImageClass::ALL` x `ServerMode::ALL` and nothing else. There
+//! is no hand-written list of cells to fall out of date, and [`expectation`] is
+//! an exhaustive `match` over the pair with no wildcard arm — so a fourth image
+//! class or a fifth server mode is a COMPILE error until somebody states what it
+//! should do. `matrix_is_the_whole_cross_product` closes the other direction: a
+//! variant added to the enum but not to `ALL` trips it.
+//!
+//! # What "old" means here, precisely
+//!
+//! [`ServerMode::Old`] is a server that predates the protocol. Such a server has
+//! no authority-mode row to consult and no `apply_launcher_authority_protocol`
+//! to call, so this harness emulates it by **not invoking the admission seam at
+//! all and rendering no `DJINN_LAUNCHER_AUTHORITY_PROTOCOL`**. The launcher then
+//! takes its documented absent-means-`leaf-v1` default and writes leaf quota.
+//! That is the real compatibility guarantee the cutover depends on: an image
+//! that declares `resize-v2` degrades to leaf authority on a server that cannot
+//! read the declaration, rather than ending up with nobody writing quota.
+//!
+//! # What is real
+//!
+//! * The three images are three independently built artifacts with three
+//!   distinct digests (`tests/fixtures/resize-matrix/`). The legacy launcher is
+//!   COMPILED from a pre-protocol revision, and
+//!   `legacy_image_binary_predates_the_protocol` scans the binary inside the
+//!   built image for both wire strings.
+//! * Admission goes through the production pair
+//!   `LauncherAuthorityModeRepository::admit_declared_protocol` (a real
+//!   PostgreSQL read of `launcher_authority_mode`) composed with
+//!   `admit_with_legacy_inventory` — the same two calls in the same order that
+//!   `ProjectRepository::admit_dispatch_image` makes. No `Fake`, no `Mock`.
+//!   `Database::open_in_memory` is a template-cloned REAL PostgreSQL database
+//!   despite the name.
+//! * The legacy allowlist is a genuinely Ed25519-signed document verified by
+//!   `LegacyDigestInventory::from_signed_document`.
+//! * Every resize PATCH body is `pod_resize::build_resize_patch`, applied with
+//!   strategic-merge semantics against the `resize` subresource.
+//! * Every CPU comparison goes through `pod_resize::CpuLimit`, i.e. parsed
+//!   millicores.
+//!
+//! # Confirmation site
+//!
+//! Confirmation for the native sidecar comes ONLY from
+//! `status.initContainerStatuses[name=cgroup-launcher]`. The regular-container
+//! status list is never consulted, and
+//! `no_helper_in_this_suite_reads_the_regular_container_status_list` is a
+//! source-level gate over this file that fails if the token so much as appears.
+//! The live half backs the gate up with a Pod that carries a MISLEADING,
+//! perfectly-matching regular-container status and no init-container status at
+//! all: a reader that fell back to it would call that Pod confirmed.
+//!
+//! # Running the live half
+//!
+//! ```text
+//! scripts/kind/setup-resize-matrix-cluster.sh up
+//! tests/fixtures/resize-matrix/build.sh djinn-resize-omp4
+//! DJINN_TEST_RESIZE_MATRIX=1 cargo test -p djinn-server \
+//!     --test task_run_resize_mixed_version -- --ignored --test-threads=1
+//! scripts/kind/setup-resize-matrix-cluster.sh down       # ALWAYS, pass or fail
+//! scripts/kind/setup-resize-matrix-cluster.sh selfcheck
+//! ```
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::Duration;
+
+use djinn_db::launcher_compatibility::{
+    AdmissionDecision, AdmissionRejection, InventoryFault, LegacyDigestInventory,
+    PreProtocolDigest, admit_with_legacy_inventory,
+};
+use djinn_db::{
+    AcquireBuildPodPermitResult, BuildPodPermitRepository, Database,
+    LauncherAuthorityModeRepository, LauncherProtocolAdmission, SetLauncherAuthorityModeResult,
+};
+use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::job::{LABEL_TASK_RUN_ID, build_task_run_job};
+use djinn_k8s::launcher::{
+    CgroupLauncherMode, LAUNCHER_CONTAINER_NAME, apply_launcher_authority_protocol,
+    render_authority_protocol,
+};
+use djinn_k8s::pod_resize::{CpuLimit, build_resize_patch};
+use djinn_launcher_protocol::{LEAF_V1_WIRE, LauncherAuthorityProtocol, RESIZE_V2_WIRE};
+use serde_json::{Value, json};
+
+// ===========================================================================
+// The two axes.
+// ===========================================================================
+
+/// One of the three REAL image classes. Not a configuration of one image: the
+/// three are independently built artifacts with three distinct digests, and
+/// `tests/fixtures/resize-matrix/build.sh` refuses to finish if two of them
+/// collide.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum ImageClass {
+    /// A launcher compiled from a revision that predates the handshake. It
+    /// makes no declaration because it cannot.
+    LegacyNoHandshake,
+    /// Current launcher, declaring `leaf-v1`.
+    LeafV1,
+    /// Current launcher, declaring `resize-v2`.
+    ResizeV2,
+}
+
+impl ImageClass {
+    const ALL: [Self; 3] = [Self::LegacyNoHandshake, Self::LeafV1, Self::ResizeV2];
+
+    /// Position in [`Self::ALL`]. Exhaustive on purpose: a fourth variant forces
+    /// a fourth arm with a fourth ordinal, and `ALL` must then grow or
+    /// `matrix_is_the_whole_cross_product` indexes past its end.
+    const fn ordinal(self) -> usize {
+        match self {
+            Self::LegacyNoHandshake => 0,
+            Self::LeafV1 => 1,
+            Self::ResizeV2 => 2,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyNoHandshake => "legacy",
+            Self::LeafV1 => "leaf-v1",
+            Self::ResizeV2 => "resize-v2",
+        }
+    }
+
+    /// What the artifact declares, as the catalog would store it. `None` is the
+    /// legacy class's defining property and is what routes it through the signed
+    /// digest inventory instead of the declaration path.
+    const fn declared(self) -> Option<LauncherAuthorityProtocol> {
+        match self {
+            Self::LegacyNoHandshake => None,
+            Self::LeafV1 => Some(LauncherAuthorityProtocol::LeafV1),
+            Self::ResizeV2 => Some(LauncherAuthorityProtocol::ResizeV2),
+        }
+    }
+
+    const fn declared_wire(self) -> Option<&'static str> {
+        match self.declared() {
+            None => None,
+            Some(protocol) => Some(protocol.as_wire()),
+        }
+    }
+}
+
+/// One of the four server modes the cutover walks through.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum ServerMode {
+    /// A server that predates the protocol: no authority-mode row, no admission
+    /// seam, no rendered protocol env. See the module docs.
+    Old,
+    /// Protocol-aware, authority `leaf-v1`. The state a fleet sits in after the
+    /// server rolls out and before activation.
+    Preparation,
+    /// Authority `resize-v2`.
+    Activated,
+    /// Back to `leaf-v1` after a `resize-v2` window. Distinct from
+    /// [`Self::Preparation`] because it is reached through a drain fence that
+    /// preparation never has to satisfy.
+    Rollback,
+}
+
+impl ServerMode {
+    const ALL: [Self; 4] = [
+        Self::Old,
+        Self::Preparation,
+        Self::Activated,
+        Self::Rollback,
+    ];
+
+    const fn ordinal(self) -> usize {
+        match self {
+            Self::Old => 0,
+            Self::Preparation => 1,
+            Self::Activated => 2,
+            Self::Rollback => 3,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Old => "old",
+            Self::Preparation => "preparation",
+            Self::Activated => "activated",
+            Self::Rollback => "rollback",
+        }
+    }
+
+    /// The authority the server enforces, or `None` for a server that has no
+    /// concept of one.
+    const fn authority(self) -> Option<LauncherAuthorityProtocol> {
+        match self {
+            Self::Old => None,
+            Self::Preparation | Self::Rollback => Some(LauncherAuthorityProtocol::LeafV1),
+            Self::Activated => Some(LauncherAuthorityProtocol::ResizeV2),
+        }
+    }
+}
+
+/// Which component wrote the Pod's CPU quota. Exactly one, always.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Authority {
+    /// The launcher wrote a numeric quota into the invocation leaf's `cpu.max`,
+    /// and no `pods/resize` PATCH was ever issued against the Pod.
+    Leaf,
+    /// Pod resize moved the sidecar's limit, and the launcher wrote NOTHING into
+    /// the leaf — not even `max` as a rewrite.
+    Resize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Outcome {
+    Admitted(Authority),
+    /// Refused at admission, before any Job or Pod object exists and therefore
+    /// before any shell in that Pod could run.
+    RefusedBeforeDispatch,
+}
+
+/// The expected outcome of one cell.
+///
+/// Exhaustive over the pair with NO wildcard arm. That is the compile-time half
+/// of AC1: adding a variant to either axis stops this function compiling until
+/// somebody decides what the new combination means.
+const fn expectation(image: ImageClass, mode: ServerMode) -> Outcome {
+    use Authority::{Leaf, Resize};
+    use ImageClass::{LeafV1, LegacyNoHandshake, ResizeV2};
+    use Outcome::{Admitted, RefusedBeforeDispatch};
+    use ServerMode::{Activated, Old, Preparation, Rollback};
+
+    match (image, mode) {
+        // A pre-protocol server reads no declaration and renders no protocol
+        // env, so every class falls to the launcher's absent-means-leaf-v1
+        // default. This row is the compatibility guarantee that lets the server
+        // roll out ahead of any image change.
+        (LegacyNoHandshake, Old) | (LeafV1, Old) | (ResizeV2, Old) => Admitted(Leaf),
+
+        // No declaration is admitted as leaf authority ONLY for an exact,
+        // signed, pre-inventoried digest, and only under a leaf-v1 mode.
+        (LegacyNoHandshake, Preparation | Rollback) => Admitted(Leaf),
+        // ... and refused under resize-v2, because a launcher that cannot
+        // handshake cannot be told to stop writing leaf quota, and resize would
+        // then be the second authority on the same Pod.
+        (LegacyNoHandshake, Activated) => RefusedBeforeDispatch,
+
+        (LeafV1, Preparation | Rollback) => Admitted(Leaf),
+        // `ProtocolMismatch`: the artifact declares leaf-v1 and would write leaf
+        // quota while resize also moved the limit.
+        (LeafV1, Activated) => RefusedBeforeDispatch,
+
+        // The one resize-authority cell in the matrix.
+        (ResizeV2, Activated) => Admitted(Resize),
+        // A resize-v2 image under a leaf-v1 mode does not dispatch: its launcher
+        // would decline to write leaf quota and nothing else would write any,
+        // leaving the Pod with ZERO authorities.
+        (ResizeV2, Preparation | Rollback) => RefusedBeforeDispatch,
+    }
+}
+
+/// One cell of the cross product.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Cell {
+    image: ImageClass,
+    mode: ServerMode,
+    expected: Outcome,
+}
+
+impl Cell {
+    fn name(self) -> String {
+        format!("{}@{}", self.image.as_str(), self.mode.as_str())
+    }
+}
+
+const MATRIX_LEN: usize = ImageClass::ALL.len() * ServerMode::ALL.len();
+
+/// The matrix, derived from the two `ALL` arrays at construction time.
+///
+/// The RETURN TYPE is the completeness proof: it is spelled in terms of the two
+/// axes' lengths, so a variant added to either `ALL` widens the array and a cell
+/// cannot be deleted without deleting a variant.
+fn matrix() -> [Cell; MATRIX_LEN] {
+    std::array::from_fn(|index| {
+        let image = ImageClass::ALL[index / ServerMode::ALL.len()];
+        let mode = ServerMode::ALL[index % ServerMode::ALL.len()];
+        Cell {
+            image,
+            mode,
+            expected: expectation(image, mode),
+        }
+    })
+}
+
+// ===========================================================================
+// Hermetic half: the matrix's shape.
+// ===========================================================================
+
+/// **AC1.** Every pair appears exactly once, and every variant of both enums is
+/// reachable through its `ALL`.
+///
+/// The ordinal round trip is what catches a variant added to the enum but not to
+/// `ALL`: `ordinal` is exhaustive, so the new variant gets an index, and the
+/// index is then out of bounds.
+#[test]
+fn matrix_is_the_whole_cross_product() {
+    for image in ImageClass::ALL {
+        assert_eq!(
+            ImageClass::ALL[image.ordinal()],
+            image,
+            "{image:?} is missing from ImageClass::ALL, or is listed out of ordinal order; the \
+             matrix would silently skip every cell that names it",
+        );
+    }
+    for mode in ServerMode::ALL {
+        assert_eq!(
+            ServerMode::ALL[mode.ordinal()],
+            mode,
+            "{mode:?} is missing from ServerMode::ALL, or is listed out of ordinal order",
+        );
+    }
+
+    let cells = matrix();
+    assert_eq!(cells.len(), MATRIX_LEN);
+    assert_eq!(
+        MATRIX_LEN, 12,
+        "the matrix is 3 image classes x 4 server modes; if this changed on purpose, the count \
+         here is the one place that says so out loud",
+    );
+
+    let pairs: BTreeSet<(usize, usize)> = cells
+        .iter()
+        .map(|cell| (cell.image.ordinal(), cell.mode.ordinal()))
+        .collect();
+    assert_eq!(
+        pairs.len(),
+        MATRIX_LEN,
+        "a pair appears twice, so some pair does not appear at all: {cells:?}",
+    );
+}
+
+/// **AC1.** Every cell has an explicit expected outcome, and both outcome kinds
+/// are actually exercised.
+///
+/// A matrix in which every cell expected the same thing would pass every other
+/// assertion in this file while testing nothing.
+#[test]
+fn every_cell_has_an_expectation_and_both_outcomes_occur() {
+    let cells = matrix();
+    let admitted_leaf = cells
+        .iter()
+        .filter(|cell| cell.expected == Outcome::Admitted(Authority::Leaf))
+        .count();
+    let admitted_resize = cells
+        .iter()
+        .filter(|cell| cell.expected == Outcome::Admitted(Authority::Resize))
+        .count();
+    let refused = cells
+        .iter()
+        .filter(|cell| cell.expected == Outcome::RefusedBeforeDispatch)
+        .count();
+
+    assert_eq!(admitted_leaf + admitted_resize + refused, MATRIX_LEN);
+    assert!(
+        admitted_leaf > 0 && admitted_resize > 0 && refused > 0,
+        "the matrix must exercise leaf authority, resize authority AND refusal; \
+         leaf={admitted_leaf} resize={admitted_resize} refused={refused}",
+    );
+}
+
+// ===========================================================================
+// Hermetic half: admission, against real PostgreSQL.
+// ===========================================================================
+
+/// The signed inventory the legacy class is vouched for by.
+///
+/// Genuinely signed with a freshly generated Ed25519 key and verified by
+/// `LegacyDigestInventory::from_signed_document`, so the whole verification path
+/// runs — a hand-constructed `LegacyDigestInventory::verified(..)` would skip
+/// exactly the code the fence depends on.
+fn signed_inventory(digests: &[&str]) -> LegacyDigestInventory {
+    use base64::Engine as _;
+    use ring::signature::KeyPair as _;
+
+    let rng = ring::rand::SystemRandom::new();
+    let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng)
+        .expect("generate an ed25519 key for the test inventory");
+    let key = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8.as_ref())
+        .expect("parse the generated key");
+
+    let document = serde_json::to_vec(&json!({
+        "schema_version": 1,
+        "issuer": "omp4-mixed-version-matrix",
+        "issued_at": "2026-07-31T00:00:00Z",
+        "digests": digests,
+    }))
+    .expect("the inventory document serializes");
+
+    let signature = key.sign(&document);
+    let base64 = base64::engine::general_purpose::STANDARD;
+    LegacyDigestInventory::from_signed_document(
+        &document,
+        Some(&base64.encode(key.public_key().as_ref())),
+        Some(&base64.encode(signature.as_ref())),
+    )
+}
+
+/// A syntactically valid, immutable digest that stands in for one image class's
+/// content address in the hermetic half. The live half uses the real one.
+fn stub_digest(class: ImageClass) -> String {
+    format!("sha256:{:0>64}", format!("{}0", class.ordinal() + 1))
+}
+
+/// Drive the production admission pair for one cell.
+///
+/// `LauncherAuthorityModeRepository::admit_declared_protocol` reads the mode out
+/// of real PostgreSQL, and `admit_with_legacy_inventory` composes that verdict
+/// with the signed inventory. This is the same two calls, in the same order,
+/// that `ProjectRepository::admit_dispatch_image` makes on the dispatch path —
+/// reached directly so the cell does not also depend on project-row plumbing
+/// that has nothing to do with the property under test.
+async fn admit(
+    modes: &LauncherAuthorityModeRepository,
+    image: ImageClass,
+    digest: Option<&str>,
+    inventory: &LegacyDigestInventory,
+) -> Result<AdmissionDecision, AdmissionRejection> {
+    let verdict: LauncherProtocolAdmission =
+        modes.admit_declared_protocol(image.declared_wire()).await;
+    admit_with_legacy_inventory(verdict, digest, inventory)
+}
+
+/// A real `task_runs` row, because `build_pod_permits.task_run_id` carries a
+/// foreign key to it.
+///
+/// Every repository here is the production one against real PostgreSQL: the
+/// permit row whose presence the drain fence counts is reachable only through
+/// the same chain dispatch walks, and a `Fake` would have let the fence pass
+/// with nothing behind it.
+async fn seed_task_run(db: &Database) -> String {
+    use djinn_db::{
+        CreateTaskRunParams, EffectiveCreatorProvenance, ProjectRepository, TaskRepository,
+        TaskRunRepository, UserRepository,
+    };
+
+    let unique = uuid::Uuid::now_v7();
+    let user = UserRepository::new(db.clone())
+        .upsert_from_github(
+            i64::try_from(unique.as_u128() % 8_000_000_000_000_000_000).expect("github id"),
+            &format!("resize-matrix-{unique}"),
+            None,
+            None,
+        )
+        .await
+        .expect("seed user");
+    let project = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create(
+            &format!("resize-matrix-{unique}"),
+            "djinnos",
+            &format!("resize-matrix-{unique}"),
+        )
+        .await
+        .expect("seed project");
+    let task = TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create_in_project_with_provenance(
+            &project.id,
+            None,
+            EffectiveCreatorProvenance::explicit_user_id(&user.id),
+            "resize matrix",
+            "description",
+            "design",
+            "task",
+            2,
+            "owner",
+            None,
+            None,
+        )
+        .await
+        .expect("seed task");
+
+    let task_run_id = uuid::Uuid::now_v7().to_string();
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: &task_run_id,
+            project_id: &project.id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed task run");
+    task_run_id
+}
+
+/// Put the server into `mode`, satisfying the drain fence.
+async fn force_mode(modes: &LauncherAuthorityModeRepository, mode: LauncherAuthorityProtocol) {
+    let row = modes
+        .read()
+        .await
+        .expect("read the authority mode")
+        .expect("migration 167 seeds the singleton row");
+    if row.mode == mode {
+        return;
+    }
+    match modes.set_mode(row.epoch, mode).await {
+        SetLauncherAuthorityModeResult::Flipped { .. }
+        | SetLauncherAuthorityModeResult::Unchanged { .. } => {}
+        other => panic!("could not reach {mode}: {other:?}"),
+    }
+}
+
+/// **AC5.** Every cell's admission outcome, decided by the production functions
+/// against a real database and a real signed inventory.
+///
+/// This is the hermetic shadow of the live matrix: it proves the DECISION for
+/// all twelve cells. The live half proves the decision was acted on before a
+/// shell ran.
+#[tokio::test]
+async fn every_cell_admits_exactly_as_the_matrix_expects() {
+    let db = Database::ephemeral().await.expect("a real test database");
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+
+    let legacy_digest = stub_digest(ImageClass::LegacyNoHandshake);
+    let inventory = signed_inventory(&[&legacy_digest]);
+
+    for cell in matrix() {
+        let Some(authority) = cell.mode.authority() else {
+            // `Old` has no admission seam at all — see the module docs. Its
+            // render behaviour is asserted by
+            // `an_old_server_renders_no_protocol_declaration`.
+            continue;
+        };
+        force_mode(&modes, authority).await;
+
+        let digest = stub_digest(cell.image);
+        let decision = admit(&modes, cell.image, Some(&digest), &inventory).await;
+
+        match cell.expected {
+            Outcome::Admitted(Authority::Leaf) => assert_eq!(
+                decision,
+                Ok(AdmissionDecision::Admitted(
+                    LauncherAuthorityProtocol::LeafV1
+                )),
+                "cell {} must admit as leaf authority",
+                cell.name(),
+            ),
+            Outcome::Admitted(Authority::Resize) => assert_eq!(
+                decision,
+                Ok(AdmissionDecision::Admitted(
+                    LauncherAuthorityProtocol::ResizeV2
+                )),
+                "cell {} must admit as resize authority",
+                cell.name(),
+            ),
+            Outcome::RefusedBeforeDispatch => assert!(
+                decision.is_err(),
+                "cell {} must be refused, got {decision:?}",
+                cell.name(),
+            ),
+        }
+    }
+}
+
+/// **AC5, mutation 2.** A no-handshake image whose digest is NOT in the signed
+/// allowlist is refused under EVERY mode, including the leaf-v1 ones where an
+/// inventoried digest would have been admitted.
+#[tokio::test]
+async fn an_uninventoried_no_handshake_digest_is_refused_under_every_mode() {
+    let db = Database::ephemeral().await.expect("a real test database");
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+
+    let inventoried = stub_digest(ImageClass::LegacyNoHandshake);
+    let inventory = signed_inventory(&[&inventoried]);
+    let stranger = format!("sha256:{}", "b".repeat(64));
+
+    for mode in ServerMode::ALL {
+        let Some(authority) = mode.authority() else {
+            continue;
+        };
+        force_mode(&modes, authority).await;
+
+        // The control: the inventoried digest is admitted under leaf-v1. Without
+        // it, "everything is refused" would satisfy this test.
+        let vouched = admit(
+            &modes,
+            ImageClass::LegacyNoHandshake,
+            Some(&inventoried),
+            &inventory,
+        )
+        .await;
+        if authority == LauncherAuthorityProtocol::LeafV1 {
+            assert_eq!(
+                vouched,
+                Ok(AdmissionDecision::Admitted(
+                    LauncherAuthorityProtocol::LeafV1
+                )),
+                "the inventoried digest must still be admitted under {mode:?}",
+            );
+        }
+
+        let refused = admit(
+            &modes,
+            ImageClass::LegacyNoHandshake,
+            Some(&stranger),
+            &inventory,
+        )
+        .await;
+        assert!(
+            matches!(refused, Err(AdmissionRejection::UninventoriedDigest(_)))
+                || matches!(
+                    refused,
+                    Err(AdmissionRejection::MissingDeclarationUnderMode { .. })
+                ),
+            "an uninventoried no-handshake digest must be refused under {mode:?}, got {refused:?}",
+        );
+    }
+}
+
+/// **AC5, mutation 3.** An allowlist entry expressed as a mutable tag is
+/// refused, and so is a dispatch that presents one.
+///
+/// This falls out of `PreProtocolDigest::parse` rather than being a separate
+/// check, which is why the rewiring to `decide_admission` was worth doing: the
+/// inventory and the dispatch path agree about what a digest is because they use
+/// the same parser.
+#[test]
+fn a_mutable_tag_is_not_a_digest_anywhere() {
+    for tag in [
+        "djinn-agent-runtime:v1",
+        "latest",
+        "sha256:short",
+        // Upper-case hex is a different string for the same content and is
+        // refused rather than folded: two spellings of one digest is two
+        // allowlist entries to keep in sync.
+        &format!("sha256:{}", "A".repeat(64)),
+        "",
+    ] {
+        assert!(
+            PreProtocolDigest::parse(tag).is_err(),
+            "{tag:?} must not parse as an immutable digest",
+        );
+    }
+    assert!(
+        PreProtocolDigest::parse(&format!("sha256:{}", "a".repeat(64))).is_ok(),
+        "a well-formed digest must still parse, or the assertions above are vacuous",
+    );
+
+    // And an inventory that lists a tag is UNUSABLE, not quietly shorter.
+    let inventory = signed_inventory(&["djinn-agent-runtime:v1"]);
+    assert!(
+        matches!(
+            inventory,
+            LegacyDigestInventory::Unusable(InventoryFault::DigestMalformed(_))
+        ),
+        "an inventory containing a mutable tag must be unusable, got {inventory:?}",
+    );
+}
+
+/// **AC5, mutation 4 / AC3 "zero authorities".** An explicit `resize-v2` image
+/// under a leaf-v1 mode does not dispatch.
+#[tokio::test]
+async fn a_resize_v2_image_does_not_dispatch_under_leaf_v1() {
+    let db = Database::ephemeral().await.expect("a real test database");
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    force_mode(&modes, LauncherAuthorityProtocol::LeafV1).await;
+
+    let inventory = signed_inventory(&[]);
+    let decision = admit(
+        &modes,
+        ImageClass::ResizeV2,
+        Some(&stub_digest(ImageClass::ResizeV2)),
+        &inventory,
+    )
+    .await;
+
+    assert!(
+        matches!(
+            decision,
+            Err(AdmissionRejection::Declared(
+                LauncherProtocolAdmission::ProtocolMismatch { .. }
+            ))
+        ),
+        "a resize-v2 image under leaf-v1 must be a protocol mismatch, got {decision:?}",
+    );
+}
+
+// ===========================================================================
+// Hermetic half: the render.
+// ===========================================================================
+
+fn harness_config(image: &str) -> KubernetesConfig {
+    KubernetesConfig {
+        namespace: NAMESPACE.into(),
+        image: image.into(),
+        image_pull_policy: "IfNotPresent".into(),
+        cgroup_launcher_mode: CgroupLauncherMode::Required,
+        task_run_cgroup_writable_enabled: true,
+        kueue_armed: false,
+        // Requests low so several cells fit on one kind node; the LIMIT is what
+        // the launcher's lease and the resize ceiling derive from, and it is
+        // deliberately the stock bare `4` (see the millicore test).
+        cpu_request: "100m".into(),
+        cpu_limit: "4".into(),
+        memory_request: "64Mi".into(),
+        memory_limit: "1Gi".into(),
+        ..KubernetesConfig::for_testing()
+    }
+}
+
+/// The rendered Job for one cell, as JSON, plus its task-run id.
+fn render_cell_job(config: &KubernetesConfig, cell: Cell) -> (Value, String) {
+    render_cell_job_as(config, cell, uuid::Uuid::now_v7().to_string())
+}
+
+/// As [`render_cell_job`], for a task-run id chosen by the caller — used where a
+/// durable `task_runs` row has to exist for the same id the Pod is labelled with.
+fn render_cell_job_as(
+    config: &KubernetesConfig,
+    cell: Cell,
+    task_run_id: String,
+) -> (Value, String) {
+    let task_run_id: uuid::Uuid = task_run_id.parse().expect("a task-run id is a uuid");
+    let mut job = build_task_run_job(
+        config,
+        &task_run_id,
+        "resize-matrix-project",
+        &format!("djinn-taskrun-{task_run_id}"),
+        &config.image,
+        &[],
+        None,
+        false,
+        None,
+    );
+
+    if let Some(authority) = cell.mode.authority() {
+        // The production render. `render_authority_protocol` is what the
+        // dispatch path uses to turn an admitted decision into the protocol the
+        // sidecar is told about, and it is called here for the same reason.
+        let protocol =
+            render_authority_protocol(Some(authority), Some(&format!("sha256:{}", "c".repeat(64))))
+                .expect("a declared authority always renders");
+        apply_launcher_authority_protocol(&mut job, config.cgroup_launcher_mode, protocol)
+            .expect("the armed render emits a launcher sidecar");
+    }
+
+    let mut manifest = serde_json::to_value(&job).expect("the rendered Job serializes");
+    manifest["apiVersion"] = Value::String("batch/v1".into());
+    manifest["kind"] = Value::String("Job".into());
+    (manifest, task_run_id.to_string())
+}
+
+/// Read `spec.template.spec` container env off a rendered manifest.
+fn rendered_env(manifest: &Value, list: &str, container: &str, key: &str) -> Option<String> {
+    manifest
+        .pointer(&format!("/spec/template/spec/{list}"))?
+        .as_array()?
+        .iter()
+        .find(|entry| entry["name"] == container)?["env"]
+        .as_array()?
+        .iter()
+        .find(|entry| entry["name"] == key)?["value"]
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// **AC3, "old" row.** A pre-protocol server renders NO protocol declaration, so
+/// the launcher takes its absent-means-leaf-v1 default and leaf authority
+/// applies. Nobody is told about resize, so resize cannot be a second authority.
+#[test]
+fn an_old_server_renders_no_protocol_declaration() {
+    let config = harness_config("djinn-resize-matrix-leaf-v1:omp4");
+    for image in ImageClass::ALL {
+        let cell = Cell {
+            image,
+            mode: ServerMode::Old,
+            expected: expectation(image, ServerMode::Old),
+        };
+        let (manifest, _) = render_cell_job(&config, cell);
+        assert_eq!(
+            rendered_env(
+                &manifest,
+                "initContainers",
+                LAUNCHER_CONTAINER_NAME,
+                "DJINN_LAUNCHER_AUTHORITY_PROTOCOL",
+            ),
+            None,
+            "an old server has no authority mode to declare; cell {} rendered one",
+            cell.name(),
+        );
+        assert_eq!(
+            cell.expected,
+            Outcome::Admitted(Authority::Leaf),
+            "with no declaration the launcher default is the only authority",
+        );
+    }
+}
+
+/// **AC3, "resize-v2 renders a ceiling; leaf-v1 renders none".** The two
+/// authorities are distinguishable in the RENDER, before any Pod exists.
+///
+/// The deliberate absence of a launcher CPU limit under `leaf-v1` is what makes
+/// the live "zero resize PATCHes" assertion observable: a resize PATCH must
+/// introduce a `limits.cpu` key that a leaf-authority Pod never has.
+#[test]
+fn only_resize_v2_renders_a_launcher_cpu_ceiling() {
+    let config = harness_config("djinn-resize-matrix-resize-v2:omp4");
+
+    let launcher_limits = |mode: ServerMode| -> Option<Value> {
+        let cell = Cell {
+            image: ImageClass::ResizeV2,
+            mode,
+            expected: expectation(ImageClass::ResizeV2, mode),
+        };
+        let (manifest, _) = render_cell_job(&config, cell);
+        manifest
+            .pointer("/spec/template/spec/initContainers")?
+            .as_array()?
+            .iter()
+            .find(|entry| entry["name"] == LAUNCHER_CONTAINER_NAME)?["resources"]["limits"]
+            .get("cpu")
+            .cloned()
+    };
+
+    assert_eq!(
+        launcher_limits(ServerMode::Preparation),
+        None,
+        "leaf-v1 must render NO launcher CPU limit; PR #2840's ceiling is resize-v2 only and a \
+         blanket clamp would silently re-enable the nsdelegate ancestor clamp launcher.rs documents",
+    );
+    assert!(
+        launcher_limits(ServerMode::Activated).is_some(),
+        "resize-v2 must render a launcher CPU ceiling for resize to move",
+    );
+}
+
+// ===========================================================================
+// Hermetic half: the PATCH body and the millicore rule.
+// ===========================================================================
+
+/// **AC6, mutation 2.** The resize body touches exactly
+/// `spec.initContainers[cgroup-launcher].resources.limits.cpu` and nothing else.
+///
+/// Enumerated rather than spot-checked: a body that also set `requests`, a
+/// second field, a second init container or any `spec.containers` entry adds a
+/// key this walk reports.
+#[test]
+fn the_resize_body_addresses_exactly_one_field() {
+    let body = build_resize_patch(CpuLimit::from_millis(2_000));
+
+    let mut paths = Vec::new();
+    fn walk(value: &Value, prefix: &str, out: &mut Vec<String>) {
+        match value {
+            Value::Object(map) => {
+                for (key, child) in map {
+                    walk(child, &format!("{prefix}/{key}"), out);
+                }
+            }
+            Value::Array(items) => {
+                for (index, child) in items.iter().enumerate() {
+                    walk(child, &format!("{prefix}/{index}"), out);
+                }
+            }
+            leaf => out.push(format!("{prefix}={leaf}")),
+        }
+    }
+    walk(&body, "", &mut paths);
+    paths.sort();
+
+    assert_eq!(
+        paths,
+        vec![
+            format!("/spec/initContainers/0/name=\"{LAUNCHER_CONTAINER_NAME}\""),
+            "/spec/initContainers/0/resources/limits/cpu=\"2000m\"".to_owned(),
+        ],
+        "the resize body must carry the merge key and the one field it changes, and nothing else",
+    );
+}
+
+/// **AC8.** Every comparison is in parsed millicores.
+///
+/// The apiserver canonicalises `4000m` to `4`, and the repository's stock worker
+/// `cpu_limit` is the bare string `"4"`. Replace `CpuLimit::parse` with string
+/// equality and this goes red on the first pair.
+#[test]
+fn cpu_comparison_is_millicores_not_strings() {
+    let pairs = [
+        ("4", "4000m"),
+        ("2", "2000m"),
+        ("0.5", "500m"),
+        ("1", "1000m"),
+    ];
+    for (canonical, spelled) in pairs {
+        let left = CpuLimit::parse(canonical).expect("the apiserver form parses");
+        let right = CpuLimit::parse(spelled).expect("the millicore form parses");
+        assert_eq!(
+            left, right,
+            "{canonical} and {spelled} are the same quantity; a string comparison would report \
+             `never reported {spelled}; last observed Some({canonical})`",
+        );
+        assert_ne!(
+            canonical, spelled,
+            "the pair must differ AS STRINGS or this test proves nothing",
+        );
+    }
+
+    // And the stock config's limit really is the bare form, so the rule above is
+    // load bearing rather than hypothetical.
+    assert_eq!(
+        harness_config("x").cpu_limit,
+        "4",
+        "the harness renders the stock bare-string CPU limit on purpose",
+    );
+}
+
+// ===========================================================================
+// Hermetic half: the confirmation-site gate and the harness guards.
+// ===========================================================================
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .expect("the server crate lives one level below the repository root")
+        .to_path_buf()
+}
+
+fn this_file() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/task_run_resize_mixed_version.rs")
+}
+
+/// **AC7, source gate.** No helper in this suite reads the regular-container
+/// status list.
+///
+/// The forbidden token is ASSEMBLED at run time rather than written out, so this
+/// gate does not trip on itself. `initContainerStatuses` is not a match: the
+/// forbidden spelling has a lower-case `c` that `initContainerStatuses` does not
+/// contain at that position.
+#[test]
+fn no_helper_in_this_suite_reads_the_regular_container_status_list() {
+    let forbidden = [
+        format!("{}{}", "container", "Statuses"),
+        format!("{}_{}", "container", "statuses"),
+    ];
+    let body = std::fs::read_to_string(this_file()).expect("this test file is readable");
+    assert!(
+        body.contains("initContainerStatuses"),
+        "the suite must actually name the ONLY confirmation site, or this gate guards nothing",
+    );
+    for token in forbidden {
+        assert!(
+            !body.contains(&token),
+            "`{token}` appears in this suite. Confirmation for the native sidecar comes ONLY from \
+             status.initContainerStatuses[name={LAUNCHER_CONTAINER_NAME}]; the regular-container \
+             list can carry a matching, stale or misleading entry and reading it is the defect \
+             this gate exists to prevent",
+        );
+    }
+}
+
+/// **AC10, hermetic half.** The harness script exists, is disposable, refuses
+/// every sibling's target, pins its context, and cannot have its floor walked
+/// back to the measured-false 1.29.
+#[test]
+fn the_kind_harness_is_disposable_and_isolated() {
+    let script = repo_root().join("scripts/kind/setup-resize-matrix-cluster.sh");
+    let body = std::fs::read_to_string(&script)
+        .unwrap_or_else(|error| panic!("{} must exist: {error}", script.display()));
+
+    assert!(
+        body.contains(HARNESS_CLUSTER) && body.contains(HARNESS_REGISTRY),
+        "the script must create THIS harness's cluster and registry",
+    );
+    assert_eq!(
+        HARNESS_CONTEXT,
+        format!("kind-{HARNESS_CLUSTER}"),
+        "the context must be DERIVED from the cluster name, never discovered from the kubeconfig",
+    );
+
+    // Disjoint from every sibling harness, in both directions: the script must
+    // reserve their names, and must not have adopted one of them as its own.
+    for sibling in SIBLING_CLUSTERS {
+        assert!(
+            body.contains(sibling),
+            "the script no longer reserves sibling cluster `{sibling}`; a `down` aimed at it \
+             would destroy a concurrent run",
+        );
+        assert_ne!(
+            *sibling, HARNESS_CLUSTER,
+            "this harness has adopted a sibling's cluster name",
+        );
+    }
+    for port in SIBLING_REG_PORTS {
+        assert!(
+            body.contains(&port.to_string()),
+            "the script no longer reserves registry port {port}",
+        );
+        assert_ne!(
+            *port, HARNESS_REG_PORT,
+            "this harness has adopted a sibling's registry port",
+        );
+    }
+
+    // The teardown and its proof.
+    assert!(
+        body.contains("trap cleanup_on_failure EXIT"),
+        "the failure path must tear the cluster down; without the trap a failed `up` leaves a \
+         cluster behind and the host fills up",
+    );
+    assert!(
+        body.contains("survived teardown"),
+        "teardown must PROVE the cluster and registry are gone rather than assume it",
+    );
+    assert!(
+        body.contains("df -Pk /"),
+        "the script must check free disk before pulling a node image and three image classes",
+    );
+
+    // The floor. 1.29 was measured false and corrected in #2818.
+    assert!(
+        body.contains("EPIC_MIN_K8S_MINOR=30"),
+        "the epic's Kubernetes floor is 1.30",
+    );
+    assert!(
+        !body.contains("MIN_K8S_MINOR=29"),
+        "the 1.29 floor was measured false and corrected in #2818; it must not come back",
+    );
+    assert!(
+        body.contains("eks") || body.contains("EKS"),
+        "the script must say out loud why a non-kind server is refused",
+    );
+}
+
+/// **AC10.** `check` runs every guard and creates nothing, and a context this
+/// harness does not own is refused with a non-zero exit.
+#[test]
+fn the_kind_harness_refuses_a_target_it_does_not_own() {
+    let script = repo_root().join("scripts/kind/setup-resize-matrix-cluster.sh");
+    if !script.exists() {
+        panic!("{} must exist", script.display());
+    }
+
+    let run = |args: &[&str]| -> Output {
+        Command::new("bash")
+            .arg(&script)
+            .args(args)
+            .current_dir(repo_root())
+            .output()
+            .expect("the harness script is runnable")
+    };
+
+    let accepted = run(&["check"]);
+    assert!(
+        accepted.status.success(),
+        "`check` must pass on the harness's own names: {}",
+        String::from_utf8_lossy(&accepted.stderr),
+    );
+    let report = String::from_utf8_lossy(&accepted.stdout).into_owned();
+    assert!(
+        report.contains(&format!("cluster={HARNESS_CLUSTER}"))
+            && report.contains(&format!("context={HARNESS_CONTEXT}")),
+        "`check` reports the target it would create; got {report:?}",
+    );
+
+    // A sibling's cluster: refused, exit 3.
+    let refused = run(&["check", "--cluster-name", SIBLING_CLUSTERS[0]]);
+    assert_eq!(
+        refused.status.code(),
+        Some(3),
+        "a reserved cluster name must be refused with EXIT_REFUSED_TARGET; stderr: {}",
+        String::from_utf8_lossy(&refused.stderr),
+    );
+
+    // A context that is not the derived one: refused, exit 3.
+    let hijacked = run(&["check", "--context", "arn-aws-eks-eu-west-3"]);
+    assert_eq!(
+        hijacked.status.code(),
+        Some(3),
+        "a context this harness does not own must be refused",
+    );
+
+    // Below the floor: refused, exit 7.
+    let ancient = run(&["check", "--k8s-version", "1.29.0"]);
+    assert_eq!(
+        ancient.status.code(),
+        Some(7),
+        "1.29 is below the floor and must be refused with EXIT_VERSION_FLOOR",
+    );
+}
+
+/// **AC2, hermetic half.** The pins are immutable content addresses, never tags.
+#[test]
+fn the_image_pins_are_immutable() {
+    let pins = repo_root().join("tests/fixtures/resize-matrix/pins.env");
+    let body =
+        std::fs::read_to_string(&pins).unwrap_or_else(|error| panic!("read pins.env: {error}"));
+
+    let value = |key: &str| -> String {
+        body.lines()
+            .find_map(|line| line.strip_prefix(&format!("{key}=")))
+            .unwrap_or_else(|| panic!("pins.env must set {key}"))
+            .trim()
+            .to_owned()
+    };
+
+    let base = value("DJINN_RESIZE_MATRIX_BASE_DIGEST");
+    PreProtocolDigest::parse(&base).unwrap_or_else(|error| {
+        panic!("the base pin must be an immutable sha256: digest, got {error}")
+    });
+
+    let commit = value("DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT");
+    assert_eq!(
+        commit.len(),
+        40,
+        "the pre-protocol pin must be a full commit sha, not a branch or tag: {commit:?}",
+    );
+    assert!(
+        commit
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "the pre-protocol pin must be lower-case hex: {commit:?}",
+    );
+
+    // Three Dockerfiles, three classes, and none of them may pin a tag.
+    for class in ImageClass::ALL {
+        let dockerfile = repo_root().join(format!(
+            "tests/fixtures/resize-matrix/Dockerfile.{}",
+            class.as_str()
+        ));
+        let text = std::fs::read_to_string(&dockerfile)
+            .unwrap_or_else(|error| panic!("read {}: {error}", dockerfile.display()));
+        assert!(
+            text.contains("@${DJINN_RESIZE_MATRIX_BASE_DIGEST}"),
+            "{} must pin its base by digest, never by tag",
+            dockerfile.display(),
+        );
+    }
+}
+
+// ===========================================================================
+// The live half.
+// ===========================================================================
+
+const HARNESS_CLUSTER: &str = "djinn-resize-omp4";
+const HARNESS_CONTEXT: &str = "kind-djinn-resize-omp4";
+const HARNESS_REGISTRY: &str = "djinn-resize-omp4-registry";
+const HARNESS_REG_PORT: u16 = 5071;
+const NAMESPACE: &str = "djinn";
+const SENTINEL_DIR: &str = "/var/tmp/djinn-resize-matrix-sentinels";
+const SENTINEL_MOUNT: &str = "/sentinel";
+const WORKER_CONTAINER_NAME: &str = "worker";
+const PROBE_BIN: &str = "/opt/djinn/bin/djinn-governor-probe";
+const PROBE_WORKLOAD: &str = "/opt/djinn/workload.bin";
+const PROBE_DECISION_PATH: &str = "/var/tmp/djinn-probe/decision";
+const LAUNCHER_BIN_IN_IMAGE: &str = "/opt/djinn/bin/djinn-cgroup-launcher";
+const IMAGE_MANIFEST: &str = "server/target/resize-matrix/images.json";
+const BUILD_SCRIPT: &str = "tests/fixtures/resize-matrix/build.sh";
+
+/// Every other disposable harness in the repository. Named so the disjointness
+/// guard is a statement about them and not only about this script's defaults.
+const SIBLING_CLUSTERS: &[&str] = &[
+    "djinn-kueue-harness",
+    "djinn-kueue-b2b",
+    "djinn-kueue-c1",
+    "djinn-resize-harness",
+    "djinn-resize-pcod",
+];
+const SIBLING_REG_PORTS: &[u16] = &[5051, 5052, 5055, 5061, 5067];
+
+const TICK: Duration = Duration::from_millis(500);
+const AWAIT_TICKS: usize = 360;
+
+fn live_tests_enabled() -> bool {
+    if std::env::var("DJINN_TEST_RESIZE_MATRIX").as_deref() != Ok("1") {
+        eprintln!(
+            "SKIP: set DJINN_TEST_RESIZE_MATRIX=1 (and stand the harness up) to run the live matrix"
+        );
+        return false;
+    }
+    for tool in ["kubectl", "kind", "docker"] {
+        if Command::new(tool)
+            .arg("--help")
+            .output()
+            .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+        {
+            panic!("DJINN_TEST_RESIZE_MATRIX=1 but {tool} is not on PATH");
+        }
+    }
+    true
+}
+
+/// Refuse anything that is not this harness's local kind cluster.
+///
+/// Guard 1 is the NAME, checked by construction: the constant is the only
+/// context this file ever passes to `kubectl`. Guard 2 is where that name
+/// resolves to, which is what catches a kubeconfig entry called
+/// `kind-djinn-resize-omp4` aimed at EKS.
+fn harness_context() -> &'static str {
+    let output = Command::new("kubectl")
+        .args([
+            "--context",
+            HARNESS_CONTEXT,
+            "config",
+            "view",
+            "--minify",
+            "-o",
+            "jsonpath={.clusters[0].cluster.server}",
+        ])
+        .output()
+        .expect("kubectl is on PATH");
+    let server = String::from_utf8_lossy(&output.stdout).into_owned();
+    assert!(
+        is_local_apiserver(server.trim()),
+        "refusing to run against {HARNESS_CONTEXT}: its API server is {server:?}, not a local \
+         kind cluster. Every context in a Djinn developer's kubeconfig is a live EKS cluster.",
+    );
+    HARNESS_CONTEXT
+}
+
+/// Host-anchored: `https://127.0.0.1.evil.example` starts with the loopback
+/// address and is a remote host.
+fn is_local_apiserver(url: &str) -> bool {
+    let Some(rest) = url.strip_prefix("https://") else {
+        return false;
+    };
+    let host = rest.split('/').next().unwrap_or_default();
+    let host = host.rsplit_once(':').map_or(host, |(head, _)| head);
+    matches!(host, "127.0.0.1" | "localhost" | "[::1]")
+}
+
+/// **AC10, hermetic.** The refusal predicate, exercised without a cluster so it
+/// cannot rot unnoticed.
+#[test]
+fn a_non_kind_apiserver_is_refused() {
+    for hostile in [
+        "https://ABCDEF.gr7.eu-west-3.eks.amazonaws.com",
+        "https://kubernetes.default.svc",
+        "https://10.0.0.1:6443",
+        "https://127.0.0.1.evil.example:6443",
+        "http://127.0.0.1:6443",
+    ] {
+        assert!(
+            !is_local_apiserver(hostile),
+            "{hostile} must be refused: it is not a local kind API server",
+        );
+    }
+    for benign in [
+        "https://127.0.0.1:6443",
+        "https://localhost:41234",
+        "https://[::1]:6443",
+    ] {
+        assert!(
+            is_local_apiserver(benign),
+            "{benign} is a local kind server"
+        );
+    }
+}
+
+fn kubectl(args: &[&str]) -> Output {
+    Command::new("kubectl")
+        .arg("--context")
+        .arg(HARNESS_CONTEXT)
+        .args(args)
+        .output()
+        .expect("kubectl is on PATH")
+}
+
+fn kubectl_ok(args: &[&str]) -> String {
+    let output = kubectl(args);
+    assert!(
+        output.status.success(),
+        "kubectl {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn kubectl_json(args: &[&str]) -> Value {
+    let mut full = args.to_vec();
+    full.extend(["-o", "json"]);
+    serde_json::from_str(&kubectl_ok(&full)).expect("kubectl -o json emits JSON")
+}
+
+/// The three built images and their immutable digests.
+struct BuiltImages {
+    manifest: Value,
+}
+
+impl BuiltImages {
+    /// Build (or reuse) the three classes and load them onto the harness node.
+    fn ensure() -> Self {
+        let built = Command::new("bash")
+            .arg(repo_root().join(BUILD_SCRIPT))
+            .arg(HARNESS_CLUSTER)
+            .current_dir(repo_root())
+            .output()
+            .expect("the image build script is runnable");
+        assert!(
+            built.status.success(),
+            "building the three image classes failed:\n{}\n{}",
+            String::from_utf8_lossy(&built.stdout),
+            String::from_utf8_lossy(&built.stderr),
+        );
+        let text = std::fs::read_to_string(repo_root().join(IMAGE_MANIFEST))
+            .expect("the build script writes the image manifest");
+        Self {
+            manifest: serde_json::from_str(&text).expect("the image manifest is JSON"),
+        }
+    }
+
+    fn tag(&self, class: ImageClass) -> String {
+        self.manifest["classes"][class.as_str()]["tag"]
+            .as_str()
+            .unwrap_or_else(|| panic!("the manifest names a tag for {}", class.as_str()))
+            .to_owned()
+    }
+
+    fn digest(&self, class: ImageClass) -> String {
+        self.manifest["classes"][class.as_str()]["digest"]
+            .as_str()
+            .unwrap_or_else(|| panic!("the manifest names a digest for {}", class.as_str()))
+            .to_owned()
+    }
+}
+
+/// How many times `needle` occurs in the launcher binary INSIDE `image`.
+fn wire_string_occurrences(image: &str, needle: &str) -> usize {
+    let output = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/sh",
+            image,
+            "-c",
+            &format!("grep -ac -- '{needle}' {LAUNCHER_BIN_IN_IMAGE} || true"),
+        ])
+        .output()
+        .expect("docker is on PATH");
+    assert!(
+        output.status.success(),
+        "scanning {image} for {needle} failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}
+
+/// **AC2.** The legacy image's launcher binary genuinely predates the protocol,
+/// proven by scanning the ARTIFACT rather than by reading its configuration.
+///
+/// The two declaring classes are the counter-proof and are asserted in the same
+/// test on purpose: without them, "the legacy binary contains neither string"
+/// would also pass against an empty file, a stripped binary or a scan that never
+/// matched anything.
+#[test]
+#[ignore = "requires docker and tests/fixtures/resize-matrix/build.sh"]
+fn legacy_image_binary_predates_the_protocol() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let images = BuiltImages::ensure();
+
+    let legacy = images.tag(ImageClass::LegacyNoHandshake);
+    assert_eq!(
+        wire_string_occurrences(&legacy, LEAF_V1_WIRE),
+        0,
+        "the legacy launcher binary carries `{LEAF_V1_WIRE}`. It was built from a modern \
+         agent-runtime with the environment withheld, which is a launcher that COULD handshake \
+         and chose not to — not a launcher that predates the handshake.",
+    );
+    assert_eq!(
+        wire_string_occurrences(&legacy, RESIZE_V2_WIRE),
+        0,
+        "the legacy launcher binary carries `{RESIZE_V2_WIRE}`; see above",
+    );
+
+    for declaring in [ImageClass::LeafV1, ImageClass::ResizeV2] {
+        let tag = images.tag(declaring);
+        assert!(
+            wire_string_occurrences(&tag, LEAF_V1_WIRE) > 0
+                && wire_string_occurrences(&tag, RESIZE_V2_WIRE) > 0,
+            "the {} image's launcher must carry BOTH wire strings, or the legacy assertion above \
+             is not a discriminator",
+            declaring.as_str(),
+        );
+    }
+
+    // Three classes, three artifacts.
+    let digests: BTreeSet<String> = ImageClass::ALL
+        .iter()
+        .map(|class| images.digest(*class))
+        .collect();
+    assert_eq!(
+        digests.len(),
+        ImageClass::ALL.len(),
+        "two image classes share a digest; they are config variants of one image, not classes",
+    );
+    for class in ImageClass::ALL {
+        PreProtocolDigest::parse(&images.digest(class))
+            .expect("every built class has an immutable sha256 content address");
+    }
+
+    // The artifact's own claim must agree with the class it is dispatched as.
+    for class in [ImageClass::LeafV1, ImageClass::ResizeV2] {
+        let baked = docker_read_file(&images.tag(class), "/opt/djinn/authority");
+        assert_eq!(
+            baked.trim(),
+            class.declared_wire().expect("a declaring class declares"),
+            "the {} artifact's baked declaration disagrees with the class it is registered as",
+            class.as_str(),
+        );
+    }
+    assert!(
+        docker_file_absent(
+            &images.tag(ImageClass::LegacyNoHandshake),
+            "/opt/djinn/authority"
+        ),
+        "the legacy artifact must make NO declaration",
+    );
+}
+
+fn docker_read_file(image: &str, path: &str) -> String {
+    let output = Command::new("docker")
+        .args(["run", "--rm", "--entrypoint", "/bin/cat", image, path])
+        .output()
+        .expect("docker is on PATH");
+    assert!(
+        output.status.success(),
+        "reading {path} from {image} failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn docker_file_absent(image: &str, path: &str) -> bool {
+    let output = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/sh",
+            image,
+            "-c",
+            &format!("test -e {path}"),
+        ])
+        .output()
+        .expect("docker is on PATH");
+    !output.status.success()
+}
+
+// ---------------------------------------------------------------------------
+// Live cells.
+// ---------------------------------------------------------------------------
+
+/// One dispatched cell on the live cluster.
+struct LiveCell {
+    cell: Cell,
+    task_run_id: String,
+    job_name: String,
+    invocation: String,
+    pod: String,
+    pod_uid: String,
+}
+
+fn sentinel_name(cell: Cell, task_run_id: &str) -> String {
+    format!("{}-{}", cell.name(), task_run_id)
+}
+
+/// Attach the AC4 sentinel and the probe to a rendered manifest.
+///
+/// Exactly two mutations, both declared: the worker's `command` becomes a shell
+/// that creates the sentinel and then execs the probe, and a hostPath volume is
+/// added for the sentinel to land in. Everything that decides the behaviour
+/// under test — `runtimeClassName`, `shareProcessNamespace`, both security
+/// contexts, the sidecar's command, env, capabilities, resources and the
+/// presence or absence of its CPU limit — stays as the production renderer
+/// emitted it.
+fn attach_probe_and_sentinel(manifest: &mut Value, cell: Cell, task_run_id: &str) -> String {
+    let invocation = format!("matrix-{task_run_id}");
+    let sentinel = sentinel_name(cell, task_run_id);
+
+    let volumes = manifest
+        .pointer_mut("/spec/template/spec/volumes")
+        .and_then(Value::as_array_mut)
+        .expect("the renderer emits volumes");
+    volumes.push(json!({
+        "name": "matrix-sentinel",
+        "hostPath": { "path": SENTINEL_DIR, "type": "Directory" },
+    }));
+
+    let containers = manifest
+        .pointer_mut("/spec/template/spec/containers")
+        .and_then(Value::as_array_mut)
+        .expect("the rendered Job has containers");
+    let worker = containers
+        .iter_mut()
+        .find(|container| container["name"] == WORKER_CONTAINER_NAME)
+        .expect("the rendered Job has a worker container");
+
+    // The sentinel is created by a REAL shell in the Pod, and only then is the
+    // probe exec'd. A cell that is refused before dispatch never reaches this
+    // command, and the sentinel's absence is the observable proof of that.
+    worker["command"] = json!([
+        "/bin/sh",
+        "-c",
+        format!("touch {SENTINEL_MOUNT}/{sentinel} && exec {PROBE_BIN}"),
+    ]);
+    worker["args"] = Value::Null;
+    worker["volumeMounts"]
+        .as_array_mut()
+        .expect("the renderer emits worker volume mounts")
+        .push(json!({ "name": "matrix-sentinel", "mountPath": SENTINEL_MOUNT }));
+
+    let env = worker["env"]
+        .as_array_mut()
+        .expect("the renderer sets worker env");
+    for (name, value) in [
+        ("DJINN_PROBE_INVOCATION", invocation.clone()),
+        ("DJINN_PROBE_FENCE", "1".to_owned()),
+        ("DJINN_PROBE_AUTHORITY", "armed".to_owned()),
+        ("DJINN_PROBE_DECISION_PATH", PROBE_DECISION_PATH.to_owned()),
+        ("DJINN_PROBE_WORKLOAD", PROBE_WORKLOAD.to_owned()),
+        ("DJINN_PROBE_CLAMP_SECONDS", "2".to_owned()),
+        ("DJINN_PROBE_LIFTED_SECONDS", "2".to_owned()),
+    ] {
+        env.push(json!({ "name": name, "value": value }));
+    }
+    invocation
+}
+
+fn apply_manifest(manifest: &Value) {
+    use std::io::Write as _;
+    let text = serde_json::to_string(manifest).expect("the manifest serializes");
+    let applied = Command::new("kubectl")
+        .args([
+            "--context",
+            HARNESS_CONTEXT,
+            "-n",
+            NAMESPACE,
+            "apply",
+            "-f",
+            "-",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin is piped")
+                .write_all(text.as_bytes())?;
+            child.wait_with_output()
+        })
+        .expect("kubectl apply runs");
+    assert!(
+        applied.status.success(),
+        "applying the rendered Job failed: {}",
+        String::from_utf8_lossy(&applied.stderr),
+    );
+}
+
+fn pods_of(task_run_id: &str) -> Vec<(String, String, String)> {
+    kubectl_json(&[
+        "-n",
+        NAMESPACE,
+        "get",
+        "pods",
+        "-l",
+        &format!("{LABEL_TASK_RUN_ID}={task_run_id}"),
+    ])["items"]
+        .as_array()
+        .expect("a List has items")
+        .iter()
+        .map(|item| {
+            (
+                item["metadata"]["name"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+                item["metadata"]["uid"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+                item["status"]["phase"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+            )
+        })
+        .collect()
+}
+
+fn await_running_pod(task_run_id: &str) -> (String, String) {
+    for _ in 0..AWAIT_TICKS {
+        if let Some((name, uid, _)) = pods_of(task_run_id)
+            .into_iter()
+            .find(|(_, _, phase)| phase == "Running")
+        {
+            return (name, uid);
+        }
+        std::thread::sleep(TICK);
+    }
+    panic!(
+        "no Pod of task-run {task_run_id} reached Running. Pods: {:?}",
+        pods_of(task_run_id),
+    );
+}
+
+fn probe_log(pod: &str) -> String {
+    String::from_utf8_lossy(
+        &kubectl(&["-n", NAMESPACE, "logs", pod, "-c", WORKER_CONTAINER_NAME]).stdout,
+    )
+    .into_owned()
+}
+
+fn await_probe_record(pod: &str, record: &str) -> String {
+    for _ in 0..AWAIT_TICKS {
+        let log = probe_log(pod);
+        if log.contains(&format!("probe.{record}")) {
+            return log;
+        }
+        if let Some(line) = log.lines().find(|line| line.starts_with("probe.fatal")) {
+            panic!("the probe in {pod} failed: {line}");
+        }
+        std::thread::sleep(TICK);
+    }
+    panic!(
+        "the probe in {pod} never emitted probe.{record}. Log:\n{}",
+        probe_log(pod),
+    );
+}
+
+/// The invocation leaf's `cpu.max`, read from INSIDE the Pod out of the
+/// launcher's own delegated cgroup root.
+///
+/// The kernel's value, read through the same `/sys/fs/cgroup` the launcher
+/// writes — never a value this test wrote and never one the probe reported. The
+/// leaf directory is mode 0700 and root-owned, hence the launcher container
+/// (uid 0) rather than the worker (uid 1000).
+fn leaf_cpu_max(pod: &str, invocation: &str) -> String {
+    let path = format!("/sys/fs/cgroup/{invocation}/cpu.max");
+    let output = kubectl(&[
+        "-n",
+        NAMESPACE,
+        "exec",
+        pod,
+        "-c",
+        LAUNCHER_CONTAINER_NAME,
+        "--",
+        "cat",
+        &path,
+    ]);
+    assert!(
+        output.status.success(),
+        "reading {path} in {pod} failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_owned()
+}
+
+/// The launcher's CPU limit as the kubelet has ACTUATED it, from the ONLY
+/// confirmation site: `status.initContainerStatuses[name=cgroup-launcher]`.
+fn actuated_launcher_cpu(pod_json: &Value) -> Option<CpuLimit> {
+    let raw = pod_json["status"]["initContainerStatuses"]
+        .as_array()?
+        .iter()
+        .find(|entry| entry["name"] == LAUNCHER_CONTAINER_NAME)?["resources"]["limits"]["cpu"]
+        .as_str()?
+        .to_owned();
+    CpuLimit::parse(&raw).ok()
+}
+
+/// Whether a `pods/resize` PATCH has ever landed on this Pod.
+///
+/// Read out of `metadata.managedFields`, which the apiserver writes itself: an
+/// entry whose `subresource` is `resize` exists if and only if somebody patched
+/// that subresource. It is the apiserver's record of the PATCH, not this test's.
+fn resize_patches_recorded(pod_json: &Value) -> usize {
+    pod_json["metadata"]["managedFields"]
+        .as_array()
+        .map(|entries| {
+            entries
+                .iter()
+                .filter(|entry| entry["subresource"] == "resize")
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn pod_json(pod: &str) -> Value {
+    kubectl_json(&["-n", NAMESPACE, "get", "pod", pod])
+}
+
+fn sentinel_exists(name: &str) -> bool {
+    let nodes = String::from_utf8_lossy(
+        &Command::new("kind")
+            .args(["get", "nodes", "--name", HARNESS_CLUSTER])
+            .output()
+            .expect("kind is on PATH")
+            .stdout,
+    )
+    .into_owned();
+    nodes.split_whitespace().any(|node| {
+        Command::new("docker")
+            .args([
+                "exec",
+                node,
+                "test",
+                "-e",
+                &format!("{SENTINEL_DIR}/{name}"),
+            ])
+            .output()
+            .expect("docker is on PATH")
+            .status
+            .success()
+    })
+}
+
+fn delete_cell(live: &LiveCell) {
+    eprintln!("--- tearing down cell {} ---", live.cell.name());
+    let _ = kubectl(&[
+        "-n",
+        NAMESPACE,
+        "delete",
+        "job",
+        &live.job_name,
+        "--ignore-not-found",
+        "--wait=false",
+    ]);
+}
+
+/// Dispatch one admitted cell and wait until its invocation leaf exists.
+fn dispatch(images: &BuiltImages, cell: Cell) -> LiveCell {
+    dispatch_as(images, cell, uuid::Uuid::now_v7().to_string())
+}
+
+fn dispatch_as(images: &BuiltImages, cell: Cell, task_run_id: String) -> LiveCell {
+    let config = harness_config(&images.tag(cell.image));
+    let (mut manifest, task_run_id) = render_cell_job_as(&config, cell, task_run_id);
+    let invocation = attach_probe_and_sentinel(&mut manifest, cell, &task_run_id);
+    let job_name = manifest["metadata"]["name"]
+        .as_str()
+        .expect("the renderer names the Job")
+        .to_owned();
+
+    apply_manifest(&manifest);
+    let (pod, pod_uid) = await_running_pod(&task_run_id);
+    await_probe_record(&pod, "awaiting_decision");
+
+    LiveCell {
+        cell,
+        task_run_id,
+        job_name,
+        invocation,
+        pod,
+        pod_uid,
+    }
+}
+
+/// **AC3 + AC4.** The whole matrix, live: exactly one quota authority per
+/// admitted Pod, and no shell at all for the refused cells.
+///
+/// One test rather than twelve so the twelve cells share one cluster and one set
+/// of images, and so the refused cells can be asserted against the SAME sentinel
+/// directory the admitted ones write into. A refused cell whose sentinel
+/// mechanism was silently broken would otherwise pass forever.
+#[test]
+#[ignore = "requires scripts/kind/setup-resize-matrix-cluster.sh up"]
+fn the_live_matrix_has_exactly_one_quota_authority_per_admitted_pod() {
+    if !live_tests_enabled() {
+        return;
+    }
+    harness_context();
+    let images = BuiltImages::ensure();
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("a tokio runtime");
+    let db = runtime
+        .block_on(Database::ephemeral())
+        .expect("a real test database");
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    let inventory = signed_inventory(&[&images.digest(ImageClass::LegacyNoHandshake)]);
+
+    let mut leaf_cells = 0_usize;
+    let mut resize_cells = 0_usize;
+    let mut refused_cells = 0_usize;
+
+    for cell in matrix() {
+        eprintln!("=== cell {} ===", cell.name());
+
+        // 1. The admission decision, from the production pair against real
+        //    PostgreSQL. `Old` has no seam; see the module docs.
+        let decision = match cell.mode.authority() {
+            None => Ok(AdmissionDecision::Admitted(
+                LauncherAuthorityProtocol::LeafV1,
+            )),
+            Some(authority) => {
+                runtime.block_on(force_mode(&modes, authority));
+                runtime.block_on(admit(
+                    &modes,
+                    cell.image,
+                    Some(&images.digest(cell.image)),
+                    &inventory,
+                ))
+            }
+        };
+
+        match cell.expected {
+            Outcome::RefusedBeforeDispatch => {
+                refused_cells += 1;
+                let rejection = decision.expect_err(&format!(
+                    "cell {} must be refused at admission",
+                    cell.name(),
+                ));
+
+                // Nothing was dispatched, so nothing may exist. A synthetic
+                // task-run id stands in for the one that would have been minted.
+                let would_have_been = uuid::Uuid::now_v7().to_string();
+                let sentinel = sentinel_name(cell, &would_have_been);
+                assert!(
+                    !sentinel_exists(&sentinel),
+                    "cell {} was refused ({rejection}) yet its sentinel exists: a shell ran \
+                     before the refusal took effect",
+                    cell.name(),
+                );
+                assert!(
+                    pods_of(&would_have_been).is_empty(),
+                    "cell {} was refused yet a Pod exists",
+                    cell.name(),
+                );
+                continue;
+            }
+            Outcome::Admitted(_) => {}
+        }
+
+        let admitted = decision
+            .unwrap_or_else(|error| panic!("cell {} must be admitted, got {error}", cell.name()));
+        assert!(
+            matches!(admitted, AdmissionDecision::Admitted(_)),
+            "cell {} must resolve an authority, got {admitted:?}",
+            cell.name(),
+        );
+
+        // 2. Dispatch it for real.
+        let live = dispatch(&images, cell);
+
+        // 3. The sentinel is the CONTROL for every refused cell above: it proves
+        //    the mechanism whose absence they rely on actually works.
+        assert!(
+            sentinel_exists(&sentinel_name(cell, &live.task_run_id)),
+            "cell {} was admitted and its shell must have run; the sentinel is missing, so \
+             every 'the sentinel is absent' assertion in this run is vacuous",
+            cell.name(),
+        );
+
+        // 4. Observed effect, never a stored column.
+        let leaf = leaf_cpu_max(&live.pod, &live.invocation);
+        let observed = pod_json(&live.pod);
+        assert_eq!(
+            observed["metadata"]["uid"].as_str(),
+            Some(live.pod_uid.as_str()),
+            "the Pod UID moved under us",
+        );
+        let patches = resize_patches_recorded(&observed);
+        let actuated = actuated_launcher_cpu(&observed);
+
+        match cell.expected {
+            Outcome::Admitted(Authority::Leaf) => {
+                leaf_cells += 1;
+                assert_ne!(
+                    leaf,
+                    "max",
+                    "cell {}: LEAF authority means the launcher wrote a numeric quota into the \
+                     invocation leaf; cpu.max reads {leaf:?}, so NOBODY wrote one",
+                    cell.name(),
+                );
+                assert_eq!(
+                    patches,
+                    0,
+                    "cell {}: a pods/resize PATCH landed on Pod {} alongside the launcher's leaf \
+                     quota. That is TWO authorities on one Pod.",
+                    cell.name(),
+                    live.pod_uid,
+                );
+                assert_eq!(
+                    actuated,
+                    None,
+                    "cell {}: the launcher carries an actuated CPU limit under leaf authority; \
+                     leaf-v1 renders none on purpose and only a resize introduces one",
+                    cell.name(),
+                );
+            }
+            Outcome::Admitted(Authority::Resize) => {
+                resize_cells += 1;
+                let before = actuated.unwrap_or_else(|| {
+                    panic!(
+                        "cell {}: resize-v2 must render a ceiling the kubelet actuates",
+                        cell.name(),
+                    )
+                });
+                assert_eq!(
+                    leaf,
+                    "max",
+                    "cell {}: RESIZE authority means the launcher wrote NOTHING into the leaf, \
+                     not even `max` as a rewrite; cpu.max reads {leaf:?}",
+                    cell.name(),
+                );
+                assert_eq!(
+                    patches,
+                    0,
+                    "cell {}: a resize PATCH landed before this test issued one",
+                    cell.name(),
+                );
+
+                // Move it, through the production body and strategic-merge
+                // semantics, and confirm from the init-container status only.
+                let target = CpuLimit::from_millis(before.millis() / 2);
+                issue_resize(&live.pod, target);
+                let after = await_actuated(&live.pod, target);
+                assert_eq!(
+                    after,
+                    target,
+                    "cell {}: the limit did not move",
+                    cell.name()
+                );
+
+                let resized = pod_json(&live.pod);
+                assert!(
+                    resize_patches_recorded(&resized) >= 1,
+                    "cell {}: the apiserver recorded no pods/resize PATCH, so the resize \
+                     authority never acted",
+                    cell.name(),
+                );
+                assert_eq!(
+                    leaf_cpu_max(&live.pod, &live.invocation),
+                    "max",
+                    "cell {}: the launcher wrote leaf quota AFTER the resize; that is a second \
+                     authority on the same Pod",
+                    cell.name(),
+                );
+            }
+            Outcome::RefusedBeforeDispatch => unreachable!("handled above"),
+        }
+
+        delete_cell(&live);
+    }
+
+    assert!(
+        leaf_cells > 0 && resize_cells > 0 && refused_cells > 0,
+        "the live matrix must have exercised all three outcomes; \
+         leaf={leaf_cells} resize={resize_cells} refused={refused_cells}",
+    );
+}
+
+/// Apply the production resize body with strategic-merge semantics against the
+/// `resize` subresource.
+fn issue_resize(pod: &str, target: CpuLimit) {
+    let body = build_resize_patch(target);
+    let text = serde_json::to_string(&body).expect("the resize body serializes");
+    let output = kubectl(&[
+        "-n",
+        NAMESPACE,
+        "patch",
+        "pod",
+        pod,
+        "--subresource",
+        "resize",
+        "--type",
+        "strategic",
+        "--patch",
+        &text,
+    ]);
+    assert!(
+        output.status.success(),
+        "the strategic resize PATCH failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn await_actuated(pod: &str, target: CpuLimit) -> CpuLimit {
+    for _ in 0..AWAIT_TICKS {
+        let observed = pod_json(pod);
+        if let Some(limit) = actuated_launcher_cpu(&observed)
+            && limit == target
+        {
+            return limit;
+        }
+        std::thread::sleep(TICK);
+    }
+    panic!(
+        "the launcher's limit never reached {target} in status.initContainerStatuses. Pod: {}",
+        pod_json(pod)["status"],
+    );
+}
+
+/// **AC6.** The strategic PATCH changes exactly the launcher's CPU limit; an RFC
+/// 7386 merge body against the same subresource is REFUSED by the apiserver.
+///
+/// Both halves are live. The first is the property; the second is the named
+/// mutation, and it is the measured behaviour the epic recorded:
+/// `spec.initContainers[0].resources.limits: Forbidden: resource limits cannot
+/// be removed`, because a merge patch replaces the whole array.
+#[test]
+#[ignore = "requires scripts/kind/setup-resize-matrix-cluster.sh up"]
+fn a_strategic_resize_leaves_every_other_container_byte_identical() {
+    if !live_tests_enabled() {
+        return;
+    }
+    harness_context();
+    let images = BuiltImages::ensure();
+    let cell = Cell {
+        image: ImageClass::ResizeV2,
+        mode: ServerMode::Activated,
+        expected: expectation(ImageClass::ResizeV2, ServerMode::Activated),
+    };
+    let live = dispatch(&images, cell);
+
+    let before = pod_json(&live.pod);
+    let before_spec = before["spec"].clone();
+    let ceiling = actuated_launcher_cpu(&before).expect("resize-v2 renders an actuated ceiling");
+    let target = CpuLimit::from_millis(ceiling.millis() / 2);
+
+    // The named mutation, run FIRST so a cluster that accepted it could not be
+    // mistaken for one where the strategic path merely happened to work.
+    let merged = kubectl(&[
+        "-n",
+        NAMESPACE,
+        "patch",
+        "pod",
+        &live.pod,
+        "--subresource",
+        "resize",
+        "--type",
+        "merge",
+        "--patch",
+        &serde_json::to_string(&build_resize_patch(target)).expect("body serializes"),
+    ]);
+    assert!(
+        !merged.status.success(),
+        "an RFC 7386 merge body against pods/resize must be REFUSED: it replaces the whole \
+         initContainers array, whose patchMergeKey is `name`. The apiserver accepted it, which \
+         means the other init containers were silently destroyed.",
+    );
+
+    issue_resize(&live.pod, target);
+    await_actuated(&live.pod, target);
+    let after = pod_json(&live.pod);
+
+    // Every other init container and every regular container, byte identical.
+    let strip = |spec: &Value, list: &str| -> Vec<Value> {
+        spec[list]
+            .as_array()
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter(|entry| entry["name"] != LAUNCHER_CONTAINER_NAME)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    for list in ["initContainers", "containers"] {
+        assert_eq!(
+            strip(&before_spec, list),
+            strip(&after["spec"], list),
+            "the resize changed {list} other than the launcher entry",
+        );
+    }
+
+    // And the launcher entry itself changed in exactly one place.
+    let launcher_of = |spec: &Value| -> Value {
+        spec["initContainers"]
+            .as_array()
+            .expect("initContainers")
+            .iter()
+            .find(|entry| entry["name"] == LAUNCHER_CONTAINER_NAME)
+            .expect("the launcher survives the resize")
+            .clone()
+    };
+    let mut before_launcher = launcher_of(&before_spec);
+    let mut after_launcher = launcher_of(&after["spec"]);
+    assert_ne!(
+        before_launcher["resources"]["limits"]["cpu"], after_launcher["resources"]["limits"]["cpu"],
+        "the resize must have moved the launcher's CPU limit",
+    );
+    before_launcher["resources"]["limits"]["cpu"] = Value::Null;
+    after_launcher["resources"]["limits"]["cpu"] = Value::Null;
+    assert_eq!(
+        before_launcher, after_launcher,
+        "the resize touched a second field on the launcher container",
+    );
+
+    delete_cell(&live);
+}
+
+/// **AC8, live.** The apiserver canonicalises `4000m` to `4`, and a millicore
+/// comparison treats them as equal where a string comparison would not.
+#[test]
+#[ignore = "requires scripts/kind/setup-resize-matrix-cluster.sh up"]
+fn the_apiserver_canonicalises_a_ceiling_and_millicores_still_match() {
+    if !live_tests_enabled() {
+        return;
+    }
+    harness_context();
+    let images = BuiltImages::ensure();
+    let cell = Cell {
+        image: ImageClass::ResizeV2,
+        mode: ServerMode::Activated,
+        expected: expectation(ImageClass::ResizeV2, ServerMode::Activated),
+    };
+    let live = dispatch(&images, cell);
+
+    // Ask for exactly four cores, spelled in millicores.
+    let target = CpuLimit::from_millis(4_000);
+    issue_resize(&live.pod, target);
+    let confirmed = await_actuated(&live.pod, target);
+    assert_eq!(confirmed, target);
+
+    // The stored spelling is the apiserver's, not ours.
+    let stored = pod_json(&live.pod)["status"]["initContainerStatuses"]
+        .as_array()
+        .expect("initContainerStatuses")
+        .iter()
+        .find(|entry| entry["name"] == LAUNCHER_CONTAINER_NAME)
+        .expect("the launcher has a status")["resources"]["limits"]["cpu"]
+        .as_str()
+        .expect("an actuated limit")
+        .to_owned();
+    assert_eq!(
+        stored, "4",
+        "the apiserver is expected to canonicalise 4000m to 4; if this changed, the millicore \
+         rule is still right but this cell no longer demonstrates why",
+    );
+    assert_ne!(
+        stored,
+        target.as_quantity(),
+        "the two spellings must DIFFER as strings or this cell proves nothing",
+    );
+    assert_eq!(
+        CpuLimit::parse(&stored).expect("the stored form parses"),
+        target,
+        "parsed millicores must compare equal; `Quantity` string equality reports \
+         `never reported 4000m; last observed Some(4)`",
+    );
+
+    delete_cell(&live);
+}
+
+/// **AC7, live.** A Pod carrying a MISLEADING, perfectly matching
+/// regular-container status and NO init-container status must be treated as
+/// unconfirmed.
+///
+/// The shape is the pre-sidecar render: `cgroup-launcher` as an ordinary
+/// container. Kubernetes forbids the same name in both lists, so this — not a
+/// duplicate — is the way a misleading match reaches the apiserver, and it is
+/// exactly the shape a rollback to a pre-1.29 render would produce.
+#[test]
+#[ignore = "requires scripts/kind/setup-resize-matrix-cluster.sh up"]
+fn a_misleading_regular_container_status_is_not_confirmation() {
+    if !live_tests_enabled() {
+        return;
+    }
+    harness_context();
+    let images = BuiltImages::ensure();
+    let tag = images.tag(ImageClass::LeafV1);
+    let name = format!("matrix-misleading-{}", uuid::Uuid::now_v7());
+
+    let target = CpuLimit::from_millis(500);
+    let pod = json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": { "name": name, "namespace": NAMESPACE },
+        "spec": {
+            "restartPolicy": "Never",
+            "containers": [{
+                // The MISLEADING entry: right name, right limit, wrong list.
+                "name": LAUNCHER_CONTAINER_NAME,
+                "image": tag,
+                "command": ["/bin/sh", "-c", "sleep 600"],
+                "resources": { "limits": { "cpu": target.as_quantity(), "memory": "128Mi" },
+                               "requests": { "cpu": "50m", "memory": "64Mi" } },
+            }],
+        }
+    });
+    apply_manifest(&pod);
+
+    let mut observed = Value::Null;
+    for _ in 0..AWAIT_TICKS {
+        observed = pod_json(&name);
+        if observed["status"]["phase"] == "Running" {
+            break;
+        }
+        std::thread::sleep(TICK);
+    }
+    assert_eq!(
+        observed["status"]["phase"], "Running",
+        "the misleading Pod must actually run, or its status lists are both empty and the \
+         assertion below is vacuous",
+    );
+
+    // The misleading entry really is there and really does match: without this
+    // the test would pass against a Pod that simply had no statuses at all.
+    let misleading = observed["status"][format!("{}{}", "container", "Statuses").as_str()]
+        .as_array()
+        .expect("the regular container has a status")
+        .iter()
+        .find(|entry| entry["name"] == LAUNCHER_CONTAINER_NAME)
+        .expect("the misleading entry exists")["resources"]["limits"]["cpu"]
+        .as_str()
+        .map(|raw| CpuLimit::parse(raw).expect("the misleading limit parses"));
+    assert_eq!(
+        misleading,
+        Some(target),
+        "the misleading entry must MATCH the target; a reader that fell back to it would call \
+         this Pod confirmed",
+    );
+
+    // The only confirmation site says nothing.
+    assert_eq!(
+        actuated_launcher_cpu(&observed),
+        None,
+        "there is no init-container status for {LAUNCHER_CONTAINER_NAME}, so this Pod is \
+         UNCONFIRMED. Changing the lookup to the regular-container list turns this green.",
+    );
+
+    let _ = kubectl(&[
+        "-n",
+        NAMESPACE,
+        "delete",
+        "pod",
+        &name,
+        "--ignore-not-found",
+        "--wait=false",
+    ]);
+}
+
+// ===========================================================================
+// AC9: the flips are fenced, against real PostgreSQL and real cluster state.
+// ===========================================================================
+
+/// **AC9, durable half.** Activation refuses to proceed while a live task-run
+/// permit exists, and rollback refuses until every nonterminal resize row is
+/// gone.
+///
+/// Real PostgreSQL, real repositories, no `Fake`. The permit is created through
+/// `BuildPodPermitRepository::acquire` — the production admission call — so the
+/// row the fence counts is the row dispatch actually writes.
+#[tokio::test]
+async fn neither_flip_proceeds_with_a_live_permit_row() {
+    let db = Database::ephemeral().await.expect("a real test database");
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    let permits = BuildPodPermitRepository::new(db.clone());
+
+    force_mode(&modes, LauncherAuthorityProtocol::LeafV1).await;
+    let drained = modes.drain_census().await.expect("read the drain census");
+    assert!(
+        drained.is_drained(),
+        "the fixture must start drained or the refusals below prove nothing: {drained:?}",
+    );
+
+    let task_run_id = seed_task_run(&db).await;
+    let acquired = permits.acquire(&task_run_id, 4).await;
+    let row = match acquired {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        other => panic!("the fixture must be able to acquire a permit: {other:?}"),
+    };
+
+    let census = modes.drain_census().await.expect("read the drain census");
+    assert!(
+        !census.is_drained(),
+        "one live permit must make the drain non-empty: {census:?}",
+    );
+
+    // Activation: refused.
+    let epoch = modes
+        .read()
+        .await
+        .expect("read the mode")
+        .expect("the singleton row")
+        .epoch;
+    let activation = modes
+        .set_mode(epoch, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert!(
+        matches!(
+            activation,
+            SetLauncherAuthorityModeResult::DrainNotEmpty { .. }
+        ),
+        "activation must refuse to proceed with a live Pod's permit outstanding, got {activation:?}",
+    );
+    assert_eq!(
+        modes
+            .read()
+            .await
+            .expect("read the mode")
+            .expect("the singleton row")
+            .mode,
+        LauncherAuthorityProtocol::LeafV1,
+        "a refused activation must not have flipped the mode anyway: an Err returned AFTER the \
+         flip is exactly the shape this assertion exists to catch",
+    );
+
+    // Drain, then activation succeeds.
+    permits
+        .release(&task_run_id, &row.permit_id, row.fencing_token, "matrix")
+        .await
+        .expect("release the permit");
+    let activation = modes
+        .set_mode(epoch, LauncherAuthorityProtocol::ResizeV2)
+        .await;
+    assert!(
+        matches!(activation, SetLauncherAuthorityModeResult::Flipped { .. }),
+        "with the drain empty, activation must proceed: {activation:?}",
+    );
+
+    // Rollback: refused again while a permit is live.
+    let rollback_task = seed_task_run(&db).await;
+    let rollback_row = match permits.acquire(&rollback_task, 4).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        other => panic!("acquire a second permit: {other:?}"),
+    };
+    let epoch = modes
+        .read()
+        .await
+        .expect("read the mode")
+        .expect("the singleton row")
+        .epoch;
+    let rollback = modes
+        .set_mode(epoch, LauncherAuthorityProtocol::LeafV1)
+        .await;
+    assert!(
+        matches!(
+            rollback,
+            SetLauncherAuthorityModeResult::DrainNotEmpty { .. }
+        ),
+        "rollback must not start until every resize-v2 Pod is gone, got {rollback:?}",
+    );
+    assert_eq!(
+        modes
+            .read()
+            .await
+            .expect("read the mode")
+            .expect("the singleton row")
+            .mode,
+        LauncherAuthorityProtocol::ResizeV2,
+        "a refused rollback must leave the mode where it was",
+    );
+
+    permits
+        .release(
+            &rollback_task,
+            &rollback_row.permit_id,
+            rollback_row.fencing_token,
+            "matrix",
+        )
+        .await
+        .expect("release the second permit");
+    let rollback = modes
+        .set_mode(epoch, LauncherAuthorityProtocol::LeafV1)
+        .await;
+    assert!(
+        matches!(rollback, SetLauncherAuthorityModeResult::Flipped { .. }),
+        "with the drain empty, rollback must proceed: {rollback:?}",
+    );
+}
+
+/// **AC9, cluster half.** A live task-run Pod on the cluster blocks activation,
+/// and the catalog selection is restored before rollback completes.
+#[test]
+#[ignore = "requires scripts/kind/setup-resize-matrix-cluster.sh up"]
+fn a_live_pod_on_the_cluster_blocks_the_flip() {
+    if !live_tests_enabled() {
+        return;
+    }
+    harness_context();
+    let images = BuiltImages::ensure();
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("a tokio runtime");
+    let db = runtime
+        .block_on(Database::ephemeral())
+        .expect("a real test database");
+    let modes = LauncherAuthorityModeRepository::new(db.clone());
+    let permits = BuildPodPermitRepository::new(db.clone());
+    runtime.block_on(force_mode(&modes, LauncherAuthorityProtocol::LeafV1));
+
+    // A REAL Pod, under the mode we are about to try to leave.
+    let cell = Cell {
+        image: ImageClass::LeafV1,
+        mode: ServerMode::Preparation,
+        expected: expectation(ImageClass::LeafV1, ServerMode::Preparation),
+    };
+    let task_run_id = runtime.block_on(seed_task_run(&db));
+    let live = dispatch_as(&images, cell, task_run_id);
+
+    // The permit that the dispatch path would have taken for it. Acquired here
+    // because this harness drives the renderer directly rather than the whole
+    // dispatch actor; the ROW is the production one either way.
+    let row = match runtime.block_on(permits.acquire(&live.task_run_id, 4)) {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        other => panic!("acquire the live Pod's permit: {other:?}"),
+    };
+
+    let epoch = runtime
+        .block_on(modes.read())
+        .expect("read the mode")
+        .expect("the singleton row")
+        .epoch;
+    let refused = runtime.block_on(modes.set_mode(epoch, LauncherAuthorityProtocol::ResizeV2));
+    assert!(
+        matches!(
+            refused,
+            SetLauncherAuthorityModeResult::DrainNotEmpty { .. }
+        ),
+        "activation must refuse while Pod {} is alive on the cluster, got {refused:?}",
+        live.pod_uid,
+    );
+
+    // The Pod really is alive — otherwise the refusal above is about a stale row
+    // rather than about live cluster state.
+    let phase = pod_json(&live.pod)["status"]["phase"].clone();
+    assert_eq!(
+        phase, "Running",
+        "the blocking Pod must actually be running, got {phase:?}",
+    );
+
+    delete_cell(&live);
+    runtime
+        .block_on(permits.release(
+            &live.task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            "matrix",
+        ))
+        .expect("release the permit");
+
+    let allowed = runtime.block_on(modes.set_mode(epoch, LauncherAuthorityProtocol::ResizeV2));
+    assert!(
+        matches!(allowed, SetLauncherAuthorityModeResult::Flipped { .. }),
+        "with the Pod gone and the permit released, activation must proceed: {allowed:?}",
+    );
+}

--- a/tests/fixtures/resize-matrix/Dockerfile.leaf-v1
+++ b/tests/fixtures/resize-matrix/Dockerfile.leaf-v1
@@ -1,0 +1,36 @@
+# The EXPLICIT `leaf-v1` image class of the mixed-version matrix.
+#
+# Independently built, not a run-time config variant of the resize-v2 image: the
+# declaration is BAKED, so the two classes are different artifacts with
+# different digests. That matters because the catalog's declaration
+# (`images.launcher_authority_protocol`) and the artifact's own claim are two
+# separate facts, and a matrix that could only ever see the catalog's copy of
+# them could not detect a catalog that lied about an artifact.
+# `server/tests/task_run_resize_mixed_version.rs` reads /opt/djinn/authority out
+# of the built image and requires it to agree with the row it dispatches.
+ARG DJINN_RESIZE_MATRIX_BASE_REPOSITORY=debian
+ARG DJINN_RESIZE_MATRIX_BASE_DIGEST
+FROM ${DJINN_RESIZE_MATRIX_BASE_REPOSITORY}@${DJINN_RESIZE_MATRIX_BASE_DIGEST}
+
+# The CURRENT launcher, from the working tree. It carries both wire strings —
+# which is precisely what makes the legacy class's provenance scan a real test
+# and not a tautology.
+COPY djinn-cgroup-launcher /opt/djinn/bin/djinn-cgroup-launcher
+COPY governor_probe /opt/djinn/bin/djinn-governor-probe
+
+# The artifact's own declaration. Note this is NOT the mechanism the renderer
+# uses — `apply_launcher_authority_protocol` sets
+# DJINN_LAUNCHER_AUTHORITY_PROTOCOL on the sidecar from the SERVER's admitted
+# decision, and that is the only thing the launcher reads. This file exists so
+# the matrix can cross-check the catalog against the artifact.
+RUN set -eu; \
+    mkdir -p /opt/djinn; \
+    printf 'leaf-v1' > /opt/djinn/authority; \
+    chmod 0644 /opt/djinn/authority; \
+    chmod 0755 /opt/djinn/bin/djinn-cgroup-launcher /opt/djinn/bin/djinn-governor-probe; \
+    head -c 33554432 /dev/urandom > /opt/djinn/workload.bin; \
+    chmod 0644 /opt/djinn/workload.bin; \
+    test -x /usr/bin/sha256sum; \
+    test -x /bin/sh
+
+# No ENTRYPOINT and no CMD: see Dockerfile.legacy.

--- a/tests/fixtures/resize-matrix/Dockerfile.legacy
+++ b/tests/fixtures/resize-matrix/Dockerfile.legacy
@@ -1,0 +1,47 @@
+# The IMMUTABLE NO-HANDSHAKE LEGACY image class of the mixed-version matrix.
+#
+# WHAT MAKES THIS LEGACY
+#
+# The launcher binary copied in below is compiled from
+# DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT (see pins.env), a revision at which the
+# authority handshake did not exist. It is not a modern launcher with an
+# environment variable withheld. That distinction is the whole reason this class
+# exists, and it is checked rather than asserted:
+# `server/tests/task_run_resize_mixed_version.rs` scans the binary INSIDE the
+# built image for the two wire strings and requires BOTH to be absent. Rebuild
+# this image from the working tree with DJINN_LAUNCHER_AUTHORITY_PROTOCOL unset
+# and that scan goes red, because the modern binary still carries both strings
+# in its rodata whatever its environment says.
+#
+# The base is pinned by digest, never by tag — a `debian:bookworm-slim` that
+# moved underneath this file would change the artifact without changing the
+# fixture, and "immutable" would be a comment rather than a property.
+ARG DJINN_RESIZE_MATRIX_BASE_REPOSITORY=debian
+ARG DJINN_RESIZE_MATRIX_BASE_DIGEST
+FROM ${DJINN_RESIZE_MATRIX_BASE_REPOSITORY}@${DJINN_RESIZE_MATRIX_BASE_DIGEST}
+
+# The pre-protocol launcher, at the path `launcher::LAUNCHER_BIN` names. The
+# renderer puts the sidecar and the worker on the SAME image tag and runs the
+# sidecar from this exact path, so the rendered command is left untouched.
+COPY djinn-cgroup-launcher-preprotocol /opt/djinn/bin/djinn-cgroup-launcher
+
+# The worker half. Modern on purpose: the image CLASS is a statement about the
+# launcher, and pairing a pre-protocol launcher with the current worker probe is
+# exactly the mixed-version combination the matrix exists to exercise.
+COPY governor_probe /opt/djinn/bin/djinn-governor-probe
+
+# This image makes NO protocol declaration. There is no /opt/djinn/authority
+# file here and no DJINN_LAUNCHER_AUTHORITY_PROTOCOL ENV, because the artifact
+# genuinely predates both. The matrix reads that absence as the legacy class's
+# defining property.
+
+RUN set -eu; \
+    chmod 0755 /opt/djinn/bin/djinn-cgroup-launcher /opt/djinn/bin/djinn-governor-probe; \
+    head -c 33554432 /dev/urandom > /opt/djinn/workload.bin; \
+    chmod 0644 /opt/djinn/workload.bin; \
+    test -x /usr/bin/sha256sum; \
+    test -x /bin/sh
+
+# No ENTRYPOINT and no CMD: every container in the rendered Job carries an
+# explicit command, and a default here could only mask a render that stopped
+# setting one.

--- a/tests/fixtures/resize-matrix/Dockerfile.legacy
+++ b/tests/fixtures/resize-matrix/Dockerfile.legacy
@@ -25,10 +25,17 @@ FROM ${DJINN_RESIZE_MATRIX_BASE_REPOSITORY}@${DJINN_RESIZE_MATRIX_BASE_DIGEST}
 # sidecar from this exact path, so the rendered command is left untouched.
 COPY djinn-cgroup-launcher-preprotocol /opt/djinn/bin/djinn-cgroup-launcher
 
-# The worker half. Modern on purpose: the image CLASS is a statement about the
-# launcher, and pairing a pre-protocol launcher with the current worker probe is
-# exactly the mixed-version combination the matrix exists to exercise.
-COPY governor_probe /opt/djinn/bin/djinn-governor-probe
+# The worker half, ALSO pre-protocol. The renderer puts the sidecar and the
+# worker container on the SAME image tag, so a legacy image is a legacy launcher
+# and a legacy worker — pairing this launcher with the current probe is not a
+# combination production can produce, and it is one that cannot work: the READY
+# payload grew a protocol byte, and the pre-protocol
+# `WorkerReadinessAssertion::from_wire` refuses anything that is not exactly 16
+# bytes. Measured on this branch as `ControlRejected(Worker)`.
+#
+# It lands at the same path as the declaring classes' probe so the worker
+# command the matrix renders is identical across all three classes.
+COPY legacy_probe /opt/djinn/bin/djinn-governor-probe
 
 # This image makes NO protocol declaration. There is no /opt/djinn/authority
 # file here and no DJINN_LAUNCHER_AUTHORITY_PROTOCOL ENV, because the artifact

--- a/tests/fixtures/resize-matrix/Dockerfile.resize-v2
+++ b/tests/fixtures/resize-matrix/Dockerfile.resize-v2
@@ -1,0 +1,25 @@
+# The EXPLICIT `resize-v2` image class of the mixed-version matrix.
+#
+# See Dockerfile.leaf-v1 for why the declaration is baked rather than passed at
+# run time. The two files are deliberately near-identical: the ONLY difference
+# between the two declaring classes is the declaration itself, so any behavioural
+# difference the matrix observes between them is attributable to the protocol and
+# to nothing else.
+ARG DJINN_RESIZE_MATRIX_BASE_REPOSITORY=debian
+ARG DJINN_RESIZE_MATRIX_BASE_DIGEST
+FROM ${DJINN_RESIZE_MATRIX_BASE_REPOSITORY}@${DJINN_RESIZE_MATRIX_BASE_DIGEST}
+
+COPY djinn-cgroup-launcher /opt/djinn/bin/djinn-cgroup-launcher
+COPY governor_probe /opt/djinn/bin/djinn-governor-probe
+
+RUN set -eu; \
+    mkdir -p /opt/djinn; \
+    printf 'resize-v2' > /opt/djinn/authority; \
+    chmod 0644 /opt/djinn/authority; \
+    chmod 0755 /opt/djinn/bin/djinn-cgroup-launcher /opt/djinn/bin/djinn-governor-probe; \
+    head -c 33554432 /dev/urandom > /opt/djinn/workload.bin; \
+    chmod 0644 /opt/djinn/workload.bin; \
+    test -x /usr/bin/sha256sum; \
+    test -x /bin/sh
+
+# No ENTRYPOINT and no CMD: see Dockerfile.legacy.

--- a/tests/fixtures/resize-matrix/build.sh
+++ b/tests/fixtures/resize-matrix/build.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Build the three REAL image classes of the mixed-version matrix (omp4).
+#
+#   build.sh [kind-cluster-name]
+#
+# Produces three independently built images and writes their immutable content
+# addresses to server/target/resize-matrix/images.json, which
+# server/tests/task_run_resize_mixed_version.rs reads. Nothing here is a config
+# variant of anything else:
+#
+#   djinn-resize-matrix-legacy    pre-protocol launcher, NO declaration
+#   djinn-resize-matrix-leaf-v1   current launcher, baked `leaf-v1`
+#   djinn-resize-matrix-resize-v2 current launcher, baked `resize-v2`
+#
+# WHY THE LEGACY LAUNCHER IS COMPILED AND NOT CONFIGURED
+#
+# The cheap way to produce a "legacy" image is to take the modern image and
+# leave DJINN_LAUNCHER_AUTHORITY_PROTOCOL unset. That is a modern launcher that
+# could handshake and chose not to, and it would pass every behavioural cell in
+# the matrix while proving nothing about compatibility with launchers that
+# genuinely predate the protocol. So the legacy launcher is compiled from
+# DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT in a detached git worktree, and the
+# matrix scans the emitted binary for both wire strings.
+#
+# `kind load docker-image` rather than a registry push, for the reason the
+# fbiy-C1 probe image gives: a pull failure surfaces as "the Pod never ran",
+# which is indistinguishable from the launcher-readiness failure under test.
+#
+# Exit codes:
+#   2  usage / not the djinn workspace
+#   3  a pin is malformed (a tag where a digest belongs)
+#   1  anything else
+set -euo pipefail
+
+CLUSTER=${1:-}
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# resize-matrix -> fixtures -> tests -> repo
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+SERVER_DIR="$REPO_ROOT/server"
+OUT_DIR="$SERVER_DIR/target/resize-matrix"
+
+fail() {
+    local code=$1
+    shift
+    printf 'FAIL: %s\n' "$*" >&2
+    exit "$code"
+}
+
+[ -d "$SERVER_DIR/crates/djinn-cgroup-launcher" ] \
+    || fail 2 "$SERVER_DIR is not the djinn server workspace"
+
+# --- pins -------------------------------------------------------------------
+# shellcheck disable=SC1091
+. "$HERE/pins.env"
+
+: "${DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT:?pins.env must set the pre-protocol commit}"
+: "${DJINN_RESIZE_MATRIX_BASE_DIGEST:?pins.env must set the base image digest}"
+: "${DJINN_RESIZE_MATRIX_BASE_REPOSITORY:?pins.env must set the base image repository}"
+
+# Guard: a pin that is a tag is not a pin. Enforced here as well as in the Rust
+# suite, because this script is also run by hand and by the workflow, and a
+# mutable base would produce a "legacy" image nobody inspected.
+[[ "$DJINN_RESIZE_MATRIX_BASE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || fail 3 "base pin '$DJINN_RESIZE_MATRIX_BASE_DIGEST' is not an immutable sha256: digest"
+[[ "$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT" =~ ^[0-9a-f]{40}$ ]] \
+    || fail 3 "pre-protocol pin '$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT' is not a full commit sha"
+
+LEGACY_IMAGE="djinn-resize-matrix-legacy:omp4"
+LEAF_IMAGE="djinn-resize-matrix-leaf-v1:omp4"
+RESIZE_IMAGE="djinn-resize-matrix-resize-v2:omp4"
+
+# --- the current binaries ---------------------------------------------------
+printf '>>> building the current djinn-cgroup-launcher and governor_probe (release)\n'
+(
+    cd "$SERVER_DIR"
+    cargo build --release -p djinn-cgroup-launcher \
+        --bin djinn-cgroup-launcher --example governor_probe
+)
+TARGET="$SERVER_DIR/target/release"
+
+# --- the pre-protocol launcher ----------------------------------------------
+LEGACY_CACHE="$OUT_DIR/legacy/$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT"
+LEGACY_BIN="$LEGACY_CACHE/djinn-cgroup-launcher"
+if [ ! -x "$LEGACY_BIN" ]; then
+    printf '>>> compiling the pre-protocol launcher at %s\n' \
+        "$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT"
+    WORKTREE="$OUT_DIR/preprotocol-worktree"
+    rm -rf "$WORKTREE"
+    mkdir -p "$OUT_DIR"
+    git -C "$REPO_ROOT" worktree prune
+    git -C "$REPO_ROOT" worktree add --detach "$WORKTREE" \
+        "$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT" >/dev/null
+    (
+        cd "$WORKTREE/server"
+        CARGO_TARGET_DIR="$OUT_DIR/preprotocol-target" \
+            cargo build --release -p djinn-cgroup-launcher --bin djinn-cgroup-launcher
+    )
+    mkdir -p "$LEGACY_CACHE"
+    cp "$OUT_DIR/preprotocol-target/release/djinn-cgroup-launcher" "$LEGACY_BIN"
+    git -C "$REPO_ROOT" worktree remove --force "$WORKTREE"
+else
+    printf '>>> reusing the cached pre-protocol launcher at %s\n' "$LEGACY_BIN"
+fi
+
+# A local sanity check, duplicated in Rust. Cheap, and it fails at build time
+# rather than three minutes into a live cell.
+if grep -aq 'leaf-v1' "$LEGACY_BIN" || grep -aq 'resize-v2' "$LEGACY_BIN"; then
+    fail 3 "the pre-protocol launcher at $LEGACY_BIN carries an authority wire string; \
+the pin no longer names a pre-protocol revision"
+fi
+
+# --- the three images -------------------------------------------------------
+CONTEXT="$(mktemp -d)"
+trap 'rm -rf "$CONTEXT"' EXIT
+
+cp "$TARGET/djinn-cgroup-launcher" "$CONTEXT/djinn-cgroup-launcher"
+cp "$TARGET/examples/governor_probe" "$CONTEXT/governor_probe"
+cp "$LEGACY_BIN" "$CONTEXT/djinn-cgroup-launcher-preprotocol"
+
+build_one() {
+    local dockerfile=$1 image=$2
+    printf '>>> docker build %s (%s)\n' "$image" "$dockerfile"
+    cp "$HERE/$dockerfile" "$CONTEXT/$dockerfile"
+    docker build --quiet \
+        --file "$CONTEXT/$dockerfile" \
+        --build-arg "DJINN_RESIZE_MATRIX_BASE_REPOSITORY=$DJINN_RESIZE_MATRIX_BASE_REPOSITORY" \
+        --build-arg "DJINN_RESIZE_MATRIX_BASE_DIGEST=$DJINN_RESIZE_MATRIX_BASE_DIGEST" \
+        --tag "$image" "$CONTEXT" >/dev/null
+}
+
+build_one Dockerfile.legacy "$LEGACY_IMAGE"
+build_one Dockerfile.leaf-v1 "$LEAF_IMAGE"
+build_one Dockerfile.resize-v2 "$RESIZE_IMAGE"
+
+digest_of() {
+    docker image inspect "$1" --format '{{.Id}}'
+}
+
+LEGACY_DIGEST="$(digest_of "$LEGACY_IMAGE")"
+LEAF_DIGEST="$(digest_of "$LEAF_IMAGE")"
+RESIZE_DIGEST="$(digest_of "$RESIZE_IMAGE")"
+
+# Three independently built images must be three distinct artifacts. If two of
+# these collide the "not a config variant of one image" requirement has been
+# quietly violated by a Dockerfile edit.
+if [ "$LEGACY_DIGEST" = "$LEAF_DIGEST" ] \
+    || [ "$LEGACY_DIGEST" = "$RESIZE_DIGEST" ] \
+    || [ "$LEAF_DIGEST" = "$RESIZE_DIGEST" ]; then
+    fail 3 "two image classes resolved to the same digest; they are config variants, not classes"
+fi
+
+if [ -n "$CLUSTER" ]; then
+    for image in "$LEGACY_IMAGE" "$LEAF_IMAGE" "$RESIZE_IMAGE"; do
+        printf '>>> kind load docker-image %s --name %s\n' "$image" "$CLUSTER"
+        kind load docker-image "$image" --name "$CLUSTER"
+    done
+fi
+
+mkdir -p "$OUT_DIR"
+MANIFEST="$OUT_DIR/images.json"
+cat >"$MANIFEST" <<EOF
+{
+  "preprotocol_commit": "$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT",
+  "base_digest": "$DJINN_RESIZE_MATRIX_BASE_DIGEST",
+  "classes": {
+    "legacy":    { "tag": "$LEGACY_IMAGE", "digest": "$LEGACY_DIGEST" },
+    "leaf-v1":   { "tag": "$LEAF_IMAGE",   "digest": "$LEAF_DIGEST" },
+    "resize-v2": { "tag": "$RESIZE_IMAGE", "digest": "$RESIZE_DIGEST" }
+  }
+}
+EOF
+
+printf 'PASS: three image classes built%s\n' "${CLUSTER:+ and loaded onto $CLUSTER}"
+printf '  manifest: %s\n' "$MANIFEST"

--- a/tests/fixtures/resize-matrix/build.sh
+++ b/tests/fixtures/resize-matrix/build.sh
@@ -82,8 +82,9 @@ TARGET="$SERVER_DIR/target/release"
 # --- the pre-protocol launcher ----------------------------------------------
 LEGACY_CACHE="$OUT_DIR/legacy/$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT"
 LEGACY_BIN="$LEGACY_CACHE/djinn-cgroup-launcher"
-if [ ! -x "$LEGACY_BIN" ]; then
-    printf '>>> compiling the pre-protocol launcher at %s\n' \
+LEGACY_PROBE="$LEGACY_CACHE/legacy_probe"
+if [ ! -x "$LEGACY_BIN" ] || [ ! -x "$LEGACY_PROBE" ]; then
+    printf '>>> compiling the pre-protocol launcher and worker probe at %s\n' \
         "$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT"
     WORKTREE="$OUT_DIR/preprotocol-worktree"
     rm -rf "$WORKTREE"
@@ -91,16 +92,27 @@ if [ ! -x "$LEGACY_BIN" ]; then
     git -C "$REPO_ROOT" worktree prune
     git -C "$REPO_ROOT" worktree add --detach "$WORKTREE" \
         "$DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT" >/dev/null
+    # The worker half must ALSO be pre-protocol. The renderer puts the sidecar
+    # and the worker on one image tag, so a legacy image is a legacy launcher
+    # AND a legacy worker; and the current worker cannot even complete the
+    # handshake against a pre-protocol launcher, because the READY payload grew
+    # a protocol byte. Copied into the THROWAWAY worktree so it links against
+    # the pre-protocol crate; nothing in the repository's own tree is touched.
+    mkdir -p "$WORKTREE/server/crates/djinn-cgroup-launcher/examples"
+    cp "$HERE/legacy_probe.rs" \
+        "$WORKTREE/server/crates/djinn-cgroup-launcher/examples/legacy_probe.rs"
     (
         cd "$WORKTREE/server"
         CARGO_TARGET_DIR="$OUT_DIR/preprotocol-target" \
-            cargo build --release -p djinn-cgroup-launcher --bin djinn-cgroup-launcher
+            cargo build --release -p djinn-cgroup-launcher \
+            --bin djinn-cgroup-launcher --example legacy_probe
     )
     mkdir -p "$LEGACY_CACHE"
     cp "$OUT_DIR/preprotocol-target/release/djinn-cgroup-launcher" "$LEGACY_BIN"
+    cp "$OUT_DIR/preprotocol-target/release/examples/legacy_probe" "$LEGACY_PROBE"
     git -C "$REPO_ROOT" worktree remove --force "$WORKTREE"
 else
-    printf '>>> reusing the cached pre-protocol launcher at %s\n' "$LEGACY_BIN"
+    printf '>>> reusing the cached pre-protocol binaries at %s\n' "$LEGACY_CACHE"
 fi
 
 # A local sanity check, duplicated in Rust. Cheap, and it fails at build time
@@ -117,6 +129,7 @@ trap 'rm -rf "$CONTEXT"' EXIT
 cp "$TARGET/djinn-cgroup-launcher" "$CONTEXT/djinn-cgroup-launcher"
 cp "$TARGET/examples/governor_probe" "$CONTEXT/governor_probe"
 cp "$LEGACY_BIN" "$CONTEXT/djinn-cgroup-launcher-preprotocol"
+cp "$LEGACY_PROBE" "$CONTEXT/legacy_probe"
 
 build_one() {
     local dockerfile=$1 image=$2

--- a/tests/fixtures/resize-matrix/legacy_probe.rs
+++ b/tests/fixtures/resize-matrix/legacy_probe.rs
@@ -1,0 +1,206 @@
+// Example: `println!` IS this binary's product. It runs as the worker container
+// of a live task-run Pod and its stdout — read back with `kubectl logs` — is the
+// only channel the harness has.
+#![allow(clippy::print_stdout)]
+//! The PRE-PROTOCOL worker half of the mixed-version matrix's legacy image
+//! class (omp4).
+//!
+//! # Why this file exists at all
+//!
+//! `djinn-k8s`'s renderer puts the launcher sidecar and the worker container on
+//! the SAME image tag. A legacy image is therefore a legacy launcher AND a
+//! legacy worker, and pairing a pre-protocol launcher with the CURRENT
+//! `governor_probe` is not a combination production can ever produce.
+//!
+//! It is also a combination that cannot work, which is worth writing down
+//! because it was measured rather than assumed. The authority handshake changed
+//! the READY payload from a bare 16-byte proof to 17 bytes (proof + protocol
+//! frame byte), and the pre-protocol `WorkerReadinessAssertion::from_wire` does
+//! `bytes.try_into()` into `[u8; 16]`. A current worker's READY against a
+//! pre-protocol launcher is refused as `ControlRejected(Worker)` before any
+//! invocation begins. The current crate's own comment says this is deliberate —
+//! "the two binaries ride one image, so there is no rolling-skew case to
+//! accommodate" — and this file is that statement taken at its word.
+//!
+//! # How it is built
+//!
+//! `build.sh` copies this file into `examples/` of the djinn-cgroup-launcher
+//! crate inside the THROWAWAY worktree it checks out at
+//! `DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT`, and builds it there. It therefore
+//! links against the pre-protocol crate and emits a pre-protocol 16-byte READY.
+//! Nothing in the repository's own tree is touched by that build.
+//!
+//! # What it does, and what it decides
+//!
+//! It performs the byte-for-byte worker handshake the pre-protocol launcher
+//! polls for (`<ipc>/worker.pid` plus the credential file at
+//! `DJINN_LAUNCHER_CREDENTIAL_PATH`), completes AUTH/READY/BEGIN/CREATE against
+//! the UNMODIFIED pre-protocol launcher binary in the rendered sidecar, and runs
+//! a real command in the invocation leaf. It decides NOTHING: it holds no cap,
+//! reads no database and never chooses its own authorization.
+//!
+//! # Output contract
+//!
+//! One `probe.<record> key=value ...` line per event, matching the subset of
+//! `governor_probe`'s wire format that
+//! `server/tests/task_run_resize_mixed_version.rs` waits on. Keep it stable.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::time::Duration;
+
+use djinn_cgroup_launcher::child::{NativeWorkerDumpability, prepare_worker_readiness};
+use djinn_cgroup_launcher::transport::UnixBrokerClient;
+use djinn_cgroup_launcher::{CommandSpec, Invocation, LeaseAuthority};
+
+/// Worker to launcher handshake filename. MUST match `WORKER_PID_FILE` in the
+/// launcher binary's `main.rs`; the launcher joins it onto the credential file's
+/// parent directory.
+const WORKER_PID_FILE: &str = "worker.pid";
+/// Size of the worker-private credential, matching `djinn-agent-worker`.
+const CREDENTIAL_BYTES: usize = 32;
+
+const POLL: Duration = Duration::from_millis(200);
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            println!("probe.fatal error={error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn env_required(key: &str) -> Result<String, String> {
+    std::env::var(key).map_err(|_| format!("missing environment variable {key}"))
+}
+
+fn env_number(key: &str, default: u64) -> Result<u64, String> {
+    match std::env::var(key) {
+        Err(_) => Ok(default),
+        Ok(raw) => raw
+            .trim()
+            .parse()
+            .map_err(|_| format!("{key} is not a number: {raw}")),
+    }
+}
+
+fn write_worker_handshake(credential_path: &Path) -> Result<Vec<u8>, String> {
+    let directory = credential_path
+        .parent()
+        .ok_or_else(|| "the credential path has no parent directory".to_owned())?;
+    let mut credential = vec![0_u8; CREDENTIAL_BYTES];
+    fs::File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(&mut credential))
+        .map_err(|error| format!("read entropy for the worker credential: {error}"))?;
+    fs::write(credential_path, &credential)
+        .map_err(|error| format!("write {}: {error}", credential_path.display()))?;
+    // The PID file LAST: the launcher polls for both and reads them together, so
+    // writing the pid first would let it read a half-written credential.
+    let pid_file = directory.join(WORKER_PID_FILE);
+    fs::write(&pid_file, std::process::id().to_string())
+        .map_err(|error| format!("write {}: {error}", pid_file.display()))?;
+    Ok(credential)
+}
+
+fn run() -> Result<(), String> {
+    // The two RENDERED variables, read from the environment the production
+    // renderer produced rather than from constants here: if djinn-k8s moves the
+    // socket, this probe must move with it or fail loudly.
+    let socket = env_required("DJINN_LAUNCHER_SOCKET")?;
+    let credential_path = PathBuf::from(env_required("DJINN_LAUNCHER_CREDENTIAL_PATH")?);
+    let invocation = env_required("DJINN_PROBE_INVOCATION")?;
+    let fence: u64 = env_required("DJINN_PROBE_FENCE")?
+        .trim()
+        .parse()
+        .map_err(|_| "DJINN_PROBE_FENCE is not a u64".to_owned())?;
+    let authority = match env_required("DJINN_PROBE_AUTHORITY")?.as_str() {
+        "armed" => LeaseAuthority::Armed,
+        "unarmed" => LeaseAuthority::Unarmed,
+        other => return Err(format!("DJINN_PROBE_AUTHORITY must be armed|unarmed: {other}")),
+    };
+    let decision_path = PathBuf::from(env_required("DJINN_PROBE_DECISION_PATH")?);
+    let workload = env_required("DJINN_PROBE_WORKLOAD")?;
+    let hold = Duration::from_secs(env_number("DJINN_PROBE_HOLD_SECONDS", 600)?);
+
+    println!("probe.start invocation={invocation} fence={fence} socket={socket} legacy=true");
+
+    let credential = write_worker_handshake(&credential_path)?;
+    println!(
+        "probe.handshake pid={} credential_path={}",
+        std::process::id(),
+        credential_path.display()
+    );
+
+    // The launcher binds its socket only after it has read the handshake, so a
+    // connect before that is a legitimate not-yet, not a failure.
+    let mut client = None;
+    for _ in 0..600 {
+        match UnixBrokerClient::connect_path(&socket, &credential) {
+            Ok(connected) => {
+                client = Some(connected);
+                break;
+            }
+            Err(_) => std::thread::sleep(POLL),
+        }
+    }
+    let mut client = client.ok_or_else(|| format!("never connected to {socket}"))?;
+
+    // The pre-protocol readiness assertion: a bare 16-byte proof, with NO
+    // protocol byte, because at this revision there is no protocol to declare.
+    let assertion = prepare_worker_readiness(&mut NativeWorkerDumpability)
+        .map_err(|error| format!("prepare worker readiness: {error:?}"))?;
+    client
+        .ready(assertion)
+        .map_err(|error| format!("READY refused: {error:?}"))?;
+    println!("probe.ready protocol=PreProtocol");
+
+    client
+        .begin(Invocation {
+            id: invocation.clone(),
+            fence,
+        })
+        .map_err(|error| format!("BEGIN refused: {error:?}"))?;
+
+    // A real command on real bytes, in the invocation leaf. `/workspace` is the
+    // only cwd `safe_command_path(cwd, true)` accepts, and the renderer mounts
+    // it into the launcher container too.
+    let command = CommandSpec {
+        program: "/bin/sh".to_owned(),
+        argv: vec![
+            "-c".to_owned(),
+            format!("while :; do /usr/bin/sha256sum {workload} >/dev/null || exit 9; done"),
+        ],
+        cwd: "/workspace".to_owned(),
+        environment: Vec::new(),
+    };
+    client
+        .create(&invocation, &invocation, authority, &command)
+        .map_err(|error| format!("CREATE refused: {error:?}"))?;
+    println!("probe.created leaf={invocation} authority={authority:?}");
+
+    // The harness reads this line, then records `cpu.max` from inside the Pod.
+    // Everything above happens without the harness having said anything.
+    println!("probe.awaiting_decision path={}", decision_path.display());
+
+    // Hold the leaf alive so the harness can observe it. Bounded, because a
+    // probe that never exits turns a failed run into a hung one.
+    let stop = decision_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("stop");
+    let ticks = hold.as_millis() / POLL.as_millis();
+    for _ in 0..ticks {
+        if stop.exists() {
+            break;
+        }
+        std::thread::sleep(POLL);
+    }
+
+    let _ = client.kill(&invocation);
+    println!("probe.done");
+    Ok(())
+}

--- a/tests/fixtures/resize-matrix/pins.env
+++ b/tests/fixtures/resize-matrix/pins.env
@@ -1,0 +1,46 @@
+# Immutable pins for the mixed-version image matrix (omp4, proposal 3i92).
+#
+# EVERY value here is content-addressed. A tag is a mutable pointer: the whole
+# point of the legacy image class is that its launcher genuinely predates the
+# authority handshake, and a tag that moved would silently turn the "legacy"
+# cell into a modern launcher that could handshake and chose not to. That defect
+# is invisible in every cell EXCEPT the provenance scan, so the pins are the
+# first line of defence and the scan is the second.
+#
+# Consumed by build.sh and re-read by
+# server/tests/task_run_resize_mixed_version.rs, which asserts the shape of each
+# value (sha256:<64 lowercase hex> / a 40-hex commit) rather than trusting the
+# comment above.
+
+# ---------------------------------------------------------------------------
+# The pre-protocol launcher revision.
+# ---------------------------------------------------------------------------
+# The parent of e82595ddc ("canonical authority-protocol crate, and make
+# resize-v2 actually reachable", ydpj-A, #2823) — the last commit at which
+# `djinn-cgroup-launcher` had NO notion of an authority protocol at all. Its
+# `main.rs` reads six environment variables and none of them is
+# DJINN_LAUNCHER_AUTHORITY_PROTOCOL, the `LauncherAuthorityProtocol` type does
+# not exist in its dependency graph, and neither wire string reaches the
+# emitted binary.
+#
+# `djinn-cgroup-launcher/src/{transport,broker}.rs` are BYTE-IDENTICAL between
+# this revision and today (`git diff` reports no hunks), which is why a
+# pre-protocol launcher still completes AUTH/READY/BEGIN/CREATE against the
+# modern `governor_probe` worker. The handshake is what did not change; the
+# authority decision is what did.
+DJINN_RESIZE_MATRIX_PREPROTOCOL_COMMIT=32a9e0923f1b802e336d43a2f874f857a84994b4
+
+# ---------------------------------------------------------------------------
+# The runtime base, by digest.
+# ---------------------------------------------------------------------------
+# debian:bookworm-slim, resolved 2026-07-31. Debian rather than distroless for
+# the same two reasons the fbiy-C1 probe image gives: the brokered workload is
+# /usr/bin/sha256sum, a real coreutils program, and /bin/sh is the driver the
+# broker execs. glibc 2.36 clears the GLIBC_2.34 floor of release-profile
+# binaries built on the developer host.
+#
+# All three image classes share this base ON PURPOSE. It makes the launcher
+# binary the ONLY difference between the legacy image and the two declaring
+# ones, so a provenance scan that goes red cannot be blamed on the base.
+DJINN_RESIZE_MATRIX_BASE_DIGEST=sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+DJINN_RESIZE_MATRIX_BASE_REPOSITORY=debian


### PR DESCRIPTION
Builds the mixed-version test matrix proposal 3i92 asks for: three REAL image
classes against four server modes, with two properties proved across the cross
product — exactly one quota authority for every admitted Pod, and refusal
before any shell runs for every incompatible combination.

**22/22 tests pass. 16 are hermetic and run on every PR with no cluster; 6 are
`#[ignore]`-gated and were measured green on a disposable kind cluster
(Kubernetes 1.36, containerd 2.x, cgroup-writable RuntimeClass). The cluster
and its registry were deleted afterwards and `selfcheck` confirmed it.**

## The matrix is derived, not listed

`matrix()` is `ImageClass::ALL` x `ServerMode::ALL` and its return type is
spelled in terms of both lengths. `expectation()` is an exhaustive `match` over
the pair with **no wildcard arm**, so a fourth image class or a fifth server
mode stops the file compiling until somebody states what the new combination
means. `matrix_is_the_whole_cross_product` closes the other direction with an
ordinal round trip: a variant added to the enum but not to `ALL` indexes past
its end.

|              | old  | preparation | activated | rollback |
|--------------|------|-------------|-----------|----------|
| legacy       | leaf | leaf        | REFUSED   | leaf     |
| leaf-v1      | leaf | leaf        | REFUSED   | leaf     |
| resize-v2    | leaf | REFUSED     | **resize**| REFUSED  |

`old` is a server that predates the protocol: it has no authority-mode row to
consult and no `apply_launcher_authority_protocol` to call, so the harness
emulates it by not invoking the admission seam and rendering no protocol env.
The launcher takes its documented absent-means-`leaf-v1` default. That row is
the compatibility guarantee the cutover depends on.

## The legacy image is genuinely pre-protocol

Compiled from `32a9e0923` — the parent of #2823, the last revision at which
`djinn-cgroup-launcher` had no notion of an authority protocol. Measured on
this branch:

* the pre-protocol binary contains **zero** occurrences of `leaf-v1` and
  **zero** of `resize-v2`;
* the current binary contains **one of each**.

So `legacy_image_binary_predates_the_protocol` is a discriminator, not a
tautology: rebuild the legacy image from the working tree with
`DJINN_LAUNCHER_AUTHORITY_PROTOCOL` unset and it goes red. The base image is
pinned by digest in `pins.env` and the three classes are checked to have three
distinct content addresses.

## Four defects the live run found

Each had left an assertion vacuous. They are the reason this PR ran on a
cluster rather than shipping on the hermetic half.

1. **The legacy image needed a legacy WORKER too.** The READY payload grew a
   protocol byte at #2823, and a current worker against a pre-protocol launcher
   is refused as `ControlRejected(Worker)` *before any invocation begins*. The
   renderer puts the sidecar and the worker on one image tag, so a legacy image
   carries a legacy worker — `legacy_probe.rs` is compiled inside the throwaway
   pre-protocol worktree so it links the pre-protocol crate and emits 16 bytes.
2. **`kubectl` strips `metadata.managedFields` from `-o json`.** Without
   `--show-managed-fields` the block reads `null`, and "zero `pods/resize`
   PATCHes landed" passed for a Pod that had just been resized.
3. **cgroup v2 `cpu.max` is two fields.** Comparing the whole line against
   `"max"` never matches; comparing it against `"max 100000"` would bind the
   test to the kernel's default period. Only the quota field is a statement
   about who wrote quota.
4. **The chart prefixes its ServiceAccount and PVC names with the release
   name** (`djinn-djinn-taskrun`), so they are resolved from the live cluster.

## Authority is proved by observed effect

Never by a stored `effective_launcher_protocol`.

* **LEAF** — the invocation leaf's `cpu.max` quota field is numeric (read from
  inside the Pod, out of the launcher's own delegated cgroup root), AND zero
  `managedFields` entries carry `subresource: resize`, AND the launcher has no
  actuated CPU limit at all (`leaf-v1` renders none on purpose; only a resize
  can introduce one).
* **RESIZE** — the leaf's quota field reads `max` (nothing was written, not
  even `max` as a rewrite), the apiserver records the resize PATCH, the limit
  moves in `status.initContainerStatuses[cgroup-launcher]`, and the leaf is
  re-read afterwards to prove the launcher did not then write quota on top.

## Refusal before shell execution

Each cell's worker command is a real shell that creates a sentinel on a node
hostPath and only then execs the probe. Refused cells assert the sentinel is
absent AND no Pod exists — and every admitted cell asserts the sentinel IS
present, which is the control that keeps the absence assertions from being
vacuous.

## The rest

* **`Patch::Strategic`** — a live cell asserts every other init container and
  every regular container survives byte-identically, and that the launcher entry
  changed in exactly one place. The named mutation runs live first: the same
  body with `--type merge` against `pods/resize` is asserted to be **refused**
  by the apiserver.
* **No `status.containerStatuses`** — a source-level gate over the whole suite
  (needle assembled at run time so it cannot trip on itself), plus a live Pod
  that carries a misleading, perfectly-matching regular-container status and no
  init-container status, which must read as unconfirmed.
* **Millicores** — a live cell patches `4000m`, the apiserver stores `4`, and
  `CpuLimit::parse` compares them equal where string equality reports `never
  reported 4000m; last observed Some(4)`.
* **Fenced flips** — real PostgreSQL, real repositories, no `Fake`. A permit
  acquired through the production chain (with a real `task_runs` row, because
  the FK requires one) makes the drain non-empty; activation and rollback are
  both refused, and the mode is re-read to prove it did not flip anyway.

## Composition and the dependency gap

`decide_admission` is delegated to rather than hand-rolled, so the mutable-tag
refusal falls out of `PreProtocolDigest::parse`. Admission runs through the
production pair `LauncherAuthorityModeRepository::admit_declared_protocol`
composed with `admit_with_legacy_inventory` — the same two calls in the same
order `ProjectRepository::admit_dispatch_image` makes.

**Honest gap:** eeky (#2858) and zpen (#2859) were still OPEN when this branched
from `origin/main`, so `ResizeRollout` and `cutover_preflight.rs` do not exist
on this base and could not be called. The flip is composed from
`LauncherAuthorityModeRepository::set_mode`, which is the drain fence
`ResizeRollout` drives. When both land, the two live flip tests should be
rewired to call the driver and the preflight instead.

## Safety

Disposable cluster `djinn-resize-omp4` / registry `djinn-resize-omp4-registry`
on port **5079**, disjoint from every sibling harness (all named in the reserved
lists, asserted in both directions by a hermetic test). Context is derived from
the cluster name, never discovered; a second guard refuses any API server that
is not on loopback. `df -h /` is checked before anything is pulled. The teardown
trap proved itself twice during development — two failed `up` runs left nothing
behind. The `.github/workflows/resize-matrix.yml` lane is `workflow_dispatch`
only, non-required, and `save-if: false` on the one cache family it reads.

Closes omp4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
