### PR TITLE
fix(slot): inject the session budget policy instead of mutating the process env

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/reply_loop/mod.rs
+++ b/server/crates/djinn-agent/src/actors/slot/reply_loop/mod.rs
@@ -434,6 +434,7 @@ pub(crate) async fn run_reply_loop(
     let (result, output, tokens_in, tokens_out, cache_read, cache_write) =
         djinn_slot::reply_loop::run_reply_loop(
             djinn_slot::reply_loop::ReplyLoopContext {
+                session_budget: None,
                 provider,
                 tools,
                 task_id,

--- a/server/crates/djinn-agent/tests/compaction_hardening/transport.rs
+++ b/server/crates/djinn-agent/tests/compaction_hardening/transport.rs
@@ -193,6 +193,7 @@ async fn run_case(
     conversation.push(Message::user("éééé"));
     let output = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             provider: &provider,
             tools: &[],
             task_id: &task.id,
@@ -311,6 +312,7 @@ async fn oversized_transport_compaction_persists_boundary_occupancy() {
     conversation.push(Message::user("éééé"));
     let result = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             provider: &provider,
             tools: &[],
             task_id: &task.id,

--- a/server/crates/djinn-slot/src/reply_loop/budget.rs
+++ b/server/crates/djinn-slot/src/reply_loop/budget.rs
@@ -108,7 +108,7 @@ impl UsageAccountingForTest {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct SessionBudgetPolicy {
+pub struct SessionBudgetPolicy {
     fallback_context_window_tokens: u32,
     soft_threshold_ratio: f64,
     hard_threshold_ratio: f64,
@@ -169,21 +169,12 @@ impl SessionBudgetPolicy {
     pub(crate) fn from_env() -> Result<Self, SessionBudgetConfigError> {
         Self::from_env_iter(env::vars())
     }
-    #[cfg(test)]
-    fn from_env_iter<I, K, V>(vars: I) -> Result<Self, SessionBudgetConfigError>
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        let env: HashMap<String, String> = vars
-            .into_iter()
-            .map(|(key, value)| (key.into(), value.into()))
-            .collect();
-        Self::from_env_map(&env)
-    }
-    #[cfg(not(test))]
-    fn from_env_iter<I, K, V>(vars: I) -> Result<Self, SessionBudgetConfigError>
+    /// Build a policy from an explicit set of `DJINN_SESSION_BUDGET_*` pairs
+    /// instead of the process environment. Tests inject the result through
+    /// [`crate::reply_loop::ReplyLoopContext::session_budget`] so a budget
+    /// override is scoped to the one reply loop under test rather than to
+    /// every test sharing the process env.
+    pub(crate) fn from_env_iter<I, K, V>(vars: I) -> Result<Self, SessionBudgetConfigError>
     where
         I: IntoIterator<Item = (K, V)>,
         K: Into<String>,

--- a/server/crates/djinn-slot/src/reply_loop/mod.rs
+++ b/server/crates/djinn-slot/src/reply_loop/mod.rs
@@ -32,17 +32,12 @@ pub mod turn;
 mod turn;
 mod turn_budget;
 
+pub use budget::SessionBudgetPolicy;
 pub use compaction_guard::CompactionCriticalSection;
 pub use phase::{SessionPhase, SessionPhaseRole, SessionPhaseTracker};
 pub use turn::{ReplyLoopContext, run_reply_loop};
 
-// Soft-budget tests hold `SESSION_BUDGET_ENV_LOCK` across `.await` on
-// purpose: the lock serializes env-var mutation (set/remove) for the
-// duration of each async test so concurrent tests cannot race the shared
-// process env. Mirrors the `AUTO_CODE_CONTEXT_ENV_LOCK` pattern in
-// `helpers/tests.rs`.
 #[cfg(test)]
-#[allow(clippy::await_holding_lock)]
 mod tests;
 
 /// Bounded, error-class-aware retry of transient MID-STREAM provider errors

--- a/server/crates/djinn-slot/src/reply_loop/streaming_retry_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/streaming_retry_tests.rs
@@ -257,6 +257,7 @@ impl Fixture {
         let worktree_path = std::path::PathBuf::from("/tmp");
         let (result, _output, _in, _out, _cr, _cw) = run_reply_loop(
             ReplyLoopContext {
+                session_budget: None,
                 compaction_cs: &super::CompactionCriticalSection::new(),
                 provider,
                 tools: &[],

--- a/server/crates/djinn-slot/src/reply_loop/tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tests.rs
@@ -7,6 +7,7 @@ use super::error_handling::{
 // keeps the size guard from re-flagging the pre-existing oversize while
 // leaving the new tests in their natural location alongside the related
 // reply-loop coverage.
+use super::budget::SessionBudgetPolicy;
 use super::loop_guard::{LoopGuardError, LoopGuardKind};
 use super::persistence::serialize_llm_input;
 use super::turn::{ReplyLoopContext, WindDownReason, run_reply_loop};
@@ -37,39 +38,6 @@ use std::time::{Duration, Instant, SystemTime};
 use tokio_util::sync::CancellationToken;
 
 mod anthropic_replay;
-
-/// Process-wide mutex that serializes the soft-budget tests' mutations of
-/// `DJINN_SESSION_BUDGET_*` env vars. The reply loop reads its
-/// `SessionBudgetPolicy` via `SessionBudgetPolicy::from_env()` at the start of
-/// `run_reply_loop`, and Rust tests run in parallel by default — so without
-/// serialization a concurrent test could observe our env override (or vice
-/// versa). The lock is held across the `.await` on `run_reply_loop` on
-/// purpose: env mutations are synchronous, the lock is uncontended in spirit
-/// (we don't yield inside the critical section), and the existing
-/// `AUTO_CODE_CONTEXT_ENV_LOCK` pattern in `helpers/tests.rs` follows the
-/// same shape. SAFETY: env mutation always happens with this lock held.
-static SESSION_BUDGET_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Clear every `DJINN_SESSION_BUDGET_*` env var that `SessionBudgetPolicy::from_env`
-/// consults. Called by soft-budget tests (under the env lock) at teardown so
-/// the test doesn't leak a tiny budget into a sibling test that doesn't
-/// expect it.
-fn clear_session_budget_env() {
-    // SAFETY: always called under SESSION_BUDGET_ENV_LOCK.
-    unsafe {
-        for role in ["WORKER", "PLANNER", "ARCHITECT", "OTHER"] {
-            for suffix in [
-                "_MAX_TURNS",
-                "_MAX_CUMULATIVE_TOKENS",
-                "_SOFT_THRESHOLD_RATIO",
-                "_HARD_THRESHOLD_RATIO",
-            ] {
-                let var = format!("DJINN_SESSION_BUDGET_{role}{suffix}");
-                std::env::remove_var(var);
-            }
-        }
-    }
-}
 
 /// Pre-scripted response: text (optional) + tool calls + token counts.
 /// When `_error` is set, `MockProvider::stream()` returns the error immediately
@@ -284,6 +252,11 @@ struct ReplyLoopHarness {
     /// Defaults to the canonical worker path; phase scripts override this to
     /// isolate their process-global collector samples from dispatcher tests.
     role_name: &'static str,
+    /// Per-harness session budget. `None` lets `run_reply_loop` resolve the
+    /// policy from the process env exactly as production does; the budget
+    /// tests set it via [`Self::with_session_budget`] so their tiny caps are
+    /// scoped to their own reply loop instead of the shared process env.
+    session_budget: Option<SessionBudgetPolicy>,
 }
 
 type ReplyLoopResult = (anyhow::Result<()>, ParsedAgentOutput, i64, i64, i64, i64);
@@ -302,6 +275,7 @@ impl ReplyLoopHarness {
             cancel,
             conv,
             role_name: "worker",
+            session_budget: None,
         }
     }
 
@@ -360,7 +334,23 @@ impl ReplyLoopHarness {
             cancel,
             conv,
             role_name: "worker",
+            session_budget: None,
         }
+    }
+
+    /// Scope a `DJINN_SESSION_BUDGET_*` override to this harness's reply loop.
+    ///
+    /// The pairs are parsed by the same `from_env_map` path the production
+    /// `SessionBudgetPolicy::from_env()` uses, so the parsing coverage the old
+    /// `std::env::set_var` version had is preserved — but the override never
+    /// touches the process environment, which every concurrently running test
+    /// shares.
+    fn with_session_budget<const N: usize>(mut self, vars: [(&str, String); N]) -> Self {
+        self.session_budget = Some(
+            SessionBudgetPolicy::from_env_iter(vars.map(|(k, v)| (k.to_string(), v)))
+                .expect("valid session budget override"),
+        );
+        self
     }
 
     /// Run the reply loop with default settings (context_window=10_000,
@@ -418,6 +408,7 @@ impl ReplyLoopHarness {
         let worktree_path = std::path::PathBuf::from("/tmp");
         run_reply_loop(
             ReplyLoopContext {
+                session_budget: self.session_budget.clone(),
                 compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
                 provider,
                 tools,
@@ -542,6 +533,7 @@ async fn proactive_compaction_fires_when_current_context_exceeds_threshold() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[],
@@ -635,6 +627,7 @@ async fn no_compaction_when_sum_large_but_current_context_small() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[],
@@ -762,6 +755,7 @@ async fn reactive_compaction_on_context_length_error() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[],
@@ -1101,6 +1095,7 @@ async fn run_scripted_reply_loop_with_dispatcher(
     conv.push(Message::user("Do the task."));
     let (result, output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider,
             tools,
@@ -1287,6 +1282,7 @@ async fn tool_choice_required_for_supported_providers() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
@@ -1405,6 +1401,7 @@ async fn max_step_cap_injects_wind_down_and_ends_gracefully() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
@@ -1509,6 +1506,7 @@ async fn max_step_wind_down_ignored_falls_back_to_hard_error() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
@@ -1562,10 +1560,6 @@ async fn max_step_wind_down_ignored_falls_back_to_hard_error() {
 
 #[tokio::test]
 async fn hard_token_budget_injects_wind_down_and_ends_gracefully() {
-    let _env_guard = SESSION_BUDGET_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
-    install_session_budget_env_with_hard(1_000, 0.5, 0.92);
     let tools = vec![dummy_tool_schema("missing_tool")];
     let mut responses = Vec::new();
     for step in 1..=2 {
@@ -1581,10 +1575,10 @@ async fn hard_token_budget_injects_wind_down_and_ends_gracefully() {
         75,
     ));
     let provider = MockProvider::new(responses);
-    let mut h = ReplyLoopHarness::new().await;
+    let mut h = ReplyLoopHarness::new()
+        .await
+        .with_session_budget(session_budget_vars_with_hard(1_000, 0.5, 0.92));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = h.run(&provider, &tools).await;
-    clear_session_budget_env();
-    let _ = &_env_guard;
     assert!(
         result.is_ok(),
         "token budget should wind down gracefully, got: {:?}",
@@ -1610,10 +1604,6 @@ async fn hard_token_budget_injects_wind_down_and_ends_gracefully() {
 
 #[tokio::test]
 async fn hard_token_budget_wind_down_ignored_falls_back_to_hard_error() {
-    let _env_guard = SESSION_BUDGET_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
-    install_session_budget_env_with_hard(1_000, 0.5, 0.92);
     let tools = vec![dummy_tool_schema("missing_tool")];
     let mut responses = Vec::new();
     for step in 1..=3 {
@@ -1625,10 +1615,10 @@ async fn hard_token_budget_wind_down_ignored_falls_back_to_hard_error() {
         ));
     }
     let provider = MockProvider::new(responses);
-    let mut h = ReplyLoopHarness::new().await;
+    let mut h = ReplyLoopHarness::new()
+        .await
+        .with_session_budget(session_budget_vars_with_hard(1_000, 0.5, 0.92));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = h.run(&provider, &tools).await;
-    clear_session_budget_env();
-    let _ = &_env_guard;
     assert!(
         result.is_err(),
         "ignoring token-budget wind-down should hard-error"
@@ -1978,38 +1968,41 @@ fn count_system_reminder_messages(conv: &Conversation) -> usize {
         .count()
 }
 
-/// Apply a `SessionBudgetPolicy` override to the env so the next
-/// `SessionBudgetPolicy::from_env()` inside `run_reply_loop` resolves a small
-/// cumulative-token cap with a low soft threshold. Always called under
-/// `SESSION_BUDGET_ENV_LOCK` and followed by `clear_session_budget_env()` at
-/// test teardown.
-fn install_session_budget_env(max_cumulative_tokens: u64, soft_ratio: f64) {
-    // SAFETY: always called under SESSION_BUDGET_ENV_LOCK.
-    unsafe {
-        std::env::set_var(
+/// The `DJINN_SESSION_BUDGET_*` pairs for a small cumulative-token cap with a
+/// low soft threshold, to hand to [`ReplyLoopHarness::with_session_budget`].
+///
+/// `MAX_TURNS` and `HARD_THRESHOLD_RATIO` are deliberately absent so the
+/// resolved policy keeps its defaults for those — the injected policy is built
+/// from these pairs alone, so unlike the previous env-var version there is no
+/// stale override from a sibling test to clear first.
+fn session_budget_vars(max_cumulative_tokens: u64, soft_ratio: f64) -> [(&'static str, String); 2] {
+    [
+        (
             "DJINN_SESSION_BUDGET_WORKER_MAX_CUMULATIVE_TOKENS",
             max_cumulative_tokens.to_string(),
-        );
-        std::env::set_var(
+        ),
+        (
             "DJINN_SESSION_BUDGET_WORKER_SOFT_THRESHOLD_RATIO",
             soft_ratio.to_string(),
-        );
-    }
+        ),
+    ]
 }
 
-fn install_session_budget_env_with_hard(
+/// [`session_budget_vars`] plus an explicit hard-threshold ratio.
+fn session_budget_vars_with_hard(
     max_cumulative_tokens: u64,
     soft_ratio: f64,
     hard_ratio: f64,
-) {
-    install_session_budget_env(max_cumulative_tokens, soft_ratio);
-    // SAFETY: always called under SESSION_BUDGET_ENV_LOCK.
-    unsafe {
-        std::env::set_var(
+) -> [(&'static str, String); 3] {
+    let [max, soft] = session_budget_vars(max_cumulative_tokens, soft_ratio);
+    [
+        max,
+        soft,
+        (
             "DJINN_SESSION_BUDGET_WORKER_HARD_THRESHOLD_RATIO",
             hard_ratio.to_string(),
-        );
-    }
+        ),
+    ]
 }
 
 /// Crossing the soft threshold exactly once — the reply loop persists and
@@ -2036,22 +2029,13 @@ fn install_session_budget_env_with_hard(
 /// stream never produces the reminder (only the reply loop does).
 #[tokio::test]
 async fn soft_budget_threshold_triggers_one_shot_converge_reminder() {
-    // Recover from a poisoned mutex so a prior test that panicked mid-env-mutation
-    // doesn't cascade its failure here. The lock still serializes; we just
-    // ignore the poison marker since the protected state is process env (which
-    // gets reset by the test's own setup/teardown anyway).
-    let _env_guard = SESSION_BUDGET_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
     // 200 token cap × 0.25 ratio = 50-token soft cap; the default hard cap
     // (92% = 184 tokens) stays safely above this test's 100-token spend.
-    install_session_budget_env(200, 0.25);
-    // Safety net: ensure no stale overrides from a previous test leak through.
-    // SAFETY: SESSION_BUDGET_ENV_LOCK held.
-    unsafe {
-        std::env::remove_var("DJINN_SESSION_BUDGET_WORKER_MAX_TURNS");
-        std::env::remove_var("DJINN_SESSION_BUDGET_WORKER_HARD_THRESHOLD_RATIO");
-    }
+    // The policy is built from these pairs alone and injected below, so
+    // `MAX_TURNS` and `HARD_THRESHOLD_RATIO` keep their defaults and no
+    // sibling test can observe or perturb this override.
+    let session_budget = SessionBudgetPolicy::from_env_iter(session_budget_vars(200, 0.25))
+        .expect("valid session budget override");
     let tools = vec![
         dummy_tool_schema("submit_work"),
         dummy_tool_schema("worker_tool"),
@@ -2083,6 +2067,7 @@ async fn soft_budget_threshold_triggers_one_shot_converge_reminder() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: Some(session_budget),
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
@@ -2096,9 +2081,9 @@ async fn soft_budget_threshold_triggers_one_shot_converge_reminder() {
             // Large context window so the context-pressure secondary signal
             // (`current_context_tokens / context_window`) never trips on its
             // own — the test exercises the cumulative `input+output` spend
-            // path only. We need `max_cumulative_tokens` (set via env) to be
-            // the dominant signal, and a 10k-token window with <100 tokens of
-            // usage keeps that ratio tiny.
+            // path only. We need `max_cumulative_tokens` (injected above) to
+            // be the dominant signal, and a 10k-token window with <100 tokens
+            // of usage keeps that ratio tiny.
             context_window: 10_000,
             model_id: "test/mock-model",
             cancel: &cancel,
@@ -2114,11 +2099,6 @@ async fn soft_budget_threshold_triggers_one_shot_converge_reminder() {
         false,
     )
     .await;
-    // SAFETY: SESSION_BUDGET_ENV_LOCK held; restore baseline before asserting.
-    clear_session_budget_env();
-    // Avoid the `_env_guard` "field never read" warning while still proving
-    // the guard was held for the duration of `run_reply_loop`.
-    let _ = &_env_guard;
     assert!(
         result.is_ok(),
         "soft-budget reminder should not fail the session; got: {:?}",
@@ -2169,20 +2149,8 @@ async fn soft_budget_threshold_triggers_one_shot_converge_reminder() {
 /// `max_cumulative_tokens * soft_threshold_ratio` no injection happens.
 #[tokio::test]
 async fn soft_budget_below_threshold_no_injection() {
-    // Recover from a poisoned mutex so a prior test that panicked mid-env-mutation
-    // doesn't cascade its failure here. See the matching comment in
-    // `soft_budget_threshold_triggers_one_shot_converge_reminder`.
-    let _env_guard = SESSION_BUDGET_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
     // 1000 token cap × 0.75 = 750-token soft cap. We'll spend a fraction of
     // that across many turns and verify no reminder fires.
-    install_session_budget_env(1_000, 0.75);
-    // SAFETY: SESSION_BUDGET_ENV_LOCK held.
-    unsafe {
-        std::env::remove_var("DJINN_SESSION_BUDGET_WORKER_MAX_TURNS");
-        std::env::remove_var("DJINN_SESSION_BUDGET_WORKER_HARD_THRESHOLD_RATIO");
-    }
     let tools = vec![
         dummy_tool_schema("submit_work"),
         dummy_tool_schema("worker_tool"),
@@ -2212,12 +2180,11 @@ async fn soft_budget_below_threshold_no_injection() {
             _error: None,
         },
     ]);
-    let mut h = ReplyLoopHarness::new().await;
+    let mut h = ReplyLoopHarness::new()
+        .await
+        .with_session_budget(session_budget_vars(1_000, 0.75));
     provider.bind_valid_submit_work_fixtures(&h.task_id);
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = h.run(&provider, &tools).await;
-    // SAFETY: SESSION_BUDGET_ENV_LOCK held; restore baseline before asserting.
-    clear_session_budget_env();
-    let _ = &_env_guard;
     assert!(
         result.is_ok(),
         "session should complete normally below the soft threshold; got: {:?}",
@@ -2241,15 +2208,6 @@ async fn soft_budget_below_threshold_no_injection() {
 
 #[tokio::test]
 async fn hard_budget_wind_down_captures_budget_summary() {
-    let _env_guard = SESSION_BUDGET_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
-    install_session_budget_env(100, 0.5);
-    // SAFETY: SESSION_BUDGET_ENV_LOCK held.
-    unsafe {
-        std::env::remove_var("DJINN_SESSION_BUDGET_WORKER_MAX_TURNS");
-        std::env::set_var("DJINN_SESSION_BUDGET_WORKER_HARD_THRESHOLD_RATIO", "0.8");
-    }
     let tools = vec![
         dummy_tool_schema("submit_work"),
         dummy_tool_schema("worker_tool"),
@@ -2259,10 +2217,10 @@ async fn hard_budget_wind_down_captures_budget_summary() {
         MockResponse::tool_call_with_input("b", "worker_tool", serde_json::json!({"step": 2}), 30), // cumulative 90 → hard wind-down before next turn
         MockResponse::text_only("Budget handoff: implemented A; B remains.", 5),
     ]);
-    let mut h = ReplyLoopHarness::new().await;
+    let mut h = ReplyLoopHarness::new()
+        .await
+        .with_session_budget(session_budget_vars_with_hard(100, 0.5, 0.8));
     let (result, output, tokens_in, tokens_out, _cr, _cw) = h.run(&provider, &tools).await;
-    clear_session_budget_env();
-    let _ = &_env_guard;
     assert!(
         result.is_ok(),
         "hard budget summary should park cleanly: {result:?}"
@@ -2355,15 +2313,6 @@ async fn hard_budget_wind_down_captures_budget_summary() {
 
 #[tokio::test]
 async fn hard_budget_wind_down_ignored_returns_typed_budget_error() {
-    let _env_guard = SESSION_BUDGET_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner());
-    install_session_budget_env(100, 0.5);
-    // SAFETY: SESSION_BUDGET_ENV_LOCK held.
-    unsafe {
-        std::env::remove_var("DJINN_SESSION_BUDGET_WORKER_MAX_TURNS");
-        std::env::set_var("DJINN_SESSION_BUDGET_WORKER_HARD_THRESHOLD_RATIO", "0.8");
-    }
     let tools = vec![
         dummy_tool_schema("submit_work"),
         dummy_tool_schema("worker_tool"),
@@ -2379,10 +2328,10 @@ async fn hard_budget_wind_down_ignored_returns_typed_budget_error() {
         // fallback as a false successful summary.
         MockResponse::text_only("fallback budget handoff that must never be consumed", 5),
     ]);
-    let mut h = ReplyLoopHarness::new().await;
+    let mut h = ReplyLoopHarness::new()
+        .await
+        .with_session_budget(session_budget_vars_with_hard(100, 0.5, 0.8));
     let (result, output, tokens_in, tokens_out, _cr, _cw) = h.run(&provider, &tools).await;
-    clear_session_budget_env();
-    let _ = &_env_guard;
     let err = result.expect_err("ignored hard-budget wind-down should return typed error");
     assert!(
         err.downcast_ref::<BudgetWindDownIgnored>().is_some(),
@@ -2516,6 +2465,7 @@ async fn dangling_tool_call_is_sanitized_before_reaching_provider() {
     });
     let (result, _output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
@@ -2645,6 +2595,7 @@ async fn first_no_progress_submit_intercepted_returns_corrective_and_continues()
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
@@ -2728,6 +2679,7 @@ async fn missing_rejected_fingerprint_skips_comparison_and_allows_finalize() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
@@ -2801,6 +2753,7 @@ async fn non_worker_role_bypasses_guard() {
     conv.push(Message::user("Plan the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
@@ -2869,6 +2822,7 @@ async fn different_fingerprint_allows_finalize() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
@@ -2966,6 +2920,7 @@ async fn empty_worktree_skips_guard_and_allows_finalize() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
@@ -3063,6 +3018,7 @@ async fn second_strike_no_progress_submission_settles_session() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
@@ -3277,6 +3233,7 @@ async fn gs37_no_edit_submit_after_rejection_keeps_one_quality_strike_and_prompt
     conv.push(Message::user("Do the task."));
     let (_result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
@@ -3438,6 +3395,7 @@ async fn changed_diff_fingerprint_does_not_trigger_no_progress_submission() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
@@ -3718,6 +3676,7 @@ async fn shared_compaction_cs_released_and_transcript_coherent_after_proactive_c
 
     let (result, _, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &shared_cs,
             provider: &provider,
             tools: &[],
@@ -3839,6 +3798,7 @@ async fn cancel_during_failed_compaction_releases_guard_no_orphaned_context() {
 
     let (result, _, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &shared_cs,
             provider: &provider,
             tools: &[],
@@ -3953,6 +3913,7 @@ async fn successful_compaction_produces_clean_post_rotation_transcript() {
 
     let (result, _, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &shared_cs,
             provider: &provider,
             tools: &[],
@@ -4210,6 +4171,7 @@ async fn compaction_cs_released_on_max_turns_exit() {
 
     let (result, _, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &shared_cs,
             provider: &provider,
             tools: &[],
@@ -4265,6 +4227,7 @@ async fn compaction_cs_released_on_cancel_exit() {
 
     let (result, _, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &shared_cs,
             provider: &provider,
             tools: &[],
@@ -4322,6 +4285,7 @@ async fn load_conversation_projects_compacted_view_while_raw_preserves_history()
 
     let (result, _, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[],
@@ -5702,6 +5666,13 @@ async fn provider_phase_scenario_cancellation_and_drop_flush_active_interval_onc
     );
 }
 
+// `PHASE_METRIC_LOCK` is held across the `.await`s below on purpose: the four
+// scenarios each measure an exact before/after delta on the process-global
+// phase-metric collector, so they must not interleave with one another. They
+// already run inside this single test function, and the dedicated
+// `PHASE_METRIC_ROLE` label keeps their samples away from the worker-role
+// dispatcher tests running in parallel, so the lock is uncontended in practice.
+#[allow(clippy::await_holding_lock)]
 #[tokio::test]
 async fn provider_phase_scripted_reply_loop_scenarios() {
     // Keep every database-backed harness and process-global refinement-role

--- a/server/crates/djinn-slot/src/reply_loop/turn.rs
+++ b/server/crates/djinn-slot/src/reply_loop/turn.rs
@@ -528,6 +528,14 @@ pub struct ReplyLoopContext<'a> {
     /// the same instance to decide whether to defer or demote work that would
     /// otherwise apply to the pre-rotation transcript.
     pub compaction_cs: &'a CompactionCriticalSection,
+    /// Session budget policy for this reply loop.
+    ///
+    /// `None` — every production caller — resolves the policy from the process
+    /// environment via `SessionBudgetPolicy::from_env()`, so the
+    /// `DJINN_SESSION_BUDGET_*` operator contract is unchanged. Tests that need
+    /// a specific budget inject it here instead of mutating the process env,
+    /// which is shared by every concurrently running test.
+    pub session_budget: Option<SessionBudgetPolicy>,
 }
 
 /// A deterministic compaction seam for downstream reply-loop fixtures. The
@@ -636,6 +644,7 @@ pub async fn run_reply_loop(
         active_mcp_server_names,
         max_turns_override,
         compaction_cs,
+        session_budget: session_budget_override,
     } = ctx;
     let tool_dispatcher = match slot_ctx.tool_dispatcher.as_ref() {
         Some(d) => d.as_ref(),
@@ -744,13 +753,15 @@ pub async fn run_reply_loop(
         let mut corrected_tool_failure_signatures: HashSet<ToolCallSignature> = HashSet::new();
         let mut last_assistant_text = String::new();
         let mut turns: u32 = 0;
-        let session_budget = SessionBudgetPolicy::from_env()
-            .unwrap_or_else(|err| {
-                tracing::warn!(
-                    error = %err,
-                    "ReplyLoop: invalid session budget configuration; using defaults"
-                );
-                SessionBudgetPolicy::default()
+        let session_budget = session_budget_override
+            .unwrap_or_else(|| {
+                SessionBudgetPolicy::from_env().unwrap_or_else(|err| {
+                    tracing::warn!(
+                        error = %err,
+                        "ReplyLoop: invalid session budget configuration; using defaults"
+                    );
+                    SessionBudgetPolicy::default()
+                })
             })
             .resolve(role_name, model_id, context_window, max_turns_override);
         let max_turns = session_budget.effective_max_turns;

--- a/server/crates/djinn-slot/src/reply_loop_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop_tests.rs
@@ -137,6 +137,7 @@ async fn run_with_provider_and_model(
     let worktree_path = worktree.as_path();
     run_reply_loop(
         ReplyLoopContext {
+            session_budget: None,
             compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider,
             tools,


### PR DESCRIPTION
## The racing shared resource

**The `DJINN_SESSION_BUDGET_WORKER_*` environment variables** — `MAX_CUMULATIVE_TOKENS`, `SOFT_THRESHOLD_RATIO`, `HARD_THRESHOLD_RATIO`, `MAX_TURNS`.

Six tests in `reply_loop/tests.rs` mutated them with `std::env::set_var` while holding `SESSION_BUDGET_ENV_LOCK`:

- `hard_token_budget_injects_wind_down_and_ends_gracefully`
- `hard_token_budget_wind_down_ignored_falls_back_to_hard_error`
- `soft_budget_threshold_triggers_one_shot_converge_reminder`
- `soft_budget_below_threshold_no_injection`
- `hard_budget_wind_down_captures_budget_summary`
- `hard_budget_wind_down_ignored_returns_typed_budget_error`

That mutex serialized the **writers** and nothing else. `run_reply_loop` resolves its policy with `SessionBudgetPolicy::from_env()` (`turn.rs:747`) on every entry, and the other 59 tests in the module — none of which take the lock — are all unguarded **readers** of the same process environment. There is one environment per process, so while any of the six held the lock, every concurrently running sibling resolved a 100–1000 token cumulative cap instead of the default.

The lock's own doc comment claimed it prevented this ("without serialization a concurrent test could observe our env override"). It could not: serializing writers does nothing when the readers never participate.

The result is the observed varying subset — whichever tests happened to overlap the override window died, in whatever way their scenario reached the cap first. Verbatim, from the same run:

```
panicked at crates/djinn-slot/src/reply_loop/tests.rs:3980:
expected ok, got: Err(budget wind-down ignored: hard token budget threshold reached:
  cumulative_tokens=8510, hard_cap=920, max_cumulative_tokens=1000,
  hard_threshold_ratio=0.92; ...)

panicked at crates/djinn-slot/src/reply_loop/tests.rs:587:
conversation should be compact after compaction, got 8 messages
```

`max_cumulative_tokens=1000, hard_threshold_ratio=0.92` is `install_session_budget_env_with_hard(1_000, 0.5, 0.92)` — another test's override, read by a compaction test that never sets a budget.

### Isolating the cause

Skipping only those six tests, changing nothing else, on pristine `main`:

```
cargo test -p djinn-slot --lib reply_loop::tests:: -- --skip hard_token_budget_injects_wind_down_and_ends_gracefully ...
run 1..6: ok. 59 passed; 0 failed   (every run)
SUMMARY: 6 clean / 0 failed
```

0/8 clean with them, 6/6 clean without them.

## The fix

Following the shape of #2820 and #2853 — a process-global made an injectable dependency with a fallback to the existing global, leaving production wiring untouched:

- **`ReplyLoopContext` gains `session_budget: Option<SessionBudgetPolicy>`.** `run_reply_loop` uses it when set and otherwise falls back to `SessionBudgetPolicy::from_env()`. All three production construction sites (`djinn-agent`'s slot reply loop, and the `reply_loop_tests` / `streaming_retry_tests` / `compaction_hardening` harnesses) pass `None`, so deployed behaviour and the `DJINN_SESSION_BUDGET_*` operator contract are **unchanged**.
- **The six tests inject their policy** through a new `ReplyLoopHarness::with_session_budget` helper (and one direct `ReplyLoopContext` literal). The policy is built by `SessionBudgetPolicy::from_env_iter`, the same `from_env_map` parsing path `from_env()` uses — so the config-parsing coverage the `set_var` version had is preserved, it just never touches the process environment.
- Because each injected policy is built from its own pairs alone, the "safety net" `remove_var` calls that guarded against a *previous* test's leaked override are gone: there is nothing left to leak.
- **`SESSION_BUDGET_ENV_LOCK`, `install_session_budget_env*`, and `clear_session_budget_env` are deleted.** No `set_var`/`remove_var` remains anywhere in the module.
- The module-wide `#![allow(clippy::await_holding_lock)]` on `mod tests` is replaced by a narrowly scoped `#[allow]` on `provider_phase_scripted_reply_loop_scenarios`, the one remaining test that holds a lock (`PHASE_METRIC_LOCK`) across an await. That lock is pre-existing, guards four exact before/after phase-metric deltas that already run inside a single test function, and is not implicated in this flake — all runs below are clean with it in place.

No `#[serial]`, no retries, no `#[ignore]`, no single-threading.

## Verification

All runs are `cargo test -p djinn-slot --lib reply_loop::tests::` with `SQLX_OFFLINE=true` and `DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres`. Rebased onto `8a35eff07` (current `main`, after #2853/#2854).

### Before — default parallelism, 8 runs

```
run 1: FAILED. 53 passed; 12 failed | gs37_no_edit_submit_after_rejection..., identical_failing_tool_call..., max_step_cap..., max_step_wind_down_ignored..., no_compaction_when_sum_large..., nudge_count_resets..., permission_denial..., proactive_compaction..., provider_declared_tool_dispatch..., shared_compaction_cs..., successful_compaction..., two_compactions_persist...
run 2: FAILED. 55 passed; 10 failed | identical_failing_tool_call..., max_step_cap..., max_step_wind_down_ignored..., mixed_successful_tool_batch..., nudge_count_resets..., permission_denial..., proactive_compaction..., productive_turns_persisted_normally, successful_compaction..., two_compactions_persist...
run 3: FAILED. 60 passed;  5 failed | permission_denial..., proactive_compaction..., shared_compaction_cs..., successful_compaction..., two_compactions_persist...
run 4: FAILED. 58 passed;  7 failed | identical_failing_tool_call..., max_step_cap..., max_step_wind_down_ignored..., mixed_successful_tool_batch..., no_compaction_when_sum_large..., successful_compaction..., two_compactions_persist...
run 5: FAILED. 60 passed;  5 failed | mixed_successful_tool_batch..., no_compaction_when_sum_large..., shared_compaction_cs..., successful_compaction..., two_compactions_persist...
run 6: FAILED. 60 passed;  5 failed | gs37_no_edit_submit_after_rejection..., identical_failing_tool_call..., max_step_cap..., no_compaction_when_sum_large..., two_compactions_persist...
run 7: FAILED. 58 passed;  7 failed | gs37_no_edit_submit_after_rejection..., identical_failing_tool_call..., max_step_wind_down_ignored..., mixed_successful_tool_batch..., no_compaction_when_sum_large..., proactive_compaction..., shared_compaction_cs...
run 8: FAILED. 57 passed;  8 failed | identical_failing_tool_call..., max_step_cap..., max_step_wind_down_ignored..., mixed_successful_tool_batch..., no_compaction_when_sum_large..., proactive_compaction..., shared_compaction_cs..., two_compactions_persist...
SUMMARY: 0 clean / 8 failed
```

14 distinct assertion sites across the 8 runs; no two runs failed the same set.

### After — default parallelism, 20 runs

```
run 1..20: ok. 65 passed; 0 failed   (every run)
SUMMARY: 20 clean / 0 failed
```

### After — other thread counts

```
--test-threads=1    5 runs   SUMMARY: 5 clean / 0 failed
--test-threads=64  10 runs   SUMMARY: 10 clean / 0 failed
```

### After — the whole `djinn-slot` lib suite (545 tests)

```
cargo test -p djinn-slot --lib
run 1..10:  reply_loop failures: 0 / 0 / 0 / 0 / 0 / 0 / 0 / 0 / 0 / 0
```

Every `reply_loop::tests::*` test passed in all 10 runs. The suite still reports failures from `llm_extraction`, which are **pre-existing and unrelated** — the same two tests fail under the full suite on pristine `main`:

```
main, cargo test -p djinn-slot --lib, 5 runs:
  llm_extraction_tests::llm_extraction_semantic_duplicate_...  FAILED 5/5
  llm_extraction::tests::llm_extraction_fallback_returns_early_...  intermittent
  plus 3-9 reply_loop::tests failures per run
```

`llm_extraction_semantic_duplicate_...` passes in isolation on `main` and fails deterministically under the full suite both before and after this change, so it is a separate shared-resource bug in a different module and is untouched here.

### Gates

`cargo fmt --all -- --check` clean; `cargo clippy -p djinn-slot --all-targets -- -D warnings` clean; `cargo clippy -p djinn-agent --all-targets -- -D warnings` clean (two of its `ReplyLoopContext` construction sites are updated).
