### PR TITLE
fix(8ne1): remove the last process-global couplings from coordinator/db tests, and gate new ones

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -661,6 +661,40 @@ jobs:
       - name: Check no include! of hand-written source
         if: needs.preflight.outputs.size == 'true'
         run: ./scripts/check-include-macro.sh
+      # Also a GATE, and for the same reason: complying costs the same keystrokes
+      # as violating (`render_isolated` instead of `render`), so there is nothing
+      # to escape to and no marker is offered.
+      #
+      # It scans the DIFF rather than the whole tree, which the include! guard
+      # above deliberately does not — the difference is that ~150 pre-existing
+      # reads exist and many sit in tests that hand work to `tokio::spawn`,
+      # where the conversion is a judgement call rather than a mechanical edit.
+      # Gating the whole tree would be a migration order. Note also that this
+      # workspace's nextest lane CANNOT observe the bug being prevented: nextest
+      # gives each test its own process, so the collision only ever appears
+      # under `cargo test` in the developer loop (measured: 21/40 runs failing
+      # under `cargo test`, 0/15 under `cargo nextest run`, same commit). That
+      # is precisely why a source-level gate is the only thing that can catch
+      # it at merge time.
+      - name: Self-test global-metrics-in-tests guard
+        if: needs.preflight.outputs.size == 'true'
+        run: ./scripts/test-check-test-global-metrics.sh
+      - name: Check tests do not read the process-global metrics registry
+        if: needs.preflight.outputs.size == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -eu
+          if [ -z "$BASE_SHA" ]; then
+            git fetch --no-tags --depth=1 origin main >/dev/null 2>&1 || true
+            BASE_SHA="$(git rev-parse --verify origin/main 2>/dev/null || true)"
+          fi
+          if [ -z "$BASE_SHA" ]; then
+            echo "::warning::Could not determine a base SHA (event=$EVENT_NAME); falling back to a whole-tree report."
+            ./scripts/check-test-global-metrics.sh --all || true
+            exit 0
+          fi
+          ./scripts/check-test-global-metrics.sh "$BASE_SHA"
       # rustfmt is NOT in server/rust-toolchain.toml's `components`, and that
       # file's own comment records why that matters: rustup syncs to exactly
       # what is listed. So `rustup toolchain install` above does not guarantee

--- a/scripts/check-test-global-metrics.sh
+++ b/scripts/check-test-global-metrics.sh
@@ -1,0 +1,257 @@
+#!/bin/sh
+# Guard: test code must not read the process-global metrics registry.
+#
+# WHY THIS EXISTS
+#
+# `djinn_telemetry::render()` renders ONE registry, installed process-wide by
+# `djinn_telemetry::init()`. `cargo test` runs every test in a binary as a
+# thread of a single process, so a test that renders that registry is reading
+# the whole binary's cumulative state. Two failure shapes follow, and this repo
+# has now hit both six times:
+#
+#   * gauges  — `set()` is last-writer-wins, so an absolute assertion is an
+#               assertion about whichever sibling test wrote most recently;
+#   * counters — a before/after delta narrows the window but does not close it,
+#               because a concurrent writer can land between the two renders.
+#
+# Both surface as low-rate flakes in a DIFFERENT test each run, which is why
+# they cost six separate investigations (#2820, #2824, #2851, and the three
+# residuals fixed alongside this script) instead of one.
+#
+# The fix is mechanical and already exists: `djinn_telemetry::render_isolated`
+# for a synchronous body, `djinn_telemetry::IsolatedRecorder` + `scope()` for an
+# async one. Both give the test a registry no other test can reach, so exact
+# assertions become deterministic without serializing anything.
+#
+# WHY IT GATES ONLY ADDED LINES
+#
+# Measured on this tree: `cargo nextest run` gives every test its own process,
+# so none of these collisions is observable in the merge queue — the workspace
+# lane cannot fail on them. Reproduced on the pre-fix djinn-db tests:
+#
+#   cargo test    -p djinn-db --lib parse_archive_window_days .... 21/40 FAILED
+#   cargo nextest run -p djinn-db --lib -E 'test(parse_...)' ....   0/15 failed
+#
+# They bite the developer loop instead (`make test` is `cargo test -p djinn-db`).
+# There are ~150 pre-existing `render()` reads across ~30 files, many inside
+# tests that hand work to `tokio::spawn` — where the conversion needs real
+# thought, not a mechanical edit. A whole-tree gate would therefore demand a
+# large migration whose payoff CI cannot even observe.
+#
+# THERE IS DELIBERATELY NO OPT-OUT MARKER, for the reason recorded at the top
+# of check-file-size.sh: that guard's `djinn:allow-oversize` escape went 0 ->
+# 108 markers while oversized files went 22 -> 79, because evading cost one
+# comment line and complying cost a restructure. Restricting this rule to added
+# lines keeps the opposite ratio — writing `render_isolated` instead of
+# `render` is the same amount of typing — so no escape hatch is needed.
+#
+# WHAT IS EXEMPT, BY PATTERN
+#
+#   1. `server/crates/djinn-telemetry/` — it owns the singleton and must be
+#      able to test `init()`/`render()` themselves.
+#   2. Production code. A `render()` outside a `#[cfg(test)]` block and outside
+#      a `#[test]`-attributed function is the metrics endpoint or a health
+#      probe doing exactly what the global registry is for.
+#
+# Usage:
+#   ./scripts/check-test-global-metrics.sh <base-sha>   # added lines vs base
+#   ./scripts/check-test-global-metrics.sh --all        # whole tree (report)
+#
+# Exit codes: 0 clean, 1 violations found, 2 usage/environment error.
+
+set -eu
+
+# Resolve the tree to scan from the CALLER's working directory rather than from
+# this script's own location. CI invokes it from the repo root either way, and
+# deriving it this way is what lets the self-test drive the real guard against a
+# throwaway fixture repo instead of a mode that only the test exercises.
+if ! REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null); then
+    echo "::error::check-test-global-metrics: not a git repository." >&2
+    exit 2
+fi
+cd "$REPO_ROOT"
+
+case "${1:-}" in
+-h | --help)
+    sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+--all) MODE=all ;;
+"")
+    echo "check-test-global-metrics: a base SHA is required (or --all)." >&2
+    echo "usage: $0 <base-sha> | --all" >&2
+    exit 2
+    ;;
+*)
+    MODE=diff
+    BASE=$1
+    ;;
+esac
+
+# Emit "lineno" for every line of $1 that is inside test code AND reads the
+# process-global registry.
+#
+# "Inside test code" is tracked structurally rather than by filename: a
+# `#[cfg(test)]`-attributed `mod ... { }` block, or a `#[test]` /
+# `#[tokio::test]` / `#[rstest]`-attributed item, up to its matching close
+# brace. Braces are counted on a line with double-quoted string literals and
+# `//` comments stripped, so neither a brace in a string nor one in a trailing
+# comment can unbalance the tracker. This is what keeps the two legitimate
+# production readers (the /metrics HTTP handler and the coordinator health
+# probe) out of scope even though both live in files that also contain tests.
+#
+# A whole file counts as test code when its path says so: an integration-test
+# directory, or a module a parent declares as `#[cfg(test)] mod x;`. In that
+# second case the attribute lives in the PARENT file, so the structural tracker
+# above sees nothing — and a bare helper `fn` in such a module (no `#[test]`
+# attribute of its own) would otherwise slip through. That is not hypothetical:
+# `extension/tests/jit_trace_tests.rs` reads the global registry from exactly
+# such a helper.
+whole_file_is_test() {
+    case "$1" in
+    */tests/*) return 0 ;;
+    */tests.rs | *_tests.rs | *_test.rs) return 0 ;;
+    esac
+    return 1
+}
+
+scan_test_reads() {
+    awk -v whole_file="${2:-0}" '
+        function strip(line,    i, n, c, out, in_str) {
+            n = length(line); i = 1; out = ""; in_str = 0
+            while (i <= n) {
+                c = substr(line, i, 1)
+                if (in_str) {
+                    if (c == "\\") { i += 2; continue }
+                    if (c == "\"") { in_str = 0 }
+                    i++
+                    continue
+                }
+                if (c == "\"") { in_str = 1; i++; continue }
+                if (c == "/" && substr(line, i + 1, 1) == "/") { break }
+                out = out c
+                i++
+            }
+            return out
+        }
+        function braces(s,    i, n, c, d) {
+            n = length(s); d = 0
+            for (i = 1; i <= n; i++) {
+                c = substr(s, i, 1)
+                if (c == "{") d++
+                else if (c == "}") d--
+            }
+            return d
+        }
+        BEGIN { depth = 0; armed = 0 }
+        {
+            s = strip($0)
+
+            if (whole_file == 1) {
+                if (s ~ /djinn_telemetry::render[ \t]*\(/) print FNR
+                next
+            }
+
+            if (depth > 0) {
+                if (s ~ /djinn_telemetry::render[ \t]*\(/) print FNR
+                depth += braces(s)
+                if (depth <= 0) depth = 0
+                next
+            }
+
+            # A test attribute arms the tracker; the block it introduces starts
+            # at the next line that opens a brace.
+            if (s ~ /^[ \t]*#\[(cfg\(test\)|test|tokio::test|rstest)/ ||
+                s ~ /^[ \t]*#\[tokio::test\(/) {
+                armed = 1
+                next
+            }
+
+            if (armed) {
+                d = braces(s)
+                if (d > 0) { depth = d; armed = 0; next }
+                # `#[cfg(test)] mod foo;` and `#[cfg(test)] use ...;` introduce
+                # no block in this file.
+                if (s ~ /;[ \t]*$/) { armed = 0 }
+                next
+            }
+        }
+    ' "$1"
+}
+
+is_exempt() {
+    case "$1" in
+    server/crates/djinn-telemetry/*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+if [ "$MODE" = all ]; then
+    FILES=$(git ls-files -- '*.rs')
+else
+    if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+        echo "::error::check-test-global-metrics: base SHA '$BASE' is not resolvable." >&2
+        exit 2
+    fi
+    FILES=$(git diff --name-only --diff-filter=AMR "$BASE...HEAD" -- '*.rs')
+fi
+
+ADDED_TMP=$(mktemp)
+trap 'rm -f "$ADDED_TMP"' EXIT INT TERM
+
+violations=""
+for f in $FILES; do
+    [ -n "$f" ] || continue
+    [ -f "$f" ] || continue
+    is_exempt "$f" && continue
+
+    if whole_file_is_test "$f"; then
+        hits=$(scan_test_reads "$f" 1)
+    else
+        hits=$(scan_test_reads "$f" 0)
+    fi
+    [ -n "$hits" ] || continue
+
+    if [ "$MODE" = diff ]; then
+        # Added line numbers in the post-image, from -U0 hunk headers.
+        added=$(git diff --unified=0 "$BASE...HEAD" -- "$f" |
+            awk '/^@@/ {
+                    match($0, /\+[0-9]+(,[0-9]+)?/)
+                    spec = substr($0, RSTART + 1, RLENGTH - 1)
+                    split(spec, p, ",")
+                    count = (p[2] == "") ? 1 : p[2]
+                    for (i = 0; i < count; i++) print p[1] + i
+                 }')
+        printf '%s\n' "$added" >"$ADDED_TMP"
+        hits=$(printf '%s\n' "$hits" | grep -Fxf "$ADDED_TMP" || true)
+        [ -n "$hits" ] || continue
+    fi
+
+    for n in $hits; do
+        violations="${violations}  ${f}:${n}: $(sed -n "${n}p" "$f" | sed 's/^[ \t]*//')
+"
+    done
+done
+
+if [ -n "$violations" ]; then
+    echo "::error::Test code must not read the process-global metrics registry. \`djinn_telemetry::render()\` returns the whole test binary's cumulative state, so a sibling test running concurrently decides what you assert on. Use \`djinn_telemetry::render_isolated\` (sync) or \`djinn_telemetry::IsolatedRecorder\` + \`scope()\` (async)." >&2
+    echo "" >&2
+    printf '%s' "$violations" >&2
+    echo "" >&2
+    echo "How to fix:" >&2
+    echo "  sync   let (_, rendered) = djinn_telemetry::render_isolated(|| emit());" >&2
+    echo "  async  let recorder = djinn_telemetry::IsolatedRecorder::new();" >&2
+    echo "         let guard = recorder.scope();   // hold across the region" >&2
+    echo "         ... ; let rendered = recorder.render();" >&2
+    echo "" >&2
+    echo "Both give the test a registry no sibling can reach, so before/after" >&2
+    echo "deltas become unnecessary and absolute assertions become exact." >&2
+    echo "There is no opt-out marker, by design." >&2
+    exit 1
+fi
+
+if [ "$MODE" = all ]; then
+    echo "OK: no test-code reads of the process-global metrics registry (whole tree)."
+else
+    echo "OK: no newly-added test-code reads of the process-global metrics registry."
+fi

--- a/scripts/test-check-test-global-metrics.sh
+++ b/scripts/test-check-test-global-metrics.sh
@@ -1,0 +1,228 @@
+#!/bin/sh
+# Self-test harness for scripts/check-test-global-metrics.sh.
+#
+# Drives the production guard against a throwaway git repository this script
+# creates (and always tears down) under a scratch directory. Pure POSIX shell
+# plus git; no cargo, no network.
+#
+# A guard nobody has watched fail is not a guard. Every assertion expecting
+# exit 1 exists to prove this one actually fires on the shapes it was written
+# for. Every assertion expecting exit 0 exists to prove the exemptions are not
+# so wide that the guard has stopped meaning anything — in particular that the
+# two legitimate production readers (the /metrics HTTP handler and the health
+# probe) stay out of scope even when they share a file with tests, and that an
+# untouched pre-existing violation does not fail an unrelated PR.
+#
+# Run from anywhere:
+#
+#   sh scripts/test-check-test-global-metrics.sh
+#
+# Exits 0 on success, 1 if any assertion failed.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GUARD="$SCRIPT_DIR/check-test-global-metrics.sh"
+
+if [ ! -f "$GUARD" ]; then
+    printf 'FATAL: production guard not found at %s\n' "$GUARD" >&2
+    exit 2
+fi
+
+WORK=$(mktemp -d)
+cleanup() { rm -rf -- "$WORK" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+PASS=0
+FAIL=0
+pass() {
+    PASS=$((PASS + 1))
+    printf '  ok   %s\n' "$1"
+}
+fail() {
+    FAIL=$((FAIL + 1))
+    printf '  FAIL %s\n' "$1" >&2
+    [ -n "${2:-}" ] && printf '       %s\n' "$2" >&2
+    return 0
+}
+
+REPO="$WORK/repo"
+mkdir -p "$REPO"
+cd "$REPO"
+git init -q .
+git config user.email guard@example.com
+git config user.name "Guard Self Test"
+git config commit.gpgsign false
+
+# ── base commit: a file with a PRE-EXISTING violation ─────────────────────
+mkdir -p server/crates/legacy/src
+cat >server/crates/legacy/src/lib.rs <<'EOF'
+pub fn thing() -> u32 { 1 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn legacy_reads_the_global_registry() {
+        let rendered = djinn_telemetry::render().unwrap();
+        assert!(rendered.contains("x"));
+    }
+}
+EOF
+git add server/crates/legacy/src/lib.rs
+git commit -qm base
+BASE=$(git rev-parse HEAD)
+
+expect() {
+    label=$1
+    want=$2
+    shift 2
+    set +e
+    out=$("$GUARD" "$@" 2>&1)
+    got=$?
+    set -e
+    if [ "$got" -eq "$want" ]; then
+        pass "$label"
+    else
+        fail "$label" "expected exit $want, got $got: $(printf '%s' "$out" | tr '\n' ' ')"
+    fi
+}
+
+echo "check-test-global-metrics self-test"
+
+# 1. An untouched legacy violation must not fail an unrelated PR. This is the
+#    load-bearing property of the added-lines scope: without it the guard is a
+#    whole-tree migration order, and the file-size guard has already shown what
+#    happens when compliance costs more than evasion.
+mkdir -p server/crates/other/src
+printf 'pub fn unrelated() {}\n' >server/crates/other/src/lib.rs
+git add server/crates/other/src/lib.rs
+git commit -qm "unrelated change"
+expect "untouched legacy violation does not fail an unrelated change" 0 "$BASE"
+
+# 2. Whole-tree mode still sees the legacy violation, so nothing is hidden.
+expect "--all reports the legacy violation" 1 --all
+
+# 3. A NEW read inside a #[cfg(test)] mod is a violation.
+cat >>server/crates/other/src/lib.rs <<'EOF'
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn new_read() {
+        let rendered = djinn_telemetry::render().unwrap();
+        assert!(rendered.is_empty());
+    }
+}
+EOF
+git add server/crates/other/src/lib.rs
+git commit -qm "add a new global read"
+expect "new read inside #[cfg(test)] mod is caught" 1 "$BASE"
+git reset -q --hard HEAD~1
+
+# 4. A NEW read in a *_tests.rs module a parent declares — the shape the
+#    structural tracker alone misses, because the #[cfg(test)] lives in the
+#    parent file — and from a bare helper fn with no #[test] attribute.
+mkdir -p server/crates/other/src
+cat >server/crates/other/src/helper_tests.rs <<'EOF'
+fn snapshot() -> String {
+    djinn_telemetry::render().expect("render")
+}
+EOF
+git add server/crates/other/src/helper_tests.rs
+git commit -qm "add helper tests module"
+expect "new read in a *_tests.rs helper fn is caught" 1 "$BASE"
+git reset -q --hard HEAD~1
+
+# 5. Production readers are NOT violations, even in a file that also has tests
+#    below them. If this ever flips, the guard has started ordering people to
+#    break the /metrics endpoint.
+mkdir -p server/src/server
+cat >server/src/server/mod.rs <<'EOF'
+pub async fn metrics_endpoint() -> String {
+    match djinn_telemetry::render() {
+        Ok(body) => body,
+        Err(e) => e,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn endpoint_exists() {
+        assert!(true);
+    }
+}
+
+pub fn health_probe() -> String {
+    djinn_telemetry::render().unwrap_or_default()
+}
+EOF
+git add server/src/server/mod.rs
+git commit -qm "add production readers"
+expect "production readers before and after a test mod are exempt" 0 "$BASE"
+git reset -q --hard HEAD~1
+
+# 6. The telemetry crate owns the singleton and must be able to test it.
+mkdir -p server/crates/djinn-telemetry/src
+cat >server/crates/djinn-telemetry/src/lib.rs <<'EOF'
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn render_works() {
+        let rendered = djinn_telemetry::render().unwrap();
+        assert!(rendered.is_empty());
+    }
+}
+EOF
+git add server/crates/djinn-telemetry/src/lib.rs
+git commit -qm "telemetry own tests"
+expect "the djinn-telemetry crate is exempt" 0 "$BASE"
+git reset -q --hard HEAD~1
+
+# 7. A mention in a comment or a string is not a call.
+cat >>server/crates/other/src/lib.rs <<'EOF'
+
+#[cfg(test)]
+mod comment_tests {
+    #[test]
+    fn mentions_only() {
+        // djinn_telemetry::render() is what this test deliberately avoids.
+        let s = "djinn_telemetry::render()";
+        assert!(!s.is_empty());
+    }
+}
+EOF
+git add server/crates/other/src/lib.rs
+git commit -qm "comment and string mentions"
+expect "a comment or string mention is not a call" 0 "$BASE"
+git reset -q --hard HEAD~1
+
+# 8. The sanctioned replacements pass.
+cat >>server/crates/other/src/lib.rs <<'EOF'
+
+#[cfg(test)]
+mod isolated_tests {
+    #[test]
+    fn sync_form() {
+        let (_, rendered) = djinn_telemetry::render_isolated(|| emit());
+        assert!(rendered.is_empty());
+    }
+
+    #[tokio::test]
+    async fn async_form() {
+        let recorder = djinn_telemetry::IsolatedRecorder::new();
+        let _guard = recorder.scope();
+        assert!(recorder.render().is_empty());
+    }
+}
+EOF
+git add server/crates/other/src/lib.rs
+git commit -qm "isolated forms"
+expect "render_isolated and IsolatedRecorder pass" 0 "$BASE"
+git reset -q --hard HEAD~1
+
+# 9. Usage errors are exit 2, distinct from a finding.
+expect "missing argument is a usage error, not a finding" 2
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -2522,8 +2522,6 @@ mod tests {
 
     #[tokio::test]
     async fn record_live_metrics_publishes_synthetic_cooldown_and_inflight_state() {
-        djinn_telemetry::init().unwrap();
-
         let db = crate::test_helpers::create_test_db();
         let (events_tx, _events_rx) = broadcast::channel(16);
         let cancel = CancellationToken::new();
@@ -2601,9 +2599,14 @@ mod tests {
             tracker.insert("pr-b".to_owned(), AutoMergeFastPathState::Reopen);
         }
 
-        actor.record_live_metrics();
-
-        let rendered = djinn_telemetry::render().unwrap();
+        // `record_live_metrics` is synchronous, so scoping it to a private
+        // recorder captures every emission and nothing else. All three series
+        // below are GAUGES on the process-global registry that
+        // `djinn_telemetry::render()` reads: any sibling test that records a
+        // live tick or a PR-poller decision overwrites them outright, so the
+        // absolute assertions here were assertions about whichever test wrote
+        // last (#2824).
+        let (_, rendered) = djinn_telemetry::render_isolated(|| actor.record_live_metrics());
         assert_eq!(
             rendered_metric_sample(&rendered, "djinn_dispatch_cooldowns_active"),
             "djinn_dispatch_cooldowns_active 2"

--- a/server/crates/djinn-coordinator/src/context.rs
+++ b/server/crates/djinn-coordinator/src/context.rs
@@ -57,9 +57,16 @@ pub struct ProposalSpecIntegritySweepConfig {
 }
 
 impl ProposalSpecIntegritySweepConfig {
+    /// The only environment read; the decision itself lives in
+    /// [`Self::from_lookup`] so tests never write a process-global.
     pub fn from_env() -> Self {
+        Self::from_lookup(|key| std::env::var(key).ok())
+    }
+
+    /// Resolve the gate from an arbitrary key/value source.
+    fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Self {
         Self {
-            enabled: std::env::var("DJINN_PROPOSAL_SPEC_INTEGRITY_SWEEP_V1")
+            enabled: lookup("DJINN_PROPOSAL_SPEC_INTEGRITY_SWEEP_V1")
                 .map(|value| parse_bool_env(&value))
                 .unwrap_or(false),
         }
@@ -281,76 +288,79 @@ impl Default for CacheCleanupConfig {
 
 impl CacheCleanupConfig {
     /// Build a config from environment variables, falling back to safe defaults.
+    ///
+    /// This is the only environment read; every decision lives in
+    /// [`Self::from_lookup`], which takes the values as a parameter.
     pub fn from_env() -> Self {
-        let mode = std::env::var("DJINN_CACHE_CLEANUP_MODE")
+        Self::from_lookup(|key| std::env::var(key).ok())
+    }
+
+    /// Resolve the config from an arbitrary key/value source.
+    ///
+    /// The parse and clamp rules used to read `std::env` directly, which made
+    /// them untestable without a `set_var`. The environment is process-global
+    /// and `cargo test` runs an entire test binary in one process, so those
+    /// writes were visible to every concurrently-running sibling — the fourth
+    /// instance of the shared-singleton flake shape that #2820/#2824/#2851
+    /// each fixed one instance of. Passing the lookup in removes the shared
+    /// cell from the test path entirely rather than trying to sequence access
+    /// to it.
+    fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Self {
+        let mode = lookup("DJINN_CACHE_CLEANUP_MODE")
             .map(|v| CacheCleanupMode::from_env_value(&v))
             .unwrap_or(CacheCleanupMode::DryRun);
 
-        let sccache_enabled = std::env::var("DJINN_CACHE_CLEANUP_SCCACHE_ENABLED")
+        let sccache_enabled = lookup("DJINN_CACHE_CLEANUP_SCCACHE_ENABLED")
             .map(|v| parse_bool_env(&v))
             .unwrap_or(true);
 
-        let sccache_max_age_hours = std::env::var("DJINN_CACHE_CLEANUP_SCCACHE_MAX_AGE_HOURS")
-            .ok()
+        let sccache_max_age_hours = lookup("DJINN_CACHE_CLEANUP_SCCACHE_MAX_AGE_HOURS")
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(24);
 
-        let sccache_delete_armed = std::env::var("DJINN_CACHE_CLEANUP_SCCACHE_DELETE_ARMED")
+        let sccache_delete_armed = lookup("DJINN_CACHE_CLEANUP_SCCACHE_DELETE_ARMED")
             .map(|v| parse_bool_env(&v))
             .unwrap_or(false);
 
-        let output_stash_delete_armed =
-            std::env::var("DJINN_CACHE_CLEANUP_OUTPUT_STASH_DELETE_ARMED")
-                .map(|v| parse_bool_env(&v))
-                .unwrap_or(false);
+        let output_stash_delete_armed = lookup("DJINN_CACHE_CLEANUP_OUTPUT_STASH_DELETE_ARMED")
+            .map(|v| parse_bool_env(&v))
+            .unwrap_or(false);
 
-        let cargo_debris_enabled = std::env::var("DJINN_CACHE_CLEANUP_CARGO_DEBRIS_ENABLED")
+        let cargo_debris_enabled = lookup("DJINN_CACHE_CLEANUP_CARGO_DEBRIS_ENABLED")
             .map(|v| parse_bool_env(&v))
             .unwrap_or(true);
 
-        let cargo_debris_max_age_days =
-            std::env::var("DJINN_CACHE_CLEANUP_CARGO_DEBRIS_MAX_AGE_DAYS")
-                .ok()
-                .and_then(|v| v.parse::<u64>().ok())
-                .unwrap_or(7);
+        let cargo_debris_max_age_days = lookup("DJINN_CACHE_CLEANUP_CARGO_DEBRIS_MAX_AGE_DAYS")
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(7);
 
         let warm_base_idle_retention_days =
-            std::env::var("DJINN_CACHE_CLEANUP_WARM_BASE_IDLE_RETENTION_DAYS")
-                .ok()
+            lookup("DJINN_CACHE_CLEANUP_WARM_BASE_IDLE_RETENTION_DAYS")
                 .and_then(|v| v.parse::<u64>().ok())
                 .unwrap_or(14);
 
-        let warm_profile_min_idle_hours =
-            std::env::var("DJINN_CACHE_CLEANUP_WARM_PROFILE_MIN_IDLE_HOURS")
-                .ok()
-                .and_then(|value| parse_unsigned_decimal(&value))
-                .unwrap_or(24);
+        let warm_profile_min_idle_hours = lookup("DJINN_CACHE_CLEANUP_WARM_PROFILE_MIN_IDLE_HOURS")
+            .and_then(|value| parse_unsigned_decimal(&value))
+            .unwrap_or(24);
 
-        let warm_base_grace_period_secs =
-            std::env::var("DJINN_CACHE_CLEANUP_WARM_BASE_GRACE_PERIOD_SECS")
-                .ok()
-                .and_then(|v| v.parse::<u64>().ok())
-                .unwrap_or(300);
+        let warm_base_grace_period_secs = lookup("DJINN_CACHE_CLEANUP_WARM_BASE_GRACE_PERIOD_SECS")
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(300);
 
-        let warm_base_low_free_ratio =
-            std::env::var("DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO")
-                .ok()
-                .and_then(|v| v.parse::<f64>().ok())
-                .filter(|v| (0.0..1.0).contains(v))
-                .unwrap_or(0.15);
+        let warm_base_low_free_ratio = lookup("DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO")
+            .and_then(|v| v.parse::<f64>().ok())
+            .filter(|v| (0.0..1.0).contains(v))
+            .unwrap_or(0.15);
 
-        let warm_base_high_free_ratio =
-            std::env::var("DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO")
-                .ok()
-                .and_then(|v| v.parse::<f64>().ok())
-                .filter(|v| (0.0..1.0).contains(v))
-                .unwrap_or(0.25);
+        let warm_base_high_free_ratio = lookup("DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO")
+            .and_then(|v| v.parse::<f64>().ok())
+            .filter(|v| (0.0..1.0).contains(v))
+            .unwrap_or(0.25);
 
         let warm_base_low_free_ratio = warm_base_low_free_ratio.min(warm_base_high_free_ratio);
 
         let warm_unrecognized_min_idle_days =
-            std::env::var("DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS")
-                .ok()
+            lookup("DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS")
                 .and_then(|value| parse_unsigned_decimal(&value))
                 .unwrap_or(7);
 
@@ -539,6 +549,18 @@ fn recover_lock<'a, T>(
 mod tests {
     use super::*;
 
+    /// A fixed key/value table to hand to `from_lookup`.
+    ///
+    /// This is the whole point of the seam: the "environment" a config test
+    /// reasons about is a local value owned by that test, not the one shared
+    /// process-wide with every sibling running on another libtest thread.
+    fn env_fixture(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
     #[test]
     fn cache_cleanup_config_default_is_safe() {
         let config = CacheCleanupConfig::default();
@@ -565,69 +587,54 @@ mod tests {
 
     #[test]
     fn cache_cleanup_unrecognized_idle_days_falls_back_to_the_shipped_default() {
-        unsafe {
-            std::env::set_var(
-                "DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS",
-                "not-a-number",
-            );
-        }
+        let invalid = env_fixture(&[(
+            "DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS",
+            "not-a-number",
+        )]);
         assert_eq!(
-            CacheCleanupConfig::from_env().warm_unrecognized_min_idle_days,
+            CacheCleanupConfig::from_lookup(|key| invalid.get(key).cloned())
+                .warm_unrecognized_min_idle_days,
             7
         );
-        unsafe {
-            std::env::set_var("DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS", "30");
-        }
+
+        let overridden =
+            env_fixture(&[("DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS", "30")]);
         assert_eq!(
-            CacheCleanupConfig::from_env().warm_unrecognized_min_idle_days,
+            CacheCleanupConfig::from_lookup(|key| overridden.get(key).cloned())
+                .warm_unrecognized_min_idle_days,
             30
         );
-        unsafe {
-            std::env::remove_var("DJINN_CACHE_CLEANUP_WARM_UNRECOGNIZED_MIN_IDLE_DAYS");
-        }
     }
 
     #[test]
     fn cache_cleanup_config_from_env_ignores_invalid_numbers() {
-        // Set invalid values and ensure we fall back to defaults, not crash.
-        unsafe {
-            std::env::set_var("DJINN_CACHE_CLEANUP_WARM_BASE_IDLE_RETENTION_DAYS", "abc");
-            std::env::set_var("DJINN_CACHE_CLEANUP_WARM_BASE_GRACE_PERIOD_SECS", "-1");
-            std::env::set_var("DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO", "1.5");
-            std::env::set_var("DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO", "nope");
-        }
+        // Supply invalid values and ensure we fall back to defaults, not crash.
+        let env = env_fixture(&[
+            ("DJINN_CACHE_CLEANUP_WARM_BASE_IDLE_RETENTION_DAYS", "abc"),
+            ("DJINN_CACHE_CLEANUP_WARM_BASE_GRACE_PERIOD_SECS", "-1"),
+            ("DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO", "1.5"),
+            ("DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO", "nope"),
+        ]);
 
-        let config = CacheCleanupConfig::from_env();
+        let config = CacheCleanupConfig::from_lookup(|key| env.get(key).cloned());
         assert_eq!(config.warm_base_idle_retention_days, 14);
         assert_eq!(config.warm_base_grace_period, Duration::from_secs(300));
         assert!((config.warm_base_low_free_ratio - 0.15).abs() < f64::EPSILON);
         assert!((config.warm_base_high_free_ratio - 0.25).abs() < f64::EPSILON);
-
-        unsafe {
-            std::env::remove_var("DJINN_CACHE_CLEANUP_WARM_BASE_IDLE_RETENTION_DAYS");
-            std::env::remove_var("DJINN_CACHE_CLEANUP_WARM_BASE_GRACE_PERIOD_SECS");
-            std::env::remove_var("DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO");
-            std::env::remove_var("DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO");
-        }
     }
 
     #[test]
     fn cache_cleanup_config_from_env_low_is_capped_to_high() {
-        unsafe {
-            std::env::set_var("DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO", "0.9");
-            std::env::set_var("DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO", "0.2");
-        }
+        let env = env_fixture(&[
+            ("DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO", "0.9"),
+            ("DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO", "0.2"),
+        ]);
 
-        let config = CacheCleanupConfig::from_env();
+        let config = CacheCleanupConfig::from_lookup(|key| env.get(key).cloned());
         // Low should be clamped to high so the stop-at-high-watermark semantics
         // are always defined.
         assert!((config.warm_base_low_free_ratio - 0.2).abs() < f64::EPSILON);
         assert!((config.warm_base_high_free_ratio - 0.2).abs() < f64::EPSILON);
-
-        unsafe {
-            std::env::remove_var("DJINN_CACHE_CLEANUP_WARM_BASE_LOW_FREE_RATIO");
-            std::env::remove_var("DJINN_CACHE_CLEANUP_WARM_BASE_HIGH_FREE_RATIO");
-        }
     }
 
     #[test]
@@ -722,12 +729,46 @@ mod tests {
 
     #[test]
     fn proposal_spec_integrity_sweep_defaults_to_disabled() {
-        unsafe { std::env::remove_var("DJINN_PROPOSAL_SPEC_INTEGRITY_SWEEP_V1") };
+        let unset = env_fixture(&[]);
         assert!(!ProposalSpecIntegritySweepConfig::default().enabled);
-        assert!(!ProposalSpecIntegritySweepConfig::from_env().enabled);
-        unsafe { std::env::set_var("DJINN_PROPOSAL_SPEC_INTEGRITY_SWEEP_V1", "true") };
-        assert!(ProposalSpecIntegritySweepConfig::from_env().enabled);
-        unsafe { std::env::remove_var("DJINN_PROPOSAL_SPEC_INTEGRITY_SWEEP_V1") };
+        assert!(
+            !ProposalSpecIntegritySweepConfig::from_lookup(|key| unset.get(key).cloned()).enabled
+        );
+
+        let armed = env_fixture(&[("DJINN_PROPOSAL_SPEC_INTEGRITY_SWEEP_V1", "true")]);
+        assert!(
+            ProposalSpecIntegritySweepConfig::from_lookup(|key| armed.get(key).cloned()).enabled
+        );
+    }
+
+    /// The `from_lookup` seams are only worth anything if the shipped
+    /// `from_env` constructors still read `std::env`. A behavioural check
+    /// would need a `set_var` — the very thing this module no longer does — so
+    /// assert the wiring textually. Deleting or renaming either `std::env::var`
+    /// call fails this; so does re-inlining the parse rules where the
+    /// `from_lookup` tests above cannot reach them.
+    #[test]
+    fn from_env_constructors_still_read_the_process_environment() {
+        let source = include_str!("context.rs");
+        for constructor in [
+            "impl CacheCleanupConfig {",
+            "impl ProposalSpecIntegritySweepConfig {",
+        ] {
+            let body = source
+                .split_once(constructor)
+                .unwrap_or_else(|| panic!("{constructor} is defined in this file"))
+                .1;
+            let from_env = body
+                .split_once("pub fn from_env() -> Self {")
+                .expect("constructor exposes from_env")
+                .1;
+            let from_env = &from_env[..from_env.find("\n    }").expect("from_env body terminates")];
+            assert!(
+                from_env.contains("Self::from_lookup(|key| std::env::var(key).ok())"),
+                "{constructor} from_env must resolve through std::env into the \
+                 tested from_lookup seam, got:\n{from_env}"
+            );
+        }
     }
 }
 
@@ -747,12 +788,12 @@ mod warm_profile_idle_config_tests {
             ("+24", 24),
             ("18446744073709551616", 24),
         ] {
-            unsafe { std::env::set_var(variable, value) };
+            let env = HashMap::from([(variable.to_owned(), value.to_owned())]);
             assert_eq!(
-                CacheCleanupConfig::from_env().warm_profile_min_idle_hours,
+                CacheCleanupConfig::from_lookup(|key| env.get(key).cloned())
+                    .warm_profile_min_idle_hours,
                 expected
             );
         }
-        unsafe { std::env::remove_var(variable) };
     }
 }

--- a/server/crates/djinn-coordinator/src/pr_poller/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tests.rs
@@ -349,26 +349,51 @@ fn auto_merge_full_cycle_inflight_then_reopen_then_respawn() {
 
 #[test]
 fn auto_merge_reopen_decision_records_merge_failure_after_lock_release() {
-    djinn_telemetry::init().unwrap();
-    let before = djinn_telemetry::render().unwrap();
-    let merge_failures_before = unlabelled_metric_value(&before, "djinn_merge_failures_total");
+    // Scoped to a recorder no sibling test can reach (#2824). The registry
+    // `djinn_telemetry::render()` reads is process-global and every test in
+    // this binary is a thread of one process, so the previous version asserted
+    // on the whole binary's cumulative state: `djinn_pr_poller_tracked` is a
+    // GAUGE, and any sibling calling `set_tracked` overwrote it outright.
+    // Matching the sibling's value by convention only papered over that — it
+    // left the assertion true for the wrong reason, and one new caller away
+    // from flaking. The before/after delta on the counter had the same hole:
+    // a concurrent `increment_merge_failure` can land between the two renders.
+    let (_, rendered) = djinn_telemetry::render_isolated(|| {
+        record_auto_merge_decision_metrics(
+            &AutoMergeTickDecision::Return(AutoMergeFastPathState::Reopen),
+            2,
+        );
+    });
 
-    // Use the same tracked value as the coordinator live-metrics regression so
-    // the process-global gauge cannot make either test flaky if libtest runs
-    // them concurrently.
-    record_auto_merge_decision_metrics(
-        &AutoMergeTickDecision::Return(AutoMergeFastPathState::Reopen),
-        2,
-    );
-
-    let rendered = djinn_telemetry::render().unwrap();
+    // Absolute, not delta: this recorder starts empty and only this closure
+    // wrote to it.
     assert_eq!(
         unlabelled_metric_value(&rendered, "djinn_pr_poller_tracked"),
         2.0
     );
     assert_eq!(
         unlabelled_metric_value(&rendered, "djinn_merge_failures_total"),
-        merge_failures_before + 1.0
+        1.0
+    );
+}
+
+#[test]
+fn auto_merge_non_reopen_decision_records_no_merge_failure() {
+    // Same isolation, opposite arm: the counter must be absent entirely rather
+    // than merely unchanged. Against the process-global registry this could
+    // not be asserted at all — a sibling's increment would have left the
+    // series present with a nonzero total.
+    let (_, rendered) = djinn_telemetry::render_isolated(|| {
+        record_auto_merge_decision_metrics(&AutoMergeTickDecision::Spawn, 5);
+    });
+
+    assert_eq!(
+        unlabelled_metric_value(&rendered, "djinn_pr_poller_tracked"),
+        5.0
+    );
+    assert!(
+        !rendered.contains("djinn_merge_failures_total"),
+        "a Spawn decision must not touch the merge-failure counter, got:\n{rendered}"
     );
 }
 

--- a/server/crates/djinn-db/src/background/housekeeping.rs
+++ b/server/crates/djinn-db/src/background/housekeeping.rs
@@ -381,10 +381,27 @@ fn parse_housekeeping_interval(raw: Option<&str>) -> Duration {
 /// This mirrors the existing housekeeping env-override pattern: resolve the
 /// operator-facing configuration at the tick boundary, then pass the concrete
 /// value into the repository sweep.
+///
+/// The environment read lives here and *only* here; every decision the parser
+/// makes is in [`resolve_archive_window_days`], which takes the raw value as a
+/// parameter. Tests exercise the parameterised form, so none of them has to
+/// mutate the process-global environment that every other test in this binary
+/// shares.
 fn parse_archive_window_days(caller_default: u32) -> u32 {
-    std::env::var(ARCHIVE_WINDOW_ENV)
-        .ok()
-        .and_then(|value| value.parse::<u32>().ok())
+    resolve_archive_window_days(
+        std::env::var(ARCHIVE_WINDOW_ENV).ok().as_deref(),
+        caller_default,
+    )
+}
+
+/// Pure resolution rule behind [`parse_archive_window_days`].
+///
+/// `raw` is the operator-supplied override exactly as the environment carried
+/// it (`None` when unset). A positive parse wins; anything else falls back to
+/// `caller_default`, and a zero `caller_default` means "use the module
+/// default".
+fn resolve_archive_window_days(raw: Option<&str>, caller_default: u32) -> u32 {
+    raw.and_then(|value| value.parse::<u32>().ok())
         .filter(|value| *value > 0)
         .or_else(|| (caller_default > 0).then_some(caller_default))
         .unwrap_or(DEFAULT_ARCHIVE_WINDOW_DAYS)
@@ -642,43 +659,67 @@ mod tests {
         assert_eq!(report.total_superseded_source_notes, 77);
     }
 
+    // These four exercise `resolve_archive_window_days`, the parameterised
+    // form, rather than `parse_archive_window_days`, which reads the ambient
+    // environment. The env var is process-global and `cargo test` runs every
+    // test in this binary as a thread of one process, so a `set_var` here is
+    // visible to every concurrently-running sibling — and every sibling's
+    // `remove_var` is visible here. Passing the raw value as an argument
+    // removes the shared cell entirely instead of trying to sequence access
+    // to it.
     #[test]
     fn parse_archive_window_days_uses_caller_default_when_env_unset() {
-        // SAFETY: single-threaded test; no other thread reads this env var
-        // here, and we restore the previous state at the end.
-        unsafe { std::env::remove_var(ARCHIVE_WINDOW_ENV) };
-        assert_eq!(parse_archive_window_days(60), 60);
+        assert_eq!(resolve_archive_window_days(None, 60), 60);
     }
 
     #[test]
     fn parse_archive_window_days_falls_back_to_60_when_caller_passes_zero() {
-        // SAFETY: single-threaded test; no other thread reads this env var
-        // here, and we restore the previous state at the end.
-        unsafe { std::env::remove_var(ARCHIVE_WINDOW_ENV) };
         // A zero caller default is treated as "use the module default", which
         // is 60 days. This mirrors the decay-window parser's contract.
-        assert_eq!(parse_archive_window_days(0), 60);
+        assert_eq!(resolve_archive_window_days(None, 0), 60);
     }
 
     #[test]
     fn parse_archive_window_days_honors_positive_env_override() {
-        // SAFETY: single-threaded test; no other thread reads this env var
-        // here, and we restore the previous state at the end.
-        unsafe { std::env::set_var(ARCHIVE_WINDOW_ENV, "90") };
         // Env wins over caller-provided value.
-        assert_eq!(parse_archive_window_days(60), 90);
-        unsafe { std::env::remove_var(ARCHIVE_WINDOW_ENV) };
+        assert_eq!(resolve_archive_window_days(Some("90"), 60), 90);
     }
 
     #[test]
     fn parse_archive_window_days_ignores_zero_and_invalid_env_values() {
-        // SAFETY: single-threaded test; no other thread reads this env var
-        // here, and we restore the previous state at the end.
-        unsafe { std::env::set_var(ARCHIVE_WINDOW_ENV, "0") };
-        assert_eq!(parse_archive_window_days(60), 60);
-        unsafe { std::env::set_var(ARCHIVE_WINDOW_ENV, "garbage") };
-        assert_eq!(parse_archive_window_days(60), 60);
-        unsafe { std::env::remove_var(ARCHIVE_WINDOW_ENV) };
+        assert_eq!(resolve_archive_window_days(Some("0"), 60), 60);
+        assert_eq!(resolve_archive_window_days(Some("garbage"), 60), 60);
+    }
+
+    /// The parameterised seam is only worth anything if production still reads
+    /// the operator's env var. A behavioural test of that read would have to
+    /// `set_var`, which is exactly what we removed, so assert the wiring
+    /// textually instead — no process-global is touched and nothing races.
+    ///
+    /// Deleting the `std::env::var` line makes this fail; so does bypassing
+    /// `resolve_archive_window_days` and re-inlining the parse rule where no
+    /// test can see it.
+    #[test]
+    fn parse_archive_window_days_still_reads_the_env_var() {
+        let source = include_str!("housekeeping.rs");
+        let after_signature = source
+            .split_once("fn parse_archive_window_days(")
+            .expect("parse_archive_window_days is defined in this file")
+            .1;
+        let body = &after_signature[..after_signature
+            .find("\n}\n")
+            .expect("parse_archive_window_days body terminates")];
+
+        assert!(
+            body.contains("std::env::var(ARCHIVE_WINDOW_ENV)"),
+            "parse_archive_window_days must keep reading {ARCHIVE_WINDOW_ENV}; \
+             without it the operator override silently stops working:\n{body}"
+        );
+        assert!(
+            body.contains("resolve_archive_window_days("),
+            "parse_archive_window_days must delegate to the resolver the unit \
+             tests above exercise, or those tests stop covering production:\n{body}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -880,9 +921,10 @@ mod tests {
             .await
             .unwrap();
 
-        // SAFETY: single-threaded test; clear any leftover override and
-        // restore at the end.
-        unsafe { std::env::remove_var(ARCHIVE_WINDOW_ENV) };
+        // No env-var housekeeping here on purpose: nothing in this binary sets
+        // DJINN_LIFECYCLE_ARCHIVE_WINDOW_DAYS any more, so there is no leftover
+        // override to clear — and a `remove_var` would itself be a write to the
+        // process-global environment that every sibling test shares.
 
         let report = run_project_housekeeping(&db, &event_bus, &project)
             .await
@@ -979,8 +1021,9 @@ mod tests {
             .await
             .unwrap();
 
-        // SAFETY: single-threaded test; clear any leftover override.
-        unsafe { std::env::remove_var(ARCHIVE_WINDOW_ENV) };
+        // No env-var housekeeping here on purpose — see the sibling archive
+        // test: nothing sets the override any more, so clearing it would only
+        // add a write to a process-global every other test can observe.
 
         let report = run_tick(&db, &event_bus).await.unwrap();
 


### PR DESCRIPTION
Closes board task `8ne1`.

The sixth instance of one shape: a test whose outcome depends on a **process-global singleton** that a concurrently-running sibling also writes. Prior instances — #2820 (`doctor::registry`, control plane), #2824 (metrics recorder), #2851 (`doctor::registry`, coordinator) — were each fixed one at a time. This PR fixes the three known residuals and adds a gate so the seventh does not need a seventh investigation.

## Reproduced first, by varying concurrency

Per the task's diagnostic warning, nothing was changed until the failure was reproduced. `cargo test` at **default** `--test-threads`, tight filters, on the pre-fix tree:

| target | filter | result |
| --- | --- | --- |
| `djinn-db --lib` | `parse_archive_window_days` | **21/40 runs FAILED** |
| `djinn-coordinator --lib` | `cache_cleanup` | **20/40 runs FAILED** |
| `djinn-coordinator --lib` | pr_poller + actor metrics, with a probe sibling writing the same gauge | **20/20 runs FAILED** |

In each case the failing test name was **not stable** — the loser was whichever test happened to read while another was mid-write. Sample from one `djinn-db` run: three tests fail with `left: 90, right: 60`; the next run, the *fourth* test fails with `left: 60, right: 90`. Reading the failing test name would have pointed at the wrong culprit, exactly as the #2851 note warned.

## Residual 1 — process-global metrics registry

`djinn_telemetry::render()` renders **one** registry, installed process-wide. `pr_poller::tests::auto_merge_reopen_decision_records_merge_failure_after_lock_release` made an absolute assertion on `djinn_pr_poller_tracked` (a **gauge**, so `set()` is last-writer-wins) and a before/after delta on `djinn_merge_failures_total` (a counter — a concurrent increment can land *between* the two renders).

The existing comment there — *"use the same tracked value as the coordinator live-metrics regression so the process-global gauge cannot make either test flaky"* — coordinated the two writers **by convention**. That left the assertion true for the wrong reason and one new caller away from flaking. Converted to `render_isolated` (the #2824 helper), and converted the sibling it was coordinating with (`actor::tests::record_live_metrics_publishes_synthetic_cooldown_and_inflight_state`) for the same reason, since the coupling was between them.

Added `auto_merge_non_reopen_decision_records_no_merge_failure`, which asserts the counter is **absent** on the Spawn arm — an assertion that could not be expressed against the shared registry at all, because a sibling's increment would leave the series present.

## Residuals 2 and 3 — process-global env vars

`CacheCleanupConfig::from_env`, `ProposalSpecIntegritySweepConfig::from_env` and `parse_archive_window_days` read `std::env` inline, so their tests had to `set_var`. Each now keeps **exactly one** environment read and delegates every parse and clamp rule to a parameterised seam (`from_lookup` / `resolve_archive_window_days`) that tests drive with a local table.

No test in either crate mutates the environment any more — including the defensive `remove_var` calls that only existed to clean up after the tests that did. (`HousekeepingConfig::from_env` in the same file already used this exact shape; the change makes its neighbour consistent with it.)

**Production behaviour is unchanged by construction**: `from_env` still resolves through `std::env` into the same rules. Two source-level tests assert that wiring, so the seams cannot go green while production reads nothing.

## Verification

Non-vacuity was established by toggling each fix against the *same* harness:

| check | pre-fix | post-fix |
| --- | --- | --- |
| `djinn-db --lib parse_archive_window_days` | 21/40 failed | **0/40 failed** |
| `djinn-coordinator --lib cache_cleanup` | 20/40 failed | **0/40 failed** |
| pr_poller + actor metrics vs. a sibling writing `set_tracked(99)` / `increment_merge_failure()` in a loop | 20/20 failed | **0/20 failed** |

All at **default concurrency**. Nothing was serialized, no timeout was extended, no retry was added.

The metrics probe deserves a note, since it is what AC 1 asks for: a temporary sibling test writing the same gauge with a different value (`99`) was added to both the pre-fix and post-fix trees. Pre-fix it fails both tests deterministically (`left: 99.0, right: 2.0`); post-fix both pass. The probe was removed before commit.

## The general guard — argued, and landed for one of the two globals

Six instances justify one. `scripts/check-test-global-metrics.sh` fails a PR that **adds** a `djinn_telemetry::render()` read from test code. `scripts/test-check-test-global-metrics.sh` is its self-test (9 assertions, all watched fail before they were made to pass), wired into the Server Guards job next to the `include!` guard.

Three design choices, each with evidence:

**It is a GATE, with no opt-out marker.** Complying costs the same keystrokes as violating (`render_isolated` instead of `render`), so there is nothing to escape to. This is the property `check-file-size.sh` lost: its `djinn:allow-oversize` escape went 0 → 108 markers in seven weeks while oversized files went 22 → 79, and zero files were ever split, because evading cost one comment and complying cost a restructure.

**It scans ADDED LINES, not the whole tree.** There are ~150 pre-existing `render()` reads across ~30 files, many in tests that hand work to `tokio::spawn` — where `IsolatedRecorder` needs a judgement call about what is captured, not a mechanical edit. A whole-tree gate would be a migration order, and the guard's self-test asserts that an untouched legacy violation does not fail an unrelated PR.

**It covers the metrics registry, NOT env vars — deliberately.** There are ~400 `set_var`/`remove_var` sites and complying means an API refactor per config type (which is what residuals 2 and 3 cost here). That is precisely the "evasion cheaper than compliance" ratio that killed the size gate, so a ban would produce a baseline file that only grows. The env class is better served by the convention this PR establishes — *a `from_env()` gets a parameterised sibling, and tests target the sibling* — enforced at review, not by a lint.

The exemptions are by pattern, never by author-supplied marker: the `djinn-telemetry` crate (it owns the singleton and must test it), and production readers, identified structurally rather than by path — a `render()` outside any `#[cfg(test)]` block and outside any `#[test]`-attributed item. Validated against the whole tree: of 75 `render()` call sites, it flags 71 and skips exactly four — the two genuine production readers (`src/server/mod.rs:83`, the `/metrics` handler; `djinn-coordinator/src/health.rs:1124`, the health probe — note the latter sits *after* a `#[cfg(test)]` block in its own file, so a naive path or first-marker heuristic would have flagged it) and two mentions inside comments.

### One finding worth recording separately

**This workspace's nextest lane cannot observe the bug the guard prevents.** nextest gives every test its own process, so the collision only ever appears under `cargo test`. Measured on the same pre-fix commit:

```
cargo test        -p djinn-db --lib parse_archive_window_days     21/40 FAILED
cargo nextest run -p djinn-db --lib -E 'test(parse_archive...)'    0/15 failed
```

`make test` is `cargo test -p djinn-db`, so the developer loop is where these land — and it is why they survived earlier flake sweeps. It is also why a source-level gate is the only thing that can catch this class at merge time; there is no test the CI runner could run that would fail.

## Out of scope, not conflated

`djinn-coordinator --lib` also aborts with `thread 'tokio-rt-worker' has overflowed its stack` at a different test each run, and the abort disappears under `RUST_MIN_STACK=16777216`. This is the known issue called out in the task as *not* part of it (reported there against `djinn-server --lib`; the same signature occurs in `djinn-coordinator --lib`). Nothing in this PR touches recursion depth — the diff is test bodies and two config constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
