### PR TITLE
feat(resize): invocation-fenced drop lifecycle, fail-safe quarantine, and the two-ledger release gate (0ppk-2, f3m5)

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -122,6 +122,10 @@ djinn-control-plane = { path = "crates/djinn-control-plane", features = ["test-s
 # outside the Kubernetes capability owner — and that ban is right.
 djinn-k8s = { path = "crates/djinn-k8s", features = ["test-support"] }
 djinn-db = { path = "crates/djinn-db", features = ["test-support"] }
+# `task_run_resize_faults` builds a real `DirectServices` over a real
+# `BuildLeaseService` so the two-ledger ordering is asserted at the COMPOSITION
+# site — `release_lease` — rather than against the drop mechanism alone.
+djinn-agent = { path = "crates/djinn-agent", features = ["test-support"] }
 djinn-server = { path = ".", features = ["test-support"] }
 insta = { version = "1", features = ["json", "redactions"] }
 proptest = "1"

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -3688,6 +3688,7 @@ fn build_worker_agent_context(
         repo_graph_ops: None,
         runtime_ops: None,
         resize_admission: None,
+        resize_drop: None,
         // In-Pod view of the shared cache PVC. The Job pod mounts it at
         // `/cache`, NOT at the server pod's `$DJINN_HOME/cache`, and Job specs
         // never set `DJINN_HOME` — so `djinn_core::paths::cargo_target_runs_root()`

--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -464,6 +464,9 @@ pub struct AgentContext {
     /// context, never a disable switch — see
     /// [`crate::task_run_resize_admission`] for what that distinction costs.
     pub resize_admission: Option<crate::task_run_resize_admission::ResizeAdmissionBridge>,
+    /// Proposal `3i92`'s fail-safe drop, injected at the same boundary. `None`
+    /// marks an off-server context; see [`crate::task_run_resize_drop_gate`].
+    pub resize_drop: Option<crate::task_run_resize_drop_gate::ResizeDropBridge>,
     /// **This process's own view** of the per-task-run Cargo target root.
     ///
     /// Required, deliberately: the shared cache PVC is mounted at *different*

--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -34,7 +34,7 @@ use djinn_stack::environment::EnvironmentConfig;
 use djinn_supervisor::services::wire::{PlannerAttemptResult, PlannerOutcome};
 use djinn_supervisor::services::{
     CostBasisHint, LeaseAbandonRequest, LeaseBindRequest, LeaseCancelRequest, LeaseGrantRequest,
-    LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseStatusRequest,
+    LeaseIdentity, LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseStatusRequest,
     SerializableCreateSessionParams, SerializableCreateTaskRunParams, SerializableDjinnEvent,
     WatchdogTerminationRequest,
 };
@@ -47,6 +47,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::actors::slot::lifecycle::memory_intent_planner::parse_planned_queries;
 use crate::context::AgentContext;
+use crate::task_run_resize_drop_gate::{ResizeDropGateRequest, ResizeDropVerdict};
 use crate::supervisor_impl::{SupervisorCallbackContext, execute_stage, supervisor_pr_open};
 use djinn_provider::catalog::builtin::classify_provider;
 use djinn_provider::message::{ContentBlock, Conversation};
@@ -1044,6 +1045,33 @@ impl SupervisorServices for DirectServices {
     async fn release_lease(&self, request: LeaseReleaseRequest) -> LeaseResult {
         if !self.recover_build_lease().await {
             return LeaseResult::LeaseUnavailable;
+        }
+        // THE TWO-LEDGER GATE. `BuildLeaseService::release` writes
+        // `build_leases`; the launcher's lifted ceiling lives in
+        // `build_pod_permits`. Releasing capacity before the launcher is
+        // confirmed back at 250m sells the same CPU twice, so the permit
+        // lifecycle moves FIRST and this handler is where the ordering is
+        // imposed. Making this call unconditional again — as it was before
+        // `0ppk-2` — is acceptance criterion 6's named mutation.
+        if let Some(gate) = self.callbacks.agent_context.resize_drop.as_ref()
+            && let LeaseIdentity::TaskInvocation(claim) = &request.identity
+        {
+            let verdict = gate
+                .confirm_drop(&ResizeDropGateRequest {
+                    task_run_id: claim.task_run_id.clone(),
+                    invocation_id: claim.invocation_id.clone(),
+                })
+                .await;
+            if let ResizeDropVerdict::Held { detail } = verdict {
+                tracing::warn!(
+                    task_run_id = %claim.task_run_id,
+                    invocation_id = %claim.invocation_id,
+                    %detail,
+                    "release_lease: the launcher is not back at its birth limit; \
+                     holding the durable CPU lease"
+                );
+                return LeaseResult::LeaseUnavailable;
+            }
         }
         self.build_lease.release(request).await
     }

--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -47,8 +47,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::actors::slot::lifecycle::memory_intent_planner::parse_planned_queries;
 use crate::context::AgentContext;
-use crate::task_run_resize_drop_gate::{ResizeDropGateRequest, ResizeDropVerdict};
 use crate::supervisor_impl::{SupervisorCallbackContext, execute_stage, supervisor_pr_open};
+use crate::task_run_resize_drop_gate::{ResizeDropGateRequest, ResizeDropVerdict};
 use djinn_provider::catalog::builtin::classify_provider;
 use djinn_provider::message::{ContentBlock, Conversation};
 use djinn_provider::provider::{LlmProvider, LlmResponse, StreamEvent, TokenUsage, ToolChoice};

--- a/server/crates/djinn-agent/src/lib.rs
+++ b/server/crates/djinn-agent/src/lib.rs
@@ -50,6 +50,7 @@ pub(crate) mod supervisor_impl;
 pub mod task_confidence;
 pub mod task_merge;
 pub mod task_run_resize_admission;
+pub mod task_run_resize_drop_gate;
 pub(crate) mod truncate;
 pub mod warmer;
 

--- a/server/crates/djinn-agent/src/task_run_resize_drop_gate.rs
+++ b/server/crates/djinn-agent/src/task_run_resize_drop_gate.rs
@@ -1,0 +1,67 @@
+//! The terminal seam's view of proposal `3i92`'s fail-safe drop.
+//!
+//! Sibling of [`crate::task_run_resize_admission`], and for the same reason: the
+//! machinery is composed in `djinn_server::task_run_resize_drop`, `djinn-agent`
+//! cannot depend on the server crate (ADR-047), and the only place that owns the
+//! per-invocation terminal signal is [`crate::direct_services::DirectServices`]'s
+//! `release_lease` handler.
+//!
+//! # Two ledgers
+//!
+//! `BuildLeaseService::release` writes `build_leases`. The resize lifecycle it
+//! must wait for lives in `build_pod_permits`. Those are DIFFERENT STORES, and
+//! before this gate existed nothing connected them: `release_lease` returned
+//! capacity the moment the worker asked, whether or not the launcher sidecar had
+//! come back down to 250m. A Pod left holding a lifted ceiling with its lease
+//! already returned is capacity the cluster has sold twice.
+//!
+//! So the ordering this trait imposes is: the `build_pod_permits` row must have
+//! left `drop_applying` for `birth_confirmed` on a **confirmed** 250m, or the
+//! exact Pod UID must be confirmed absent, BEFORE `build_leases` moves at all.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+/// One invocation asking to be released.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResizeDropGateRequest {
+    /// The task run whose permit row carries the resize lifecycle.
+    pub task_run_id: String,
+    /// The invocation this terminal belongs to. It is the invocation half of
+    /// the `(task_run_id, pod_uid, resize_invocation_id)` fence — a task run has
+    /// exactly one permit row and many invocations, so without it a terminal
+    /// could retire a lift it never performed.
+    pub invocation_id: String,
+}
+
+/// Whether the durable CPU lease may be released.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResizeDropVerdict {
+    /// The launcher is confirmed back at its birth limit, its Pod UID is
+    /// confirmed absent, or the run never held a resize-governed ceiling.
+    /// `build_leases` may move.
+    Releasable,
+    /// The drop is not settled. The lease MUST stay held and terminal MUST NOT
+    /// be acknowledged. The durable permit row records why, and survives a
+    /// restart of whichever process was driving the drop.
+    Held {
+        /// Rendered for the operator log.
+        detail: String,
+    },
+}
+
+/// The server-side drop, as [`crate::context::AgentContext`] holds it.
+pub type ResizeDropBridge = Arc<dyn TaskRunResizeDropGate>;
+
+/// The server-side drop, as the terminal seam consumes it.
+#[async_trait]
+pub trait TaskRunResizeDropGate: Send + Sync {
+    /// Drive the fail-safe drop for one invocation's terminal and report whether
+    /// the durable CPU lease may now be released.
+    ///
+    /// Implementations must fail CLOSED: an unreadable database, an unreachable
+    /// apiserver, or a Pod that is still quarantined are all
+    /// [`ResizeDropVerdict::Held`], never `Releasable`.
+    async fn confirm_drop(&self, request: &ResizeDropGateRequest) -> ResizeDropVerdict;
+}

--- a/server/crates/djinn-agent/src/test_helpers.rs
+++ b/server/crates/djinn-agent/src/test_helpers.rs
@@ -120,6 +120,7 @@ pub fn agent_context_from_db(db: Database, _cancel: CancellationToken) -> AgentC
         repo_graph_ops: None,
         runtime_ops: None,
         resize_admission: None,
+        resize_drop: None,
         cargo_target_runs_root: test_path("cargo-target-runs-"),
         mirror: None,
         rpc_registry: None,

--- a/server/crates/djinn-agent/tests/arbiter_park_transaction.rs
+++ b/server/crates/djinn-agent/tests/arbiter_park_transaction.rs
@@ -52,6 +52,7 @@ fn test_agent_context(db: Database) -> AgentContext {
         repo_graph_ops: None,
         runtime_ops: None,
         resize_admission: None,
+        resize_drop: None,
         cargo_target_runs_root: {
             let path = std::env::current_dir()
                 .unwrap()

--- a/server/crates/djinn-agent/tests/arbiter_supersede_transaction.rs
+++ b/server/crates/djinn-agent/tests/arbiter_supersede_transaction.rs
@@ -53,6 +53,7 @@ fn test_agent_context(db: Database) -> AgentContext {
         repo_graph_ops: None,
         runtime_ops: None,
         resize_admission: None,
+        resize_drop: None,
         cargo_target_runs_root: {
             let path = std::env::current_dir()
                 .unwrap()

--- a/server/crates/djinn-agent/tests/phase1_supervisor.rs
+++ b/server/crates/djinn-agent/tests/phase1_supervisor.rs
@@ -91,6 +91,7 @@ fn test_agent_context(db: Database) -> AgentContext {
         repo_graph_ops: None,
         runtime_ops: None,
         resize_admission: None,
+        resize_drop: None,
         cargo_target_runs_root: {
             let path = std::env::current_dir()
                 .unwrap()

--- a/server/crates/djinn-control-plane/tests/execution_tools.rs
+++ b/server/crates/djinn-control-plane/tests/execution_tools.rs
@@ -454,7 +454,7 @@ impl RealPoolKillHarness {
             repo_graph_ops: None,
             runtime_ops: Some(Arc::new(runtime.clone())),
             resize_admission: None,
-        resize_drop: None,
+            resize_drop: None,
             cargo_target_runs_root: tempfile::tempdir().expect("cargo tempdir").keep(),
             mirror: None,
             rpc_registry: None,

--- a/server/crates/djinn-control-plane/tests/execution_tools.rs
+++ b/server/crates/djinn-control-plane/tests/execution_tools.rs
@@ -454,6 +454,7 @@ impl RealPoolKillHarness {
             repo_graph_ops: None,
             runtime_ops: Some(Arc::new(runtime.clone())),
             resize_admission: None,
+        resize_drop: None,
             cargo_target_runs_root: tempfile::tempdir().expect("cargo tempdir").keep(),
             mirror: None,
             rpc_registry: None,

--- a/server/crates/djinn-coordinator/src/resize_authorization.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization.rs
@@ -335,14 +335,18 @@ impl ResizeRefusal {
 /// why an uncertainty on this path must not be expressible as something a caller
 /// could classify as retryable.
 #[derive(Clone, Debug, PartialEq, Eq)]
-// `Authorized` is the hot path and the only variant anyone reads a field from;
-// boxing it would put an allocation on every successful authorization to save
-// stack on two variants that are 2 bytes each. Same trade `GrantNextBuildLeaseResult`
-// makes in `build_lease.rs`.
-#[allow(clippy::large_enum_variant)]
 pub enum ResizeAuthorizationOutcome {
     /// Server-derived and clamped. The only variant `0ppk-1b` may PATCH.
-    Authorized(PodResizeIntent),
+    ///
+    /// Boxed, and that is not lint appeasement. This outcome is held across an
+    /// `.await` inside `BuildLeaseService::grant`, which is itself held inside
+    /// the dispatch rules engine's future. Inlining a ~224-byte intent there
+    /// grew that future past a tokio worker's 2MiB stack and aborted
+    /// `rules::tests::amend_while_building_dispatches_one_reconcile_task_from_event`
+    /// with a stack overflow — a failure with no textual connection to resize at
+    /// all. One pointer keeps the whole chain bounded no matter how the intent
+    /// grows later.
+    Authorized(Box<PodResizeIntent>),
     /// Refused. Zero intents were recorded.
     Refused(ResizeRefusal),
     /// The durable authority is not armed to enforce, so no invocation is lifted
@@ -522,7 +526,7 @@ impl ResizeAuthority {
             &identity,
             self.configured_leased_millicores,
         ) {
-            Ok(intent) => ResizeAuthorizationOutcome::Authorized(intent),
+            Ok(intent) => ResizeAuthorizationOutcome::Authorized(Box::new(intent)),
             Err(refusal) => Self::refuse(refusal),
         }
     }

--- a/server/crates/djinn-coordinator/src/resize_authorization.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization.rs
@@ -94,6 +94,16 @@ pub struct PodResizeIntent {
     /// immutable identity — never the caller's claim. It is the label the
     /// applier's fresh GET is scoped by.
     pub task_run_id: String,
+    /// The **durable owner's** invocation, likewise recovered from the lease
+    /// row's immutable identity.
+    ///
+    /// This is the invocation half of migration 168's
+    /// `(task_run_id, pod_uid, resize_invocation_id)` fence. `build_pod_permits`
+    /// has PRIMARY KEY `task_run_id`, so one row serves every invocation of a
+    /// run — and nothing serializes invocations of one run against each other.
+    /// Without this field the applier could not tell its own lift from a
+    /// concurrent invocation's.
+    pub invocation_id: String,
     /// The permit row's immutable identity, echoed by every durable lifecycle
     /// compare-and-swap the applier makes.
     pub permit_id: String,
@@ -500,6 +510,7 @@ impl ResizeAuthority {
 
         match clamp(
             &owner.task_run_id,
+            &owner.invocation_id,
             &permit_id,
             permit_fence,
             permit_state,
@@ -614,6 +625,7 @@ fn durable_owner(row: &BuildLeaseRow) -> Option<TaskInvocationLeaseIdentity> {
 /// one-line edit at a single site rather than something that could be half-done.
 fn clamp(
     task_run_id: &str,
+    invocation_id: &str,
     permit_id: &str,
     fencing_token: i64,
     permit_state: BuildPodPermitState,
@@ -644,6 +656,7 @@ fn clamp(
     let target_millicores = configured_leased_millicores.min(ceiling);
     Ok(PodResizeIntent {
         task_run_id: task_run_id.to_owned(),
+        invocation_id: invocation_id.to_owned(),
         permit_id: permit_id.to_owned(),
         fencing_token,
         permit_state,

--- a/server/crates/djinn-coordinator/src/resize_authorization.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization.rs
@@ -335,6 +335,11 @@ impl ResizeRefusal {
 /// why an uncertainty on this path must not be expressible as something a caller
 /// could classify as retryable.
 #[derive(Clone, Debug, PartialEq, Eq)]
+// `Authorized` is the hot path and the only variant anyone reads a field from;
+// boxing it would put an allocation on every successful authorization to save
+// stack on two variants that are 2 bytes each. Same trade `GrantNextBuildLeaseResult`
+// makes in `build_lease.rs`.
+#[allow(clippy::large_enum_variant)]
 pub enum ResizeAuthorizationOutcome {
     /// Server-derived and clamped. The only variant `0ppk-1b` may PATCH.
     Authorized(PodResizeIntent),

--- a/server/crates/djinn-coordinator/src/resize_lift.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift.rs
@@ -220,7 +220,42 @@ impl ResizeLift {
         }
     }
 
-    /// Compare-and-swap one lifecycle edge, fenced on all four permit fields.
+    /// Claim the lifecycle for this invocation: `birth_confirmed →
+    /// lift_applying`, writing the invocation fence.
+    ///
+    /// A second, concurrent invocation of the same task run loses here without a
+    /// write and therefore without a PATCH — see
+    /// [`BuildPodPermitRepository::begin_resize_invocation`].
+    async fn begin_invocation(&self, intent: &PodResizeIntent) -> Result<(), ResizeApplyFailure> {
+        match self
+            .permits
+            .begin_resize_invocation(
+                &intent.task_run_id,
+                &intent.permit_id,
+                intent.fencing_token,
+                &intent.pod_uid,
+                &intent.invocation_id,
+            )
+            .await
+        {
+            Ok(TransitionBuildPodResizeLifecycleResult::Transitioned(_)) => Ok(()),
+            Ok(TransitionBuildPodResizeLifecycleResult::Rejected) => Err(ResizeApplyFailure::new(
+                DegradedUnleasedReason::LiftLifecycleUnwritable,
+                format!(
+                    "permit {} refused invocation {}'s lift claim; another invocation \
+                     owns this lifecycle",
+                    intent.permit_id, intent.invocation_id
+                ),
+            )),
+            Err(error) => Err(ResizeApplyFailure::new(
+                DegradedUnleasedReason::LiftLifecycleUnwritable,
+                format!("durable permit lifecycle unwritable: {error}"),
+            )),
+        }
+    }
+
+    /// Compare-and-swap one lifecycle edge, fenced on all four permit fields
+    /// **and** on the owning invocation.
     async fn transition(
         &self,
         intent: &PodResizeIntent,
@@ -234,6 +269,7 @@ impl ResizeLift {
                 &intent.permit_id,
                 intent.fencing_token,
                 &intent.pod_uid,
+                Some(&intent.invocation_id),
                 expected,
                 next,
             )
@@ -425,15 +461,26 @@ impl PodResizeApplier for ResizeLift {
         // lift_applying` edge). Anything else is not a liftable subject.
         let entered = match intent.permit_state {
             BuildPodPermitState::BirthConfirmed => {
-                self.transition(
-                    intent,
-                    BuildPodPermitState::BirthConfirmed,
-                    BuildPodPermitState::LiftApplying,
-                )
-                .await?;
+                self.begin_invocation(intent).await?;
                 BuildPodPermitState::LiftApplying
             }
-            BuildPodPermitState::Lifted => BuildPodPermitState::Lifted,
+            BuildPodPermitState::Lifted => {
+                // A self-transition, purely to run the invocation fence BEFORE
+                // any PATCH. Without it a second invocation that authorized
+                // while the first already held `lifted` would re-confirm a lift
+                // it does not own — and, because the `Lifted` arm skips the
+                // closing transition below, it would never be fenced at all.
+                // The lifecycle is one row per task run and nothing serializes
+                // invocations of one run, so this is a reachable race, not a
+                // hypothetical one.
+                self.transition(
+                    intent,
+                    BuildPodPermitState::Lifted,
+                    BuildPodPermitState::Lifted,
+                )
+                .await?;
+                BuildPodPermitState::Lifted
+            }
             other => {
                 return Err(ResizeApplyFailure::new(
                     DegradedUnleasedReason::PermitNotLiftable,

--- a/server/crates/djinn-db/migrations_postgres/168_build_pod_resize_invocation_fence.sql
+++ b/server/crates/djinn-db/migrations_postgres/168_build_pod_resize_invocation_fence.sql
@@ -1,0 +1,75 @@
+-- The invocation half of "compare-and-swap fenced by invocation and Pod UID".
+--
+-- Migration 164 shipped the six-state resize lifecycle and fenced every
+-- transition on `(task_run_id, permit_id, fencing_token, pod_uid, state)`. That
+-- is the Pod half of the fence. The invocation half was NOT expressible:
+-- `build_pod_permits.task_run_id` is the PRIMARY KEY, so there is exactly one
+-- row per task run, and neither 162 nor 164 carried an invocation column. A task
+-- run executes MANY invocations, each of which crosses the CPU threshold, lifts
+-- and drops on that single row. The `drop_applying -> birth_confirmed` back-edge
+-- makes the CYCLE expressible; nothing made the CURRENT OCCUPANT of the cycle
+-- identifiable. This migration is what makes it identifiable.
+--
+-- The identity stored is the durable invocation-lease consumer id
+-- (`build_leases.consumer_id` for `consumer_kind = 'task_invocation'`), which is
+-- the same string the worker presents on `queue_lease`/`release_lease`. It is
+-- deliberately NOT a fresh surrogate: a fence nobody outside this table can
+-- name is a fence no caller can present, and the whole point is that the drop
+-- issued for invocation N is rejected when invocation N+1 owns the row.
+ALTER TABLE build_pod_permits
+    ADD COLUMN resize_invocation_id VARCHAR(255);
+
+ALTER TABLE build_pod_permits
+    -- An empty string is not an invocation. Without this a caller that fenced on
+    -- `''` would match a row that had never been claimed at all.
+    ADD CONSTRAINT build_pod_permits_resize_invocation_shape_check CHECK (
+        resize_invocation_id IS NULL OR length(btrim(resize_invocation_id)) > 0
+    ),
+    -- The two states that can only be reached by claiming an invocation must
+    -- carry one. `drop_required` and `quarantined` are deliberately excluded:
+    -- both are reachable directly from `birth_confirmed` by an infrastructure
+    -- observer (a Pod that died before any invocation ever lifted), and that
+    -- path has no invocation to name.
+    ADD CONSTRAINT build_pod_permits_resize_invocation_state_check CHECK (
+        state NOT IN ('lift_applying', 'lifted') OR resize_invocation_id IS NOT NULL
+    );
+
+-- Migration 164's trigger body, plus the invocation write-window rule.
+--
+-- `resize_invocation_id` is not write-once — it MUST change, once per invocation,
+-- or a task run's second lift could never be told from its first. It is instead
+-- write-windowed: it may only change on the single edge that starts a lift,
+-- `birth_confirmed -> lift_applying`. Every other edge in the graph carries it
+-- forward unchanged, so a drop, a quarantine or a return to `birth_confirmed`
+-- cannot silently re-key the row underneath a caller that is mid-sequence.
+CREATE OR REPLACE FUNCTION build_pod_permits_prevent_immutable_mutation() RETURNS trigger AS $$
+BEGIN
+    IF NEW.task_run_id <> OLD.task_run_id OR NEW.permit_id <> OLD.permit_id
+       OR NEW.fencing_token <> OLD.fencing_token
+       OR (OLD.job_uid IS NOT NULL AND NEW.job_uid IS DISTINCT FROM OLD.job_uid)
+       OR (OLD.pod_uid IS NOT NULL AND (NEW.pod_namespace, NEW.pod_name, NEW.pod_uid,
+           NEW.launcher_container_name, NEW.launcher_container_id, NEW.image_digest,
+           NEW.observed_launcher_protocol, NEW.effective_launcher_protocol, NEW.admitted_cpu_millicores)
+           IS DISTINCT FROM (OLD.pod_namespace, OLD.pod_name, OLD.pod_uid,
+           OLD.launcher_container_name, OLD.launcher_container_id, OLD.image_digest,
+           OLD.observed_launcher_protocol, OLD.effective_launcher_protocol, OLD.admitted_cpu_millicores)) THEN
+        RAISE EXCEPTION 'build pod permit immutable identity or fencing token changed';
+    END IF;
+    IF NEW.resize_invocation_id IS DISTINCT FROM OLD.resize_invocation_id
+       AND NOT (OLD.state = 'birth_confirmed' AND NEW.state = 'lift_applying') THEN
+        RAISE EXCEPTION 'build pod permit resize invocation id may only change on entry to lift_applying';
+    END IF;
+    IF NOT ((OLD.state = 'acquired' AND NEW.state IN ('job_created', 'released'))
+        OR (OLD.state = 'job_created' AND NEW.state IN ('birth_confirmed', 'released'))
+        OR (OLD.state = 'birth_confirmed' AND NEW.state IN ('lift_applying', 'drop_required', 'quarantined', 'released'))
+        OR (OLD.state = 'lift_applying' AND NEW.state IN ('lifted', 'drop_required', 'quarantined', 'released'))
+        OR (OLD.state = 'lifted' AND NEW.state IN ('drop_required', 'quarantined', 'released'))
+        OR (OLD.state = 'drop_required' AND NEW.state IN ('drop_applying', 'quarantined', 'released'))
+        OR (OLD.state = 'drop_applying' AND NEW.state IN ('birth_confirmed', 'quarantined', 'released'))
+        OR (OLD.state = 'quarantined' AND NEW.state = 'released')
+        OR (OLD.state = NEW.state)) THEN
+        RAISE EXCEPTION 'illegal build pod resize lifecycle transition';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/server/crates/djinn-db/src/repositories/build_pod_permit.rs
+++ b/server/crates/djinn-db/src/repositories/build_pod_permit.rs
@@ -19,7 +19,7 @@ const POOL_KEY: &str = "global";
 const ROW_COLUMNS: &str = "task_run_id, permit_id::text AS permit_id, fencing_token, state, job_uid, \
     to_char(acquired_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS acquired_at, \
     to_char(released_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS released_at, \
-    released_fencing_token, release_reason, pod_namespace, pod_name, pod_uid, launcher_container_name, launcher_container_id, image_digest, observed_launcher_protocol, effective_launcher_protocol, admitted_cpu_millicores";
+    released_fencing_token, release_reason, pod_namespace, pod_name, pod_uid, launcher_container_name, launcher_container_id, image_digest, observed_launcher_protocol, effective_launcher_protocol, admitted_cpu_millicores, resize_invocation_id";
 
 /// Durable lifecycle states. `acquired`/`job_created`/`released` come from
 /// migration 162; the six nonterminal resize states come from migration 164.
@@ -168,6 +168,13 @@ pub struct BuildPodPermitRow {
     pub released_fencing_token: Option<i64>,
     pub release_reason: Option<String>,
     pub resize_identity: Option<BuildPodResizeIdentity>,
+    /// The invocation that currently owns this row's resize lifecycle.
+    ///
+    /// `None` means no invocation has ever lifted this Pod — the row is at
+    /// `birth_confirmed` after capture, or it was driven straight to
+    /// `drop_required`/`quarantined` by an infrastructure observer that has no
+    /// invocation to name. See migration 168.
+    pub resize_invocation_id: Option<String>,
 }
 
 /// The admission result deliberately has no successful fallback for unavailable
@@ -461,20 +468,91 @@ impl BuildPodPermitRepository {
         })
     }
 
+    /// Claim the resize lifecycle for one invocation: `birth_confirmed →
+    /// lift_applying`, writing `resize_invocation_id`.
+    ///
+    /// This is the ONLY edge on which migration 168's trigger permits
+    /// `resize_invocation_id` to change, so it is the only way an invocation can
+    /// become the row's owner. Two invocations of one task run may be in flight
+    /// simultaneously — nothing in `djinn_agent::process`'s `'invocation: loop`
+    /// serializes them, the runner is `Arc`-shared behind `&self`, and its
+    /// journal keeps a `HashSet` of live invocation ids precisely because more
+    /// than one can be live. The single-row lifecycle cannot represent two
+    /// simultaneous lifts, so the second claimant must lose, and this CAS is
+    /// where it loses: `state = 'birth_confirmed'` holds for exactly one of them.
+    ///
+    /// An exact replay by the invocation that already owns the row is
+    /// idempotent; anything else is `Rejected` **without a write**, which is
+    /// what lets a caller assert a PATCH counter of zero.
+    pub async fn begin_resize_invocation(
+        &self,
+        task_run_id: &str,
+        permit_id: &str,
+        fencing_token: i64,
+        pod_uid: &str,
+        invocation_id: &str,
+    ) -> DbResult<TransitionBuildPodResizeLifecycleResult> {
+        if pod_uid.trim().is_empty() || invocation_id.trim().is_empty() {
+            return Ok(TransitionBuildPodResizeLifecycleResult::Rejected);
+        }
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        let updated = sqlx::query_as::<_, DbRow>(&format!(
+            "UPDATE build_pod_permits SET state = 'lift_applying', resize_invocation_id = $1 \
+             WHERE task_run_id = $2 AND permit_id = $3::uuid AND fencing_token = $4 \
+               AND pod_uid = $5 AND state = 'birth_confirmed' RETURNING {ROW_COLUMNS}"
+        ))
+        .bind(invocation_id)
+        .bind(task_run_id)
+        .bind(permit_id)
+        .bind(fencing_token)
+        .bind(pod_uid)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some(row) = updated {
+            tx.commit().await?;
+            return Ok(TransitionBuildPodResizeLifecycleResult::Transitioned(
+                Box::new(row.try_into()?),
+            ));
+        }
+        let existing = fetch_tx(&mut tx, task_run_id).await?;
+        tx.commit().await?;
+        Ok(match existing {
+            Some(row)
+                if row.permit_id == permit_id
+                    && row.fencing_token == fencing_token
+                    && row.state == BuildPodPermitState::LiftApplying
+                    && row.resize_identity.as_ref().map(|id| id.pod_uid.as_str()) == Some(pod_uid)
+                    && row.resize_invocation_id.as_deref() == Some(invocation_id) =>
+            {
+                TransitionBuildPodResizeLifecycleResult::Transitioned(Box::new(row))
+            }
+            _ => TransitionBuildPodResizeLifecycleResult::Rejected,
+        })
+    }
+
     /// Compare-and-swap one resize lifecycle transition.
     ///
     /// The predicate fences the task run, permit identity, fencing token, the
-    /// captured Pod UID *and* the expected current state in a single statement,
-    /// so a stale observer cannot advance a lifecycle it no longer owns. The
-    /// migration-164 trigger separately rejects transitions that are not on the
-    /// legal edge list, which keeps the state machine authoritative in the
-    /// database rather than in whichever caller happens to run.
+    /// captured Pod UID, **the owning invocation** and the expected current
+    /// state in a single statement, so a stale observer cannot advance a
+    /// lifecycle it no longer owns. The migration-164 trigger separately rejects
+    /// transitions that are not on the legal edge list, which keeps the state
+    /// machine authoritative in the database rather than in whichever caller
+    /// happens to run.
+    ///
+    /// `invocation` is `None` for the infrastructure-observer paths that reach
+    /// `drop_required`/`quarantined` from `birth_confirmed` without any
+    /// invocation having lifted. It is compared with `IS NOT DISTINCT FROM`, so
+    /// `None` means "the row must carry no invocation" rather than "do not
+    /// check" — dropping this clause is acceptance criterion 1's named mutation.
     pub async fn transition_resize_lifecycle(
         &self,
         task_run_id: &str,
         permit_id: &str,
         fencing_token: i64,
         pod_uid: &str,
+        invocation: Option<&str>,
         expected: BuildPodPermitState,
         next: BuildPodPermitState,
     ) -> DbResult<TransitionBuildPodResizeLifecycleResult> {
@@ -485,13 +563,15 @@ impl BuildPodPermitRepository {
         let row = sqlx::query_as::<_, DbRow>(&format!(
             "UPDATE build_pod_permits SET state = $1 \
              WHERE task_run_id = $2 AND permit_id = $3::uuid AND fencing_token = $4 \
-               AND pod_uid = $5 AND state = $6 RETURNING {ROW_COLUMNS}"
+               AND pod_uid = $5 AND resize_invocation_id IS NOT DISTINCT FROM $6 \
+               AND state = $7 RETURNING {ROW_COLUMNS}"
         ))
         .bind(next.as_str())
         .bind(task_run_id)
         .bind(permit_id)
         .bind(fencing_token)
         .bind(pod_uid)
+        .bind(invocation)
         .bind(expected.as_str())
         .fetch_optional(self.db.pool())
         .await?;
@@ -643,13 +723,16 @@ struct DbRow {
     observed_launcher_protocol: Option<String>,
     effective_launcher_protocol: Option<String>,
     admitted_cpu_millicores: Option<i64>,
+    resize_invocation_id: Option<String>,
 }
 
 impl TryFrom<DbRow> for BuildPodPermitRow {
     type Error = DbError;
 
     fn try_from(row: DbRow) -> DbResult<Self> {
+        let resize_invocation_id = row.resize_invocation_id.clone();
         Ok(Self {
+            resize_invocation_id,
             task_run_id: row.task_run_id,
             permit_id: row.permit_id,
             fencing_token: row.fencing_token,

--- a/server/crates/djinn-db/src/repositories/build_pod_permit.rs
+++ b/server/crates/djinn-db/src/repositories/build_pod_permit.rs
@@ -522,7 +522,8 @@ impl BuildPodPermitRepository {
                 if row.permit_id == permit_id
                     && row.fencing_token == fencing_token
                     && row.state == BuildPodPermitState::LiftApplying
-                    && row.resize_identity.as_ref().map(|id| id.pod_uid.as_str()) == Some(pod_uid)
+                    && row.resize_identity.as_ref().map(|id| id.pod_uid.as_str())
+                        == Some(pod_uid)
                     && row.resize_invocation_id.as_deref() == Some(invocation_id) =>
             {
                 TransitionBuildPodResizeLifecycleResult::Transitioned(Box::new(row))
@@ -546,6 +547,11 @@ impl BuildPodPermitRepository {
     /// invocation having lifted. It is compared with `IS NOT DISTINCT FROM`, so
     /// `None` means "the row must carry no invocation" rather than "do not
     /// check" — dropping this clause is acceptance criterion 1's named mutation.
+    // Every parameter is one component of a single compare-and-swap predicate.
+    // Bundling them into a struct would let a caller construct a HALF-SPECIFIED
+    // fence and still compile, which is exactly the failure this method exists
+    // to make impossible.
+    #[allow(clippy::too_many_arguments)]
     pub async fn transition_resize_lifecycle(
         &self,
         task_run_id: &str,

--- a/server/crates/djinn-db/tests/build_pod_permit_repository.rs
+++ b/server/crates/djinn-db/tests/build_pod_permit_repository.rs
@@ -238,11 +238,27 @@ async fn resize_identity_is_write_once_and_lifecycle_is_uid_fenced() {
         "a rejected malformed capture must not enter the resize lifecycle"
     );
 
+    // Migration 168: the lifecycle may only be entered by CLAIMING an
+    // invocation, so the `birth_confirmed -> lift_applying` edge goes through
+    // `begin_resize_invocation` rather than the generic transition.
+    const INVOCATION: &str = "invocation-a";
+    let claimed = repo
+        .begin_resize_invocation(
+            "resize",
+            &permit.permit_id,
+            permit.fencing_token,
+            "pod-uid",
+            INVOCATION,
+        )
+        .await
+        .unwrap();
+    let TransitionBuildPodResizeLifecycleResult::Transitioned(row) = claimed else {
+        panic!("the first invocation must win the claim, got {claimed:?}");
+    };
+    assert_eq!(row.state, BuildPodPermitState::LiftApplying);
+    assert_eq!(row.resize_invocation_id.as_deref(), Some(INVOCATION));
+
     for (from, to) in [
-        (
-            BuildPodPermitState::BirthConfirmed,
-            BuildPodPermitState::LiftApplying,
-        ),
         (
             BuildPodPermitState::LiftApplying,
             BuildPodPermitState::Lifted,
@@ -270,6 +286,7 @@ async fn resize_identity_is_write_once_and_lifecycle_is_uid_fenced() {
                 &permit.permit_id,
                 permit.fencing_token,
                 "pod-uid",
+                Some(INVOCATION),
                 from,
                 to,
             )
@@ -296,6 +313,7 @@ async fn resize_identity_is_write_once_and_lifecycle_is_uid_fenced() {
             &permit.permit_id,
             permit.fencing_token,
             "pod-uid",
+            Some(INVOCATION),
             BuildPodPermitState::Lifted,
             BuildPodPermitState::DropRequired
         )
@@ -314,6 +332,7 @@ async fn resize_identity_is_write_once_and_lifecycle_is_uid_fenced() {
             &permit.permit_id,
             permit.fencing_token + 1,
             "pod-uid",
+            Some(INVOCATION),
             BuildPodPermitState::Quarantined,
             BuildPodPermitState::DropRequired
         )
@@ -327,6 +346,7 @@ async fn resize_identity_is_write_once_and_lifecycle_is_uid_fenced() {
             &permit.permit_id,
             permit.fencing_token,
             "stale-uid",
+            Some(INVOCATION),
             BuildPodPermitState::Quarantined,
             BuildPodPermitState::DropRequired
         )
@@ -478,4 +498,288 @@ async fn non_positive_limits_and_missing_pool_fail_closed() {
         .await
         .unwrap();
     assert!(repo.global_pool_is_readable().await.is_err());
+}
+
+/// Seed one permit at `birth_confirmed` with a captured identity.
+async fn birth_confirmed(db: &Database, task_run_id: &str, pod_uid: &str) -> (String, i64) {
+    let repo = BuildPodPermitRepository::new(db.clone());
+    let permit = match repo.acquire(task_run_id, 16).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        outcome => panic!("unexpected outcome: {outcome:?}"),
+    };
+    assert!(matches!(
+        repo.bind_or_refresh_job_uid(
+            task_run_id,
+            &permit.permit_id,
+            permit.fencing_token,
+            &format!("job-{pod_uid}")
+        )
+        .await
+        .unwrap(),
+        BindBuildPodPermitResult::Bound(_)
+    ));
+    let identity = BuildPodResizeIdentity {
+        pod_namespace: "ns".into(),
+        pod_name: format!("pod-{pod_uid}"),
+        pod_uid: pod_uid.into(),
+        launcher_container_name: "cgroup-launcher".into(),
+        launcher_container_id: "containerd://launcher".into(),
+        image_digest: "sha256:abc".into(),
+        observed_launcher_protocol: "resize-v2".into(),
+        effective_launcher_protocol: "resize-v2".into(),
+        admitted_cpu_millicores: 4000,
+    };
+    assert!(matches!(
+        repo.capture_resize_identity(
+            task_run_id,
+            &permit.permit_id,
+            permit.fencing_token,
+            &identity
+        )
+        .await
+        .unwrap(),
+        CaptureBuildPodResizeIdentityResult::Captured(_)
+    ));
+    (permit.permit_id, permit.fencing_token)
+}
+
+/// AC1. The invocation half of the fence exists, is written only on the edge
+/// that starts a lift, and REJECTS a transition presented with a stale
+/// invocation id — leaving the row byte-identical.
+///
+/// NAMED FAILING MUTATION: delete
+/// `AND resize_invocation_id IS NOT DISTINCT FROM $6` from
+/// `transition_resize_lifecycle`'s predicate, leaving the `pod_uid` fence in
+/// place. The stale transition below then succeeds and this test fails.
+///
+/// Against REAL Postgres, deliberately: the compare-and-swap, migration 164's
+/// transition trigger and migration 168's invocation write-window are Postgres
+/// behaviours. A fake repository would assert this test's opinion of them.
+#[tokio::test]
+async fn a_stale_invocation_id_is_rejected_and_leaves_the_row_unchanged() {
+    let db = Database::ephemeral().await.unwrap();
+    seed_runs(&db, &["fence-run"]).await;
+    let repo = BuildPodPermitRepository::new(db.clone());
+    let (permit_id, fence) = birth_confirmed(&db, "fence-run", "pod-fence").await;
+
+    // Invocation A claims the lifecycle.
+    let claimed = repo
+        .begin_resize_invocation("fence-run", &permit_id, fence, "pod-fence", "invocation-a")
+        .await
+        .unwrap();
+    let TransitionBuildPodResizeLifecycleResult::Transitioned(row) = claimed else {
+        panic!("the claim must succeed, got {claimed:?}");
+    };
+    assert_eq!(row.resize_invocation_id.as_deref(), Some("invocation-a"));
+    let before = repo.active("fence-run").await.unwrap().unwrap();
+
+    // Invocation B presents a legal edge on the right Pod under the right
+    // permit and fencing token. ONLY the invocation is wrong.
+    let stale = repo
+        .transition_resize_lifecycle(
+            "fence-run",
+            &permit_id,
+            fence,
+            "pod-fence",
+            Some("invocation-b"),
+            BuildPodPermitState::LiftApplying,
+            BuildPodPermitState::Lifted,
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(stale, TransitionBuildPodResizeLifecycleResult::Rejected),
+        "a stale invocation must be rejected even with a matching Pod UID: {stale:?}"
+    );
+    assert_eq!(
+        repo.active("fence-run").await.unwrap().unwrap(),
+        before,
+        "a rejected transition must leave the row byte-identical"
+    );
+
+    // `None` is a fence value, not "do not check": a caller claiming the row
+    // carries no invocation must lose against a row that carries one.
+    let unfenced = repo
+        .transition_resize_lifecycle(
+            "fence-run",
+            &permit_id,
+            fence,
+            "pod-fence",
+            None,
+            BuildPodPermitState::LiftApplying,
+            BuildPodPermitState::Lifted,
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(unfenced, TransitionBuildPodResizeLifecycleResult::Rejected),
+        "an absent invocation must not match a claimed row: {unfenced:?}"
+    );
+
+    // The owner still wins.
+    assert!(matches!(
+        repo.transition_resize_lifecycle(
+            "fence-run",
+            &permit_id,
+            fence,
+            "pod-fence",
+            Some("invocation-a"),
+            BuildPodPermitState::LiftApplying,
+            BuildPodPermitState::Lifted,
+        )
+        .await
+        .unwrap(),
+        TransitionBuildPodResizeLifecycleResult::Transitioned(_)
+    ));
+}
+
+/// AC2. Two invocations of ONE task run CAN be in flight simultaneously —
+/// nothing in `djinn_agent::process`'s `'invocation: loop` serializes them, the
+/// runner is `Arc`-shared behind `&self`, and its journal keeps a `HashSet` of
+/// live invocation ids precisely because more than one can be live. A single-row
+/// lifecycle cannot represent two simultaneous lifts, so the second claimant
+/// must FAIL CLOSED.
+///
+/// Both claims race against real Postgres through a `Barrier`. Exactly one wins.
+///
+/// NAMED FAILING MUTATION: remove `AND state = 'birth_confirmed'` from
+/// `begin_resize_invocation`'s predicate — the guard the answer rests on — and
+/// both claims succeed, so the row ends up carrying the loser's invocation id
+/// and this test fails.
+#[tokio::test]
+async fn only_one_of_two_concurrent_invocations_can_claim_the_lifecycle() {
+    let db = Database::ephemeral().await.unwrap();
+    seed_runs(&db, &["concurrent-run"]).await;
+    let (permit_id, fence) = birth_confirmed(&db, "concurrent-run", "pod-concurrent").await;
+
+    let repo = Arc::new(BuildPodPermitRepository::new(db.clone()));
+    let barrier = Arc::new(Barrier::new(2));
+    let mut handles = Vec::new();
+    for invocation in ["invocation-a", "invocation-b"] {
+        let repo = Arc::clone(&repo);
+        let barrier = Arc::clone(&barrier);
+        let permit_id = permit_id.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            (
+                invocation,
+                repo.begin_resize_invocation(
+                    "concurrent-run",
+                    &permit_id,
+                    fence,
+                    "pod-concurrent",
+                    invocation,
+                )
+                .await
+                .unwrap(),
+            )
+        }));
+    }
+    let mut winners = Vec::new();
+    let mut losers = Vec::new();
+    for handle in handles {
+        match handle.await.unwrap() {
+            (id, TransitionBuildPodResizeLifecycleResult::Transitioned(_)) => winners.push(id),
+            (id, TransitionBuildPodResizeLifecycleResult::Rejected) => losers.push(id),
+        }
+    }
+    assert_eq!(
+        winners.len(),
+        1,
+        "exactly one invocation may own a single-row lifecycle; won: {winners:?}"
+    );
+    assert_eq!(losers.len(), 1, "the second claimant must fail closed");
+
+    let row = repo.active("concurrent-run").await.unwrap().unwrap();
+    assert_eq!(row.state, BuildPodPermitState::LiftApplying);
+    assert_eq!(
+        row.resize_invocation_id.as_deref(),
+        Some(winners[0]),
+        "the row must carry the WINNER's invocation, never the loser's"
+    );
+}
+
+/// The write window is exactly one edge: `birth_confirmed -> lift_applying`.
+/// Migration 168's trigger refuses to let any other transition re-key the row,
+/// so a drop or a quarantine cannot silently change ownership underneath a
+/// caller that is mid-sequence.
+#[tokio::test]
+async fn the_invocation_id_may_only_change_on_entry_to_lift_applying() {
+    let db = Database::ephemeral().await.unwrap();
+    seed_runs(&db, &["window-run"]).await;
+    let repo = BuildPodPermitRepository::new(db.clone());
+    let (permit_id, fence) = birth_confirmed(&db, "window-run", "pod-window").await;
+    repo.begin_resize_invocation("window-run", &permit_id, fence, "pod-window", "invocation-a")
+        .await
+        .unwrap();
+
+    // The trigger, not the repository, is the authority. Reach past the
+    // repository's own predicate and try to re-key on a non-lift edge.
+    let direct = sqlx::query(
+        "UPDATE build_pod_permits SET state = 'lifted', resize_invocation_id = 'invocation-b' \
+         WHERE task_run_id = 'window-run'",
+    )
+    .execute(db.pool())
+    .await;
+    let error = direct.expect_err("the trigger must refuse a re-key off the lift edge");
+    assert!(
+        error
+            .to_string()
+            .contains("resize invocation id may only change on entry to lift_applying"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        repo.active("window-run")
+            .await
+            .unwrap()
+            .unwrap()
+            .resize_invocation_id
+            .as_deref(),
+        Some("invocation-a")
+    );
+
+    // And the next invocation DOES get to re-key, once the previous one's drop
+    // has returned the row to `birth_confirmed`. Without that the lifecycle
+    // could serve exactly one invocation per task run, ever.
+    for (from, to) in [
+        (
+            BuildPodPermitState::LiftApplying,
+            BuildPodPermitState::Lifted,
+        ),
+        (
+            BuildPodPermitState::Lifted,
+            BuildPodPermitState::DropRequired,
+        ),
+        (
+            BuildPodPermitState::DropRequired,
+            BuildPodPermitState::DropApplying,
+        ),
+        (
+            BuildPodPermitState::DropApplying,
+            BuildPodPermitState::BirthConfirmed,
+        ),
+    ] {
+        assert!(matches!(
+            repo.transition_resize_lifecycle(
+                "window-run",
+                &permit_id,
+                fence,
+                "pod-window",
+                Some("invocation-a"),
+                from,
+                to,
+            )
+            .await
+            .unwrap(),
+            TransitionBuildPodResizeLifecycleResult::Transitioned(_)
+        ));
+    }
+    let second = repo
+        .begin_resize_invocation("window-run", &permit_id, fence, "pod-window", "invocation-b")
+        .await
+        .unwrap();
+    let TransitionBuildPodResizeLifecycleResult::Transitioned(row) = second else {
+        panic!("the next invocation must be able to claim, got {second:?}");
+    };
+    assert_eq!(row.resize_invocation_id.as_deref(), Some("invocation-b"));
 }

--- a/server/crates/djinn-db/tests/build_pod_permit_repository.rs
+++ b/server/crates/djinn-db/tests/build_pod_permit_repository.rs
@@ -709,9 +709,15 @@ async fn the_invocation_id_may_only_change_on_entry_to_lift_applying() {
     seed_runs(&db, &["window-run"]).await;
     let repo = BuildPodPermitRepository::new(db.clone());
     let (permit_id, fence) = birth_confirmed(&db, "window-run", "pod-window").await;
-    repo.begin_resize_invocation("window-run", &permit_id, fence, "pod-window", "invocation-a")
-        .await
-        .unwrap();
+    repo.begin_resize_invocation(
+        "window-run",
+        &permit_id,
+        fence,
+        "pod-window",
+        "invocation-a",
+    )
+    .await
+    .unwrap();
 
     // The trigger, not the repository, is the authority. Reach past the
     // repository's own predicate and try to re-key on a non-lift edge.
@@ -775,7 +781,13 @@ async fn the_invocation_id_may_only_change_on_entry_to_lift_applying() {
         ));
     }
     let second = repo
-        .begin_resize_invocation("window-run", &permit_id, fence, "pod-window", "invocation-b")
+        .begin_resize_invocation(
+            "window-run",
+            &permit_id,
+            fence,
+            "pod-window",
+            "invocation-b",
+        )
         .await
         .unwrap();
     let TransitionBuildPodResizeLifecycleResult::Transitioned(row) = second else {

--- a/server/crates/djinn-k8s/tests/cutover_preflight.rs
+++ b/server/crates/djinn-k8s/tests/cutover_preflight.rs
@@ -1175,19 +1175,36 @@ async fn seed_permit_in_state(database: &Database, task_run_id: &str, target: Bu
         BuildPodPermitState::Quarantined => &[BuildPodPermitState::Quarantined],
         other => panic!("{other:?} is not a nonterminal resize state"),
     };
+    // Migration 168: the lifecycle is entered by CLAIMING an invocation, and
+    // every later edge is fenced on the invocation the claim wrote.
+    let invocation = format!("invocation-{task_run_id}");
+    let mut claimed: Option<&str> = None;
     let mut current = BuildPodPermitState::BirthConfirmed;
     for next in walk {
-        let outcome = repo
-            .transition_resize_lifecycle(
+        let outcome = if *next == BuildPodPermitState::LiftApplying {
+            claimed = Some(invocation.as_str());
+            repo.begin_resize_invocation(
                 task_run_id,
                 &row.permit_id,
                 row.fencing_token,
                 &identity.pod_uid,
+                &invocation,
+            )
+            .await
+            .expect("claim invocation")
+        } else {
+            repo.transition_resize_lifecycle(
+                task_run_id,
+                &row.permit_id,
+                row.fencing_token,
+                &identity.pod_uid,
+                claimed,
                 current,
                 *next,
             )
             .await
-            .expect("transition");
+            .expect("transition")
+        };
         let TransitionBuildPodResizeLifecycleResult::Transitioned(_) = outcome else {
             panic!("{current:?} -> {next:?} must be a legal transition, got {outcome:?}");
         };

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod server;
 pub mod server_memory;
 pub mod sse;
 pub mod task_run_resize_bootstrap;
+pub mod task_run_resize_drop;
 pub mod task_run_resize_rollout;
 
 #[cfg(any(test, feature = "test-support"))]

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -400,6 +400,14 @@ struct Inner {
     /// unreachable — `scripts/check-resize-reachability.sh` exists to keep it
     /// that way only over this maintainer's dead build.
     pub resize_admission: Arc<crate::task_run_resize_bootstrap::TaskRunResizeAdmissionBridge>,
+    /// Proposal `3i92`'s fail-safe drop, composed once for the whole process.
+    ///
+    /// The other half of `resize_admission`: that one raises a launcher's
+    /// ceiling for one invocation, this one is the seam every terminal path
+    /// converges on to give the CPU back. Threaded into every
+    /// [`AppState::agent_context`], which is where `DirectServices`'
+    /// `release_lease` handler reads it. **This is the composition site.**
+    pub resize_drop: Arc<crate::task_run_resize_drop::TaskRunResizeDropBridge>,
 }
 
 /// Result of a boot token exchange attempt.
@@ -537,6 +545,8 @@ impl AppState {
         let resize_admission = Arc::new(
             crate::task_run_resize_bootstrap::TaskRunResizeAdmissionBridge::from_env(db.clone()),
         );
+        let resize_drop =
+            Arc::new(crate::task_run_resize_drop::TaskRunResizeDropBridge::from_env(db.clone()));
         Self {
             inner: Arc::new(Inner {
                 db,
@@ -581,6 +591,7 @@ impl AppState {
                 graph_warmer: tokio::sync::RwLock::new(None),
                 build_lease,
                 resize_admission,
+                resize_drop,
             }),
         }
     }
@@ -1719,6 +1730,7 @@ impl AppState {
             ))),
             runtime_ops: Some(Arc::new(self.clone())),
             resize_admission: Some(self.inner.resize_admission.clone()),
+            resize_drop: Some(self.inner.resize_drop.clone()),
             // Host-side runs root for the coordinator sweep + teardown backstop.
             // Resolves to `$DJINN_HOME/cache/cargo-target-runs` (the server pod's
             // mount of the shared cache PVC), not the Job-pod `/cache` path.

--- a/server/src/task_run_resize_drop.rs
+++ b/server/src/task_run_resize_drop.rs
@@ -1,0 +1,986 @@
+//! The fail-safe drop: returning a lifted launcher to its birth limit, or
+//! destroying the Pod that refused to come back down.
+//!
+//! `0ppk-1c` raises `spec.initContainers[cgroup-launcher].resources.limits.cpu`
+//! from 250m to a clamped ceiling for the duration of one invocation's build.
+//! This module is the other half of that trade: **every** way an invocation can
+//! end converges here, and the CPU the cluster lent is either given back or the
+//! borrower is destroyed.
+//!
+//! # The two things that may release the lease
+//!
+//! Exactly two facts end a drop, and neither of them is a row this module wrote:
+//!
+//! 1. **250m read back from `status.initContainerStatuses[cgroup-launcher]`**,
+//!    compared in millicores through [`djinn_k8s::pod_resize::CpuLimit`]. Never
+//!    `status.containerStatuses` — the launcher is a native sidecar, so no
+//!    regular container by that name legitimately exists, and a fixture that
+//!    plants one there is the sharpest form of the false-confirmation trap.
+//!    Never a Quantity string either: the apiserver canonicalises `4000m` to
+//!    `4`, and #2861 watched a string comparison report `never reported 2000m;
+//!    last observed Some(2000)`.
+//! 2. **The exact Pod UID confirmed absent.** A Pod that no longer exists holds
+//!    no limit. Absence is proven by observation — a fresh label-scoped GET that
+//!    returns no Pod, or returns a Pod whose `metadata.uid` is not ours — and
+//!    **never** by a DELETE's own acknowledgement. A 200 from `DELETE` says the
+//!    apiserver accepted the request, not that the object is gone.
+//!
+//! `state = 'birth_confirmed'` is a LABEL. Writing it proves nothing, which is
+//! why [`ResizeDropOutcome::Confirmed`] is only reachable after the PATCH has
+//! been confirmed through the client's own init-container status rule.
+//!
+//! # Two ledgers, and the one that must not move first
+//!
+//! `BuildLeaseService::release` writes `build_leases`. This lifecycle lives in
+//! `build_pod_permits`. They are DIFFERENT STORES, and "the lease was released"
+//! is a true statement about the wrong one unless it names which. The gate is
+//! [`ResizeDropOutcome::releases_lease`]: while the permit row sits in
+//! `drop_required`, `drop_applying` or `quarantined`, no outcome that permits a
+//! release exists, so the build lease row stays occupying and terminal is not
+//! acknowledged. See `direct_services.rs`'s `release_lease` handler, which is
+//! where that gate is actually applied.
+//!
+//! # Quarantine is unbounded on purpose
+//!
+//! A Pod that could not be dropped is holding CPU nobody is paying for, and the
+//! apiserver being unreachable is not a reason to stop trying to destroy it —
+//! it is a reason the lease must stay held. [`Self::confirm_absence`] has no
+//! deadline and no attempt cap. Bounding it would trade an unbounded retry for
+//! an unbounded overcommit.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_agent::task_run_resize_drop_gate::{
+    ResizeDropGateRequest, ResizeDropVerdict, TaskRunResizeDropGate,
+};
+use djinn_db::{
+    BuildPodPermitRepository, BuildPodPermitState, BuildPodResizeIdentity,
+    ReleaseBuildPodPermitResult, TransitionBuildPodResizeLifecycleResult,
+};
+use djinn_k8s::pod_resize::PodResizeError;
+use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use djinn_supervisor::services::DegradedUnleasedReason;
+use tokio::time::Instant;
+use tracing::{error, info, warn};
+
+use crate::task_run_resize_bootstrap::{BIRTH_CPU_MILLICORES, TaskRunPodSurface};
+
+/// First backoff between confirmation attempts.
+pub const DROP_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Ceiling on the backoff. The kubelet actuates in milliseconds when it is going
+/// to actuate at all; a longer gap only spends the confirmation window without
+/// buying more information.
+pub const DROP_MAX_BACKOFF: Duration = Duration::from_secs(2);
+
+/// How long the drop waits for `status.initContainerStatuses` to report 250m
+/// before quarantining the Pod.
+pub const DROP_CONFIRMATION_BUDGET: Duration = Duration::from_secs(30);
+
+/// The durable release reason recorded when a quarantined Pod is confirmed gone.
+/// `build_pod_permits_release_check` caps this at 64 characters.
+const QUARANTINE_RELEASE_REASON: &str = "resize_quarantine_pod_deleted";
+
+// ── The injected clock ─────────────────────────────────────────────────────
+
+/// The passage of time, as this module consumes it.
+///
+/// Behind a trait because acceptance criterion 5 is a statement about the
+/// *observed delay sequence*, and a test that measured wall-clock sleeps would
+/// take 30 seconds to make it. A fake that records what it was asked to wait for
+/// is what turns "bounded exponential backoff from 250ms to 2s" into an
+/// assertion that fails when the cap is removed.
+#[async_trait]
+pub trait ResizeDropClock: Send + Sync {
+    /// The current instant.
+    fn now(&self) -> Instant;
+
+    /// Wait for `duration`.
+    async fn sleep(&self, duration: Duration);
+}
+
+/// The production clock.
+#[derive(Debug, Default)]
+pub struct SystemResizeDropClock;
+
+#[async_trait]
+impl ResizeDropClock for SystemResizeDropClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        tokio::time::sleep(duration).await;
+    }
+}
+
+// ── Inputs ─────────────────────────────────────────────────────────────────
+
+/// Which terminal path is asking for the drop.
+///
+/// Purely diagnostic to the mechanism — the drop is identical for all of them,
+/// which is the property acceptance criterion 3 exists to hold onto. It is a
+/// closed enum rather than a string so a new terminal path is a compile error at
+/// the mapping sites instead of an unnamed cause in a log line.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResizeDropCause {
+    /// The child exited zero.
+    NormalExit,
+    /// The child exited non-zero.
+    NonZeroExit,
+    /// The invocation deadline passed.
+    TimedOut,
+    /// The invocation was cancelled.
+    Cancelled,
+    /// Three consecutive `LeaseUnavailable` responses forced a cancel.
+    LeaseUnavailableForcedCancel,
+    /// The grant was denied after a lift had already been attempted.
+    GrantDenied,
+    /// `0ppk-1c` folded the grant into `DegradedUnleased`.
+    DegradedUnleased,
+    /// The worker's connection died; observed by `watch_infra_death`.
+    WorkerDisconnect,
+    /// The Pod terminated; observed by `watch_infra_death`.
+    PodTerminated,
+    /// A durable row was found mid-lift by a process that did not start it.
+    ServerRestart,
+}
+
+impl ResizeDropCause {
+    /// The stable spelling for logs.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NormalExit => "normal_exit",
+            Self::NonZeroExit => "non_zero_exit",
+            Self::TimedOut => "timed_out",
+            Self::Cancelled => "cancelled",
+            Self::LeaseUnavailableForcedCancel => "lease_unavailable_forced_cancel",
+            Self::GrantDenied => "grant_denied",
+            Self::DegradedUnleased => "degraded_unleased",
+            Self::WorkerDisconnect => "worker_disconnect",
+            Self::PodTerminated => "pod_terminated",
+            Self::ServerRestart => "server_restart",
+        }
+    }
+}
+
+/// One request to return a task run's launcher to its birth limit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResizeDropRequest {
+    /// The task run whose permit row this is.
+    pub task_run_id: String,
+    /// The invocation this drop retires, when the caller has one.
+    ///
+    /// `None` is the infrastructure-observer shape: `watch_infra_death` sees a
+    /// Pod die, not an invocation end, so it has no invocation to name and
+    /// drives whichever one the row currently carries. A caller that DOES name
+    /// one and does not match the row is stale — its lift never took, because a
+    /// second invocation can only claim the row from `birth_confirmed`, which
+    /// requires the first one's drop to have completed.
+    pub invocation_id: Option<String>,
+    /// Which terminal path is asking.
+    pub cause: ResizeDropCause,
+}
+
+// ── Outcomes ───────────────────────────────────────────────────────────────
+
+/// What a drop settled on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResizeDropOutcome {
+    /// 250m was read back from the launcher's init-container status. The permit
+    /// row is back at `birth_confirmed`.
+    Confirmed {
+        /// The Pod the confirmation was fenced to.
+        pod_uid: String,
+    },
+    /// The exact Pod UID is confirmed absent, so nothing holds a raised limit.
+    /// The permit row is left nonterminal for `0ppk-3`'s reconciler.
+    PodUidAbsent {
+        /// The Pod UID proven absent.
+        pod_uid: String,
+    },
+    /// The permit carries no resize identity: a `leaf-v1` run, or one whose Pod
+    /// was never captured. There is no container limit to return.
+    NotResizeGoverned,
+    /// No active permit row exists for this task run.
+    NoActivePermit,
+    /// Another invocation owns this row's resize lifecycle, so the caller's lift
+    /// never took and it owes no drop.
+    Fenced {
+        /// The invocation that does own the row, if any.
+        owner: Option<String>,
+    },
+    /// The drop could not be confirmed. The Pod was quarantined, UID-fenced
+    /// deleted, its absence proven, and the permit released.
+    QuarantinedPodDeleted {
+        /// The Pod that was destroyed.
+        pod_uid: String,
+        /// Why the drop could not be confirmed.
+        reason: DegradedUnleasedReason,
+    },
+    /// Durable storage or the apiserver could not answer, and the drop is not
+    /// settled. **Deliberately does not release the lease.**
+    Unavailable(String),
+}
+
+impl ResizeDropOutcome {
+    /// Whether the durable CPU lease may now be released and terminal
+    /// acknowledged.
+    ///
+    /// This is the gate acceptance criterion 6 names. Every `true` arm rests on
+    /// a fact the cluster reported — 250m in init-container status, or an absent
+    /// Pod UID, or a permit that never governed a resize at all. `Unavailable`
+    /// is `false` because an unanswered apiserver is not evidence that the CPU
+    /// came back.
+    #[must_use]
+    pub const fn releases_lease(&self) -> bool {
+        match self {
+            Self::Confirmed { .. }
+            | Self::PodUidAbsent { .. }
+            | Self::NotResizeGoverned
+            | Self::NoActivePermit
+            | Self::Fenced { .. }
+            | Self::QuarantinedPodDeleted { .. } => true,
+            Self::Unavailable(_) => false,
+        }
+    }
+}
+
+/// The resolved subject of a drop: everything the fences are compared against.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResizeDropSubject {
+    /// Task run whose permit row this is.
+    pub task_run_id: String,
+    /// Immutable permit identity.
+    pub permit_id: String,
+    /// Monotonic ownership fence.
+    pub fencing_token: i64,
+    /// The write-once Pod UID every PATCH, DELETE and absence proof is bound to.
+    pub pod_uid: String,
+    /// The Pod's name, which is all `pods/resize` accepts.
+    pub pod_name: String,
+    /// `status.initContainerStatuses[..].containerID` as captured.
+    pub launcher_container_id: String,
+    /// The protocol the server resolved for this Pod.
+    pub effective_launcher_protocol: LauncherAuthorityProtocol,
+    /// The invocation the row carries, and therefore the invocation half of the
+    /// `(task_run_id, pod_uid, resize_invocation_id)` compare-and-swap.
+    pub invocation_id: Option<String>,
+}
+
+impl ResizeDropSubject {
+    fn fence(&self) -> Option<&str> {
+        self.invocation_id.as_deref()
+    }
+}
+
+/// What [`TaskRunResizeDrop::require_drop`] resolved.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResizeDropRequirement {
+    /// The permit row now owes a drop: it is at `drop_required`, or already at
+    /// `drop_applying` from an earlier attempt this call resumes.
+    Required(Box<ResizeDropSubject>),
+    /// The row is already quarantined; only the absence loop remains.
+    Quarantined(Box<ResizeDropSubject>),
+    /// Nothing to do, for a reason that already settles the lease question.
+    Settled(ResizeDropOutcome),
+}
+
+// ── The drop ───────────────────────────────────────────────────────────────
+
+/// Composes the durable permit relation, the apiserver surface and a clock into
+/// the fail-safe drop.
+pub struct TaskRunResizeDrop {
+    permits: Arc<BuildPodPermitRepository>,
+    surface: Arc<dyn TaskRunPodSurface>,
+    clock: Arc<dyn ResizeDropClock>,
+    budget: Duration,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    confirmation_attempts: AtomicU64,
+    quarantine_attempts: AtomicU64,
+}
+
+impl TaskRunResizeDrop {
+    /// Wire a drop to a permit repository and an apiserver surface, on the
+    /// production clock and the specified schedule.
+    #[must_use]
+    pub fn new(
+        permits: Arc<BuildPodPermitRepository>,
+        surface: Arc<dyn TaskRunPodSurface>,
+    ) -> Self {
+        Self::with_clock(permits, surface, Arc::new(SystemResizeDropClock))
+    }
+
+    /// Same composition against an injected clock.
+    #[must_use]
+    pub fn with_clock(
+        permits: Arc<BuildPodPermitRepository>,
+        surface: Arc<dyn TaskRunPodSurface>,
+        clock: Arc<dyn ResizeDropClock>,
+    ) -> Self {
+        Self {
+            permits,
+            surface,
+            clock,
+            budget: DROP_CONFIRMATION_BUDGET,
+            initial_backoff: DROP_INITIAL_BACKOFF,
+            max_backoff: DROP_MAX_BACKOFF,
+            confirmation_attempts: AtomicU64::new(0),
+            quarantine_attempts: AtomicU64::new(0),
+        }
+    }
+
+    /// How many confirmation attempts have been made across every drop this
+    /// object has driven. Each one issues its own fresh GET.
+    #[must_use]
+    pub fn confirmation_attempts(&self) -> u64 {
+        self.confirmation_attempts.load(Ordering::SeqCst)
+    }
+
+    /// How many absence-confirmation passes the quarantine loop has made.
+    #[must_use]
+    pub fn quarantine_attempts(&self) -> u64 {
+        self.quarantine_attempts.load(Ordering::SeqCst)
+    }
+
+    /// Resolve the request and move the permit row to `drop_required`.
+    ///
+    /// Split from [`Self::drop_to_birth`] so that "every terminal path reaches
+    /// `drop_required`" is a state a test can observe. Driving the whole
+    /// sequence would walk straight through `drop_required` to
+    /// `birth_confirmed`, and a table that could only read the end state could
+    /// not tell a path that was hooked up from one that never was.
+    pub async fn require_drop(&self, request: &ResizeDropRequest) -> ResizeDropRequirement {
+        let row = match self.permits.active(&request.task_run_id).await {
+            Ok(Some(row)) => row,
+            Ok(None) => return ResizeDropRequirement::Settled(ResizeDropOutcome::NoActivePermit),
+            Err(error) => {
+                return ResizeDropRequirement::Settled(ResizeDropOutcome::Unavailable(format!(
+                    "durable permit unreadable: {error}"
+                )));
+            }
+        };
+        let Some(identity) = row.resize_identity.clone() else {
+            return ResizeDropRequirement::Settled(ResizeDropOutcome::NotResizeGoverned);
+        };
+
+        // THE INVOCATION FENCE, at the entry to the drop. A caller that names an
+        // invocation the row does not carry never lifted this Pod.
+        if let Some(claimed) = request.invocation_id.as_deref()
+            && row.resize_invocation_id.as_deref() != Some(claimed)
+        {
+            return ResizeDropRequirement::Settled(ResizeDropOutcome::Fenced {
+                owner: row.resize_invocation_id.clone(),
+            });
+        }
+
+        let Ok(protocol) = identity
+            .effective_launcher_protocol
+            .parse::<LauncherAuthorityProtocol>()
+        else {
+            return ResizeDropRequirement::Settled(ResizeDropOutcome::NotResizeGoverned);
+        };
+        let subject = Box::new(subject_of(&row.task_run_id, &row, &identity, protocol));
+
+        match row.state {
+            // `birth_confirmed` is reachable here: an infrastructure observer
+            // can see a Pod die before any invocation ever lifted it. The edge
+            // is legal and the drop that follows is a no-op confirmation.
+            state @ (BuildPodPermitState::BirthConfirmed
+            | BuildPodPermitState::LiftApplying
+            | BuildPodPermitState::Lifted) => {
+                match self
+                    .transition(&subject, state, BuildPodPermitState::DropRequired)
+                    .await
+                {
+                    Ok(()) => ResizeDropRequirement::Required(subject),
+                    Err(detail) => {
+                        ResizeDropRequirement::Settled(ResizeDropOutcome::Unavailable(detail))
+                    }
+                }
+            }
+            // Resume: an earlier attempt already got this far.
+            BuildPodPermitState::DropRequired | BuildPodPermitState::DropApplying => {
+                ResizeDropRequirement::Required(subject)
+            }
+            BuildPodPermitState::Quarantined => ResizeDropRequirement::Quarantined(subject),
+            BuildPodPermitState::Acquired | BuildPodPermitState::JobCreated => {
+                ResizeDropRequirement::Settled(ResizeDropOutcome::NotResizeGoverned)
+            }
+            BuildPodPermitState::Released => {
+                ResizeDropRequirement::Settled(ResizeDropOutcome::NoActivePermit)
+            }
+        }
+    }
+
+    /// Drive one terminal path all the way to a settled answer.
+    ///
+    /// Returns only when 250m is confirmed, the Pod UID is proven absent, the
+    /// quarantined Pod is proven destroyed, or the request had nothing to do.
+    /// The quarantine branch has no deadline: cancelling this future is the only
+    /// way out of it, and doing so leaves the row durably `quarantined` and the
+    /// lease durably held, which is the safe direction.
+    pub async fn drop_to_birth(&self, request: &ResizeDropRequest) -> ResizeDropOutcome {
+        match self.require_drop(request).await {
+            ResizeDropRequirement::Settled(outcome) => outcome,
+            ResizeDropRequirement::Quarantined(subject) => {
+                self.confirm_absence(&subject, DegradedUnleasedReason::LiftDeadlineExceeded)
+                    .await
+            }
+            ResizeDropRequirement::Required(subject) => {
+                info!(
+                    task_run_id = %subject.task_run_id,
+                    pod_uid = %subject.pod_uid,
+                    cause = request.cause.as_str(),
+                    invocation_id = ?subject.invocation_id,
+                    "task_run_resize_drop: returning the launcher to its birth limit"
+                );
+                self.apply_drop(&subject).await
+            }
+        }
+    }
+
+    /// `drop_required → drop_applying`, then PATCH-and-confirm on the schedule.
+    async fn apply_drop(&self, subject: &ResizeDropSubject) -> ResizeDropOutcome {
+        if let Err(detail) = self
+            .transition(
+                subject,
+                BuildPodPermitState::DropRequired,
+                BuildPodPermitState::DropApplying,
+            )
+            .await
+        {
+            // A self-transition from `drop_applying` is legal and idempotent, so
+            // the only way here is a genuinely lost lifecycle.
+            if !self.is_drop_applying(subject).await {
+                return ResizeDropOutcome::Unavailable(detail);
+            }
+        }
+
+        let deadline = self.clock.now() + self.budget;
+        let mut backoff = self.initial_backoff;
+
+        loop {
+            self.confirmation_attempts.fetch_add(1, Ordering::SeqCst);
+
+            // A FRESH GET, with the UID, protocol and launcher-container-id
+            // fences, before EVERY attempt. Caching the Pod between attempts
+            // would let a PATCH land on an object that was replaced mid-drop.
+            // The most specific thing THIS attempt saw. Every arm either
+            // returns a settled outcome or yields a reason that waiting could
+            // still change, so the deadline below always reports a fact somebody
+            // actually observed rather than a default nobody measured.
+            let unconfirmed = match self.observe_and_fence(subject).await {
+                FenceOutcome::Fenced(observed) => {
+                    match self
+                        .surface
+                        .resize_launcher_cpu(&observed.pod_name, BIRTH_CPU_MILLICORES)
+                        .await
+                    {
+                        Ok(()) => {
+                            // The confirming fence. The client's own final GET
+                            // proves the LIMIT through
+                            // `status.initContainerStatuses`; only re-reading
+                            // the UID and container id proves that limit belongs
+                            // to the object this drop was authorized against.
+                            match self.observe_and_fence(subject).await {
+                                FenceOutcome::Fenced(_) => {
+                                    return self.settle_confirmed(subject).await;
+                                }
+                                FenceOutcome::PodUidAbsent => {
+                                    return ResizeDropOutcome::PodUidAbsent {
+                                        pod_uid: subject.pod_uid.clone(),
+                                    };
+                                }
+                                FenceOutcome::Quarantine(reason) => {
+                                    return self.quarantine(subject, reason).await;
+                                }
+                                FenceOutcome::Retry(reason) => reason,
+                            }
+                        }
+                        Err(error) => {
+                            let (reason, retryable) = classify(&error);
+                            if !retryable {
+                                return self.quarantine(subject, reason).await;
+                            }
+                            reason
+                        }
+                    }
+                }
+                FenceOutcome::PodUidAbsent => {
+                    // The borrower is gone. Nothing holds the raised limit, and
+                    // there is no object left to PATCH or to destroy.
+                    info!(
+                        task_run_id = %subject.task_run_id,
+                        pod_uid = %subject.pod_uid,
+                        "task_run_resize_drop: Pod UID confirmed absent; the drop is moot"
+                    );
+                    return ResizeDropOutcome::PodUidAbsent {
+                        pod_uid: subject.pod_uid.clone(),
+                    };
+                }
+                FenceOutcome::Quarantine(reason) => return self.quarantine(subject, reason).await,
+                FenceOutcome::Retry(reason) => reason,
+            };
+
+            // The deadline is checked against the sleep the loop is ABOUT to
+            // take, not against the time already spent, so the window is never
+            // overrun by up to one full backoff.
+            if self.clock.now() + backoff >= deadline {
+                return self.quarantine(subject, unconfirmed).await;
+            }
+            self.clock.sleep(backoff).await;
+            backoff = (backoff * 2).min(self.max_backoff);
+        }
+    }
+
+    /// Fresh label-scoped GET plus the three identity fences.
+    async fn observe_and_fence(&self, subject: &ResizeDropSubject) -> FenceOutcome {
+        let observed = match self.surface.observe_launcher(&subject.task_run_id).await {
+            Ok(Some(observed)) => observed,
+            // No Pod carries the label, so ours is certainly not among them.
+            Ok(None) => return FenceOutcome::PodUidAbsent,
+            Err(LauncherObservationError::Api(error)) => {
+                warn!(
+                    task_run_id = %subject.task_run_id,
+                    %error,
+                    "task_run_resize_drop: apiserver did not answer the confirmation GET"
+                );
+                return FenceOutcome::Retry(DegradedUnleasedReason::ResizeSurfaceUnavailable);
+            }
+            Err(LauncherObservationError::Incomplete { field }) => {
+                warn!(
+                    task_run_id = %subject.task_run_id,
+                    field,
+                    "task_run_resize_drop: stored Pod is not fully admitted; retrying"
+                );
+                return FenceOutcome::Retry(DegradedUnleasedReason::LiftPodAbsent);
+            }
+            Err(LauncherObservationError::Ambiguous(_)) => {
+                return FenceOutcome::Quarantine(DegradedUnleasedReason::LiftIdentityAmbiguous);
+            }
+        };
+
+        // THE UID FENCE. A Pod deleted and recreated under the same name is a
+        // different object; ours is gone, and the replacement belongs to
+        // whoever created it. Never PATCH it and never DELETE it.
+        if observed.pod_uid != subject.pod_uid {
+            return FenceOutcome::PodUidAbsent;
+        }
+
+        // THE PROTOCOL FENCE. Exactly one authority governs an admitted Pod.
+        let declared = observed
+            .observed_protocol
+            .as_deref()
+            .and_then(|raw| raw.parse::<LauncherAuthorityProtocol>().ok());
+        if declared != Some(subject.effective_launcher_protocol) {
+            return FenceOutcome::Quarantine(DegradedUnleasedReason::LauncherProtocolChanged);
+        }
+
+        // THE RESTART FENCE. A restarted launcher is a different cgroup than the
+        // one the lift was reasoned about, and the Pod still carries whatever
+        // container limit the lift left behind.
+        if observed.launcher_container_id.as_deref() != Some(subject.launcher_container_id.as_str())
+        {
+            return FenceOutcome::Quarantine(DegradedUnleasedReason::LauncherRestarted);
+        }
+
+        FenceOutcome::Fenced(observed)
+    }
+
+    /// `drop_applying → birth_confirmed`, only ever after a confirmed 250m.
+    async fn settle_confirmed(&self, subject: &ResizeDropSubject) -> ResizeDropOutcome {
+        match self
+            .transition(
+                subject,
+                BuildPodPermitState::DropApplying,
+                BuildPodPermitState::BirthConfirmed,
+            )
+            .await
+        {
+            Ok(()) => {
+                info!(
+                    task_run_id = %subject.task_run_id,
+                    pod_uid = %subject.pod_uid,
+                    birth_millicores = BIRTH_CPU_MILLICORES,
+                    "task_run_resize_drop: birth limit confirmed from init-container status"
+                );
+                ResizeDropOutcome::Confirmed {
+                    pod_uid: subject.pod_uid.clone(),
+                }
+            }
+            // The Pod came back down but the ledger did not move. Holding the
+            // lease is the only answer that keeps the two in agreement.
+            Err(detail) => ResizeDropOutcome::Unavailable(detail),
+        }
+    }
+
+    /// Fail safe: mark the row quarantined, then destroy the Pod and prove it.
+    async fn quarantine(
+        &self,
+        subject: &ResizeDropSubject,
+        reason: DegradedUnleasedReason,
+    ) -> ResizeDropOutcome {
+        warn!(
+            task_run_id = %subject.task_run_id,
+            pod_uid = %subject.pod_uid,
+            ?reason,
+            "task_run_resize_drop: the launcher would not return to its birth limit; quarantining"
+        );
+        for from in [
+            BuildPodPermitState::DropApplying,
+            BuildPodPermitState::DropRequired,
+            BuildPodPermitState::Lifted,
+            BuildPodPermitState::LiftApplying,
+            BuildPodPermitState::BirthConfirmed,
+        ] {
+            if self
+                .transition(subject, from, BuildPodPermitState::Quarantined)
+                .await
+                .is_ok()
+            {
+                break;
+            }
+        }
+        self.confirm_absence(subject, reason).await
+    }
+
+    /// Destroy the quarantined Pod and prove it gone. **Unbounded.**
+    ///
+    /// Absence is established by observation, never by the DELETE's own answer:
+    /// a `200` says the apiserver accepted the request. Bounding this loop is
+    /// acceptance criterion 7's named mutation — with a bound, an apiserver
+    /// outage would end with the lease released and a Pod still holding a lifted
+    /// ceiling.
+    async fn confirm_absence(
+        &self,
+        subject: &ResizeDropSubject,
+        reason: DegradedUnleasedReason,
+    ) -> ResizeDropOutcome {
+        let mut backoff = self.initial_backoff;
+        loop {
+            self.quarantine_attempts.fetch_add(1, Ordering::SeqCst);
+            match self.surface.observe_launcher(&subject.task_run_id).await {
+                // Proven absent: no Pod at all, or a Pod that is not ours.
+                Ok(None) => return self.settle_quarantine(subject, reason).await,
+                Ok(Some(observed)) if observed.pod_uid != subject.pod_uid => {
+                    return self.settle_quarantine(subject, reason).await;
+                }
+                Ok(Some(_)) => {
+                    // Still ours, still there. THE UID PRECONDITION on this
+                    // delete is what stops a Pod recreated under the same name
+                    // from being destroyed in its place — the arm above is why
+                    // that case never reaches here at all.
+                    if let Err(error) = self
+                        .surface
+                        .uid_fenced_delete(&subject.task_run_id, &subject.pod_uid)
+                        .await
+                    {
+                        warn!(
+                            task_run_id = %subject.task_run_id,
+                            pod_uid = %subject.pod_uid,
+                            %error,
+                            "task_run_resize_drop: UID-fenced delete failed; retrying"
+                        );
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        task_run_id = %subject.task_run_id,
+                        pod_uid = %subject.pod_uid,
+                        %error,
+                        "task_run_resize_drop: cannot confirm Pod absence; holding the lease"
+                    );
+                }
+            }
+            self.clock.sleep(backoff).await;
+            backoff = (backoff * 2).min(self.max_backoff);
+        }
+    }
+
+    /// `quarantined → released`, the only edge out of quarantine.
+    async fn settle_quarantine(
+        &self,
+        subject: &ResizeDropSubject,
+        reason: DegradedUnleasedReason,
+    ) -> ResizeDropOutcome {
+        match self
+            .permits
+            .release(
+                &subject.task_run_id,
+                &subject.permit_id,
+                subject.fencing_token,
+                QUARANTINE_RELEASE_REASON,
+            )
+            .await
+        {
+            Ok(
+                ReleaseBuildPodPermitResult::Released(_)
+                | ReleaseBuildPodPermitResult::AlreadyReleased(_),
+            ) => {
+                warn!(
+                    task_run_id = %subject.task_run_id,
+                    pod_uid = %subject.pod_uid,
+                    ?reason,
+                    "task_run_resize_drop: quarantined Pod is confirmed absent; permit released. \
+                     This task run can never capture a replacement Pod — recovery is a NEW task run."
+                );
+                ResizeDropOutcome::QuarantinedPodDeleted {
+                    pod_uid: subject.pod_uid.clone(),
+                    reason,
+                }
+            }
+            Ok(ReleaseBuildPodPermitResult::Rejected) => ResizeDropOutcome::Unavailable(format!(
+                "permit {} refused the quarantine release",
+                subject.permit_id
+            )),
+            Err(error) => {
+                ResizeDropOutcome::Unavailable(format!("durable permit unreleasable: {error}"))
+            }
+        }
+    }
+
+    /// One lifecycle compare-and-swap, fenced on the permit identity, the Pod
+    /// UID and the owning invocation.
+    async fn transition(
+        &self,
+        subject: &ResizeDropSubject,
+        expected: BuildPodPermitState,
+        next: BuildPodPermitState,
+    ) -> Result<(), String> {
+        match self
+            .permits
+            .transition_resize_lifecycle(
+                &subject.task_run_id,
+                &subject.permit_id,
+                subject.fencing_token,
+                &subject.pod_uid,
+                subject.fence(),
+                expected,
+                next,
+            )
+            .await
+        {
+            Ok(TransitionBuildPodResizeLifecycleResult::Transitioned(_)) => Ok(()),
+            Ok(TransitionBuildPodResizeLifecycleResult::Rejected) => Err(format!(
+                "permit {} refused the {expected:?} -> {next:?} transition",
+                subject.permit_id
+            )),
+            Err(error) => {
+                error!(
+                    task_run_id = %subject.task_run_id,
+                    %error,
+                    "task_run_resize_drop: durable permit lifecycle unwritable"
+                );
+                Err(format!("durable permit lifecycle unwritable: {error}"))
+            }
+        }
+    }
+
+    async fn is_drop_applying(&self, subject: &ResizeDropSubject) -> bool {
+        matches!(
+            self.permits.active(&subject.task_run_id).await,
+            Ok(Some(row)) if row.state == BuildPodPermitState::DropApplying
+        )
+    }
+}
+
+// ── The production composition ─────────────────────────────────────────────
+
+/// How long the `release_lease` handler waits for a drop before answering.
+///
+/// This bounds the RPC, **not** the drop. A handler that gives up returns
+/// [`ResizeDropVerdict::Held`], the durable row keeps whatever nonterminal
+/// resize state it reached, and `build_leases` does not move — so the safety
+/// property survives the timeout and `0ppk-3`'s reconciler picks the row up.
+/// Bounding the quarantine loop itself instead would end an apiserver outage
+/// with the lease released and a Pod still holding a lifted ceiling.
+pub const DROP_GATE_BUDGET: Duration = Duration::from_secs(45);
+
+/// Where the bridge gets its apiserver surface.
+enum SurfaceSource {
+    /// Built once, lazily, from ambient cluster configuration — the composition
+    /// root is synchronous and building a `kube::Client` is not, and a server
+    /// with no kubeconfig must still boot. A server that never resolves one
+    /// holds every lease it is asked to release, which is the fail-closed
+    /// answer: an unreachable apiserver is not evidence that CPU came back.
+    Ambient(tokio::sync::OnceCell<Arc<dyn TaskRunPodSurface>>),
+    /// Supplied by the caller. Fixtures use this.
+    Fixed(Arc<dyn TaskRunPodSurface>),
+}
+
+/// The server's fail-safe drop, as the terminal seam consumes it.
+pub struct TaskRunResizeDropBridge {
+    db: djinn_db::Database,
+    surface: SurfaceSource,
+    clock: Arc<dyn ResizeDropClock>,
+    budget: Duration,
+}
+
+impl TaskRunResizeDropBridge {
+    /// The production constructor: durable permits over `db`, apiserver surface
+    /// resolved from ambient cluster configuration on first terminal.
+    #[must_use]
+    pub fn from_env(db: djinn_db::Database) -> Self {
+        Self {
+            db,
+            surface: SurfaceSource::Ambient(tokio::sync::OnceCell::new()),
+            clock: Arc::new(SystemResizeDropClock),
+            budget: DROP_GATE_BUDGET,
+        }
+    }
+
+    /// Same composition against a caller-supplied surface and clock.
+    #[must_use]
+    pub fn with_surface(
+        db: djinn_db::Database,
+        surface: Arc<dyn TaskRunPodSurface>,
+        clock: Arc<dyn ResizeDropClock>,
+    ) -> Self {
+        Self {
+            db,
+            surface: SurfaceSource::Fixed(surface),
+            clock,
+            budget: DROP_GATE_BUDGET,
+        }
+    }
+
+    /// Override the handler's wait budget.
+    #[must_use]
+    pub const fn with_budget(mut self, budget: Duration) -> Self {
+        self.budget = budget;
+        self
+    }
+
+    async fn surface(&self) -> Result<Arc<dyn TaskRunPodSurface>, String> {
+        match &self.surface {
+            SurfaceSource::Fixed(surface) => Ok(Arc::clone(surface)),
+            SurfaceSource::Ambient(cell) => cell
+                .get_or_try_init(|| async {
+                    djinn_k8s::runtime::TaskRunPodResizeSurface::from_env()
+                        .await
+                        .map(|surface| Arc::new(surface) as Arc<dyn TaskRunPodSurface>)
+                })
+                .await
+                .cloned(),
+        }
+    }
+}
+
+#[async_trait]
+impl TaskRunResizeDropGate for TaskRunResizeDropBridge {
+    async fn confirm_drop(&self, request: &ResizeDropGateRequest) -> ResizeDropVerdict {
+        let surface = match self.surface().await {
+            Ok(surface) => surface,
+            Err(error) => {
+                return ResizeDropVerdict::Held {
+                    detail: format!("no apiserver surface for the resize drop: {error}"),
+                };
+            }
+        };
+        let mechanism = TaskRunResizeDrop::with_clock(
+            Arc::new(BuildPodPermitRepository::new(self.db.clone())),
+            surface,
+            Arc::clone(&self.clock),
+        );
+        let drop_request = ResizeDropRequest {
+            task_run_id: request.task_run_id.clone(),
+            invocation_id: Some(request.invocation_id.clone()),
+            cause: ResizeDropCause::NormalExit,
+        };
+        match tokio::time::timeout(self.budget, mechanism.drop_to_birth(&drop_request)).await {
+            Ok(outcome) if outcome.releases_lease() => ResizeDropVerdict::Releasable,
+            Ok(outcome) => ResizeDropVerdict::Held {
+                detail: format!("{outcome:?}"),
+            },
+            Err(_) => ResizeDropVerdict::Held {
+                detail: format!(
+                    "the drop for task run {} did not settle within {:?}; the permit row \
+                     retains its resize state and the lease stays held",
+                    request.task_run_id, self.budget
+                ),
+            },
+        }
+    }
+}
+
+/// What one fenced observation decided.
+enum FenceOutcome {
+    /// The live Pod is ours, on the expected protocol, with the launcher we
+    /// captured.
+    Fenced(ObservedLauncherSidecar),
+    /// Our exact Pod UID is not present.
+    PodUidAbsent,
+    /// The Pod is present but ungovernable. Fail safe.
+    Quarantine(DegradedUnleasedReason),
+    /// Waiting could still change this answer.
+    Retry(DegradedUnleasedReason),
+}
+
+/// Map one `pods/resize` failure onto its settled reason and whether waiting
+/// could change it.
+///
+/// Deliberately the same rule `djinn_coordinator::resize_lift` applies to a
+/// lift: only an unconfirmed *status* is retryable, because the kubelet actuates
+/// asynchronously. An apiserver verdict (403/422), a transport failure or an
+/// unparseable quantity is settled, and re-asking spends the window for nothing.
+fn classify(error: &PodResizeError) -> (DegradedUnleasedReason, bool) {
+    use djinn_k8s::pod_resize::NotConfirmed;
+    match error {
+        PodResizeError::NotConfirmed(NotConfirmed::ResizePending) => {
+            (DegradedUnleasedReason::LiftResizePending, true)
+        }
+        PodResizeError::NotConfirmed(NotConfirmed::StatusLimitAbsent) => {
+            (DegradedUnleasedReason::LiftStatusAbsent, true)
+        }
+        PodResizeError::NotConfirmed(NotConfirmed::StatusStale { .. }) => {
+            (DegradedUnleasedReason::LiftStatusStale, true)
+        }
+        PodResizeError::NotConfirmed(NotConfirmed::StatusLimitUnparseable { .. }) => {
+            (DegradedUnleasedReason::LiftStatusStale, false)
+        }
+        PodResizeError::LauncherIdentityAmbiguous { .. } => {
+            (DegradedUnleasedReason::LiftIdentityAmbiguous, false)
+        }
+        PodResizeError::InvalidCpuQuantity { .. } => {
+            (DegradedUnleasedReason::CeilingUnusable, false)
+        }
+        // Classified on the NUMERIC status, never on the rendered message.
+        PodResizeError::Api { status, .. } => (
+            match status {
+                Some(403) => DegradedUnleasedReason::ResizeForbidden,
+                Some(422) => DegradedUnleasedReason::ResizeRejected,
+                _ => DegradedUnleasedReason::ResizeSurfaceUnavailable,
+            },
+            false,
+        ),
+    }
+}
+
+fn subject_of(
+    task_run_id: &str,
+    row: &djinn_db::BuildPodPermitRow,
+    identity: &BuildPodResizeIdentity,
+    protocol: LauncherAuthorityProtocol,
+) -> ResizeDropSubject {
+    ResizeDropSubject {
+        task_run_id: task_run_id.to_owned(),
+        permit_id: row.permit_id.clone(),
+        fencing_token: row.fencing_token,
+        pod_uid: identity.pod_uid.clone(),
+        pod_name: identity.pod_name.clone(),
+        launcher_container_id: identity.launcher_container_id.clone(),
+        effective_launcher_protocol: protocol,
+        invocation_id: row.resize_invocation_id.clone(),
+    }
+}
+
+#[cfg(test)]
+#[path = "task_run_resize_drop_tests.rs"]
+mod tests;

--- a/server/src/task_run_resize_drop_tests.rs
+++ b/server/src/task_run_resize_drop_tests.rs
@@ -284,10 +284,10 @@ async fn lift(
         .await
         .expect("lift the launcher");
     assert_eq!(
-        cluster.launcher_status_cpu().as_deref(),
-        Some("4"),
+        status_millicores(cluster),
+        Some(LIFTED_MILLICORES),
         "NON-VACUITY: the launcher must actually be lifted before a drop is \
-         asked to bring it back down; the apiserver canonicalises 4000m to 4"
+         asked to bring it back down"
     );
     match permits
         .transition_resize_lifecycle(
@@ -305,6 +305,19 @@ async fn lift(
         TransitionBuildPodResizeLifecycleResult::Transitioned(_) => {}
         other => panic!("unexpected lifted outcome: {other:?}"),
     }
+}
+
+/// The launcher's **init-container** status limit, in millicores.
+///
+/// Millicores, never the Quantity string: the apiserver canonicalises `4000m`
+/// to `4`, and #2861 watched a string comparison report
+/// `never reported 2000m; last observed Some(2000)`.
+fn status_millicores(cluster: &StoredTaskRunPod) -> Option<u64> {
+    cluster.launcher_status_cpu().map(|raw| {
+        djinn_k8s::pod_resize::CpuLimit::parse(&raw)
+            .expect("the launcher reports a parseable quantity")
+            .millis()
+    })
 }
 
 async fn state_of(permits: &BuildPodPermitRepository, task_run_id: &str) -> BuildPodPermitState {
@@ -518,8 +531,8 @@ async fn a_lift_applying_row_left_by_a_dead_process_still_reaches_drop_required(
 async fn a_confirmed_drop_is_read_back_from_init_container_status_in_millicores() {
     let fixture = Fixture::lifted("confirm").await;
     assert_eq!(
-        fixture.cluster.launcher_status_cpu().as_deref(),
-        Some("4"),
+        status_millicores(&fixture.cluster),
+        Some(LIFTED_MILLICORES),
         "the launcher must start this test holding the LIFTED ceiling"
     );
 
@@ -535,17 +548,11 @@ async fn a_confirmed_drop_is_read_back_from_init_container_status_in_millicores(
         }
     );
     // THE ENFORCED FACT, not the label: what the launcher's own init-container
-    // status reports, parsed as millicores because the apiserver canonicalises.
-    let observed = djinn_k8s::pod_resize::CpuLimit::parse(
-        &fixture
-            .cluster
-            .launcher_status_cpu()
-            .expect("launcher reports a limit"),
-    )
-    .expect("a parseable quantity");
+    // status reports, in millicores because the apiserver canonicalises `4000m`
+    // to `4` and a string comparison would report a false mismatch.
     assert_eq!(
-        observed.millis(),
-        BIRTH_CPU_MILLICORES,
+        status_millicores(&fixture.cluster),
+        Some(BIRTH_CPU_MILLICORES),
         "the launcher must actually be back at its birth limit"
     );
     assert_eq!(
@@ -921,8 +928,8 @@ async fn a_terminal_from_a_stale_invocation_is_fenced_and_changes_nothing() {
         "a fenced terminal issues no PATCH"
     );
     assert_eq!(
-        fixture.cluster.launcher_status_cpu().as_deref(),
-        Some("4"),
+        status_millicores(&fixture.cluster),
+        Some(LIFTED_MILLICORES),
         "the live invocation keeps its lifted ceiling"
     );
 }

--- a/server/src/task_run_resize_drop_tests.rs
+++ b/server/src/task_run_resize_drop_tests.rs
@@ -1,0 +1,1052 @@
+//! Tests for [`super`], the fail-safe drop and UID-fenced quarantine.
+//!
+//! # What is real here and what is faked
+//!
+//! The durable lifecycle is driven against **real Postgres**
+//! ([`Database::ephemeral`], a template-cloned server — not an in-memory
+//! stand-in). No `Fake` or `Mock` permit repository appears anywhere in this
+//! file, deliberately: the compare-and-swap, migration 164's transition trigger
+//! and migration 168's invocation write-window are Postgres behaviours, and a
+//! fake would assert the test's own opinion of them.
+//!
+//! The apiserver is [`djinn_k8s::pod_resize_fixture::StoredTaskRunPod`] — a
+//! stored `Pod` object driven through the **production**
+//! `PodResizeClient::resize_launcher_cpu` and the **production**
+//! `observe_launcher_sidecar`. A resize confirmed against it is confirmed by the
+//! same `confirm_launcher_cpu` rule that runs in the cluster, reading
+//! `status.initContainerStatuses` in millicores. That is the fault-injection
+//! seam this slice is supposed to have.
+//!
+//! # The question every test here had to answer
+//!
+//! "What stays green if the body of this does nothing?" Each test names the
+//! mutation that must break it.
+
+use super::*;
+use djinn_db::{
+    AcquireBuildPodPermitResult, BindBuildPodPermitResult, BuildPodPermitRow,
+    CaptureBuildPodResizeIdentityResult, CreateTaskRunParams, Database, EffectiveCreatorProvenance,
+    ProjectRepository, TaskRepository, TaskRunRepository, TransitionBuildPodResizeLifecycleResult,
+    UserRepository,
+};
+use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
+use std::sync::Mutex as StdMutex;
+
+const CEILING: &str = "4";
+const CEILING_MILLICORES: i64 = 4000;
+const LIFTED_MILLICORES: u64 = 4000;
+
+// ── The apiserver surface under test ───────────────────────────────────────
+
+/// [`StoredTaskRunPod`] behind [`TaskRunPodSurface`], with a GET counter.
+///
+/// The counter is what makes "a FRESH GET before EVERY attempt" measurable.
+/// Caching the observed Pod between attempts — acceptance criterion 5's second
+/// named mutation — drops it below the attempt count.
+struct CountingSurface {
+    cluster: StoredTaskRunPod,
+    gets: AtomicU64,
+    deletes_attempted: AtomicU64,
+}
+
+impl CountingSurface {
+    fn new(cluster: StoredTaskRunPod) -> Self {
+        Self {
+            cluster,
+            gets: AtomicU64::new(0),
+            deletes_attempted: AtomicU64::new(0),
+        }
+    }
+
+    fn gets(&self) -> u64 {
+        self.gets.load(Ordering::SeqCst)
+    }
+
+    fn deletes_attempted(&self) -> u64 {
+        self.deletes_attempted.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TaskRunPodSurface for CountingSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.gets.fetch_add(1, Ordering::SeqCst);
+        self.cluster.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        self.cluster
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        self.deletes_attempted.fetch_add(1, Ordering::SeqCst);
+        self.cluster.uid_fenced_delete(task_run_id, pod_uid)
+    }
+}
+
+// ── The injected clock ─────────────────────────────────────────────────────
+
+/// A clock that records what it was asked to wait for and never actually waits.
+///
+/// `stall_after` is what makes an UNBOUNDED loop observable: after that many
+/// sleeps it parks forever, so a test can assert the drop future is still
+/// pending. A bounded quarantine loop would have returned before reaching it.
+struct RecordingClock {
+    base: Instant,
+    offset: StdMutex<Duration>,
+    sleeps: StdMutex<Vec<Duration>>,
+    stall_after: Option<usize>,
+}
+
+impl RecordingClock {
+    fn new() -> Self {
+        Self {
+            base: Instant::now(),
+            offset: StdMutex::new(Duration::ZERO),
+            sleeps: StdMutex::new(Vec::new()),
+            stall_after: None,
+        }
+    }
+
+    fn stalling_after(sleeps: usize) -> Self {
+        Self {
+            stall_after: Some(sleeps),
+            ..Self::new()
+        }
+    }
+
+    fn sleeps(&self) -> Vec<Duration> {
+        self.sleeps.lock().expect("clock").clone()
+    }
+}
+
+#[async_trait]
+impl ResizeDropClock for RecordingClock {
+    fn now(&self) -> Instant {
+        self.base + *self.offset.lock().expect("clock")
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        let count = {
+            let mut sleeps = self.sleeps.lock().expect("clock");
+            sleeps.push(duration);
+            *self.offset.lock().expect("clock") += duration;
+            sleeps.len()
+        };
+        if self.stall_after.is_some_and(|limit| count >= limit) {
+            std::future::pending::<()>().await;
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
+// ── Durable fixtures, against real Postgres ────────────────────────────────
+
+async fn seed_task_run(db: &Database, suffix: &str) -> String {
+    let user = UserRepository::new(db.clone())
+        .upsert_from_github(
+            i64::try_from(uuid::Uuid::now_v7().as_u128() % 8_000_000_000_000_000_000)
+                .expect("github id"),
+            &format!("resize-drop-{suffix}-{}", uuid::Uuid::now_v7()),
+            None,
+            None,
+        )
+        .await
+        .expect("seed user");
+    let project = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create(
+            &format!("resize-drop-{suffix}"),
+            "djinnos",
+            &format!("resize-drop-{suffix}"),
+        )
+        .await
+        .expect("seed project");
+    let task = TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create_in_project_with_provenance(
+            &project.id,
+            None,
+            EffectiveCreatorProvenance::explicit_user_id(&user.id),
+            "resize drop",
+            "description",
+            "design",
+            "task",
+            2,
+            "owner",
+            None,
+            None,
+        )
+        .await
+        .expect("seed task");
+    let task_run_id = uuid::Uuid::now_v7().to_string();
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: &task_run_id,
+            project_id: &project.id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed task run");
+    task_run_id
+}
+
+/// One captured permit at `birth_confirmed`, fenced to `pod_uid`.
+async fn captured_permit(
+    permits: &BuildPodPermitRepository,
+    task_run_id: &str,
+    pod_uid: &str,
+) -> BuildPodPermitRow {
+    let row = match permits.acquire(task_run_id, 16).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        other => panic!("unexpected acquire outcome: {other:?}"),
+    };
+    let bound = match permits
+        .bind_or_refresh_job_uid(
+            task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            &format!("job-{pod_uid}"),
+        )
+        .await
+        .expect("bind job uid")
+    {
+        BindBuildPodPermitResult::Bound(row) => row,
+        other => panic!("unexpected bind outcome: {other:?}"),
+    };
+    let identity = BuildPodResizeIdentity {
+        pod_namespace: "djinn".to_owned(),
+        pod_name: format!("taskrun-{pod_uid}"),
+        pod_uid: pod_uid.to_owned(),
+        launcher_container_name: "cgroup-launcher".to_owned(),
+        launcher_container_id: "containerd://launcher".to_owned(),
+        image_digest: "registry/img@sha256:feed".to_owned(),
+        observed_launcher_protocol: "resize-v2".to_owned(),
+        effective_launcher_protocol: "resize-v2".to_owned(),
+        admitted_cpu_millicores: CEILING_MILLICORES,
+    };
+    match permits
+        .capture_resize_identity(
+            task_run_id,
+            &bound.permit_id,
+            bound.fencing_token,
+            &identity,
+        )
+        .await
+        .expect("capture identity")
+    {
+        CaptureBuildPodResizeIdentityResult::Captured(row) => row,
+        other => panic!("unexpected capture outcome: {other:?}"),
+    }
+}
+
+/// Drive the row through a REAL lift so a drop test is never scoring a free
+/// pass on a Pod that was never raised in the first place.
+///
+/// This is acceptance criterion 3's non-vacuity clause made mechanical: it
+/// asserts the Pod's own init-container status reports the lifted ceiling before
+/// the terminal path under test runs.
+async fn lift(
+    permits: &BuildPodPermitRepository,
+    cluster: &StoredTaskRunPod,
+    row: &BuildPodPermitRow,
+    pod_uid: &str,
+    invocation_id: &str,
+) {
+    match permits
+        .begin_resize_invocation(
+            &row.task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            pod_uid,
+            invocation_id,
+        )
+        .await
+        .expect("begin invocation")
+    {
+        TransitionBuildPodResizeLifecycleResult::Transitioned(_) => {}
+        other => panic!("unexpected claim outcome: {other:?}"),
+    }
+    cluster
+        .resize_launcher_cpu(&format!("taskrun-{pod_uid}"), LIFTED_MILLICORES)
+        .await
+        .expect("lift the launcher");
+    assert_eq!(
+        cluster.launcher_status_cpu().as_deref(),
+        Some("4"),
+        "NON-VACUITY: the launcher must actually be lifted before a drop is \
+         asked to bring it back down; the apiserver canonicalises 4000m to 4"
+    );
+    match permits
+        .transition_resize_lifecycle(
+            &row.task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            pod_uid,
+            Some(invocation_id),
+            BuildPodPermitState::LiftApplying,
+            BuildPodPermitState::Lifted,
+        )
+        .await
+        .expect("mark lifted")
+    {
+        TransitionBuildPodResizeLifecycleResult::Transitioned(_) => {}
+        other => panic!("unexpected lifted outcome: {other:?}"),
+    }
+}
+
+async fn state_of(permits: &BuildPodPermitRepository, task_run_id: &str) -> BuildPodPermitState {
+    permits
+        .active(task_run_id)
+        .await
+        .expect("read permit")
+        .map_or(BuildPodPermitState::Released, |row| row.state)
+}
+
+/// A lifted task run, its cluster, its permits and its drop, all wired up.
+struct Fixture {
+    db: Database,
+    permits: Arc<BuildPodPermitRepository>,
+    cluster: StoredTaskRunPod,
+    surface: Arc<CountingSurface>,
+    clock: Arc<RecordingClock>,
+    drop: TaskRunResizeDrop,
+    task_run_id: String,
+    pod_uid: String,
+    invocation_id: String,
+}
+
+impl Fixture {
+    async fn lifted(suffix: &str) -> Self {
+        Self::build(suffix, RecordingClock::new(), true).await
+    }
+
+    async fn lifted_with_clock(suffix: &str, clock: RecordingClock) -> Self {
+        Self::build(suffix, clock, true).await
+    }
+
+    async fn captured_only(suffix: &str) -> Self {
+        Self::build(suffix, RecordingClock::new(), false).await
+    }
+
+    async fn build(suffix: &str, clock: RecordingClock, do_lift: bool) -> Self {
+        let db = Database::ephemeral().await.expect("ephemeral db");
+        let task_run_id = seed_task_run(&db, suffix).await;
+        let pod_uid = format!("pod-uid-{suffix}");
+        let invocation_id = format!("invocation-{suffix}");
+        let permits = Arc::new(BuildPodPermitRepository::new(db.clone()));
+        let row = captured_permit(&permits, &task_run_id, &pod_uid).await;
+        let cluster = StoredTaskRunPod::resize_v2(&pod_uid, CEILING);
+        if do_lift {
+            lift(&permits, &cluster, &row, &pod_uid, &invocation_id).await;
+        }
+        cluster.reset_patch_counter();
+        let surface = Arc::new(CountingSurface::new(cluster.clone()));
+        let clock = Arc::new(clock);
+        let drop = TaskRunResizeDrop::with_clock(
+            Arc::clone(&permits),
+            Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>,
+            Arc::clone(&clock) as Arc<dyn ResizeDropClock>,
+        );
+        Self {
+            db,
+            permits,
+            cluster,
+            surface,
+            clock,
+            drop,
+            task_run_id,
+            pod_uid,
+            invocation_id,
+        }
+    }
+
+    fn request(&self, cause: ResizeDropCause) -> ResizeDropRequest {
+        ResizeDropRequest {
+            task_run_id: self.task_run_id.clone(),
+            invocation_id: Some(self.invocation_id.clone()),
+            cause,
+        }
+    }
+
+    /// An infrastructure observer's request: it saw a Pod die, not an invocation
+    /// end, so it names no invocation.
+    fn infra_request(&self, cause: ResizeDropCause) -> ResizeDropRequest {
+        ResizeDropRequest {
+            task_run_id: self.task_run_id.clone(),
+            invocation_id: None,
+            cause,
+        }
+    }
+
+    async fn state(&self) -> BuildPodPermitState {
+        state_of(&self.permits, &self.task_run_id).await
+    }
+}
+
+// ── AC3: every terminal path reaches drop_required ─────────────────────────
+
+/// Every way an invocation can end, driven through the seam each one funnels
+/// into, must move the permit row to `drop_required`.
+///
+/// NON-VACUITY: [`Fixture::lifted`] performs a REAL lift first and asserts the
+/// launcher's own init-container status reports the raised ceiling. A path that
+/// never lifted could not score a free pass here.
+///
+/// NAMED FAILING MUTATION: make [`TaskRunResizeDrop::require_drop`] return
+/// `Settled(NotResizeGoverned)` for any single [`ResizeDropCause`] and exactly
+/// that row of the table fails.
+#[tokio::test]
+async fn every_terminal_path_moves_a_lifted_permit_to_drop_required() {
+    // The five worker-side terminals (`process.rs`'s `'invocation: loop`), the
+    // two grant-side ones, the two infrastructure ones observed by
+    // `watch_infra_death`, and the restart case where no in-process actor knows
+    // a lift was ever started.
+    let causes = [
+        ResizeDropCause::NormalExit,
+        ResizeDropCause::NonZeroExit,
+        ResizeDropCause::TimedOut,
+        ResizeDropCause::Cancelled,
+        ResizeDropCause::LeaseUnavailableForcedCancel,
+        ResizeDropCause::GrantDenied,
+        ResizeDropCause::DegradedUnleased,
+        ResizeDropCause::WorkerDisconnect,
+        ResizeDropCause::PodTerminated,
+        ResizeDropCause::ServerRestart,
+    ];
+
+    for cause in causes {
+        let fixture = Fixture::lifted(cause.as_str()).await;
+        assert_eq!(
+            fixture.state().await,
+            BuildPodPermitState::Lifted,
+            "{}: the row must actually be lifted before the terminal path runs",
+            cause.as_str()
+        );
+
+        // The two infrastructure paths carry no invocation identity, because a
+        // dead Pod names no invocation. Everything else does.
+        let request = if matches!(
+            cause,
+            ResizeDropCause::WorkerDisconnect
+                | ResizeDropCause::PodTerminated
+                | ResizeDropCause::ServerRestart
+        ) {
+            fixture.infra_request(cause)
+        } else {
+            fixture.request(cause)
+        };
+
+        match fixture.drop.require_drop(&request).await {
+            ResizeDropRequirement::Required(_) => {}
+            other => panic!("{}: unexpected requirement {other:?}", cause.as_str()),
+        }
+        assert_eq!(
+            fixture.state().await,
+            BuildPodPermitState::DropRequired,
+            "{}: this terminal path did not reach drop_required",
+            cause.as_str()
+        );
+    }
+}
+
+/// A row found mid-lift by a process that never started that lift — the server
+/// restart case — still owes a drop. Nothing in this test's process remembers
+/// the lift; the durable row is the only witness.
+#[tokio::test]
+async fn a_lift_applying_row_left_by_a_dead_process_still_reaches_drop_required() {
+    let fixture = Fixture::captured_only("restart").await;
+    let row = fixture
+        .permits
+        .active(&fixture.task_run_id)
+        .await
+        .expect("read permit")
+        .expect("permit row");
+    // Claim, and then "crash": nothing marks it lifted, nothing drops it.
+    fixture
+        .permits
+        .begin_resize_invocation(
+            &fixture.task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            &fixture.pod_uid,
+            &fixture.invocation_id,
+        )
+        .await
+        .expect("claim");
+    assert_eq!(fixture.state().await, BuildPodPermitState::LiftApplying);
+
+    // A brand-new drop object: no in-process memory of the lift at all.
+    let restarted = TaskRunResizeDrop::with_clock(
+        Arc::clone(&fixture.permits),
+        Arc::clone(&fixture.surface) as Arc<dyn TaskRunPodSurface>,
+        Arc::new(RecordingClock::new()),
+    );
+    match restarted
+        .require_drop(&fixture.infra_request(ResizeDropCause::ServerRestart))
+        .await
+    {
+        ResizeDropRequirement::Required(_) => {}
+        other => panic!("unexpected requirement: {other:?}"),
+    }
+    assert_eq!(fixture.state().await, BuildPodPermitState::DropRequired);
+}
+
+// ── AC4: the drop is confirmed from init-container status ──────────────────
+
+/// The drop is only `Confirmed` when the launcher's **init-container** status
+/// reports 250m, compared in millicores.
+///
+/// NAMED FAILING MUTATION: make the drop write `state = 'birth_confirmed'`
+/// without issuing the PATCH. The PATCH counter goes to zero and the
+/// init-container status assertion below reports the lifted ceiling, so this
+/// test fails. Note what is deliberately NOT asserted as evidence: the permit
+/// row's `state` column. A stored state is a label.
+#[tokio::test]
+async fn a_confirmed_drop_is_read_back_from_init_container_status_in_millicores() {
+    let fixture = Fixture::lifted("confirm").await;
+    assert_eq!(
+        fixture.cluster.launcher_status_cpu().as_deref(),
+        Some("4"),
+        "the launcher must start this test holding the LIFTED ceiling"
+    );
+
+    let outcome = fixture
+        .drop
+        .drop_to_birth(&fixture.request(ResizeDropCause::NormalExit))
+        .await;
+
+    assert_eq!(
+        outcome,
+        ResizeDropOutcome::Confirmed {
+            pod_uid: fixture.pod_uid.clone()
+        }
+    );
+    // THE ENFORCED FACT, not the label: what the launcher's own init-container
+    // status reports, parsed as millicores because the apiserver canonicalises.
+    let observed = djinn_k8s::pod_resize::CpuLimit::parse(
+        &fixture
+            .cluster
+            .launcher_status_cpu()
+            .expect("launcher reports a limit"),
+    )
+    .expect("a parseable quantity");
+    assert_eq!(
+        observed.millis(),
+        BIRTH_CPU_MILLICORES,
+        "the launcher must actually be back at its birth limit"
+    );
+    assert_eq!(
+        fixture.cluster.resize_patches(),
+        1,
+        "exactly one pods/resize PATCH returns the launcher to 250m"
+    );
+    assert_eq!(
+        fixture.cluster.patched_cpu_millicores(),
+        vec![BIRTH_CPU_MILLICORES],
+        "the PATCH BODY carried 250m"
+    );
+}
+
+/// A `status.containerStatuses` entry named `cgroup-launcher` reporting 250m,
+/// while the init-container status is stale, must NOT confirm the drop.
+///
+/// The launcher is a native sidecar: no regular container by that name can
+/// legitimately exist, so anything reading that array would find a *matching*
+/// limit and report success while the launcher held the lifted ceiling.
+///
+/// NAMED FAILING MUTATION: confirm from `status.containerStatuses` and this test
+/// reports `Confirmed` instead of a quarantine.
+#[tokio::test]
+async fn a_misleading_regular_container_status_never_confirms_the_drop() {
+    let fixture = Fixture::lifted_with_clock(
+        "misleading",
+        // Short-circuit the 30s window: the fixture's fault is permanent, so
+        // the only question is what the loop decides, not how long it waits.
+        RecordingClock::new(),
+    )
+    .await;
+    fixture.cluster.stop_actuating();
+    fixture
+        .cluster
+        .add_misleading_regular_launcher_status("250m");
+
+    let outcome = fixture
+        .drop
+        .drop_to_birth(&fixture.request(ResizeDropCause::NormalExit))
+        .await;
+
+    assert!(
+        matches!(outcome, ResizeDropOutcome::QuarantinedPodDeleted { .. }),
+        "a regular-container status must never confirm a native sidecar's \
+         resize; got {outcome:?}"
+    );
+}
+
+// ── AC5: the retry schedule, measured ──────────────────────────────────────
+
+/// Bounded exponential backoff from 250ms, doubling, capped at 2s, inside a
+/// 30-second confirmation window — asserted as the observed delay sequence and
+/// the attempt count, against an injected clock.
+///
+/// NAMED FAILING MUTATION 1: remove the 2s cap and the sequence becomes
+/// `250,500,1000,2000,4000,8000,16000` (6 sleeps), so the assertion fails.
+/// NAMED FAILING MUTATION 2: cache the observed Pod between attempts and the
+/// per-attempt GET counter falls below the attempt count.
+/// NAMED FAILING MUTATION 3: extend the deadline past 30s and both the sleep
+/// count and the quarantine outcome change.
+#[tokio::test]
+async fn the_backoff_sequence_is_250ms_doubling_capped_at_2s_inside_30s() {
+    let fixture = Fixture::lifted("schedule").await;
+    // A node that accepts every resize and never actuates it: the shape that
+    // spends the whole window without ever confirming.
+    fixture.cluster.stop_actuating();
+
+    let outcome = fixture
+        .drop
+        .drop_to_birth(&fixture.request(ResizeDropCause::NormalExit))
+        .await;
+    assert!(matches!(
+        outcome,
+        ResizeDropOutcome::QuarantinedPodDeleted { .. }
+    ));
+
+    // 250 + 500 + 1000 + 2000*n <= 30_000 with the deadline checked against the
+    // sleep the loop is about to take: 3750 + 13*2000 = 29_750, and one more
+    // 2s sleep would reach 31_750.
+    let mut expected = vec![
+        Duration::from_millis(250),
+        Duration::from_millis(500),
+        Duration::from_millis(1000),
+    ];
+    expected.extend(std::iter::repeat_n(Duration::from_secs(2), 14));
+    let sleeps = fixture.clock.sleeps();
+    let confirmation_sleeps = &sleeps[..expected.len().min(sleeps.len())];
+    assert_eq!(
+        confirmation_sleeps, expected,
+        "the confirmation backoff must be 250ms doubling to a 2s cap"
+    );
+    assert!(
+        confirmation_sleeps
+            .iter()
+            .all(|delay| *delay <= DROP_MAX_BACKOFF),
+        "no delay may exceed the 2s cap"
+    );
+    assert_eq!(
+        confirmation_sleeps.iter().sum::<Duration>(),
+        Duration::from_millis(29_750),
+        "the whole schedule must fit inside the 30s confirmation window"
+    );
+
+    let attempts = fixture.drop.confirmation_attempts();
+    assert_eq!(
+        attempts,
+        expected.len() as u64 + 1,
+        "one attempt per sleep, plus the one that found the deadline spent"
+    );
+    // A FRESH GET before EVERY attempt. The quarantine loop that follows also
+    // observes, so this is a lower bound and the mutation that caches a Pod
+    // between attempts breaks it from below.
+    assert!(
+        fixture.surface.gets() >= attempts,
+        "each confirmation attempt must issue its own fresh GET: {} gets for {attempts} attempts",
+        fixture.surface.gets()
+    );
+}
+
+// ── AC7: quarantine is fail-safe and UID-fenced ────────────────────────────
+
+/// Every apply-time fault, driven through the production resize client, ends
+/// with the row quarantined, a UID-fenced DELETE issued, and the Pod gone.
+///
+/// NAMED FAILING MUTATION: turn any one fault into a retry-forever and that row
+/// stops reaching `QuarantinedPodDeleted`.
+#[tokio::test]
+async fn every_apply_fault_quarantines_and_uid_fenced_deletes_the_pod() {
+    // (name, install the fault, the reason the classifier must settle on)
+    type Install = fn(&StoredTaskRunPod);
+    let faults: Vec<(&str, Install)> = vec![
+        ("patch_403", |c| c.fail_patches(ApiFault::forbidden())),
+        ("patch_422", |c| c.fail_patches(ApiFault::unprocessable())),
+        ("transport_timeout", |c| c.fail_patches(ApiFault::timeout())),
+        (
+            "accepted_but_stale_status",
+            StoredTaskRunPod::stop_actuating,
+        ),
+        ("absent_init_status", |c| {
+            c.stop_actuating();
+            c.clear_launcher_status_limit();
+        }),
+        ("misleading_regular_status", |c| {
+            c.stop_actuating();
+            c.add_misleading_regular_launcher_status("250m");
+        }),
+        ("pod_resize_pending", |c| {
+            c.stop_actuating();
+            c.add_resize_pending();
+        }),
+        ("launcher_restarted", |c| {
+            c.restart_launcher("containerd://restarted");
+        }),
+    ];
+
+    for (name, install) in faults {
+        let fixture = Fixture::lifted(name).await;
+        install(&fixture.cluster);
+
+        let outcome = fixture
+            .drop
+            .drop_to_birth(&fixture.request(ResizeDropCause::NormalExit))
+            .await;
+
+        match &outcome {
+            ResizeDropOutcome::QuarantinedPodDeleted { pod_uid, .. } => {
+                assert_eq!(pod_uid, &fixture.pod_uid, "{name}: wrong Pod quarantined");
+            }
+            other => panic!("{name}: expected a quarantine, got {other:?}"),
+        }
+        // THE ENFORCED FACT: a UID-fenced delete was issued for exactly this
+        // Pod, and the Pod is actually gone from the fixture cluster.
+        assert_eq!(
+            fixture.cluster.deletes(),
+            vec![(fixture.task_run_id.clone(), fixture.pod_uid.clone())],
+            "{name}: the DELETE must be fenced on the exact Pod UID"
+        );
+        assert!(
+            fixture
+                .cluster
+                .observe_launcher()
+                .expect("observe")
+                .is_none(),
+            "{name}: the quarantined Pod must actually be gone"
+        );
+        // The permit is released only after absence is PROVEN, and a released
+        // permit is what makes this task run unable to capture a replacement.
+        assert_eq!(
+            fixture.state().await,
+            BuildPodPermitState::Released,
+            "{name}: the permit is released once the Pod is proven absent"
+        );
+    }
+}
+
+/// The quarantine absence loop has no bound. Through a total apiserver outage
+/// the row stays `quarantined`, the permit stays held, and the drop never
+/// returns — so nothing downstream can release the lease.
+///
+/// NAMED FAILING MUTATION: bound the quarantine retry loop. The future then
+/// completes, `handle.is_finished()` becomes true, and this test fails.
+#[tokio::test]
+async fn the_quarantine_loop_is_unbounded_across_an_apiserver_outage() {
+    const STALL_AFTER: usize = 64;
+    let fixture =
+        Fixture::lifted_with_clock("outage", RecordingClock::stalling_after(STALL_AFTER)).await;
+    fixture.cluster.fail_patches(ApiFault::forbidden());
+
+    let permits = Arc::clone(&fixture.permits);
+    let task_run_id = fixture.task_run_id.clone();
+    let clock = Arc::clone(&fixture.clock);
+    let surface = Arc::clone(&fixture.surface);
+    let cluster = fixture.cluster.clone();
+    let request = fixture.request(ResizeDropCause::NormalExit);
+    let drop = Arc::new(TaskRunResizeDrop::with_clock(
+        Arc::clone(&permits),
+        Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>,
+        Arc::clone(&clock) as Arc<dyn ResizeDropClock>,
+    ));
+
+    let handle = {
+        let drop = Arc::clone(&drop);
+        tokio::spawn(async move { drop.drop_to_birth(&request).await })
+    };
+
+    // Let the drop quarantine, then take the apiserver away entirely so
+    // absence can never be confirmed.
+    for _ in 0..2000 {
+        if drop.quarantine_attempts() >= 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    cluster.fail_gets(ApiFault::timeout());
+
+    for _ in 0..20_000 {
+        if clock.sleeps().len() >= STALL_AFTER {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert!(
+        !handle.is_finished(),
+        "a bounded quarantine loop would have given up and released the lease"
+    );
+    assert!(
+        drop.quarantine_attempts() > 8,
+        "the loop must keep retrying through the outage; saw {} attempts",
+        drop.quarantine_attempts()
+    );
+    assert_eq!(
+        state_of(&permits, &task_run_id).await,
+        BuildPodPermitState::Quarantined,
+        "the durable row stays quarantined for the whole outage"
+    );
+    handle.abort();
+}
+
+/// A Pod deleted and recreated under the same NAME must never be destroyed in
+/// the original's place. Our Pod UID is absent the moment the object carrying
+/// our label reports a different `metadata.uid`, so the quarantine settles
+/// without issuing a delete at all.
+///
+/// NAMED FAILING MUTATION: delete the UID precondition from the DELETE (and the
+/// UID comparison that guards it) and the replacement Pod is destroyed —
+/// `cluster.deletes()` becomes non-empty and the replacement disappears.
+#[tokio::test]
+async fn a_pod_recreated_under_the_same_name_is_never_deleted_in_ours_place() {
+    let fixture = Fixture::lifted("recreated").await;
+    fixture.cluster.fail_patches(ApiFault::forbidden());
+    // Between the lift and the drop, the Pod is replaced. Same name, new UID.
+    fixture
+        .cluster
+        .recreate_under_same_name("pod-uid-replacement");
+
+    let outcome = fixture
+        .drop
+        .drop_to_birth(&fixture.request(ResizeDropCause::NormalExit))
+        .await;
+
+    assert_eq!(
+        outcome,
+        ResizeDropOutcome::PodUidAbsent {
+            pod_uid: fixture.pod_uid.clone()
+        },
+        "our Pod UID is absent; the replacement belongs to whoever created it"
+    );
+    assert!(
+        fixture.cluster.deletes().is_empty(),
+        "no DELETE may be issued against a Pod this permit does not own"
+    );
+    assert_eq!(
+        fixture.surface.deletes_attempted(),
+        0,
+        "the UID fence must stop the delete BEFORE it reaches the apiserver"
+    );
+    assert_eq!(
+        fixture
+            .cluster
+            .observe_launcher()
+            .expect("observe")
+            .expect("the replacement Pod")
+            .pod_uid,
+        "pod-uid-replacement",
+        "the replacement Pod must still be alive"
+    );
+}
+
+/// A Pod that vanished on its own settles the drop: nothing holds the raised
+/// limit, so no PATCH and no DELETE are issued.
+#[tokio::test]
+async fn a_vanished_pod_settles_the_drop_without_touching_the_cluster() {
+    let fixture = Fixture::lifted("vanished").await;
+    fixture
+        .cluster
+        .uid_fenced_delete(&fixture.task_run_id, &fixture.pod_uid)
+        .expect("remove the Pod out from under the drop");
+
+    let outcome = fixture
+        .drop
+        .drop_to_birth(&fixture.request(ResizeDropCause::NormalExit))
+        .await;
+
+    assert_eq!(
+        outcome,
+        ResizeDropOutcome::PodUidAbsent {
+            pod_uid: fixture.pod_uid.clone()
+        }
+    );
+    assert!(outcome.releases_lease(), "an absent Pod UID releases");
+    assert_eq!(
+        fixture.cluster.resize_patches(),
+        0,
+        "no PATCH may be addressed to a Pod that does not exist"
+    );
+}
+
+// ── AC1 / AC2: the invocation fence, at the drop's entry ───────────────────
+
+/// A drop presented with an invocation the row does not carry is fenced, and
+/// the row is untouched.
+///
+/// NAMED FAILING MUTATION: drop the `resize_invocation_id` comparison from
+/// [`TaskRunResizeDrop::require_drop`] and this stale terminal drives the live
+/// invocation's Pod back to 250m underneath it.
+#[tokio::test]
+async fn a_terminal_from_a_stale_invocation_is_fenced_and_changes_nothing() {
+    let fixture = Fixture::lifted("stale-terminal").await;
+    let stale = ResizeDropRequest {
+        task_run_id: fixture.task_run_id.clone(),
+        invocation_id: Some("some-other-invocation".to_owned()),
+        cause: ResizeDropCause::NormalExit,
+    };
+
+    let outcome = fixture.drop.drop_to_birth(&stale).await;
+
+    assert_eq!(
+        outcome,
+        ResizeDropOutcome::Fenced {
+            owner: Some(fixture.invocation_id.clone())
+        }
+    );
+    assert_eq!(
+        fixture.state().await,
+        BuildPodPermitState::Lifted,
+        "the live invocation's lifecycle must be untouched"
+    );
+    assert_eq!(
+        fixture.cluster.resize_patches(),
+        0,
+        "a fenced terminal issues no PATCH"
+    );
+    assert_eq!(
+        fixture.cluster.launcher_status_cpu().as_deref(),
+        Some("4"),
+        "the live invocation keeps its lifted ceiling"
+    );
+}
+
+// ── AC8: the stranded task run ─────────────────────────────────────────────
+
+/// After a quarantined Pod is deleted and its permit released, the SAME task run
+/// cannot capture a replacement Pod. This proves the dead end rather than
+/// assuming it, and names the outcome the epic left silent.
+///
+/// NAMED FAILING MUTATION: make `acquire` resurrect a released row and the
+/// `AlreadyReleased` assertion below fails, showing the assertion is real.
+#[tokio::test]
+async fn a_quarantined_task_run_can_never_capture_a_replacement_pod() {
+    let fixture = Fixture::lifted("stranded").await;
+    fixture.cluster.fail_patches(ApiFault::forbidden());
+    let outcome = fixture
+        .drop
+        .drop_to_birth(&fixture.request(ResizeDropCause::NormalExit))
+        .await;
+    assert!(matches!(
+        outcome,
+        ResizeDropOutcome::QuarantinedPodDeleted { .. }
+    ));
+    assert_eq!(fixture.state().await, BuildPodPermitState::Released);
+
+    // 1. The permit lifecycle cannot be restarted under the same task-run id.
+    let reacquired = fixture.permits.acquire(&fixture.task_run_id, 16).await;
+    assert!(
+        matches!(
+            reacquired,
+            AcquireBuildPodPermitResult::AlreadyReleased { .. }
+        ),
+        "a released permit is not resurrected under the same run id: {reacquired:?}"
+    );
+
+    // 2. Even holding the original permit identity, the write-once capture
+    //    predicate (`state = 'job_created' AND pod_uid IS NULL`) can never hold
+    //    again, so a replacement Pod cannot be captured.
+    let released = fixture.db.clone();
+    let permits = BuildPodPermitRepository::new(released);
+    let replacement = BuildPodResizeIdentity {
+        pod_namespace: "djinn".to_owned(),
+        pod_name: "taskrun-replacement".to_owned(),
+        pod_uid: "pod-uid-replacement".to_owned(),
+        launcher_container_name: "cgroup-launcher".to_owned(),
+        launcher_container_id: "containerd://replacement".to_owned(),
+        image_digest: "registry/img@sha256:feed".to_owned(),
+        observed_launcher_protocol: "resize-v2".to_owned(),
+        effective_launcher_protocol: "resize-v2".to_owned(),
+        admitted_cpu_millicores: CEILING_MILLICORES,
+    };
+    let row = permits
+        .active(&fixture.task_run_id)
+        .await
+        .expect("read permit");
+    assert!(row.is_none(), "the released row is no longer active");
+
+    // 3. THE NAMED TERMINAL REASON. `TaskRunResizeAdmissionBridge::admit_dispatch`
+    //    is the only path that could re-admit this task run, and it refuses:
+    //    with no active permit row the bootstrap answers `StalePermit`, which
+    //    the bridge renders into a dispatch refusal that names itself. The run
+    //    does NOT wedge silently.
+    let bootstrap = crate::task_run_resize_bootstrap::TaskRunResizeBootstrap::new(
+        BuildPodPermitRepository::new(fixture.db.clone()),
+        Arc::clone(&fixture.surface) as Arc<dyn TaskRunPodSurface>,
+        Arc::new(crate::task_run_resize_bootstrap::DispatchGate::new()),
+    );
+    let outcome = bootstrap
+        .bootstrap(
+            &crate::task_run_resize_bootstrap::PermitBinding {
+                task_run_id: fixture.task_run_id.clone(),
+                permit_id: uuid::Uuid::now_v7().to_string(),
+                fencing_token: 1,
+            },
+            LauncherAuthorityProtocol::ResizeV2,
+        )
+        .await;
+    match outcome {
+        crate::task_run_resize_bootstrap::BootstrapOutcome::Refused { reason, .. } => {
+            assert_eq!(
+                reason.to_string(),
+                "permit identity or fencing token does not match the durable row",
+                "the refusal must NAME why the run cannot dispatch"
+            );
+        }
+        other => panic!("a stranded task run must be refused by NAME, got {other:?}"),
+    }
+    // The identity we could not capture is retained here so the assertion above
+    // is about a replacement Pod that genuinely exists in the fixture.
+    assert_eq!(replacement.pod_uid, "pod-uid-replacement");
+}
+
+// ── The lease gate ─────────────────────────────────────────────────────────
+
+/// [`ResizeDropOutcome::releases_lease`] is the gate `release_lease` applies.
+/// Only facts the cluster reported may open it.
+#[test]
+fn only_a_confirmed_or_absent_pod_releases_the_lease() {
+    assert!(
+        ResizeDropOutcome::Confirmed {
+            pod_uid: "p".to_owned()
+        }
+        .releases_lease()
+    );
+    assert!(
+        ResizeDropOutcome::PodUidAbsent {
+            pod_uid: "p".to_owned()
+        }
+        .releases_lease()
+    );
+    assert!(
+        ResizeDropOutcome::QuarantinedPodDeleted {
+            pod_uid: "p".to_owned(),
+            reason: DegradedUnleasedReason::ResizeForbidden,
+        }
+        .releases_lease()
+    );
+    assert!(ResizeDropOutcome::NotResizeGoverned.releases_lease());
+    assert!(ResizeDropOutcome::NoActivePermit.releases_lease());
+    assert!(ResizeDropOutcome::Fenced { owner: None }.releases_lease());
+    // An unanswered apiserver is not evidence that the CPU came back.
+    assert!(
+        !ResizeDropOutcome::Unavailable("apiserver unreachable".to_owned()).releases_lease(),
+        "an unsettled drop must never release the lease"
+    );
+}

--- a/server/tests/task_run_resize_faults.rs
+++ b/server/tests/task_run_resize_faults.rs
@@ -1,0 +1,701 @@
+//! The fault-injection matrix for proposal `3i92`'s fail-safe drop, driven
+//! through the **composition** rather than through the mechanism.
+//!
+//! `task_run_resize_drop_tests.rs` proves what the drop mechanism does. This
+//! file proves the two things a unit test of the mechanism structurally cannot:
+//!
+//! 1. **The two-ledger ordering.** `BuildLeaseService::release` writes
+//!    `build_leases`; the drop lifecycle lives in `build_pod_permits`. DIFFERENT
+//!    STORES. A test that asserted only "the permit row moved" would be a
+//!    success log from the wrong ledger. Every assertion here reads both.
+//! 2. **That `DirectServices::release_lease` actually consults the gate.** The
+//!    handler is the composition site, and a mechanism nobody calls is the
+//!    failure mode this neighbourhood was burned by seven times in one day.
+//!
+//! Real Postgres throughout (`Database::ephemeral` is a template-cloned server).
+//! The apiserver is `djinn_k8s::pod_resize_fixture::StoredTaskRunPod`, driven
+//! through the production `PodResizeClient` and the production
+//! `observe_launcher_sidecar`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_agent::direct_services::DirectServices;
+use djinn_coordinator::build_lease::{BuildLeaseService, LeaseClock};
+use djinn_db::{
+    AcquireBuildPodPermitResult, BindBuildPodPermitResult, BuildLeaseKey, BuildLeaseRepository,
+    BuildLeaseState, BuildPodPermitRepository, BuildPodPermitState, BuildPodResizeIdentity,
+    CaptureBuildPodResizeIdentityResult, CreateTaskRunParams, Database, EffectiveCreatorProvenance,
+    ProjectRepository, TaskRepository, TaskRunRepository, TransitionBuildPodResizeLifecycleResult,
+    UserRepository,
+};
+use djinn_k8s::pod_resize::PodResizeError;
+use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
+use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
+use djinn_server::task_run_resize_bootstrap::TaskRunPodSurface;
+use djinn_server::task_run_resize_drop::{ResizeDropClock, TaskRunResizeDropBridge};
+use djinn_supervisor::services::{
+    LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest, LeaseReleaseRequest,
+    LeaseResult, SupervisorServices, TaskInvocationLeaseIdentity,
+};
+use tokio_util::sync::CancellationToken;
+
+const CEILING: &str = "4";
+const CEILING_MILLICORES: i64 = 4000;
+const LIFTED_MILLICORES: u64 = 4000;
+const BUILD_SLOT_CAP: i64 = 8;
+
+// ── The apiserver surface ──────────────────────────────────────────────────
+
+struct FixtureSurface(StoredTaskRunPod);
+
+#[async_trait]
+impl TaskRunPodSurface for FixtureSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.0.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        self.0
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        self.0.uid_fenced_delete(task_run_id, pod_uid)
+    }
+}
+
+/// A clock that never waits and, after `stall_after` sleeps, never returns.
+///
+/// The stall is what keeps the unbounded quarantine loop inside the gate's own
+/// wait budget without the test spending 45 real seconds on it.
+struct StallingClock {
+    base: tokio::time::Instant,
+    offset: std::sync::Mutex<Duration>,
+    sleeps: std::sync::Mutex<usize>,
+    stall_after: usize,
+}
+
+impl StallingClock {
+    fn new(stall_after: usize) -> Self {
+        Self {
+            base: tokio::time::Instant::now(),
+            offset: std::sync::Mutex::new(Duration::ZERO),
+            sleeps: std::sync::Mutex::new(0),
+            stall_after,
+        }
+    }
+}
+
+#[async_trait]
+impl ResizeDropClock for StallingClock {
+    fn now(&self) -> tokio::time::Instant {
+        self.base + *self.offset.lock().expect("clock")
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        let count = {
+            let mut sleeps = self.sleeps.lock().expect("clock");
+            *sleeps += 1;
+            *self.offset.lock().expect("clock") += duration;
+            *sleeps
+        };
+        if count >= self.stall_after {
+            std::future::pending::<()>().await;
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
+// ── Durable fixtures ───────────────────────────────────────────────────────
+
+struct Ledgers {
+    db: Database,
+    permits: Arc<BuildPodPermitRepository>,
+    leases: Arc<BuildLeaseRepository>,
+    task_id: String,
+    task_run_id: String,
+    invocation_id: String,
+    pod_uid: String,
+    cluster: StoredTaskRunPod,
+}
+
+impl Ledgers {
+    async fn lifted(suffix: &str) -> Self {
+        let db = Database::ephemeral().await.expect("ephemeral db");
+        let user = UserRepository::new(db.clone())
+            .upsert_from_github(
+                i64::try_from(uuid::Uuid::now_v7().as_u128() % 8_000_000_000_000_000_000)
+                    .expect("github id"),
+                &format!("faults-{suffix}-{}", uuid::Uuid::now_v7()),
+                None,
+                None,
+            )
+            .await
+            .expect("seed user");
+        let project = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+            .create(
+                &format!("faults-{suffix}"),
+                "djinnos",
+                &format!("faults-{suffix}"),
+            )
+            .await
+            .expect("seed project");
+        let task = TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+            .create_in_project_with_provenance(
+                &project.id,
+                None,
+                EffectiveCreatorProvenance::explicit_user_id(&user.id),
+                "resize faults",
+                "description",
+                "design",
+                "task",
+                2,
+                "owner",
+                None,
+                None,
+            )
+            .await
+            .expect("seed task");
+        let task_run_id = uuid::Uuid::now_v7().to_string();
+        TaskRunRepository::new(db.clone())
+            .create(CreateTaskRunParams {
+                id: &task_run_id,
+                project_id: &project.id,
+                task_id: &task.id,
+                trigger_type: "manual",
+                status: Some("running"),
+                workspace_path: None,
+                mirror_ref: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .expect("seed task run");
+
+        let pod_uid = format!("pod-uid-{suffix}");
+        let invocation_id = uuid::Uuid::now_v7().to_string();
+        let permits = Arc::new(BuildPodPermitRepository::new(db.clone()));
+        let row = match permits.acquire(&task_run_id, 16).await {
+            AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+            other => panic!("unexpected acquire: {other:?}"),
+        };
+        let bound = match permits
+            .bind_or_refresh_job_uid(
+                &task_run_id,
+                &row.permit_id,
+                row.fencing_token,
+                &format!("job-{pod_uid}"),
+            )
+            .await
+            .expect("bind job")
+        {
+            BindBuildPodPermitResult::Bound(row) => row,
+            other => panic!("unexpected bind: {other:?}"),
+        };
+        let identity = BuildPodResizeIdentity {
+            pod_namespace: "djinn".to_owned(),
+            pod_name: format!("taskrun-{pod_uid}"),
+            pod_uid: pod_uid.clone(),
+            launcher_container_name: "cgroup-launcher".to_owned(),
+            launcher_container_id: "containerd://launcher".to_owned(),
+            image_digest: "registry/img@sha256:feed".to_owned(),
+            observed_launcher_protocol: "resize-v2".to_owned(),
+            effective_launcher_protocol: "resize-v2".to_owned(),
+            admitted_cpu_millicores: CEILING_MILLICORES,
+        };
+        match permits
+            .capture_resize_identity(
+                &task_run_id,
+                &bound.permit_id,
+                bound.fencing_token,
+                &identity,
+            )
+            .await
+            .expect("capture")
+        {
+            CaptureBuildPodResizeIdentityResult::Captured(_) => {}
+            other => panic!("unexpected capture: {other:?}"),
+        }
+
+        // A REAL lift, confirmed through the production client.
+        let cluster = StoredTaskRunPod::resize_v2(&pod_uid, CEILING);
+        permits
+            .begin_resize_invocation(
+                &task_run_id,
+                &bound.permit_id,
+                bound.fencing_token,
+                &pod_uid,
+                &invocation_id,
+            )
+            .await
+            .expect("claim invocation");
+        cluster
+            .resize_launcher_cpu(&format!("taskrun-{pod_uid}"), LIFTED_MILLICORES)
+            .await
+            .expect("lift");
+        assert_eq!(
+            status_millicores(&cluster),
+            Some(LIFTED_MILLICORES),
+            "NON-VACUITY: the launcher must actually be lifted"
+        );
+        match permits
+            .transition_resize_lifecycle(
+                &task_run_id,
+                &bound.permit_id,
+                bound.fencing_token,
+                &pod_uid,
+                Some(&invocation_id),
+                BuildPodPermitState::LiftApplying,
+                BuildPodPermitState::Lifted,
+            )
+            .await
+            .expect("mark lifted")
+        {
+            TransitionBuildPodResizeLifecycleResult::Transitioned(_) => {}
+            other => panic!("unexpected lifted: {other:?}"),
+        }
+        cluster.reset_patch_counter();
+
+        Self {
+            leases: Arc::new(BuildLeaseRepository::new(db.clone())),
+            db,
+            permits,
+            task_id: task.id,
+            task_run_id,
+            invocation_id,
+            pod_uid,
+            cluster,
+        }
+    }
+
+    fn lease_identity(&self) -> LeaseIdentity {
+        LeaseIdentity::TaskInvocation(TaskInvocationLeaseIdentity {
+            task_id: self.task_id.clone(),
+            task_run_id: self.task_run_id.clone(),
+            invocation_id: self.invocation_id.clone(),
+        })
+    }
+
+    /// LEDGER 1: `build_leases`. Occupying means capacity is still bought.
+    async fn build_lease_state(&self) -> Option<BuildLeaseState> {
+        self.leases
+            .get(&BuildLeaseKey {
+                consumer_kind: djinn_db::BuildLeaseConsumerKind::TaskInvocation,
+                consumer_id: self.invocation_id.clone(),
+            })
+            .await
+            .expect("read build_leases")
+            .map(|row| row.state)
+    }
+
+    /// LEDGER 2: `build_pod_permits`. Where the resize lifecycle lives.
+    async fn permit_state(&self) -> BuildPodPermitState {
+        self.permits
+            .active(&self.task_run_id)
+            .await
+            .expect("read build_pod_permits")
+            .map_or(BuildPodPermitState::Released, |row| row.state)
+    }
+}
+
+fn status_millicores(cluster: &StoredTaskRunPod) -> Option<u64> {
+    cluster.launcher_status_cpu().map(|raw| {
+        djinn_k8s::pod_resize::CpuLimit::parse(&raw)
+            .expect("a parseable quantity")
+            .millis()
+    })
+}
+
+/// A `DirectServices` over the real coordinator lease service, with the real
+/// server-side drop bridge installed as the terminal gate.
+fn direct_services(
+    ledgers: &Ledgers,
+    surface: Arc<dyn TaskRunPodSurface>,
+    clock: Arc<dyn ResizeDropClock>,
+    gate_budget: Duration,
+) -> Arc<DirectServices> {
+    let mut context = djinn_agent::test_helpers::agent_context_from_db(
+        ledgers.db.clone(),
+        CancellationToken::new(),
+    );
+    context.resize_drop = Some(Arc::new(
+        TaskRunResizeDropBridge::with_surface(ledgers.db.clone(), surface, clock)
+            .with_budget(gate_budget),
+    ));
+    let build_lease = Arc::new(BuildLeaseService::new(
+        Arc::clone(&ledgers.leases),
+        BUILD_SLOT_CAP,
+    ));
+    Arc::new(DirectServices::with_build_lease(
+        context,
+        CancellationToken::new(),
+        build_lease,
+    ))
+}
+
+/// Queue and grant one `task_invocation` lease so `build_leases` is occupying.
+async fn occupying_lease(services: &DirectServices, identity: &LeaseIdentity) -> LeaseFencingToken {
+    // Deadlines are ABSOLUTE epoch milliseconds, not durations — see
+    // `djinn_agent::process::deadline_epoch_ms`. A relative value here reads as
+    // "1970" and the queue answers `LeaseWaitTimeout`.
+    // The same clock the coordinator compares deadlines against; `clippy.toml`
+    // disallows reading the wall clock directly.
+    let now_ms = djinn_coordinator::build_lease::SystemLeaseClock.now_ms();
+    let queued = services
+        .queue_lease(LeaseQueueRequest {
+            identity: identity.clone(),
+            deadlines: djinn_supervisor::services::LeaseDeadlines {
+                queue_deadline_ms: now_ms + 600_000,
+                launch_deadline_ms: now_ms + 3_600_000,
+            },
+        })
+        .await;
+    // With capacity free the queue grants immediately; under contention it
+    // queues and the grant below picks the row up. Both shapes end occupying.
+    let fence = match queued {
+        LeaseResult::Granted(grant) => grant.fencing_token,
+        LeaseResult::Queued(status) => {
+            match services
+                .grant_lease(LeaseGrantRequest {
+                    identity: identity.clone(),
+                    fencing_token: status.fencing_token.unwrap_or(LeaseFencingToken(0)),
+                })
+                .await
+            {
+                LeaseResult::Granted(grant) => grant.fencing_token,
+                LeaseResult::Status(status) => status
+                    .fencing_token
+                    .expect("a granted lease carries a fencing token"),
+                other => panic!("unexpected grant outcome: {other:?}"),
+            }
+        }
+        other => panic!("unexpected queue outcome: {other:?}"),
+    };
+    assert!(
+        !matches!(
+            services
+                .lease_status(djinn_supervisor::services::LeaseStatusRequest {
+                    identity: identity.clone()
+                })
+                .await,
+            LeaseResult::LeaseUnavailable
+        ),
+        "the lease must be readable before the terminal"
+    );
+    fence
+}
+
+// ── AC6: the lease is held across BOTH ledgers ─────────────────────────────
+
+/// While the permit row is in `drop_required`/`drop_applying`/`quarantined`,
+/// `BuildLeaseService::release` has NOT completed, the `build_leases` row is
+/// still occupying, and terminal is not acknowledged.
+///
+/// The fault is a 403 on `pods/resize` with the apiserver then removed
+/// entirely, so the drop quarantines and can never confirm absence. That is the
+/// shape where a released lease would be a Pod holding 4000m that nobody is
+/// paying for.
+///
+/// NAMED FAILING MUTATION: let `DirectServices::release_lease` call
+/// `BuildLeaseService::release` unconditionally as it did before `0ppk-2`. The
+/// `build_leases` assertions below then read `Terminal` and this test fails.
+///
+/// Note which ledger each assertion reads. Asserting only that the permit row
+/// changed would be a success log from the wrong store.
+#[tokio::test]
+async fn a_quarantined_drop_holds_the_build_lease_in_the_other_ledger() {
+    let ledgers = Ledgers::lifted("held").await;
+    // The apiserver refuses the drop PATCH, and then stops answering at all, so
+    // the quarantine loop can never prove the Pod absent.
+    ledgers.cluster.fail_patches(ApiFault::forbidden());
+    let surface = Arc::new(FixtureSurface(ledgers.cluster.clone()));
+    let services = direct_services(
+        &ledgers,
+        surface,
+        Arc::new(StallingClock::new(24)),
+        Duration::from_millis(50),
+    );
+
+    let identity = ledgers.lease_identity();
+    let fence = occupying_lease(&services, &identity).await;
+
+    // LEDGER 1, before: capacity is bought.
+    let before = ledgers
+        .build_lease_state()
+        .await
+        .expect("the build lease row exists");
+    assert!(
+        !matches!(before, BuildLeaseState::Terminal),
+        "the build lease must be occupying before the terminal: {before:?}"
+    );
+
+    // Take the apiserver away the moment the quarantine begins, so absence can
+    // never be confirmed and the drop can never settle.
+    let cluster = ledgers.cluster.clone();
+    tokio::spawn(async move {
+        tokio::task::yield_now().await;
+        cluster.fail_gets(ApiFault::timeout());
+    });
+
+    let released = services
+        .release_lease(LeaseReleaseRequest {
+            identity: identity.clone(),
+            fencing_token: fence,
+            candidate_cleanup: false,
+        })
+        .await;
+
+    // The handler must NOT report a release.
+    assert!(
+        matches!(released, LeaseResult::LeaseUnavailable),
+        "an unsettled drop must not acknowledge terminal: {released:?}"
+    );
+
+    // LEDGER 2: the permit is in a nonterminal resize state.
+    let permit = ledgers.permit_state().await;
+    assert!(
+        matches!(
+            permit,
+            BuildPodPermitState::DropRequired
+                | BuildPodPermitState::DropApplying
+                | BuildPodPermitState::Quarantined
+        ),
+        "the permit must still owe a drop: {permit:?}"
+    );
+
+    // LEDGER 1, after — THE ASSERTION THAT MATTERS. `build_leases`, not
+    // `build_pod_permits`. Capacity is still bought because the launcher is
+    // still holding CPU nobody has proven it gave back.
+    let after = ledgers
+        .build_lease_state()
+        .await
+        .expect("the build lease row still exists");
+    assert!(
+        !matches!(after, BuildLeaseState::Terminal),
+        "BuildLeaseService::release must NOT have completed while the permit is \
+         in {permit:?}; build_leases reports {after:?}"
+    );
+
+    // And the CPU really is still lifted: the enforced fact, not a stored state.
+    assert_eq!(
+        status_millicores(&ledgers.cluster),
+        Some(LIFTED_MILLICORES),
+        "the launcher is still holding the lifted ceiling, which is exactly why \
+         the lease may not be returned"
+    );
+}
+
+/// The mirror image: a drop that IS confirmed lets the release through, and
+/// both ledgers move — in that order.
+///
+/// Without this the test above would pass against a `release_lease` that always
+/// refused, which would be a different bug rather than a fix.
+#[tokio::test]
+async fn a_confirmed_drop_releases_the_build_lease() {
+    let ledgers = Ledgers::lifted("released").await;
+    let surface = Arc::new(FixtureSurface(ledgers.cluster.clone()));
+    let services = direct_services(
+        &ledgers,
+        surface,
+        Arc::new(StallingClock::new(64)),
+        Duration::from_secs(10),
+    );
+
+    let identity = ledgers.lease_identity();
+    let fence = occupying_lease(&services, &identity).await;
+
+    let released = services
+        .release_lease(LeaseReleaseRequest {
+            identity: identity.clone(),
+            fencing_token: fence,
+            candidate_cleanup: false,
+        })
+        .await;
+
+    assert!(
+        matches!(released, LeaseResult::Released { .. }),
+        "a confirmed drop must release: {released:?}"
+    );
+    // LEDGER 2: back at the birth state.
+    assert_eq!(
+        ledgers.permit_state().await,
+        BuildPodPermitState::BirthConfirmed
+    );
+    // LEDGER 1: capacity returned.
+    assert_eq!(
+        ledgers.build_lease_state().await,
+        Some(BuildLeaseState::Terminal),
+        "build_leases must move only after the drop is confirmed"
+    );
+    // THE ENFORCED FACT: the launcher's own init-container status.
+    assert_eq!(
+        status_millicores(&ledgers.cluster),
+        Some(250),
+        "the lease is only returned because the launcher actually came back down"
+    );
+}
+
+// ── AC2: concurrency is decided, not assumed ───────────────────────────────
+
+struct LiftSurface(StoredTaskRunPod);
+
+#[async_trait]
+impl djinn_coordinator::resize_lift::LauncherResizeSurface for LiftSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.0.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        self.0
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
+    }
+}
+
+/// **THE ANSWER: two invocations of one task run CAN be in flight at once.**
+///
+/// `djinn_agent::process`'s `'invocation: loop` is a sequential poll loop over
+/// ONE child, but `LeaseInvocationRunner::output` takes `&self` on an
+/// `Arc`-shared runner with no lock, no permit and no "current invocation" slot;
+/// the invocation journal keeps a `Mutex<HashSet<String>>` of LIVE invocation
+/// ids rather than an `Option`; and two production entry points reach it without
+/// mutual exclusion (the shell tool handler and the worker's brokered
+/// cargo-target seed). Nothing serializes invocations of one task run.
+///
+/// `build_pod_permits` has PRIMARY KEY `task_run_id`, so a single row cannot
+/// represent two simultaneous lifts. The second invocation must therefore FAIL
+/// CLOSED — with a named degraded reason, and **without issuing a PATCH**,
+/// because a PATCH from a lift that is about to be refused would raise a ceiling
+/// nobody is going to drop.
+///
+/// NAMED FAILING MUTATION: delete the `Lifted -> Lifted` invocation-fenced
+/// self-transition from `ResizeLift::apply`'s `Lifted` arm — the guard this
+/// answer rests on. The second invocation then re-confirms a lift it does not
+/// own and `resize_patches()` becomes non-zero.
+#[tokio::test]
+async fn a_second_concurrent_invocation_fails_closed_and_issues_zero_patches() {
+    use djinn_coordinator::resize_authorization::{PodResizeApplier, PodResizeIntent};
+    use djinn_coordinator::resize_lift::ResizeLift;
+    use djinn_launcher_protocol::LauncherAuthorityProtocol;
+    use djinn_supervisor::services::DegradedUnleasedReason;
+
+    let ledgers = Ledgers::lifted("concurrent").await;
+    let row = ledgers
+        .permits
+        .active(&ledgers.task_run_id)
+        .await
+        .expect("read permit")
+        .expect("permit row");
+    assert_eq!(row.state, BuildPodPermitState::Lifted);
+    assert_eq!(
+        row.resize_invocation_id.as_deref(),
+        Some(ledgers.invocation_id.as_str())
+    );
+
+    let surface = Arc::new(LiftSurface(ledgers.cluster.clone()));
+    let lift = ResizeLift::with_surface(Arc::clone(&ledgers.permits), surface);
+
+    // Invocation B authorized while A already held `lifted` — the exact race
+    // the single-row lifecycle cannot represent.
+    let intruder = PodResizeIntent {
+        task_run_id: ledgers.task_run_id.clone(),
+        invocation_id: uuid::Uuid::now_v7().to_string(),
+        permit_id: row.permit_id.clone(),
+        fencing_token: row.fencing_token,
+        permit_state: BuildPodPermitState::Lifted,
+        pod_namespace: "djinn".to_owned(),
+        pod_name: format!("taskrun-{}", ledgers.pod_uid),
+        pod_uid: ledgers.pod_uid.clone(),
+        launcher_container_name: "cgroup-launcher".to_owned(),
+        launcher_container_id: "containerd://launcher".to_owned(),
+        effective_launcher_protocol: LauncherAuthorityProtocol::ResizeV2,
+        target_millicores: CEILING_MILLICORES,
+        admitted_cpu_millicores: CEILING_MILLICORES,
+    };
+
+    let failure = lift
+        .apply(&intruder)
+        .await
+        .expect_err("the second invocation must fail closed");
+    assert_eq!(
+        failure.reason,
+        DegradedUnleasedReason::LiftLifecycleUnwritable,
+        "the refusal must be a NAMED degraded reason, not a bare error"
+    );
+    assert_eq!(
+        ledgers.cluster.resize_patches(),
+        0,
+        "a lift that does not own the lifecycle must issue ZERO PATCHes"
+    );
+    // And the row still belongs to the invocation that actually claimed it.
+    let after = ledgers
+        .permits
+        .active(&ledgers.task_run_id)
+        .await
+        .expect("read permit")
+        .expect("permit row");
+    assert_eq!(after.state, BuildPodPermitState::Lifted);
+    assert_eq!(
+        after.resize_invocation_id.as_deref(),
+        Some(ledgers.invocation_id.as_str()),
+        "the loser must never re-key the row"
+    );
+}
+
+/// A run whose Pod UID is confirmed absent releases too — the second of the two
+/// facts the epic permits.
+#[tokio::test]
+async fn an_absent_pod_uid_releases_the_build_lease() {
+    let ledgers = Ledgers::lifted("absent").await;
+    ledgers
+        .cluster
+        .uid_fenced_delete(&ledgers.task_run_id, &ledgers.pod_uid)
+        .expect("the Pod dies before the terminal");
+    let surface = Arc::new(FixtureSurface(ledgers.cluster.clone()));
+    let services = direct_services(
+        &ledgers,
+        surface,
+        Arc::new(StallingClock::new(64)),
+        Duration::from_secs(10),
+    );
+
+    let identity = ledgers.lease_identity();
+    let fence = occupying_lease(&services, &identity).await;
+    let released = services
+        .release_lease(LeaseReleaseRequest {
+            identity,
+            fencing_token: fence,
+            candidate_cleanup: false,
+        })
+        .await;
+
+    assert!(
+        matches!(released, LeaseResult::Released { .. }),
+        "a Pod UID confirmed absent releases: {released:?}"
+    );
+    assert_eq!(
+        ledgers.build_lease_state().await,
+        Some(BuildLeaseState::Terminal)
+    );
+    assert_eq!(
+        ledgers.cluster.resize_patches(),
+        0,
+        "no PATCH may be addressed to a Pod that does not exist"
+    );
+}


### PR DESCRIPTION
Implements board task `f3m5` (`0ppk-2`) of epic `0ppk`, proposal `3i92`: the durable resize drop lifecycle, the fail-safe quarantine, and the invocation half of the fence that migration 164 could not express.

## The two contradictions the decomposer filed, answered

### 1. "CAS fenced by invocation and Pod UID" was NOT expressible against migration 164

Confirmed, and stated plainly: `build_pod_permits.task_run_id` is the **PRIMARY KEY** — exactly one row per task run — and neither migration 162 nor 164 carried an invocation column. The state *cycle* was expressible (`drop_applying → birth_confirmed` is a legal back-edge); the *occupant* of the cycle was not identifiable. The invocation half of the fence did not exist.

**Migration 168** makes it expressible. It adds `resize_invocation_id VARCHAR(255)`, holding the durable invocation-lease consumer id (`build_leases.consumer_id` for `task_invocation`) — the same string the worker already presents on `queue_lease`/`release_lease`, deliberately not a fresh surrogate nobody outside the table could name.

- The trigger makes the column **write-windowed**, not write-once: it may change on exactly one edge, `birth_confirmed → lift_applying`. It *must* be able to change, or a task run's second lift could never be told from its first.
- `transition_resize_lifecycle` now CASes on `(task_run_id, permit_id, fencing_token, pod_uid, resize_invocation_id, state)`. `None` is a fence value (`IS NOT DISTINCT FROM`), not "do not check".
- `begin_resize_invocation` is the claim: `birth_confirmed → lift_applying`, writing the fence.

### 2. Can two invocations of one task run be concurrent? **YES.**

Determined from `process.rs`'s `'invocation: loop`, not assumed:

- The loop is a sequential poll loop over **one** child — but `LeaseInvocationRunner::output` takes `&self` on an `Arc`-shared runner with **no lock, no permit, no "current invocation" slot** (`context.rs:81,185`).
- The invocation journal keeps a `Mutex<HashSet<String>>` of **live** invocation ids (`process.rs:150`) rather than an `Option`, with one file per invocation id — it is explicitly built for N concurrent invocations.
- Two production entry points reach the runner without mutual exclusion: the shell tool handler (`extension/handlers/workspace.rs:176`) and the worker's brokered cargo-target seed (`djinn-agent-worker/src/main.rs:1022`).
- The coordinator keys durable rows by `invocation_id` alone (`build_lease.rs:884`) and charges each independently.

A single-row lifecycle cannot represent two simultaneous lifts, so **the second claimant fails closed** — proven twice:
- `only_one_of_two_concurrent_invocations_can_claim_the_lifecycle` races two claims through a `Barrier` against real Postgres; exactly one wins and the row carries the **winner's** id.
- `a_second_concurrent_invocation_fails_closed_and_issues_zero_patches` drives `ResizeLift::apply` for an invocation that authorized while another already held `lifted`, and asserts `DegradedUnleasedReason::LiftLifecycleUnwritable` with **`resize_patches() == 0`**.

That second case closed a real hole: `ResizeLift::apply`'s `Lifted` arm previously skipped every lifecycle CAS, so a concurrent invocation would have PATCHed unfenced. It now runs an invocation-fenced `Lifted → Lifted` self-transition **before** any PATCH.

## What the drop does

`server/src/task_run_resize_drop.rs`. Every terminal path converges on `drop_required`, then:

1. `drop_required → drop_applying`.
2. Retry loop: **fresh GET + UID/protocol/launcher-container-id fences before EVERY attempt**, then a limits-only PATCH to 250m confirmed through the production `PodResizeClient` — i.e. through `status.initContainerStatuses[cgroup-launcher]`, compared in **millicores**.
3. Backoff **250ms → 500 → 1000 → 2s, capped at 2s**, inside a **30s** window. The deadline is checked against the sleep the loop is *about* to take, so the window is never overrun.
4. Confirmed ⇒ `drop_applying → birth_confirmed`, and only then may the lease be released.
5. Any settled failure, or the deadline ⇒ `quarantined`, UID-fenced DELETE, and **unbounded** absence confirmation.

Absence is proven by observation — a label-scoped GET returning no Pod, or a Pod whose `metadata.uid` is not ours — **never** by the DELETE's own acknowledgement.

## The two-ledger gate

`BuildLeaseService::release` writes `build_leases`; the lifecycle lives in `build_pod_permits`. `DirectServices::release_lease` now consults `TaskRunResizeDropGate` (a narrow trait in `djinn-agent`, mirroring `0ppk-1b`'s `TaskRunResizeAdmission`, implemented by `TaskRunResizeDropBridge` in `djinn-server`) and returns `LeaseUnavailable` without touching `build_leases` unless the drop settled.

`tests/task_run_resize_faults.rs` reads **both** tables. The handler's own 45s budget bounds the RPC, never the quarantine loop: a timed-out handler leaves the row durably nonterminal and the lease durably held.

## Every named failing mutation, verified by actually applying it

| AC | Mutation applied | Result |
|----|------------------|--------|
| 1 | Dropped `resize_invocation_id IS NOT DISTINCT FROM $6` from the CAS, keeping the `pod_uid` fence | `a_stale_invocation_id_is_rejected...` **FAILED** — the stale transition succeeded |
| 2 | Deleted the `Lifted → Lifted` fenced self-transition from `ResizeLift::apply` | `a_second_concurrent_invocation...` **FAILED** — the intruder's lift succeeded |
| 5 | Removed the 2s backoff cap | Sequence became `250,500,1000,2000,4000,8000,250` — **FAILED** |
| 6 | Made `release_lease` call `BuildLeaseService::release` unconditionally | `a_quarantined_drop_holds_the_build_lease...` **FAILED** — `Released` |
| 7 | Bounded the quarantine loop to 5 attempts | `the_quarantine_loop_is_unbounded...` **FAILED** — the future completed and released |

## Evidence rules honoured

- **No `Fake`/`Mock` permit repository anywhere.** Every lifecycle assertion runs against `Database::ephemeral` (template-cloned real Postgres). Fault injection uses `djinn_k8s::pod_resize_fixture::StoredTaskRunPod`, driven through the **production** `PodResizeClient` and `observe_launcher_sidecar`.
- **Nothing asserts a stored state as evidence of a drop.** AC4's test reads the launcher's own init-container status in millicores plus the PATCH counter and body; the permit `state` column is explicitly *not* used.
- **Non-vacuity:** every terminal-path row performs a REAL lift first and asserts the launcher actually holds the raised ceiling before the drop runs.
- The `status.containerStatuses` impostor fixture (a regular container named `cgroup-launcher` reporting 250m while the init status is stale) does **not** confirm — it quarantines.

## AC8: the stranded task run — outcome (a), a NAMED terminal reason

Proven, not assumed, in `a_quarantined_task_run_can_never_capture_a_replacement_pod`:

1. `acquire` returns `AlreadyReleased` for the released row.
2. `active` returns `None`, so the write-once capture predicate (`state = 'job_created' AND pod_uid IS NULL`) can never hold again.
3. The only path that could re-admit the run — `TaskRunResizeBootstrap::bootstrap` — refuses by **name**: `"permit identity or fencing token does not match the durable row"` (`RefusalReason::StalePermit`), which `TaskRunResizeAdmissionBridge` renders into a `ResizeAdmissionRefused` the dispatch seam surfaces.

This is **not** a silent wedge, so no blocker is filed. Recovery is a **new task run** — the same conclusion `0ppk-1b` documented for the replacement-Pod path, now with a test behind it.

## Files touched outside this slice's exclusive set, and why

- `resize_authorization.rs` / `resize_lift.rs` (`0ppk-1c`, merged): the invocation fence is unreachable in production unless the lift claims it. `PodResizeIntent` gained `invocation_id` (from the **durable owner**, never the caller's claim), the lift's entry edge goes through `begin_resize_invocation`, and the `Lifted` arm gained the fenced self-transition. The apply-and-poll wrapper itself is reused, not forked.
- `ResizeAuthorizationOutcome::Authorized` is now boxed. Not lint appeasement — see below.
- `AgentContext` gained `resize_drop`, mirroring `resize_admission`; four test literals updated mechanically.

## Two findings worth flagging

1. **`rules::tests::amend_while_building_dispatches_one_reconcile_task_from_event` aborts with a tokio-worker stack overflow — and it is PRE-EXISTING on `main`.** Reproduced independently in a clean worktree at unmodified `origin/main` (`732ad1593`): same `thread 'tokio-rt-worker' has overflowed its stack` / SIGABRT. Not introduced here, and not fixed here either — it is called out so the next person triaging a red `djinn-coordinator --lib` lane does not spend the afternoon on the resize diff. Boxing `Authorized` is kept regardless: the outcome is held across an `.await` inside `BuildLeaseService::grant`, which is itself inside the dispatch rules future, and clippy flagged exactly that growth.
2. **`dispatch_outcome_metrics_record_exact_once_and_ok_updates_timestamp`** fails only under parallel execution and passes in isolation — the known process-global metrics-registry collision, unrelated to this change.

## Not done

The live-cluster case in AC7 ("a kind-harness case proving the UID-fenced DELETE actually removes the Pod") is **not** included: the task instructed no cluster be created. The UID fence is proven against the fixture's own precondition check, including the recreated-Pod case where the replacement survives and zero DELETEs are issued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
