### PR TITLE
fix(coordinator): bound the actor's poll-frame chain to fit a 2 MiB stack

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1937,7 +1937,19 @@ jobs:
         if: steps.shard.outputs.active == 'true'
         env:
           NEXTEST_PROFILE: ${{ github.event_name == 'pull_request' && 'pull-request' || github.event_name == 'merge_group' && 'merge-group' || 'full-validation' }}
-          RUST_MIN_STACK: "8388608"
+          # NOTE: there is deliberately NO `RUST_MIN_STACK` here. One used to be
+          # (`8388608`, added in 1b4641fc0 "eliminate coordinator shard
+          # stack-overflow failures"), and it masked a real defect for eleven
+          # days: `CoordinatorActor::run`'s nested `async fn` chain consumed
+          # 2,210,352 bytes — 105% of tokio's 2 MiB worker stack — in a debug
+          # build, and the worst-case path through the actor reached 3.6 MiB.
+          # Production has no equivalent override (`server/src/main.rs` builds
+          # `new_multi_thread()` with the default 2 MiB stacks), so the override
+          # bought CI a green tick on a configuration production never ran.
+          # The chain is now structurally bounded — see
+          # `djinn-coordinator/src/poll_stack.rs` — so CI and local runs see the
+          # same 2 MiB budget. Do not re-add it: raising the stack here hides
+          # exactly the regression this gate exists to catch.
         run: |
           set -uo pipefail
           started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -12,6 +12,7 @@ use super::health;
 use super::messages::CoordinatorMessage;
 use super::types::*;
 use crate::cargo_warm_base_gc::{WarmJobGuard, WarmJobListerGuard};
+use crate::poll_stack;
 use crate::roles::RoleRegistry;
 use djinn_control_plane::bridge::RuntimeOps;
 use djinn_core::clock::{Clock, SystemClock};
@@ -1051,39 +1052,45 @@ impl CoordinatorActor {
 
     pub(super) async fn run(mut self) {
         tracing::info!("CoordinatorActor started");
-        self.register_coordinator_incarnation().await;
+        // Every sub-pass awaited from here down is entered through
+        // `poll_stack::boxed` — see that module for why the coordinator's poll
+        // chain cannot afford to build its sub-futures in the caller's frame.
+        poll_stack::boxed(|| self.register_coordinator_incarnation()).await;
         // Keep the incarnation lease fresh from a dedicated task so a slow tick
         // never lets the reaper read this live coordinator as expired.
         self.spawn_incarnation_renewal();
 
-        let _startup_imports_complete = match ProjectRepository::new(
+        let startup_project_repo = ProjectRepository::new(
             self.db.clone(),
             crate::events::event_bus_for(&self.events_tx),
-        )
-        .list()
-        .await
+        );
+        let _startup_imports_complete = match poll_stack::boxed(|| startup_project_repo.list())
+            .await
         {
             Ok(projects) => {
                 let db = self.db.clone();
-                complete_legacy_settings_import_phase(projects, move |project| {
-                    let db = db.clone();
-                    async move {
-                        let checkout = djinn_core::paths::project_dir(
-                            &project.github_owner,
-                            &project.github_repo,
-                        );
-                        if let Err(error) = djinn_workspace::import_legacy_settings_file(
-                            db,
-                            &project.id,
-                            &checkout,
-                        )
-                        .await
-                        {
-                            tracing::error!(project_id = %project.id, checkout = %checkout.display(), %error, "legacy settings import failed; retained source for this project");
+                let import_phase = complete_legacy_settings_import_phase(
+                    projects,
+                    move |project| {
+                        let db = db.clone();
+                        async move {
+                            let checkout = djinn_core::paths::project_dir(
+                                &project.github_owner,
+                                &project.github_repo,
+                            );
+                            if let Err(error) = djinn_workspace::import_legacy_settings_file(
+                                db,
+                                &project.id,
+                                &checkout,
+                            )
+                            .await
+                            {
+                                tracing::error!(project_id = %project.id, checkout = %checkout.display(), %error, "legacy settings import failed; retained source for this project");
+                            }
                         }
-                    }
-                })
-                .await
+                    },
+                );
+                poll_stack::boxed(|| import_phase).await
             }
             Err(error) => {
                 tracing::error!(%error, "cannot enumerate projects for legacy settings import");
@@ -1107,25 +1114,30 @@ impl CoordinatorActor {
         // that owned it can no longer flush a terminal RPC to us. Run the
         // same sweep the 15-min tick uses so the dev UI / queries don't show
         // weeks-old stale rows after every restart.
-        health::reap_stale_task_runs_for_startup(&self.db).await;
+        poll_stack::boxed(|| health::reap_stale_task_runs_for_startup(&self.db)).await;
         // Reap pending task_attempts orphaned while this coordinator was down
         // (or wedged from before the reaper existed) so the respawn guard
         // unblocks those (task, role) pairs immediately after a deploy.
-        health::reap_orphaned_pending_attempts_for_startup(
-            &self.db,
-            &self.coordinator_incarnation_id,
-        )
+        poll_stack::boxed(|| {
+            health::reap_orphaned_pending_attempts_for_startup(
+                &self.db,
+                &self.coordinator_incarnation_id,
+            )
+        })
         .await;
         let startup_context = self.maintenance_context();
-        health::reap_orphaned_taskrun_jobs_for_startup(&self.db, &startup_context).await;
-        self.rehydrate_durable_dispatch_state().await;
+        poll_stack::boxed(|| {
+            health::reap_orphaned_taskrun_jobs_for_startup(&self.db, &startup_context)
+        })
+        .await;
+        poll_stack::boxed(|| self.rehydrate_durable_dispatch_state()).await;
 
         // Reconcile refinements whose in-memory loop was lost across this
         // restart: their durable `refinement_start` rows still report `active`
         // but no loop drives them. Stop them cleanly so they don't linger as
         // zombies. Runs before the loop starts, so `active_refinements` is
         // empty and there is no race with a freshly-started refinement.
-        self.recover_interrupted_refinements().await;
+        poll_stack::boxed(|| self.recover_interrupted_refinements()).await;
 
         // Recover any linked evidence spikes that reached a terminal task
         // state while the coordinator was down, so missed closed-task events are
@@ -1133,9 +1145,9 @@ impl CoordinatorActor {
         // repository primitive.  For successful findings the durable evidence
         // link/claim is cleared and the in-memory refinement loop is advanced;
         // for failed spikes the proposal remains blocked.
-        self.recover_terminal_linked_spike_evidence().await;
+        poll_stack::boxed(|| self.recover_terminal_linked_spike_evidence()).await;
 
-        self.run_dispatch_loop(_startup_imports_complete).await;
+        poll_stack::boxed(|| self.run_dispatch_loop(_startup_imports_complete)).await;
         tracing::info!("CoordinatorActor stopped");
     }
 
@@ -1158,19 +1170,19 @@ impl CoordinatorActor {
                         tracing::debug!("CoordinatorActor: message channel closed");
                         break;
                     };
-                    Self::run_pass_with_watchdog("message", self.handle_message(msg)).await;
+                    Self::run_pass_with_watchdog("message", poll_stack::boxed(|| self.handle_message(msg))).await;
                 }
 
                 // 3. Domain events from repositories.
                 event = self.events.recv() => {
-                    Self::run_pass_with_watchdog("event", self.handle_event_result(event)).await;
+                    Self::run_pass_with_watchdog("event", poll_stack::boxed(|| self.handle_event_result(event))).await;
                 }
 
                 // 4. 30s safety-net tick — stuck detection + dispatch pass for
                 //    any tasks that missed an event (e.g. needs_lead_intervention
                 //    tasks surviving a server restart).
                 _ = self.tick.tick() => {
-                    Self::run_pass_with_watchdog("tick", self.run_tick()).await;
+                    Self::run_pass_with_watchdog("tick", poll_stack::boxed(|| self.run_tick())).await;
                 }
             }
         }
@@ -1182,14 +1194,16 @@ impl CoordinatorActor {
         fields(cycle_id = self.prune_tick_counter + 1, pass_kind = "tick")
     )]
     async fn run_tick(&mut self) {
-        self.enforce_session_stall_timeout().await;
-        self.reap_zombie_sessions().await;
-        self.reap_idle_chat_sessions().await;
-        self.detect_and_recover_stuck_filtered(None).await;
+        poll_stack::boxed(|| self.enforce_session_stall_timeout()).await;
+        poll_stack::boxed(|| self.reap_zombie_sessions()).await;
+        poll_stack::boxed(|| self.reap_idle_chat_sessions()).await;
+        poll_stack::boxed(|| self.detect_and_recover_stuck_filtered(None)).await;
 
-        self.mismatch_scan
-            .trigger(crate::doctor::mismatch_scan::Trigger::Timer)
-            .await;
+        poll_stack::boxed(|| {
+            self.mismatch_scan
+                .trigger(crate::doctor::mismatch_scan::Trigger::Timer)
+        })
+        .await;
 
         // Doctor framework integration (epic 4q1t, task 1lx0). Run only the
         // cheap subset so cluster-facing on-demand checks (e.g. k8s.pod_leak)
@@ -1199,34 +1213,38 @@ impl CoordinatorActor {
         // The run_id is monotonic per-tick so a future `doctor_list_findings`
         // call can scope its query back to one leader-tick invocation.
         if let Some(source) = self.stranded_ready_source.as_ref() {
-            source.refresh().await;
+            poll_stack::boxed(|| source.refresh()).await;
         }
         if let Some(source) = self.closed_parent_open_children_source.as_ref() {
-            source.refresh().await;
+            poll_stack::boxed(|| source.refresh()).await;
         }
         let doctor_run_id = format!("leader-tick-{}", self.prune_tick_counter.wrapping_add(1));
         #[cfg(not(test))]
         let retrieval_health_source = self.retrieval_health_source.as_ref();
         #[cfg(test)]
         let retrieval_health_source = None;
-        crate::doctor::leader_tick::run_elected_retrieval_refresh_and_cheap_checks(
-            true,
-            retrieval_health_source,
-            self.doctor_registry(),
-            &self.db,
-            &self.events_tx,
-            Some(&doctor_run_id),
-        )
+        poll_stack::boxed(|| {
+            crate::doctor::leader_tick::run_elected_retrieval_refresh_and_cheap_checks(
+                true,
+                retrieval_health_source,
+                self.doctor_registry(),
+                &self.db,
+                &self.events_tx,
+                Some(&doctor_run_id),
+            )
+        })
         .await;
 
         // Separate async DB sweep; its flag is checked before proposal sources
         // are constructed, avoiding scans and body loads while disabled.
         let proposal_integrity_sweep = crate::context::ProposalSpecIntegritySweepConfig::from_env();
-        crate::doctor::leader_tick::run_proposal_spec_integrity_sweep(
-            proposal_integrity_sweep.enabled,
-            &self.db,
-            Some(&doctor_run_id),
-        )
+        poll_stack::boxed(|| {
+            crate::doctor::leader_tick::run_proposal_spec_integrity_sweep(
+                proposal_integrity_sweep.enabled,
+                &self.db,
+                Some(&doctor_run_id),
+            )
+        })
         .await;
 
         // Audit sampler scheduler (epic ihf1, task 0utu). Materializes
@@ -1240,12 +1258,14 @@ impl CoordinatorActor {
             self.db.clone(),
             crate::events::event_bus_for(&self.events_tx),
         );
-        let audit_result = crate::audit_sampler::scheduler::run_audit_scheduler(
-            &audit_config,
-            &audit_repo,
-            &task_repo,
-            &epic_repo,
-        )
+        let audit_result = poll_stack::boxed(|| {
+            crate::audit_sampler::scheduler::run_audit_scheduler(
+                &audit_config,
+                &audit_repo,
+                &task_repo,
+                &epic_repo,
+            )
+        })
         .await;
         if audit_result.ran && !audit_result.materialized_items.is_empty() {
             tracing::info!(
@@ -1285,45 +1305,50 @@ impl CoordinatorActor {
         };
 
         if !memory_throttled {
-            self.dispatch_ready_tasks(None).await;
-            self.drive_active_refinements().await;
+            poll_stack::boxed(|| self.dispatch_ready_tasks(None)).await;
+            poll_stack::boxed(|| self.drive_active_refinements()).await;
         }
-        self.process_approved_tasks().await;
-        self.poll_pr_statuses().await;
+        poll_stack::boxed(|| self.process_approved_tasks()).await;
+        poll_stack::boxed(|| self.poll_pr_statuses()).await;
         if self.last_stale_sweep.elapsed() >= STALE_SWEEP_INTERVAL {
             let app_state = self.maintenance_context();
             // The incarnation lease is NOT renewed here: it lives on the
             // dedicated `spawn_incarnation_renewal` task so a slow tick or this
             // heavy sweep can never let the reaper (run inside
             // `sweep_stale_resources`) read this live coordinator as expired.
-            health::sweep_stale_resources(&self.db, &app_state).await;
+            poll_stack::boxed(|| health::sweep_stale_resources(&self.db, &app_state)).await;
             // Piggyback on the slow stale-sweep cadence (never per tick): close
             // the PR poller's blind spot by reconciling merged-but-unnoticed PRs
             // for non-terminal tasks that sit outside poller-owned statuses.
-            self.reconcile_blindspot_merged_prs().await;
+            poll_stack::boxed(|| self.reconcile_blindspot_merged_prs()).await;
             self.last_stale_sweep = SystemClock::new().now_instant();
         }
         if self.last_auto_dispatch_sweep.elapsed() >= AUTO_DISPATCH_SWEEP_INTERVAL {
-            self.sweep_stale_auto_dispatches().await;
+            poll_stack::boxed(|| self.sweep_stale_auto_dispatches()).await;
             self.last_auto_dispatch_sweep = SystemClock::new().now_instant();
         }
         if self.last_proposal_review_sweep.elapsed() >= STALE_SWEEP_INTERVAL {
-            self.sweep_proposals_needing_review().await;
-            self.sweep_proposals_needing_reconcile().await;
+            poll_stack::boxed(|| self.sweep_proposals_needing_review()).await;
+            poll_stack::boxed(|| self.sweep_proposals_needing_reconcile()).await;
             self.last_proposal_review_sweep = SystemClock::new().now_instant();
         }
         if self.last_graph_refresh.elapsed() >= GRAPH_REFRESH_INTERVAL {
-            self.refresh_canonical_graphs_if_stale().await;
+            poll_stack::boxed(|| self.refresh_canonical_graphs_if_stale()).await;
             self.last_graph_refresh = SystemClock::new().now_instant();
         }
         // Run association pruning once per ~hour (120 ticks at 30s intervals)
         self.prune_tick_counter += 1;
         if self.prune_tick_counter >= 120 {
             self.prune_tick_counter = 0;
-            self.prune_note_associations().await;
+            poll_stack::boxed(|| self.prune_note_associations()).await;
             if !self.should_skip_background_llm_work("hourly_note_consolidation") {
-                super::consolidation::run_note_consolidation(&self.db, &self.consolidation_runner)
-                    .await;
+                poll_stack::boxed(|| {
+                    super::consolidation::run_note_consolidation(
+                        &self.db,
+                        &self.consolidation_runner,
+                    )
+                })
+                .await;
             }
             self.evict_throughput_events();
         }
@@ -1339,7 +1364,7 @@ impl CoordinatorActor {
         }
         // Only attempt a new sweep when no sweep is already running.
         if self.idle_consolidation_handle.is_none() {
-            self.maybe_start_idle_consolidation().await;
+            poll_stack::boxed(|| self.maybe_start_idle_consolidation()).await;
         }
     }
 
@@ -1453,13 +1478,13 @@ impl CoordinatorActor {
                 // re-dispatched, fails again, frees the slot, triggers
                 // dispatch, etc.  The 30-second tick is sufficient for stuck
                 // recovery.
-                self.dispatch_ready_tasks(None).await;
+                poll_stack::boxed(|| self.dispatch_ready_tasks(None)).await;
             }
             CoordinatorMessage::TriggerProjectDispatch { project_id } => {
-                self.dispatch_ready_tasks(Some(&project_id)).await;
+                poll_stack::boxed(|| self.dispatch_ready_tasks(Some(&project_id))).await;
             }
             CoordinatorMessage::TriggerStuckScan => {
-                self.detect_and_recover_stuck_filtered(None).await;
+                poll_stack::boxed(|| self.detect_and_recover_stuck_filtered(None)).await;
             }
             CoordinatorMessage::TriggerBoardHealthMismatchScan => {
                 self.mismatch_scan
@@ -1486,24 +1511,28 @@ impl CoordinatorActor {
                 reason,
                 project_id,
             } => {
-                self.dispatch_planner_escalation(&source_task_id, &reason, &project_id)
-                    .await;
+                poll_stack::boxed(|| {
+                    self.dispatch_planner_escalation(&source_task_id, &reason, &project_id)
+                })
+                .await;
             }
             CoordinatorMessage::RouteLoopGuardPlannerIntervention {
                 source_task_id,
                 role,
                 reason,
             } => {
-                self.route_loop_guard_planner_intervention(&source_task_id, role, &reason)
-                    .await;
+                poll_stack::boxed(|| {
+                    self.route_loop_guard_planner_intervention(&source_task_id, role, &reason)
+                })
+                .await;
             }
             CoordinatorMessage::ClearPlannedDispatchCompletion { task_id, reason } => {
-                self.clear_planned_dispatch_completion(&task_id, &reason)
+                poll_stack::boxed(|| self.clear_planned_dispatch_completion(&task_id, &reason))
                     .await;
-                self.route_settled_noop_without_live_mover(&task_id).await;
+                poll_stack::boxed(|| self.route_settled_noop_without_live_mover(&task_id)).await;
             }
             CoordinatorMessage::RouteSettledNoopWithoutLiveMover { task_id } => {
-                self.route_settled_noop_without_live_mover(&task_id).await;
+                poll_stack::boxed(|| self.route_settled_noop_without_live_mover(&task_id)).await;
             }
             CoordinatorMessage::RefreshRetrievalHealth {
                 check_names,
@@ -1547,7 +1576,7 @@ impl CoordinatorActor {
                 let _ = reply.send(self.dispatch_state_snapshot());
             }
             CoordinatorMessage::WakeRefinementRun { run_id } => {
-                self.hydrate_refinement_wake(&run_id).await;
+                poll_stack::boxed(|| self.hydrate_refinement_wake(&run_id)).await;
             }
             CoordinatorMessage::StartProposalRefinement {
                 proposal_id,
@@ -1743,15 +1772,15 @@ impl CoordinatorActor {
         result: Result<DjinnEventEnvelope, broadcast::error::RecvError>,
     ) {
         match result {
-            Ok(envelope) => self.handle_event(envelope).await,
+            Ok(envelope) => poll_stack::boxed(|| self.handle_event(envelope)).await,
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 tracing::warn!(
                     missed = n,
                     "CoordinatorActor: lagged behind event stream, re-subscribing"
                 );
                 self.events = self.events_tx.subscribe();
-                self.detect_and_recover_stuck_filtered(None).await;
-                self.dispatch_ready_tasks(None).await;
+                poll_stack::boxed(|| self.detect_and_recover_stuck_filtered(None)).await;
+                poll_stack::boxed(|| self.dispatch_ready_tasks(None)).await;
             }
             Err(broadcast::error::RecvError::Closed) => {
                 tracing::warn!("CoordinatorActor: event broadcast channel closed");
@@ -1762,7 +1791,7 @@ impl CoordinatorActor {
     pub(super) async fn handle_event(&mut self, envelope: DjinnEventEnvelope) {
         match (envelope.entity_type, envelope.action) {
             ("activity", "logged") => {
-                self.handle_task_outcome_activity(&envelope).await;
+                poll_stack::boxed(|| self.handle_task_outcome_activity(&envelope)).await;
             }
             // Epic created → create a planning task for the Planner (wave 1),
             // gated to `open` epics with auto_breakdown enabled.
@@ -1770,7 +1799,7 @@ impl CoordinatorActor {
                 let Some(epic) = envelope.parse_payload::<djinn_core::models::Epic>() else {
                     return;
                 };
-                self.maybe_create_planning_task(&epic).await;
+                poll_stack::boxed(|| self.maybe_create_planning_task(&epic)).await;
             }
             // Epic updated → if the epic is now open, create a planning task
             // (e.g. a reopened epic, or a re-emitted epic.updated). If the epic
@@ -1780,9 +1809,9 @@ impl CoordinatorActor {
                 let Some(epic) = envelope.parse_payload::<djinn_core::models::Epic>() else {
                     return;
                 };
-                self.maybe_create_planning_task(&epic).await;
+                poll_stack::boxed(|| self.maybe_create_planning_task(&epic)).await;
                 if epic.status == "closed" {
-                    self.maybe_review_proposal_on_epic_close(&epic).await;
+                    poll_stack::boxed(|| self.maybe_review_proposal_on_epic_close(&epic)).await;
                 }
             }
             // Proposal updated → if a material amend landed while the proposal
@@ -1793,7 +1822,7 @@ impl CoordinatorActor {
                 else {
                     return;
                 };
-                self.maybe_reconcile_proposal_on_update(&proposal).await;
+                poll_stack::boxed(|| self.maybe_reconcile_proposal_on_update(&proposal)).await;
             }
             // ADR-051 §7 — exit recheck.  When a planner session ends, look
             // up the epic its task was attached to and recheck whether an
@@ -1830,7 +1859,7 @@ impl CoordinatorActor {
                         .await;
                 }
                 // Existing planner-specific epic recheck.
-                self.handle_planner_session_ended(&session).await;
+                poll_stack::boxed(|| self.handle_planner_session_ended(&session)).await;
             }
             ("task", "created") | ("task", "updated") => {
                 let Some(task_payload) = envelope
@@ -1849,7 +1878,7 @@ impl CoordinatorActor {
                 if task.status == "closed" {
                     // Terminalize the live attempt when a task closes via a
                     // force-close path. Best-effort; does not block the event.
-                    self.terminalize_force_close_attempt(&task).await;
+                    poll_stack::boxed(|| self.terminalize_force_close_attempt(&task)).await;
 
                     // Record throughput event when a task with a merge commit closes.
                     if task.merge_commit_sha.is_some()
@@ -1857,16 +1886,18 @@ impl CoordinatorActor {
                     {
                         self.record_merge_event(epic_id);
                     }
-                    self.persist_terminal_linked_spike_evidence_from_closed_task(&task)
-                        .await;
+                    poll_stack::boxed(|| {
+                        self.persist_terminal_linked_spike_evidence_from_closed_task(&task)
+                    })
+                    .await;
                     // Tripwire: a closed `human-review-hold` task means a human
                     // resolved the hold — emit `tripwire.hold.released` on each
                     // held source so the merge-boundary gate can clear for the
                     // current head (no release producer existed before; hold
                     // task `yynd` never cleared its gate on close).
-                    self.emit_tripwire_release_on_hold_close(&task).await;
+                    poll_stack::boxed(|| self.emit_tripwire_release_on_hold_close(&task)).await;
                     // Fire epic completion rules (spike/batch).
-                    self.on_task_closed(&task).await;
+                    poll_stack::boxed(|| self.on_task_closed(&task)).await;
                 }
                 if matches!(
                     task.status.as_str(),
@@ -1877,7 +1908,7 @@ impl CoordinatorActor {
                         status = %task.status,
                         "CoordinatorActor: ready-task event → dispatch pass"
                     );
-                    self.dispatch_ready_tasks(Some(&task.project_id)).await;
+                    poll_stack::boxed(|| self.dispatch_ready_tasks(Some(&task.project_id))).await;
                 }
             }
             // A credential was (re)connected or replaced — typically the owner
@@ -1900,7 +1931,7 @@ impl CoordinatorActor {
                         cleared,
                         "CoordinatorActor: credential (re)connected — cleared breaker buckets, re-dispatching"
                     );
-                    self.dispatch_ready_tasks(None).await;
+                    poll_stack::boxed(|| self.dispatch_ready_tasks(None)).await;
                 }
             }
             _ => {}
@@ -1932,7 +1963,8 @@ impl CoordinatorActor {
             return;
         };
 
-        if let Err(e) = self.maybe_apply_task_outcome_confidence(&task).await {
+        if let Err(e) = poll_stack::boxed(|| self.maybe_apply_task_outcome_confidence(&task)).await
+        {
             tracing::warn!(
                 task_id = %task_id,
                 error = %e,
@@ -1951,9 +1983,8 @@ impl CoordinatorActor {
                 .task_outcome_marker_exists(task, TASK_OUTCOME_FAILED_CLOSE)
                 .await?
         {
-            self.apply_task_outcome_confidence_to_task_refs(task)
-                .await?;
-            self.record_task_outcome_marker(task, TASK_OUTCOME_FAILED_CLOSE)
+            poll_stack::boxed(|| self.apply_task_outcome_confidence_to_task_refs(task)).await?;
+            poll_stack::boxed(|| self.record_task_outcome_marker(task, TASK_OUTCOME_FAILED_CLOSE))
                 .await?;
         }
 
@@ -1963,9 +1994,8 @@ impl CoordinatorActor {
                 .task_outcome_marker_exists(task, TASK_OUTCOME_REOPEN_COUNT)
                 .await?
         {
-            self.apply_task_outcome_confidence_to_task_refs(task)
-                .await?;
-            self.record_task_outcome_marker(task, TASK_OUTCOME_REOPEN_COUNT)
+            poll_stack::boxed(|| self.apply_task_outcome_confidence_to_task_refs(task)).await?;
+            poll_stack::boxed(|| self.record_task_outcome_marker(task, TASK_OUTCOME_REOPEN_COUNT))
                 .await?;
         }
 
@@ -2263,7 +2293,7 @@ impl CoordinatorActor {
         // the same rejected acceptance criterion forever instead of
         // escalating to a Planner that can decompose/rescope/close them.
         if selected.is_empty() {
-            return self.resolve_user_model_priority(user_id, role).await;
+            return poll_stack::boxed(|| self.resolve_user_model_priority(user_id, role)).await;
         }
         selected
     }
@@ -2297,7 +2327,7 @@ impl CoordinatorActor {
         let Some(epic_id) = task.epic_id.as_deref() else {
             return;
         };
-        self.recheck_epic_after_planner_end(epic_id).await;
+        poll_stack::boxed(|| self.recheck_epic_after_planner_end(epic_id)).await;
     }
 
     /// Re-run the eligibility check for an epic that was just touched by
@@ -2334,12 +2364,14 @@ impl CoordinatorActor {
         let Ok(Some(epic)) = epic_repo.get(epic_id).await else {
             return;
         };
-        self.create_planning_task_by_ids(
-            &task_repo,
-            epic_id,
-            &epic.project_id,
-            "post_planner_recheck",
-        )
+        poll_stack::boxed(|| {
+            self.create_planning_task_by_ids(
+                &task_repo,
+                epic_id,
+                &epic.project_id,
+                "post_planner_recheck",
+            )
+        })
         .await;
     }
 
@@ -2376,7 +2408,7 @@ impl CoordinatorActor {
             // exists, if the epic has unresolved epic-blockers, or if a planner
             // is already active on it), so calling it here is an idempotent,
             // loop-safe backstop that self-heals within one sweep interval.
-            self.maybe_create_planning_task(&epic).await;
+            poll_stack::boxed(|| self.maybe_create_planning_task(&epic)).await;
 
             if !self
                 .epic_is_eligible_for_next_wave(&task_repo, &epic.id)
@@ -2395,12 +2427,14 @@ impl CoordinatorActor {
             {
                 continue;
             }
-            self.create_planning_task_by_ids(
-                &task_repo,
-                &epic.id,
-                &epic.project_id,
-                "stale_auto_dispatch_sweep",
-            )
+            poll_stack::boxed(|| {
+                self.create_planning_task_by_ids(
+                    &task_repo,
+                    &epic.id,
+                    &epic.project_id,
+                    "stale_auto_dispatch_sweep",
+                )
+            })
             .await;
         }
     }

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -394,8 +394,10 @@ impl CoordinatorActor {
         created_by_user_id: Option<&str>,
         base_role: &str,
     ) -> Vec<String> {
-        self.resolve_user_model_priority_with_lane(created_by_user_id, base_role, None)
-            .await
+        poll_stack::boxed(|| {
+            self.resolve_user_model_priority_with_lane(created_by_user_id, base_role, None)
+        })
+        .await
     }
 
     /// Resolve a `provider/model` list for a DB role's `model_preference`.
@@ -548,8 +550,10 @@ impl CoordinatorActor {
             task.reopen_count
         );
         tracing::Span::current().record("attempt", quality_strikes);
-        self.route_planner_intervention(task, "worker", &reason, None, quality_strikes)
-            .await
+        poll_stack::boxed(|| {
+            self.route_planner_intervention(task, "worker", &reason, None, quality_strikes)
+        })
+        .await
     }
 
     /// Trigger B: route a task cycling on same-role redispatches to a Planner
@@ -615,8 +619,10 @@ impl CoordinatorActor {
              work on the task branch is already sufficient or the task is moot/duplicate.",
             task.status, task.reopen_count
         );
-        self.route_planner_intervention(task, role, &reason, None, task.reopen_count)
-            .await
+        poll_stack::boxed(|| {
+            self.route_planner_intervention(task, role, &reason, None, task.reopen_count)
+        })
+        .await
     }
 
     /// Is the model this task last ran on currently auto-disabled by its own
@@ -723,7 +729,7 @@ impl CoordinatorActor {
         task: &djinn_core::models::Task,
         role: &'static str,
     ) -> bool {
-        if self.provider_breaker_blames_model(task, role).await {
+        if poll_stack::boxed(|| self.provider_breaker_blames_model(task, role)).await {
             return false;
         }
         let strike_count = {
@@ -776,15 +782,19 @@ impl CoordinatorActor {
         self.provider_failure_streak.remove(&task.id);
         self.dispatch_failure_streak.remove(&task.id);
         self.dispatch_cooldowns.remove(&task.id);
-        self.clear_durable_dispatch_backoff_state(
-            &task.id,
-            Some(&task.short_id),
-            "failure_streak_planner_intervention_handoff_clear",
-        )
+        poll_stack::boxed(|| {
+            self.clear_durable_dispatch_backoff_state(
+                &task.id,
+                Some(&task.short_id),
+                "failure_streak_planner_intervention_handoff_clear",
+            )
+        })
         .await;
 
-        self.route_loop_guard_planner_intervention(&task.id, role, &intervention_reason)
-            .await
+        poll_stack::boxed(|| {
+            self.route_loop_guard_planner_intervention(&task.id, role, &intervention_reason)
+        })
+        .await
     }
 
     /// Trigger C: a worker/reviewer run completed degenerate because the
@@ -821,8 +831,10 @@ impl CoordinatorActor {
             }
         };
 
-        self.route_planner_intervention(&task, role, reason, None, task.reopen_count)
-            .await
+        poll_stack::boxed(|| {
+            self.route_planner_intervention(&task, role, reason, None, task.reopen_count)
+        })
+        .await
     }
 
     /// uv3p Part B: what the fleet actually did since the current intervention
@@ -1379,13 +1391,16 @@ impl CoordinatorActor {
             .quality_reopen_count(&task.id)
             .await
             .unwrap_or(task.intervention_count);
-        self.park_source_human_review_with_dossier(
-            task,
-            &format!("Arbitration deadline expired for hold cycle {hold_cycle}"),
-            quality_strikes,
-            Some(dossier.clone()),
-            &dossier,
-        )
+        let park_reason = format!("Arbitration deadline expired for hold cycle {hold_cycle}");
+        poll_stack::boxed(|| {
+            self.park_source_human_review_with_dossier(
+                task,
+                &park_reason,
+                quality_strikes,
+                Some(dossier.clone()),
+                &dossier,
+            )
+        })
         .await
     }
     /// Shared intervention router behind triggers A and B: second-strike
@@ -1427,8 +1442,11 @@ impl CoordinatorActor {
             // unconsumed row). A genuinely in-flight arbiter is left to finish
             // — it may still approve or supersede — and is separately bounded
             // by the 24h arbitration deadline and the decision-failure cap.
-            let final_disposition = self.arbiter_hold_cycle_ceiling_reached(task).await;
-            if final_disposition && self.hold_cycle_ceiling_already_recorded(&task.id).await {
+            let final_disposition =
+                poll_stack::boxed(|| self.arbiter_hold_cycle_ceiling_reached(task)).await;
+            if final_disposition
+                && poll_stack::boxed(|| self.hold_cycle_ceiling_already_recorded(&task.id)).await
+            {
                 let dossier = serde_json::json!({
                     "kind": "final_arbiter_reentry",
                     "hold_description": "The one-shot final arbiter disposition already ran",
@@ -1454,13 +1472,13 @@ impl CoordinatorActor {
             // a rescope, before ANY post-intervention session was ever dispatched.
             // Compute what actually happened since the intervention/hold release
             // and refuse to park on evidence the fleet never tried.
-            let history = self.post_intervention_history(task).await;
+            let history = poll_stack::boxed(|| self.post_intervention_history(task)).await;
 
             // Build the attempt ledger for inclusion in arbiter dossiers.
             // This captures all post-intervention attempt rows (all roles)
             // so operator-facing arbitration payloads consume the durable
             // attempt rows rather than reassembling bespoke history objects.
-            let attempt_ledger = self.attempt_ledger_for_task(task).await;
+            let attempt_ledger = poll_stack::boxed(|| self.attempt_ledger_for_task(task)).await;
 
             // CI staleness check (2vxr): CI evidence whose head SHA predates
             // the latest submitted work must not serve as the park-triggering
@@ -1487,14 +1505,16 @@ impl CoordinatorActor {
                     .as_deref()
                     .filter(|f| !f.is_empty())
             {
-                match self.park_fingerprint_seen(task, fingerprint).await {
+                match poll_stack::boxed(|| self.park_fingerprint_seen(task, fingerprint)).await {
                     Ok(false) => {
-                        self.record_park_redispatch_marker(
-                            task,
-                            "first_occurrence_fingerprint",
-                            Some(fingerprint),
-                            history.non_attempt_models.len(),
-                        )
+                        poll_stack::boxed(|| {
+                            self.record_park_redispatch_marker(
+                                task,
+                                "first_occurrence_fingerprint",
+                                Some(fingerprint),
+                                history.non_attempt_models.len(),
+                            )
+                        })
                         .await;
                         tracing::warn!(
                             task_id = %task.short_id,
@@ -1544,12 +1564,14 @@ impl CoordinatorActor {
                     prior_declines,
                 )
             {
-                self.record_park_redispatch_marker(
-                    task,
-                    NO_ATTEMPTED_REMEDIATION_KIND,
-                    None,
-                    history.non_attempt_models.len(),
-                )
+                poll_stack::boxed(|| {
+                    self.record_park_redispatch_marker(
+                        task,
+                        NO_ATTEMPTED_REMEDIATION_KIND,
+                        None,
+                        history.non_attempt_models.len(),
+                    )
+                })
                 .await;
                 tracing::warn!(
                     task_id = %task.short_id,
@@ -1569,8 +1591,10 @@ impl CoordinatorActor {
             // strike. If the task is in needs_task_review/in_task_review with no
             // rejection newer than the submission, do not park.
             if !final_disposition && history.any_submitted && history.submission_pending_review {
-                self.record_park_redispatch_marker(task, "submission_pending_review", None, 0)
-                    .await;
+                poll_stack::boxed(|| {
+                    self.record_park_redispatch_marker(task, "submission_pending_review", None, 0)
+                })
+                .await;
                 tracing::warn!(
                     task_id = %task.short_id,
                     task_status = %task.status,
@@ -1973,26 +1997,30 @@ impl CoordinatorActor {
             match create_result {
                 TryCreateResult::Created(_) => {
                     if final_disposition {
-                        self.record_hold_cycle_ceiling_final_dispatch(
-                            task,
-                            role,
-                            quality_strikes,
-                            hold_cycle,
-                        )
+                        poll_stack::boxed(|| {
+                            self.record_hold_cycle_ceiling_final_dispatch(
+                                task,
+                                role,
+                                quality_strikes,
+                                hold_cycle,
+                            )
+                        })
                         .await;
                     }
                     // Arbiter dispatch path — fresh arbitration row created.
-                    self.dispatch_arbiter_second_strike(
-                        task,
-                        hold_cycle,
-                        quality_strikes,
-                        &reason,
-                        role,
-                        &history,
-                        &attempt_ledger,
-                        mirror_head_sha.as_deref(),
-                        &failing_ci_job_ids,
-                    )
+                    poll_stack::boxed(|| {
+                        self.dispatch_arbiter_second_strike(
+                            task,
+                            hold_cycle,
+                            quality_strikes,
+                            &reason,
+                            role,
+                            &history,
+                            &attempt_ledger,
+                            mirror_head_sha.as_deref(),
+                            &failing_ci_job_ids,
+                        )
+                    })
                     .await;
                     // Log the arbiter_dispatched outbox payload — only on
                     // initial creation so outbox replay (AlreadyExistsUnconsumed)
@@ -2161,11 +2189,13 @@ impl CoordinatorActor {
         self.dispatch_cooldowns.remove(&task.id);
         self.last_dispatched.remove(&task.id);
         self.inflight_dispatches.remove(&task.id);
-        self.clear_durable_dispatch_backoff_state(
-            &task.id,
-            Some(&task.short_id),
-            "planner_intervention_handoff_clear",
-        )
+        poll_stack::boxed(|| {
+            self.clear_durable_dispatch_backoff_state(
+                &task.id,
+                Some(&task.short_id),
+                "planner_intervention_handoff_clear",
+            )
+        })
         .await;
 
         // Append the merge-queue lane facts (run id, failing checks,
@@ -2183,8 +2213,10 @@ impl CoordinatorActor {
             Some(sections) => format!("{reason}\n\n**CI Failure Details:**\n{sections}"),
             None => reason.to_string(),
         };
-        self.dispatch_planner_escalation(&task.id, &enriched_reason, &task.project_id)
-            .await;
+        poll_stack::boxed(|| {
+            self.dispatch_planner_escalation(&task.id, &enriched_reason, &task.project_id)
+        })
+        .await;
         true
     }
 
@@ -2386,11 +2418,13 @@ impl CoordinatorActor {
         self.dispatch_cooldowns.remove(&task.id);
         self.last_dispatched.remove(&task.id);
         self.inflight_dispatches.remove(&task.id);
-        self.clear_durable_dispatch_backoff_state(
-            &task.id,
-            Some(&task.short_id),
-            "planner_second_strike_arbiter_dispatch",
-        )
+        poll_stack::boxed(|| {
+            self.clear_durable_dispatch_backoff_state(
+                &task.id,
+                Some(&task.short_id),
+                "planner_second_strike_arbiter_dispatch",
+            )
+        })
         .await;
         // Interrupt any running session for this task so parking it
         // actually frees the dispatch slot.
@@ -2548,7 +2582,7 @@ impl CoordinatorActor {
             enriched_reason.push_str("\n\nArbiter re-entry / failure dossier:\n");
             enriched_reason.push_str(&dossier_text);
         }
-        self.park_source_human_review(task, &enriched_reason, quality_strikes)
+        poll_stack::boxed(|| self.park_source_human_review(task, &enriched_reason, quality_strikes))
             .await
     }
 
@@ -2642,7 +2676,7 @@ impl CoordinatorActor {
         task: &djinn_core::models::Task,
         reason: &str,
     ) -> bool {
-        let prior = self.planner_escalation_count(&task.id).await;
+        let prior = poll_stack::boxed(|| self.planner_escalation_count(&task.id)).await;
         if prior >= MAX_AUTONOMOUS_ESCALATIONS {
             let terminal_reason = format!(
                 "Autonomous remediation ladder exhausted: {prior} planner-park escalations already \
@@ -2656,7 +2690,7 @@ impl CoordinatorActor {
                 ceiling = MAX_AUTONOMOUS_ESCALATIONS,
                 "CoordinatorActor: autonomous-escalation ceiling reached — terminally failing task (no human park)"
             );
-            self.terminally_fail_task(task, "coordinator", &terminal_reason)
+            poll_stack::boxed(|| self.terminally_fail_task(task, "coordinator", &terminal_reason))
                 .await;
             return false;
         }
@@ -2664,14 +2698,16 @@ impl CoordinatorActor {
         // only if it isn't already held), THEN park the source to `open`. The
         // blocker is added before the park, so the open task is never
         // dispatchable without its blocker in place.
-        self.create_remediation_task(
-            &task.id,
-            reason,
-            &task.project_id,
-            RemediationKind::PlannerEscalation,
-        )
+        poll_stack::boxed(|| {
+            self.create_remediation_task(
+                &task.id,
+                reason,
+                &task.project_id,
+                RemediationKind::PlannerEscalation,
+            )
+        })
         .await;
-        self.park_source_open(&task.id, reason).await;
+        poll_stack::boxed(|| self.park_source_open(&task.id, reason)).await;
         true
     }
 
@@ -2815,7 +2851,7 @@ impl CoordinatorActor {
 
         // Durable one-shot marker. Re-entry sees this marker and routes directly
         // to the Planner escalation instead of dispatching another final arbiter.
-        if !self.hold_cycle_ceiling_already_recorded(&task.id).await {
+        if !poll_stack::boxed(|| self.hold_cycle_ceiling_already_recorded(&task.id)).await {
             let payload = serde_json::json!({
                 "event": "arbiter_hold_cycle_ceiling",
                 "task_id": task.short_id,
@@ -2852,7 +2888,7 @@ impl CoordinatorActor {
                 djinn_telemetry::arbiter::PARK_REASON_HOLD_CYCLE_CEILING,
                 djinn_telemetry::arbiter::PARK_OUTCOME_SUCCESS,
             );
-            self.record_task_parked_metric(task, quality_strikes).await;
+            poll_stack::boxed(|| self.record_task_parked_metric(task, quality_strikes)).await;
         }
     }
 
@@ -2930,11 +2966,13 @@ impl CoordinatorActor {
         self.dispatch_cooldowns.remove(&task.id);
         self.last_dispatched.remove(&task.id);
         self.inflight_dispatches.remove(&task.id);
-        self.clear_durable_dispatch_backoff_state(
-            &task.id,
-            Some(&task.short_id),
-            "planner_second_strike_hold_clear",
-        )
+        poll_stack::boxed(|| {
+            self.clear_durable_dispatch_backoff_state(
+                &task.id,
+                Some(&task.short_id),
+                "planner_second_strike_hold_clear",
+            )
+        })
         .await;
         // Interrupt any running session for this task so parking it actually
         // frees the dispatch slot (a parked task must not keep burning one).
@@ -2949,9 +2987,8 @@ impl CoordinatorActor {
                 "CoordinatorActor: failed to interrupt running sessions while parking second-strike task"
             );
         }
-        self.escalate_to_planner_or_terminally_fail(task, reason)
-            .await;
-        self.record_task_parked_metric(task, quality_strikes).await;
+        poll_stack::boxed(|| self.escalate_to_planner_or_terminally_fail(task, reason)).await;
+        poll_stack::boxed(|| self.record_task_parked_metric(task, quality_strikes)).await;
         true
     }
 
@@ -2985,8 +3022,15 @@ impl CoordinatorActor {
         reason: &str,
         project_id: &str,
     ) {
-        self.create_remediation_task(source_task_id, reason, project_id, RemediationKind::Planner)
-            .await;
+        poll_stack::boxed(|| {
+            self.create_remediation_task(
+                source_task_id,
+                reason,
+                project_id,
+                RemediationKind::Planner,
+            )
+        })
+        .await;
     }
 
     /// Create a remediation review task that blocks the stuck `source_task_id`,
@@ -3075,7 +3119,8 @@ impl CoordinatorActor {
                 // fresh DB + inflight-ledger snapshot so a just-recorded admission in
                 // this same tick is visible.
                 let model_ids: Vec<String> = if let Some(creator) = source_creator.as_deref() {
-                    let (running_by_model, running_by_lane) = self.effective_running_counts().await;
+                    let (running_by_model, running_by_lane) =
+                        poll_stack::boxed(|| self.effective_running_counts()).await;
                     let settings = djinn_db::UserSettingsRepository::new(self.db.clone())
                         .get(creator)
                         .await
@@ -3118,7 +3163,9 @@ impl CoordinatorActor {
                     model_ids
                 };
 
-                let Some(project_path) = self.project_path_for_id(project_id).await else {
+                let Some(project_path) =
+                    poll_stack::boxed(|| self.project_path_for_id(project_id)).await
+                else {
                     tracing::warn!(
                         project_id = %project_id,
                         source_task_id = %source_task_id,
@@ -3405,13 +3452,15 @@ impl CoordinatorActor {
                     })
                     .cloned();
                 if let Some(model) = dispatched_model {
-                    self.record_inflight_dispatch(
-                        &review_task.id,
-                        Some(&review_task.short_id),
-                        Some(review_task.created_by_user_id.as_str()),
-                        &model,
-                        "planner",
-                    )
+                    poll_stack::boxed(|| {
+                        self.record_inflight_dispatch(
+                            &review_task.id,
+                            Some(&review_task.short_id),
+                            Some(review_task.created_by_user_id.as_str()),
+                            &model,
+                            "planner",
+                        )
+                    })
                     .await;
                 }
                 self.publish_status();

--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -483,27 +483,31 @@ impl CoordinatorActor {
                     },
                     reason
                 );
-                self.route_loop_guard_planner_intervention(
-                    task_id,
-                    "coordinator",
-                    &intervention_reason,
-                )
+                poll_stack::boxed(|| {
+                    self.route_loop_guard_planner_intervention(
+                        task_id,
+                        "coordinator",
+                        &intervention_reason,
+                    )
+                })
                 .await;
 
                 // Terminalize the matching attempt as a loop-guard trip: a
                 // token/turn ceiling kill is a runaway guard, routed through the
                 // loop-guard planner intervention rather than a stall/timeout.
-                self.terminalize_recovery_attempt(
-                    task_id,
-                    &session.agent_type,
-                    TaskAttemptOutcome::LoopGuardTripped,
-                    "session_recovery_ceiling",
-                    Some(&session.id),
-                    session.task_run_id.as_deref(),
-                    Some("dead"),
-                    Some("ceiling_kill"),
-                    Some(&reason),
-                )
+                poll_stack::boxed(|| {
+                    self.terminalize_recovery_attempt(
+                        task_id,
+                        &session.agent_type,
+                        TaskAttemptOutcome::LoopGuardTripped,
+                        "session_recovery_ceiling",
+                        Some(&session.id),
+                        session.task_run_id.as_deref(),
+                        Some("dead"),
+                        Some("ceiling_kill"),
+                        Some(&reason),
+                    )
+                })
                 .await;
 
                 tracing::warn!(
@@ -634,17 +638,19 @@ impl CoordinatorActor {
                     // Terminalize the matching attempt as a timeout: a
                     // no-progress controlled exit reclaims a session that stopped
                     // making durable progress (a stall variant).
-                    self.terminalize_recovery_attempt(
-                        task_id,
-                        &session.agent_type,
-                        TaskAttemptOutcome::TimedOut,
-                        "session_recovery_no_progress",
-                        Some(&session.id),
-                        session.task_run_id.as_deref(),
-                        Some("dead"),
-                        Some("no_progress"),
-                        None,
-                    )
+                    poll_stack::boxed(|| {
+                        self.terminalize_recovery_attempt(
+                            task_id,
+                            &session.agent_type,
+                            TaskAttemptOutcome::TimedOut,
+                            "session_recovery_no_progress",
+                            Some(&session.id),
+                            session.task_run_id.as_deref(),
+                            Some("dead"),
+                            Some("no_progress"),
+                            None,
+                        )
+                    })
                     .await;
 
                     tracing::warn!(
@@ -715,7 +721,7 @@ impl CoordinatorActor {
             // Classification runs unconditionally so the result is available
             // for dead_reclaimed / kill_noop evidence persistence after the
             // kill, regardless of whether slow-extension is enabled.
-            let classification = self.classify_task_liveness(task_id).await;
+            let classification = poll_stack::boxed(|| self.classify_task_liveness(task_id)).await;
             let slow_ext = &self.worker_lifecycle_config.slow_extension;
             if slow_ext.enabled
                 && let Some(ref result) = classification
@@ -1045,17 +1051,19 @@ impl CoordinatorActor {
                 djinn_telemetry::reasoning_kill::OUTCOME_KILLED,
             );
 
-            self.terminalize_recovery_attempt(
-                task_id,
-                &session.agent_type,
-                TaskAttemptOutcome::TimedOut,
-                "session_recovery_stall",
-                Some(&session.id),
-                session.task_run_id.as_deref(),
-                stall_verdict,
-                Some(stall_failure_class),
-                Some(reason),
-            )
+            poll_stack::boxed(|| {
+                self.terminalize_recovery_attempt(
+                    task_id,
+                    &session.agent_type,
+                    TaskAttemptOutcome::TimedOut,
+                    "session_recovery_stall",
+                    Some(&session.id),
+                    session.task_run_id.as_deref(),
+                    stall_verdict,
+                    Some(stall_failure_class),
+                    Some(reason),
+                )
+            })
             .await;
 
             // ── Zero-output wall-clock observation ────────────────────
@@ -1140,11 +1148,13 @@ impl CoordinatorActor {
                 // Clear the streak so a post-intervention run starts fresh (and a
                 // re-armed intervention is not double-counted).
                 self.stall_cancel_streak.remove(task_id);
-                self.route_loop_guard_planner_intervention(
-                    task_id,
-                    "coordinator",
-                    &intervention_reason,
-                )
+                poll_stack::boxed(|| {
+                    self.route_loop_guard_planner_intervention(
+                        task_id,
+                        "coordinator",
+                        &intervention_reason,
+                    )
+                })
                 .await;
             }
         }
@@ -1297,7 +1307,7 @@ impl CoordinatorActor {
             // `Verdict::Live` for terminal tasks (the verdict is moot;
             // only the outcome matters). Without this ordering the `Live`
             // arm fires and the KillNoop handling is unreachable.
-            let classification = self.classify_task_liveness(task_id).await;
+            let classification = poll_stack::boxed(|| self.classify_task_liveness(task_id)).await;
             if let Some(ref result) = classification {
                 // Terminal task race: task is already terminal.
                 // classify_task_liveness already persisted the KillNoop
@@ -1345,11 +1355,13 @@ impl CoordinatorActor {
                         );
                     }
                     // Teardown any leaked K8s Job for this task-run.
-                    self.teardown_zombie_taskrun_job(
-                        task_id,
-                        &session.id,
-                        session.task_run_id.as_deref(),
-                    )
+                    poll_stack::boxed(|| {
+                        self.teardown_zombie_taskrun_job(
+                            task_id,
+                            &session.id,
+                            session.task_run_id.as_deref(),
+                        )
+                    })
                     .await;
                     self.stall_killed.remove(&session.id);
                     continue;
@@ -1489,8 +1501,14 @@ impl CoordinatorActor {
 
             // Forcibly reclaim the (likely leaked) slot so the reopened task is
             // not rejected with `SessionAlreadyActive` on redispatch.
-            self.teardown_zombie_taskrun_job(task_id, &session.id, session.task_run_id.as_deref())
-                .await;
+            poll_stack::boxed(|| {
+                self.teardown_zombie_taskrun_job(
+                    task_id,
+                    &session.id,
+                    session.task_run_id.as_deref(),
+                )
+            })
+            .await;
             let evict_task_id = task_id.to_owned();
             let evict_session_id = session.id.clone();
             let evict_span = tracing::info_span!(
@@ -1568,17 +1586,19 @@ impl CoordinatorActor {
                 .as_ref()
                 .map(|c| c.verdict.as_str())
                 .unwrap_or("dead");
-            self.terminalize_recovery_attempt(
-                task_id,
-                &session.agent_type,
-                zombie_outcome,
-                "session_recovery_zombie_reap",
-                Some(&session.id),
-                session.task_run_id.as_deref(),
-                Some(zombie_verdict),
-                Some(zombie_failure_class),
-                None,
-            )
+            poll_stack::boxed(|| {
+                self.terminalize_recovery_attempt(
+                    task_id,
+                    &session.agent_type,
+                    zombie_outcome,
+                    "session_recovery_zombie_reap",
+                    Some(&session.id),
+                    session.task_run_id.as_deref(),
+                    Some(zombie_verdict),
+                    Some(zombie_failure_class),
+                    None,
+                )
+            })
             .await;
 
             djinn_telemetry::zombie::increment_reap(djinn_telemetry::zombie::KIND_STALL);
@@ -1840,7 +1860,8 @@ impl CoordinatorActor {
                     // (verified by has_session and background-work checks
                     // above), so the classifier will normally return Dead.
                     // If the task is already terminal, record KillNoop.
-                    let classification = self.classify_task_liveness(&task.id).await;
+                    let classification =
+                        poll_stack::boxed(|| self.classify_task_liveness(&task.id)).await;
                     if let Some(ref result) = classification {
                         if result.outcome == Some(LivenessOutcome::KillNoop) {
                             let liveness_repo = LivenessRepository::new(self.db.clone());
@@ -1897,17 +1918,19 @@ impl CoordinatorActor {
                                 .as_ref()
                                 .map(|c| c.verdict.as_str())
                                 .unwrap_or("dead");
-                            self.terminalize_recovery_attempt(
-                                &task.id,
-                                &running_session.agent_type,
-                                TaskAttemptOutcome::Crashed,
-                                "session_recovery_stale_ready_state",
-                                Some(&running_session.id),
-                                running_session.task_run_id.as_deref(),
-                                Some(orphan_verdict),
-                                Some("stale_ready_state_orphan"),
-                                None,
-                            )
+                            poll_stack::boxed(|| {
+                                self.terminalize_recovery_attempt(
+                                    &task.id,
+                                    &running_session.agent_type,
+                                    TaskAttemptOutcome::Crashed,
+                                    "session_recovery_stale_ready_state",
+                                    Some(&running_session.id),
+                                    running_session.task_run_id.as_deref(),
+                                    Some(orphan_verdict),
+                                    Some("stale_ready_state_orphan"),
+                                    None,
+                                )
+                            })
                             .await;
                             affected += 1;
                         }
@@ -1961,7 +1984,8 @@ impl CoordinatorActor {
                 // and no background work. Consult the classifier to confirm
                 // this is a dead-orphan reclaim, and to detect concurrent
                 // terminal transitions.
-                let classification = self.classify_task_liveness(&task.id).await;
+                let classification =
+                    poll_stack::boxed(|| self.classify_task_liveness(&task.id)).await;
                 if let Some(ref result) = classification {
                     if result.outcome == Some(LivenessOutcome::KillNoop) {
                         let liveness_repo = LivenessRepository::new(self.db.clone());
@@ -2200,7 +2224,7 @@ impl CoordinatorActor {
                     "",
                     djinn_telemetry::preservation::TRIGGER_TERMINAL_FAIL,
                 );
-                self.log_preservation_result(&result).await;
+                poll_stack::boxed(|| self.log_preservation_result(&result)).await;
                 djinn_telemetry::preservation::increment_attempt(
                     djinn_telemetry::preservation::OUTCOME_RUNTIME_UNAVAILABLE,
                     djinn_telemetry::preservation::TRIGGER_TERMINAL_FAIL,
@@ -2233,7 +2257,7 @@ impl CoordinatorActor {
                 );
             }
         }
-        self.cleanup_pr_and_branch_on_close(&latest, CloseKind::NonMerge)
+        poll_stack::boxed(|| self.cleanup_pr_and_branch_on_close(&latest, CloseKind::NonMerge))
             .await;
         true
     }
@@ -2270,7 +2294,7 @@ impl CoordinatorActor {
         // coordinator) — record an explicit "runtime unavailable" result.
         if self.runtime_ops.is_none() {
             let result = PreservationGateResult::runtime_unavailable(task_id, session_id, trigger);
-            self.log_preservation_result(&result).await;
+            poll_stack::boxed(|| self.log_preservation_result(&result)).await;
             djinn_telemetry::preservation::increment_attempt(
                 djinn_telemetry::preservation::OUTCOME_RUNTIME_UNAVAILABLE,
                 trigger,
@@ -2282,7 +2306,7 @@ impl CoordinatorActor {
         let Some(run_id) = task_run_id else {
             let result =
                 PreservationGateResult::unavailable_worker(task_id, session_id, None, trigger);
-            self.log_preservation_result(&result).await;
+            poll_stack::boxed(|| self.log_preservation_result(&result)).await;
             djinn_telemetry::preservation::increment_attempt(
                 djinn_telemetry::preservation::OUTCOME_UNAVAILABLE_WORKER,
                 trigger,
@@ -2296,7 +2320,7 @@ impl CoordinatorActor {
         } else {
             // No connection registry — treat as runtime unavailable.
             let result = PreservationGateResult::runtime_unavailable(task_id, session_id, trigger);
-            self.log_preservation_result(&result).await;
+            poll_stack::boxed(|| self.log_preservation_result(&result)).await;
             djinn_telemetry::preservation::increment_attempt(
                 djinn_telemetry::preservation::OUTCOME_RUNTIME_UNAVAILABLE,
                 trigger,
@@ -2311,7 +2335,7 @@ impl CoordinatorActor {
                 Some(run_id),
                 trigger,
             );
-            self.log_preservation_result(&result).await;
+            poll_stack::boxed(|| self.log_preservation_result(&result)).await;
             djinn_telemetry::preservation::increment_attempt(
                 djinn_telemetry::preservation::OUTCOME_UNAVAILABLE_WORKER,
                 trigger,
@@ -2346,7 +2370,7 @@ impl CoordinatorActor {
             None, // commit_sha — filled by worker RPC when wired
             None, // ref_name — filled by worker RPC when wired
         );
-        self.log_preservation_result(&result).await;
+        poll_stack::boxed(|| self.log_preservation_result(&result)).await;
         djinn_telemetry::preservation::increment_attempt(
             djinn_telemetry::preservation::OUTCOME_SUCCEEDED,
             trigger,
@@ -2788,17 +2812,19 @@ impl CoordinatorActor {
                         "session exited failed while task nonterminal",
                     )
                 };
-            self.terminalize_recovery_attempt(
-                task_id,
-                role,
-                attempt_outcome,
-                "session_exit_liveness",
-                Some(session_id),
-                task_run_id,
-                Some(result.verdict.as_str()),
-                Some(failure_class),
-                Some(summary),
-            )
+            poll_stack::boxed(|| {
+                self.terminalize_recovery_attempt(
+                    task_id,
+                    role,
+                    attempt_outcome,
+                    "session_exit_liveness",
+                    Some(session_id),
+                    task_run_id,
+                    Some(result.verdict.as_str()),
+                    Some(failure_class),
+                    Some(summary),
+                )
+            })
             .await;
         }
 

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -204,15 +204,17 @@ impl CoordinatorActor {
                     retain_inflight_reservation(task_id, active_task_ids, Some(&live))
                 });
                 for task_id in stale_inflight_task_ids {
-                    self.persist_durable_dispatch_state_update(
-                        &task_id,
-                        None,
-                        "inflight_ledger_reconcile_clear",
-                        DurableDispatchStateUpdate {
-                            inflight: Some(None),
-                            ..Default::default()
-                        },
-                    )
+                    poll_stack::boxed(|| {
+                        self.persist_durable_dispatch_state_update(
+                            &task_id,
+                            None,
+                            "inflight_ledger_reconcile_clear",
+                            DurableDispatchStateUpdate {
+                                inflight: Some(None),
+                                ..Default::default()
+                            },
+                        )
+                    })
                     .await;
                 }
             }
@@ -232,15 +234,17 @@ impl CoordinatorActor {
                     retain_inflight_reservation(task_id, active_task_ids, None)
                 });
                 for task_id in started_task_ids {
-                    self.persist_durable_dispatch_state_update(
-                        &task_id,
-                        None,
-                        "inflight_ledger_session_started_clear",
-                        DurableDispatchStateUpdate {
-                            inflight: Some(None),
-                            ..Default::default()
-                        },
-                    )
+                    poll_stack::boxed(|| {
+                        self.persist_durable_dispatch_state_update(
+                            &task_id,
+                            None,
+                            "inflight_ledger_session_started_clear",
+                            DurableDispatchStateUpdate {
+                                inflight: Some(None),
+                                ..Default::default()
+                            },
+                        )
+                    })
                     .await;
                 }
             }
@@ -305,8 +309,7 @@ impl CoordinatorActor {
                 HashMap::new()
             }
         };
-        self.reconcile_inflight_dispatch_ledger(&active_task_ids)
-            .await;
+        poll_stack::boxed(|| self.reconcile_inflight_dispatch_ledger(&active_task_ids)).await;
         overlay_inflight_ledger(&mut by_model, &self.inflight_dispatches);
         overlay_inflight_lane_ledger(&mut by_lane, &self.inflight_dispatches);
         self.overlay_provisional_admissions(&mut by_model, &mut by_lane);
@@ -328,7 +331,8 @@ impl CoordinatorActor {
         running_by_user_model: &mut HashMap<(String, String), u32>,
         running_by_user_lane: &mut HashMap<(String, djinn_core::models::ModelLane), u32>,
     ) {
-        let (fresh_by_model, fresh_by_lane) = self.effective_running_counts().await;
+        let (fresh_by_model, fresh_by_lane) =
+            poll_stack::boxed(|| self.effective_running_counts()).await;
         *running_by_user_model = fresh_by_model;
         *running_by_user_lane = fresh_by_lane;
     }
@@ -362,15 +366,17 @@ impl CoordinatorActor {
                 self.dispatch_cooldowns.len(),
                 self.inflight_dispatches.len(),
             );
-            self.persist_durable_dispatch_state_update(
-                task_id,
-                task_short_id,
-                "inflight_ledger_insert",
-                DurableDispatchStateUpdate {
-                    inflight: Some(Some((Some(c.to_string()), model.to_string()))),
-                    ..Default::default()
-                },
-            )
+            poll_stack::boxed(|| {
+                self.persist_durable_dispatch_state_update(
+                    task_id,
+                    task_short_id,
+                    "inflight_ledger_insert",
+                    DurableDispatchStateUpdate {
+                        inflight: Some(Some((Some(c.to_string()), model.to_string()))),
+                        ..Default::default()
+                    },
+                )
+            })
             .await;
         }
     }
@@ -474,8 +480,9 @@ impl CoordinatorActor {
         task: &djinn_core::models::Task,
     ) -> crate::WorkerLifecycleMetadata {
         crate::WorkerLifecycleMetadata {
-            checkpoint: self.checkpoint_lifecycle_from_activity(task).await,
-            model_rotation: self.model_rotation_lifecycle_from_activity(task).await,
+            checkpoint: poll_stack::boxed(|| self.checkpoint_lifecycle_from_activity(task)).await,
+            model_rotation: poll_stack::boxed(|| self.model_rotation_lifecycle_from_activity(task))
+                .await,
             ..Default::default()
         }
     }
@@ -645,7 +652,8 @@ impl CoordinatorActor {
         role: &str,
         lane_cap: Option<u32>,
     ) -> bool {
-        let (running_by_model, running_by_lane) = self.effective_running_counts().await;
+        let (running_by_model, running_by_lane) =
+            poll_stack::boxed(|| self.effective_running_counts()).await;
         let lane = djinn_core::models::ModelLane::for_role(role);
         model_under_user_cap(&running_by_model, user, model, model_cap)
             && lane_under_user_cap(&running_by_lane, user, lane, lane_cap)
@@ -669,15 +677,17 @@ impl CoordinatorActor {
                 self.dispatch_cooldowns.len(),
                 self.inflight_dispatches.len(),
             );
-            self.persist_durable_dispatch_state_update(
-                task_id,
-                None,
-                "inflight_ledger_clear",
-                DurableDispatchStateUpdate {
-                    inflight: Some(None),
-                    ..Default::default()
-                },
-            )
+            poll_stack::boxed(|| {
+                self.persist_durable_dispatch_state_update(
+                    task_id,
+                    None,
+                    "inflight_ledger_clear",
+                    DurableDispatchStateUpdate {
+                        inflight: Some(None),
+                        ..Default::default()
+                    },
+                )
+            })
             .await;
         }
     }
@@ -720,8 +730,10 @@ impl CoordinatorActor {
     ) {
         self.provisional_admissions.remove(provisional_key);
         self.inflight_dispatches.remove(provisional_key);
-        self.record_inflight_dispatch(real_task_id, None, Some(creator), model, role)
-            .await;
+        poll_stack::boxed(|| {
+            self.record_inflight_dispatch(real_task_id, None, Some(creator), model, role)
+        })
+        .await;
     }
 
     /// Clear a provisional refinement admission.
@@ -815,17 +827,19 @@ impl CoordinatorActor {
         task_short_id: Option<&str>,
         reason: &str,
     ) {
-        self.persist_durable_dispatch_state_update(
-            task_id,
-            task_short_id,
-            reason,
-            DurableDispatchStateUpdate {
-                failure_streak: Some(0),
-                cooldown_until: Some(None),
-                last_dispatched: Some(None),
-                inflight: Some(None),
-            },
-        )
+        poll_stack::boxed(|| {
+            self.persist_durable_dispatch_state_update(
+                task_id,
+                task_short_id,
+                reason,
+                DurableDispatchStateUpdate {
+                    failure_streak: Some(0),
+                    cooldown_until: Some(None),
+                    last_dispatched: Some(None),
+                    inflight: Some(None),
+                },
+            )
+        })
         .await;
     }
 
@@ -886,7 +900,7 @@ impl CoordinatorActor {
         self.dispatch_cooldowns.remove(task_id);
         self.last_dispatched.remove(task_id);
         self.inflight_dispatches.remove(task_id);
-        self.clear_durable_dispatch_backoff_state(task_id, None, reason)
+        poll_stack::boxed(|| self.clear_durable_dispatch_backoff_state(task_id, None, reason))
             .await;
     }
 
@@ -1296,8 +1310,10 @@ impl CoordinatorActor {
         }
 
         if breaker_open_for_all_candidates {
-            self.apply_breaker_open_exhaustion_backoff(task, role, candidate_models)
-                .await;
+            poll_stack::boxed(|| {
+                self.apply_breaker_open_exhaustion_backoff(task, role, candidate_models)
+            })
+            .await;
             return;
         }
 
@@ -1316,22 +1332,26 @@ impl CoordinatorActor {
         };
 
         if streak >= MAX_DISPATCH_FAILURES {
-            self.terminally_fail_task(
-                task,
-                role,
-                "all failover candidates exhausted after multiple attempts. \
+            poll_stack::boxed(|| {
+                self.terminally_fail_task(
+                    task,
+                    role,
+                    "all failover candidates exhausted after multiple attempts. \
                  The task could not be dispatched to any configured model. \
                  Resolve the underlying issue and reopen.",
-            )
+                )
+            })
             .await;
             self.dispatch_failure_streak.remove(&task.id);
             self.dispatch_cooldowns.remove(&task.id);
             self.inflight_dispatches.remove(&task.id);
-            self.clear_durable_dispatch_backoff_state(
-                &task.id,
-                Some(&task.short_id),
-                "chain_exhaustion_terminal_close_clear",
-            )
+            poll_stack::boxed(|| {
+                self.clear_durable_dispatch_backoff_state(
+                    &task.id,
+                    Some(&task.short_id),
+                    "chain_exhaustion_terminal_close_clear",
+                )
+            })
             .await;
         } else {
             let cooldown = escalating_dispatch_cooldown(streak);
@@ -1345,17 +1365,19 @@ impl CoordinatorActor {
             );
             self.dispatch_cooldowns
                 .insert(task.id.clone(), SystemClock::new().now_instant() + cooldown);
-            self.persist_durable_dispatch_state_update(
-                &task.id,
-                Some(&task.short_id),
-                "chain_exhaustion_backoff",
-                DurableDispatchStateUpdate {
-                    failure_streak: Some(streak),
-                    cooldown_until: Some(dispatch_wall_clock_after(cooldown)),
-                    last_dispatched: Some(None),
-                    ..Default::default()
-                },
-            )
+            poll_stack::boxed(|| {
+                self.persist_durable_dispatch_state_update(
+                    &task.id,
+                    Some(&task.short_id),
+                    "chain_exhaustion_backoff",
+                    DurableDispatchStateUpdate {
+                        failure_streak: Some(streak),
+                        cooldown_until: Some(dispatch_wall_clock_after(cooldown)),
+                        last_dispatched: Some(None),
+                        ..Default::default()
+                    },
+                )
+            })
             .await;
 
             // Single-candidate lanes cannot fail *over* to anything: when the
@@ -1368,12 +1390,14 @@ impl CoordinatorActor {
             // the environment heals.
             if candidate_models.len() == 1 && streak == SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD
             {
-                self.emit_single_candidate_exhaustion_signal(
-                    task,
-                    role,
-                    &candidate_models[0],
-                    streak,
-                )
+                poll_stack::boxed(|| {
+                    self.emit_single_candidate_exhaustion_signal(
+                        task,
+                        role,
+                        &candidate_models[0],
+                        streak,
+                    )
+                })
                 .await;
             }
         }
@@ -1444,21 +1468,25 @@ impl CoordinatorActor {
         // `failure_streak: None` leaves the durable streak untouched — the
         // write-through helper carries the stored value forward. Only the
         // cooldown moves.
-        self.persist_durable_dispatch_state_update(
-            &task.id,
-            Some(&task.short_id),
-            "breaker_open_exhaustion_backoff",
-            DurableDispatchStateUpdate {
-                cooldown_until: Some(dispatch_wall_clock_after(cooldown)),
-                last_dispatched: Some(None),
-                ..Default::default()
-            },
-        )
+        poll_stack::boxed(|| {
+            self.persist_durable_dispatch_state_update(
+                &task.id,
+                Some(&task.short_id),
+                "breaker_open_exhaustion_backoff",
+                DurableDispatchStateUpdate {
+                    cooldown_until: Some(dispatch_wall_clock_after(cooldown)),
+                    last_dispatched: Some(None),
+                    ..Default::default()
+                },
+            )
+        })
         .await;
 
         if streak == BREAKER_OPEN_EXHAUSTION_SIGNAL_THRESHOLD {
-            self.emit_breaker_open_exhaustion_signal(task, role, candidate_models, streak)
-                .await;
+            poll_stack::boxed(|| {
+                self.emit_breaker_open_exhaustion_signal(task, role, candidate_models, streak)
+            })
+            .await;
         }
     }
 
@@ -1742,7 +1770,7 @@ impl CoordinatorActor {
         // PR creation depends on minting installation tokens, which requires
         // GITHUB_APP_ID + private key; without them every dispatch would
         // fail-retry at merge time.
-        if !self.has_github_credentials().await {
+        if !poll_stack::boxed(|| self.has_github_credentials()).await {
             tracing::warn!(
                 "CoordinatorActor: GitHub App not configured (GITHUB_APP_ID unset or \
                  private key missing), skipping dispatch. Configure the App env vars \
@@ -1859,15 +1887,17 @@ impl CoordinatorActor {
             *expiry > prune_now || paused_ready_task_ids.contains(task_id)
         });
         for task_id in expired_cooldown_task_ids {
-            self.persist_durable_dispatch_state_update(
-                &task_id,
-                None,
-                "cooldown_expired_prune",
-                DurableDispatchStateUpdate {
-                    cooldown_until: Some(None),
-                    ..Default::default()
-                },
-            )
+            poll_stack::boxed(|| {
+                self.persist_durable_dispatch_state_update(
+                    &task_id,
+                    None,
+                    "cooldown_expired_prune",
+                    DurableDispatchStateUpdate {
+                        cooldown_until: Some(None),
+                        ..Default::default()
+                    },
+                )
+            })
             .await;
         }
         let expired_last_dispatched_task_ids: Vec<String> = self
@@ -1884,15 +1914,17 @@ impl CoordinatorActor {
                 || paused_ready_task_ids.contains(task_id)
         });
         for task_id in expired_last_dispatched_task_ids {
-            self.persist_durable_dispatch_state_update(
-                &task_id,
-                None,
-                "last_dispatched_expired_prune",
-                DurableDispatchStateUpdate {
-                    last_dispatched: Some(None),
-                    ..Default::default()
-                },
-            )
+            poll_stack::boxed(|| {
+                self.persist_durable_dispatch_state_update(
+                    &task_id,
+                    None,
+                    "last_dispatched_expired_prune",
+                    DurableDispatchStateUpdate {
+                        last_dispatched: Some(None),
+                        ..Default::default()
+                    },
+                )
+            })
             .await;
         }
 
@@ -1965,8 +1997,7 @@ impl CoordinatorActor {
         // between the active-id and count reads is conservatively double-counted
         // for one pass; it is never missed during the handoff. DB rows remain
         // the durable floor across server restarts.
-        self.reconcile_inflight_dispatch_ledger(&active_task_ids)
-            .await;
+        poll_stack::boxed(|| self.reconcile_inflight_dispatch_ledger(&active_task_ids)).await;
         overlay_inflight_ledger(&mut running_by_user_model, &self.inflight_dispatches);
         overlay_inflight_lane_ledger(&mut running_by_user_lane, &self.inflight_dispatches);
         self.overlay_provisional_admissions(&mut running_by_user_model, &mut running_by_user_lane);
@@ -2069,7 +2100,7 @@ impl CoordinatorActor {
             // dispatch a task with no resolved owner. Park it loudly rather than
             // silently consuming org-shared credentials under no identity — this
             // surfaces an ownership regression instead of running ownerless.
-            if self.task_is_ownerless(&task).await {
+            if poll_stack::boxed(|| self.task_is_ownerless(&task)).await {
                 tracing::warn!(
                     task_id = %task.short_id,
                     task_uuid = %task.id,
@@ -2178,7 +2209,7 @@ impl CoordinatorActor {
                      cannot make forward progress by re-running. Escalating for terminal resolution.",
                     task.ci_same_signature_count, head,
                 );
-                self.escalate_to_planner_or_terminally_fail(&task, &reason)
+                poll_stack::boxed(|| self.escalate_to_planner_or_terminally_fail(&task, &reason))
                     .await;
                 continue;
             }
@@ -2274,7 +2305,7 @@ impl CoordinatorActor {
                 pr_rework_signal == Some(super::respawn_guard::PrReworkSignal::MergeConflict);
             if role == "worker"
                 && !is_merge_conflict_rework
-                && self.maybe_intervene_on_stuck_task(&task).await
+                && poll_stack::boxed(|| self.maybe_intervene_on_stuck_task(&task)).await
             {
                 // The planner escalation dispatched a new session (under the
                 // same creator, potentially the same model). Bump the local
@@ -2282,10 +2313,12 @@ impl CoordinatorActor {
                 // reduced capacity — the inflight ledger is already updated
                 // inside dispatch_planner_escalation, but the local
                 // running_by_user_model was seeded before this admission.
-                self.bump_local_cap_for_last_planner_admission(
-                    &mut running_by_user_model,
-                    &mut running_by_user_lane,
-                )
+                poll_stack::boxed(|| {
+                    self.bump_local_cap_for_last_planner_admission(
+                        &mut running_by_user_model,
+                        &mut running_by_user_lane,
+                    )
+                })
                 .await;
                 continue;
             }
@@ -2325,7 +2358,7 @@ impl CoordinatorActor {
                     reappearing,
                     Some(ReappearingDispatch::SameRoleFailure { .. })
                 ) {
-                    self.latest_attempt_strike_decision(&task.id, role).await
+                    poll_stack::boxed(|| self.latest_attempt_strike_decision(&task.id, role)).await
                 } else {
                     None
                 };
@@ -2339,11 +2372,13 @@ impl CoordinatorActor {
                     self.dispatch_failure_streak.remove(&task.id);
                     self.provider_failure_streak.remove(&task.id);
                     self.dispatch_cooldowns.remove(&task.id);
-                    self.clear_durable_dispatch_backoff_state(
-                        &task.id,
-                        Some(&task.short_id),
-                        "environmental_interrupt_no_dispatch_penalty",
-                    )
+                    poll_stack::boxed(|| {
+                        self.clear_durable_dispatch_backoff_state(
+                            &task.id,
+                            Some(&task.short_id),
+                            "environmental_interrupt_no_dispatch_penalty",
+                        )
+                    })
                     .await;
                     tracing::info!(
                         task_id = %task.short_id,
@@ -2407,10 +2442,12 @@ impl CoordinatorActor {
                                 // Bump the local cap to reflect the planner session
                                 // the intervention just dispatched (same as trigger
                                 // B and the stuck-task path).
-                                self.bump_local_cap_for_last_planner_admission(
-                                    &mut running_by_user_model,
-                                    &mut running_by_user_lane,
-                                )
+                                poll_stack::boxed(|| {
+                                    self.bump_local_cap_for_last_planner_admission(
+                                        &mut running_by_user_model,
+                                        &mut running_by_user_lane,
+                                    )
+                                })
                                 .await;
                                 continue;
                             }
@@ -2455,18 +2492,22 @@ impl CoordinatorActor {
                                 self.dispatch_failure_streak.remove(&task.id);
                                 self.provider_failure_streak.remove(&task.id);
                                 self.dispatch_cooldowns.remove(&task.id);
-                                self.clear_durable_dispatch_backoff_state(
-                                    &task.id,
-                                    Some(&task.short_id),
-                                    "cycling_planner_intervention_handoff_clear",
-                                )
+                                poll_stack::boxed(|| {
+                                    self.clear_durable_dispatch_backoff_state(
+                                        &task.id,
+                                        Some(&task.short_id),
+                                        "cycling_planner_intervention_handoff_clear",
+                                    )
+                                })
                                 .await;
                                 // Bump local cap to reflect the planner session the
                                 // intervention just dispatched (same as Trigger A).
-                                self.bump_local_cap_for_last_planner_admission(
-                                    &mut running_by_user_model,
-                                    &mut running_by_user_lane,
-                                )
+                                poll_stack::boxed(|| {
+                                    self.bump_local_cap_for_last_planner_admission(
+                                        &mut running_by_user_model,
+                                        &mut running_by_user_lane,
+                                    )
+                                })
                                 .await;
                                 continue;
                             }
@@ -2478,22 +2519,26 @@ impl CoordinatorActor {
                             // quota window or a provider outage must never terminally
                             // close the task.
                             if !throttle && !transient && next_streak >= MAX_DISPATCH_FAILURES {
-                                self.terminally_fail_task(
+                                poll_stack::boxed(|| {
+                                    self.terminally_fail_task(
                                     &task,
                                     role,
                                     "repeated dispatch failures: the task could not complete after \
                                  multiple attempts. Resolve the underlying issue and reopen.",
                                 )
+                                })
                                 .await;
                                 self.dispatch_failure_streak.remove(&task.id);
                                 self.provider_failure_streak.remove(&task.id);
                                 self.dispatch_cooldowns.remove(&task.id);
                                 self.inflight_dispatches.remove(&task.id);
-                                self.clear_durable_dispatch_backoff_state(
-                                    &task.id,
-                                    Some(&task.short_id),
-                                    "same_role_terminal_close_clear",
-                                )
+                                poll_stack::boxed(|| {
+                                    self.clear_durable_dispatch_backoff_state(
+                                        &task.id,
+                                        Some(&task.short_id),
+                                        "same_role_terminal_close_clear",
+                                    )
+                                })
                                 .await;
                                 continue;
                             }
@@ -2561,19 +2606,21 @@ impl CoordinatorActor {
                                 task.id.clone(),
                                 SystemClock::new().now_instant() + effective_cooldown,
                             );
-                            self.persist_durable_dispatch_state_update(
-                                &task.id,
-                                Some(&task.short_id),
-                                "same_role_failure_backoff",
-                                DurableDispatchStateUpdate {
-                                    failure_streak: Some(stored_streak),
-                                    cooldown_until: Some(dispatch_wall_clock_after(
-                                        effective_cooldown,
-                                    )),
-                                    last_dispatched: Some(None),
-                                    ..Default::default()
-                                },
-                            )
+                            poll_stack::boxed(|| {
+                                self.persist_durable_dispatch_state_update(
+                                    &task.id,
+                                    Some(&task.short_id),
+                                    "same_role_failure_backoff",
+                                    DurableDispatchStateUpdate {
+                                        failure_streak: Some(stored_streak),
+                                        cooldown_until: Some(dispatch_wall_clock_after(
+                                            effective_cooldown,
+                                        )),
+                                        last_dispatched: Some(None),
+                                        ..Default::default()
+                                    },
+                                )
+                            })
                             .await;
                             continue;
                         }
@@ -2581,11 +2628,13 @@ impl CoordinatorActor {
                             self.dispatch_failure_streak.remove(&task.id);
                             self.provider_failure_streak.remove(&task.id);
                             self.dispatch_cooldowns.remove(&task.id);
-                            self.clear_durable_dispatch_backoff_state(
-                                &task.id,
-                                Some(&task.short_id),
-                                "role_transition_dispatch_state_clear",
-                            )
+                            poll_stack::boxed(|| {
+                                self.clear_durable_dispatch_backoff_state(
+                                    &task.id,
+                                    Some(&task.short_id),
+                                    "role_transition_dispatch_state_clear",
+                                )
+                            })
                             .await;
                         }
                     }
@@ -2655,7 +2704,7 @@ impl CoordinatorActor {
             // Degrades to the unfiltered list when exclusion would empty it
             // (only one viable model → plan-lane retry, then park at the bound).
             if role == "worker" && task.intervention_count >= 1 {
-                let history = self.post_intervention_history(&task).await;
+                let history = poll_stack::boxed(|| self.post_intervention_history(&task)).await;
                 let rotation_excluded = history.rotation_excluded_models();
                 if !rotation_excluded.is_empty() {
                     let filtered: Vec<String> = model_ids
@@ -2722,8 +2771,14 @@ impl CoordinatorActor {
             // task. Reorders in place (entries != implementer first, preserving
             // priority); collapses to same-model when nothing else is viable.
             if role == "reviewer" {
-                self.apply_diverse_review_ordering(&task, Some(creator.as_str()), &mut model_ids)
-                    .await;
+                poll_stack::boxed(|| {
+                    self.apply_diverse_review_ordering(
+                        &task,
+                        Some(creator.as_str()),
+                        &mut model_ids,
+                    )
+                })
+                .await;
             }
 
             // Dispatch-time throttle deprioritization: move any model that is
@@ -2804,13 +2859,16 @@ impl CoordinatorActor {
                         .quality_reopen_count(&task.id)
                         .await
                         .unwrap_or(0);
-                    self.park_source_human_review_with_dossier(
-                        &task,
-                        park_reason,
-                        quality_strikes,
-                        Some(dossier),
-                        &serde_json::json!({}),
-                    )
+                    let empty_evidence = serde_json::json!({});
+                    poll_stack::boxed(|| {
+                        self.park_source_human_review_with_dossier(
+                            &task,
+                            park_reason,
+                            quality_strikes,
+                            Some(dossier),
+                            &empty_evidence,
+                        )
+                    })
                     .await;
                     continue;
                 }
@@ -2831,22 +2889,26 @@ impl CoordinatorActor {
                     *s
                 };
                 if streak >= MAX_DISPATCH_FAILURES {
-                    self.terminally_fail_task(
+                    poll_stack::boxed(|| {
+                        self.terminally_fail_task(
                         &task,
                         role,
                         "no model available for this task's owner: none of the role's configured \
                          models have a provider connected for them. Connect a provider/model for \
                          the owner and reopen.",
                     )
+                    })
                     .await;
                     self.dispatch_failure_streak.remove(&task.id);
                     self.dispatch_cooldowns.remove(&task.id);
                     self.inflight_dispatches.remove(&task.id);
-                    self.clear_durable_dispatch_backoff_state(
-                        &task.id,
-                        Some(&task.short_id),
-                        "no_eligible_model_terminal_close_clear",
-                    )
+                    poll_stack::boxed(|| {
+                        self.clear_durable_dispatch_backoff_state(
+                            &task.id,
+                            Some(&task.short_id),
+                            "no_eligible_model_terminal_close_clear",
+                        )
+                    })
                     .await;
                 } else {
                     let cooldown = escalating_dispatch_cooldown(streak);
@@ -2859,17 +2921,19 @@ impl CoordinatorActor {
                     );
                     self.dispatch_cooldowns
                         .insert(task.id.clone(), SystemClock::new().now_instant() + cooldown);
-                    self.persist_durable_dispatch_state_update(
-                        &task.id,
-                        Some(&task.short_id),
-                        "no_eligible_model_backoff",
-                        DurableDispatchStateUpdate {
-                            failure_streak: Some(streak),
-                            cooldown_until: Some(dispatch_wall_clock_after(cooldown)),
-                            last_dispatched: Some(None),
-                            ..Default::default()
-                        },
-                    )
+                    poll_stack::boxed(|| {
+                        self.persist_durable_dispatch_state_update(
+                            &task.id,
+                            Some(&task.short_id),
+                            "no_eligible_model_backoff",
+                            DurableDispatchStateUpdate {
+                                failure_streak: Some(streak),
+                                cooldown_until: Some(dispatch_wall_clock_after(cooldown)),
+                                last_dispatched: Some(None),
+                                ..Default::default()
+                            },
+                        )
+                    })
                     .await;
                 }
                 continue;
@@ -2972,7 +3036,9 @@ impl CoordinatorActor {
                 }
             }
 
-            let Some(project_path) = self.project_path_for_id(&task.project_id).await else {
+            let Some(project_path) =
+                poll_stack::boxed(|| self.project_path_for_id(&task.project_id)).await
+            else {
                 tracing::warn!(task_id = %task.short_id, project_id = %task.project_id, "CoordinatorActor: project path not found, skipping dispatch");
                 continue;
             };
@@ -3112,18 +3178,20 @@ impl CoordinatorActor {
                     // ladder this task was climbing is over — reset it so a
                     // future, unrelated outage starts back at the first rung.
                     self.breaker_open_backoff_streak.remove(&task.id);
-                    self.persist_durable_dispatch_state_update(
-                        &task.id,
-                        Some(&task.short_id),
-                        "successful_dispatch_marker",
-                        DurableDispatchStateUpdate {
-                            cooldown_until: Some(None),
-                            last_dispatched: Some(
-                                dispatch_wall_clock_now().map(|ts| (ts, role.to_owned())),
-                            ),
-                            ..Default::default()
-                        },
-                    )
+                    poll_stack::boxed(|| {
+                        self.persist_durable_dispatch_state_update(
+                            &task.id,
+                            Some(&task.short_id),
+                            "successful_dispatch_marker",
+                            DurableDispatchStateUpdate {
+                                cooldown_until: Some(None),
+                                last_dispatched: Some(
+                                    dispatch_wall_clock_now().map(|ts| (ts, role.to_owned())),
+                                ),
+                                ..Default::default()
+                            },
+                        )
+                    })
                     .await;
                     self.dispatched += 1;
                     // Attempt lifecycle: record the dispatch-start as a
@@ -3176,13 +3244,15 @@ impl CoordinatorActor {
                             // lands (pod boot lags 20-60s). Reconciled against
                             // the live pool at the top of each pass, so it drops
                             // out the moment the task completes.
-                            self.record_inflight_dispatch(
-                                &task.id,
-                                Some(&task.short_id),
-                                Some(c),
-                                used,
-                                role,
-                            )
+                            poll_stack::boxed(|| {
+                                self.record_inflight_dispatch(
+                                    &task.id,
+                                    Some(&task.short_id),
+                                    Some(c),
+                                    used,
+                                    role,
+                                )
+                            })
                             .await;
                         }
                     }
@@ -3241,13 +3311,15 @@ impl CoordinatorActor {
                     // the exhaustion says nothing about this task and must back
                     // off WITHOUT advancing the streak that force-closes at
                     // MAX_DISPATCH_FAILURES.
-                    self.apply_chain_exhaustion_side_effects(
-                        &task,
-                        role,
-                        model_ids,
-                        &exhausted_observations,
-                        breaker_open_for_all_candidates,
-                    )
+                    poll_stack::boxed(|| {
+                        self.apply_chain_exhaustion_side_effects(
+                            &task,
+                            role,
+                            model_ids,
+                            &exhausted_observations,
+                            breaker_open_for_all_candidates,
+                        )
+                    })
                     .await;
                 }
             }

--- a/server/crates/djinn-coordinator/src/dispatch/wave_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/wave_dispatch.rs
@@ -129,8 +129,10 @@ impl CoordinatorActor {
                     .await
                 {
                     Ok(_) => {
-                        self.cleanup_pr_and_branch_on_close(&task, CloseKind::NonMerge)
-                            .await;
+                        poll_stack::boxed(|| {
+                            self.cleanup_pr_and_branch_on_close(&task, CloseKind::NonMerge)
+                        })
+                        .await;
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -216,11 +218,13 @@ impl CoordinatorActor {
             // source of merge-queue rejections. Best-effort: a conflict or any
             // git failure logs and proceeds; `supervisor_pr_open` (and the
             // downstream pr_poller conflict/merge-queue handling) run unchanged.
-            self.proactively_rebase_approved_branch(
-                &task.project_id,
-                &spec.task_branch,
-                &spec.base_branch,
-            )
+            poll_stack::boxed(|| {
+                self.proactively_rebase_approved_branch(
+                    &task.project_id,
+                    &spec.task_branch,
+                    &spec.base_branch,
+                )
+            })
             .await;
 
             let callbacks = crate::supervisor_impl::SupervisorCallbackContext {
@@ -247,13 +251,15 @@ impl CoordinatorActor {
                     // worker attempt as `adopted_pr`. A fresh open leaves the
                     // attempt live — it continues through PR review. Best-effort.
                     if pr_url_existed_before {
-                        self.terminalize_wave_dispatch_attempt(
-                            &task,
-                            WaveDispatchAttemptOutcome::AdoptedPr {
-                                pr_url: &url,
-                                head_sha: &sha,
-                            },
-                        )
+                        poll_stack::boxed(|| {
+                            self.terminalize_wave_dispatch_attempt(
+                                &task,
+                                WaveDispatchAttemptOutcome::AdoptedPr {
+                                    pr_url: &url,
+                                    head_sha: &sha,
+                                },
+                            )
+                        })
                         .await;
                     }
                 }
@@ -272,13 +278,15 @@ impl CoordinatorActor {
                     // stops here — the task is closed without a PR. Terminalize
                     // as `handoff` (another process — the close itself — takes
                     // over). Best-effort.
-                    self.terminalize_wave_dispatch_attempt(
-                        &task,
-                        WaveDispatchAttemptOutcome::Handoff {
-                            reason: &reason,
-                            replacement: "task_closed_no_commits",
-                        },
-                    )
+                    poll_stack::boxed(|| {
+                        self.terminalize_wave_dispatch_attempt(
+                            &task,
+                            WaveDispatchAttemptOutcome::Handoff {
+                                reason: &reason,
+                                replacement: "task_closed_no_commits",
+                            },
+                        )
+                    })
                     .await;
                 }
                 djinn_runtime::TaskRunOutcome::Failed { stage, reason, .. } => {
@@ -348,11 +356,13 @@ impl CoordinatorActor {
                             error = %reason,
                             "CoordinatorActor: PR push rejected (oversized blob in history) — escalating to Planner to rewrite history"
                         );
-                        self.dispatch_planner_escalation(
-                            &task.id,
-                            &escalation_reason,
-                            &task.project_id,
-                        )
+                        poll_stack::boxed(|| {
+                            self.dispatch_planner_escalation(
+                                &task.id,
+                                &escalation_reason,
+                                &task.project_id,
+                            )
+                        })
                         .await;
                         if let Err(e) = repo
                             .transition(
@@ -379,13 +389,15 @@ impl CoordinatorActor {
                         // push was rejected by GitHub for a non-transient reason
                         // (oversized blob in branch history). Terminalize the
                         // current worker attempt as `force_closed`. Best-effort.
-                        self.terminalize_wave_dispatch_attempt(
-                            &task,
-                            WaveDispatchAttemptOutcome::ForceClosed {
-                                reason: &reason,
-                                close_reason: "oversized_blob_in_branch_history",
-                            },
-                        )
+                        poll_stack::boxed(|| {
+                            self.terminalize_wave_dispatch_attempt(
+                                &task,
+                                WaveDispatchAttemptOutcome::ForceClosed {
+                                    reason: &reason,
+                                    close_reason: "oversized_blob_in_branch_history",
+                                },
+                            )
+                        })
                         .await;
                     } else if branch_missing && task.pr_url.is_none() {
                         tracing::warn!(
@@ -421,10 +433,12 @@ impl CoordinatorActor {
                         // this reopen — honoring #1719's invariant that every
                         // rework reopen leaves a `reopened` latest attempt.
                         // Best-effort.
-                        self.terminalize_wave_dispatch_attempt(
-                            &task,
-                            WaveDispatchAttemptOutcome::Reopened { reason: &reason },
-                        )
+                        poll_stack::boxed(|| {
+                            self.terminalize_wave_dispatch_attempt(
+                                &task,
+                                WaveDispatchAttemptOutcome::Reopened { reason: &reason },
+                            )
+                        })
                         .await;
                     } else if task.pr_url.is_some() {
                         tracing::info!(
@@ -462,13 +476,15 @@ impl CoordinatorActor {
                     // the current worker attempt and re-routed the task to
                     // another process (remediation or a fresh worker round).
                     // Terminalize as `handoff`. Best-effort.
-                    self.terminalize_wave_dispatch_attempt(
-                        &task,
-                        WaveDispatchAttemptOutcome::Handoff {
-                            reason: &reason,
-                            replacement: "pre_pr_gate_rerouted",
-                        },
-                    )
+                    poll_stack::boxed(|| {
+                        self.terminalize_wave_dispatch_attempt(
+                            &task,
+                            WaveDispatchAttemptOutcome::Handoff {
+                                reason: &reason,
+                                replacement: "pre_pr_gate_rerouted",
+                            },
+                        )
+                    })
                     .await;
                 }
                 other => {

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -146,6 +146,7 @@ mod evidence_lifecycle_state;
 pub mod handle;
 mod health;
 pub mod messages;
+pub(crate) mod poll_stack;
 pub mod pr_poller;
 mod recover_terminal_linked_spike_evidence;
 mod reentrance;

--- a/server/crates/djinn-coordinator/src/poll_stack.rs
+++ b/server/crates/djinn-coordinator/src/poll_stack.rs
@@ -1,0 +1,72 @@
+//! Heap detours for the coordinator's deeply nested `async fn` chain.
+//!
+//! # Why this module exists
+//!
+//! `CoordinatorActor::run` is the root of an eight-deep chain of nested
+//! `async fn`s (`run` → `run_dispatch_loop` → `run_pass_with_watchdog` →
+//! `run_tick` → `dispatch_ready_tasks` → …), and every link is polled inside
+//! the frame of the link above it. That is fine in a release build, but the
+//! debug/test profile is compiled at `opt-level = 0`, where LLVM does **not**
+//! run its stack-colouring pass: every `alloca` in a function gets its own
+//! distinct stack slot, and none are ever reused.
+//!
+//! For an `async fn` that is the difference between a small frame and an
+//! enormous one. Awaiting a sub-future costs the enclosing coroutine's poll
+//! frame **two** slots the size of that sub-future — one to build it in, one to
+//! move it into the coroutine state — and, with no reuse, those slots are
+//! summed over *every* `await` in the body rather than overlapped. A pass with
+//! thirty awaits therefore reserves roughly `2 × Σ size_of(sub-future)` bytes of
+//! stack, and the chain multiplies out: measured on `main`, one poll of the 30s
+//! tick consumed 2,210,352 bytes — 105% of tokio's 2 MiB worker stack — and the
+//! worst-case path through the actor reached 3,666,896 bytes (175%). The
+//! `--lib` test suite aborted with `has overflowed its stack`.
+//!
+//! # Why [`boxed`] takes a closure
+//!
+//! The obvious fix, `Box::pin(self.dispatch_ready_tasks(None)).await`, only
+//! halves the cost. `Box::pin` takes its argument **by value**, so the caller
+//! still has to materialise the whole sub-future in one of its own stack slots
+//! before handing it over; only the second slot (the copy into the coroutine
+//! state) is saved. Measured on a synthetic ten-await chain: 451,336 → 226,296
+//! bytes.
+//!
+//! Passing a *thunk* instead moves the construction into [`boxed`]'s own frame.
+//! The caller only ever materialises the closure (a couple of captured
+//! references) and receives back a 16-byte fat pointer, so its frame stops
+//! scaling with the size of what it awaits entirely — the same synthetic chain
+//! drops to 536 bytes. [`boxed`]'s frame does hold the sub-future while it is
+//! being constructed, but that frame is popped before the returned future is
+//! ever polled, so it never stacks with the poll chain underneath it.
+//!
+//! # When to use it
+//!
+//! At the *nesting points*: an `await` on another sizeable coordinator pass.
+//! It is not worth applying to small leaf awaits — each call costs one heap
+//! allocation, and the frames that matter are the ones that nest.
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// Await a coordinator sub-pass on the heap instead of in the caller's poll
+/// frame.
+///
+/// `make` is called immediately; the future it returns is boxed inside *this*
+/// function's stack frame, which is gone by the time the caller polls the
+/// result. See the [module docs](self) for why this takes a closure rather
+/// than the future itself.
+///
+/// ```ignore
+/// // before: costs run_tick's poll frame 2 × size_of(dispatch_ready_tasks future)
+/// self.dispatch_ready_tasks(None).await;
+/// // after: costs it 16 bytes
+/// poll_stack::boxed(|| self.dispatch_ready_tasks(None)).await;
+/// ```
+pub(crate) fn boxed<'a, T, F>(
+    make: impl FnOnce() -> F,
+) -> Pin<Box<dyn Future<Output = T> + Send + 'a>>
+where
+    T: 'a,
+    F: Future<Output = T> + Send + 'a,
+{
+    Box::pin(make())
+}

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_helpers.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_helpers.rs
@@ -243,16 +243,18 @@ impl CoordinatorActor {
         // Set last_remediation_base_sha to the current failing head so later
         // submit handling can compare against that baseline.
         let blocking_names: Vec<String> = blocking.iter().map(|cr| cr.name.clone()).collect();
-        self.persist_ci_snapshot(
-            task_id,
-            pull_number,
-            current_sha,
-            CiStatus::Failing,
-            blocking_names,
-            Some(fingerprint.clone()),
-            total_consecutive,
-            Some(current_sha.to_owned()),
-        )
+        poll_stack::boxed(|| {
+            self.persist_ci_snapshot(
+                task_id,
+                pull_number,
+                current_sha,
+                CiStatus::Failing,
+                blocking_names,
+                Some(fingerprint.clone()),
+                total_consecutive,
+                Some(current_sha.to_owned()),
+            )
+        })
         .await;
 
         // ── Emit divergence-aware activity event when strike is suppressed ────
@@ -372,13 +374,15 @@ impl CoordinatorActor {
                          all reproduction-context fetches failed; escalating generically"
                     );
                     let sections_text = ci_failure_sections.join("\n");
-                    self.route_planner_intervention(
-                        task,
-                        "worker",
-                        &reason,
-                        Some(&sections_text),
-                        task.reopen_count,
-                    )
+                    poll_stack::boxed(|| {
+                        self.route_planner_intervention(
+                            task,
+                            "worker",
+                            &reason,
+                            Some(&sections_text),
+                            task.reopen_count,
+                        )
+                    })
                     .await;
                 }
                 SameSignatureEscalationRoute::UnreproducibleIntervention => {
@@ -403,8 +407,15 @@ impl CoordinatorActor {
                     // Create a HumanReview remediation task with the
                     // unreproducible reason.  No Planner dispatch — a human
                     // must resolve it.
-                    self.escalate_ci_failure_and_park(task, pr_url, &reason, &ci_failure_sections)
-                        .await;
+                    poll_stack::boxed(|| {
+                        self.escalate_ci_failure_and_park(
+                            task,
+                            pr_url,
+                            &reason,
+                            &ci_failure_sections,
+                        )
+                    })
+                    .await;
                 }
                 SameSignatureEscalationRoute::ReproductionPlan => {
                     // At least one reproducible bundle: build a focused
@@ -430,8 +441,15 @@ impl CoordinatorActor {
                     // plan as the reason.  This parks the source on the blocker
                     // without dispatching a Planner (no scope reshape for
                     // ordinary reproduced CI loops).
-                    self.escalate_ci_failure_and_park(task, pr_url, &reason, &ci_failure_sections)
-                        .await;
+                    poll_stack::boxed(|| {
+                        self.escalate_ci_failure_and_park(
+                            task,
+                            pr_url,
+                            &reason,
+                            &ci_failure_sections,
+                        )
+                    })
+                    .await;
                 }
             }
             return true;
@@ -493,25 +511,29 @@ impl CoordinatorActor {
                 failing_crates = failing_crates.join(", "),
             );
             let sections_text = ci_failure_sections.join("\n");
-            self.route_planner_intervention(
-                task,
-                "worker",
-                &reason,
-                Some(&sections_text),
-                task.reopen_count,
-            )
+            poll_stack::boxed(|| {
+                self.route_planner_intervention(
+                    task,
+                    "worker",
+                    &reason,
+                    Some(&sections_text),
+                    task.reopen_count,
+                )
+            })
             .await;
-            self.terminalize_for_pr_outcome(
-                task_id,
-                djinn_core::models::task_attempt::TaskAttemptOutcome::Reopened,
-                Some(&TransitionAction::PrCiFailed),
-                Some(&reason),
-            )
+            poll_stack::boxed(|| {
+                self.terminalize_for_pr_outcome(
+                    task_id,
+                    djinn_core::models::task_attempt::TaskAttemptOutcome::Reopened,
+                    Some(&TransitionAction::PrCiFailed),
+                    Some(&reason),
+                )
+            })
             .await;
             // Park the source to `open` so it is held by the blocker the
             // intervention added (not left in pr_draft/pr_review) and revivable
             // when the remediation closes.
-            self.park_source_open(task_id, &reason).await;
+            poll_stack::boxed(|| self.park_source_open(task_id, &reason)).await;
             return true;
         }
         // If Some(false): normal worker bug, fall through to existing retry path.
@@ -541,8 +563,10 @@ impl CoordinatorActor {
                     sha = %current_sha,
                     "PR poller: CI failed but branch is diff-empty vs base — escalating + parking (held on remediation blocker)"
                 );
-                self.escalate_ci_failure_and_park(task, pr_url, &reason, &ci_failure_sections)
-                    .await;
+                poll_stack::boxed(|| {
+                    self.escalate_ci_failure_and_park(task, pr_url, &reason, &ci_failure_sections)
+                })
+                .await;
                 return true;
             }
             Ok(_) => {}
@@ -600,8 +624,10 @@ impl CoordinatorActor {
                 threshold = PR_CI_FAILURE_THRESHOLD,
                 "PR poller: CI-failure rework threshold exceeded — escalating + parking (held on remediation blocker)"
             );
-            self.escalate_ci_failure_and_park(task, pr_url, &reason, &ci_failure_sections)
-                .await;
+            poll_stack::boxed(|| {
+                self.escalate_ci_failure_and_park(task, pr_url, &reason, &ci_failure_sections)
+            })
+            .await;
             return true;
         }
 
@@ -636,11 +662,13 @@ impl CoordinatorActor {
             round,
             PR_CI_FAILURE_THRESHOLD,
         );
-        self.apply_pr_transition(
-            task_id,
-            TransitionAction::PrCiFailed,
-            Some("CI checks failed on PR"),
-        )
+        poll_stack::boxed(|| {
+            self.apply_pr_transition(
+                task_id,
+                TransitionAction::PrCiFailed,
+                Some("CI checks failed on PR"),
+            )
+        })
         .await;
         // Non-required failures ride along as informational context so the
         // rework worker knows about them without treating them as blockers.
@@ -651,16 +679,18 @@ impl CoordinatorActor {
             .filter(|cr| !blocking_names.contains(cr.name.as_str()))
             .copied()
             .collect();
-        self.log_ci_failure_comment(
-            task_id,
-            &blocking,
-            &advisory,
-            pr_url,
-            current_sha,
-            gh_client,
-            owner,
-            repo,
-        )
+        poll_stack::boxed(|| {
+            self.log_ci_failure_comment(
+                task_id,
+                &blocking,
+                &advisory,
+                pr_url,
+                current_sha,
+                gh_client,
+                owner,
+                repo,
+            )
+        })
         .await;
         true
     }
@@ -681,12 +711,14 @@ impl CoordinatorActor {
     ) {
         let task_repo = self.task_repo();
 
-        self.terminalize_for_pr_outcome(
-            &task.id,
-            djinn_core::models::task_attempt::TaskAttemptOutcome::Reopened,
-            Some(&TransitionAction::PrCiFailed),
-            Some(reason),
-        )
+        poll_stack::boxed(|| {
+            self.terminalize_for_pr_outcome(
+                &task.id,
+                djinn_core::models::task_attempt::TaskAttemptOutcome::Reopened,
+                Some(&TransitionAction::PrCiFailed),
+                Some(reason),
+            )
+        })
         .await;
 
         // Fold the merge-queue lane facts (run id, failing checks,
@@ -774,7 +806,7 @@ impl CoordinatorActor {
         // parking the source, so the open task is never dispatchable without its
         // blocker; when the ceiling is reached it ForceCloses the source instead
         // (which releases its blockers) and does NOT park.
-        self.escalate_to_planner_or_terminally_fail(task, &enriched_reason)
+        poll_stack::boxed(|| self.escalate_to_planner_or_terminally_fail(task, &enriched_reason))
             .await;
         self.pr_status_cache.remove(&task.id);
         self.pr_draft_first_seen.remove(&task.id);
@@ -794,8 +826,10 @@ impl CoordinatorActor {
     /// without its blocker. Once parked, `list_ready` filters it out (blocked)
     /// and `emit_unblocked_tasks` revives it when the remediation closes.
     pub(crate) async fn park_source_open(&self, task_id: &str, reason: &str) {
-        self.apply_pr_transition(task_id, TransitionAction::ParkForRemediation, Some(reason))
-            .await;
+        poll_stack::boxed(|| {
+            self.apply_pr_transition(task_id, TransitionAction::ParkForRemediation, Some(reason))
+        })
+        .await;
     }
 
     /// Resolve the merge methods this repository actually permits, in Djinn's

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_review_watcher.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_review_watcher.rs
@@ -75,26 +75,30 @@ impl CoordinatorActor {
                     );
                     // Record `unknown` for existing snapshot.
                     let pr_number = pull_number as i64;
-                    self.record_ci_snapshot_unavailable(&task.id, &task.short_id, pr_number)
-                        .await;
+                    poll_stack::boxed(|| {
+                        self.record_ci_snapshot_unavailable(&task.id, &task.short_id, pr_number)
+                    })
+                    .await;
                     continue;
                 }
             };
 
             // ── Record CI snapshot (sole writer for GitHub-derived fields) ──
             let pr_number_i64 = pull_number as i64;
-            self.record_ci_snapshot(
-                &task.id,
-                &task.short_id,
-                pr_number_i64,
-                &pr.head.sha,
-                &pr.base.ref_name,
-                pull_number,
-                gh_client,
-                &owner,
-                &repo,
-                &checks,
-            )
+            poll_stack::boxed(|| {
+                self.record_ci_snapshot(
+                    &task.id,
+                    &task.short_id,
+                    pr_number_i64,
+                    &pr.head.sha,
+                    &pr.base.ref_name,
+                    pull_number,
+                    gh_client,
+                    &owner,
+                    &repo,
+                    &checks,
+                )
+            })
             .await;
 
             let current_sha = pr.head.sha.clone();
@@ -106,18 +110,21 @@ impl CoordinatorActor {
                     pr = pull_number,
                     "PR poller: PR merged → closing task"
                 );
-                let durable_review = self.durable_pr_review_verdict(pr_url).await;
+                let durable_review =
+                    poll_stack::boxed(|| self.durable_pr_review_verdict(pr_url)).await;
                 let (review, merge_queue) = merged_review_outcome(
                     durable_review.as_deref(),
                     self.delegated_to_github.contains_key(&task.id),
                 );
-                self.apply_pr_merge(
-                    &task.id,
-                    pr_url,
-                    pr.merge_commit_sha.as_deref(),
-                    Some(review),
-                    merge_queue,
-                )
+                poll_stack::boxed(|| {
+                    self.apply_pr_merge(
+                        &task.id,
+                        pr_url,
+                        pr.merge_commit_sha.as_deref(),
+                        Some(review),
+                        merge_queue,
+                    )
+                })
                 .await;
                 self.pr_status_cache.remove(&task.id);
                 self.review_stuck_sha_first_seen.remove(&task.id);
@@ -134,11 +141,13 @@ impl CoordinatorActor {
                     pr = pull_number,
                     "PR poller: PR closed without merge → force-closing task"
                 );
-                self.apply_pr_transition(
-                    &task.id,
-                    TransitionAction::ForceClose,
-                    Some("PR was closed without merging"),
-                )
+                poll_stack::boxed(|| {
+                    self.apply_pr_transition(
+                        &task.id,
+                        TransitionAction::ForceClose,
+                        Some("PR was closed without merging"),
+                    )
+                })
                 .await;
                 self.pr_status_cache.remove(&task.id);
                 self.review_stuck_sha_first_seen.remove(&task.id);
@@ -198,8 +207,10 @@ impl CoordinatorActor {
                 };
 
                 // Attach feedback + handle escalation threshold.
-                self.attach_pr_review_feedback(&task.id, &task.short_id, feedback)
-                    .await;
+                poll_stack::boxed(|| {
+                    self.attach_pr_review_feedback(&task.id, &task.short_id, feedback)
+                })
+                .await;
 
                 // Evaluate CI in the same tick so changes-requested AND
                 // failing required checks surface together. Use
@@ -243,16 +254,18 @@ impl CoordinatorActor {
                         // (the reviewer's request is the primary driver).
                         let snap_blocking_names: Vec<String> =
                             blocking.iter().map(|cr| cr.name.clone()).collect();
-                        self.persist_ci_snapshot(
-                            &task.id,
-                            pull_number,
-                            &current_sha,
-                            CiStatus::Failing,
-                            snap_blocking_names,
-                            None,
-                            0,
-                            None,
-                        )
+                        poll_stack::boxed(|| {
+                            self.persist_ci_snapshot(
+                                &task.id,
+                                pull_number,
+                                &current_sha,
+                                CiStatus::Failing,
+                                snap_blocking_names,
+                                None,
+                                0,
+                                None,
+                            )
+                        })
                         .await;
                         tracing::info!(
                             task_id = %task.short_id,
@@ -265,16 +278,18 @@ impl CoordinatorActor {
                     // driven reopen below still spawns a worker — give it the
                     // advisory list as context rather than nothing.
                     if !blocking.is_empty() || !advisory.is_empty() {
-                        self.log_ci_failure_comment(
-                            &task.id,
-                            &blocking,
-                            &advisory,
-                            pr_url,
-                            &current_sha,
-                            gh_client,
-                            &owner,
-                            &repo,
-                        )
+                        poll_stack::boxed(|| {
+                            self.log_ci_failure_comment(
+                                &task.id,
+                                &blocking,
+                                &advisory,
+                                pr_url,
+                                &current_sha,
+                                gh_client,
+                                &owner,
+                                &repo,
+                            )
+                        })
                         .await;
                     }
                 }
@@ -283,20 +298,24 @@ impl CoordinatorActor {
                 // level so the live submit-work guard can detect no-progress
                 // resubmissions across task runs after a PR reviewer requests
                 // changes.
-                self.record_pr_rejection_fingerprint(&task.id).await;
+                poll_stack::boxed(|| self.record_pr_rejection_fingerprint(&task.id)).await;
 
-                self.record_pr_outcome_facts(
-                    pr_url,
-                    Some("rejected"),
-                    None,
-                    Some("review_rejected"),
-                )
+                poll_stack::boxed(|| {
+                    self.record_pr_outcome_facts(
+                        pr_url,
+                        Some("rejected"),
+                        None,
+                        Some("review_rejected"),
+                    )
+                })
                 .await;
-                self.apply_pr_transition(
-                    &task.id,
-                    TransitionAction::PrChangesRequested,
-                    Some("Reviewer requested changes on PR"),
-                )
+                poll_stack::boxed(|| {
+                    self.apply_pr_transition(
+                        &task.id,
+                        TransitionAction::PrChangesRequested,
+                        Some("Reviewer requested changes on PR"),
+                    )
+                })
                 .await;
                 self.pr_status_cache.remove(&task.id);
                 self.review_stuck_sha_first_seen.remove(&task.id);
@@ -379,16 +398,18 @@ impl CoordinatorActor {
                 // fast path (`poll_pr_draft_tasks`).
                 self.pr_status_cache
                     .insert(task.id.clone(), current_sha.clone());
-                self.persist_ci_snapshot(
-                    &task.id,
-                    pull_number,
-                    &current_sha,
-                    CiStatus::Passing,
-                    vec![],
-                    None,
-                    0,
-                    None,
-                )
+                poll_stack::boxed(|| {
+                    self.persist_ci_snapshot(
+                        &task.id,
+                        pull_number,
+                        &current_sha,
+                        CiStatus::Passing,
+                        vec![],
+                        None,
+                        0,
+                        None,
+                    )
+                })
                 .await;
             } else if (sha_changed || !self.pr_status_cache.contains_key(&task.id))
                 && !checks.check_runs.is_empty()
@@ -443,29 +464,33 @@ impl CoordinatorActor {
                     self.pr_status_cache
                         .insert(task.id.clone(), current_sha.clone());
                     // All required checks passed (or only advisory failed).
-                    self.persist_ci_snapshot(
-                        &task.id,
-                        pull_number,
-                        &current_sha,
-                        CiStatus::Passing,
-                        vec![],
-                        None,
-                        0,
-                        None,
-                    )
+                    poll_stack::boxed(|| {
+                        self.persist_ci_snapshot(
+                            &task.id,
+                            pull_number,
+                            &current_sha,
+                            CiStatus::Passing,
+                            vec![],
+                            None,
+                            0,
+                            None,
+                        )
+                    })
                     .await;
                 } else {
                     // Checks still running — persist pending status.
-                    self.persist_ci_snapshot(
-                        &task.id,
-                        pull_number,
-                        &current_sha,
-                        CiStatus::Pending,
-                        vec![],
-                        None,
-                        0,
-                        None,
-                    )
+                    poll_stack::boxed(|| {
+                        self.persist_ci_snapshot(
+                            &task.id,
+                            pull_number,
+                            &current_sha,
+                            CiStatus::Pending,
+                            vec![],
+                            None,
+                            0,
+                            None,
+                        )
+                    })
                     .await;
                 }
             }
@@ -499,12 +524,14 @@ impl CoordinatorActor {
                 let reason = self
                     .build_pr_conflict_reason(&task.short_id, &task.project_id)
                     .await;
-                self.apply_pr_transition(&task.id, TransitionAction::PrConflict, Some(&reason))
-                    .await;
+                poll_stack::boxed(|| {
+                    self.apply_pr_transition(&task.id, TransitionAction::PrConflict, Some(&reason))
+                })
+                .await;
                 // Reactive auto-blocker: if exactly one racing same-epic sibling
                 // is landing on main, make this task WAIT for it (beside the
                 // reopen above) instead of looping on the moving main.
-                self.add_conflict_blocker_for_sibling(&task).await;
+                poll_stack::boxed(|| self.add_conflict_blocker_for_sibling(&task)).await;
                 self.pr_status_cache.remove(&task.id);
                 self.review_stuck_sha_first_seen.remove(&task.id);
                 self.merge_fail_count.remove(&task.id);
@@ -524,14 +551,16 @@ impl CoordinatorActor {
             if has_reviews && !has_approved {
                 // Merge-gating reviews exist but none APPROVED (and no CHANGES_REQUESTED
                 // handled above). Wait for approval.
-                self.maybe_re_request_review(
-                    &task.id,
-                    &task.short_id,
-                    gh_client,
-                    &owner,
-                    &repo,
-                    pull_number,
-                )
+                poll_stack::boxed(|| {
+                    self.maybe_re_request_review(
+                        &task.id,
+                        &task.short_id,
+                        gh_client,
+                        &owner,
+                        &repo,
+                        pull_number,
+                    )
+                })
                 .await;
                 continue;
             }
@@ -755,18 +784,20 @@ impl CoordinatorActor {
                 .get(&task.id)
                 .is_some_and(|sha| sha == &current_sha);
             if pr.auto_merge.is_some() || delegated_for_current_sha {
-                self.observe_auto_merge_state(
-                    gh_client,
-                    &task.id,
-                    &task.short_id,
-                    pr_url,
-                    &owner,
-                    &repo,
-                    pull_number,
-                    &pr.node_id,
-                    has_approved,
-                    &current_sha,
-                )
+                poll_stack::boxed(|| {
+                    self.observe_auto_merge_state(
+                        gh_client,
+                        &task.id,
+                        &task.short_id,
+                        pr_url,
+                        &owner,
+                        &repo,
+                        pull_number,
+                        &pr.node_id,
+                        has_approved,
+                        &current_sha,
+                    )
+                })
                 .await;
                 continue;
             }
@@ -832,13 +863,15 @@ impl CoordinatorActor {
                         sha = merge_commit_sha.as_deref().unwrap_or("<unknown>"),
                         "PR poller: merge succeeded → closing task"
                     );
-                    self.apply_pr_merge(
-                        &task.id,
-                        pr_url,
-                        merge_commit_sha.as_deref(),
-                        Some(delegated_review_verdict(has_approved)),
-                        "not_applicable",
-                    )
+                    poll_stack::boxed(|| {
+                        self.apply_pr_merge(
+                            &task.id,
+                            pr_url,
+                            merge_commit_sha.as_deref(),
+                            Some(delegated_review_verdict(has_approved)),
+                            "not_applicable",
+                        )
+                    })
                     .await;
                     self.pr_status_cache.remove(&task.id);
                     self.review_stuck_sha_first_seen.remove(&task.id);
@@ -870,12 +903,14 @@ impl CoordinatorActor {
                                 // fetched. Preserve this authoritative decision
                                 // now through the unique PR-to-attempt association;
                                 // apply_pr_merge will add `passed` to that run.
-                                self.record_pr_outcome_facts(
-                                    pr_url,
-                                    Some(delegated_review_verdict(has_approved)),
-                                    None,
-                                    None,
-                                )
+                                poll_stack::boxed(|| {
+                                    self.record_pr_outcome_facts(
+                                        pr_url,
+                                        Some(delegated_review_verdict(has_approved)),
+                                        None,
+                                        None,
+                                    )
+                                })
                                 .await;
                                 self.merge_fail_count.remove(&task.id);
                             }
@@ -900,12 +935,14 @@ impl CoordinatorActor {
                                 // Adoption is the same delegated lifecycle
                                 // boundary as enqueue: retain the review outcome
                                 // before a later merged poll loses this snapshot.
-                                self.record_pr_outcome_facts(
-                                    pr_url,
-                                    Some(delegated_review_verdict(has_approved)),
-                                    None,
-                                    None,
-                                )
+                                poll_stack::boxed(|| {
+                                    self.record_pr_outcome_facts(
+                                        pr_url,
+                                        Some(delegated_review_verdict(has_approved)),
+                                        None,
+                                        None,
+                                    )
+                                })
                                 .await;
                                 self.merge_fail_count.remove(&task.id);
                             }
@@ -997,8 +1034,10 @@ impl CoordinatorActor {
                                  protection), not something a code change can fix — escalating for \
                                  intervention instead of retrying forever."
                             );
-                            self.escalate_to_planner_or_terminally_fail(&task, &reason)
-                                .await;
+                            poll_stack::boxed(|| {
+                                self.escalate_to_planner_or_terminally_fail(&task, &reason)
+                            })
+                            .await;
                             self.pr_status_cache.remove(&task.id);
                             self.review_stuck_sha_first_seen.remove(&task.id);
                             self.merge_fail_count.remove(&task.id);

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs
@@ -5,9 +5,9 @@ use djinn_core::models::CiStatus;
 impl CoordinatorActor {
     pub(crate) async fn poll_pr_statuses(&mut self) {
         // Polling has no request token; each task uses its GitHub App installation token.
-        self.poll_pr_draft_tasks().await;
-        self.poll_pr_review_tasks().await;
-        self.poll_pr_review_stuck_tasks().await;
+        poll_stack::boxed(|| self.poll_pr_draft_tasks()).await;
+        poll_stack::boxed(|| self.poll_pr_review_tasks()).await;
+        poll_stack::boxed(|| self.poll_pr_review_stuck_tasks()).await;
     }
 
     // ── pr_draft polling (CI monitoring) ─────────────────────────────────────
@@ -103,8 +103,10 @@ impl CoordinatorActor {
                     // tasks see updated observation timestamps without
                     // escalating to remediation.
                     let pr_number = pull_number as i64;
-                    self.record_ci_snapshot_unavailable(&task.id, &task.short_id, pr_number)
-                        .await;
+                    poll_stack::boxed(|| {
+                        self.record_ci_snapshot_unavailable(&task.id, &task.short_id, pr_number)
+                    })
+                    .await;
                     continue;
                 }
             };
@@ -146,13 +148,15 @@ impl CoordinatorActor {
                     pr = pull_number,
                     "PR poller: PR merged → closing task"
                 );
-                self.apply_pr_merge(
-                    &task.id,
-                    task.pr_url.as_deref().unwrap_or_default(),
-                    pr.merge_commit_sha.as_deref(),
-                    Some("not_applicable"),
-                    "not_applicable",
-                )
+                poll_stack::boxed(|| {
+                    self.apply_pr_merge(
+                        &task.id,
+                        task.pr_url.as_deref().unwrap_or_default(),
+                        pr.merge_commit_sha.as_deref(),
+                        Some("not_applicable"),
+                        "not_applicable",
+                    )
+                })
                 .await;
                 self.pr_status_cache.remove(&task.id);
                 self.pr_draft_first_seen.remove(&task.id);
@@ -167,11 +171,13 @@ impl CoordinatorActor {
                     pr = pull_number,
                     "PR poller: PR closed without merge → force-closing task"
                 );
-                self.apply_pr_transition(
-                    &task.id,
-                    TransitionAction::ForceClose,
-                    Some("PR was closed without merging"),
-                )
+                poll_stack::boxed(|| {
+                    self.apply_pr_transition(
+                        &task.id,
+                        TransitionAction::ForceClose,
+                        Some("PR was closed without merging"),
+                    )
+                })
                 .await;
                 self.pr_status_cache.remove(&task.id);
                 self.pr_draft_first_seen.remove(&task.id);
@@ -190,16 +196,18 @@ impl CoordinatorActor {
                     // remediation attempt here is what burned six sessions on
                     // task `tlu1`: agents were sent to fix code that had never
                     // been shown to be broken.
-                    self.retrigger_inconclusive_run(
-                        gh_client,
-                        &task.id,
-                        &task.short_id,
-                        &pr.head.sha,
-                        &owner,
-                        &repo,
-                        pull_number,
-                        &checks,
-                    )
+                    poll_stack::boxed(|| {
+                        self.retrigger_inconclusive_run(
+                            gh_client,
+                            &task.id,
+                            &task.short_id,
+                            &pr.head.sha,
+                            &owner,
+                            &repo,
+                            pull_number,
+                            &checks,
+                        )
+                    })
                     .await;
                     continue;
                 }
@@ -211,16 +219,18 @@ impl CoordinatorActor {
                             pr = pull_number,
                             "PR poller: no CI check-runs found after min-age guard — treating as passed"
                         );
-                        self.persist_ci_snapshot(
-                            &task.id,
-                            pull_number,
-                            &pr.head.sha,
-                            CiStatus::Passing,
-                            vec![],
-                            None,
-                            0,
-                            None,
-                        )
+                        poll_stack::boxed(|| {
+                            self.persist_ci_snapshot(
+                                &task.id,
+                                pull_number,
+                                &pr.head.sha,
+                                CiStatus::Passing,
+                                vec![],
+                                None,
+                                0,
+                                None,
+                            )
+                        })
                         .await;
                     } else {
                         // CI checks still running or state unknown — hold
@@ -260,16 +270,18 @@ impl CoordinatorActor {
                     }
                     // Advisory-only failures slipped through (required checks
                     // are green).  Overwrite the failing snapshot with passing.
-                    self.persist_ci_snapshot(
-                        &task.id,
-                        pull_number,
-                        &pr.head.sha,
-                        CiStatus::Passing,
-                        vec![],
-                        None,
-                        0,
-                        None,
-                    )
+                    poll_stack::boxed(|| {
+                        self.persist_ci_snapshot(
+                            &task.id,
+                            pull_number,
+                            &pr.head.sha,
+                            CiStatus::Passing,
+                            vec![],
+                            None,
+                            0,
+                            None,
+                        )
+                    })
                     .await;
                 }
                 CiStatus::Passing => {
@@ -303,12 +315,14 @@ impl CoordinatorActor {
                 let reason = self
                     .build_pr_conflict_reason(&task.short_id, &task.project_id)
                     .await;
-                self.apply_pr_transition(&task.id, TransitionAction::PrConflict, Some(&reason))
-                    .await;
+                poll_stack::boxed(|| {
+                    self.apply_pr_transition(&task.id, TransitionAction::PrConflict, Some(&reason))
+                })
+                .await;
                 // Reactive auto-blocker: if exactly one racing same-epic sibling
                 // is landing on main, make this task WAIT for it (beside the
                 // reopen above) instead of looping on the moving main.
-                self.add_conflict_blocker_for_sibling(&task).await;
+                poll_stack::boxed(|| self.add_conflict_blocker_for_sibling(&task)).await;
                 self.pr_status_cache.remove(&task.id);
                 self.pr_draft_first_seen.remove(&task.id);
                 self.review_stuck_sha_first_seen.remove(&task.id);
@@ -430,7 +444,10 @@ impl CoordinatorActor {
                                 )
                                 .await;
                             if !proceed {
-                                self.create_tripwire_hold(&task, result, &pr.head.sha).await;
+                                poll_stack::boxed(|| {
+                                    self.create_tripwire_hold(&task, result, &pr.head.sha)
+                                })
+                                .await;
                                 self.pr_status_cache.remove(&task.id);
                                 self.pr_draft_first_seen.remove(&task.id);
                                 self.review_stuck_sha_first_seen.remove(&task.id);
@@ -499,8 +516,10 @@ impl CoordinatorActor {
                     )
                     .await;
 
-                    self.apply_pr_transition(&task.id, TransitionAction::PrUndraft, None)
-                        .await;
+                    poll_stack::boxed(|| {
+                        self.apply_pr_transition(&task.id, TransitionAction::PrUndraft, None)
+                    })
+                    .await;
                     self.pr_status_cache.remove(&task.id);
                     self.pr_draft_first_seen.remove(&task.id);
                     self.review_stuck_sha_first_seen.remove(&task.id);
@@ -728,26 +747,30 @@ impl CoordinatorActor {
                     );
                     // Record `unknown` for existing snapshot.
                     let pr_number = pull_number as i64;
-                    self.record_ci_snapshot_unavailable(&task.id, &task.short_id, pr_number)
-                        .await;
+                    poll_stack::boxed(|| {
+                        self.record_ci_snapshot_unavailable(&task.id, &task.short_id, pr_number)
+                    })
+                    .await;
                     continue;
                 }
             };
 
             // ── Record CI snapshot (sole writer for GitHub-derived fields) ──
             let pr_number = pull_number as i64;
-            self.record_ci_snapshot(
-                &task.id,
-                &task.short_id,
-                pr_number,
-                &pr.head.sha,
-                &pr.base.ref_name,
-                pull_number,
-                gh_client,
-                &owner,
-                &repo,
-                &checks,
-            )
+            poll_stack::boxed(|| {
+                self.record_ci_snapshot(
+                    &task.id,
+                    &task.short_id,
+                    pr_number,
+                    &pr.head.sha,
+                    &pr.base.ref_name,
+                    pull_number,
+                    gh_client,
+                    &owner,
+                    &repo,
+                    &checks,
+                )
+            })
             .await;
 
             if pr.merged == Some(true) || pr.state == PrState::Closed {
@@ -784,16 +807,18 @@ impl CoordinatorActor {
 
             // Persist the failing CI snapshot for the review-stuck observation.
             let blocking_names: Vec<String> = blocking.iter().map(|cr| cr.name.clone()).collect();
-            self.persist_ci_snapshot(
-                &task.id,
-                pull_number,
-                &current_sha,
-                CiStatus::Failing,
-                blocking_names,
-                None,
-                0,
-                None,
-            )
+            poll_stack::boxed(|| {
+                self.persist_ci_snapshot(
+                    &task.id,
+                    pull_number,
+                    &current_sha,
+                    CiStatus::Failing,
+                    blocking_names,
+                    None,
+                    0,
+                    None,
+                )
+            })
             .await;
 
             let first_seen = match self.review_stuck_sha_first_seen.get(&task.id) {

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -33,6 +33,7 @@ use super::actor::CoordinatorActor;
 use super::refinement_inflight::DurableInflightRegistration;
 use super::refinement_outcome::RefinementOutcomeApplication;
 use super::types::{InflightDispatch, REFINEMENT_INTENT_CLAIM_LEASE_MILLIS};
+use crate::poll_stack;
 use djinn_core::clock::{Clock, SystemClock};
 use djinn_core::models::TaskRefinementCorrelation;
 use djinn_core::refinement_liveness::RefinementRole;
@@ -168,7 +169,7 @@ impl CoordinatorActor {
         if run_ids.is_empty() {
             // The durable ledger remains dispatch authority when no disposable
             // projection survived to this tick.
-            self.drive_durable_refinement_intents().await;
+            poll_stack::boxed(|| self.drive_durable_refinement_intents()).await;
             return;
         }
 
@@ -208,15 +209,14 @@ impl CoordinatorActor {
         };
 
         for run_id in run_ids {
-            self.drive_one_refinement(&run_id, running_tasks.as_ref())
-                .await;
+            poll_stack::boxed(|| self.drive_one_refinement(&run_id, running_tasks.as_ref())).await;
         }
 
         // The durable intent ledger is the dispatch authority. Run it after
         // monitoring the projections that existed at tick entry: a successful
         // enqueue must leave its newly-created outcome projection intact until
         // the next tick can observe its real session/outcome evidence.
-        self.drive_durable_refinement_intents().await;
+        poll_stack::boxed(|| self.drive_durable_refinement_intents()).await;
 
         // Clean up completed refinements.
         self.active_refinements
@@ -277,18 +277,22 @@ impl CoordinatorActor {
                             // before this coordinator rebuilt its disposable
                             // projection. Recover that outcome without sending a
                             // closed role task through the pool again.
-                            let role_ran = self.refinement_session_has_started(&task.id).await;
+                            let role_ran =
+                                poll_stack::boxed(|| self.refinement_session_has_started(&task.id))
+                                    .await;
                             if role_ran {
-                                self.register_durable_refinement_inflight(
-                                    DurableInflightRegistration {
-                                        run_id: &run.run_id,
-                                        generation: run.generation,
-                                        proposal: &proposal,
-                                        phase: intent.phase,
-                                        round: intent.round,
-                                        task_id: &task.id,
-                                    },
-                                )
+                                poll_stack::boxed(|| {
+                                    self.register_durable_refinement_inflight(
+                                        DurableInflightRegistration {
+                                            run_id: &run.run_id,
+                                            generation: run.generation,
+                                            proposal: &proposal,
+                                            phase: intent.phase,
+                                            round: intent.round,
+                                            task_id: &task.id,
+                                        },
+                                    )
+                                })
                                 .await;
                                 continue;
                             }
@@ -332,22 +336,26 @@ impl CoordinatorActor {
                             else {
                                 continue;
                             };
-                            let project_path =
-                                self.resolve_refinement_project_path(&run.proposal_id).await;
+                            let project_path = poll_stack::boxed(|| {
+                                self.resolve_refinement_project_path(&run.proposal_id)
+                            })
+                            .await;
                             match self.pool.dispatch(&task.id, &project_path, &model_id).await {
                                 Ok(()) => {
                                     // Do not manufacture the outcome projection
                                     // until this retry enqueue has succeeded.
-                                    self.register_durable_refinement_inflight(
-                                        DurableInflightRegistration {
-                                            run_id: &run.run_id,
-                                            generation: run.generation,
-                                            proposal: &proposal,
-                                            phase: intent.phase,
-                                            round: intent.round,
-                                            task_id: &task.id,
-                                        },
-                                    )
+                                    poll_stack::boxed(|| {
+                                        self.register_durable_refinement_inflight(
+                                            DurableInflightRegistration {
+                                                run_id: &run.run_id,
+                                                generation: run.generation,
+                                                proposal: &proposal,
+                                                phase: intent.phase,
+                                                round: intent.round,
+                                                task_id: &task.id,
+                                            },
+                                        )
+                                    })
                                     .await;
                                     if let Some(session) =
                                         self.refinement_sessions.get_mut(&run.run_id)
@@ -543,18 +551,22 @@ impl CoordinatorActor {
                 {
                     continue;
                 }
-                let project_path = self.resolve_refinement_project_path(&run.proposal_id).await;
+                let project_path =
+                    poll_stack::boxed(|| self.resolve_refinement_project_path(&run.proposal_id))
+                        .await;
                 match self.pool.dispatch(&task_id, &project_path, &model_id).await {
                     Ok(()) => {
                         // Register only after the pool accepted this exact task.
                         // This is the run-keyed bridge to outcome completion.
-                        self.register_durable_refinement_inflight(DurableInflightRegistration {
-                            run_id: &lease.run_id,
-                            generation: lease.generation,
-                            proposal: &proposal,
-                            phase: lease.phase,
-                            round: lease.round,
-                            task_id: &task_id,
+                        poll_stack::boxed(|| {
+                            self.register_durable_refinement_inflight(DurableInflightRegistration {
+                                run_id: &lease.run_id,
+                                generation: lease.generation,
+                                proposal: &proposal,
+                                phase: lease.phase,
+                                round: lease.round,
+                                task_id: &task_id,
+                            })
                         })
                         .await;
                         if let Some(session) = self.refinement_sessions.get_mut(&lease.run_id)
@@ -596,7 +608,9 @@ impl CoordinatorActor {
         &self,
         proposal_id: &str,
     ) -> Option<DurableDispatchBlock> {
-        let Some(proposal) = self.load_proposal_for_lifecycle(proposal_id).await else {
+        let Some(proposal) =
+            poll_stack::boxed(|| self.load_proposal_for_lifecycle(proposal_id)).await
+        else {
             tracing::warn!(
                 proposal_id = %proposal_id,
                 "Durable refinement dispatch skipped: could not load proposal for evidence \
@@ -604,7 +618,7 @@ impl CoordinatorActor {
             );
             return Some(DurableDispatchBlock::ProposalUnreadable);
         };
-        match self.derive_proposal_evidence_lifecycle(&proposal).await {
+        match poll_stack::boxed(|| self.derive_proposal_evidence_lifecycle(&proposal)).await {
             EvidenceLifecycleState::PausedOrFrozen => {
                 tracing::info!(
                     proposal_id = %proposal_id,
@@ -663,7 +677,8 @@ impl CoordinatorActor {
         }
 
         let phase = refinement_phase_for_intent(phase);
-        let diverse_refinement = self.read_diverse_refinement_setting(proposal_id).await;
+        let diverse_refinement =
+            poll_stack::boxed(|| self.read_diverse_refinement_setting(proposal_id)).await;
         let (agent_type, model_id) = self
             .resolve_refinement_dispatch_params(phase, diverse_refinement, Some(owner.as_str()))
             .await?;
@@ -681,9 +696,11 @@ impl CoordinatorActor {
         let lane_cap = settings
             .and_then(|settings| settings.lane_max_sessions)
             .map(|limits| limits.for_role(&agent_type));
-        self.check_user_model_admission(&owner, &model_id, model_cap, &agent_type, lane_cap)
-            .await
-            .then_some((agent_type, model_id))
+        poll_stack::boxed(|| {
+            self.check_user_model_admission(&owner, &model_id, model_cap, &agent_type, lane_cap)
+        })
+        .await
+        .then_some((agent_type, model_id))
     }
 
     /// Drive a single refinement loop. `running_tasks` is the pool's running
@@ -741,7 +758,11 @@ impl CoordinatorActor {
                 let session_started_at = match session.session_started_at {
                     Some(started) => Some(started),
                     None => {
-                        if self.refinement_session_has_started(&session.task_id).await {
+                        if poll_stack::boxed(|| {
+                            self.refinement_session_has_started(&session.task_id)
+                        })
+                        .await
+                        {
                             let observed = SystemClock::new().now_instant();
                             if let Some(s) = self.refinement_sessions.get_mut(run_id) {
                                 s.session_started_at = Some(observed);
@@ -764,19 +785,23 @@ impl CoordinatorActor {
                                 phase = ?session.phase,
                                 "Refinement session timed out (execution budget from session start)"
                             );
-                            self.close_refinement_task(
-                                &session.task_id,
-                                "refinement session timed out",
-                            )
+                            poll_stack::boxed(|| {
+                                self.close_refinement_task(
+                                    &session.task_id,
+                                    "refinement session timed out",
+                                )
+                            })
                             .await;
-                            self.terminate_refinement(
-                                run_id,
-                                StopReason::AgentFailure {
-                                    role: role_for_phase(session.phase),
-                                    error_code: "agent_failure".into(),
-                                    message: "session timeout".into(),
-                                },
-                            )
+                            poll_stack::boxed(|| {
+                                self.terminate_refinement(
+                                    run_id,
+                                    StopReason::AgentFailure {
+                                        role: role_for_phase(session.phase),
+                                        error_code: "agent_failure".into(),
+                                        message: "session timeout".into(),
+                                    },
+                                )
+                            })
                             .await;
                         }
                     }
@@ -801,13 +826,13 @@ impl CoordinatorActor {
                                 "role session failed to start {REFINEMENT_DISPATCH_RETRY_CAP} times \
                                  (task-run pod stuck Pending in scheduler queue)"
                             );
-                            self.retry_or_terminate_unstarted_refinement(
+                            poll_stack::boxed(|| self.retry_or_terminate_unstarted_refinement(
                                 run_id,
                                 &session,
                                 "refinement role session never started (task-run pod stuck Pending)",
                                 over_cap_error,
                                 true,
-                            )
+                            ))
                             .await;
                         }
                     }
@@ -824,7 +849,8 @@ impl CoordinatorActor {
             // Treating (b) as a completed-but-"dry" round silently burns rounds
             // on a dispatch outage and can hollow-converge the tribunal. Tell
             // them apart by whether any session row exists for the task.
-            let session_ran = self.refinement_session_has_started(&session.task_id).await;
+            let session_ran =
+                poll_stack::boxed(|| self.refinement_session_has_started(&session.task_id)).await;
 
             if !session_ran {
                 // Dispatch/setup failure: the role never executed. Re-dispatch
@@ -836,13 +862,15 @@ impl CoordinatorActor {
                     "role session failed to start {REFINEMENT_DISPATCH_RETRY_CAP} times \
                      (runtime/devcontainer setup failure)"
                 );
-                self.retry_or_terminate_unstarted_refinement(
-                    run_id,
-                    &session,
-                    "refinement role session never started (dispatch/setup failure)",
-                    over_cap_error,
-                    false,
-                )
+                poll_stack::boxed(|| {
+                    self.retry_or_terminate_unstarted_refinement(
+                        run_id,
+                        &session,
+                        "refinement role session never started (dispatch/setup failure)",
+                        over_cap_error,
+                        false,
+                    )
+                })
                 .await;
                 return;
             }
@@ -869,13 +897,15 @@ impl CoordinatorActor {
                      {REFINEMENT_DISPATCH_RETRY_CAP} times (upstream 5xx / overload / \
                      mid-flight stream death)"
                 );
-                self.retry_or_terminate_unstarted_refinement(
+                poll_stack::boxed(|| {
+                    self.retry_or_terminate_unstarted_refinement(
                     run_id,
                     &session,
                     "refinement role session died on a transient provider fault (parked for retry)",
                     over_cap_error,
                     false,
                 )
+                })
                 .await;
                 return;
             }
@@ -883,14 +913,16 @@ impl CoordinatorActor {
             // Session actually ran — clear the dispatch-failure counter and
             // process the outcome, then close the task so finished phase/round
             // tasks don't linger `open` on the board.
-            if self.process_refinement_outcome(run_id, &session).await
+            if poll_stack::boxed(|| self.process_refinement_outcome(run_id, &session)).await
                 == RefinementOutcomeApplication::Committed
             {
                 if let Some(state) = self.active_refinements.get_mut(run_id) {
                     state.dispatch_failures = 0;
                 }
-                self.close_refinement_task(&session.task_id, "refinement phase complete")
-                    .await;
+                poll_stack::boxed(|| {
+                    self.close_refinement_task(&session.task_id, "refinement phase complete")
+                })
+                .await;
                 self.refinement_sessions.remove(run_id);
             }
             return;
@@ -904,7 +936,7 @@ impl CoordinatorActor {
         }
 
         // Legacy non-durable compatibility path only.
-        self.dispatch_next_refinement_phase(run_id).await;
+        poll_stack::boxed(|| self.dispatch_next_refinement_phase(run_id)).await;
     }
 
     /// Whether an agent session row exists yet for a dispatched refinement
@@ -1015,9 +1047,9 @@ impl CoordinatorActor {
                             "Failed to tear down terminal Pending refinement task-run"
                         );
                     }
-                    self.clear_inflight_dispatch(&session.task_id).await;
+                    poll_stack::boxed(|| self.clear_inflight_dispatch(&session.task_id)).await;
                 }
-                self.close_refinement_task(&session.task_id, close_reason)
+                poll_stack::boxed(|| self.close_refinement_task(&session.task_id, close_reason))
                     .await;
             }
             return;
@@ -1036,10 +1068,9 @@ impl CoordinatorActor {
                     "Failed to tear down Pending refinement task-run; proceeding with retry"
                 );
             }
-            self.clear_inflight_dispatch(&session.task_id).await;
+            poll_stack::boxed(|| self.clear_inflight_dispatch(&session.task_id)).await;
         }
-        self.close_refinement_task(&session.task_id, close_reason)
-            .await;
+        poll_stack::boxed(|| self.close_refinement_task(&session.task_id, close_reason)).await;
         self.refinement_sessions.remove(run_id);
         tracing::warn!(
             run_id = %run_id,
@@ -1073,7 +1104,7 @@ impl CoordinatorActor {
         run_id: &str,
         phase: RefinementPhase,
     ) -> RefinementRoleContext {
-        let readiness = self.evaluate_proposal_readiness(proposal_id).await;
+        let readiness = poll_stack::boxed(|| self.evaluate_proposal_readiness(proposal_id)).await;
         let mut readiness_context = readiness
             .as_ref()
             .map(CoordinatorActor::format_readiness_context)
@@ -1166,7 +1197,7 @@ impl CoordinatorActor {
         }
 
         // Administrative dispatch-pause gate.
-        if self.refinement_dispatch_paused(&proposal_id).await {
+        if poll_stack::boxed(|| self.refinement_dispatch_paused(&proposal_id)).await {
             tracing::info!(
                 proposal_id = %proposal_id,
                 phase = ?phase,
@@ -1188,9 +1219,11 @@ impl CoordinatorActor {
         // The in-memory `AwaitingEvidence` and admin-dispause checks above
         // serve as fast-path early returns that avoid DB reads when the
         // in-memory state is already parked.
-        let lifecycle_proposal = self.load_proposal_for_lifecycle(&proposal_id).await;
+        let lifecycle_proposal =
+            poll_stack::boxed(|| self.load_proposal_for_lifecycle(&proposal_id)).await;
         if let Some(ref proposal) = lifecycle_proposal {
-            let lifecycle_state = self.derive_proposal_evidence_lifecycle(proposal).await;
+            let lifecycle_state =
+                poll_stack::boxed(|| self.derive_proposal_evidence_lifecycle(proposal)).await;
             match lifecycle_state {
                 EvidenceLifecycleState::Active | EvidenceLifecycleState::EvidenceReady => {
                     // Proceed to dispatch — either normal refinement or
@@ -1261,15 +1294,18 @@ impl CoordinatorActor {
                  (no explicit attributed_user_id and no proposal author). \
                  Refusing to dispatch without a real user identity."
             );
-            self.terminate_refinement(
-                run_id,
-                StopReason::AgentFailure {
-                    role: role_for_phase(phase),
-                    error_code: "agent_failure".into(),
-                    message: "attribution unresolvable: no user identity for refinement dispatch"
-                        .into(),
-                },
-            )
+            poll_stack::boxed(|| {
+                self.terminate_refinement(
+                    run_id,
+                    StopReason::AgentFailure {
+                        role: role_for_phase(phase),
+                        error_code: "agent_failure".into(),
+                        message:
+                            "attribution unresolvable: no user identity for refinement dispatch"
+                                .into(),
+                    },
+                )
+            })
             .await;
             return;
         };
@@ -1282,14 +1318,16 @@ impl CoordinatorActor {
                 explicit = ?state.attributed_user_id,
                 "Refinement dispatch: attributed user is empty — failing closed"
             );
-            self.terminate_refinement(
-                run_id,
-                StopReason::AgentFailure {
-                    role: role_for_phase(phase),
-                    error_code: "agent_failure".into(),
-                    message: "attributed user is empty".into(),
-                },
-            )
+            poll_stack::boxed(|| {
+                self.terminate_refinement(
+                    run_id,
+                    StopReason::AgentFailure {
+                        role: role_for_phase(phase),
+                        error_code: "agent_failure".into(),
+                        message: "attributed user is empty".into(),
+                    },
+                )
+            })
             .await;
             return;
         }
@@ -1307,14 +1345,16 @@ impl CoordinatorActor {
                     user_id = %user_id,
                     "Refinement dispatch: attributed user does not resolve to a row — failing closed"
                 );
-                self.terminate_refinement(
-                    run_id,
-                    StopReason::AgentFailure {
-                        role: role_for_phase(phase),
-                        error_code: "agent_failure".into(),
-                        message: format!("attributed user {user_id} not found in users table"),
-                    },
-                )
+                poll_stack::boxed(|| {
+                    self.terminate_refinement(
+                        run_id,
+                        StopReason::AgentFailure {
+                            role: role_for_phase(phase),
+                            error_code: "agent_failure".into(),
+                            message: format!("attributed user {user_id} not found in users table"),
+                        },
+                    )
+                })
                 .await;
                 return;
             }
@@ -1331,9 +1371,10 @@ impl CoordinatorActor {
         }
 
         // Read diverse_refinement setting at the round boundary.
-        let diverse_refinement = self.read_diverse_refinement_setting(&proposal_id).await;
+        let diverse_refinement =
+            poll_stack::boxed(|| self.read_diverse_refinement_setting(&proposal_id)).await;
 
-        let readiness = self.evaluate_proposal_readiness(&proposal_id).await;
+        let readiness = poll_stack::boxed(|| self.evaluate_proposal_readiness(&proposal_id)).await;
 
         if let Some(ref readiness) = readiness
             && !readiness.ready
@@ -1356,14 +1397,16 @@ impl CoordinatorActor {
                 user_id = %user_id,
                 "Refinement dispatch FAIL-CLOSED: durable owner has no eligible credential-backed model; no task or spawn will be created"
             );
-            self.terminate_refinement(
-                run_id,
-                StopReason::AgentFailure {
-                    role: role_for_phase(phase),
-                    error_code: "agent_failure".into(),
-                    message: "no eligible credential-backed model for refinement owner".into(),
-                },
-            )
+            poll_stack::boxed(|| {
+                self.terminate_refinement(
+                    run_id,
+                    StopReason::AgentFailure {
+                        role: role_for_phase(phase),
+                        error_code: "agent_failure".into(),
+                        message: "no eligible credential-backed model for refinement owner".into(),
+                    },
+                )
+            })
             .await;
             return;
         };
@@ -1490,13 +1533,15 @@ impl CoordinatorActor {
         // existing reconciliation (pool liveness check) and session-start
         // cleanup can clear it, and so subsequent candidates for the same
         // (user, model) see the reservation under the durable key.
-        self.rekey_provisional_to_inflight(
-            &provisional_key,
-            &task_id,
-            user_id,
-            &model_id,
-            &agent_type,
-        )
+        poll_stack::boxed(|| {
+            self.rekey_provisional_to_inflight(
+                &provisional_key,
+                &task_id,
+                user_id,
+                &model_id,
+                &agent_type,
+            )
+        })
         .await;
 
         // ── Step 4: Consume spawn budget ────────────────────────────────────
@@ -1512,19 +1557,22 @@ impl CoordinatorActor {
                     ?reason,
                     "Refinement spawn cap reached"
                 );
-                self.clear_inflight_dispatch(&task_id).await;
-                self.close_refinement_task(
-                    &task_id,
-                    "refinement spawn cap reached — task will not be dispatched",
-                )
+                poll_stack::boxed(|| self.clear_inflight_dispatch(&task_id)).await;
+                poll_stack::boxed(|| {
+                    self.close_refinement_task(
+                        &task_id,
+                        "refinement spawn cap reached — task will not be dispatched",
+                    )
+                })
                 .await;
-                self.persist_refinement_stop(&proposal_id, &reason).await;
+                poll_stack::boxed(|| self.persist_refinement_stop(&proposal_id, &reason)).await;
                 self.refinement_sessions.remove(run_id);
                 return;
             }
         }
 
-        let project_path = self.resolve_refinement_project_path(&proposal_id).await;
+        let project_path =
+            poll_stack::boxed(|| self.resolve_refinement_project_path(&proposal_id)).await;
 
         // ── Step 5: Dispatch through the slot pool (last side effect) ───────
         //
@@ -1555,9 +1603,11 @@ impl CoordinatorActor {
                 );
             }
             Err(e) => {
-                self.clear_inflight_dispatch(&task_id).await;
-                self.close_refinement_task(&task_id, "refinement dispatch failed (pool error)")
-                    .await;
+                poll_stack::boxed(|| self.clear_inflight_dispatch(&task_id)).await;
+                poll_stack::boxed(|| {
+                    self.close_refinement_task(&task_id, "refinement dispatch failed (pool error)")
+                })
+                .await;
                 tracing::warn!(
                     proposal_id = %proposal_id,
                     task_id = %task_id,
@@ -1603,7 +1653,8 @@ impl CoordinatorActor {
                     state.resume_after_evidence_received();
                 }
 
-                let lifecycle_state = self.derive_proposal_evidence_lifecycle(&proposal).await;
+                let lifecycle_state =
+                    poll_stack::boxed(|| self.derive_proposal_evidence_lifecycle(&proposal)).await;
                 if matches!(lifecycle_state, EvidenceLifecycleState::PausedOrFrozen) {
                     tracing::info!(
                         proposal_id = %proposal_id,
@@ -1614,7 +1665,7 @@ impl CoordinatorActor {
                     return;
                 }
 
-                self.dispatch_next_refinement_phase(&run_id).await;
+                poll_stack::boxed(|| self.dispatch_next_refinement_phase(&run_id)).await;
             }
             Err(e) => {
                 tracing::warn!(


### PR DESCRIPTION
## The bug

`CoordinatorActor::run` is the root of an eight-deep chain of nested `async fn`s, every link polled inside the frame of the link above it. In the debug/test profile (`opt-level = 0`) LLVM does not run its stack-colouring pass, so each `await` costs the enclosing coroutine's poll frame **two** un-reused slots the size of the sub-future being awaited — summed over every `await` in the body rather than overlapped. `#[tracing::instrument]` doubles the frame count (span construction wrapper + body), and `run_dispatch_loop`'s `select!` embeds its branch futures inline.

On `main`, one poll of the 30s tick consumed **2,210,352 bytes — 105% of tokio's 2 MiB worker stack**, and `cargo test -p djinn-server --lib` aborted:

```
thread 'tokio-rt-worker' has overflowed its stack
fatal runtime error: stack overflow, aborting
... (signal: 6, SIGABRT: process abort signal)
```

## The fix

Awaited sub-passes are entered through a new `djinn-coordinator/src/poll_stack.rs`:

```rust
pub(crate) fn boxed<'a, T, F>(make: impl FnOnce() -> F) -> Pin<Box<dyn Future<Output = T> + Send + 'a>>
```

It takes a **thunk**, not a future. `Box::pin(self.foo()).await` only halves the cost — `Box::pin` takes its argument by value, so the caller still materialises the whole sub-future in one of its own stack slots and only the copy into the coroutine state is saved. Passing a closure moves the construction into `boxed`'s frame, which is popped before the returned future is ever polled, so the caller keeps only a 16-byte fat pointer. Measured on a synthetic ten-await chain: **451,336 → 226,296 (`Box::pin`) → 536 bytes (thunk)**.

Applied at the nesting points in `run`, `run_dispatch_loop`, `run_tick`, `dispatch_ready_tasks`, and the deep intervention/PR-poller/refinement passes the measurement showed to be load-bearing.

## Frame measurement

Frames were read statically out of each function's prologue (callee-saved pushes + `sub $N,%rsp`, including the stack-probe form), and the chain is the maximum-weight acyclic path over the call graph — direct calls, GOT-indirect calls resolved through `.rela.dyn`, and the `dyn Future` vtable hop re-attached from the `poll_stack::boxed::<T, F, Thunk>` monomorphisation (without that last step the "after" numbers would be flattering nonsense). The method reproduces the originally reported gdb frames to within the 8-byte return address.

### The reported tick chain

| frame | dev before | dev after | release before | release after |
| --- | ---: | ---: | ---: | ---: |
| `dispatch_ready_tasks` (async body) | 633,216 | 255,776 | 39,952 | 4,152 |
| `dispatch_ready_tasks` (`#[instrument]` wrapper) | 148,944 | 76,992 | 49,584 | 4,144 |
| `run_tick` (async body) | 466,848 | 4,104 | 47,520 | 4,152 |
| `run_tick` (`#[instrument]` wrapper) | 181,008 | 4,104 | inlined | 2,320 |
| `tokio::time::Timeout::poll` | 48 | 48 | 60,288 | inlined |
| `run_pass_with_watchdog` | 121,664 | 1,056 | inlined | 352 |
| `run_dispatch_loop` | 442,640 | 4,104 | inlined | 4,152 |
| `CoordinatorActor::run` | 215,984 | 4,104 | 95,312 | 4,152 |
| **total** | **2,210,352** | **350,288** | **292,656** | **23,424** |

### Worst-case chain from `CoordinatorActor::run`

The reported chain was not the worst one — `dispatch_ready_tasks` re-enters through `route_loop_guard_planner_intervention` → `route_planner_intervention` → `create_remediation_task`, and that path was over budget by 75%.

| profile | before | after |
| --- | ---: | ---: |
| dev (`opt-level = 0`) | 3,666,896 B — **174.9% of 2 MiB** | 977,968 B — **46.6%** |
| release (`opt-level = 3`) | 436,184 B — 20.8% | 35,568 B — **1.7%** |

Incremental, dev: 3,666,896 → 2,645,312 (boxed `run`/`run_dispatch_loop`/`run_tick`) → 2,011,472 (single-line nesting points) → 977,968 (multi-line nesting points).

## Production exposure

Production was **not** protected by the CI override and never has been:

* `server/src/main.rs:131` builds `tokio::runtime::Builder::new_multi_thread()` with no `thread_stack_size`.
* `RUST_MIN_STACK` appears in **zero** files under `deploy/`, `server/docker/`, `Tiltfile`, `docker-compose.yml`.
* `djinn-coordinator/src/handle.rs:53` does `tokio::spawn(actor.run())` on that runtime.

So the production coordinator ran the same chain on 2 MiB. It did not overflow because release is compiled at `opt-level = 3`, where LLVM's stack colouring applies: the worst-case release path measured **436,184 bytes, 20.8% of the 2 MiB budget** — real headroom, but headroom that had been silently consumed by an unbounded structure with no gate watching it. The debug profile was the canary, and the canary had been muted. After this change the release worst case is 35,568 bytes (1.7%).

## The CI override is removed

`.github/workflows/quality-gate.yml` carried `RUST_MIN_STACK: "8388608"`, added in `1b4641fc0` — the commit whose message reads *"eliminate coordinator shard stack-overflow failures"*, and which is also the commit that added `complete_legacy_settings_import_phase` to `run()` and deepened the chain. It is deleted, with a comment recording why it must not come back. CI and local runs now see the same 2 MiB budget.

## Verification

* **Before:** literal SIGABRT from pristine `main` (above).
* **After:** `cargo test -p djinn-server --lib` at default parallelism, **without** `RUST_MIN_STACK` — **5 consecutive runs, 629 passed / 0 failed / 2 ignored** each.
* `cargo nextest run -p djinn-server --lib` with the override removed: 629 passed, 2 skipped.
* `cargo test -p djinn-coordinator`: 1991 passed / 0 failed.
* `cargo clippy -p djinn-coordinator -p djinn-server --features qdrant --all-targets -- -D warnings`: clean.
* `cargo fmt --all --check`: clean. `actionlint`: clean.
* Test count unchanged (629 + 2 ignored).

### Pre-existing flake noted, not introduced here

While another agent's build was saturating the box (load average 19–22, shared test Postgres), `server::tests::debug::test_debug_dispatch_state_lock_contention_under_5s` — a wall-clock assertion that 1000 actor round-trips finish in under 5s — failed intermittently. It is **not** a regression from this change: pristine `main` with `RUST_MIN_STACK=8388608` (exactly the configuration CI ran) failed 2 of 5 runs under the same load, once on that test and once on `server::tests::metrics_debug_dispatch::debug_dispatch_state_returns_wedge_to_admin_and_403_to_non_admin`. On an unloaded machine this branch passed 5/5. CI is insulated because nextest gives each test its own process; `cargo test` shares one 16-thread process. Worth a separate task to make that budget load-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
