### PR TITLE
fix(d3qd): execute pwys's live birth-downsize arm — two production defects found, claim proven

### DIFF
--- a/scripts/kind/setup-resize-cluster.sh
+++ b/scripts/kind/setup-resize-cluster.sh
@@ -280,20 +280,45 @@ if ! "$DOCKER" inspect "$REG_NAME" >/dev/null 2>&1; then
         --name "$REG_NAME" registry:2 >/dev/null
 fi
 
+# Guard 5b: state the feature gate only where stating it is legal.
+#
+# `InPlacePodVerticalScaling` is beta-on-by-default at 1.33 and GA from
+# 1.$GA_K8S_MINOR. Naming a GA gate is tolerated with a deprecation warning until
+# it is removed, and naming a REMOVED gate is a hard kubelet start failure — so
+# an unconditional `featureGates:` block silently pins this harness to a closing
+# window of node images. Below the GA minor the explicit statement still earns
+# its place: it is the only thing standing between a node image whose beta
+# default flipped and a run that reports "not confirmed" for a reason that has
+# nothing to do with the code under test.
+GA_K8S_MINOR=34
+FEATURE_GATES_BLOCK=""
+if [ "$K8S_MINOR" -lt "$GA_K8S_MINOR" ]; then
+    FEATURE_GATES_BLOCK=$'featureGates:\n  InPlacePodVerticalScaling: true'
+    info "k8s 1.${K8S_MINOR}: stating InPlacePodVerticalScaling=true explicitly (beta)"
+else
+    info "k8s 1.${K8S_MINOR}: InPlacePodVerticalScaling is GA; naming it would only earn a removal warning"
+fi
+
 info "creating kind cluster ${CLUSTER_NAME} (k8s ${KIND_IMAGE_VERSION})"
 "$KIND" create cluster --name "$CLUSTER_NAME" --image "kindest/node:v${KIND_IMAGE_VERSION}" \
     --config /dev/stdin <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-# Stated explicitly rather than relying on the 1.33 default. A node image whose
-# default flipped would otherwise leave the subresource present and the resize
-# unactuated, which is indistinguishable from the defect under test.
-featureGates:
-  InPlacePodVerticalScaling: true
+${FEATURE_GATES_BLOCK}
+# The registry is wired through containerd's per-host \`certs.d\` directory, NOT
+# through a \`registry.mirrors\` table. kind's node image already sets
+# \`config_path\`, and containerd v2 refuses to load its CRI image plugin at all
+# when both are present: "\`mirrors\` cannot be set when \`config_path\` is
+# provided". That refusal is total and silent from the outside — the CRI service
+# never registers, the kubelet dies on "unknown service runtime.v1.RuntimeService",
+# and \`kind create\` fails four minutes later at "waiting for a healthy kubelet"
+# with nothing in its output naming containerd. Restating \`config_path\` here is
+# what \`scripts/kind/setup-kueue-cluster.sh\` does and is the only shape that
+# works on a containerd v2 node.
 containerdConfigPatches:
   - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REG_PORT}"]
-      endpoint = ["http://${REG_NAME}:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
 nodes:
   - role: control-plane
 EOF
@@ -303,13 +328,39 @@ if [ "$("$DOCKER" inspect -f '{{json .NetworkSettings.Networks.kind}}' "$REG_NAM
     "$DOCKER" network connect kind "$REG_NAME" >/dev/null
 fi
 
+# Both spellings, because a manifest may name the registry either from the host
+# (`localhost:$REG_PORT`) or from inside the cluster (`$REG_NAME:5000`).
+info "pointing the node's certs.d at the registry"
+REGISTRY_HOST_DIR="/etc/containerd/certs.d/localhost:${REG_PORT}"
+REGISTRY_INTERNAL_DIR="/etc/containerd/certs.d/${REG_NAME}:5000"
+for node in $("$KIND" get nodes --name "$CLUSTER_NAME"); do
+    "$DOCKER" exec "$node" mkdir -p "$REGISTRY_HOST_DIR" "$REGISTRY_INTERNAL_DIR"
+    "$DOCKER" exec -i "$node" cp /dev/stdin "$REGISTRY_HOST_DIR/hosts.toml" <<EOF
+[host."http://${REG_NAME}:5000"]
+  capabilities = ["pull", "resolve"]
+EOF
+    "$DOCKER" exec -i "$node" cp /dev/stdin "$REGISTRY_INTERNAL_DIR/hosts.toml" <<EOF
+[host."http://${REG_NAME}:5000"]
+  capabilities = ["pull", "resolve"]
+EOF
+done
+
 info "waiting for the node to become Ready"
 "${KUBECTL[@]}" wait --for=condition=Ready node --all \
     --timeout="${READY_TIMEOUT_SECONDS}s" >/dev/null
 
 # Guard 6: re-check the floor against the LIVE API server, not the requested
 # image tag. A tag can lie; the server cannot.
-LIVE_MINOR=$("${KUBECTL[@]}" version -o json | awk -F'"' '/"minor"/ { gsub(/[^0-9]/, "", $4); print $4; exit }')
+#
+# Read through `get --raw /version`, which returns the SERVER's version object and
+# nothing else. `kubectl version -o json` emits `clientVersion` FIRST and
+# `serverVersion` second, so the obvious `awk '/"minor"/ { ...; exit }'` over it
+# reads the local kubectl's minor and calls it the cluster's. That is not a
+# cosmetic slip: it is a floor guard measuring the wrong ledger, and it would
+# have waved through a 1.20 API server on any developer machine with a current
+# kubectl — exactly the "the tag can lie" case this guard exists for. Observed
+# live: a 1.33.1 cluster reported as "k8s: 1.36".
+LIVE_MINOR=$("${KUBECTL[@]}" get --raw /version | awk -F'"' '/"minor"/ { gsub(/[^0-9]/, "", $4); print $4; exit }')
 [ -n "$LIVE_MINOR" ] || fail 1 "could not read the live API server minor version"
 [ "$LIVE_MINOR" -ge "$MIN_K8S_MINOR" ] || fail "$EXIT_VERSION_FLOOR" \
     "the created cluster reports Kubernetes 1.${LIVE_MINOR}, below the 1.${MIN_K8S_MINOR} in-place-resize floor"

--- a/scripts/kind/setup-resize-cluster.sh
+++ b/scripts/kind/setup-resize-cluster.sh
@@ -282,10 +282,12 @@ fi
 
 # Guard 5b: state the feature gate only where stating it is legal.
 #
-# `InPlacePodVerticalScaling` is beta-on-by-default at 1.33 and GA from
-# 1.$GA_K8S_MINOR. Naming a GA gate is tolerated with a deprecation warning until
-# it is removed, and naming a REMOVED gate is a hard kubelet start failure — so
-# an unconditional `featureGates:` block silently pins this harness to a closing
+# `InPlacePodVerticalScaling` is beta-on-by-default at 1.33 and GA from 1.34
+# (measured 2026-07-31: a 1.35.0 kubelet logs "Setting GA feature gate
+# InPlacePodVerticalScaling=true. It will be removed in a future release").
+# Naming a GA gate is tolerated with a deprecation warning until it is removed,
+# and naming a REMOVED gate is a hard kubelet start failure — so an
+# unconditional `featureGates:` block silently pins this harness to a closing
 # window of node images. Below the GA minor the explicit statement still earns
 # its place: it is the only thing standing between a node image whose beta
 # default flipped and a run that reports "not confirmed" for a reason that has

--- a/server/crates/djinn-k8s/src/pod_resize.rs
+++ b/server/crates/djinn-k8s/src/pod_resize.rs
@@ -504,7 +504,26 @@ impl PodResizeApi for KubePodResizeApi {
         // Strategic, not Merge: `initContainers` has `patchMergeKey: name`, so
         // a strategic patch merges into the named entry. A Merge patch would
         // replace the entire array and drop every other init container.
-        let params = PatchParams::apply(&self.field_manager).force();
+        //
+        // `field_manager` only — NOT `PatchParams::apply(..).force()`.
+        // `apply()` is the server-side-apply constructor and `force` is an SSA
+        // conflict override; `kube` validates the pair CLIENT-SIDE and rejects
+        // any non-`Patch::Apply` body carrying `force` with
+        //
+        //     Failed to build request: failed to validate request:
+        //     PatchParams::force only works with Patch::Apply
+        //
+        // That refusal happens before a byte leaves the process, so it has no
+        // HTTP status and never appears in an apiserver audit log. Every resize
+        // this client could ever issue failed there — measured 2026-07-31
+        // against a real 1.33.1 kubelet. It survived review because
+        // `KubePodResizeApi` is the one part of this module no hermetic test
+        // constructs: every other test drives `PodResizeApi` through a fixture,
+        // so the transport had no coverage at all.
+        let params = PatchParams {
+            field_manager: Some(self.field_manager.clone()),
+            ..PatchParams::default()
+        };
         self.pods
             .patch_subresource(RESIZE_SUBRESOURCE, name, &params, &Patch::Strategic(body))
             .await

--- a/server/crates/djinn-k8s/tests/pod_resize_kind.rs
+++ b/server/crates/djinn-k8s/tests/pod_resize_kind.rs
@@ -64,6 +64,8 @@ use djinn_k8s::pod_resize::{
     CpuLimit, KubePodResizeApi, PodResizeClient, PodResizeError, confirm_launcher_cpu,
     declared_launcher_cpu_limit, locate_launcher_spec, locate_launcher_status,
 };
+use djinn_k8s::runtime::{ObservedLauncherSidecar, TaskRunPodResizeSurface};
+use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::{DeleteParams, PostParams};
 use kube::{Api, Client};
@@ -236,8 +238,9 @@ async fn harness_client() -> Client {
     Client::try_from(config).expect("build a kube client for the harness context")
 }
 
-/// The production render, with only its image references made pullable.
-fn rendered_resize_v2_pod(task_run_id: &Uuid) -> Pod {
+/// The production render of a `resize-v2` task-run Job, with only its image
+/// references made pullable.
+fn rendered_resize_v2_job(task_run_id: &Uuid) -> Job {
     let config = KubernetesConfig::from_env();
     let mut job = djinn_k8s::job::build_task_run_job_with_read_sources(
         &config,
@@ -257,6 +260,12 @@ fn rendered_resize_v2_pod(task_run_id: &Uuid) -> Pod {
         LauncherAuthorityProtocol::ResizeV2,
     )
     .expect("the render must produce a launcher sidecar under resize-v2");
+    job
+}
+
+/// The production render, with only its image references made pullable.
+fn rendered_resize_v2_pod(task_run_id: &Uuid) -> Pod {
+    let job = rendered_resize_v2_job(task_run_id);
 
     let template = job
         .spec
@@ -752,4 +761,189 @@ async fn confirm_whole_core(client: &Client, pods: &Api<Pod>, name: &str, target
         tokio::time::sleep(TICK).await;
     }
     panic!("a real kubelet never confirmed {target}; last refusal: {last}");
+}
+
+// ── The production surface, live ──────────────────────────────────────────
+
+/// Namespace for the surface test. Distinct from [`HARNESS_NAMESPACE`] because
+/// both live tests purge every object in the namespace they own and cargo runs
+/// them on separate threads: sharing one namespace would make each test's
+/// cleanup the other's flake.
+const SURFACE_NAMESPACE: &str = "djinn-resize-harness-surface";
+
+/// **The type the server actually holds, against a real apiserver.**
+///
+/// `TaskRunPodResizeSurface` is what `TaskRunResizeAdmissionBridge` resolves and
+/// drives; `server/tests/task_run_resize_dispatch_seam.rs` proves the bridge and
+/// the `DispatchGate` are on the production dispatch path, but it substitutes
+/// this surface for a fixture. So until now none of its three operations had
+/// ever spoken to an apiserver — and the one of them this file DID exercise,
+/// `resize_launcher_cpu`, turned out to be broken at the transport in a way no
+/// hermetic test could see. Its two siblings deserve the same treatment rather
+/// than the benefit of the doubt.
+///
+/// Driven from a real Job, not a hand-built Pod: `observe_launcher` resolves by
+/// the `djinn.app/task-run-id` LABEL and `uid_fenced_delete` reads the Job's own
+/// UID, so a Pod created directly would exercise neither.
+#[tokio::test]
+#[ignore = "requires scripts/kind/setup-resize-cluster.sh up"]
+async fn live_production_resize_surface_observes_and_uid_fences_a_real_job() {
+    if !live_tests_enabled() {
+        return;
+    }
+    let client = harness_client().await;
+    ensure_named_namespace(&client, SURFACE_NAMESPACE).await;
+    let jobs: Api<Job> = Api::namespaced(client.clone(), SURFACE_NAMESPACE);
+    let pods: Api<Pod> = Api::namespaced(client.clone(), SURFACE_NAMESPACE);
+    purge_harness_jobs(&jobs).await;
+    purge_harness_pods(&pods).await;
+
+    let task_run_uuid = Uuid::now_v7();
+    let mut job = rendered_resize_v2_job(&task_run_uuid);
+    job.metadata.namespace = Some(SURFACE_NAMESPACE.to_owned());
+    {
+        let template = job
+            .spec
+            .as_mut()
+            .and_then(|spec| spec.template.spec.as_mut())
+            .expect("pod template spec");
+        // `make_pullable` takes a Pod; wrap the template in one so the Job's
+        // template gets exactly the same treatment the standalone Pod gets.
+        let mut carrier = Pod {
+            spec: Some(template.clone()),
+            ..Default::default()
+        };
+        make_pullable(&mut carrier);
+        *template = carrier.spec.expect("carrier spec");
+    }
+    let created = jobs
+        .create(&PostParams::default(), &job)
+        .await
+        .expect("create the rendered harness job");
+    let job_uid = created.metadata.uid.clone().expect("the Job has a uid");
+
+    let surface =
+        TaskRunPodResizeSurface::new(client.clone(), SURFACE_NAMESPACE, "djinn-resize-harness");
+    let task_run_id = task_run_uuid.to_string();
+
+    // 1. `observe_launcher` — the label lookup, live.
+    let observed = await_observed_launcher(&surface, &task_run_id).await;
+    assert_eq!(
+        observed.launcher_container_name, LAUNCHER_CONTAINER_NAME,
+        "the observed sidecar is the launcher",
+    );
+    assert_eq!(
+        observed.namespace, SURFACE_NAMESPACE,
+        "the surface reports the namespace it is bound to",
+    );
+    assert_eq!(
+        observed.observed_protocol.as_deref(),
+        Some("resize-v2"),
+        "the protocol is read off the STORED spec, which is where a live \
+         mismatch between render and cluster would show",
+    );
+    assert_eq!(
+        observed.admitted_cpu_millicores,
+        Some(4000),
+        "the admitted ceiling is the canonicalised `{RENDERED_CEILING}` parsed to \
+         millicores, not the `4000m` the render emitted",
+    );
+    let pod_uid = observed.pod_uid.clone();
+    assert!(!pod_uid.is_empty(), "the fence needs a real Pod UID");
+    assert_ne!(
+        pod_uid, job_uid,
+        "the fence is the POD's uid, never the Job's — the Job's uid survives a \
+         Pod recreate and would fence nothing",
+    );
+
+    // 2. `resize_launcher_cpu` — the same production call the bridge makes,
+    //    reached through the surface rather than the raw client.
+    let mut cycles = 0;
+    loop {
+        cycles += 1;
+        assert!(cycles <= 120, "the surface never confirmed the birth limit");
+        match surface
+            .resize_launcher_cpu(&observed.pod_name, BIRTH_MILLICORES)
+            .await
+        {
+            Ok(()) => break,
+            Err(PodResizeError::NotConfirmed(_)) => {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Err(other) => panic!("the surface's resize failed outright: {other}"),
+        }
+    }
+    let confirmed = pods
+        .get(&observed.pod_name)
+        .await
+        .expect("re-read the resized pod");
+    confirm_launcher_cpu(&confirmed, CpuLimit::from_millis(BIRTH_MILLICORES))
+        .expect("the surface's resize is confirmed from status.initContainerStatuses");
+
+    // 3. `uid_fenced_delete` — refuses a wrong UID, accepts the observed one.
+    let wrong = surface
+        .uid_fenced_delete(&task_run_id, "00000000-0000-0000-0000-000000000000")
+        .await;
+    assert!(
+        wrong.is_err(),
+        "a delete fenced to a UID this task run never had must refuse; accepting \
+         it would mean the fence is decorative and a stale watchdog could destroy \
+         a Pod belonging to a later attempt",
+    );
+    assert!(
+        pods.get_opt(&observed.pod_name)
+            .await
+            .expect("re-read after the refused delete")
+            .is_some(),
+        "the refused delete must not have destroyed anything",
+    );
+    surface
+        .uid_fenced_delete(&task_run_id, &pod_uid)
+        .await
+        .expect("a delete fenced to the OBSERVED uid is accepted");
+
+    purge_harness_jobs(&jobs).await;
+    purge_harness_pods(&pods).await;
+}
+
+async fn ensure_named_namespace(client: &Client, name: &str) {
+    use k8s_openapi::api::core::v1::Namespace;
+    let namespaces: Api<Namespace> = Api::all(client.clone());
+    let namespace = Namespace {
+        metadata: kube::api::ObjectMeta {
+            name: Some(name.to_owned()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    match namespaces.create(&PostParams::default(), &namespace).await {
+        Ok(_) => {}
+        Err(kube::Error::Api(response)) if response.code == 409 => {}
+        Err(error) => panic!("create harness namespace {name}: {error}"),
+    }
+}
+
+async fn purge_harness_jobs(jobs: &Api<Job>) {
+    jobs.delete_collection(&DeleteParams::background(), &Default::default())
+        .await
+        .expect("purge Jobs left by a previous harness run");
+}
+
+/// Poll until the surface reports a launcher the kubelet has actually started.
+async fn await_observed_launcher(
+    surface: &TaskRunPodResizeSurface,
+    task_run_id: &str,
+) -> ObservedLauncherSidecar {
+    const TICKS: usize = 90;
+    let mut last = String::from("no observation yet");
+    for _ in 0..TICKS {
+        match surface.observe_launcher(task_run_id).await {
+            Ok(Some(observed)) if observed.launcher_container_id.is_some() => return observed,
+            Ok(Some(_)) => last = "observed, but the kubelet has not started it".to_owned(),
+            Ok(None) => last = "no Pod carries this task-run label yet".to_owned(),
+            Err(error) => last = error.to_string(),
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    panic!("the production surface never observed a started launcher: {last}");
 }

--- a/server/crates/djinn-k8s/tests/pod_resize_kind.rs
+++ b/server/crates/djinn-k8s/tests/pod_resize_kind.rs
@@ -61,13 +61,15 @@ use djinn_cgroup_launcher::LauncherAuthorityProtocol;
 use djinn_k8s::KubernetesConfig;
 use djinn_k8s::launcher::LAUNCHER_CONTAINER_NAME;
 use djinn_k8s::pod_resize::{
-    CpuLimit, KubePodResizeApi, PodResizeClient, confirm_launcher_cpu, declared_launcher_cpu_limit,
-    locate_launcher_spec, locate_launcher_status,
+    CpuLimit, KubePodResizeApi, PodResizeClient, PodResizeError, confirm_launcher_cpu,
+    declared_launcher_cpu_limit, locate_launcher_spec, locate_launcher_status,
 };
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::{DeleteParams, PostParams};
 use kube::{Api, Client};
 use uuid::Uuid;
+
+mod support;
 
 /// The only cluster this harness will ever talk to.
 const HARNESS_CLUSTER: &str = "djinn-resize-harness";
@@ -82,6 +84,12 @@ const HARNESS_NAMESPACE: &str = "djinn-resize-harness";
 
 /// The birth limit under test.
 const BIRTH_MILLICORES: u64 = 250;
+
+/// The launcher CPU ceiling **as the apiserver stores it**, not as the render
+/// emits it. `apply_launcher_cpu_ceiling` writes `4000m`; `Quantity` is
+/// canonicalised on the way in and reads back as `4`. That gap is the whole
+/// reason confirmation compares millicores, and it is asserted live below.
+const RENDERED_CEILING: &str = "4";
 
 /// Names this harness must never operate on, mirroring
 /// `scripts/kind/setup-resize-cluster.sh`'s `RESERVED_*` arrays. Duplicated
@@ -199,6 +207,13 @@ fn live_tests_enabled() -> bool {
 
 /// A client pinned to [`HARNESS_CONTEXT`], after two independent refusals.
 async fn harness_client() -> Client {
+    // Before anything else: `kube::Client` builds its TLS config eagerly, and
+    // this workspace enables both rustls providers, so without an explicit
+    // install the very first client construction panics inside rustls with
+    // "Could not automatically determine the process-level CryptoProvider" —
+    // before a single byte reaches the apiserver. `server/src/main.rs` does this
+    // for the production binary; a test binary has no `main` to do it here.
+    support::install_crypto_provider();
     let requested =
         env::var("DJINN_TEST_RESIZE_CONTEXT").unwrap_or_else(|_| HARNESS_CONTEXT.to_owned());
     assert_eq!(
@@ -277,6 +292,31 @@ fn make_pullable(pod: &mut Pod) {
     spec.node_selector = None;
     spec.tolerations = None;
     spec.affinity = None;
+    // The production render carries `runtimeClassName: djinn-cgroup-writable`
+    // (`job.rs`), and a Pod naming a RuntimeClass that does not exist is
+    // REJECTED at admission — 403 "pod rejected: RuntimeClass
+    // \"djinn-cgroup-writable\" not found" — so without this the Pod is never
+    // created at all and nothing downstream runs. Cleared rather than installed
+    // on purpose:
+    //
+    // * The claim under test is that the KUBELET actuates a limits-only
+    //   in-place resize and reports it in `status.initContainerStatuses`. The
+    //   kubelet issues that through CRI `UpdateContainerResources` against the
+    //   same `io.containerd.runc.v2` shim either way; `cgroup_writable` changes
+    //   only whether `/sys/fs/cgroup` is writable *inside* the container, which
+    //   nothing here touches.
+    // * Declaring a RuntimeClass named `djinn-cgroup-writable` backed by plain
+    //   `runc` — the obvious shortcut — would be the exact silent-wrong-handler
+    //   trap `scripts/kind/setup-kueue-cluster.sh --cgroup-writable` was built
+    //   to catch: the class resolves, the Pod is admitted, and the sandbox comes
+    //   up with a read-only `/sys/fs/cgroup` while every assertion still passes.
+    //   Installing the REAL handler is that script's job, and this node image
+    //   (1.33.1, containerd v2.1.1) is not the one it is verified against.
+    //
+    // Resize under the production runtime handler is therefore NOT proven here.
+    // It is proven in `tests/kueue_cluster_harness.rs`'s cluster that the
+    // handler loads at all; the intersection of the two remains open.
+    spec.runtime_class_name = None;
     for container in spec.init_containers.iter_mut().flatten() {
         container.image = Some(PAUSE.to_owned());
         container.command = None;
@@ -318,6 +358,22 @@ async fn ensure_namespace(client: &Client) {
     }
 }
 
+/// Delete every Pod this harness left behind in its own namespace.
+///
+/// A failed run panics before its trailing `delete`, so without this each retry
+/// leaves a 4-core-limit Pod parked on a single-node cluster. Two of those and
+/// the next run's Pod never schedules — which surfaces as "launcher sidecar
+/// never became admitted", i.e. quota exhaustion wearing the costume of the
+/// defect under test.
+///
+/// Safe to make unconditional: `HARNESS_NAMESPACE` is created and owned by this
+/// file, and `harness_client` has already refused any non-loopback apiserver.
+async fn purge_harness_pods(pods: &Api<Pod>) {
+    pods.delete_collection(&DeleteParams::default(), &Default::default())
+        .await
+        .expect("purge Pods left by a previous harness run");
+}
+
 /// Poll until the launcher sidecar is present and started in BOTH
 /// `spec.initContainers` and `status.initContainerStatuses`.
 async fn await_admitted_launcher(pods: &Api<Pod>, name: &str) -> Pod {
@@ -346,14 +402,98 @@ async fn await_admitted_launcher(pods: &Api<Pod>, name: &str) -> Pod {
     );
 }
 
-/// **AC8.** Render a real `resize-v2` task-run Pod, capture the ceiling the
-/// apiserver actually stored, downsize to the birth limit, and confirm from
-/// `status.initContainerStatuses`.
+/// The birth downsize, driven exactly as production drives it.
 ///
-/// Swap `Patch::Strategic` for `Patch::Merge` in
-/// `KubePodResizeApi::patch_resize` and the init-container count assertion
-/// fails: an RFC 7386 merge replaces the whole array and drops every other init
-/// container.
+/// `PodResizeClient::resize_launcher_cpu` performs one GET / PATCH / GET and
+/// nothing more — by design; the retry budget belongs to `0ppk`'s
+/// `TaskRunResizeAdmissionBridge`, which re-runs the whole bootstrap on a poll
+/// interval until its budget expires. So does this, for the same reason and with
+/// the same idempotence: resizing to a value the launcher already holds confirms
+/// on the next read.
+///
+/// Returns what the *first* cycle observed, which is the interesting number: it
+/// is the width of the window between "the apiserver accepted the PATCH" and
+/// "the kubelet actuated it", and that window is the entire reason a dispatch
+/// gate exists.
+struct BirthDownsize {
+    /// Cycles until `status.initContainerStatuses` agreed. 1 means the first
+    /// GET / PATCH / GET confirmed.
+    cycles: usize,
+    /// `spec.initContainers[cgroup-launcher].resources.limits.cpu`, in
+    /// millicores, read fresh immediately after the first PATCH was accepted.
+    spec_millis_after_first_patch: Option<u64>,
+    /// The same instant's
+    /// `status.initContainerStatuses[cgroup-launcher].resources.limits.cpu`.
+    status_millis_after_first_patch: Option<u64>,
+}
+
+async fn confirm_birth_downsize(client: &Client, pods: &Api<Pod>, name: &str) -> BirthDownsize {
+    // Iteration-counted rather than deadline-based: `Instant::now` is a
+    // workspace-disallowed method (`clippy.toml`).
+    const TICKS: usize = 120;
+    const TICK: Duration = Duration::from_millis(500);
+
+    let resize = PodResizeClient::new(KubePodResizeApi::new(
+        client.clone(),
+        HARNESS_NAMESPACE,
+        "djinn-resize-harness",
+    ));
+    let target = CpuLimit::from_millis(BIRTH_MILLICORES);
+    let mut observed = BirthDownsize {
+        cycles: 0,
+        spec_millis_after_first_patch: None,
+        status_millis_after_first_patch: None,
+    };
+    let mut last = String::new();
+
+    for tick in 0..TICKS {
+        observed.cycles = tick + 1;
+        let outcome = resize.resize_launcher_cpu(name, target).await;
+        if tick == 0 {
+            // Snapshot both halves before the retry loop can blur them. The
+            // apiserver updates `spec` synchronously with an accepted PATCH; the
+            // kubelet updates `status` when it has actually moved the cgroup.
+            let snapshot = pods.get(name).await.expect("snapshot after first patch");
+            observed.spec_millis_after_first_patch = declared_launcher_cpu_limit(&snapshot)
+                .ok()
+                .map(CpuLimit::millis);
+            observed.status_millis_after_first_patch = locate_launcher_status(&snapshot)
+                .ok()
+                .and_then(|status| status.resources.as_ref())
+                .and_then(|resources| resources.limits.as_ref())
+                .and_then(|limits| limits.get("cpu"))
+                .and_then(|quantity| CpuLimit::parse(&quantity.0).ok())
+                .map(CpuLimit::millis);
+        }
+        match outcome {
+            Ok(()) => return observed,
+            Err(PodResizeError::NotConfirmed(reason)) => last = reason.to_string(),
+            Err(other) => panic!("the birth downsize failed outright: {other}"),
+        }
+        tokio::time::sleep(TICK).await;
+    }
+    panic!(
+        "a real kubelet never confirmed the {BIRTH_MILLICORES}m birth limit in \
+         status.initContainerStatuses within {TICKS} cycles; last refusal: {last}",
+    );
+}
+
+/// **AC8, live.** Render a real `resize-v2` task-run Pod, capture the ceiling the
+/// apiserver actually stored, downsize to the birth limit, and confirm from
+/// `status.initContainerStatuses` — against a real kubelet.
+///
+/// # What each mutation costs
+///
+/// * Swap `Patch::Strategic` for `Patch::Merge` in
+///   `KubePodResizeApi::patch_resize`: the apiserver rejects it outright with
+///   `spec.initContainers[0].resources.limits: Forbidden: resource limits cannot
+///   be removed`, because an RFC 7386 merge replaces the whole array.
+/// * Point confirmation at `status.containerStatuses`: the assertions under
+///   "the wrong array" below show what it would read on this very Pod — a
+///   `cgroup-launcher` entry that does not exist, beside a `worker` entry
+///   holding a *coincidentally rendered* `cpu: 4`.
+/// * Compare `Quantity` strings instead of millicores: the ceiling assertions
+///   below show the apiserver stored the string `4` for a render of `4000m`.
 #[tokio::test]
 #[ignore = "requires scripts/kind/setup-resize-cluster.sh up"]
 async fn live_birth_downsize_is_confirmed_by_a_real_kubelet() {
@@ -363,6 +503,7 @@ async fn live_birth_downsize_is_confirmed_by_a_real_kubelet() {
     let client = harness_client().await;
     ensure_namespace(&client).await;
     let pods: Api<Pod> = Api::namespaced(client.clone(), HARNESS_NAMESPACE);
+    purge_harness_pods(&pods).await;
 
     let task_run_id = Uuid::now_v7();
     let rendered = rendered_resize_v2_pod(&task_run_id);
@@ -377,12 +518,40 @@ async fn live_birth_downsize_is_confirmed_by_a_real_kubelet() {
 
     let admitted = await_admitted_launcher(&pods, &name).await;
 
-    // The ceiling is read off the STORED Pod, never off the render input.
-    let ceiling = declared_launcher_cpu_limit(&admitted)
+    // ── The ceiling, and why millicores are not a stylistic choice ──────────
+    //
+    // The render writes `4000m` (`apply_launcher_cpu_ceiling` formats
+    // `{millicores}m`). What the apiserver STORED is asserted here, off the
+    // stored Pod, never off the render input.
+    let raw_ceiling = locate_launcher_spec(&admitted)
+        .expect("launcher spec")
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.limits.as_ref())
+        .and_then(|limits| limits.get("cpu"))
+        .map(|quantity| quantity.0.clone())
         .expect("a resize-v2 render declares a launcher CPU ceiling");
+    assert_eq!(
+        raw_ceiling, RENDERED_CEILING,
+        "the apiserver canonicalises Quantity on the way in",
+    );
+    assert_ne!(
+        raw_ceiling, "4000m",
+        "AC2, live and non-vacuous: the render emitted `4000m` and the apiserver \
+         stored `{RENDERED_CEILING}`. A confirmation that compared Quantity \
+         STRINGS would therefore never match a whole-core target, and would \
+         report `never reported 4000m; last observed Some(4)` forever",
+    );
+    let ceiling =
+        declared_launcher_cpu_limit(&admitted).expect("the stored ceiling parses through CpuLimit");
+    assert_eq!(
+        ceiling.millis(),
+        4000,
+        "parsed to millicores, `{RENDERED_CEILING}` and `4000m` are the same number",
+    );
     assert!(
         ceiling.millis() > BIRTH_MILLICORES,
-        "the fixture ceiling ({ceiling}) must be above the birth limit, or the \
+        "the rendered ceiling ({ceiling}) must be above the birth limit, or the \
          downsize would be an upsize and prove nothing",
     );
 
@@ -404,18 +573,70 @@ async fn live_birth_downsize_is_confirmed_by_a_real_kubelet() {
         .as_ref()
         .and_then(|status| status.qos_class.clone());
 
-    PodResizeClient::new(KubePodResizeApi::new(
-        client.clone(),
-        HARNESS_NAMESPACE,
-        "djinn-resize-harness",
-    ))
-    .resize_launcher_cpu(&name, CpuLimit::from_millis(BIRTH_MILLICORES))
-    .await
-    .expect("the birth downsize must confirm from status.initContainerStatuses");
+    // ── The downsize, and the acceptance/actuation window it opens ──────────
+    let downsize = confirm_birth_downsize(&client, &pods, &name).await;
+    eprintln!(
+        "pod_resize_kind: a real kubelet confirmed {BIRTH_MILLICORES}m after \
+         {} cycle(s); after the first accepted PATCH spec={:?}m status={:?}m",
+        downsize.cycles,
+        downsize.spec_millis_after_first_patch,
+        downsize.status_millis_after_first_patch,
+    );
+
+    // AC1, live and non-vacuous: whatever the kubelet's latency was on this run,
+    // the apiserver had ALREADY stored the new spec by the time the first PATCH
+    // returned. The PATCH response and the spec are therefore both available to
+    // a caller that has no confirmation at all — which is precisely why neither
+    // may be the confirmation source.
+    assert_eq!(
+        downsize.spec_millis_after_first_patch,
+        Some(BIRTH_MILLICORES),
+        "an accepted PATCH updates `spec` synchronously; if this is not already \
+         250m the PATCH was not accepted and the rest of this test measures \
+         nothing",
+    );
 
     let after = pods.get(&name).await.expect("re-read the resized pod");
     confirm_launcher_cpu(&after, CpuLimit::from_millis(BIRTH_MILLICORES))
         .expect("a fresh read still confirms the birth limit");
+
+    // ── The wrong array, on this very Pod ───────────────────────────────────
+    //
+    // AC1's non-vacuity, stated against live data rather than a fixture: point
+    // confirmation at `status.containerStatuses` and there is no launcher entry
+    // to find, while the entry that IS there reports a limit that is not the
+    // birth limit. Reading the wrong array does not read nothing; it reads a
+    // number, and that number is wrong.
+    let regular_statuses = after
+        .status
+        .as_ref()
+        .and_then(|status| status.container_statuses.as_ref())
+        .expect("the live Pod publishes regular container statuses");
+    assert!(
+        !regular_statuses
+            .iter()
+            .any(|status| status.name == LAUNCHER_CONTAINER_NAME),
+        "the launcher is a NATIVE SIDECAR: a `{LAUNCHER_CONTAINER_NAME}` entry in \
+         status.containerStatuses is a documented failure mode, not a fallback",
+    );
+    let worker_limit = regular_statuses
+        .iter()
+        .find(|status| status.name == "worker")
+        .and_then(|status| status.resources.as_ref())
+        .and_then(|resources| resources.limits.as_ref())
+        .and_then(|limits| limits.get("cpu"))
+        .map(|quantity| quantity.0.clone())
+        .expect("the worker container reports a cpu limit");
+    assert_ne!(
+        CpuLimit::parse(&worker_limit)
+            .expect("the worker limit parses")
+            .millis(),
+        BIRTH_MILLICORES,
+        "status.containerStatuses[worker] reports {worker_limit}, never the birth \
+         limit; a confirmation that read this array would refuse forever, and a \
+         render that happened to size the worker at 250m would make it confirm a \
+         resize that never happened",
+    );
 
     let after_status = locate_launcher_status(&after).expect("launcher status after");
     assert_eq!(
@@ -459,7 +680,76 @@ async fn live_birth_downsize_is_confirmed_by_a_real_kubelet() {
         "the resize target is still the launcher and only the launcher",
     );
 
+    // ── AC2's non-vacuity, on the CONFIRMATION path ─────────────────────────
+    //
+    // 250m survives a round trip as the string `250m`, so the birth downsize
+    // alone cannot show what comparing `Quantity` strings would cost. A
+    // whole-core target can: the apiserver canonicalises it in BOTH `spec` and
+    // `status`, so `raw == "1000m"` never matches and a string-comparing
+    // confirmation waits out its budget reporting "never reported 1000m; last
+    // observed 1". The lease lift this stack exists to perform moves the
+    // launcher to whole cores, so this is the operating case, not a corner one.
+    let whole_core = CpuLimit::from_millis(1000);
+    confirm_whole_core(&client, &pods, &name, whole_core).await;
+    let lifted = pods.get(&name).await.expect("re-read the lifted pod");
+    let raw_lifted = locate_launcher_status(&lifted)
+        .expect("launcher status after the lift")
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.limits.as_ref())
+        .and_then(|limits| limits.get("cpu"))
+        .map(|quantity| quantity.0.clone())
+        .expect("the lifted launcher reports a cpu limit");
+    assert_eq!(
+        raw_lifted, "1",
+        "the kubelet reports the CANONICALISED quantity, not the one we sent",
+    );
+    assert_ne!(
+        raw_lifted,
+        whole_core.as_quantity(),
+        "AC2, live and non-vacuous: this client emits `{}` and the apiserver \
+         reports `{raw_lifted}`. String equality is not merely fragile here, it \
+         is never true — which is why `confirm_launcher_cpu` parses both sides",
+        whole_core.as_quantity(),
+    );
+    assert_eq!(
+        CpuLimit::parse(&raw_lifted)
+            .expect("the canonicalised quantity parses")
+            .millis(),
+        whole_core.millis(),
+        "parsed to millicores the two agree, and that is the only comparison \
+         that survives canonicalisation",
+    );
+
     pods.delete(&name, &DeleteParams::default())
         .await
         .expect("delete the harness pod");
+}
+
+/// Drive one further confirmed resize, with the same production client and the
+/// same retry shape as [`confirm_birth_downsize`].
+async fn confirm_whole_core(client: &Client, pods: &Api<Pod>, name: &str, target: CpuLimit) {
+    const TICKS: usize = 120;
+    const TICK: Duration = Duration::from_millis(500);
+
+    let resize = PodResizeClient::new(KubePodResizeApi::new(
+        client.clone(),
+        HARNESS_NAMESPACE,
+        "djinn-resize-harness",
+    ));
+    let mut last = String::new();
+    for _ in 0..TICKS {
+        match resize.resize_launcher_cpu(name, target).await {
+            Ok(()) => {
+                // Belt and braces: a fresh read outside the client agrees.
+                let fresh = pods.get(name).await.expect("fresh read after the lift");
+                confirm_launcher_cpu(&fresh, target).expect("a fresh read still confirms");
+                return;
+            }
+            Err(PodResizeError::NotConfirmed(reason)) => last = reason.to_string(),
+            Err(other) => panic!("the whole-core lift failed outright: {other}"),
+        }
+        tokio::time::sleep(TICK).await;
+    }
+    panic!("a real kubelet never confirmed {target}; last refusal: {last}");
 }

--- a/server/tests/task_run_resize_kind.rs
+++ b/server/tests/task_run_resize_kind.rs
@@ -173,6 +173,60 @@ fn read_repo_file(relative: &str) -> String {
         .unwrap_or_else(|error| panic!("read {relative}: {error}"))
 }
 
+/// `text` with whole-line comments removed.
+///
+/// Every text guard in this file matches against SOURCE, and a comment is not
+/// source: it cannot call a function, set a variable, or arm a workflow step. So
+/// a comment must neither satisfy a positive assertion nor trip a negative one,
+/// and both directions have now bitten this campaign:
+///
+/// * **False negative.** `1j64`'s teardown-trap guard matched the prose in a
+///   header and stayed green when the real `trap` line was deleted. `0vku`'s CI
+///   guard passed on a commented-out arming call. The guard immediately below
+///   already carries the scar tissue from the first of those.
+/// * **False positive.** On 2026-07-31 the `Patch::Apply` ban fired on a comment
+///   in `pod_resize.rs` explaining that `PatchParams::force` is rejected
+///   client-side on any non-apply body — a comment recording a real production
+///   defect. A guard that punishes the comment naming the wrong variant is a
+///   guard that argues against being told why the code is the way it is.
+///
+/// Only WHOLE-line comments are dropped, deliberately: a trailing comment must
+/// not be able to hide the code in front of it. Block comments are not handled
+/// because none of the guarded files use them; a `/* … */` naming a banned token
+/// would still be a false positive, and the fix then is to delete the block
+/// comment, not to widen this.
+fn code_lines(text: &str, comment_prefix: &str) -> String {
+    text.lines()
+        .filter(|line| !line.trim_start().starts_with(comment_prefix))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// [`code_lines`] for Rust. Covers `//`, `///` and `//!`.
+fn rust_code(source: &str) -> String {
+    code_lines(source, "//")
+}
+
+/// [`code_lines`] for shell and YAML, which share the `#` comment marker.
+fn script_code(text: &str) -> String {
+    code_lines(text, "#")
+}
+
+/// The `Patch` variants that must never reach the wire for this subresource.
+const BANNED_PATCH_VARIANTS: [&str; 3] = ["Patch::Merge", "Patch::Json", "Patch::Apply"];
+
+/// The banned `Patch` variant `source` actually CONSTRUCTS, if any.
+///
+/// Split out from its guard so the guard's own logic is testable against
+/// synthetic input — otherwise "ignore comments" and "ignore everything" are
+/// indistinguishable from a green run.
+fn banned_patch_variant_in(source: &str) -> Option<&'static str> {
+    let code = rust_code(source);
+    BANNED_PATCH_VARIANTS
+        .into_iter()
+        .find(|wrong| code.contains(wrong))
+}
+
 fn run_script(args: &[&str]) -> Output {
     Command::new("bash")
         .arg(repo_root().join(SETUP_SCRIPT))
@@ -297,7 +351,7 @@ fn guard_both_kubernetes_floors_are_enforced() {
         );
     }
 
-    let script = read_repo_file(SETUP_SCRIPT);
+    let script = script_code(&read_repo_file(SETUP_SCRIPT));
     assert!(
         script.contains("MIN_K8S_MINOR=30") && script.contains("RESIZE_MIN_K8S_MINOR=33"),
         "the two floors must be named constants, not inline literals"
@@ -343,14 +397,20 @@ fn guard_the_teardown_trap_precedes_everything_it_must_clean_up() {
         trap < registry && trap < cluster,
         "the EXIT trap is installed on line {trap}, after the registry ({registry}) or the cluster ({cluster}); everything the harness creates must be created UNDER the trap"
     );
+    // `script` above stays RAW because the ordering assertion needs real line
+    // numbers. These two are presence checks, so they read code only — a comment
+    // saying "the failure path calls teardown" must not be able to satisfy them.
+    // That is `1j64`'s defect verbatim, and this guard already carries the scar
+    // from it on the `trap` line above.
+    let code = script_code(&script);
     assert!(
-        script.contains("teardown || true"),
+        code.contains("teardown || true"),
         "the failure path must call teardown"
     );
     // The live lane runs `selftest`, which injects a real failure and proves
     // the registry container is gone. This is its hermetic half.
     assert!(
-        script.contains("DJINN_RESIZE_HARNESS_FAIL_AFTER=registry"),
+        code.contains("DJINN_RESIZE_HARNESS_FAIL_AFTER=registry"),
         "the selftest's injection point is gone; the trap would then be untested"
     );
 }
@@ -360,7 +420,7 @@ fn guard_the_teardown_trap_precedes_everything_it_must_clean_up() {
 /// resolved from the live node rather than assumed.
 #[test]
 fn guard_the_harness_installs_cgroup_delegation_rather_than_disabling_it() {
-    let script = read_repo_file(SETUP_SCRIPT);
+    let script = script_code(&read_repo_file(SETUP_SCRIPT));
     // The sibling harness makes the writable-cgroup node opt-in behind a
     // `--cgroup-writable)` case arm and a `CGROUP_WRITABLE` toggle. Neither may
     // exist here: a run without the node would not fail, it would pass a weaker
@@ -460,7 +520,7 @@ fn guard_the_source_admits_no_forbidden_shortcut() {
     ] {
         let burner = format!("{head}{tail}");
         assert!(
-            !source.contains(burner.as_str()),
+            !rust_code(&source).contains(burner.as_str()),
             "the suite contains the synthetic burner `{burner}`; the measured workload is the probe's brokered `sha256sum` and nothing else"
         );
     }
@@ -487,18 +547,27 @@ fn guard_the_source_admits_no_forbidden_shortcut() {
 #[test]
 fn guard_the_production_resize_patch_is_strategic_and_minimal() {
     let source = read_repo_file(POD_RESIZE_SOURCE);
+    let code = rust_code(&source);
     assert!(
-        source.contains("Patch::Strategic"),
+        code.contains("Patch::Strategic"),
         "{POD_RESIZE_SOURCE} no longer uses a strategic merge patch; the initContainers array carries `patchMergeKey: name`, so a JSON-merge body REPLACES the whole array and destroys every other init container"
     );
-    for wrong in ["Patch::Merge", "Patch::Json", "Patch::Apply"] {
-        assert!(
-            !source.contains(wrong),
-            "{POD_RESIZE_SOURCE} uses {wrong}; only Patch::Strategic survives the initContainers merge key"
-        );
-    }
+    assert_eq!(
+        banned_patch_variant_in(&source),
+        None,
+        "{POD_RESIZE_SOURCE} constructs a banned Patch variant; only Patch::Strategic survives the initContainers merge key"
+    );
+    // `PatchParams::force()` is an SSA-only knob: `kube` rejects it client-side
+    // on any non-`Patch::Apply` body, before a byte leaves the process and with
+    // no HTTP status to notice. That is how every resize this client could ever
+    // issue failed silently until 2026-07-31, so it is guarded here beside the
+    // variant it is invalid with.
     assert!(
-        source.contains("patch_subresource(RESIZE_SUBRESOURCE"),
+        !code.contains(".force()"),
+        "{POD_RESIZE_SOURCE} calls PatchParams::force(); `force` is a server-side-apply conflict override and kube REFUSES it client-side alongside a strategic patch with `PatchParams::force only works with Patch::Apply`. The refusal has no HTTP status and never reaches an apiserver audit log"
+    );
+    assert!(
+        code.contains("patch_subresource(RESIZE_SUBRESOURCE"),
         "the PATCH must go to the pods/resize subresource, not to the Pod itself"
     );
     assert_eq!(RESIZE_SUBRESOURCE, "resize");
@@ -646,6 +715,10 @@ fn the_misleading_container_status_is_not_confirmation() {
 #[test]
 fn guard_the_live_lane_is_wired() {
     let workflow = read_repo_file(WORKFLOW);
+    // Code only, both directions: a YAML comment naming the lane must not
+    // satisfy the presence checks, and one mentioning `continue-on-error` must
+    // not trip the ban.
+    let workflow_code = script_code(&workflow);
     for required in [
         SETUP_SCRIPT,
         "task_run_resize_kind",
@@ -655,12 +728,12 @@ fn guard_the_live_lane_is_wired() {
         "down",
     ] {
         assert!(
-            workflow.contains(required),
+            workflow_code.contains(required),
             "{WORKFLOW} no longer references {required}"
         );
     }
     assert!(
-        !workflow.contains("continue-on-error"),
+        !workflow_code.contains("continue-on-error"),
         "a live proof that cannot fail the lane is not a proof"
     );
     // The same non-vacuity device `brokered_lease_lift_boundary.rs` uses: the
@@ -670,7 +743,7 @@ fn guard_the_live_lane_is_wired() {
         .matches("\n#[ignore")
         .count();
     assert!(
-        workflow.contains(&format!("RESIZE_KIND_EXPECTED_PROOFS: \"{expected}\"")),
+        workflow_code.contains(&format!("RESIZE_KIND_EXPECTED_PROOFS: \"{expected}\"")),
         "{WORKFLOW} declares a different live-proof count than the {expected} this file carries"
     );
 }
@@ -1904,4 +1977,80 @@ fn measure_effective_cpu(pod: &str, invocation: &str) -> Effective {
         wall_millis,
         effective_millicores: usage_usec.saturating_mul(1_000) / (wall_millis.max(1) * 1_000),
     }
+}
+
+/// **The comment-stripping guards are accurate, not merely quiet.**
+///
+/// "Ignore comments" and "ignore everything" are indistinguishable from a green
+/// run, so the predicate the source guards share is exercised here against
+/// synthetic input where the right answer is known. Without this, the
+/// 2026-07-31 fix for the `Patch::Apply` false positive would have been a
+/// licence to make every text guard in this file vacuous.
+#[test]
+fn guard_the_source_guards_read_code_and_not_comments() {
+    // The false positive this was written for: a comment naming a banned
+    // variant is not a call site.
+    assert_eq!(
+        banned_patch_variant_in(
+            "// kube rejects force on any non-apply body\nlet p = Patch::Strategic(&body);"
+        ),
+        None,
+        "a comment naming a banned variant must not fail the guard",
+    );
+    // The property that must survive that fix: real code still fails it.
+    assert_eq!(
+        banned_patch_variant_in("let p = Patch::Merge(&body);"),
+        Some("Patch::Merge"),
+        "a REAL Patch::Merge must still be caught; if this ever returns None the \
+         comment fix turned the guard into a no-op",
+    );
+    assert_eq!(
+        banned_patch_variant_in("    let p = Patch::Json(&body);"),
+        Some("Patch::Json"),
+        "indentation is not a comment",
+    );
+    assert_eq!(
+        banned_patch_variant_in("let p = Patch::Apply(&body);"),
+        Some("Patch::Apply"),
+    );
+    // A TRAILING comment must not hide the code in front of it — the stripping
+    // is whole-line only, and this is the case that proves the difference.
+    assert_eq!(
+        banned_patch_variant_in("let p = Patch::Merge(&body); // sorry"),
+        Some("Patch::Merge"),
+        "a trailing comment must not launder the code before it",
+    );
+    // Doc comments are comments.
+    assert_eq!(
+        banned_patch_variant_in("/// See the merge variant for why this is wrong.\nlet p = ();"),
+        None,
+    );
+
+    // The shell/YAML half, in both directions.
+    assert!(
+        !script_code("# MIN_K8S_MINOR=29 was the floor before #2818").contains("MIN_K8S_MINOR=29"),
+        "a shell comment must not trip a negative script guard",
+    );
+    assert!(
+        script_code("MIN_K8S_MINOR=29").contains("MIN_K8S_MINOR=29"),
+        "a real assignment must still be caught",
+    );
+    assert!(
+        !script_code("  # continue-on-error: true").contains("continue-on-error"),
+        "a YAML comment must not trip the continue-on-error ban",
+    );
+    assert!(
+        script_code("  continue-on-error: true").contains("continue-on-error"),
+        "a real YAML key must still be caught",
+    );
+    assert!(
+        !script_code("# the failure path calls teardown || true").contains("teardown || true"),
+        "prose describing the teardown call must not SATISFY the presence check; \
+         that is 1j64's defect, where a guard matched a header comment and stayed \
+         green after the real trap line was deleted",
+    );
+    assert!(
+        script_code("    teardown || true").contains("teardown || true"),
+        "the real call must still satisfy it",
+    );
 }

--- a/server/tests/task_run_resize_kind.rs
+++ b/server/tests/task_run_resize_kind.rs
@@ -511,6 +511,10 @@ fn guard_the_source_admits_no_forbidden_shortcut() {
     );
     // Assembled from halves for the same reason the status token above is: a
     // gate that spelled its own forbidden strings would always find them.
+    //
+    // Code only, and hoisted out of the loop: the module docs must stay free to
+    // name a burner while explaining why it is forbidden.
+    let suite_code = rust_code(source);
     for (head, tail) in [
         ("while :", "; do"),
         ("dd if=", "/dev/zero"),
@@ -520,7 +524,7 @@ fn guard_the_source_admits_no_forbidden_shortcut() {
     ] {
         let burner = format!("{head}{tail}");
         assert!(
-            !rust_code(&source).contains(burner.as_str()),
+            !suite_code.contains(burner.as_str()),
             "the suite contains the synthetic burner `{burner}`; the measured workload is the probe's brokered `sha256sum` and nothing else"
         );
     }


### PR DESCRIPTION
Executes `pwys`'s (#2860) live birth-downsize arm, which that task authored under a no-cluster scope and flagged honestly as unproven. Running it found **five defects, two of them in production code**, and then proved the claim.

## Does this run anywhere automatically? **No.**

Stated plainly, because that is an acceptance criterion. The two `live_*` tests are `#[ignore]`d **and** gated on `DJINN_TEST_RESIZE_CLUSTER=1`, and no workflow, script or CI lane invokes either. They run only when a human runs:

```
scripts/kind/setup-resize-cluster.sh up
DJINN_TEST_RESIZE_CLUSTER=1 cargo test -p djinn-k8s --test pod_resize_kind -- --include-ignored
scripts/kind/setup-resize-cluster.sh down   # ALWAYS, pass or fail
```

The four hermetic `guard_*` tests do run in ordinary CI, and are **unmodified** by this PR. What CI gains from this PR is the `PatchParams` fix; the live proof itself remains a manual gate.

## The headline measurement

Against a real kubelet (kind, `kindest/node:v1.33.1`, containerd v2.1.1):

```
a real kubelet confirmed 250m after 4-5 cycle(s);
after the first accepted PATCH  spec=Some(250)m  status=Some(4000)m
```

For roughly two seconds after the apiserver accepts the PATCH, `spec` reads 250m while the launcher is still running at 4000m. That gap is the `DispatchGate`'s entire reason to exist, and it is now a measured number rather than an argument.

## Production defect 1 — every resize PATCH failed before leaving the process

`KubePodResizeApi::patch_resize` built `PatchParams::apply(&field_manager).force()`. `apply()` is the server-side-apply constructor and `force` is an SSA conflict override; `kube` validates the pair **client-side** and rejects any non-`Patch::Apply` body carrying it:

```
Failed to build request: failed to validate request:
PatchParams::force only works with Patch::Apply
```

No HTTP status. No apiserver audit entry. Nothing reached the cluster.

`KubePodResizeApi` is the one type in that module no hermetic test constructs — every other test drives `PodResizeApi` through a fixture — so the transport had **zero** coverage and 3i92's resize arm could never have worked in production. It is unreachable on the current fleet only because every dispatch still takes the leaf-v1 arm; flipping the authority mode would have hit it on the first `resize-v2` dispatch.

## Production defect 2 (harness) — the cluster script never produced a cluster

`containerdConfigPatches` set `registry.mirrors`, which containerd v2 refuses alongside the `config_path` kind's node image already sets:

```
invalid cri image config: `mirrors` cannot be set when `config_path` is provided
```

The CRI plugin then fails to load **entirely**, the kubelet dies on `unknown service runtime.v1.RuntimeService`, and `kind create` fails four minutes later at "waiting for a healthy kubelet" with nothing in its output naming containerd. Replaced with the `config_path` + `certs.d/hosts.toml` shape `setup-kueue-cluster.sh` already uses.

## Harness defect 3 — the version floor guard measured the wrong ledger

Guard 6 exists to "re-check the floor against the LIVE API server, not the requested image tag — a tag can lie; the server cannot". It read the **first** `"minor"` out of `kubectl version -o json`, which is `clientVersion`. A 1.33.1 cluster reported as `k8s: 1.36`. The guard would have waved through any server version on a machine with a current kubectl. Now reads `get --raw /version`, which returns the server object and nothing else.

## Harness defects 4 and 5

- The test binary installed no rustls `CryptoProvider`, so the first `kube::Client` panicked before a byte reached the apiserver. Wired to the existing `tests/support::install_crypto_provider`.
- The rendered Pod kept `runtimeClassName: djinn-cgroup-writable`, which this cluster does not have, so admission rejected it 403. Cleared alongside the other cluster-specific fields `make_pullable` already strips — see its comment for why declaring a same-named RuntimeClass backed by plain `runc` was deliberately **not** the fix.

## Non-vacuity, each verified by mutating the source and re-running live

| Mutation | Live result |
|---|---|
| confirmation reads `status.containerStatuses[worker]` | reports **4000m forever**, never confirms — the worker's coincidentally rendered `cpu: 4` |
| `Patch::Strategic` → `Patch::Merge` | 422 `spec.initContainers[0].resources.limits: Forbidden: resource limits cannot be removed` |
| `Quantity` string comparison | a 1000m resize is stored **and reported** as the string `1`, so string equality is never true |

The third is now a permanent assertion rather than a one-off mutation: the test ends with a whole-core lift phase, because the lease lift this stack exists to perform moves the launcher to whole cores. 250m alone survives a round trip as `250m` and could never have shown the cost.

## Second live test: the production surface

`TaskRunPodResizeSurface` is the type `TaskRunResizeAdmissionBridge` resolves and drives. The hermetic seam test proves the bridge and gate sit on the real dispatch path but substitutes this surface for a fixture, so none of its three operations had ever spoken to an apiserver. Given that one of the three turned out to be fatally broken at the transport, the other two got exercised rather than assumed.

Driven from a real **Job**, because that is the only shape that reaches the code: `observe_launcher` resolves by the `djinn.app/task-run-id` label and `uid_fenced_delete` reads the Job's own UID. Proven live: the label lookup finds the Pod and reports `resize-v2` with a 4000m admitted ceiling parsed from the canonicalised `4`; the fence is the **Pod's** uid and is not the Job's; `uid_fenced_delete` **refuses** a uid this task run never had and leaves the Pod intact, while the same call with the observed uid is accepted.

## A fourth defect, found by CI: the guard that fired was wrong

`guard_the_production_resize_patch_is_strategic_and_minimal` failed on the first push. The production fix is correct; the guard did a raw `source.contains(..)` over `["Patch::Merge", "Patch::Json", "Patch::Apply"]` with **no comment stripping**, and the new comment in `pod_resize.rs` explains that `PatchParams::force` is rejected on any non-apply body. It fired on the comment recording the defect it exists to keep fixed.

**This is the third occurrence of the same root cause in this campaign.** `1j64`'s teardown-trap guard matched a header comment mentioning `trap on_exit EXIT` and stayed green when the real line was deleted; `0vku`'s CI guard passed on a commented-out arming call. Those two were false *negatives*; this one is a false *positive*. All three are text matching without comment awareness. The sibling loop directly below this assertion already filtered `//` lines — the fix simply never spread.

So it is shared now rather than spot-fixed: `code_lines` plus `rust_code` / `script_code` (shell and YAML share `#`), with **every** text assertion in the file routed through them in both directions — the Patch-variant ban and the `Patch::Strategic` requirement, both Kubernetes floors, `teardown || true`, `DJINN_RESIZE_HARNESS_FAIL_AFTER=registry`, the `--cgroup-writable` arm and `CGROUP_WRITABLE` toggles, the required containerd references, the hardcoded runtime tables, the synthetic-burner ban over the suite's own source, every workflow presence check, the `continue-on-error` ban, and the declared live-proof count.

**Audit result:** all of them still pass with comments stripped, so none of this file's positive assertions was being satisfied by prose. The false-negative half of this class was not present here — only the false positive was.

**Strictness is unchanged, and proven rather than asserted:**

- `guard_the_source_guards_read_code_and_not_comments` exercises the shared predicate against synthetic input in both directions, including that a **trailing** comment must not launder the code in front of it.
- Verified end to end against the real file: introducing a real `Patch::Merge` while **leaving `Patch::Strategic` in place** fails the guard with `left: Some("Patch::Merge")`. Replacing `Patch::Strategic` outright fails it on the other arm.

`.force()` is now banned in code beside the variant it is invalid with, so the production defect above cannot return silently.

**Scope note:** `server/tests/task_run_resize_kind.rs` is pcod's file (#2861, merged), outside this task's original set. Edited deliberately, for the reason above.

## Two script decisions, stated

**Kept a separate cluster script rather than consolidating onto `setup-kueue-cluster.sh --cgroup-writable`.** That script installs Kueue (CRDs, controller, conversion webhooks) which this harness needs none of, and it pins its own Kubernetes version, which would put the `pods/resize` floor under Kueue's control. The cgroup-writable handler it installs is also not what is under test here — see below.

**The feature gate is now stated conditionally.** `InPlacePodVerticalScaling` is beta-on-by-default at 1.33 and **GA from 1.34** (measured: a 1.35.0 kubelet logs `Setting GA feature gate InPlacePodVerticalScaling=true. It will be removed in a future release.`). Naming a removed gate is a hard kubelet start failure, so an unconditional `featureGates:` block silently pinned this harness to a closing window of node images.

## What is still not proven

- **Resize under the production runtime handler.** The Pod runs without `runtimeClassName`. The kubelet issues the resize through CRI `UpdateContainerResources` against the same `io.containerd.runc.v2` shim either way, and `cgroup_writable` only affects whether `/sys/fs/cgroup` is writable *inside* the container — which nothing here touches. But the intersection of "resize-v2" and "runc-cgroupwritable" is untested. Note `kindest/node:v1.33.1` ships containerd v2.1.1; `setup-kueue-cluster.sh` is verified against 2.2.0 (1.35.0), so proving the intersection needs a node image choice that satisfies both.
- **AC3's live non-vacuity is not met as written.** The AC asks for the `dispatches_before_birth_confirmation` counter to move on the live cluster with the gate removed. That counter lives on `djinn-server`'s `DispatchGate`, and `deny.toml` bars `djinn-server` from `kube`/`k8s-openapi`, so a live seam test needs new production API in `djinn-k8s` to hand a context-pinned surface across. I did not build that. What is covered instead: the hermetic seam test already drives the real `execute_runtime_report_phase`, real `DispatchGate` and real permit repository, and proves both that an accepted-but-unactuated resize dispatches nothing and that the counter can move; and this PR measures live the ~2s window that makes the gate load-bearing, plus proves live the three surface operations the bridge calls. The composition of those two halves over one live cluster remains untested.
- **k8s 1.34+.** Only 1.33.1 was exercised end to end. A 1.35.0 attempt is what surfaced the GA-gate finding, but its cluster never came up (that run is what found the containerd defect).

## Safety

Disposable kind cluster only, `djinn-resize-harness` / `djinn-resize-harness-registry` / port 5052 — no collision with 5051, 5055, 5061, 5067, 5071 or 5079. `--context` pinned on every call, and the test refuses any apiserver that does not resolve to loopback. No EKS context was ever selected and nothing was ssh'd. Cluster and registry deleted after the run and the deletion verified: `kind get clusters` empty, only the pre-existing `djinn-postgres-test` container remains, disk unchanged at 53%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
