### PR TITLE
feat(resize): externally owned resize watcher and startup reconciler (0ppk-3, r37r)

### DIFF
--- a/scripts/check-resize-reachability.sh
+++ b/scripts/check-resize-reachability.sh
@@ -50,11 +50,20 @@ ROOT=${GUARD_ROOT:-$REPO_ROOT}
 cd "$ROOT"
 
 # symbol|extended-regex for a call site|file must also mention this token
+#
+# `0ppk-3` added the last two. Before it, `list_nonterminal_resize` had ZERO
+# callers of ANY kind outside one repository test — the read the whole external
+# reconciler exists to perform, merged and unreachable — and
+# `task_run_resize_reconcile::spawn` is the seam that makes a dead worker's
+# stranded Pod somebody's problem at all. Both are exactly the shape this guard
+# exists to catch.
 GUARDED_SYMBOLS="
 TaskRunResizeBootstrap::bootstrap|\.bootstrap\(|TaskRunResizeBootstrap
 DispatchGate::admit|\.admit\(|DispatchGate
 BuildPodPermitRepository::acquire|\.acquire\(|BuildPodPermitRepository
 BuildPodPermitRepository::capture_resize_identity|\.capture_resize_identity\(|BuildPodPermitRepository
+BuildPodPermitRepository::list_nonterminal_resize|\.list_nonterminal_resize\(|BuildPodPermitRepository
+task_run_resize_reconcile::spawn|task_run_resize_reconcile::spawn\(|become_leader
 "
 
 # file|extended-regex|why this anchor exists
@@ -65,6 +74,7 @@ server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs|acquire_build_pod
 server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs|bind_build_pod_permit_job_uid\(|the dispatch seam must bind the Job UID the runtime just created
 server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs|admit_task_run_dispatch\(|the dispatch seam must gate stdio attach on the birth downsize
 server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs|record_dispatch_started\(|the dispatch site must report itself so the gate's absence is observable
+server/src/server/state/mod.rs|task_run_resize_reconcile::spawn\(self\.clone\(\)\)|the resize reconciler must be armed from become_leader, or a worker death strands its Pod forever
 "
 
 status=0

--- a/scripts/check-resize-reachability.sh
+++ b/scripts/check-resize-reachability.sh
@@ -81,13 +81,32 @@ status=0
 
 # Emit `path:line:text` for every PRODUCTION line of every Rust source file.
 #
-# `#[cfg(test)]` truncation is per-file and deliberately unconditional: the
-# repository convention is one test module at the bottom of a file (or an
-# adjacent `*_tests.rs`), so everything from that marker onwards is test code.
-# Erring toward truncating too much makes this guard fail closed — a real
-# production call site hidden below a `#[cfg(test)]` marker reads as "no caller"
-# and the guard complains, which is the safe direction for a guard whose entire
-# purpose is to refuse to believe that something is reachable.
+# TEST CODE IS TRACKED STRUCTURALLY, NOT BY FIRST MARKER.
+#
+# This used to truncate the whole file from the first `#[cfg(test)]` line
+# onwards, on the theory that the repository convention is one test module at
+# the bottom of a file. That theory is wrong twice over, and `0ppk-3` hit both:
+#
+#   1. `#[cfg(test)]` is an ordinary item attribute. `server/src/server/state/
+#      mod.rs` carries one at line 342 — on a STRUCT FIELD inside `Inner`, 1800
+#      lines above `become_leader` — so first-marker truncation hid every
+#      production call site in the composition root. The guard reported
+#      "task_run_resize_reconcile::spawn has ZERO production callers" in the
+#      same run in which its own anchor check FOUND that exact call, in that
+#      exact file. A guard that contradicts itself teaches people to delete it.
+#   2. A `#[cfg(test)] mod tests { .. }` is not always last. Production code
+#      after one is still production code.
+#
+# So the tracker counts braces, exactly as `scripts/check-test-global-metrics.sh`
+# does for the same reason (PR #2867 found its health-probe reader sitting after
+# a `#[cfg(test)]` block in its own file). A test attribute arms the tracker; if
+# the item it attaches to opens a block, everything to the matching close brace
+# is test code and nothing after it is. An attribute on a field, a variant or a
+# match arm attaches to no block and suppresses nothing.
+#
+# Braces are counted with double-quoted literals and `//` comments stripped, so
+# neither a brace inside a string nor one in a trailing comment can unbalance
+# the tracker.
 production_lines() {
     find server -name '*.rs' -type f \
         -not -path '*/target/*' \
@@ -99,9 +118,78 @@ production_lines() {
         -not -name 'test_runtime.rs' \
         -print0 |
         xargs -0 -r awk '
-            FNR == 1 { skip = 0 }
-            /^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$/ { skip = 1 }
-            skip == 0 { print FILENAME ":" FNR ":" $0 }
+            function strip(line,    i, n, c, out, in_str) {
+                n = length(line); i = 1; out = ""; in_str = 0
+                while (i <= n) {
+                    c = substr(line, i, 1)
+                    if (in_str) {
+                        if (c == "\\") { i += 2; continue }
+                        if (c == "\"") { in_str = 0 }
+                        i++
+                        continue
+                    }
+                    if (c == "\"") { in_str = 1; i++; continue }
+                    if (c == "/" && substr(line, i + 1, 1) == "/") { break }
+                    out = out c
+                    i++
+                }
+                return out
+            }
+            function braces(s,    i, n, c, d) {
+                n = length(s); d = 0
+                for (i = 1; i <= n; i++) {
+                    c = substr(s, i, 1)
+                    if (c == "{") d++
+                    else if (c == "}") d--
+                }
+                return d
+            }
+            FNR == 1 { depth = 0; armed = 0; waiting = 0 }
+            {
+                s = strip($0)
+
+                # Inside a test block: consume to the matching close brace.
+                if (depth > 0) {
+                    depth += braces(s)
+                    if (depth < 0) depth = 0
+                    next
+                }
+
+                # An item that a test attribute introduced, whose opening brace
+                # has not arrived yet (a multi-line `fn` signature).
+                if (waiting == 1) {
+                    d = braces(s)
+                    if (d > 0) { depth = d; waiting = 0; next }
+                    if (s ~ /;[ \t]*$/) { waiting = 0 }
+                    next
+                }
+
+                if (armed == 1) {
+                    # Further attributes, or a blank/doc gap, before the item.
+                    if (s ~ /^[ \t]*#\[/ || s ~ /^[ \t]*$/) next
+                    if (s ~ /^[ \t]*(pub([ \t]*\([^)]*\))?[ \t]+)?(default[ \t]+)?(async[ \t]+)?(unsafe[ \t]+)?(extern[ \t]+"[^"]*"[ \t]+)?(fn|mod|impl|struct|enum|trait|union|use|const|static|type|macro_rules!)[ \t!(]/) {
+                        armed = 0
+                        d = braces(s)
+                        # `#[cfg(test)] mod tests;` opens no block HERE — the
+                        # module is a separate file, already excluded by name.
+                        if (d > 0) { depth = d; next }
+                        if (s ~ /;[ \t]*$/) next
+                        waiting = 1
+                        next
+                    }
+                    # The attribute was on a field, a variant or a match arm.
+                    # It governs that one line and nothing after it.
+                    armed = 0
+                    next
+                }
+
+                if (s ~ /^[ \t]*#\[(cfg\(test\)|test|tokio::test|rstest)/) {
+                    armed = 1
+                    next
+                }
+
+                print FILENAME ":" FNR ":" $0
+            }
         '
 }
 

--- a/scripts/test-check-resize-reachability.sh
+++ b/scripts/test-check-resize-reachability.sh
@@ -15,6 +15,12 @@
 #   * `list_nonterminal_resize` loses its only production caller, which is the
 #     state main was in before `0ppk-3` — a durable read with no reader.
 #
+# It also pins the inverse, which is what the guard got WRONG: production code
+# that merely SITS AFTER a `#[cfg(test)]` attribute — on a struct field, or
+# after a closed test module — is still production code. The first-marker
+# heuristic reported "ZERO production callers" about a call the guard's own
+# anchor check found in the same file in the same run.
+#
 # Run from anywhere:
 #
 #   sh scripts/test-check-resize-reachability.sh
@@ -63,6 +69,40 @@ write_state() {
 fn new_inner() {
     let resize_admission =
         Arc::new(TaskRunResizeAdmissionBridge::from_env(db.clone()));
+}
+fn agent_context() {
+    AgentContext {
+        resize_admission: Some(self.inner.resize_admission.clone()),
+    }
+}
+pub async fn become_leader(&self) {
+    crate::task_run_resize_reconcile::spawn(self.clone());
+}
+EOF
+}
+
+# The composition root as it ACTUALLY looks: a `#[cfg(test)]` attribute on a
+# struct field near the top, and a closed `#[cfg(test)] mod tests { }` block,
+# both ABOVE the production call site. Every line below them is production.
+write_state_with_test_markers_above_the_call_site() {
+    mkdir -p -- "$SCRATCH/$(dirname "$STATE")"
+    cat >"$SCRATCH/$STATE" <<'EOF'
+// Composition root fixture, with test markers above the call site.
+struct Inner {
+    #[cfg(test)]
+    pub image_controller: RwLock<Option<Arc<ImageController>>>,
+    pub resize_admission: Arc<TaskRunResizeAdmissionBridge>,
+}
+fn new_inner() {
+    let resize_admission =
+        Arc::new(TaskRunResizeAdmissionBridge::from_env(db.clone()));
+}
+#[cfg(test)]
+mod early_tests {
+    #[test]
+    fn t() {
+        crate::task_run_resize_reconcile::spawn(fake);
+    }
 }
 fn agent_context() {
     AgentContext {
@@ -297,6 +337,26 @@ printf 'crate::task_run_resize_reconcile::spawn(other);\n' >>"$SCRATCH/$STATE"
 expect_fail_naming \
     "a reconciler armed from anywhere but become_leader fails the anchor" \
     "task_run_resize_reconcile::spawn"
+
+# 13. THE GUARD'S OWN BUG: production code after a `#[cfg(test)]` attribute is
+#     still production code. `server/src/server/state/mod.rs` carries a
+#     `#[cfg(test)]` on a STRUCT FIELD 1800 lines above `become_leader`, and a
+#     first-marker heuristic reported "ZERO production callers" about a call the
+#     guard's own ANCHOR check found in that same file in that same run.
+fixture
+write_state_with_test_markers_above_the_call_site
+expect_pass "production code after a #[cfg(test)] block is still production"
+
+# 14. And the tracker has not simply stopped looking at test code: with ONLY the
+#     in-test call site left, the guard must still fail. Case 13 would pass
+#     vacuously if the scanner had been widened to count test callers too.
+fixture
+write_state_with_test_markers_above_the_call_site
+grep -v 'task_run_resize_reconcile::spawn(self.clone())' "$SCRATCH/$STATE" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$STATE"
+expect_fail_naming \
+    "a spawn that survives only inside a #[cfg(test)] mod does not count" \
+    "task_run_resize_reconcile::spawn has ZERO production callers"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test-check-resize-reachability.sh
+++ b/scripts/test-check-resize-reachability.sh
@@ -10,7 +10,10 @@
 #   * the call site still exists but only in a `*_tests.rs` file;
 #   * the call site still exists but only under a `tests/` directory;
 #   * the caller exists and nothing composes it (the trait-override failure);
-#   * an anchor file was renamed away, which must fail rather than pass vacuously.
+#   * an anchor file was renamed away, which must fail rather than pass vacuously;
+#   * `0ppk-3`'s reconciler spawn is deleted from `become_leader`;
+#   * `list_nonterminal_resize` loses its only production caller, which is the
+#     state main was in before `0ppk-3` — a durable read with no reader.
 #
 # Run from anywhere:
 #
@@ -28,6 +31,7 @@ SCRATCH="$REPO_ROOT/.resize-reachability-guard-selftest"
 STATE=server/src/server/state/mod.rs
 BRIDGE=server/src/task_run_resize_bootstrap.rs
 SEAM=server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+RECONCILE=server/src/task_run_resize_reconcile.rs
 
 cleanup() {
     rm -rf -- "$SCRATCH" 2>/dev/null || true
@@ -65,6 +69,25 @@ fn agent_context() {
         resize_admission: Some(self.inner.resize_admission.clone()),
     }
 }
+pub async fn become_leader(&self) {
+    crate::task_run_resize_reconcile::spawn(self.clone());
+}
+EOF
+}
+
+write_reconcile() {
+    mkdir -p -- "$SCRATCH/$(dirname "$RECONCILE")"
+    cat >"$SCRATCH/$RECONCILE" <<'EOF'
+// Reconciler fixture: the durable read the external reconciler is FOR.
+use djinn_db::BuildPodPermitRepository;
+
+impl TaskRunResizeReconciler {
+    async fn run_pass(&self) {
+        let rows = self.permits.list_nonterminal_resize().await;
+    }
+}
+
+pub fn spawn(state: AppState) {}
 EOF
 }
 
@@ -118,6 +141,7 @@ fixture() {
     write_state
     write_bridge
     write_seam
+    write_reconcile
 }
 
 run_guard() {
@@ -242,6 +266,37 @@ mv "$SCRATCH/.tmp" "$SCRATCH/$SEAM"
 expect_fail_naming \
     "dropping record_dispatch_started fails on the dispatch-site anchor" \
     "record_dispatch_started"
+
+# 10. THE 0ppk-3 NAMED MUTATION: delete the reconciler spawn from become_leader.
+#     A worker death would then strand its Pod forever, and nothing else in the
+#     process would ever notice.
+fixture
+grep -v 'task_run_resize_reconcile::spawn(self.clone())' "$SCRATCH/$STATE" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$STATE"
+expect_fail_naming \
+    "deleting the reconciler spawn fails, naming the symbol" \
+    "task_run_resize_reconcile::spawn has ZERO production callers"
+
+# 11. `list_nonterminal_resize` loses its only production caller. This is
+#     VERBATIM the state main was in before 0ppk-3: a durable read written for a
+#     reconciler that did not exist, with zero callers anywhere but one
+#     repository test.
+fixture
+grep -v 'list_nonterminal_resize' "$SCRATCH/$RECONCILE" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$RECONCILE"
+expect_fail_naming \
+    "a nonterminal-resize scan nobody calls does not count" \
+    "BuildPodPermitRepository::list_nonterminal_resize has ZERO production callers"
+
+# 12. The reconciler module exists and calls the scan, but nothing arms it from
+#     become_leader. Reachable-looking code behind a loop nobody spawns.
+fixture
+grep -v 'task_run_resize_reconcile::spawn(self.clone())' "$SCRATCH/$STATE" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$STATE"
+printf 'crate::task_run_resize_reconcile::spawn(other);\n' >>"$SCRATCH/$STATE"
+expect_fail_naming \
+    "a reconciler armed from anywhere but become_leader fails the anchor" \
+    "task_run_resize_reconcile::spawn"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -256,6 +256,24 @@ impl Database {
         &self.pool
     }
 
+    /// The DSN of this handle's isolated per-test database, when it has one.
+    ///
+    /// `None` for a production handle: there is nothing here a test could not
+    /// already read from its own configuration, and the point is to make a
+    /// *restart* expressible. A test that wants to prove durability across a
+    /// lost process has to drop every in-memory object it built and rebuild
+    /// from nothing but a connection string; without this it can only re-invoke
+    /// a function on a live object, which proves the opposite.
+    ///
+    /// The returned DSN addresses the same template-cloned database, so the
+    /// original handle must stay alive for the reopened one to have a database
+    /// to connect to — dropping the last handle DROPs it.
+    pub fn test_dsn(&self) -> Option<String> {
+        self.test_branch
+            .as_ref()
+            .map(|branch| format!("{}/{}", branch.server_prefix, branch.test_db))
+    }
+
     /// Acquire a permit from the background full-text search semaphore.
     ///
     /// Latency-insensitive background fan-out (post-session extraction novelty

--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -267,11 +267,43 @@ impl Database {
     ///
     /// The returned DSN addresses the same template-cloned database, so the
     /// original handle must stay alive for the reopened one to have a database
-    /// to connect to — dropping the last handle DROPs it.
+    /// to connect to — dropping the last handle DROPs it. Pair it with
+    /// [`Self::reopen_test`].
     pub fn test_dsn(&self) -> Option<String> {
         self.test_branch
             .as_ref()
             .map(|branch| format!("{}/{}", branch.server_prefix, branch.test_db))
+    }
+
+    /// Reopen a [`Self::test_dsn`] behind a brand-new connection pool.
+    ///
+    /// This is what a test uses to express a **restart**: every in-memory object
+    /// built on the old handle is dropped, and the new one is constructed from
+    /// nothing but a connection string.
+    ///
+    /// Two things distinguish it from [`Self::open_with_config`], and both
+    /// matter:
+    ///
+    /// * The pool is the same **4** connections [`Self::open_in_memory`] uses,
+    ///   not the production default of 32. A suite that reopens two or three
+    ///   handles per test and runs a dozen tests in parallel exhausts the test
+    ///   server's connection limit at 32 apiece, and the symptom is not a clean
+    ///   error — it is an unrelated test somewhere else timing out while it
+    ///   waits for a connection it will never get.
+    /// * It carries **no** `TestDbInit`, so dropping it does not DROP the
+    ///   database out from under the handle that owns the clone.
+    ///
+    /// # Errors
+    ///
+    /// The rendered connection failure.
+    pub fn reopen_test(dsn: &str) -> DbResult<Self> {
+        Self::open_postgres_inner(
+            &PostgresDatabaseConfig {
+                url: dsn.to_owned(),
+            },
+            4,
+            None,
+        )
     }
 
     /// Acquire a permit from the background full-text search semaphore.

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -20,6 +20,7 @@ pub mod server_memory;
 pub mod sse;
 pub mod task_run_resize_bootstrap;
 pub mod task_run_resize_drop;
+pub mod task_run_resize_reconcile;
 pub mod task_run_resize_rollout;
 
 #[cfg(any(test, feature = "test-support"))]

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -1582,6 +1582,26 @@ impl AppState {
         &self.inner.cancel
     }
 
+    /// The process-wide durable CPU lease authority (`build_leases`).
+    ///
+    /// Handed out rather than reconstructed because the cap, the arming latch
+    /// and the recovery snapshot live on THIS instance: a second
+    /// `BuildLeaseService` over the same pool would be unarmed and would refuse
+    /// every operation.
+    pub fn build_lease(&self) -> Arc<djinn_coordinator::build_lease::BuildLeaseService> {
+        Arc::clone(&self.inner.build_lease)
+    }
+
+    /// Proposal `3i92`'s fail-safe drop, as composed for this process.
+    ///
+    /// The `release_lease` handler reaches it through the agent context; the
+    /// `0ppk-3` reconciler reaches it here, so a worker's terminal path and the
+    /// reconciler that speaks for a dead worker share one apiserver surface and
+    /// one retry schedule.
+    pub fn resize_drop(&self) -> Arc<crate::task_run_resize_drop::TaskRunResizeDropBridge> {
+        Arc::clone(&self.inner.resize_drop)
+    }
+
     pub fn events(&self) -> &broadcast::Sender<DjinnEventEnvelope> {
         &self.inner.events
     }
@@ -2118,6 +2138,20 @@ impl AppState {
         // ordering is deliberate -- gating the WIRING instead of the ACTION is
         // how a feature ends up shipped and permanently unreachable.
         crate::scip_index_watcher::spawn(self.clone());
+
+        // Proposal 3i92 / epic 0ppk: the externally owned resize reconciler.
+        // Leader-only because it PATCHes and DELETEs Pods, moves
+        // `build_pod_permits` lifecycle rows and releases `build_leases` rows —
+        // a standby doing that concurrently would give one stranded Pod two
+        // drivers.
+        //
+        // `release_lease` is only ever sent by a worker that survived, so a Pod
+        // that dies mid-invocation strands its own drop inside itself. This is
+        // the only thing that can ever finish it. Wired UNCONDITIONALLY for the
+        // same reason as `scip_index_watcher` directly above: whether a tick
+        // acts is decided per tick by `DJINN_RESIZE_RECONCILE`, and gating the
+        // WIRING instead would ship a reconciler that can never run.
+        crate::task_run_resize_reconcile::spawn(self.clone());
 
         // Periodic `git gc` over every project's mirror + working clone. Both
         // fetch with `--prune` but never reclaim the objects behind deleted

--- a/server/src/task_run_resize_drop.rs
+++ b/server/src/task_run_resize_drop.rs
@@ -871,24 +871,58 @@ impl TaskRunResizeDropBridge {
                 .cloned(),
         }
     }
+
+    /// The same apiserver surface the drop itself patches through.
+    ///
+    /// Exposed for `0ppk-3`'s reconciler, whose strand predicate has to ask
+    /// "is the exact Pod UID still there?" before it decides a live build's
+    /// launcher is the reconciler's responsibility. Handing out the composed
+    /// surface rather than letting the caller build its own is what keeps the
+    /// reconciler's read and the drop's PATCH pointed at the same cluster —
+    /// and, in a fixture, at the same stored Pod.
+    ///
+    /// # Errors
+    ///
+    /// The rendered failure from resolving an ambient `kube::Client`.
+    pub async fn resize_pod_surface(&self) -> Result<Arc<dyn TaskRunPodSurface>, String> {
+        self.surface().await
+    }
+
+    /// Build the fail-safe drop this bridge composes.
+    ///
+    /// **The one constructor.** `0ppk-3`'s reconciler resumes stranded rows
+    /// through this, so the backoff schedule, the 30-second confirmation
+    /// budget, the fresh-GET fences and the UID-fenced deletion exist exactly
+    /// once. A reconciler that built its own `TaskRunResizeDrop` from its own
+    /// constants would be a second copy of the retry schedule and a second
+    /// thing to drift.
+    ///
+    /// # Errors
+    ///
+    /// The rendered failure from resolving an ambient `kube::Client`.
+    pub async fn resize_drop_mechanism(&self) -> Result<TaskRunResizeDrop, String> {
+        Ok(TaskRunResizeDrop::with_clock(
+            Arc::new(BuildPodPermitRepository::new(self.db.clone())),
+            self.surface().await?,
+            Arc::clone(&self.clock),
+        ))
+    }
 }
 
 #[async_trait]
 impl TaskRunResizeDropGate for TaskRunResizeDropBridge {
     async fn confirm_drop(&self, request: &ResizeDropGateRequest) -> ResizeDropVerdict {
-        let surface = match self.surface().await {
-            Ok(surface) => surface,
+        // The SAME constructor `0ppk-3`'s reconciler uses. One schedule, one
+        // budget, one set of fences, reached from both the living worker's
+        // terminal path and the reconciler that speaks for a dead one.
+        let mechanism = match self.resize_drop_mechanism().await {
+            Ok(mechanism) => mechanism,
             Err(error) => {
                 return ResizeDropVerdict::Held {
                     detail: format!("no apiserver surface for the resize drop: {error}"),
                 };
             }
         };
-        let mechanism = TaskRunResizeDrop::with_clock(
-            Arc::new(BuildPodPermitRepository::new(self.db.clone())),
-            surface,
-            Arc::clone(&self.clock),
-        );
         let drop_request = ResizeDropRequest {
             task_run_id: request.task_run_id.clone(),
             invocation_id: Some(request.invocation_id.clone()),

--- a/server/src/task_run_resize_reconcile.rs
+++ b/server/src/task_run_resize_reconcile.rs
@@ -1,0 +1,753 @@
+//! The externally owned resize reconciler: a worker's death must not strand
+//! resize responsibility inside the Pod that died.
+//!
+//! # Why this is load-bearing, not defensive
+//!
+//! The only per-invocation terminal signal the server ever receives is the
+//! `release_lease` RPC. It is emitted **only** by a worker that reached
+//! `queued == true` and survived long enough to run `reconcile_terminal_lease`.
+//! A Pod that is OOM-killed, evicted, or whose node disappears sends nothing at
+//! all, and a server that restarts mid-lift loses every in-process handle that
+//! could have noticed. In both cases the launcher keeps whatever ceiling the
+//! lift left on it, the `build_pod_permits` row never leaves its nonterminal
+//! resize state, and the durable `build_leases` row is held by nobody who will
+//! ever release it.
+//!
+//! So the drop cannot be owned by the process that performed the lift. It has
+//! to be owned by something that outlives it, reads the durable row, and does
+//! not need one line of code in the dead worker to cooperate. That is this
+//! module.
+//!
+//! # What "owned externally" costs, and how it is paid
+//!
+//! Everything this reconciler knows comes from
+//! [`BuildPodPermitRepository::list_nonterminal_resize`] — a durable read. It
+//! holds no map of live invocations, and deliberately so: a cache is exactly
+//! the state a restart destroys, and seeding resumption from one would make
+//! every criterion in this slice pass against a process that never restarted.
+//!
+//! # The strand predicate, and why a live build is not touched
+//!
+//! `lifted` is the NORMAL state of a healthy build, and `birth_confirmed` is
+//! the resting state of every captured permit between invocations. A reconciler
+//! that dropped every nonterminal row it found would take the CPU away from
+//! every running build in the cluster on its first tick. So a row is the
+//! reconciler's responsibility only when one of two **worker-independent**
+//! facts is true:
+//!
+//! 1. **A drop is already owed.** `drop_required`, `drop_applying` and
+//!    `quarantined` are states no live driver rests in — something moved the row
+//!    there and then stopped. Resume unconditionally.
+//! 2. **The owner is gone.** The task run reached a terminal status (or its row
+//!    is gone entirely), or — for a row that is actually holding lifted CPU —
+//!    the exact Pod UID is confirmed absent from a fresh apiserver read.
+//!
+//! Both facts are established without asking the worker anything. The task-run
+//! status is written by the coordinator's own Job/session reconciliation, and
+//! Pod absence is read from the apiserver. Neither can be withheld by a process
+//! that has already died.
+//!
+//! # Two ledgers
+//!
+//! `BuildLeaseService::release` writes `build_leases`. The resize lifecycle
+//! lives in `build_pod_permits`. This module is the only thing that can ever
+//! release the first for a worker that never sent `release_lease`, and it does
+//! so **only** after the drop settled on a fact the cluster reported: 250m read
+//! back from `status.initContainerStatuses`, or the exact Pod UID confirmed
+//! absent. [`ResizeDropOutcome::releases_lease`] is that gate, and it is the
+//! same gate the `release_lease` handler applies — not a second copy of the
+//! rule.
+//!
+//! # No forked machinery
+//!
+//! The retry schedule, the 30-second confirmation budget, the fresh-GET fences
+//! and the UID-fenced deletion all live in [`crate::task_run_resize_drop`], and
+//! this module reaches them through
+//! [`TaskRunResizeDropBridge::resize_drop_mechanism`] — the same constructor
+//! the `release_lease` handler uses. Changing a backoff constant there changes
+//! this module's observed timing, which is what keeps the two from drifting.
+//!
+//! # The gate is on the ACTION
+//!
+//! [`spawn`] is called unconditionally from `AppState::become_leader` and the
+//! mode is re-read on **every tick**. Gating the wiring instead — returning
+//! early before the loop exists — is how this repository has repeatedly shipped
+//! a subsystem that was merged, green, and permanently unreachable. A disarmed
+//! reconciler here is a loop that ticks and declines to act, and arming it is a
+//! configuration change rather than a restart.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use djinn_coordinator::build_lease::BuildLeaseService;
+use djinn_db::{
+    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildPodPermitRepository,
+    BuildPodPermitRow, BuildPodPermitState, Database, TaskRunRepository,
+    TransitionBuildPodResizeLifecycleResult,
+};
+use djinn_supervisor::services::{
+    LeaseFencingToken, LeaseIdentity, LeaseReleaseRequest, LeaseResult, TaskInvocationLeaseIdentity,
+};
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use crate::server::AppState;
+use crate::task_run_resize_drop::{
+    ResizeDropCause, ResizeDropOutcome, ResizeDropRequest, TaskRunResizeDropBridge,
+};
+
+/// How often the sweep runs when no override is configured.
+///
+/// A worker that dies at minute 40 of a live server produces a stranded row
+/// that no startup scan will ever see, so the cadence — not the startup pass —
+/// is what makes this reconciler self-healing. Thirty seconds is short relative
+/// to the CPU an unreleased lift withholds and long relative to one durable
+/// SELECT over a table with a handful of nonterminal rows.
+pub const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How long one row's resumption may occupy a pass before it is left for the
+/// next tick.
+///
+/// This bounds the PASS, never the drop's own safety properties: a resumption
+/// that runs out of budget leaves the durable row exactly where it was, holding
+/// the lease, and the next tick picks it up again. The quarantine absence loop
+/// is deliberately unbounded inside `task_run_resize_drop`, which is precisely
+/// why the reconciler must impose a bound out here instead — otherwise one
+/// unreachable Pod would starve every other stranded row in the sweep.
+pub const DEFAULT_ROW_BUDGET: Duration = Duration::from_secs(45);
+
+/// Environment variable naming the reconciler's per-tick mode.
+pub const MODE_ENV: &str = "DJINN_RESIZE_RECONCILE";
+
+/// Environment variable overriding [`DEFAULT_SWEEP_INTERVAL`], in seconds.
+pub const INTERVAL_ENV: &str = "DJINN_RESIZE_RECONCILE_INTERVAL_SECONDS";
+
+// ── The per-tick gate ──────────────────────────────────────────────────────
+
+/// What the reconciler is permitted to do on one tick.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ResizeReconcileMode {
+    /// Scan nothing and act on nothing. The loop still ticks.
+    Off,
+    /// Scan and classify, and log what would be resumed, but issue no PATCH,
+    /// no DELETE and no lease release.
+    Observe,
+    /// Scan, classify and resume.
+    #[default]
+    Enforce,
+}
+
+impl ResizeReconcileMode {
+    /// Parse the configured spelling. Anything unrecognised is
+    /// [`Self::Enforce`], because the failure this module exists to prevent is
+    /// a stranded Pod holding CPU nobody is accounting for, and a typo in a
+    /// deployment value must not silently buy that.
+    #[must_use]
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "off" | "0" | "false" | "disabled" => Self::Off,
+            "observe" | "dry_run" | "dry-run" => Self::Observe,
+            _ => Self::Enforce,
+        }
+    }
+
+    /// The stable spelling for logs and metrics.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Observe => "observe",
+            Self::Enforce => "enforce",
+        }
+    }
+
+    /// Whether this mode may issue a PATCH, a DELETE or a lease release.
+    #[must_use]
+    pub const fn acts(self) -> bool {
+        matches!(self, Self::Enforce)
+    }
+}
+
+/// The mode, re-read once per tick.
+///
+/// Behind a trait for exactly one reason: the property acceptance criterion 2
+/// names is that the loop *asks again on every tick*, and a test that could only
+/// observe a value captured at spawn time cannot tell a per-tick gate from a
+/// wiring gate. A fake that flips between ticks is what makes the difference
+/// observable without mutating a process-global environment variable that
+/// sibling tests share.
+pub trait ResizeReconcileGate: Send + Sync {
+    /// The mode this tick runs under.
+    fn mode(&self) -> ResizeReconcileMode;
+}
+
+/// The production gate: reads [`MODE_ENV`] on every call.
+#[derive(Debug, Default)]
+pub struct EnvResizeReconcileGate;
+
+impl ResizeReconcileGate for EnvResizeReconcileGate {
+    fn mode(&self) -> ResizeReconcileMode {
+        std::env::var(MODE_ENV).map_or(ResizeReconcileMode::default(), |raw| {
+            ResizeReconcileMode::parse(&raw)
+        })
+    }
+}
+
+/// The configured sweep cadence.
+#[must_use]
+pub fn sweep_interval_from_env() -> Duration {
+    std::env::var(INTERVAL_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map_or(DEFAULT_SWEEP_INTERVAL, Duration::from_secs)
+}
+
+// ── What one pass did ──────────────────────────────────────────────────────
+
+/// Why a scanned row was left alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SkipReason {
+    /// The task run is still live and the Pod is still present, so a live
+    /// driver owns this row.
+    OwnerLive,
+    /// The permit carries no resize identity, so there is no container limit to
+    /// return.
+    NotResizeGoverned,
+    /// Another driver moved the row out from under this pass's claim.
+    ClaimLost,
+    /// The durable read for this row failed; the next tick retries.
+    Unreadable,
+}
+
+/// The observable result of one sweep.
+///
+/// Every field is a count of something that was *done*, never of something that
+/// was *considered*: a pass that scanned ten rows and resumed none reports
+/// `resumed = 0`, which is what lets a test tell an idle loop from a working one.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ResizeReconcilePass {
+    /// The mode this pass ran under.
+    pub mode: Option<ResizeReconcileMode>,
+    /// Rows `list_nonterminal_resize` returned.
+    pub scanned: usize,
+    /// Rows this pass drove a drop or quarantine for.
+    pub resumed: usize,
+    /// Rows an [`ResizeReconcileMode::Observe`] pass would have resumed.
+    pub would_resume: usize,
+    /// Rows left alone, with the reason.
+    pub skipped: Vec<(String, SkipReason)>,
+    /// Rows whose drop settled on a fact that permits releasing the durable
+    /// `build_leases` row, and for which that release was issued.
+    pub leases_released: usize,
+    /// Rows whose resumption did not settle inside [`DEFAULT_ROW_BUDGET`].
+    pub unsettled: usize,
+    /// `true` when the durable scan itself failed.
+    pub scan_failed: bool,
+}
+
+// ── The reconciler ─────────────────────────────────────────────────────────
+
+/// The externally owned resumption of `build_pod_permits`' resize lifecycle.
+pub struct TaskRunResizeReconciler {
+    permits: Arc<BuildPodPermitRepository>,
+    task_runs: TaskRunRepository,
+    lease_rows: BuildLeaseRepository,
+    leases: Option<Arc<BuildLeaseService>>,
+    drop_bridge: Arc<TaskRunResizeDropBridge>,
+    gate: Arc<dyn ResizeReconcileGate>,
+    row_budget: Duration,
+    /// Task runs a pass in this process is currently driving.
+    ///
+    /// Two invocations of one task run can be concurrent — the runner is
+    /// `Arc`-shared behind `&self` with no lock — and two overlapping ticks
+    /// would be a third driver. This is not a substitute for the durable CAS
+    /// (which is what fences a driver in ANOTHER process); it is what stops this
+    /// process from racing itself into two PATCHes for one drop.
+    in_flight: Mutex<HashSet<String>>,
+    passes: AtomicU64,
+}
+
+impl TaskRunResizeReconciler {
+    /// Wire a reconciler to the durable relations and the fail-safe drop.
+    #[must_use]
+    pub fn new(
+        db: Database,
+        drop_bridge: Arc<TaskRunResizeDropBridge>,
+        leases: Option<Arc<BuildLeaseService>>,
+        gate: Arc<dyn ResizeReconcileGate>,
+    ) -> Self {
+        Self {
+            permits: Arc::new(BuildPodPermitRepository::new(db.clone())),
+            task_runs: TaskRunRepository::new(db.clone()),
+            lease_rows: BuildLeaseRepository::new(db),
+            leases,
+            drop_bridge,
+            gate,
+            row_budget: DEFAULT_ROW_BUDGET,
+            in_flight: Mutex::new(HashSet::new()),
+            passes: AtomicU64::new(0),
+        }
+    }
+
+    /// Override the per-row budget.
+    #[must_use]
+    pub const fn with_row_budget(mut self, budget: Duration) -> Self {
+        self.row_budget = budget;
+        self
+    }
+
+    /// How many passes this reconciler has run, whatever each one decided.
+    ///
+    /// A disarmed pass still increments it. That is the point: it is how a test
+    /// distinguishes "the loop is running and declining to act" from "the loop
+    /// was never spawned", which is the whole of acceptance criterion 2.
+    #[must_use]
+    pub fn passes(&self) -> u64 {
+        self.passes.load(Ordering::SeqCst)
+    }
+
+    /// One sweep over every nonterminal resize row.
+    pub async fn run_pass(&self) -> ResizeReconcilePass {
+        self.passes.fetch_add(1, Ordering::SeqCst);
+        let mode = self.gate.mode();
+        let mut pass = ResizeReconcilePass {
+            mode: Some(mode),
+            ..ResizeReconcilePass::default()
+        };
+        if mode == ResizeReconcileMode::Off {
+            return pass;
+        }
+
+        // THE DURABLE READ. Not a cache, not an in-process registry of live
+        // invocations: the rows Postgres holds right now. A restart destroys
+        // every other source of this information and leaves this one intact.
+        let rows = match self.permits.list_nonterminal_resize().await {
+            Ok(rows) => rows,
+            Err(error) => {
+                warn!(
+                    %error,
+                    "task_run_resize_reconcile: the nonterminal resize scan failed; \
+                     stranded rows keep their lease until the next tick"
+                );
+                pass.scan_failed = true;
+                return pass;
+            }
+        };
+        pass.scanned = rows.len();
+
+        for row in rows {
+            let task_run_id = row.task_run_id.clone();
+            if row.resize_identity.is_none() {
+                pass.skipped
+                    .push((task_run_id, SkipReason::NotResizeGoverned));
+                continue;
+            }
+            match self.is_stranded(&row).await {
+                Ok(false) => {
+                    pass.skipped.push((task_run_id, SkipReason::OwnerLive));
+                    continue;
+                }
+                Err(()) => {
+                    pass.skipped.push((task_run_id, SkipReason::Unreadable));
+                    continue;
+                }
+                Ok(true) => {}
+            }
+            if !mode.acts() {
+                pass.would_resume += 1;
+                info!(
+                    task_run_id = %task_run_id,
+                    state = ?row.state,
+                    mode = mode.as_str(),
+                    "task_run_resize_reconcile: would resume this stranded resize row"
+                );
+                continue;
+            }
+            let Some(_guard) = InFlightGuard::claim(&self.in_flight, &task_run_id) else {
+                pass.skipped.push((task_run_id, SkipReason::ClaimLost));
+                continue;
+            };
+            // THE CLAIM. A reconciler has no prior claim on a row that is
+            // resting in a lift state: it must WIN the compare-and-swap into
+            // `drop_required` before it touches the Pod. A driver that loses
+            // returns here without issuing a single PATCH, which is what keeps
+            // a concurrent worker and this reconciler from both actuating one
+            // drop.
+            if !self.claim(&row).await {
+                pass.skipped.push((task_run_id, SkipReason::ClaimLost));
+                continue;
+            }
+            pass.resumed += 1;
+            match self.resume(&row).await {
+                Some(outcome) if outcome.releases_lease() => {
+                    if self.release_durable_lease(&row).await {
+                        pass.leases_released += 1;
+                    }
+                }
+                Some(_) => {}
+                None => pass.unsettled += 1,
+            }
+        }
+        pass
+    }
+
+    /// Whether this row is the reconciler's responsibility.
+    ///
+    /// `Err(())` means the evidence could not be read at all, which is never
+    /// grounds to act: an unanswered database is not proof that a worker died.
+    async fn is_stranded(&self, row: &BuildPodPermitRow) -> Result<bool, ()> {
+        match row.state {
+            // A drop is already owed. No live driver rests in these states —
+            // something moved the row here and then stopped, which is exactly
+            // the shape a dead worker or a restarted server leaves behind.
+            BuildPodPermitState::DropRequired
+            | BuildPodPermitState::DropApplying
+            | BuildPodPermitState::Quarantined => Ok(true),
+            BuildPodPermitState::BirthConfirmed
+            | BuildPodPermitState::LiftApplying
+            | BuildPodPermitState::Lifted => {
+                if self.owner_is_gone(&row.task_run_id).await? {
+                    return Ok(true);
+                }
+                // A row that is HOLDING lifted CPU earns one fresh apiserver
+                // read even while its task run still reads live: a Pod whose
+                // node vanished leaves the run's status behind for as long as
+                // the coordinator takes to notice, and the ceiling is withheld
+                // for the whole of that window.
+                if matches!(
+                    row.state,
+                    BuildPodPermitState::LiftApplying | BuildPodPermitState::Lifted
+                ) {
+                    return Ok(self.pod_uid_absent(row).await);
+                }
+                Ok(false)
+            }
+            // Not in the nonterminal resize set at all; nothing to resume.
+            BuildPodPermitState::Acquired
+            | BuildPodPermitState::JobCreated
+            | BuildPodPermitState::Released => Ok(false),
+        }
+    }
+
+    /// Whether the task run that owns this permit has ended.
+    ///
+    /// Written by the coordinator's own Job and session reconciliation, so it
+    /// is available even when every line of code in the worker has stopped
+    /// running.
+    async fn owner_is_gone(&self, task_run_id: &str) -> Result<bool, ()> {
+        match self.task_runs.get(task_run_id).await {
+            // No task run row at all: nothing will ever drive this permit.
+            Ok(None) => Ok(true),
+            Ok(Some(run)) => Ok(matches!(
+                run.status.as_str(),
+                "completed" | "failed" | "interrupted"
+            )),
+            Err(error) => {
+                warn!(
+                    %task_run_id,
+                    %error,
+                    "task_run_resize_reconcile: task-run status unreadable; not acting"
+                );
+                Err(())
+            }
+        }
+    }
+
+    /// A fresh, UID-fenced read: is the exact Pod this lift was bound to gone?
+    ///
+    /// An apiserver that does not answer reports `false` — "not proven absent"
+    /// — because an unreachable apiserver is not evidence that a worker died,
+    /// and acting on it would drop a live build's ceiling.
+    async fn pod_uid_absent(&self, row: &BuildPodPermitRow) -> bool {
+        let Some(identity) = row.resize_identity.as_ref() else {
+            return false;
+        };
+        let Ok(surface) = self.drop_bridge.resize_pod_surface().await else {
+            return false;
+        };
+        match surface.observe_launcher(&row.task_run_id).await {
+            Ok(None) => true,
+            Ok(Some(observed)) => observed.pod_uid != identity.pod_uid,
+            Err(_) => false,
+        }
+    }
+
+    /// Move a resting row into `drop_required`, fenced on the full tuple.
+    ///
+    /// Rows already at `drop_required`, `drop_applying` or `quarantined` need no
+    /// claim — the transition would be a self-transition and the drop resumes
+    /// them idempotently.
+    async fn claim(&self, row: &BuildPodPermitRow) -> bool {
+        let from = match row.state {
+            state @ (BuildPodPermitState::BirthConfirmed
+            | BuildPodPermitState::LiftApplying
+            | BuildPodPermitState::Lifted) => state,
+            _ => return true,
+        };
+        let Some(identity) = row.resize_identity.as_ref() else {
+            return false;
+        };
+        match self
+            .permits
+            .transition_resize_lifecycle(
+                &row.task_run_id,
+                &row.permit_id,
+                row.fencing_token,
+                &identity.pod_uid,
+                row.resize_invocation_id.as_deref(),
+                from,
+                BuildPodPermitState::DropRequired,
+            )
+            .await
+        {
+            Ok(TransitionBuildPodResizeLifecycleResult::Transitioned(_)) => true,
+            Ok(TransitionBuildPodResizeLifecycleResult::Rejected) => {
+                info!(
+                    task_run_id = %row.task_run_id,
+                    from = ?from,
+                    "task_run_resize_reconcile: another driver holds this row; not patching"
+                );
+                false
+            }
+            Err(error) => {
+                warn!(
+                    task_run_id = %row.task_run_id,
+                    %error,
+                    "task_run_resize_reconcile: the claim could not be written"
+                );
+                false
+            }
+        }
+    }
+
+    /// Drive the fail-safe drop for one stranded row.
+    ///
+    /// `invocation_id: None` is deliberate and is the infrastructure-observer
+    /// shape `task_run_resize_drop` documents: the reconciler did not perform
+    /// the lift and has no invocation of its own to name, so it drives whichever
+    /// one the durable row carries — and every durable write below it is still
+    /// fenced on that invocation, so a driver holding a different one is
+    /// rejected without a PATCH.
+    async fn resume(&self, row: &BuildPodPermitRow) -> Option<ResizeDropOutcome> {
+        let mechanism = match self.drop_bridge.resize_drop_mechanism().await {
+            Ok(mechanism) => mechanism,
+            Err(error) => {
+                warn!(
+                    task_run_id = %row.task_run_id,
+                    %error,
+                    "task_run_resize_reconcile: no apiserver surface; the lease stays held"
+                );
+                return Some(ResizeDropOutcome::Unavailable(error));
+            }
+        };
+        let request = ResizeDropRequest {
+            task_run_id: row.task_run_id.clone(),
+            invocation_id: None,
+            cause: ResizeDropCause::ServerRestart,
+        };
+        info!(
+            task_run_id = %row.task_run_id,
+            state = ?row.state,
+            invocation_id = ?row.resize_invocation_id,
+            "task_run_resize_reconcile: resuming a stranded resize row from persisted state"
+        );
+        match tokio::time::timeout(self.row_budget, mechanism.drop_to_birth(&request)).await {
+            Ok(outcome) => Some(outcome),
+            Err(_) => {
+                warn!(
+                    task_run_id = %row.task_run_id,
+                    budget = ?self.row_budget,
+                    "task_run_resize_reconcile: resumption did not settle in this pass; the \
+                     durable row keeps its state and the lease stays held"
+                );
+                None
+            }
+        }
+    }
+
+    /// THE OTHER LEDGER. Release the durable `build_leases` row this permit's
+    /// invocation is holding.
+    ///
+    /// Only ever reached from an outcome whose `releases_lease()` is true, which
+    /// means the cluster reported either 250m in `status.initContainerStatuses`
+    /// or the exact Pod UID absent. Writing `build_pod_permits` does not release
+    /// capacity, and saying "the lease was released" without naming the store is
+    /// how a success log comes from the wrong ledger.
+    async fn release_durable_lease(&self, row: &BuildPodPermitRow) -> bool {
+        let Some(leases) = self.leases.as_ref() else {
+            return false;
+        };
+        let Some(invocation_id) = row.resize_invocation_id.clone() else {
+            // No invocation ever claimed this row, so no per-invocation lease
+            // was ever taken against it.
+            return false;
+        };
+        let task_id = match self.task_runs.get(&row.task_run_id).await {
+            Ok(Some(run)) => run.task_id,
+            Ok(None) | Err(_) => return false,
+        };
+        let key = BuildLeaseKey {
+            consumer_kind: BuildLeaseConsumerKind::TaskInvocation,
+            consumer_id: invocation_id.clone(),
+        };
+        let Ok(Some(lease)) = self.lease_rows.get(&key).await else {
+            return false;
+        };
+        let Some(token) = lease.fencing_token else {
+            return false;
+        };
+        let result = leases
+            .release(LeaseReleaseRequest {
+                identity: LeaseIdentity::TaskInvocation(TaskInvocationLeaseIdentity {
+                    task_id,
+                    task_run_id: row.task_run_id.clone(),
+                    invocation_id: invocation_id.clone(),
+                }),
+                fencing_token: LeaseFencingToken(token.unsigned_abs()),
+                candidate_cleanup: false,
+            })
+            .await;
+        let released = matches!(result, LeaseResult::Released { .. });
+        if released {
+            info!(
+                task_run_id = %row.task_run_id,
+                %invocation_id,
+                "task_run_resize_reconcile: the launcher is back at its birth limit or gone; \
+                 the durable build_leases row is released"
+            );
+        } else {
+            warn!(
+                task_run_id = %row.task_run_id,
+                %invocation_id,
+                ?result,
+                "task_run_resize_reconcile: build_leases refused the release; retrying next tick"
+            );
+        }
+        released
+    }
+}
+
+/// A process-local claim on one task run's resumption, released on drop.
+struct InFlightGuard<'a> {
+    set: &'a Mutex<HashSet<String>>,
+    task_run_id: String,
+}
+
+impl<'a> InFlightGuard<'a> {
+    fn claim(set: &'a Mutex<HashSet<String>>, task_run_id: &str) -> Option<Self> {
+        let mut guard = set.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !guard.insert(task_run_id.to_owned()) {
+            return None;
+        }
+        Some(Self {
+            set,
+            task_run_id: task_run_id.to_owned(),
+        })
+    }
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        let mut guard = self
+            .set
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.remove(&self.task_run_id);
+    }
+}
+
+// ── The production composition ─────────────────────────────────────────────
+
+/// Start the resize reconciler. Leader-only: composed exclusively from
+/// `AppState::become_leader`.
+///
+/// Leader-only because it WRITES — it moves `build_pod_permits` lifecycle rows,
+/// PATCHes and DELETEs Pods, and releases `build_leases` rows. A standby pod
+/// running this concurrently would give one stranded Pod two drivers, which is
+/// the single-active-writer invariant the coordinator advisory lock exists to
+/// hold.
+///
+/// **The spawn is unconditional.** Whether a tick acts is decided per tick by
+/// [`EnvResizeReconcileGate`]. Moving that decision out here — returning before
+/// the loop exists — would leave a module nothing calls and a green test suite,
+/// which is the exact failure the comment above `scip_index_watcher::spawn` in
+/// `AppState::become_leader` records.
+pub fn spawn(state: AppState) {
+    // Everything AppState-derived is extracted here and the handle released
+    // immediately: what survives into the background is a pool handle, two
+    // Arcs and a cancellation token, never the coordinator or the git actors.
+    let db = state.db().clone();
+    let cancel = state.cancel().clone();
+    let drop_bridge = state.resize_drop();
+    let leases = state.build_lease();
+    drop(state);
+
+    let reconciler = Arc::new(TaskRunResizeReconciler::new(
+        db,
+        drop_bridge,
+        Some(leases),
+        Arc::new(EnvResizeReconcileGate),
+    ));
+    let interval = sweep_interval_from_env();
+    tokio::spawn(async move {
+        info!(
+            ?interval,
+            "task_run_resize_reconcile: started (leader-only); the mode is re-read every tick"
+        );
+        run_loop(interval, cancel, move || {
+            let reconciler = Arc::clone(&reconciler);
+            async move {
+                let pass = reconciler.run_pass().await;
+                if pass.resumed > 0 || pass.would_resume > 0 || pass.scan_failed {
+                    info!(
+                        mode = pass.mode.map(ResizeReconcileMode::as_str),
+                        scanned = pass.scanned,
+                        resumed = pass.resumed,
+                        would_resume = pass.would_resume,
+                        leases_released = pass.leases_released,
+                        unsettled = pass.unsettled,
+                        scan_failed = pass.scan_failed,
+                        "task_run_resize_reconcile: sweep"
+                    );
+                }
+            }
+        })
+        .await;
+        warn!(
+            "task_run_resize_reconcile: the sweep loop stopped; stranded resize rows will not \
+             be resumed by this process"
+        );
+    });
+}
+
+/// The ticker seam production and the cancellation tests share.
+///
+/// The FIRST tick fires immediately, before any interval has elapsed: that is
+/// the startup scan, and it is the same code path as every later sweep rather
+/// than a separate one-shot. A startup-only reaper paired with a read-only
+/// doctor is how this repository produced a phantom-active state that never
+/// self-healed; there is deliberately only one scan implementation here, and it
+/// is periodic.
+pub async fn run_loop<F, Fut>(interval: Duration, cancel: CancellationToken, mut tick: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            _ = ticker.tick() => tick().await,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "task_run_resize_reconcile_tests.rs"]
+mod tests;

--- a/server/src/task_run_resize_reconcile.rs
+++ b/server/src/task_run_resize_reconcile.rs
@@ -855,7 +855,10 @@ where
     loop {
         tokio::select! {
             () = cancel.cancelled() => break,
-            _ = ticker.tick() => tick().await,
+            _ = ticker.tick() => {
+                tick().await;
+                break;
+            }
         }
     }
 }

--- a/server/src/task_run_resize_reconcile.rs
+++ b/server/src/task_run_resize_reconcile.rs
@@ -85,8 +85,8 @@ use std::time::Duration;
 use djinn_coordinator::build_lease::BuildLeaseService;
 use djinn_db::{
     BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildPodPermitRepository,
-    BuildPodPermitRow, BuildPodPermitState, Database, ReleaseBuildPodPermitResult, TaskRunRepository,
-    TransitionBuildPodResizeLifecycleResult,
+    BuildPodPermitRow, BuildPodPermitState, Database, ReleaseBuildPodPermitResult,
+    TaskRunRepository, TransitionBuildPodResizeLifecycleResult,
 };
 use djinn_supervisor::services::{
     LeaseFencingToken, LeaseIdentity, LeaseReleaseRequest, LeaseResult, TaskInvocationLeaseIdentity,
@@ -471,12 +471,7 @@ impl TaskRunResizeReconciler {
         };
         match self
             .permits
-            .release(
-                &row.task_run_id,
-                &row.permit_id,
-                row.fencing_token,
-                reason,
-            )
+            .release(&row.task_run_id, &row.permit_id, row.fencing_token, reason)
             .await
         {
             Ok(ReleaseBuildPodPermitResult::Released(_)) => {
@@ -752,7 +747,9 @@ struct InFlightGuard<'a> {
 
 impl<'a> InFlightGuard<'a> {
     fn claim(set: &'a Mutex<HashSet<String>>, task_run_id: &str) -> Option<Self> {
-        let mut guard = set.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut guard = set
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if !guard.insert(task_run_id.to_owned()) {
             return None;
         }
@@ -855,10 +852,7 @@ where
     loop {
         tokio::select! {
             () = cancel.cancelled() => break,
-            _ = ticker.tick() => {
-                tick().await;
-                break;
-            }
+            _ = ticker.tick() => tick().await,
         }
     }
 }

--- a/server/src/task_run_resize_reconcile.rs
+++ b/server/src/task_run_resize_reconcile.rs
@@ -85,7 +85,7 @@ use std::time::Duration;
 use djinn_coordinator::build_lease::BuildLeaseService;
 use djinn_db::{
     BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildPodPermitRepository,
-    BuildPodPermitRow, BuildPodPermitState, Database, TaskRunRepository,
+    BuildPodPermitRow, BuildPodPermitState, Database, ReleaseBuildPodPermitResult, TaskRunRepository,
     TransitionBuildPodResizeLifecycleResult,
 };
 use djinn_supervisor::services::{
@@ -224,6 +224,32 @@ pub enum SkipReason {
     Unreadable,
 }
 
+/// Why a row is — or is not — the reconciler's responsibility.
+///
+/// A bool would have been enough to decide whether to act. It is not enough to
+/// decide what to do AFTERWARDS: a permit whose task run has ended is dead
+/// weight that nothing else will ever retire, while one whose run is still live
+/// belongs to the dispatch path. Collapsing the two into "stranded" is how a
+/// reconciler ends up either leaking permit rows forever or retiring one out
+/// from under a live build.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Strandedness {
+    /// A live driver owns this row.
+    Live,
+    /// The task run reached a terminal status, or its row is gone.
+    OwnerGone,
+    /// The exact Pod UID is confirmed absent.
+    PodGone,
+    /// The row is parked in a state no live driver rests in.
+    DropOwed,
+}
+
+impl Strandedness {
+    const fn acts(self) -> bool {
+        !matches!(self, Self::Live)
+    }
+}
+
 /// The observable result of one sweep.
 ///
 /// Every field is a count of something that was *done*, never of something that
@@ -244,6 +270,9 @@ pub struct ResizeReconcilePass {
     /// Rows whose drop settled on a fact that permits releasing the durable
     /// `build_leases` row, and for which that release was issued.
     pub leases_released: usize,
+    /// Rows whose `build_pod_permits` permit this pass retired, because nothing
+    /// else ever will.
+    pub permits_retired: usize,
     /// Rows whose resumption did not settle inside [`DEFAULT_ROW_BUDGET`].
     pub unsettled: usize,
     /// `true` when the durable scan itself failed.
@@ -347,8 +376,9 @@ impl TaskRunResizeReconciler {
                     .push((task_run_id, SkipReason::NotResizeGoverned));
                 continue;
             }
-            match self.is_stranded(&row).await {
-                Ok(false) => {
+            let strandedness = match self.strandedness(&row).await {
+                Ok(strandedness) if strandedness.acts() => strandedness,
+                Ok(_) => {
                     pass.skipped.push((task_run_id, SkipReason::OwnerLive));
                     continue;
                 }
@@ -356,8 +386,7 @@ impl TaskRunResizeReconciler {
                     pass.skipped.push((task_run_id, SkipReason::Unreadable));
                     continue;
                 }
-                Ok(true) => {}
-            }
+            };
             if !mode.acts() {
                 pass.would_resume += 1;
                 info!(
@@ -383,36 +412,118 @@ impl TaskRunResizeReconciler {
                 continue;
             }
             pass.resumed += 1;
-            match self.resume(&row).await {
-                Some(outcome) if outcome.releases_lease() => {
-                    if self.release_durable_lease(&row).await {
-                        pass.leases_released += 1;
-                    }
-                }
-                Some(_) => {}
-                None => pass.unsettled += 1,
+            let Some(outcome) = self.resume(&row).await else {
+                pass.unsettled += 1;
+                continue;
+            };
+            // THE PERMIT LEDGER MOVES FIRST. `build_pod_permits` is retired
+            // before `build_leases` is released, which is the same ordering the
+            // `release_lease` handler imposes: capacity may never be handed back
+            // ahead of the lifecycle that proves the CPU came with it.
+            if self.retire_permit(&row, &outcome, strandedness).await {
+                pass.permits_retired += 1;
+            }
+            if outcome.releases_lease() && self.release_durable_lease(&row).await {
+                pass.leases_released += 1;
             }
         }
         pass
+    }
+
+    /// Retire the `build_pod_permits` row when nothing else ever will.
+    ///
+    /// `acquire_build_pod_permit` in the dispatch seam records that "the resize
+    /// lifecycle that reclaims a permit (lift, drop, quarantine, release)
+    /// belongs to `0ppk-3`'s reconciler", and
+    /// [`ResizeDropOutcome::PodUidAbsent`] says in as many words that it leaves
+    /// the row nonterminal for this module. This is that.
+    ///
+    /// Retiring is also what makes the sweep TERMINATE. A row left at
+    /// `birth_confirmed` with a dead owner is stranded again by the next tick's
+    /// own predicate, so a reconciler that only ever dropped would re-drop the
+    /// same dead task run every 30 seconds forever.
+    async fn retire_permit(
+        &self,
+        row: &BuildPodPermitRow,
+        outcome: &ResizeDropOutcome,
+        strandedness: Strandedness,
+    ) -> bool {
+        let reason = match outcome {
+            // The Pod is gone. `capture_resize_identity` is write-once and
+            // `acquire` refuses to resurrect a released row, so this task run
+            // can never capture a replacement — recovery is a NEW task run.
+            ResizeDropOutcome::PodUidAbsent { .. } => "resize_pod_uid_absent",
+            // The launcher is back at 250m, and the run that borrowed the CPU
+            // has ended. Nothing will come back for this permit.
+            ResizeDropOutcome::Confirmed { .. } | ResizeDropOutcome::NotResizeGoverned
+                if strandedness != Strandedness::Live =>
+            {
+                if !matches!(strandedness, Strandedness::OwnerGone)
+                    && !self.owner_is_gone(&row.task_run_id).await.unwrap_or(false)
+                {
+                    return false;
+                }
+                "resize_owner_gone"
+            }
+            // `QuarantinedPodDeleted` already released the permit inside the
+            // drop; every other outcome is unsettled and must keep its row.
+            _ => return false,
+        };
+        match self
+            .permits
+            .release(
+                &row.task_run_id,
+                &row.permit_id,
+                row.fencing_token,
+                reason,
+            )
+            .await
+        {
+            Ok(ReleaseBuildPodPermitResult::Released(_)) => {
+                info!(
+                    task_run_id = %row.task_run_id,
+                    reason,
+                    "task_run_resize_reconcile: permit retired; this task run can never \
+                     capture a replacement Pod — recovery is a NEW task run"
+                );
+                true
+            }
+            Ok(ReleaseBuildPodPermitResult::AlreadyReleased(_)) => false,
+            Ok(ReleaseBuildPodPermitResult::Rejected) => {
+                warn!(
+                    task_run_id = %row.task_run_id,
+                    "task_run_resize_reconcile: the permit refused retirement"
+                );
+                false
+            }
+            Err(error) => {
+                warn!(
+                    task_run_id = %row.task_run_id,
+                    %error,
+                    "task_run_resize_reconcile: the permit could not be retired"
+                );
+                false
+            }
+        }
     }
 
     /// Whether this row is the reconciler's responsibility.
     ///
     /// `Err(())` means the evidence could not be read at all, which is never
     /// grounds to act: an unanswered database is not proof that a worker died.
-    async fn is_stranded(&self, row: &BuildPodPermitRow) -> Result<bool, ()> {
+    async fn strandedness(&self, row: &BuildPodPermitRow) -> Result<Strandedness, ()> {
         match row.state {
             // A drop is already owed. No live driver rests in these states —
             // something moved the row here and then stopped, which is exactly
             // the shape a dead worker or a restarted server leaves behind.
             BuildPodPermitState::DropRequired
             | BuildPodPermitState::DropApplying
-            | BuildPodPermitState::Quarantined => Ok(true),
+            | BuildPodPermitState::Quarantined => Ok(Strandedness::DropOwed),
             BuildPodPermitState::BirthConfirmed
             | BuildPodPermitState::LiftApplying
             | BuildPodPermitState::Lifted => {
                 if self.owner_is_gone(&row.task_run_id).await? {
-                    return Ok(true);
+                    return Ok(Strandedness::OwnerGone);
                 }
                 // A row that is HOLDING lifted CPU earns one fresh apiserver
                 // read even while its task run still reads live: a Pod whose
@@ -422,15 +533,16 @@ impl TaskRunResizeReconciler {
                 if matches!(
                     row.state,
                     BuildPodPermitState::LiftApplying | BuildPodPermitState::Lifted
-                ) {
-                    return Ok(self.pod_uid_absent(row).await);
+                ) && self.pod_uid_absent(row).await
+                {
+                    return Ok(Strandedness::PodGone);
                 }
-                Ok(false)
+                Ok(Strandedness::Live)
             }
             // Not in the nonterminal resize set at all; nothing to resume.
             BuildPodPermitState::Acquired
             | BuildPodPermitState::JobCreated
-            | BuildPodPermitState::Released => Ok(false),
+            | BuildPodPermitState::Released => Ok(Strandedness::Live),
         }
     }
 

--- a/server/src/task_run_resize_reconcile_tests.rs
+++ b/server/src/task_run_resize_reconcile_tests.rs
@@ -1,0 +1,176 @@
+//! Unit tests for [`super`]'s pure seams: the per-tick mode and the ticker.
+//!
+//! Everything that is a statement about DURABLE resumption lives in
+//! `server/tests/task_run_resize_recovery.rs`, against real Postgres. Nothing
+//! here stands in for that: a mode enum and a ticker are the only parts of this
+//! module that have no database in them, and they are tested here precisely so
+//! the durable file is not diluted with assertions that would pass against a
+//! fake.
+//!
+//! The question every test answers: "what stays green if the body of this does
+//! nothing?"
+
+use super::*;
+use std::sync::atomic::AtomicUsize;
+
+/// An unrecognised configuration value must ARM the reconciler, not disarm it.
+///
+/// A typo in a deployment value deciding that stranded Pods keep their CPU is
+/// the wrong direction to fail in, and a default that silently reads `off` is
+/// how this repository has repeatedly shipped an inert subsystem.
+///
+/// NAMED FAILING MUTATION: make the fallback arm `Self::Off` and the last two
+/// rows fail.
+#[test]
+fn an_unrecognised_mode_arms_rather_than_disarms() {
+    for raw in ["off", "OFF", " off ", "0", "false", "disabled"] {
+        assert_eq!(
+            ResizeReconcileMode::parse(raw),
+            ResizeReconcileMode::Off,
+            "{raw} must disarm"
+        );
+    }
+    for raw in ["observe", "dry_run", "dry-run"] {
+        assert_eq!(ResizeReconcileMode::parse(raw), ResizeReconcileMode::Observe);
+    }
+    for raw in ["enforce", "on", "1", "", "yes-please", "enfroce"] {
+        assert_eq!(
+            ResizeReconcileMode::parse(raw),
+            ResizeReconcileMode::Enforce,
+            "{raw} must NOT silently disarm the reconciler"
+        );
+    }
+    assert_eq!(ResizeReconcileMode::default(), ResizeReconcileMode::Enforce);
+    assert!(!ResizeReconcileMode::Off.acts());
+    assert!(!ResizeReconcileMode::Observe.acts());
+    assert!(ResizeReconcileMode::Enforce.acts());
+}
+
+/// The FIRST tick fires before any interval elapses, and every later tick keeps
+/// firing until cancellation.
+///
+/// The startup scan and the periodic sweep are the same code path here, which
+/// is the structural reason this module cannot repeat the startup-only-reaper
+/// failure: there is no separate one-shot to forget to make periodic.
+///
+/// NAMED FAILING MUTATION: add a leading `ticker.tick().await;` before the loop
+/// (which is what `graph_retention::run_loop` does to SKIP the immediate tick)
+/// and the first assertion fails — no tick lands inside the paused clock's
+/// first interval.
+#[tokio::test(start_paused = true)]
+async fn the_first_tick_is_immediate_and_the_loop_keeps_ticking() {
+    let ticks = Arc::new(AtomicUsize::new(0));
+    let cancel = CancellationToken::new();
+    let loop_ticks = Arc::clone(&ticks);
+    let loop_cancel = cancel.clone();
+    let handle = tokio::spawn(async move {
+        run_loop(Duration::from_secs(30), loop_cancel, move || {
+            let ticks = Arc::clone(&loop_ticks);
+            async move {
+                ticks.fetch_add(1, Ordering::SeqCst);
+            }
+        })
+        .await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(1)).await;
+    assert_eq!(
+        ticks.load(Ordering::SeqCst),
+        1,
+        "the startup scan must not wait a full interval: a server that restarts \
+         with stranded rows has to see them now"
+    );
+
+    tokio::time::sleep(Duration::from_secs(95)).await;
+    let periodic = ticks.load(Ordering::SeqCst);
+    assert!(
+        periodic >= 4,
+        "the sweep must be PERIODIC, not startup-only; saw {periodic} ticks in \
+         95s at a 30s cadence"
+    );
+
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(5), handle)
+        .await
+        .expect("the loop must stop on cancellation")
+        .expect("the loop task must not panic");
+    let at_cancel = ticks.load(Ordering::SeqCst);
+    tokio::time::sleep(Duration::from_secs(120)).await;
+    assert_eq!(
+        ticks.load(Ordering::SeqCst),
+        at_cancel,
+        "a cancelled loop must stop ticking"
+    );
+}
+
+/// The production gate re-reads its environment on EVERY call.
+///
+/// This is the half of acceptance criterion 2 that is about the gate itself;
+/// that the LOOP calls it once per tick is proven durably in
+/// `server/tests/task_run_resize_recovery.rs`, where a stranded row is left
+/// alone and then picked up without a restart.
+///
+/// NAMED FAILING MUTATION: cache the parsed mode in `EnvResizeReconcileGate`
+/// (a field set at construction) and the second half of this test fails,
+/// because the gate would still report the value it was built with.
+#[test]
+fn the_env_gate_rereads_its_variable_on_every_call() {
+    // SAFETY: single-threaded `#[test]`, and the variable is restored before
+    // returning. It is namespaced to this module and no other test reads it.
+    let restore = std::env::var(MODE_ENV).ok();
+    let gate = EnvResizeReconcileGate;
+
+    unsafe { std::env::set_var(MODE_ENV, "off") };
+    assert_eq!(gate.mode(), ResizeReconcileMode::Off);
+
+    unsafe { std::env::set_var(MODE_ENV, "enforce") };
+    assert_eq!(
+        gate.mode(),
+        ResizeReconcileMode::Enforce,
+        "the SAME gate object must observe the change: arming is a configuration \
+         change, not a restart"
+    );
+
+    unsafe { std::env::remove_var(MODE_ENV) };
+    assert_eq!(
+        gate.mode(),
+        ResizeReconcileMode::Enforce,
+        "unset must arm; an operator who never sets this must still be protected \
+         from stranded Pods"
+    );
+
+    match restore {
+        Some(value) => unsafe { std::env::set_var(MODE_ENV, value) },
+        None => unsafe { std::env::remove_var(MODE_ENV) },
+    }
+}
+
+/// A configured cadence overrides the default, and a nonsense one does not.
+///
+/// NAMED FAILING MUTATION: drop the `> 0` filter and `0` yields a zero-duration
+/// interval, which `tokio::time::interval` panics on — a spin loop against
+/// Postgres in production.
+#[test]
+fn the_sweep_interval_rejects_values_that_would_spin() {
+    let restore = std::env::var(INTERVAL_ENV).ok();
+
+    unsafe { std::env::remove_var(INTERVAL_ENV) };
+    assert_eq!(sweep_interval_from_env(), DEFAULT_SWEEP_INTERVAL);
+
+    unsafe { std::env::set_var(INTERVAL_ENV, "5") };
+    assert_eq!(sweep_interval_from_env(), Duration::from_secs(5));
+
+    for bad in ["0", "-1", "soon", ""] {
+        unsafe { std::env::set_var(INTERVAL_ENV, bad) };
+        assert_eq!(
+            sweep_interval_from_env(),
+            DEFAULT_SWEEP_INTERVAL,
+            "{bad} must fall back rather than produce a spinning ticker"
+        );
+    }
+
+    match restore {
+        Some(value) => unsafe { std::env::set_var(INTERVAL_ENV, value) },
+        None => unsafe { std::env::remove_var(INTERVAL_ENV) },
+    }
+}

--- a/server/src/task_run_resize_reconcile_tests.rs
+++ b/server/src/task_run_resize_reconcile_tests.rs
@@ -31,7 +31,10 @@ fn an_unrecognised_mode_arms_rather_than_disarms() {
         );
     }
     for raw in ["observe", "dry_run", "dry-run"] {
-        assert_eq!(ResizeReconcileMode::parse(raw), ResizeReconcileMode::Observe);
+        assert_eq!(
+            ResizeReconcileMode::parse(raw),
+            ResizeReconcileMode::Observe
+        );
     }
     for raw in ["enforce", "on", "1", "", "yes-please", "enfroce"] {
         assert_eq!(

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -657,13 +657,11 @@ async fn every_nonterminal_state_resumes_after_the_process_that_lifted_it_is_gon
              state; pass was {pass:?}"
         );
         let settled = permit_state(&db, &task_run_id).await;
-        assert!(
-            matches!(
-                settled,
-                BuildPodPermitState::BirthConfirmed | BuildPodPermitState::Released
-            ),
-            "{state:?}: resumption must settle at the birth limit or destroy the \
-             Pod, got {settled:?}"
+        assert_eq!(
+            settled,
+            BuildPodPermitState::Released,
+            "{state:?}: a permit whose task run has ended must be RETIRED, or the \
+             next sweep re-drops the same dead run every tick forever"
         );
         // THE POD IS NEVER RETURNED TO SERVICE: whatever happened, no launcher
         // is left holding a lifted ceiling.
@@ -860,10 +858,15 @@ async fn a_lifted_row_whose_pod_vanished_is_stranded_even_while_the_run_reads_li
         "an absent Pod UID strands the row on its own; pass was {pass:?}"
     );
     assert_eq!(
+        pass.permits_retired, 1,
+        "`PodUidAbsent` leaves the row nonterminal inside the drop and hands it \
+         to THIS module to retire; pass was {pass:?}"
+    );
+    assert_eq!(
         permit_state(&db, &task_run_id).await,
-        BuildPodPermitState::DropRequired,
-        "the row is claimed and settles as `PodUidAbsent`, which is nonterminal \
-         and stays visible to the next sweep"
+        BuildPodPermitState::Released,
+        "the write-once identity means this task run can never capture a \
+         replacement Pod, so the permit is dead weight nothing else will retire"
     );
 }
 
@@ -955,7 +958,7 @@ async fn the_gate_is_evaluated_every_tick_and_arming_needs_no_restart() {
 
     assert_eq!(
         permit_state(&db, &task_run_id).await,
-        BuildPodPermitState::BirthConfirmed,
+        BuildPodPermitState::Released,
         "arming is a configuration change, not a restart: the SAME loop must \
          pick the stranded row up on a later tick"
     );
@@ -1068,7 +1071,7 @@ async fn a_row_stranded_while_the_loop_runs_is_picked_up_on_a_later_tick() {
     wait_until(|| {
         let db = db.clone();
         let task_run_id = task_run_id.clone();
-        async move { permit_state(&db, &task_run_id).await == BuildPodPermitState::BirthConfirmed }
+        async move { permit_state(&db, &task_run_id).await == BuildPodPermitState::Released }
     })
     .await;
 
@@ -1142,8 +1145,12 @@ async fn the_build_lease_is_released_only_after_the_cluster_confirms_the_drop() 
          init-container status, in millicores"
     );
     assert_eq!(
+        pass.permits_retired, 1,
+        "the permit ledger moves FIRST; pass was {pass:?}"
+    );
+    assert_eq!(
         permit_state(&db, &task_run_id).await,
-        BuildPodPermitState::BirthConfirmed
+        BuildPodPermitState::Released
     );
     assert_eq!(
         build_lease_state(&db, invocation_id).await,
@@ -1297,6 +1304,10 @@ async fn two_concurrent_drivers_issue_exactly_one_patch() {
         "exactly one pods/resize PATCH per drop, across both drivers"
     );
     assert_eq!(status_millicores(&cluster), Some(BIRTH_MILLICORES));
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Released
+    );
 }
 
 /// A leadership handover mid-drop: the new leader resumes and the OLD leader's
@@ -1329,12 +1340,13 @@ async fn a_leadership_handover_mid_drop_lets_only_the_new_leader_commit() {
     hold_build_lease(&leases, &task_id, &task_run_id, invocation_id).await;
     kill_the_worker(&db, &task_run_id).await;
 
-    // THE OLD LEADER. Its Pod refuses to actuate, so it parks in the retry loop
-    // holding a resumption it believes it owns.
-    let stalled_cluster = cluster.clone();
-    stalled_cluster.stop_actuating();
+    // THE OLD LEADER, mid-drop and stuck. Its view of the cluster never
+    // actuates — which is exactly WHY it is still in flight — so it is given its
+    // own stored Pod carrying the same UID. The DURABLE row is shared, and the
+    // durable row is the thing under test.
+    let stalled_view = StoredTaskRunPod::resize_v2(pod_uid, CEILING).never_actuating();
     let old_clock = Arc::new(RecordingClock::stalling_after(2));
-    let old = restart.restart(stalled_cluster, Arc::clone(&old_clock));
+    let old = restart.restart(stalled_view, Arc::clone(&old_clock));
     let old_reconciler = old.reconciler(Some(Arc::clone(&leases)), Arc::new(ArmedGate));
     let old_leader = tokio::spawn(async move { old_reconciler.run_pass().await });
     wait_until(|| {
@@ -1345,10 +1357,10 @@ async fn a_leadership_handover_mid_drop_lets_only_the_new_leader_commit() {
     assert_eq!(
         permit_state(&db, &task_run_id).await,
         BuildPodPermitState::DropApplying,
-        "precondition: the old leader is mid-drop"
+        "precondition: the old leader is mid-drop and has committed nothing"
     );
 
-    // THE NEW LEADER, on a Pod that answers. Same durable row.
+    // THE NEW LEADER, on a cluster that answers. Same durable row.
     cluster.reset_patch_counter();
     let new = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
     let new_pass = new
@@ -1360,15 +1372,42 @@ async fn a_leadership_handover_mid_drop_lets_only_the_new_leader_commit() {
     assert_eq!(new_pass.leases_released, 1, "pass was {new_pass:?}");
     assert_eq!(
         permit_state(&db, &task_run_id).await,
-        BuildPodPermitState::BirthConfirmed
+        BuildPodPermitState::Released
     );
     assert_eq!(
         build_lease_state(&db, invocation_id).await,
         Some(BuildLeaseState::Terminal)
     );
 
-    // The old leader is still parked. Nothing it does from here may commit.
-    assert!(!old_leader.is_finished());
+    // The old leader is still parked, holding the exact fences it entered with.
+    assert!(
+        !old_leader.is_finished(),
+        "precondition: the old leader really is still in flight"
+    );
+
+    // ITS IN-FLIGHT COMMIT CANNOT LAND. This is the write the stalled driver
+    // would issue the moment its Pod finally reported 250m: the settle out of
+    // `drop_applying`, fenced on the same permit, token, Pod UID and invocation.
+    let rejected = permits
+        .transition_resize_lifecycle(
+            &task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            pod_uid,
+            Some(invocation_id),
+            BuildPodPermitState::DropApplying,
+            BuildPodPermitState::BirthConfirmed,
+        )
+        .await
+        .expect("the compare-and-swap must answer");
+    assert_eq!(
+        rejected,
+        TransitionBuildPodResizeLifecycleResult::Rejected,
+        "the old leader's in-flight attempt must be REJECTED by the durable \
+         compare-and-swap; without the fence it would commit a second settlement \
+         on top of the new leader's and release the lease twice"
+    );
+
     old_leader.abort();
 }
 

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -1,0 +1,1651 @@
+// djinn:allow-oversize — task `r37r`'s design names
+// `server/tests/task_run_resize_recovery.rs` as the single exclusive path for
+// the restart/worker-death matrix, so the durable fixtures cannot move into a
+// sibling module without leaving that set.
+//! Durable recovery for proposal `3i92`'s resize lifecycle (epic `0ppk`, task
+//! `r37r`): the externally owned reconciler, proven against real Postgres.
+//!
+//! # The property, stated so it cannot be satisfied cheaply
+//!
+//! `release_lease` is **only ever sent by a worker that reached
+//! `queued == true` and survived**. A Pod that dies mid-invocation sends
+//! nothing. So the drop cannot belong to the process that performed the lift:
+//! if it does, a worker death strands resize responsibility inside the Pod that
+//! died, the `build_pod_permits` row never leaves its nonterminal state, and
+//! the durable `build_leases` row is held by nobody who will ever release it.
+//!
+//! Everything below therefore either (a) destroys the in-memory state and
+//! rebuilds from a connection string, or (b) never lets the worker's code path
+//! run at all.
+//!
+//! # What is real here and what is faked
+//!
+//! * **Postgres is real.** [`Database::open_in_memory`] is a template-cloned
+//!   real Postgres database, not an in-memory stand-in. There is no `Fake` or
+//!   `Mock` permit repository anywhere in this file, deliberately: "resumes from
+//!   PERSISTED state" is the whole property, and a fake holding in-memory rows
+//!   would assert the exact opposite.
+//! * **The restart is real.** [`Restart::restart`] drops every in-memory object
+//!   — reconciler, drop bridge, apiserver surface, connection pool — and
+//!   rebuilds them from nothing but the database's DSN. Re-invoking a function
+//!   on a live object would prove nothing about durability.
+//! * **Leadership is real.** The standby proof races two
+//!   [`djinn_server::leadership::run_with_leadership`] futures for the same
+//!   Postgres advisory lock, in the test's own isolated database.
+//! * **The apiserver is faked**, through
+//!   [`djinn_k8s::pod_resize_fixture::StoredTaskRunPod`] — a stored `Pod` driven
+//!   by the PRODUCTION `PodResizeClient` and the PRODUCTION
+//!   `observe_launcher_sidecar`. A confirmation here is confirmed by the same
+//!   `status.initContainerStatuses` millicore rule that runs in the cluster.
+//!   That is the fault-injection seam, and it is the only fake.
+//!
+//! # A safety landmine this file does NOT step on
+//!
+//! Every `KubernetesRuntime` constructor resolves through
+//! `kube::Client::try_default()`, which reads the CURRENT kubeconfig context —
+//! and every context on a maintainer's machine is a live EKS production
+//! cluster. Composing the production Pod plane in a test would silently arm
+//! production with no `--context` flag involved and nothing looking wrong.
+//! Nothing here constructs `TaskRunPodResizeSurface`; the bridge is always
+//! built through `with_surface`, which never resolves an ambient client.
+
+#![allow(clippy::too_many_lines)]
+
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_coordinator::build_lease::BuildLeaseService;
+use djinn_db::{
+    AcquireBuildPodPermitResult, BindBuildPodPermitResult, BuildLeaseConsumerKind, BuildLeaseKey,
+    BuildLeaseRepository, BuildLeaseState, BuildPodPermitRepository, BuildPodPermitRow,
+    BuildPodPermitState, BuildPodResizeIdentity, CaptureBuildPodResizeIdentityResult,
+    CreateTaskRunParams, Database, DatabaseConnectConfig, EffectiveCreatorProvenance,
+    PostgresDatabaseConfig, ProjectRepository, TaskRepository, TaskRunRepository,
+    TransitionBuildPodResizeLifecycleResult,
+};
+use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
+use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
+use djinn_server::task_run_resize_bootstrap::TaskRunPodSurface;
+use djinn_server::task_run_resize_drop::{ResizeDropClock, TaskRunResizeDropBridge};
+use djinn_server::task_run_resize_reconcile::{
+    ResizeReconcileGate, ResizeReconcileMode, SkipReason, TaskRunResizeReconciler, run_loop,
+};
+use djinn_supervisor::services::{
+    LeaseDeadlines, LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest,
+    LeaseResult, TaskInvocationLeaseIdentity,
+};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+const CEILING: &str = "4";
+const CEILING_MILLICORES: i64 = 4000;
+const LIFTED_MILLICORES: u64 = 4000;
+const BIRTH_MILLICORES: u64 = 250;
+
+// ── The apiserver surface, counted ─────────────────────────────────────────
+
+/// [`StoredTaskRunPod`] behind [`TaskRunPodSurface`], counting GETs and DELETEs.
+///
+/// The PATCH counter lives on the stored Pod itself
+/// ([`StoredTaskRunPod::resize_patches`]), which is what makes "exactly one
+/// PATCH across two concurrent drivers" an assertion about the cluster rather
+/// than about this wrapper.
+struct CountingSurface {
+    cluster: StoredTaskRunPod,
+    gets: AtomicU64,
+    deletes_attempted: AtomicU64,
+}
+
+impl CountingSurface {
+    fn new(cluster: StoredTaskRunPod) -> Self {
+        Self {
+            cluster,
+            gets: AtomicU64::new(0),
+            deletes_attempted: AtomicU64::new(0),
+        }
+    }
+
+    /// Fresh apiserver reads. A drop that cached the observed Pod between
+    /// attempts would drop this below the attempt count.
+    fn gets(&self) -> u64 {
+        self.gets.load(Ordering::SeqCst)
+    }
+
+    fn deletes_attempted(&self) -> u64 {
+        self.deletes_attempted.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TaskRunPodSurface for CountingSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.gets.fetch_add(1, Ordering::SeqCst);
+        self.cluster.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), djinn_k8s::pod_resize::PodResizeError> {
+        self.cluster
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        self.deletes_attempted.fetch_add(1, Ordering::SeqCst);
+        self.cluster.uid_fenced_delete(task_run_id, pod_uid)
+    }
+}
+
+// ── The injected clock ─────────────────────────────────────────────────────
+
+/// Records what it was asked to wait for and never actually waits.
+///
+/// The recorded sequence is how the reconciler's timing is compared against
+/// `task_run_resize_drop`'s constants without spending 30 seconds of wall clock
+/// per test.
+struct RecordingClock {
+    base: Instant,
+    offset: StdMutex<Duration>,
+    sleeps: StdMutex<Vec<Duration>>,
+    stall_after: Option<usize>,
+}
+
+impl RecordingClock {
+    fn new() -> Self {
+        Self {
+            base: Instant::now(),
+            offset: StdMutex::new(Duration::ZERO),
+            sleeps: StdMutex::new(Vec::new()),
+            stall_after: None,
+        }
+    }
+
+    fn stalling_after(sleeps: usize) -> Self {
+        Self {
+            stall_after: Some(sleeps),
+            ..Self::new()
+        }
+    }
+
+    fn sleeps(&self) -> Vec<Duration> {
+        self.sleeps.lock().expect("clock").clone()
+    }
+}
+
+#[async_trait]
+impl ResizeDropClock for RecordingClock {
+    fn now(&self) -> Instant {
+        self.base + *self.offset.lock().expect("clock")
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        let count = {
+            let mut sleeps = self.sleeps.lock().expect("clock");
+            sleeps.push(duration);
+            *self.offset.lock().expect("clock") += duration;
+            sleeps.len()
+        };
+        if self.stall_after.is_some_and(|limit| count >= limit) {
+            std::future::pending::<()>().await;
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
+// ── The per-tick gate, under test control ──────────────────────────────────
+
+/// A gate whose mode a test can change while the loop is running, and which
+/// counts how many times the loop asked.
+struct FlippableGate {
+    mode: StdMutex<ResizeReconcileMode>,
+    asks: AtomicUsize,
+}
+
+impl FlippableGate {
+    fn starting(mode: ResizeReconcileMode) -> Self {
+        Self {
+            mode: StdMutex::new(mode),
+            asks: AtomicUsize::new(0),
+        }
+    }
+
+    fn set(&self, mode: ResizeReconcileMode) {
+        *self.mode.lock().expect("gate") = mode;
+    }
+
+    fn asks(&self) -> usize {
+        self.asks.load(Ordering::SeqCst)
+    }
+}
+
+impl ResizeReconcileGate for FlippableGate {
+    fn mode(&self) -> ResizeReconcileMode {
+        self.asks.fetch_add(1, Ordering::SeqCst);
+        *self.mode.lock().expect("gate")
+    }
+}
+
+/// A gate fixed at [`ResizeReconcileMode::Enforce`].
+struct ArmedGate;
+
+impl ResizeReconcileGate for ArmedGate {
+    fn mode(&self) -> ResizeReconcileMode {
+        ResizeReconcileMode::Enforce
+    }
+}
+
+// ── Durable seeding, against real Postgres ─────────────────────────────────
+
+async fn seed_task_run(db: &Database, suffix: &str) -> (String, String) {
+    let user = djinn_db::UserRepository::new(db.clone())
+        .upsert_from_github(
+            i64::try_from(uuid::Uuid::now_v7().as_u128() % 8_000_000_000_000_000_000)
+                .expect("github id"),
+            &format!("resize-recover-{suffix}-{}", uuid::Uuid::now_v7()),
+            None,
+            None,
+        )
+        .await
+        .expect("seed user");
+    let project = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create(
+            &format!("resize-recover-{suffix}"),
+            "djinnos",
+            &format!("resize-recover-{suffix}"),
+        )
+        .await
+        .expect("seed project");
+    let task = TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create_in_project_with_provenance(
+            &project.id,
+            None,
+            EffectiveCreatorProvenance::explicit_user_id(&user.id),
+            "resize recovery",
+            "description",
+            "design",
+            "task",
+            2,
+            "owner",
+            None,
+            None,
+        )
+        .await
+        .expect("seed task");
+    let task_run_id = uuid::Uuid::now_v7().to_string();
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: &task_run_id,
+            project_id: &project.id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed task run");
+    (task.id, task_run_id)
+}
+
+/// Kill the worker, as the durable record sees it.
+///
+/// This is the ONLY signal the tests below ever give that a worker has died,
+/// and it is written by the coordinator's own reconciliation rather than by the
+/// worker: a Pod that was OOM-killed cannot send anything, which is the whole
+/// premise. No `release_lease` is ever sent anywhere in this file.
+async fn kill_the_worker(db: &Database, task_run_id: &str) {
+    TaskRunRepository::new(db.clone())
+        .update_status(task_run_id, djinn_core::models::TaskRunStatus::Failed)
+        .await
+        .expect("terminalise the task run");
+}
+
+async fn captured_permit(
+    permits: &BuildPodPermitRepository,
+    task_run_id: &str,
+    pod_uid: &str,
+) -> BuildPodPermitRow {
+    let row = match permits.acquire(task_run_id, 16).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        other => panic!("unexpected acquire outcome: {other:?}"),
+    };
+    let bound = match permits
+        .bind_or_refresh_job_uid(
+            task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            &format!("job-{pod_uid}"),
+        )
+        .await
+        .expect("bind job uid")
+    {
+        BindBuildPodPermitResult::Bound(row) => row,
+        other => panic!("unexpected bind outcome: {other:?}"),
+    };
+    let identity = BuildPodResizeIdentity {
+        pod_namespace: "djinn".to_owned(),
+        pod_name: format!("taskrun-{pod_uid}"),
+        pod_uid: pod_uid.to_owned(),
+        launcher_container_name: "cgroup-launcher".to_owned(),
+        launcher_container_id: "containerd://launcher".to_owned(),
+        image_digest: "registry/img@sha256:feed".to_owned(),
+        observed_launcher_protocol: "resize-v2".to_owned(),
+        effective_launcher_protocol: "resize-v2".to_owned(),
+        admitted_cpu_millicores: CEILING_MILLICORES,
+    };
+    match permits
+        .capture_resize_identity(
+            task_run_id,
+            &bound.permit_id,
+            bound.fencing_token,
+            &identity,
+        )
+        .await
+        .expect("capture identity")
+    {
+        CaptureBuildPodResizeIdentityResult::Captured(row) => row,
+        other => panic!("unexpected capture outcome: {other:?}"),
+    }
+}
+
+/// Drive the row and the Pod through a REAL lift, then park it in `state`.
+///
+/// NON-VACUITY: this asserts the launcher's own init-container status reports
+/// the lifted ceiling before any resumption is asked to bring it back down, so
+/// a "drop confirmed" below can never be a Pod that was never raised.
+async fn lift_then_park(
+    permits: &BuildPodPermitRepository,
+    cluster: &StoredTaskRunPod,
+    row: &BuildPodPermitRow,
+    pod_uid: &str,
+    invocation_id: &str,
+    state: BuildPodPermitState,
+) {
+    if state == BuildPodPermitState::BirthConfirmed {
+        return;
+    }
+    match permits
+        .begin_resize_invocation(
+            &row.task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            pod_uid,
+            invocation_id,
+        )
+        .await
+        .expect("begin invocation")
+    {
+        TransitionBuildPodResizeLifecycleResult::Transitioned(_) => {}
+        other => panic!("unexpected claim outcome: {other:?}"),
+    }
+    cluster
+        .resize_launcher_cpu(&format!("taskrun-{pod_uid}"), LIFTED_MILLICORES)
+        .await
+        .expect("lift the launcher");
+    assert_eq!(
+        status_millicores(cluster),
+        Some(LIFTED_MILLICORES),
+        "NON-VACUITY: the launcher must actually be lifted before recovery is \
+         asked to bring it back down"
+    );
+    if state == BuildPodPermitState::LiftApplying {
+        return;
+    }
+    let mut current = BuildPodPermitState::LiftApplying;
+    for next in [
+        BuildPodPermitState::Lifted,
+        BuildPodPermitState::DropRequired,
+        BuildPodPermitState::DropApplying,
+        BuildPodPermitState::Quarantined,
+    ] {
+        match permits
+            .transition_resize_lifecycle(
+                &row.task_run_id,
+                &row.permit_id,
+                row.fencing_token,
+                pod_uid,
+                Some(invocation_id),
+                current,
+                next,
+            )
+            .await
+            .expect("park the row")
+        {
+            TransitionBuildPodResizeLifecycleResult::Transitioned(_) => {}
+            other => panic!("unexpected {current:?} -> {next:?} outcome: {other:?}"),
+        }
+        current = next;
+        if current == state {
+            return;
+        }
+    }
+    panic!("cannot park a row at {state:?}");
+}
+
+/// The launcher's **init-container** status limit, in millicores.
+///
+/// Millicores, never the Quantity string: the apiserver canonicalises `4000m`
+/// to `4`.
+fn status_millicores(cluster: &StoredTaskRunPod) -> Option<u64> {
+    cluster.launcher_status_cpu().map(|raw| {
+        djinn_k8s::pod_resize::CpuLimit::parse(&raw)
+            .expect("the launcher reports a parseable quantity")
+            .millis()
+    })
+}
+
+async fn permit_state(db: &Database, task_run_id: &str) -> BuildPodPermitState {
+    BuildPodPermitRepository::new(db.clone())
+        .active(task_run_id)
+        .await
+        .expect("read permit")
+        .map_or(BuildPodPermitState::Released, |row| row.state)
+}
+
+// ── The other ledger ───────────────────────────────────────────────────────
+
+/// Take a real, occupying `build_leases` row for one invocation.
+///
+/// Returned so a test can prove the lease is still HELD, which is a statement
+/// about `build_leases` and cannot be made by reading `build_pod_permits`.
+async fn hold_build_lease(
+    leases: &BuildLeaseService,
+    task_id: &str,
+    task_run_id: &str,
+    invocation_id: &str,
+) -> LeaseFencingToken {
+    let identity = LeaseIdentity::TaskInvocation(TaskInvocationLeaseIdentity {
+        task_id: task_id.to_owned(),
+        task_run_id: task_run_id.to_owned(),
+        invocation_id: invocation_id.to_owned(),
+    });
+    let token = match leases
+        .queue(LeaseQueueRequest {
+            identity: identity.clone(),
+            deadlines: LeaseDeadlines {
+                queue_deadline_ms: 0,
+                launch_deadline_ms: 0,
+            },
+        })
+        .await
+    {
+        LeaseResult::Granted(grant) => grant.fencing_token,
+        other => panic!("expected a grant, got {other:?}"),
+    };
+    match leases
+        .grant(LeaseGrantRequest {
+            identity,
+            fencing_token: token.clone(),
+        })
+        .await
+    {
+        LeaseResult::Status(_) => {}
+        other => panic!("expected the grant acknowledgement, got {other:?}"),
+    }
+    token
+}
+
+async fn build_lease_state(db: &Database, invocation_id: &str) -> Option<BuildLeaseState> {
+    BuildLeaseRepository::new(db.clone())
+        .get(&BuildLeaseKey {
+            consumer_kind: BuildLeaseConsumerKind::TaskInvocation,
+            consumer_id: invocation_id.to_owned(),
+        })
+        .await
+        .expect("read build_leases")
+        .map(|row| row.state)
+}
+
+async fn armed_lease_service(db: &Database) -> Arc<BuildLeaseService> {
+    let service = Arc::new(BuildLeaseService::new(
+        Arc::new(BuildLeaseRepository::new(db.clone())),
+        8,
+    ));
+    assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+    assert!(matches!(service.set_cap(8).await, LeaseResult::Status(_)));
+    service
+}
+
+// ── The restart ────────────────────────────────────────────────────────────
+
+/// A durable database whose in-memory attachments can be thrown away.
+///
+/// [`Self::owner`] is retained ONLY so the template-cloned test database is not
+/// DROPped when the last handle goes; nothing reads through it after a restart.
+/// [`Self::restart`] opens a brand-new pool from the DSN and builds a brand-new
+/// reconciler, drop bridge and apiserver surface — the objects a lost process
+/// takes with it.
+struct Restart {
+    owner: Database,
+    dsn: String,
+}
+
+impl Restart {
+    async fn new() -> Self {
+        let owner = Database::ephemeral().await.expect("ephemeral db");
+        let dsn = owner
+            .test_dsn()
+            .expect("the ephemeral harness must expose its DSN");
+        Self { owner, dsn }
+    }
+
+    fn db(&self) -> &Database {
+        &self.owner
+    }
+
+    /// Rebuild everything a restarted process would have to rebuild.
+    fn restart(&self, cluster: StoredTaskRunPod, clock: Arc<RecordingClock>) -> Rebuilt {
+        let db = Database::open_with_config(DatabaseConnectConfig::Postgres(
+            PostgresDatabaseConfig {
+                url: self.dsn.clone(),
+            },
+        ))
+        .expect("reopen the same database from its DSN alone");
+        let surface = Arc::new(CountingSurface::new(cluster));
+        let bridge = Arc::new(TaskRunResizeDropBridge::with_surface(
+            db.clone(),
+            Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>,
+            Arc::clone(&clock) as Arc<dyn ResizeDropClock>,
+        ));
+        Rebuilt {
+            db,
+            surface,
+            bridge,
+        }
+    }
+}
+
+struct Rebuilt {
+    db: Database,
+    surface: Arc<CountingSurface>,
+    bridge: Arc<TaskRunResizeDropBridge>,
+}
+
+impl Rebuilt {
+    fn reconciler(
+        &self,
+        leases: Option<Arc<BuildLeaseService>>,
+        gate: Arc<dyn ResizeReconcileGate>,
+    ) -> Arc<TaskRunResizeReconciler> {
+        Arc::new(
+            TaskRunResizeReconciler::new(self.db.clone(), Arc::clone(&self.bridge), leases, gate)
+                .with_row_budget(Duration::from_secs(5)),
+        )
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC3 — restart resumes from persisted state, in every nonterminal state
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Every nonterminal resize state resumes after the process that lifted the Pod
+/// is gone, and a TERMINAL row is skipped.
+///
+/// The seeding never constructs a reconciler: the row is written by the
+/// repository directly, then every in-memory object is dropped and rebuilt from
+/// the DSN. The reconciler therefore has no possible source for what to do
+/// except `list_nonterminal_resize`.
+///
+/// NAMED FAILING MUTATION: seed the resumption from an in-memory cache instead
+/// of `list_nonterminal_resize` and EVERY row of this table fails — a rebuilt
+/// process has no cache to read.
+///
+/// NON-VACUITY: the seventh case is a released (terminal) row, and it must be
+/// left exactly where it is. A scan that acted on everything would move it.
+#[tokio::test]
+async fn every_nonterminal_state_resumes_after_the_process_that_lifted_it_is_gone() {
+    for (index, state) in [
+        BuildPodPermitState::BirthConfirmed,
+        BuildPodPermitState::LiftApplying,
+        BuildPodPermitState::Lifted,
+        BuildPodPermitState::DropRequired,
+        BuildPodPermitState::DropApplying,
+        BuildPodPermitState::Quarantined,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let restart = Restart::new().await;
+        let db = restart.db().clone();
+        let suffix = format!("state-{index}");
+        let (_task_id, task_run_id) = seed_task_run(&db, &suffix).await;
+        let pod_uid = format!("pod-uid-{suffix}");
+        let invocation_id = format!("invocation-{suffix}");
+        let cluster = StoredTaskRunPod::resize_v2(&pod_uid, CEILING);
+        {
+            // The process that performed the lift. Everything in this block is
+            // dropped before the reconciler exists.
+            let permits = BuildPodPermitRepository::new(db.clone());
+            let row = captured_permit(&permits, &task_run_id, &pod_uid).await;
+            lift_then_park(
+                &permits,
+                &cluster,
+                &row,
+                &pod_uid,
+                &invocation_id,
+                state,
+            )
+            .await;
+        }
+        kill_the_worker(&db, &task_run_id).await;
+        assert_eq!(
+            permit_state(&db, &task_run_id).await,
+            state,
+            "precondition: the durable row is parked at {state:?}"
+        );
+
+        cluster.reset_patch_counter();
+        let clock = Arc::new(RecordingClock::new());
+        let rebuilt = restart.restart(cluster.clone(), Arc::clone(&clock));
+        let reconciler = rebuilt.reconciler(None, Arc::new(ArmedGate));
+
+        let pass = reconciler.run_pass().await;
+
+        assert_eq!(
+            pass.resumed, 1,
+            "{state:?}: the rebuilt process must resume this row from persisted \
+             state; pass was {pass:?}"
+        );
+        let settled = permit_state(&db, &task_run_id).await;
+        assert!(
+            matches!(
+                settled,
+                BuildPodPermitState::BirthConfirmed | BuildPodPermitState::Released
+            ),
+            "{state:?}: resumption must settle at the birth limit or destroy the \
+             Pod, got {settled:?}"
+        );
+        // THE POD IS NEVER RETURNED TO SERVICE: whatever happened, no launcher
+        // is left holding a lifted ceiling.
+        match status_millicores(&cluster) {
+            Some(millicores) => assert_eq!(
+                millicores, BIRTH_MILLICORES,
+                "{state:?}: the launcher must be back at its birth limit, \
+                 confirmed through status.initContainerStatuses in MILLICORES"
+            ),
+            None => assert!(
+                cluster.observe_launcher().expect("observe").is_none(),
+                "{state:?}: a launcher with no status limit must be a Pod that \
+                 no longer exists"
+            ),
+        }
+        assert_ne!(
+            settled,
+            BuildPodPermitState::Lifted,
+            "{state:?}: the Pod must never be returned to service"
+        );
+        drop(rebuilt);
+    }
+}
+
+/// NON-VACUITY for the table above: a terminal row is invisible to the scan.
+///
+/// NAMED FAILING MUTATION: widen `NONTERMINAL_RESIZE_STATES` (or scan the whole
+/// table) and `scanned` becomes 1 and the released row is driven.
+#[tokio::test]
+async fn a_terminal_row_is_not_scanned_and_not_acted_on() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "terminal").await;
+    let pod_uid = "pod-uid-terminal";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    permits
+        .release(
+            &task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            "test_terminal",
+        )
+        .await
+        .expect("release the permit");
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Released,
+        "precondition: the row is terminal"
+    );
+    kill_the_worker(&db, &task_run_id).await;
+
+    cluster.reset_patch_counter();
+    let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let pass = rebuilt
+        .reconciler(None, Arc::new(ArmedGate))
+        .run_pass()
+        .await;
+
+    assert_eq!(
+        pass.scanned, 0,
+        "a terminal row must not even be returned by the scan; pass was {pass:?}"
+    );
+    assert_eq!(pass.resumed, 0);
+    assert_eq!(
+        cluster.resize_patches(),
+        0,
+        "no PATCH may be issued for a released permit"
+    );
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Released
+    );
+}
+
+/// A LIVE build is not touched.
+///
+/// `lifted` is the normal state of a healthy invocation. A reconciler that
+/// resumed every nonterminal row it found would take the CPU away from every
+/// running build in the cluster on its first tick — the failure mode that makes
+/// this whole slice dangerous rather than merely inert.
+///
+/// NAMED FAILING MUTATION: make `is_stranded` return `Ok(true)` unconditionally
+/// and this test fails with the launcher back at 250m while its build is still
+/// running.
+#[tokio::test]
+async fn a_live_build_keeps_its_lift() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "live").await;
+    let pod_uid = "pod-uid-live";
+    let invocation_id = "invocation-live";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+    // The worker is ALIVE: the task run is still `running` and the exact Pod is
+    // still present.
+    cluster.reset_patch_counter();
+
+    let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let pass = rebuilt
+        .reconciler(None, Arc::new(ArmedGate))
+        .run_pass()
+        .await;
+
+    assert_eq!(pass.scanned, 1, "the row IS in the scan; pass was {pass:?}");
+    assert_eq!(
+        pass.resumed, 0,
+        "a live build must keep its lift; pass was {pass:?}"
+    );
+    assert_eq!(
+        pass.skipped,
+        vec![(task_run_id.clone(), SkipReason::OwnerLive)]
+    );
+    assert_eq!(
+        cluster.resize_patches(),
+        0,
+        "not one PATCH may be issued against a live build"
+    );
+    assert_eq!(
+        status_millicores(&cluster),
+        Some(LIFTED_MILLICORES),
+        "the live launcher keeps the ceiling its invocation was granted"
+    );
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Lifted
+    );
+}
+
+/// A live task run whose Pod is GONE is still stranded.
+///
+/// The task-run status is written by the coordinator and can lag a node that
+/// disappeared; the exact Pod UID being absent is a second, independent
+/// worker-independent fact, and the ceiling is withheld for the whole of that
+/// window.
+///
+/// NAMED FAILING MUTATION: delete the `pod_uid_absent` disjunct from
+/// `is_stranded` and this row is never resumed.
+#[tokio::test]
+async fn a_lifted_row_whose_pod_vanished_is_stranded_even_while_the_run_reads_live() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "vanished").await;
+    let pod_uid = "pod-uid-vanished";
+    let invocation_id = "invocation-vanished";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+    // The node took the Pod with it. The task run still reads `running`.
+    cluster.uid_fenced_delete(&task_run_id, pod_uid).expect("delete");
+    assert!(
+        cluster.observe_launcher().expect("observe").is_none(),
+        "precondition: the Pod is gone"
+    );
+    assert_eq!(
+        TaskRunRepository::new(db.clone())
+            .get(&task_run_id)
+            .await
+            .expect("read run")
+            .expect("run exists")
+            .status,
+        "running",
+        "precondition: nothing has terminalised the task run"
+    );
+
+    let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let pass = rebuilt
+        .reconciler(None, Arc::new(ArmedGate))
+        .run_pass()
+        .await;
+
+    assert_eq!(
+        pass.resumed, 1,
+        "an absent Pod UID strands the row on its own; pass was {pass:?}"
+    );
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::DropRequired,
+        "the row is claimed and settles as `PodUidAbsent`, which is nonterminal \
+         and stays visible to the next sweep"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC2 — the gate is on the ACTION, evaluated per tick
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A disarmed reconciler is a loop that RUNS and declines to act, and arming it
+/// takes effect on the next tick without a restart.
+///
+/// NAMED FAILING MUTATION: move the gate to wrap the `spawn(...)` call — i.e.
+/// decide at wiring time — and this test cannot even be written: there would be
+/// no loop to observe ticking, `gate.asks()` would stay at 0 or 1, and the row
+/// would never be picked up after the flip.
+///
+/// NAMED FAILING MUTATION 2: read the mode once before the loop and cache it,
+/// and the second half fails with the row still stranded.
+#[tokio::test]
+async fn the_gate_is_evaluated_every_tick_and_arming_needs_no_restart() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "gate").await;
+    let pod_uid = "pod-uid-gate";
+    let invocation_id = "invocation-gate";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+    kill_the_worker(&db, &task_run_id).await;
+    cluster.reset_patch_counter();
+
+    let gate = Arc::new(FlippableGate::starting(ResizeReconcileMode::Off));
+    let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let reconciler = rebuilt.reconciler(None, Arc::clone(&gate) as Arc<dyn ResizeReconcileGate>);
+
+    let cancel = CancellationToken::new();
+    let loop_reconciler = Arc::clone(&reconciler);
+    let loop_cancel = cancel.clone();
+    let handle = tokio::spawn(async move {
+        run_loop(Duration::from_millis(20), loop_cancel, move || {
+            let reconciler = Arc::clone(&loop_reconciler);
+            async move {
+                reconciler.run_pass().await;
+            }
+        })
+        .await;
+    });
+
+    // ── Disarmed: the loop is RUNNING and idle. ──
+    wait_until(|| {
+        let reconciler = Arc::clone(&reconciler);
+        async move { reconciler.passes() >= 4 }
+    })
+    .await;
+    assert!(
+        gate.asks() >= 4,
+        "the loop must ask the gate on every tick; asked {} times",
+        gate.asks()
+    );
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Lifted,
+        "a disarmed tick must not move the durable row"
+    );
+    assert_eq!(
+        cluster.resize_patches(),
+        0,
+        "a disarmed tick must not touch the cluster"
+    );
+
+    // ── Armed mid-flight. No restart, no respawn. ──
+    gate.set(ResizeReconcileMode::Enforce);
+    wait_until(|| {
+        let cluster = cluster.clone();
+        async move { cluster.resize_patches() > 0 }
+    })
+    .await;
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::BirthConfirmed,
+        "arming is a configuration change, not a restart: the SAME loop must \
+         pick the stranded row up on a later tick"
+    );
+    assert_eq!(status_millicores(&cluster), Some(BIRTH_MILLICORES));
+}
+
+/// `observe` classifies but never acts.
+///
+/// NAMED FAILING MUTATION: make `acts()` return true for `Observe` and the
+/// PATCH counter leaves zero.
+#[tokio::test]
+async fn observe_mode_classifies_without_touching_the_cluster() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "observe").await;
+    let pod_uid = "pod-uid-observe";
+    let invocation_id = "invocation-observe";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+    kill_the_worker(&db, &task_run_id).await;
+    cluster.reset_patch_counter();
+
+    let gate = Arc::new(FlippableGate::starting(ResizeReconcileMode::Observe));
+    let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let pass = rebuilt
+        .reconciler(None, gate as Arc<dyn ResizeReconcileGate>)
+        .run_pass()
+        .await;
+
+    assert_eq!(pass.would_resume, 1, "pass was {pass:?}");
+    assert_eq!(pass.resumed, 0);
+    assert_eq!(cluster.resize_patches(), 0);
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Lifted,
+        "observe must leave the durable row exactly where it found it"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC4 — the sweep is periodic, not startup-only
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A row that becomes stranded while the reconciler is ALREADY RUNNING is
+/// picked up on a later tick, with no restart.
+///
+/// This is the criterion that exists because this repository shipped a
+/// startup-only reaper paired with a read-only doctor and produced a
+/// phantom-active state that never self-healed.
+///
+/// NAMED FAILING MUTATION: make the scan run once at startup and return, and
+/// this test fails by leaving the row stranded forever — the row does not even
+/// exist when the loop starts.
+#[tokio::test]
+async fn a_row_stranded_while_the_loop_runs_is_picked_up_on_a_later_tick() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "midflight").await;
+    let pod_uid = "pod-uid-midflight";
+    let invocation_id = "invocation-midflight";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+
+    let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let reconciler = rebuilt.reconciler(None, Arc::new(ArmedGate));
+    let cancel = CancellationToken::new();
+    let loop_reconciler = Arc::clone(&reconciler);
+    let loop_cancel = cancel.clone();
+    let handle = tokio::spawn(async move {
+        run_loop(Duration::from_millis(20), loop_cancel, move || {
+            let reconciler = Arc::clone(&loop_reconciler);
+            async move {
+                reconciler.run_pass().await;
+            }
+        })
+        .await;
+    });
+
+    // The loop has already done its startup scan over an EMPTY table.
+    wait_until(|| {
+        let reconciler = Arc::clone(&reconciler);
+        async move { reconciler.passes() >= 3 }
+    })
+    .await;
+
+    // Only now does a build start, lift, and lose its worker.
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+    kill_the_worker(&db, &task_run_id).await;
+    cluster.reset_patch_counter();
+
+    wait_until(|| {
+        let db = db.clone();
+        let task_run_id = task_run_id.clone();
+        async move { permit_state(&db, &task_run_id).await == BuildPodPermitState::BirthConfirmed }
+    })
+    .await;
+
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+
+    assert_eq!(
+        status_millicores(&cluster),
+        Some(BIRTH_MILLICORES),
+        "the launcher a dead worker left lifted must come back down without any \
+         restart of the reconciler"
+    );
+    assert!(cluster.resize_patches() >= 1);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC6 — release is gated on the OTHER ledger
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// `build_leases` moves only after the CLUSTER confirmed the drop.
+///
+/// Both ledgers are read. Asserting `build_pod_permits.state` alone would be a
+/// success log from the wrong store.
+///
+/// NAMED FAILING MUTATION: release the lease whenever the pass resumed a row
+/// (rather than on `releases_lease()`), and the unavailability test below fails.
+#[tokio::test]
+async fn the_build_lease_is_released_only_after_the_cluster_confirms_the_drop() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (task_id, task_run_id) = seed_task_run(&db, "ledger").await;
+    let pod_uid = "pod-uid-ledger";
+    let invocation_id = "invocation-ledger";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+
+    let leases = armed_lease_service(&db).await;
+    hold_build_lease(&leases, &task_id, &task_run_id, invocation_id).await;
+    assert_eq!(
+        build_lease_state(&db, invocation_id).await,
+        Some(BuildLeaseState::Launching),
+        "precondition: the OTHER ledger holds an occupying row"
+    );
+
+    // The worker dies without ever sending `release_lease`.
+    kill_the_worker(&db, &task_run_id).await;
+    cluster.reset_patch_counter();
+
+    let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let pass = rebuilt
+        .reconciler(Some(Arc::clone(&leases)), Arc::new(ArmedGate))
+        .run_pass()
+        .await;
+
+    assert_eq!(pass.resumed, 1, "pass was {pass:?}");
+    assert_eq!(pass.leases_released, 1, "pass was {pass:?}");
+    assert_eq!(
+        status_millicores(&cluster),
+        Some(BIRTH_MILLICORES),
+        "the confirmation that authorised the release came from the launcher's \
+         init-container status, in millicores"
+    );
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::BirthConfirmed
+    );
+    assert_eq!(
+        build_lease_state(&db, invocation_id).await,
+        Some(BuildLeaseState::Terminal),
+        "THE OTHER LEDGER: `build_leases` is what capacity is counted from, and \
+         it must be released by the reconciler for a worker that never sent \
+         `release_lease`"
+    );
+}
+
+/// An unreachable apiserver holds the lease and keeps the row nonterminal,
+/// retrying forever.
+///
+/// NAMED FAILING MUTATION: release the lease when the row reaches `quarantined`
+/// and this test fails with `build_leases` terminal while a Pod still holds a
+/// lifted ceiling nobody is accounting for.
+#[tokio::test]
+async fn an_unreachable_apiserver_holds_the_lease_and_keeps_retrying() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (task_id, task_run_id) = seed_task_run(&db, "unreachable").await;
+    let pod_uid = "pod-uid-unreachable";
+    let invocation_id = "invocation-unreachable";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+
+    let leases = armed_lease_service(&db).await;
+    hold_build_lease(&leases, &task_id, &task_run_id, invocation_id).await;
+    kill_the_worker(&db, &task_run_id).await;
+
+    // The apiserver stops answering entirely. Nothing can be confirmed and
+    // nothing can be proven absent.
+    cluster.fail_gets(ApiFault::timeout());
+    cluster.fail_patches(ApiFault::timeout());
+    cluster.reset_patch_counter();
+
+    // The clock stalls after enough sleeps to prove the loop is UNBOUNDED: if
+    // the quarantine absence loop had a cap it would have returned by now.
+    const STALL_AFTER: usize = 40;
+    let clock = Arc::new(RecordingClock::stalling_after(STALL_AFTER));
+    let rebuilt = restart.restart(cluster.clone(), Arc::clone(&clock));
+    let reconciler = rebuilt.reconciler(Some(Arc::clone(&leases)), Arc::new(ArmedGate));
+
+    let pass = tokio::time::timeout(Duration::from_secs(30), reconciler.run_pass())
+        .await
+        .expect("the pass must return once its per-row budget expires");
+
+    assert!(
+        clock.sleeps().len() >= STALL_AFTER,
+        "the drop must still have been retrying when the pass gave up; only \
+         {} sleeps observed",
+        clock.sleeps().len()
+    );
+    assert_eq!(
+        pass.unsettled, 1,
+        "the resumption did not settle; pass was {pass:?}"
+    );
+    assert_eq!(
+        pass.leases_released, 0,
+        "an unanswered apiserver is not evidence that CPU came back"
+    );
+    assert_eq!(
+        build_lease_state(&db, invocation_id).await,
+        Some(BuildLeaseState::Launching),
+        "THE OTHER LEDGER: `build_leases` must still be HELD"
+    );
+    let settled = permit_state(&db, &task_run_id).await;
+    assert!(
+        matches!(
+            settled,
+            BuildPodPermitState::DropApplying | BuildPodPermitState::Quarantined
+        ),
+        "the permit row stays nonterminal so the next sweep picks it up, got \
+         {settled:?}"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC7 — concurrent ownership is fenced
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Two concurrent drivers over one stranded row issue exactly ONE PATCH.
+///
+/// The reconciler has no prior claim on a row resting in a lift state: it must
+/// WIN the compare-and-swap into `drop_required` before it may touch the Pod.
+///
+/// NAMED FAILING MUTATION: delete the `claim` call (drive `drop_to_birth`
+/// directly, as the worker's own terminal path does) and this fails with a
+/// doubled PATCH counter — both drivers actuate the same drop.
+#[tokio::test]
+async fn two_concurrent_drivers_issue_exactly_one_patch() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "concurrent").await;
+    let pod_uid = "pod-uid-concurrent";
+    let invocation_id = "invocation-concurrent";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+    kill_the_worker(&db, &task_run_id).await;
+    cluster.reset_patch_counter();
+
+    // TWO SEPARATE PROCESSES: separate pools, separate reconcilers, separate
+    // in-flight sets. Only the durable compare-and-swap can serialise them.
+    let left = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let right = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let left_reconciler = left.reconciler(None, Arc::new(ArmedGate));
+    let right_reconciler = right.reconciler(None, Arc::new(ArmedGate));
+
+    let (left_pass, right_pass) = tokio::join!(
+        left_reconciler.run_pass(),
+        right_reconciler.run_pass(),
+    );
+
+    let resumed = left_pass.resumed + right_pass.resumed;
+    assert_eq!(
+        resumed, 1,
+        "exactly one driver may claim the row; left={left_pass:?} right={right_pass:?}"
+    );
+    assert!(
+        left_pass
+            .skipped
+            .iter()
+            .chain(right_pass.skipped.iter())
+            .any(|(_, reason)| *reason == SkipReason::ClaimLost),
+        "the losing driver must be REJECTED, not merely idle; \
+         left={left_pass:?} right={right_pass:?}"
+    );
+    assert_eq!(
+        cluster.resize_patches(),
+        1,
+        "exactly one pods/resize PATCH per drop, across both drivers"
+    );
+    assert_eq!(status_millicores(&cluster), Some(BIRTH_MILLICORES));
+}
+
+/// A leadership handover mid-drop: the new leader resumes and the OLD leader's
+/// in-flight attempt cannot commit.
+///
+/// NAMED FAILING MUTATION: drop the invocation/Pod-UID fence from
+/// `transition_resize_lifecycle` (or settle on the row's current state without
+/// a compare-and-swap) and the stalled old leader commits a second settlement
+/// on top of the new leader's, releasing the lease twice.
+#[tokio::test]
+async fn a_leadership_handover_mid_drop_lets_only_the_new_leader_commit() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (task_id, task_run_id) = seed_task_run(&db, "handover").await;
+    let pod_uid = "pod-uid-handover";
+    let invocation_id = "invocation-handover";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::DropApplying,
+    )
+    .await;
+    let leases = armed_lease_service(&db).await;
+    hold_build_lease(&leases, &task_id, &task_run_id, invocation_id).await;
+    kill_the_worker(&db, &task_run_id).await;
+
+    // THE OLD LEADER. Its Pod refuses to actuate, so it parks in the retry loop
+    // holding a resumption it believes it owns.
+    let stalled_cluster = cluster.clone();
+    stalled_cluster.stop_actuating();
+    let old_clock = Arc::new(RecordingClock::stalling_after(2));
+    let old = restart.restart(stalled_cluster, Arc::clone(&old_clock));
+    let old_reconciler = old.reconciler(Some(Arc::clone(&leases)), Arc::new(ArmedGate));
+    let old_leader = tokio::spawn(async move { old_reconciler.run_pass().await });
+    wait_until(|| {
+        let clock = Arc::clone(&old_clock);
+        async move { clock.sleeps().len() >= 2 }
+    })
+    .await;
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::DropApplying,
+        "precondition: the old leader is mid-drop"
+    );
+
+    // THE NEW LEADER, on a Pod that answers. Same durable row.
+    cluster.reset_patch_counter();
+    let new = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let new_pass = new
+        .reconciler(Some(Arc::clone(&leases)), Arc::new(ArmedGate))
+        .run_pass()
+        .await;
+
+    assert_eq!(new_pass.resumed, 1, "pass was {new_pass:?}");
+    assert_eq!(new_pass.leases_released, 1, "pass was {new_pass:?}");
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::BirthConfirmed
+    );
+    assert_eq!(
+        build_lease_state(&db, invocation_id).await,
+        Some(BuildLeaseState::Terminal)
+    );
+
+    // The old leader is still parked. Nothing it does from here may commit.
+    assert!(!old_leader.is_finished());
+    old_leader.abort();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC8 — no duplicated machinery
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// The reconciler's observed backoff IS `task_run_resize_drop`'s schedule.
+///
+/// The literals are spelled out rather than referenced through the constants:
+/// asserting `sleeps == [DROP_INITIAL_BACKOFF, ...]` would keep passing after
+/// someone changed them, which is the opposite of what this criterion wants.
+///
+/// NAMED FAILING MUTATION: change `DROP_INITIAL_BACKOFF`, `DROP_MAX_BACKOFF` or
+/// `DROP_CONFIRMATION_BUDGET` in `task_run_resize_drop.rs` alone and BOTH this
+/// test and `0ppk-2`'s
+/// `the_backoff_sequence_is_250ms_doubling_capped_at_2s_inside_30s` fail
+/// together. If only one fails, the schedule has been forked.
+#[tokio::test]
+async fn the_reconcilers_backoff_is_the_drops_backoff() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "backoff").await;
+    let pod_uid = "pod-uid-backoff";
+    let invocation_id = "invocation-backoff";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING).never_actuating();
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+    kill_the_worker(&db, &task_run_id).await;
+
+    let clock = Arc::new(RecordingClock::new());
+    let rebuilt = restart.restart(cluster.clone(), Arc::clone(&clock));
+    let reconciler = rebuilt
+        .reconciler(None, Arc::new(ArmedGate))
+        .run_pass()
+        .await;
+    assert_eq!(reconciler.resumed, 1, "pass was {reconciler:?}");
+
+    // 250 + 500 + 1000 + 2000*n <= 30_000, with the deadline checked against
+    // the sleep the loop is ABOUT to take.
+    let mut expected = vec![
+        Duration::from_millis(250),
+        Duration::from_millis(500),
+        Duration::from_millis(1000),
+    ];
+    expected.extend(std::iter::repeat_n(Duration::from_secs(2), 14));
+    let sleeps = clock.sleeps();
+    assert_eq!(
+        &sleeps[..expected.len()],
+        &expected[..],
+        "the reconciler must observe `task_run_resize_drop`'s schedule, not a \
+         second copy of it"
+    );
+    assert!(
+        rebuilt.surface.gets() as usize >= sleeps.len(),
+        "a FRESH GET before EVERY attempt: {} gets for {} sleeps",
+        rebuilt.surface.gets(),
+        sleeps.len()
+    );
+}
+
+/// A quarantined Pod is destroyed with a UID-FENCED delete and the permit is
+/// released only after its absence is OBSERVED.
+///
+/// A `200` from `DELETE` says the apiserver accepted the request, not that the
+/// object is gone.
+///
+/// NAMED FAILING MUTATION: settle the quarantine on the delete's own
+/// acknowledgement rather than on a subsequent observation, and the assertion
+/// that the Pod is actually gone fails.
+#[tokio::test]
+async fn a_quarantined_pod_is_uid_fence_deleted_and_proven_absent() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (task_id, task_run_id) = seed_task_run(&db, "quarantine").await;
+    let pod_uid = "pod-uid-quarantine";
+    let invocation_id = "invocation-quarantine";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Quarantined,
+    )
+    .await;
+    let leases = armed_lease_service(&db).await;
+    hold_build_lease(&leases, &task_id, &task_run_id, invocation_id).await;
+    kill_the_worker(&db, &task_run_id).await;
+
+    let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+    let pass = rebuilt
+        .reconciler(Some(Arc::clone(&leases)), Arc::new(ArmedGate))
+        .run_pass()
+        .await;
+
+    assert_eq!(pass.resumed, 1, "pass was {pass:?}");
+    assert!(
+        rebuilt.surface.deletes_attempted() >= 1,
+        "the quarantined Pod must be destroyed"
+    );
+    assert_eq!(
+        cluster.deletes(),
+        vec![(task_run_id.clone(), pod_uid.to_owned())],
+        "the DELETE must be fenced to the EXACT Pod UID"
+    );
+    assert!(
+        cluster.observe_launcher().expect("observe").is_none(),
+        "absence is proven by observation, never by the DELETE's own answer"
+    );
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Released
+    );
+    assert_eq!(
+        build_lease_state(&db, invocation_id).await,
+        Some(BuildLeaseState::Terminal),
+        "THE OTHER LEDGER: only an ABSENT Pod UID may release build_leases here"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC1 — reachability: leadership, and the composition site
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// The spawn lives in `become_leader` and NOWHERE in the every-pod
+/// `initialize` path.
+///
+/// `become_leader` cannot be invoked from a test — it exits the process on a
+/// Zot retention preflight failure and starts the coordinator, the RPC listener
+/// and the image controller — so the composition site is asserted the way this
+/// file's neighbours already assert theirs: against the source text, plus the
+/// standby proof below against real leadership, plus
+/// `scripts/check-resize-reachability.sh`, which fails when the symbol has no
+/// production caller at all.
+///
+/// NAMED FAILING MUTATION: delete the spawn line and this test fails.
+#[test]
+fn the_reconciler_is_spawned_from_become_leader_and_not_from_initialize() {
+    let source = include_str!("../src/server/state/mod.rs");
+    // Assembled at runtime so this assertion cannot match its own literal.
+    let call = format!("crate::task_run_resize_{}::spawn(self.clone());", "reconcile");
+    assert_eq!(
+        source.matches(call.as_str()).count(),
+        1,
+        "exactly one production call site"
+    );
+    let initialize = source
+        .find("pub async fn initialize(&self)")
+        .expect("initialize exists");
+    let leader = source
+        .find("pub async fn become_leader")
+        .expect("become_leader exists");
+    let site = source.find(call.as_str()).expect("call site exists");
+    assert!(
+        site > leader,
+        "the reconciler must be armed inside become_leader"
+    );
+    assert!(
+        !source[initialize..leader].contains(call.as_str()),
+        "a standby pod running drop reconciliation would race the leader"
+    );
+}
+
+/// A standby pod never reconciles, proven through the REAL advisory-lock
+/// leadership transition.
+///
+/// Two processes race `run_with_leadership` for the coordinator lock in this
+/// test's own isolated database. The winner's `on_acquire` runs a pass; the
+/// loser's never fires at all, so its reconciler never sees the stranded row.
+///
+/// NAMED FAILING MUTATION: move the spawn into `initialize` (which every pod
+/// runs) and the property this asserts — that only the lock holder acts —
+/// stops being true of production, though this test would keep passing;
+/// `the_reconciler_is_spawned_from_become_leader_and_not_from_initialize` above
+/// is the assertion that catches that move, and the two are deliberately paired.
+#[tokio::test]
+async fn only_the_leader_reconciles_across_a_real_advisory_lock_race() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (_task_id, task_run_id) = seed_task_run(&db, "standby").await;
+    let pod_uid = "pod-uid-standby";
+    let invocation_id = "invocation-standby";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::Lifted,
+    )
+    .await;
+    kill_the_worker(&db, &task_run_id).await;
+    cluster.reset_patch_counter();
+
+    let dsn = restart.db().test_dsn().expect("dsn");
+    let acquired = Arc::new(AtomicUsize::new(0));
+    let cancel = CancellationToken::new();
+
+    let mut pods = Vec::new();
+    for _ in 0..2 {
+        let rebuilt = restart.restart(cluster.clone(), Arc::new(RecordingClock::new()));
+        let reconciler = rebuilt.reconciler(None, Arc::new(ArmedGate));
+        let acquired = Arc::clone(&acquired);
+        let dsn = dsn.clone();
+        let cancel = cancel.clone();
+        pods.push(tokio::spawn(async move {
+            let _rebuilt = rebuilt;
+            djinn_server::leadership::run_with_leadership(Some(dsn), cancel, || async move {
+                acquired.fetch_add(1, Ordering::SeqCst);
+                reconciler.run_pass().await;
+            })
+            .await;
+        }));
+    }
+
+    wait_until(|| {
+        let db = db.clone();
+        let task_run_id = task_run_id.clone();
+        async move { permit_state(&db, &task_run_id).await == BuildPodPermitState::BirthConfirmed }
+    })
+    .await;
+    // Give the standby ample opportunity to promote itself if it were going to.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    assert_eq!(
+        acquired.load(Ordering::SeqCst),
+        1,
+        "exactly one process may hold the coordinator advisory lock, and only \
+         that one may reconcile"
+    );
+    assert_eq!(
+        cluster.resize_patches(),
+        1,
+        "the standby must not have touched the Pod"
+    );
+
+    cancel.cancel();
+    for pod in pods {
+        let _ = tokio::time::timeout(Duration::from_secs(10), pod).await;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Poll `condition` until it holds, or fail the test after 30 seconds.
+async fn wait_until<F, Fut>(mut condition: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if condition().await {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "condition never became true within 30s"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -572,12 +572,11 @@ impl Restart {
 
     /// Rebuild everything a restarted process would have to rebuild.
     fn restart(&self, cluster: StoredTaskRunPod, clock: Arc<RecordingClock>) -> Rebuilt {
-        let db = Database::open_with_config(DatabaseConnectConfig::Postgres(
-            PostgresDatabaseConfig {
+        let db =
+            Database::open_with_config(DatabaseConnectConfig::Postgres(PostgresDatabaseConfig {
                 url: self.dsn.clone(),
-            },
-        ))
-        .expect("reopen the same database from its DSN alone");
+            }))
+            .expect("reopen the same database from its DSN alone");
         let surface = Arc::new(CountingSurface::new(cluster));
         let bridge = Arc::new(TaskRunResizeDropBridge::with_surface(
             db.clone(),
@@ -654,15 +653,7 @@ async fn every_nonterminal_state_resumes_after_the_process_that_lifted_it_is_gon
             // dropped before the reconciler exists.
             let permits = BuildPodPermitRepository::new(db.clone());
             let row = captured_permit(&permits, &task_run_id, &pod_uid).await;
-            lift_then_park(
-                &permits,
-                &cluster,
-                &row,
-                &pod_uid,
-                &invocation_id,
-                state,
-            )
-            .await;
+            lift_then_park(&permits, &cluster, &row, &pod_uid, &invocation_id, state).await;
         }
         kill_the_worker(&db, &task_run_id).await;
         assert_eq!(
@@ -858,7 +849,9 @@ async fn a_lifted_row_whose_pod_vanished_is_stranded_even_while_the_run_reads_li
     )
     .await;
     // The node took the Pod with it. The task run still reads `running`.
-    cluster.uid_fenced_delete(&task_run_id, pod_uid).expect("delete");
+    cluster
+        .uid_fenced_delete(&task_run_id, pod_uid)
+        .expect("delete");
     assert!(
         cluster.observe_launcher().expect("observe").is_none(),
         "precondition: the Pod is gone"
@@ -1306,10 +1299,8 @@ async fn two_concurrent_drivers_issue_exactly_one_patch() {
     let left_reconciler = left.reconciler(None, Arc::new(ArmedGate));
     let right_reconciler = right.reconciler(None, Arc::new(ArmedGate));
 
-    let (left_pass, right_pass) = tokio::join!(
-        left_reconciler.run_pass(),
-        right_reconciler.run_pass(),
-    );
+    let (left_pass, right_pass) =
+        tokio::join!(left_reconciler.run_pass(), right_reconciler.run_pass(),);
 
     let resumed = left_pass.resumed + right_pass.resumed;
     assert_eq!(
@@ -1588,7 +1579,10 @@ async fn a_quarantined_pod_is_uid_fence_deleted_and_proven_absent() {
 fn the_reconciler_is_spawned_from_become_leader_and_not_from_initialize() {
     let source = include_str!("../src/server/state/mod.rs");
     // Assembled at runtime so this assertion cannot match its own literal.
-    let call = format!("crate::task_run_resize_{}::spawn(self.clone());", "reconcile");
+    let call = format!(
+        "crate::task_run_resize_{}::spawn(self.clone());",
+        "reconcile"
+    );
     assert_eq!(
         source.matches(call.as_str()).count(),
         1,
@@ -1703,13 +1697,13 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = bool>,
 {
-    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + Duration::from_secs(30);
     loop {
         if condition().await {
             return;
         }
         assert!(
-            std::time::Instant::now() < deadline,
+            Instant::now() < deadline,
             "condition never became true within 30s"
         );
         tokio::time::sleep(Duration::from_millis(10)).await;

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -39,6 +39,33 @@
 //!   `status.initContainerStatuses` millicore rule that runs in the cluster.
 //!   That is the fault-injection seam, and it is the only fake.
 //!
+//! # The one criterion this file does NOT prove, and why it cannot
+//!
+//! Task `r37r`'s acceptance criterion 5 asks for the worker-death scenario
+//! against a LIVE kind cluster. It is not here, and this is a structural
+//! boundary rather than an omission:
+//!
+//! * The reconciler lives in `djinn-server`. Driving a live apiserver from a
+//!   `djinn-server` test requires a `kube::Client`, and `deny.toml` bans a
+//!   direct `k8s-openapi`/`kube` dependency outside `djinn-k8s`, the Kubernetes
+//!   capability owner. That ban is right and this slice does not weaken it.
+//! * The natural fix — a context-pinned surface constructor on
+//!   `djinn_k8s::runtime` so the server test never names `kube` — lands in
+//!   `djinn-k8s/src/runtime.rs`, which `r37r`'s design places on the
+//!   DO-NOT-TOUCH list.
+//! * `djinn-k8s` cannot depend on `djinn-server`, so the test cannot move there
+//!   either.
+//!
+//! What the live half would add over what is here is the KUBELET's actuation.
+//! Everything else in that criterion — the 250ms→2s bounded retry inside a 30s
+//! budget, quarantine on deadline, the UID-fenced DELETE, and releasing the
+//! durable lease only after the exact Pod UID is proven absent — is proven
+//! below through the PRODUCTION `PodResizeClient` and the PRODUCTION
+//! `confirm_launcher_cpu`, against a stored `Pod`. The "no `release_lease` ever
+//! arrives" half is structural here and stronger than an assertion: this file
+//! composes no RPC listener and no `DirectServices` at all, so there is nothing
+//! a worker could have sent a terminal signal to.
+//!
 //! # A safety landmine this file does NOT step on
 //!
 //! Every `KubernetesRuntime` constructor resolves through

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -89,9 +89,8 @@ use djinn_db::{
     AcquireBuildPodPermitResult, BindBuildPodPermitResult, BuildLeaseConsumerKind, BuildLeaseKey,
     BuildLeaseRepository, BuildLeaseState, BuildPodPermitRepository, BuildPodPermitRow,
     BuildPodPermitState, BuildPodResizeIdentity, CaptureBuildPodResizeIdentityResult,
-    CreateTaskRunParams, Database, DatabaseConnectConfig, EffectiveCreatorProvenance,
-    PostgresDatabaseConfig, ProjectRepository, TaskRepository, TaskRunRepository,
-    TransitionBuildPodResizeLifecycleResult,
+    CreateTaskRunParams, Database, EffectiveCreatorProvenance, ProjectRepository, TaskRepository,
+    TaskRunRepository, TransitionBuildPodResizeLifecycleResult,
 };
 use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
 use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
@@ -573,21 +572,102 @@ impl Restart {
     /// Rebuild everything a restarted process would have to rebuild.
     fn restart(&self, cluster: StoredTaskRunPod, clock: Arc<RecordingClock>) -> Rebuilt {
         let db =
-            Database::open_with_config(DatabaseConnectConfig::Postgres(PostgresDatabaseConfig {
-                url: self.dsn.clone(),
-            }))
-            .expect("reopen the same database from its DSN alone");
+            Database::reopen_test(&self.dsn).expect("reopen the same database from its DSN alone");
         let surface = Arc::new(CountingSurface::new(cluster));
-        let bridge = Arc::new(TaskRunResizeDropBridge::with_surface(
-            db.clone(),
-            Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>,
-            Arc::clone(&clock) as Arc<dyn ResizeDropClock>,
-        ));
         Rebuilt {
+            bridge: Arc::new(TaskRunResizeDropBridge::with_surface(
+                db.clone(),
+                Arc::clone(&surface) as Arc<dyn TaskRunPodSurface>,
+                Arc::clone(&clock) as Arc<dyn ResizeDropClock>,
+            )),
             db,
             surface,
-            bridge,
         }
+    }
+
+    /// Restart onto a surface that races the ledger. See
+    /// [`LedgerRacingSurface`].
+    fn restart_racing_the_ledger(
+        &self,
+        cluster: StoredTaskRunPod,
+        permit: &BuildPodPermitRow,
+    ) -> Arc<TaskRunResizeDropBridge> {
+        let db = Database::reopen_test(&self.dsn).expect("reopen from the DSN");
+        let surface = Arc::new(LedgerRacingSurface {
+            cluster,
+            permits: BuildPodPermitRepository::new(db.clone()),
+            task_run_id: permit.task_run_id.clone(),
+            permit_id: permit.permit_id.clone(),
+            fencing_token: permit.fencing_token,
+            observations: AtomicU64::new(0),
+        });
+        Arc::new(TaskRunResizeDropBridge::with_surface(
+            db,
+            surface as Arc<dyn TaskRunPodSurface>,
+            Arc::new(RecordingClock::new()) as Arc<dyn ResizeDropClock>,
+        ))
+    }
+}
+
+/// A surface that moves the durable ledger out from under a drop, between its
+/// PATCH and its settle.
+///
+/// The launcher REALLY comes back to 250m and the cluster REALLY reports it.
+/// But the permit row is retired by somebody else in the same instant, so
+/// `settle_confirmed`'s compare-and-swap is rejected and the drop settles as
+/// [`ResizeDropOutcome::Unavailable`] — "the Pod came back down but the ledger
+/// did not move".
+///
+/// This is the ONLY shape that reaches the reconciler's `releases_lease()`
+/// guard at all: a resumption that runs out of its row budget returns `None` and
+/// takes the `unsettled` arm long before it. An earlier version of this file
+/// claimed the apiserver-unavailability test covered that guard; it did not, and
+/// deleting the guard left the whole suite green.
+struct LedgerRacingSurface {
+    cluster: StoredTaskRunPod,
+    permits: BuildPodPermitRepository,
+    task_run_id: String,
+    permit_id: String,
+    fencing_token: i64,
+    observations: AtomicU64,
+}
+
+#[async_trait]
+impl TaskRunPodSurface for LedgerRacingSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        // Observation 1 is the fencing read before the PATCH; observation 2 is
+        // the CONFIRMING read the settle immediately follows. Racing the ledger
+        // at 2 is what lands the rejection on the settle rather than on the
+        // entry transition.
+        if self.observations.fetch_add(1, Ordering::SeqCst) == 1 {
+            self.permits
+                .release(
+                    &self.task_run_id,
+                    &self.permit_id,
+                    self.fencing_token,
+                    "test_ledger_race",
+                )
+                .await
+                .expect("retire the permit under the drop");
+        }
+        self.cluster.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), djinn_k8s::pod_resize::PodResizeError> {
+        self.cluster
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        self.cluster.uid_fenced_delete(task_run_id, pod_uid)
     }
 }
 
@@ -1258,6 +1338,81 @@ async fn an_unreachable_apiserver_holds_the_lease_and_keeps_retrying() {
     );
 }
 
+/// A SETTLED outcome that is not releasable still holds the lease.
+///
+/// The launcher is confirmed back at 250m — the cluster said so, through
+/// `status.initContainerStatuses` — and the lease is STILL not released,
+/// because the durable lifecycle did not move with it. Holding is the only
+/// answer that keeps the two ledgers in agreement.
+///
+/// This is the test that guards `outcome.releases_lease() &&` in `run_pass`.
+/// It exists because the apiserver-unavailability test above does NOT: an
+/// unsettled resumption returns `None` and takes the `unsettled` arm before the
+/// release site is ever evaluated, so deleting that condition left the entire
+/// suite green. The named mutation was verified against a real deletion.
+///
+/// NAMED FAILING MUTATION: drop `outcome.releases_lease() &&` from the release
+/// condition in `run_pass` and this fails with `build_leases` terminal.
+#[tokio::test]
+async fn a_settled_but_unreleasable_outcome_still_holds_the_lease() {
+    let restart = Restart::new().await;
+    let db = restart.db().clone();
+    let (task_id, task_run_id) = seed_task_run(&db, "unreleasable").await;
+    let pod_uid = "pod-uid-unreleasable";
+    let invocation_id = "invocation-unreleasable";
+    let cluster = StoredTaskRunPod::resize_v2(pod_uid, CEILING);
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let row = captured_permit(&permits, &task_run_id, pod_uid).await;
+    lift_then_park(
+        &permits,
+        &cluster,
+        &row,
+        pod_uid,
+        invocation_id,
+        BuildPodPermitState::DropApplying,
+    )
+    .await;
+    let leases = armed_lease_service(&db).await;
+    hold_build_lease(&leases, &task_id, &task_run_id, invocation_id).await;
+    kill_the_worker(&db, &task_run_id).await;
+    cluster.reset_patch_counter();
+
+    let bridge = restart.restart_racing_the_ledger(cluster.clone(), &row);
+    let reconciler = Arc::new(
+        TaskRunResizeReconciler::new(
+            Database::reopen_test(&restart.dsn).expect("reopen"),
+            bridge,
+            Some(Arc::clone(&leases)),
+            Arc::new(ArmedGate),
+        )
+        .with_row_budget(Duration::from_secs(5)),
+    );
+    let pass = reconciler.run_pass().await;
+
+    assert_eq!(pass.resumed, 1, "pass was {pass:?}");
+    assert_eq!(
+        pass.unsettled, 0,
+        "NON-VACUITY: this must be a SETTLED outcome, not one that ran out of \
+         budget — the budget path returns before the release site; pass was {pass:?}"
+    );
+    assert_eq!(
+        status_millicores(&cluster),
+        Some(BIRTH_MILLICORES),
+        "NON-VACUITY: the cluster really did bring the launcher back down, so \
+         'the lease is held' is not held because nothing happened"
+    );
+    assert_eq!(
+        pass.leases_released, 0,
+        "an outcome the drop refused to call releasable must not release the \
+         durable lease; pass was {pass:?}"
+    );
+    assert_eq!(
+        build_lease_state(&db, invocation_id).await,
+        Some(BuildLeaseState::Launching),
+        "THE OTHER LEDGER: `build_leases` must still be HELD"
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // AC7 — concurrent ownership is fenced
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1617,7 +1772,12 @@ fn the_reconciler_is_spawned_from_become_leader_and_not_from_initialize() {
 /// stops being true of production, though this test would keep passing;
 /// `the_reconciler_is_spawned_from_become_leader_and_not_from_initialize` above
 /// is the assertion that catches that move, and the two are deliberately paired.
-#[tokio::test]
+/// Multi-threaded on purpose: this is the only test here that runs two
+/// long-lived background processes AND a polling loop at the same time, and on
+/// the default current-thread runtime they all contend for one thread. Under
+/// `--test-threads 4` that showed up as a 30-second timeout on a test that takes
+/// three seconds alone, which is a flake, not a finding.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn only_the_leader_reconciles_across_a_real_advisory_lock_race() {
     let restart = Restart::new().await;
     let db = restart.db().clone();
@@ -1652,18 +1812,33 @@ async fn only_the_leader_reconciles_across_a_real_advisory_lock_race() {
         let cancel = cancel.clone();
         pods.push(tokio::spawn(async move {
             let _rebuilt = rebuilt;
+            let loop_cancel = cancel.clone();
             djinn_server::leadership::run_with_leadership(Some(dsn), cancel, || async move {
                 acquired.fetch_add(1, Ordering::SeqCst);
-                reconciler.run_pass().await;
+                // The PRODUCTION shape: a loop, not a single pass. A one-shot
+                // here would make the test hostage to any transient database
+                // hiccup — one failed scan and the row is stranded for the rest
+                // of the test — which is exactly the startup-only failure mode
+                // this whole slice exists to avoid.
+                run_loop(Duration::from_millis(50), loop_cancel, move || {
+                    let reconciler = Arc::clone(&reconciler);
+                    async move {
+                        reconciler.run_pass().await;
+                    }
+                })
+                .await;
             })
             .await;
         }));
     }
 
+    // `Released`, not `BirthConfirmed`: the pass drives the row all the way
+    // through the birth limit to permit retirement, so polling for the
+    // intermediate state is a race the poller usually loses.
     wait_until(|| {
         let db = db.clone();
         let task_run_id = task_run_id.clone();
-        async move { permit_state(&db, &task_run_id).await == BuildPodPermitState::BirthConfirmed }
+        async move { permit_state(&db, &task_run_id).await == BuildPodPermitState::Released }
     })
     .await;
     // Give the standby ample opportunity to promote itself if it were going to.
@@ -1697,14 +1872,14 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = bool>,
 {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + Duration::from_secs(60);
     loop {
         if condition().await {
             return;
         }
         assert!(
             Instant::now() < deadline,
-            "condition never became true within 30s"
+            "condition never became true within 60s"
         );
         tokio::time::sleep(Duration::from_millis(10)).await;
     }


### PR DESCRIPTION
Epic `0ppk`, proposal `3i92`, task `r37r` — the final slice.

## Why this is load-bearing, not defensive

`release_lease` is **only ever sent by a worker that reached `queued == true` and survived**. A Pod that is OOM-killed, evicted, or whose node vanishes sends nothing, and a server that restarts mid-lift loses every in-process handle that could have noticed. In both cases the launcher keeps whatever ceiling the lift left on it, the `build_pod_permits` row never leaves its nonterminal resize state, and the durable `build_leases` row is held by nobody who will ever release it.

`BuildPodPermitRepository::list_nonterminal_resize` exists exactly for this. This PR gives it the reader it was written for.

## What lands

**`server/src/task_run_resize_reconcile.rs`** — a leader-only sweep, spawned **unconditionally** from `AppState::become_leader` alongside `scip_index_watcher::spawn`, whose mode is re-read on **every tick**. That ordering is the rule the comment already at that seam states: *"gating the WIRING instead of the ACTION is how a feature ends up shipped and permanently unreachable."*

Each tick:
1. `list_nonterminal_resize()` — a **durable** read. The reconciler holds no map of live invocations; a cache is exactly the state a restart destroys.
2. Classify each row. A row is the reconciler's responsibility only on a **worker-independent** fact: a drop already owed (`drop_required` / `drop_applying` / `quarantined` — states no live driver rests in), or an owner that is gone (task-run terminal, or the exact Pod UID confirmed absent). `lifted` is the normal state of a healthy build and is left alone.
3. **Claim** via the migration-167/168 compare-and-swap into `drop_required`. A reconciler has no prior claim on a resting row; a driver that loses the CAS returns without issuing a single PATCH.
4. Resume through `TaskRunResizeDropBridge::resize_drop_mechanism` — **the same constructor** `release_lease`'s `confirm_drop` now uses. One retry schedule, one 30s budget, one set of fences.
5. **Retire the permit**, then release `build_leases`. The dispatch seam records that "the resize lifecycle that reclaims a permit belongs to `0ppk-3`'s reconciler", and `ResizeDropOutcome::PodUidAbsent` says in as many words that it leaves the row nonterminal for this module. Retiring is also what makes the sweep terminate — a row left at `birth_confirmed` with a dead owner is stranded again by the next tick's own predicate.

**`server/tests/task_run_resize_recovery.rs`** — 16 tests against **real Postgres** (`open_in_memory`, a template-cloned real database). No `Fake`/`Mock` permit repository anywhere. The restart is real: `Database::test_dsn()` / `reopen_test()` let the test drop every in-memory object — reconciler, drop bridge, apiserver surface, connection pool — and rebuild from nothing but a connection string. The leadership race is real: two `run_with_leadership` futures contend for the Postgres advisory lock in the test's own isolated database. The apiserver is the only fake, and it is driven through the **production** `PodResizeClient` and **production** `confirm_launcher_cpu`.

**`scripts/check-resize-reachability.sh`** — `task_run_resize_reconcile::spawn` and `BuildPodPermitRepository::list_nonterminal_resize` are now guarded symbols, plus a `become_leader` composition anchor.

## Every named mutation was actually applied and verified

Not asserted — run. Each mutation was applied to the tree, the named test was executed, and the tree restored:

| AC | Mutation | Named test | Failed? |
|----|----------|-----------|---------|
| 1 | delete the `spawn` line from `become_leader` | `the_reconciler_is_spawned_from_become_leader_and_not_from_initialize` | yes |
| 2 | hard-code the mode instead of asking per tick | `the_gate_is_evaluated_every_tick_and_arming_needs_no_restart` | yes (`asked 0 times`) |
| 3 | seed the scan from an empty in-memory source | `every_nonterminal_state_resumes_after_the_process_that_lifted_it_is_gone` | yes |
| 4 | `break` after the first tick | `a_row_stranded_while_the_loop_runs_is_picked_up_on_a_later_tick` | yes |
| 6 | drop `outcome.releases_lease() &&` | `a_settled_but_unreleasable_outcome_still_holds_the_lease` | yes |
| 7 | delete the claim CAS | `two_concurrent_drivers_issue_exactly_one_patch` | yes (PATCH counter 2, not 1) |
| 8 | `DROP_INITIAL_BACKOFF` 250ms → 300ms | `the_reconcilers_backoff_is_the_drops_backoff` **and** `0ppk-2`'s `the_backoff_sequence_is_250ms_doubling_capped_at_2s_inside_30s` | **both**, together |

**AC6's first attempt did NOT hold, and that is why the test above exists.** The apiserver-unavailability test was documented as covering the release guard. It did not: an unsettled resumption returns `None` and takes the `unsettled` arm before the release site is ever evaluated, so deleting `outcome.releases_lease() &&` left the whole suite green. Reaching the guard needs a *settled* outcome that is not releasable, so `LedgerRacingSurface` retires the permit between the drop's PATCH and its settle — the launcher really does come back to 250m, the ledger does not move with it, and the lease is held. That mutation now fails.

## Two guard bugs fixed along the way

**`check-resize-reachability.sh` contradicted itself.** Its anchor check found `task_run_resize_reconcile::spawn` in `state/mod.rs` while its caller check reported ZERO production callers — same file, same string, same run. Cause: a first-marker `#[cfg(test)]` heuristic. `state/mod.rs` carries `#[cfg(test)]` on a *struct field* 1800 lines above `become_leader`, so everything below it read as test code. The tracker now counts braces the way `scripts/check-test-global-metrics.sh` does (PR #2867 hit this for its health-probe reader): an attribute suppresses only the block it actually governs, and production code after a closed test module is still production code. Two new self-test cases pin both directions — the call is found, and a `spawn` surviving only inside `#[cfg(test)] mod` still fails. 14/14 self-test cases pass.

**A real flake, found by stressing rather than by rerunning.** `only_the_leader_reconciles_across_a_real_advisory_lock_race` polled for the intermediate `birth_confirmed` state that the pass now drives straight through to `released` — a 10 ms poller usually loses that race. Its `on_acquire` also ran a single pass, so one transient scan failure stranded the row for the rest of the test; it now runs the production `run_loop`. And `Restart` no longer opens 32-connection production pools per reopen. Six consecutive full-suite runs at `--test-threads 4`, clean.

## Two small enabling additions

- `TaskRunResizeDropBridge::resize_drop_mechanism` / `resize_pod_surface`, and `confirm_drop` rewired to use the first. This is what makes "no duplicated machinery" structural rather than a promise.
- `Database::test_dsn()` / `reopen_test()`, so a test can express a *restart* instead of re-invoking a function on a live object.

## AC5 is NOT met, and the reason is structural

Acceptance criterion 5 asks for the worker-death scenario against a live kind cluster. It is not here:

- The reconciler lives in `djinn-server`. Driving a live apiserver from a `djinn-server` test needs a `kube::Client`, and `deny.toml` bans a direct `kube`/`k8s-openapi` dependency outside `djinn-k8s`. That ban is right; this slice does not weaken it.
- The natural fix — a context-pinned surface constructor so the server test never names `kube` — lands in `djinn-k8s/src/runtime.rs`, which `r37r`'s design places on the DO-NOT-TOUCH list.
- `djinn-k8s` cannot depend on `djinn-server`, so it cannot move there either.

What the live half would add over what is here is the **kubelet's actuation**. The rest of that criterion — the 250ms→2s bounded retry inside a 30s budget, quarantine on deadline, the UID-fenced DELETE, and releasing the durable lease only after the exact Pod UID is proven absent — is proven here through the production resize client against a stored Pod. The "no `release_lease` ever arrives" half is structural and stronger than an assertion: this file composes no RPC listener and no `DirectServices` at all, so there is nothing a worker could have signalled.

No live cluster was created (a sibling agent has one running).

## One note on history

Commit `b555e6252` picked up a stray one-line edit from a concurrent mutation-testing run in the same worktree (a `break` in `run_loop`). It was reverted in `97e149350` and **HEAD is correct** — but that intermediate commit would not stand on its own under `git bisect` or commit-by-commit review. Left in place rather than force-pushed mid-CI; say the word and I will rewrite the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
