### PR TITLE
fix(resize): an override Pod lifts to its OWN admitted ceiling, and the over-ceiling clamp moves to the PATCH site (gvix)

### DIFF
--- a/server/crates/djinn-coordinator/src/resize_authorization.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization.rs
@@ -34,15 +34,34 @@
 //! owner. A caller that names another task run's invocation is refused at step
 //! 4, before any permit is read and long before any Kubernetes call could exist.
 //!
-//! # The clamp
+//! # The target is the Pod's OWN admitted ceiling
 //!
-//! The target is `min(configured_leased_millicores, admitted_cpu_millicores)`.
-//! The ceiling is the value `g8jk-3` captured from the **stored** Pod after
-//! admission, so it already includes whatever a mutating webhook did to the
-//! render. Lifting above it would ask the kubelet for CPU the Pod was never
-//! admitted for; the clamp is what makes a misconfigured
-//! `DJINN_LAUNCHER_LEASED_MILLICORES` a slow build rather than a rejected or
-//! evicted Pod.
+//! `target = admitted_cpu_millicores`. That value is what `g8jk-3` captured
+//! from the **stored** Pod after admission — the launcher sidecar's rendered
+//! `limits.cpu`, which `djinn_k8s::launcher_cpu::rendered_lease_millicores`
+//! reads back off the sidecar rather than recomputing from config precisely
+//! because `build_resources::apply_resolved_resources` may already have
+//! re-pointed it at a per-project `build_resources.task.cpu_limit` override.
+//! Lifting to it therefore restores the limit the apiserver already admitted,
+//! and it already reflects both the override and whatever a mutating webhook
+//! did to the render.
+//!
+//! `0ppk-1a` shipped `min(configured_leased_millicores, admitted)`, where the
+//! first term was **this process's** `DJINN_LAUNCHER_LEASED_MILLICORES` — a
+//! deployment-wide default. That second term is the only per-Pod one, and
+//! taking a `min` against a fleet-wide number reproduced the exact defect
+//! `rendered_lease_millicores` exists to prevent: a Pod admitted at 8000m
+//! through a per-project override lifted only to the 4000m default, below the
+//! lease its own launcher grants. `gvix` removed the deployment default from
+//! this computation entirely — there is no longer a second input to plumb, so
+//! the regression cannot return through a one-line edit.
+//!
+//! The safety half is unchanged and did not move here: a target above the
+//! admitted ceiling must never reach the apiserver. It is now enforced where
+//! the PATCH is actually issued — see
+//! [`crate::resize_lift::clamp_to_admitted_ceiling`] — because
+//! [`PodResizeIntent`]'s fields are `pub` and this function is not the only
+//! way one can be built in a future caller.
 //!
 //! # Where this is reachable from, and where it deliberately is not
 //!
@@ -133,11 +152,14 @@ pub struct PodResizeIntent {
     /// a different one is a hard failure — exactly one authority governs an
     /// admitted Pod.
     pub effective_launcher_protocol: LauncherAuthorityProtocol,
-    /// Already clamped to the stored ceiling. See [`ResizeAuthority::authorize`].
+    /// The CPU the launcher is lifted to: this Pod's own admitted ceiling. See
+    /// [`ResizeAuthority::authorize`].
     pub target_millicores: i64,
-    /// The ceiling this target was clamped against, carried for the assertion
-    /// that `target_millicores <= admitted_cpu_millicores` can be made on the
-    /// intent itself rather than on a value a test had to re-derive.
+    /// The ceiling this target is bounded by, carried so the assertion
+    /// `target_millicores <= admitted_cpu_millicores` can be made on the intent
+    /// itself rather than on a value a test had to re-derive — and so
+    /// [`crate::resize_lift::clamp_to_admitted_ceiling`] has a bound to enforce
+    /// at the PATCH site without re-reading the durable row.
     pub admitted_cpu_millicores: i64,
 }
 
@@ -375,28 +397,30 @@ pub struct ResizeAuthority {
     leases: Arc<BuildLeaseRepository>,
     permits: Arc<BuildPodPermitRepository>,
     lift: Arc<dyn InvocationLiftAuthority>,
-    /// `DJINN_LAUNCHER_LEASED_MILLICORES` as this process rendered it —
-    /// `djinn_k8s::launcher_cpu::launcher_leased_millicores(config)`. Passed as
-    /// a plain number rather than a `KubernetesConfig` so this module has no
-    /// Kubernetes dependency at all, in either direction.
-    configured_leased_millicores: i64,
     applier: Arc<dyn PodResizeApplier>,
 }
 
 impl ResizeAuthority {
+    /// # A deployment-wide CPU number is deliberately NOT a parameter here
+    ///
+    /// `0ppk-1a` took `configured_leased_millicores` — this process's rendered
+    /// `DJINN_LAUNCHER_LEASED_MILLICORES` — and `min`'d the per-Pod ceiling
+    /// against it. `gvix` deleted the parameter rather than merely stopping the
+    /// `min`, because a value that is still plumbed in is one edit away from
+    /// clamping a per-project-override Pod below its own rendered lease again.
+    /// Every CPU quantity this authority reasons about now comes from the
+    /// write-once permit row. See this module's header.
     #[must_use]
     pub fn new(
         leases: Arc<BuildLeaseRepository>,
         permits: Arc<BuildPodPermitRepository>,
         lift: Arc<dyn InvocationLiftAuthority>,
-        configured_leased_millicores: i64,
         applier: Arc<dyn PodResizeApplier>,
     ) -> Self {
         Self {
             leases,
             permits,
             lift,
-            configured_leased_millicores,
             applier,
         }
     }
@@ -415,7 +439,7 @@ impl ResizeAuthority {
     ///    refuse unless the caller's claim matches, in full.
     /// 5. Resolve the permit from the **durable owner's** task-run id.
     /// 6. Require a captured write-once resize identity on a resizable protocol.
-    /// 7. Clamp the target to the stored ceiling and emit the intent.
+    /// 7. Take the target from the stored ceiling and emit the intent.
     ///
     /// It deliberately performs **no** Kubernetes call. Applying the authorized
     /// intent is [`Self::fold_into_grant`]'s job, so that an apply failure is a
@@ -517,14 +541,13 @@ impl ResizeAuthority {
             ));
         };
 
-        match clamp(
+        match resolve_target(
             &owner.task_run_id,
             &owner.invocation_id,
             &permit_id,
             permit_fence,
             permit_state,
             &identity,
-            self.configured_leased_millicores,
         ) {
             Ok(intent) => ResizeAuthorizationOutcome::Authorized(Box::new(intent)),
             Err(refusal) => Self::refuse(refusal),
@@ -627,19 +650,17 @@ fn durable_owner(row: &BuildLeaseRow) -> Option<TaskInvocationLeaseIdentity> {
     })
 }
 
-/// The clamp: `min(configured, admitted)`, on a resizable protocol only.
+/// The target: this Pod's own admitted ceiling, on a resizable protocol only.
 ///
 /// Split out as a free function so the ceiling arithmetic is testable without a
-/// database, and so acceptance criterion 2's mutation ("remove the clamp") is a
-/// one-line edit at a single site rather than something that could be half-done.
-fn clamp(
+/// database, and so there is exactly ONE place a CPU quantity enters an intent.
+fn resolve_target(
     task_run_id: &str,
     invocation_id: &str,
     permit_id: &str,
     fencing_token: i64,
     permit_state: BuildPodPermitState,
     identity: &BuildPodResizeIdentity,
-    configured_leased_millicores: i64,
 ) -> Result<PodResizeIntent, ResizeRefusal> {
     // `leaf-v1` renders no launcher `limits.cpu` at all, so a container limit
     // there would be an ancestor clamp over every process in the Pod. Parsing
@@ -655,14 +676,21 @@ fn clamp(
         ));
     }
     let ceiling = identity.admitted_cpu_millicores;
-    if ceiling <= 0 || configured_leased_millicores <= 0 {
+    if ceiling <= 0 {
         return Err(ResizeRefusal::uncertain(
             DegradedUnleasedReason::CeilingUnusable,
         ));
     }
-    // THE CLAMP. Removing the `.min(ceiling)` here is acceptance criterion 2's
-    // stated mutation, and it must make `intents_above_ceiling()` report 1.
-    let target_millicores = configured_leased_millicores.min(ceiling);
+    // THE TARGET IS THE CEILING. Not `min(deployment_default, ceiling)` — see
+    // this module's header. The Pod's launcher was admitted holding exactly
+    // this limit and `0ppk-1b`'s birth downsize took it away; the lift puts it
+    // back, and there is no second quantity in scope that could hold it lower.
+    //
+    // The over-ceiling protection is NOT weakened by this: it now lives at the
+    // PATCH site (`resize_lift::clamp_to_admitted_ceiling`), where it bounds
+    // whatever target an intent actually carries rather than only the one this
+    // function derives.
+    let target_millicores = ceiling;
     Ok(PodResizeIntent {
         task_run_id: task_run_id.to_owned(),
         invocation_id: invocation_id.to_owned(),

--- a/server/crates/djinn-coordinator/src/resize_authorization_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_authorization_tests.rs
@@ -39,14 +39,24 @@ use crate::resize_authorization::{
 /// participates in an authorization assertion.
 const CONFIGURED_CAP: i64 = 9;
 
-/// `DJINN_LAUNCHER_LEASED_MILLICORES` as the default render sets it.
-const CONFIGURED_LEASED: i64 = 4_000;
+/// `DJINN_LAUNCHER_LEASED_MILLICORES` as the DEPLOYMENT DEFAULT render sets it.
+///
+/// No longer an input to the authority — `gvix` deleted that parameter — but
+/// still the number the per-Pod assertions below are meaningful *against*: a
+/// ceiling on either side of it is what tells "the Pod's own admitted value"
+/// apart from "the fleet-wide default".
+const DEPLOYMENT_DEFAULT_LEASED: i64 = 4_000;
 
 /// The ceiling `g8jk-3` captured from the STORED Pod. Deliberately BELOW
-/// [`CONFIGURED_LEASED`] — a mutating webhook shrank what was rendered — so the
-/// clamp has something to bite on and an unclamped target is a different number
-/// rather than a coincidence.
+/// [`DEPLOYMENT_DEFAULT_LEASED`] — a mutating webhook shrank what was rendered.
 const ADMITTED_CEILING: i64 = 2_500;
+
+/// A Pod whose per-project `build_resources.task.cpu_limit` override raised its
+/// rendered launcher lease ABOVE the deployment default. `retune_launcher_lease`
+/// re-points `DJINN_LAUNCHER_LEASED_MILLICORES` at the override and
+/// `resolve_launcher_cpu_ceiling` reads it back off the rendered sidecar, so
+/// this is the ceiling such a Pod is admitted with.
+const OVERRIDE_CEILING: i64 = 8_000;
 
 const OWNER_RUN: &str = "01983f00-0000-7000-8000-00000000a001";
 const OWNER_TASK: &str = "01983f00-0000-7000-8000-00000000b001";
@@ -159,7 +169,6 @@ impl Fixture {
             Arc::clone(&leases),
             Arc::clone(&permits),
             lift,
-            CONFIGURED_LEASED,
             Arc::clone(&applier) as Arc<dyn crate::resize_authorization::PodResizeApplier>,
         ));
 
@@ -414,18 +423,19 @@ async fn a_mismatched_fencing_token_is_denied_with_zero_kubernetes_calls() {
     assert_eq!(fixture.applier.calls(), 0, "ZERO Kubernetes calls");
 }
 
-// ─── AC2: the ceiling clamp ─────────────────────────────────────────────────
+// ─── AC2 / gvix: the target is the Pod's OWN admitted ceiling ───────────────
 
-/// **ACCEPTANCE CRITERION 2.**
+/// **`0ppk-1a` ACCEPTANCE CRITERION 2** — a Pod a webhook shrank below the
+/// deployment default lifts to what it was actually admitted with, and no
+/// intent may ask for more than the ceiling it is bounded by.
 ///
-/// The process is configured to lift to 4000m; the Pod was admitted at 2500m.
-/// The target must be the stored ceiling, and NO intent may ask for more than
-/// the ceiling it was clamped against.
-///
-/// NON-VACUITY (run, do not assume): delete `.min(ceiling)` in
-/// `resize_authorization::clamp` and `intents_above_ceiling()` becomes 1.
+/// NON-VACUITY (run, do not assume): substitute the deployment default for
+/// `identity.admitted_cpu_millicores` in `resize_authorization::resolve_target`
+/// — the mutation `gvix`'s criterion 3 names — and the target here reads 4000
+/// against a 2500m ceiling, so both assertions fail and
+/// `intents_above_ceiling()` becomes 1.
 #[tokio::test]
-async fn a_configured_lift_above_the_stored_ceiling_clamps_to_the_ceiling() {
+async fn a_pod_admitted_below_the_deployment_default_lifts_to_its_admitted_ceiling() {
     let fixture = Fixture::armed().await;
     fixture
         .seed_permit(
@@ -434,15 +444,15 @@ async fn a_configured_lift_above_the_stored_ceiling_clamps_to_the_ceiling() {
             LauncherAuthorityProtocol::ResizeV2,
         )
         .await;
-    // The precondition that makes this test able to tell a clamp from a
-    // passthrough. A `const` block so it is checked at COMPILE time: editing
-    // either constant into agreement should fail the build, not produce a test
-    // that still passes while asserting nothing.
+    // The precondition that makes this test able to tell the Pod's own value
+    // from the fleet-wide one. A `const` block so it is checked at COMPILE
+    // time: editing either constant into agreement should fail the build, not
+    // produce a test that still passes while asserting nothing.
     const {
         assert!(
-            CONFIGURED_LEASED > ADMITTED_CEILING,
-            "the configured lift must exceed the stored ceiling, or this test \
-             cannot distinguish a clamp from a passthrough"
+            DEPLOYMENT_DEFAULT_LEASED > ADMITTED_CEILING,
+            "the deployment default must exceed this Pod's admitted ceiling, or \
+             this test cannot distinguish the two sources"
         );
     }
 
@@ -462,18 +472,49 @@ async fn a_configured_lift_above_the_stored_ceiling_clamps_to_the_ceiling() {
     );
     assert_eq!(
         intents[0].target_millicores, ADMITTED_CEILING,
-        "the target must be min(configured 4000m, admitted 2500m)"
+        "the target must be this Pod's admitted 2500m, not the 4000m default"
     );
 }
 
-/// The clamp is a `min`, not a constant: a ceiling ABOVE the configured lift
-/// must leave the configured value alone. Without this, hard-coding
-/// `target = ceiling` would pass the test above.
+/// **`gvix` ACCEPTANCE CRITERION 1 — the defect this task exists to fix.**
+///
+/// A Pod whose per-project `build_resources.task.cpu_limit` override raised its
+/// rendered launcher lease to 8000m must lift to **8000m**, not to the 4000m
+/// deployment default. `retune_launcher_lease` re-points the sidecar's
+/// `DJINN_LAUNCHER_LEASED_MILLICORES` at the override and
+/// `resolve_launcher_cpu_ceiling` reads the ceiling back off the *rendered*
+/// sidecar, so the launcher inside such a Pod will hand out leases up to 8000m.
+/// A lift that stopped at 4000m would leave half the CPU the project paid for
+/// unreachable — the 7deu ancestor clamp, re-entered through the override door.
+///
+/// This test is the inverse of `0ppk-1a`'s
+/// `a_ceiling_above_the_configured_lift_does_not_raise_the_target`, which
+/// asserted 4000m here. That assertion was the defect: `0ppk`'s AC6 asked for
+/// `min(configured, admitted)` and its AC7 asked for `admitted`, and the `0vku`
+/// agent implemented AC6 and reported AC7's behavioural half unmet rather than
+/// quietly redesigning the clamp. This is the resolution.
+///
+/// NON-VACUITY (run, do not assume): restore the `min()` clamp — reinstate
+/// `ResizeAuthority`'s `configured_leased_millicores` and make the target
+/// `configured.min(ceiling)`, or simply write
+/// `ceiling.min(DEPLOYMENT_DEFAULT_LEASED)` in `resolve_target` — and this
+/// reads 4000 instead of 8000.
 #[tokio::test]
-async fn a_ceiling_above_the_configured_lift_does_not_raise_the_target() {
+async fn an_override_pod_lifts_to_its_own_ceiling_not_the_deployment_default() {
+    const {
+        assert!(
+            OVERRIDE_CEILING > DEPLOYMENT_DEFAULT_LEASED,
+            "the override must RAISE the Pod's ceiling above the deployment \
+             default, or there is nothing here to distinguish"
+        );
+    }
     let fixture = Fixture::armed().await;
     fixture
-        .seed_permit(OWNER_RUN, 16_000, LauncherAuthorityProtocol::ResizeV2)
+        .seed_permit(
+            OWNER_RUN,
+            OVERRIDE_CEILING,
+            LauncherAuthorityProtocol::ResizeV2,
+        )
         .await;
     let token = fixture
         .granted(OWNER_TASK, OWNER_RUN, OWNER_INVOCATION)
@@ -485,8 +526,14 @@ async fn a_ceiling_above_the_configured_lift_does_not_raise_the_target() {
     let intents = fixture.applier.intents();
     assert_eq!(intents.len(), 1);
     assert_eq!(
-        intents[0].target_millicores, CONFIGURED_LEASED,
-        "a generous ceiling must not lift the process above what it configured"
+        intents[0].admitted_cpu_millicores, OVERRIDE_CEILING,
+        "precondition: the bound is the Pod's OWN captured ceiling"
+    );
+    assert_eq!(
+        intents[0].target_millicores, OVERRIDE_CEILING,
+        "an override Pod admitted at 8000m must REACH 8000m. Reading 4000 here \
+         is the min() clamp against the deployment default coming back, and it \
+         strands every override Pod below its own rendered lease"
     );
     assert_eq!(fixture.applier.intents_above_ceiling(), 0);
 }

--- a/server/crates/djinn-coordinator/src/resize_lift.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift.rs
@@ -24,6 +24,11 @@
 //!    `status.initContainerStatuses` is populated asynchronously, so a single
 //!    immediate confirming GET usually reads stale. The bounded confirmation
 //!    poll lives here, because the deadline has to have exactly one owner.
+//! 5. **No ceiling.** It sends whatever millicores it is handed. The bound —
+//!    the ceiling the Pod was actually admitted with — is applied to the value
+//!    about to go on the wire by [`clamp_to_admitted_ceiling`], so no caller
+//!    that can build a [`PodResizeIntent`] can talk it into an over-ceiling
+//!    PATCH.
 //!
 //! What it *does* get right is reused verbatim and never re-derived here:
 //! `Patch::Strategic` (because `initContainers` carries `patchMergeKey: name`,
@@ -394,15 +399,7 @@ impl ResizeLift {
         surface: &Arc<dyn LauncherResizeSurface>,
         intent: &PodResizeIntent,
     ) -> Result<(), ResizeApplyFailure> {
-        let target = u64::try_from(intent.target_millicores).map_err(|_| {
-            ResizeApplyFailure::new(
-                DegradedUnleasedReason::CeilingUnusable,
-                format!(
-                    "clamped target {}m is not a CPU quantity",
-                    intent.target_millicores
-                ),
-            )
-        })?;
+        let target = clamp_to_admitted_ceiling(intent)?;
 
         let deadline = tokio::time::Instant::now() + self.budget;
         let mut waited = false;
@@ -526,6 +523,64 @@ impl PodResizeApplier for ResizeLift {
             }
         }
     }
+}
+
+/// THE LAST FENCE BEFORE THE WIRE: the millicores one PATCH body may carry.
+///
+/// `min(intent.target_millicores, intent.admitted_cpu_millicores)`, refusing
+/// anything that is not a positive CPU quantity. Every PATCH this module issues
+/// goes through it, so "zero PATCH bodies above the admitted ceiling" is a
+/// property of the code that sends them rather than of the code that derived
+/// the target.
+///
+/// # Why the clamp lives here and not only in `resize_authorization`
+///
+/// `0ppk-1a` clamped while *deriving* the target, as
+/// `min(configured_leased_millicores, admitted)`. `gvix` deleted that first
+/// term — a deployment-wide default has no business bounding a per-Pod lift, and
+/// it held every per-project-override Pod below its own rendered lease. But
+/// deleting it must not delete the safety property with it, and a clamp that
+/// sits in the derivation only ever constrains the one caller that derives.
+/// [`PodResizeIntent`] is a `pub` struct of `pub` fields; anything that builds
+/// one — a future reconciler, a test, a second authority — reaches
+/// `resize_launcher_cpu` through here. So the bound is enforced against the
+/// value that is about to be sent, next to the call that sends it.
+///
+/// NAMED FAILING MUTATION for `0ppk-1a`'s acceptance criterion 2: replace the
+/// `.min(ceiling)` below with `intent.target_millicores` and
+/// `an_intent_above_its_own_ceiling_still_patches_at_the_ceiling` observes a
+/// PATCH body above the ceiling.
+///
+/// # Errors
+///
+/// [`ResizeApplyFailure`] with [`DegradedUnleasedReason::CeilingUnusable`] when
+/// the ceiling or the clamped target is not a positive millicore count. A
+/// non-positive quantity is refused rather than sent: `0m` is a rejected PATCH
+/// at best and an unbounded one at worst, and either way it is not a lift.
+pub fn clamp_to_admitted_ceiling(intent: &PodResizeIntent) -> Result<u64, ResizeApplyFailure> {
+    let unusable =
+        |detail: String| ResizeApplyFailure::new(DegradedUnleasedReason::CeilingUnusable, detail);
+    if intent.admitted_cpu_millicores <= 0 {
+        return Err(unusable(format!(
+            "permit carries admitted ceiling {}m, which is not a CPU quantity",
+            intent.admitted_cpu_millicores
+        )));
+    }
+    let clamped = intent.target_millicores.min(intent.admitted_cpu_millicores);
+    if clamped != intent.target_millicores {
+        tracing::warn!(
+            task_run_id = %intent.task_run_id,
+            pod_uid = %intent.pod_uid,
+            requested_millicores = intent.target_millicores,
+            admitted_cpu_millicores = intent.admitted_cpu_millicores,
+            "resize lift: target exceeded the admitted ceiling and was clamped \
+             before the PATCH"
+        );
+    }
+    u64::try_from(clamped)
+        .ok()
+        .filter(|millicores| *millicores > 0)
+        .ok_or_else(|| unusable(format!("clamped target {clamped}m is not a CPU quantity")))
 }
 
 /// Whether waiting could still change this answer.

--- a/server/crates/djinn-coordinator/src/resize_lift_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift_tests.rs
@@ -48,10 +48,17 @@ use crate::resize_authorization::{PodResizeApplier, ResizeAuthority};
 use crate::resize_lift::{LauncherResizeSurface, ResizeLift};
 
 const CONFIGURED_CAP: i64 = 9;
-/// `DJINN_LAUNCHER_LEASED_MILLICORES` as the default render sets it.
-const CONFIGURED_LEASED: i64 = 4_000;
+/// `DJINN_LAUNCHER_LEASED_MILLICORES` as the DEPLOYMENT DEFAULT render sets it.
+///
+/// `gvix` removed this from the lift's inputs entirely — no CPU quantity
+/// reaches `ResizeAuthority` from process configuration any more. It survives
+/// as the number the per-Pod ceilings below are placed on either side of, which
+/// is what makes "the Pod's own admitted value" distinguishable from "the
+/// fleet-wide default" in the assertions.
+const DEPLOYMENT_DEFAULT_LEASED: u64 = 4_000;
 /// What the fixture Pod was admitted with. Deliberately BELOW
-/// [`CONFIGURED_LEASED`] so the clamp has something to bite on.
+/// [`DEPLOYMENT_DEFAULT_LEASED`] so a target taken from the default would be a
+/// visibly different number.
 const ADMITTED_CEILING: u64 = 2_500;
 /// `djinn_server::task_run_resize_bootstrap::BIRTH_CPU_MILLICORES`. Restated
 /// rather than imported because `djinn-server` depends on this crate, not the
@@ -174,7 +181,6 @@ impl Fixture {
             Arc::clone(&leases),
             Arc::clone(&permits),
             lift,
-            CONFIGURED_LEASED,
             Arc::clone(&applier) as Arc<dyn PodResizeApplier>,
         ));
         let service = Arc::new(
@@ -829,20 +835,23 @@ async fn twenty_lift_cycles_leave_requests_qos_and_the_container_untouched() {
     );
 }
 
-// ── AC6 / AC7: the clamp is the effective bound, and the CEILING comes from
+// ── AC6 / AC7: the admitted ceiling is the effective bound, and it comes from
 //              the write-once row ──────────────────────────────────────────
 
 /// **ACCEPTANCE CRITERION 6, cluster-free half.**
 ///
-/// The process is configured to lift to 4000m; the Pod was admitted at 2500m.
-/// The value that ends up in `status.initContainerStatuses` must be the
-/// CEILING, and **zero PATCH bodies** may carry a value above it — measured on
+/// The deployment default is 4000m; this Pod was admitted at 2500m. The value
+/// that ends up in `status.initContainerStatuses` must be that Pod's OWN
+/// ceiling, and **zero PATCH bodies** may carry a value above it — measured on
 /// the bodies actually sent, parsed back through `CpuLimit` so the apiserver's
 /// canonicalisation cannot disguise an above-ceiling request.
 ///
-/// NAMED FAILING MUTATION: delete the `.min(ceiling)` in
-/// `resize_authorization::clamp` and the above-ceiling body counter becomes 1
-/// (a 4000m body against a 2500m ceiling).
+/// NAMED FAILING MUTATION: substitute the deployment default for
+/// `identity.admitted_cpu_millicores` in `resize_authorization::resolve_target`
+/// and the above-ceiling body counter becomes 1 (a 4000m body against a 2500m
+/// ceiling). The clamp that would otherwise catch such a body has moved to
+/// `resize_lift::clamp_to_admitted_ceiling`, whose own mutation is
+/// `an_intent_above_its_own_ceiling_still_patches_at_the_ceiling`.
 ///
 /// LIVE-CLUSTER GAP, stated rather than papered over: the criterion also asks
 /// for a companion control that issues the same oversubscribed value DIRECTLY
@@ -853,9 +862,9 @@ async fn twenty_lift_cycles_leave_requests_qos_and_the_container_untouched() {
 async fn the_clamp_is_the_effective_bound_measured_on_the_patch_bodies() {
     const {
         assert!(
-            CONFIGURED_LEASED as u64 > ADMITTED_CEILING,
-            "the configured lift must exceed the admitted ceiling, or this test \
-             cannot distinguish a clamp from a passthrough"
+            DEPLOYMENT_DEFAULT_LEASED > ADMITTED_CEILING,
+            "the deployment default must exceed the admitted ceiling, or this \
+             test cannot distinguish the two sources"
         );
     }
     let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
@@ -880,39 +889,48 @@ async fn the_clamp_is_the_effective_bound_measured_on_the_patch_bodies() {
     );
 }
 
-/// **ACCEPTANCE CRITERION 7 — the ceiling's PROVENANCE.**
+/// **ACCEPTANCE CRITERION 7, both halves — and `gvix`'s criterion 1.**
 ///
 /// A Pod rendered with a per-project `build_resources.task.cpu_limit` override
-/// is admitted with a launcher ceiling ABOVE the deployment default. The bound
-/// the lift is clamped against must be that Pod's own captured value, not the
-/// process's `launcher_leased_millicores`.
+/// is admitted with a launcher ceiling ABOVE the deployment default. Two things
+/// must hold, and `0ppk-1a` only delivered the first:
 ///
-/// NAMED FAILING MUTATION: recompute the ceiling in `resize_authorization::clamp`
-/// from the process's configured value instead of
-/// `identity.admitted_cpu_millicores`, and `intent.admitted_cpu_millicores` here
-/// reads 4000 instead of 8000 — this fails. (The clamped *target* is 4000 either
-/// way, which is exactly why this assertion is on the carried ceiling: it is the
-/// only place the two implementations differ.)
+/// * **PROVENANCE.** The bound must be that Pod's own captured value, not the
+///   process's `launcher_leased_millicores`.
+/// * **BEHAVIOUR.** The launcher must actually END UP at 8000m. The override
+///   raised the lease the Pod's own launcher hands out; a lift that stopped at
+///   the 4000m default would strand half the CPU the project configured —
+///   7deu's ancestor clamp, re-entered through the override door.
 ///
-/// HONEST LIMIT, and it is a real one: with the shipped
-/// `min(configured, admitted)` clamp, an override Pod admitted at 8000m still
-/// lifts only to the deployment default of 4000m — it does NOT lift to its own
-/// rendered lease. Satisfying that literally requires the target to be
-/// `admitted` rather than `min(configured, admitted)`, which would contradict
-/// criterion 6's premise that a lift can be "configured ABOVE the captured
-/// ceiling". See the PR body; the clamp is left exactly as `0ppk-1a` shipped it
-/// rather than redesigned here.
+/// The second half is asserted on `status.initContainerStatuses` — the only
+/// field that confirms a resize — and on the PATCH bodies actually sent, in
+/// MILLICORES. String comparison would not do: `#2861` observed the apiserver
+/// canonicalise `2000m` to `2`.
+///
+/// NAMED FAILING MUTATIONS, either of which must break this test:
+/// * Substitute the deployment default for `identity.admitted_cpu_millicores`
+///   in `resize_authorization::resolve_target` — the carried bound reads 4000.
+/// * Restore `0ppk-1a`'s clamp, `ceiling.min(deployment_default)` — the target,
+///   the PATCH bodies and the confirmed status all read 4000 against an 8000m
+///   ceiling.
 #[tokio::test]
-async fn the_ceiling_comes_from_the_write_once_row_not_the_deployment_default() {
+async fn an_override_pod_lifts_to_its_own_admitted_ceiling() {
     const OVERRIDE_CEILING: u64 = 8_000;
     const {
         assert!(
-            OVERRIDE_CEILING > CONFIGURED_LEASED as u64,
+            OVERRIDE_CEILING > DEPLOYMENT_DEFAULT_LEASED,
             "the per-project override must RAISE the Pod's ceiling above the \
              deployment default, or there is no provenance to distinguish"
         );
     }
     let fixture = Fixture::armed(pod_admitted_at(OVERRIDE_CEILING), NO_WAIT).await;
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{BIRTH_MILLICORES}m").as_str()),
+        "precondition: the launcher sits at its birth limit, so reaching 8000m \
+         is something the lift had to DO"
+    );
+
     let result = fixture.lift().await;
     assert!(matches!(result, LeaseResult::Status(_)), "{result:?}");
 
@@ -925,8 +943,117 @@ async fn the_ceiling_comes_from_the_write_once_row_not_the_deployment_default() 
          means the ceiling was recomputed from the deployment default, which \
          clamps every per-project-override Pod below its own rendered lease"
     );
+    assert_eq!(
+        intents[0].target_millicores,
+        i64::try_from(OVERRIDE_CEILING).unwrap(),
+        "AND THE TARGET IS THAT CEILING. Reading 4000 here is `0ppk-1a`'s \
+         min() against the deployment default coming back — the AC6/AC7 \
+         contradiction `gvix` exists to resolve"
+    );
+    assert_eq!(
+        fixture.pod.patched_cpu_millicores(),
+        vec![OVERRIDE_CEILING],
+        "the PATCH body sent to the apiserver carries the override, in \
+         millicores"
+    );
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{OVERRIDE_CEILING}m").as_str()),
+        "and the launcher's INIT-container status — the only field that \
+         confirms a resize — must have MOVED from {BIRTH_MILLICORES}m to \
+         {OVERRIDE_CEILING}m, not to the 4000m default"
+    );
+    assert_eq!(
+        fixture.permit_state().await,
+        BuildPodPermitState::Lifted,
+        "a confirmed lift advances the durable lifecycle to `lifted`"
+    );
+}
+
+/// **`0ppk-1a` ACCEPTANCE CRITERION 2, relocated to the site that sends the
+/// PATCH.**
+///
+/// `gvix` removed the deployment default from the target derivation, so
+/// `resize_authorization` can no longer produce an over-ceiling target at all.
+/// That must not mean the over-ceiling protection stopped being tested — so it
+/// is exercised where it now lives: an intent is built BY HAND carrying a
+/// target above its own `admitted_cpu_millicores` and handed straight to the
+/// real [`ResizeLift`]. [`PodResizeIntent`] is a `pub` struct of `pub` fields,
+/// so this is not a hypothetical caller.
+///
+/// Zero PATCH bodies above the ceiling, measured on the bodies actually sent
+/// and parsed back through `CpuLimit`.
+///
+/// NAMED FAILING MUTATION: replace the `.min(...)` in
+/// `resize_lift::clamp_to_admitted_ceiling` with `intent.target_millicores`,
+/// and the above-ceiling body counter becomes 1 — a 9999m body against a 2500m
+/// ceiling.
+#[tokio::test]
+async fn an_intent_above_its_own_ceiling_still_patches_at_the_ceiling() {
+    const OVER_CEILING: i64 = 9_999;
+    const {
+        assert!(
+            OVER_CEILING as u64 > ADMITTED_CEILING,
+            "the hand-built target must exceed the ceiling, or the clamp has \
+             nothing to bite on"
+        );
+    }
+    let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
+    let permit = fixture
+        .permits
+        .active(RUN)
+        .await
+        .expect("the permit is readable")
+        .expect("the permit exists");
+    let identity = permit
+        .resize_identity
+        .clone()
+        .expect("the fixture captured a resize identity");
+    assert_eq!(
+        permit.state,
+        BuildPodPermitState::BirthConfirmed,
+        "precondition: the lift starts from birth_confirmed"
+    );
+
+    // Every coordinate is the durable permit's; only the target is forged.
+    let intent = crate::resize_authorization::PodResizeIntent {
+        task_run_id: RUN.into(),
+        invocation_id: INVOCATION.into(),
+        permit_id: permit.permit_id.clone(),
+        fencing_token: permit.fencing_token,
+        permit_state: permit.state,
+        pod_namespace: identity.pod_namespace.clone(),
+        pod_name: identity.pod_name.clone(),
+        pod_uid: identity.pod_uid.clone(),
+        launcher_container_name: identity.launcher_container_name.clone(),
+        launcher_container_id: identity.launcher_container_id.clone(),
+        effective_launcher_protocol: identity
+            .effective_launcher_protocol
+            .parse()
+            .expect("the fixture renders a known protocol"),
+        target_millicores: OVER_CEILING,
+        admitted_cpu_millicores: identity.admitted_cpu_millicores,
+    };
+
+    let applied = fixture.applier.inner.apply(&intent).await;
     assert!(
-        intents[0].target_millicores <= intents[0].admitted_cpu_millicores,
-        "and the target never exceeds the bound it was clamped against"
+        applied.is_ok(),
+        "the clamped lift still confirms: {applied:?}"
+    );
+
+    let bodies = fixture.pod.patched_cpu_millicores();
+    assert!(!bodies.is_empty(), "the lift must actually have patched");
+    assert_eq!(
+        bodies
+            .iter()
+            .filter(|millis| **millis > ADMITTED_CEILING)
+            .count(),
+        0,
+        "ZERO PATCH bodies above the admitted ceiling; observed {bodies:?}"
+    );
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{ADMITTED_CEILING}m").as_str()),
+        "and the launcher ends up holding the CEILING, not the forged 9999m"
     );
 }

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -512,13 +512,13 @@ impl AppState {
                         "server AppState",
                     ),
                 ),
-                // The process's own rendered lease, from the SAME `KubernetesConfig`
-                // the manifests are rendered from. The per-Pod ceiling it is clamped
-                // against comes from the write-once permit row, never from here —
-                // see `resize_authorization::clamp`.
-                i64::from(djinn_k8s::launcher::launcher_leased_millicores(
-                    &djinn_k8s::KubernetesConfig::from_env(),
-                )),
+                // No CPU quantity is passed from here on purpose. `0ppk-1a`
+                // handed this process's rendered `launcher_leased_millicores`
+                // in and the clamp `min`'d the per-Pod ceiling against it,
+                // which held every per-project-`cpu_limit`-override Pod below
+                // its own rendered lease (`gvix`). The lift target is now the
+                // write-once permit row's `admitted_cpu_millicores` alone —
+                // see `resize_authorization`'s header.
                 Arc::new(djinn_coordinator::resize_lift::ResizeLift::from_env(
                     Arc::clone(&permits),
                 )),


### PR DESCRIPTION
Board task `gvix`, epic `0ppk`, proposal `3i92`. Branched from `551b23b7b` (`f3m5` / #2869), which is rebased onto, not undone.

## The contradiction

`0ppk`'s AC6 required the lift target to be `min(configured_leased, admitted_cpu_millicores)`. Its AC7 required `admitted_cpu_millicores`. Both cannot hold.

The `0vku` agent (#2864) implemented AC6's `min()` as specced, proved AC7's ceiling-**provenance** half, and reported AC7's **behavioural** half **not met** rather than redesigning a merged slice mid-task to hide the contradiction. That was the right call, and this PR is the resolution it recommended.

It is a real behavioural bug, not a wording nit: **a Pod whose per-project `build_resources.task.cpu_limit` override raised its rendered launcher lease to 8000m lifted only to the 4000m deployment default.**

## Why `min()` was wrong, mechanically

The first term of that `min()` was **this process's** rendered `DJINN_LAUNCHER_LEASED_MILLICORES` — a fleet-wide number. The second is the only per-Pod one:

- `build_resources::apply_resolved_resources` applies the per-project `cpu_limit` override to the built Job and `retune_launcher_lease` re-points the sidecar's `DJINN_LAUNCHER_LEASED_MILLICORES` at it.
- `resolve_launcher_cpu_ceiling` reads the ceiling back off the **rendered sidecar** via `rendered_lease_millicores` — which carries a comment saying, in as many words, that recomputing it from the deployment default *"would clamp such a pod below the lease its own launcher grants — the 7deu ancestor clamp, re-entered through the override path."*
- `g8jk-3` then captures that rendered value post-admission off the **stored** Pod, write-once per Pod UID, so it already reflects both the override and any mutating-webhook adjustment.

`min`'ing that against the fleet-wide default re-entered the exact defect the read-back exists to prevent. `target = admitted_cpu_millicores` restores the limit the apiserver already admitted.

## What changed

**`resize_authorization.rs`** — `target = admitted_cpu_millicores`. The `configured_leased_millicores` constructor parameter is **deleted**, not merely left unused: a fleet-wide CPU quantity that is still plumbed in is one edit away from clamping an override Pod below its own rendered lease again. There is now no deployment-wide CPU number reaching this authority at all, and `AppState::new_inner` no longer passes one. `clamp()` is renamed `resolve_target()` because it no longer clamps.

**`resize_lift.rs`** — the over-ceiling protection is **not** weakened; it is relocated to where it now bites. `clamp_to_admitted_ceiling()` bounds the millicores about to go on the wire against `intent.admitted_cpu_millicores`, and every PATCH this module issues goes through it. This is strictly stronger than the old placement: `PodResizeIntent` is a `pub` struct of `pub` fields, so the bound now constrains **every** caller that can build one, not just the single derivation site. It also absorbs the old non-positive-quantity refusal (`CeilingUnusable`).

`0ppk-1a`'s AC2 — "a lift above the ceiling clamps to it and issues zero PATCHes above it" — therefore still holds, and is now testable against a genuinely over-ceiling request instead of one that could no longer be constructed.

## The one deleted assertion, stated plainly

`0ppk-1a`'s `a_ceiling_above_the_configured_lift_does_not_raise_the_target` asserted `target == 4000` for a Pod admitted at 16000m, with the comment *"Without this, hard-coding `target = ceiling` would pass the test above."* That assertion **was** the defect, and it is replaced by its inverse. Every other `0ppk-1a` / `0ppk-1c` assertion is unchanged — the UID / restart / protocol fences, the 20-cycle QoS invariance, the confirmation rule, the drop-required lifecycle, `f3m5`'s invocation fence and lifecycle CAS.

## Mutation testing — actual output

All 22 resize tests green at baseline; 2004/2004 `djinn-coordinator` lib tests green.

**Mutation A — restore `0ppk-1a`'s clamp** (`let target_millicores = ceiling.min(4_000);`), the mutation `gvix` AC1 names:

```
test resize_lift_tests::an_override_pod_lifts_to_its_own_admitted_ceiling ... FAILED
test resize_authorization_tests::an_override_pod_lifts_to_its_own_ceiling_not_the_deployment_default ... FAILED

assertion `left == right` failed: AND THE TARGET IS THAT CEILING. Reading 4000 here is
`0ppk-1a`'s min() against the deployment default coming back — the AC6/AC7 contradiction
`gvix` exists to resolve
  left: 4000
 right: 8000

assertion `left == right` failed: an override Pod admitted at 8000m must REACH 8000m.
Reading 4000 here is the min() clamp against the deployment default coming back, and it
strands every override Pod below its own rendered lease
  left: 4000
 right: 8000

test result: FAILED. 20 passed; 2 failed
```

**Mutation B — remove the PATCH-site clamp** (`let clamped = intent.target_millicores;`), `0ppk-1a` AC2's non-vacuity:

```
test resize_lift_tests::an_intent_above_its_own_ceiling_still_patches_at_the_ceiling ... FAILED

assertion `left == right` failed: ZERO PATCH bodies above the admitted ceiling; observed [9999]
  left: 1
 right: 0

test result: FAILED. 21 passed; 1 failed
```

The over-ceiling PATCH counter goes non-zero, measured on the body actually sent and parsed back through `CpuLimit` so the apiserver's `2000m` → `2` canonicalisation cannot disguise it.

**Mutation C — substitute the deployment default for the stored admitted value** (`let ceiling = 4_000;`), `gvix` AC3's provenance mutation:

```
test resize_authorization_tests::a_pod_admitted_below_the_deployment_default_lifts_to_its_admitted_ceiling ... FAILED
test resize_lift_tests::an_override_pod_lifts_to_its_own_admitted_ceiling ... FAILED
test resize_authorization_tests::an_override_pod_lifts_to_its_own_ceiling_not_the_deployment_default ... FAILED
test resize_authorization_tests::the_owner_is_authorized_against_its_own_durable_permit ... FAILED
test resize_lift_tests::a_status_confirmed_lift_grants_and_records_lifted ... FAILED
test resize_lift_tests::the_clamp_is_the_effective_bound_measured_on_the_patch_bodies ... FAILED

  left: Some("4000m")   right: Some("2500m")     (the confirmed init-container status)
  left: [4000] → 1 body above the 2500m ceiling  right: 0

test result: FAILED. 16 passed; 6 failed
```

## Non-vacuity of the headline case

`an_override_pod_lifts_to_its_own_admitted_ceiling` is not an assertion about a derived number. The fixture Pod is first driven to its **birth limit** of 250m by `0ppk-1b`'s real downsize and the PATCH counter reset, so reaching 8000m is something the lift had to *do*. It then asserts, in millicores:

- the carried bound is 8000 (provenance),
- the target is 8000 (behaviour — the half `0vku` reported unmet),
- the PATCH body sent to the apiserver is exactly `[8000]`,
- `status.initContainerStatuses` — the only field that confirms a resize — reads `8000m`,
- the durable permit reached `lifted`.

## Verification

- `cargo test -p djinn-coordinator --lib` — **2004 passed, 0 failed**
- `cargo clippy -p djinn-coordinator -p djinn-server --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `scripts/check-resize-authorization-boundary.sh` — passes, including check 4 (the arming still has a production caller)
- No live cluster used or created.

## Unrelated observation, reported not fixed

`cargo test -p djinn-coordinator --lib rules::tests` aborts with `thread 'tokio-rt-worker' has overflowed its stack` on a default local build. It reproduces identically on **unmodified `origin/main` (551b23b7b)** and on its parent `cf6220411`, so it is not from this PR or from `f3m5`. CI does not see it because `quality-gate.yml` sets `RUST_MIN_STACK: "8388608"`; the failure only appears at the 2 MiB tokio default. Same failure family as the note on `ResizeAuthorizationOutcome::Authorized(Box<_>)`, which was boxed for exactly this reason. Flagging it because the margin is evidently thin and this epic keeps growing the future that sits in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
