### PR TITLE
fix(guards): audit and harden every source-text guard — 8 vacuous, 7 live false negatives, one shared scanner

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -205,6 +205,12 @@ jobs:
         run: node --test scripts/ci-mold-trixie-apt-smoke.test.mjs
       - name: Verify routed-scope contract
         run: node --test scripts/ci-changed-scope.test.mjs
+      # scripts/lib/source-text.mjs is the shared comment stripper behind the
+      # workflow-text guards below. A regression in it is silent — a guard
+      # whose stripper returned "" would assert nothing and still exit 0 — so
+      # it is proven before its consumers run.
+      - name: Verify source-text stripper contract
+        run: node --test scripts/ci-source-text.test.mjs
       - name: Verify cache ownership policy
         run: node --test scripts/ci-cache-policy.test.mjs
       - name: Verify qa-smoke workflow contract

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -655,6 +655,15 @@ jobs:
       # what the size gate's per-file line limit used to reward. It also scans
       # the whole tree rather than the diff: a grep over tracked *.rs with no
       # build, and a whole-tree scan cannot be dodged by a base-SHA trick.
+      # scripts/lib/rust-source-scan.awk is the single comment-stripping and
+      # `#[cfg(test)]`-tracking implementation behind five guards below
+      # (include!, global metrics, raw SQL, capability boundaries, resize
+      # authorization). A regression in it takes all five down at once and does
+      # so SILENTLY — a guard whose scanner matches nothing still exits 0. This
+      # runs before any of them so the shared piece is proven first.
+      - name: Self-test shared Rust source scanner
+        if: needs.preflight.outputs.size == 'true'
+        run: ./scripts/test-rust-source-scan.sh
       - name: Self-test include! guard
         if: needs.preflight.outputs.size == 'true'
         run: ./scripts/test-check-include-macro.sh

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -781,7 +781,13 @@ jobs:
           ./scripts/check-k8s-boundary.sh
       - name: Check architectural boundaries
         if: needs.preflight.outputs.boundaries == 'true'
-        run: python3 scripts/check_boundaries.py
+        run: |
+          # The self-test exists and was never wired up, so nothing enforced
+          # that a checker edit still caught a violation. Its file-rule cases
+          # are paired in both directions — a scan that matched nothing would
+          # report "no boundary violations" forever.
+          python3 scripts/check_boundaries.py --self-test
+          python3 scripts/check_boundaries.py
   server-clippy:
     name: Server Clippy
     needs: preflight

--- a/deploy/helm/djinn/tests/kueue-topology-render.sh
+++ b/deploy/helm/djinn/tests/kueue-topology-render.sh
@@ -112,81 +112,291 @@ def fail(message):
 
 
 def strip_comments(text):
-    """Blank out Rust comments, leaving string literals and line numbers intact.
+    """Blank out Rust comments, returning TWO length-identical forms of the file.
 
     Without this a doc comment mentioning `requests:` reads as a request site
     and the unparsed-shape check below fires on prose.
+
+    Returns `(keep, blank)`:
+      * `keep`  — string literals verbatim. This is what the extractor scans;
+                  its resource names ARE string literals (`"cpu".to_string()`).
+      * `blank` — string BODIES replaced by spaces, delimiters and newlines kept.
+                  Only `strip_cfg_test` reads this, and only to count braces: a
+                  `println!("{")` inside a test must not be able to unbalance the
+                  brace depth and take production code down with it.
+
+    Both forms are byte-for-byte the same length as the input, so they split into
+    the same lines at the same indices and `line_of` still reports real line
+    numbers.
+
+    A trailing comment never eats the code in front of it: `foo(); // requests:`
+    keeps `foo();`. And a `//` inside a string literal is not a comment, so
+    `"https://x"` does not blank the rest of its line.
     """
-    out, i, n = [], 0, len(text)
+    keep, blank, i, n = [], [], 0, len(text)
     while i < n:
         char = text[i]
+        # A char literal whose value IS a double quote must not open a phantom
+        # string and swallow the rest of the file. Same-length placeholder.
+        if char == "'":
+            for width in (3, 4):
+                if text[i : i + width] in ("'\"'", "'\\\"'"):
+                    placeholder = "'" + "q" * (width - 2) + "'"
+                    keep.append(placeholder)
+                    blank.append(placeholder)
+                    i += width
+                    break
+            else:
+                keep.append(char)
+                blank.append(char)
+                i += 1
+            continue
         if char == '"':
-            out.append(char)
+            keep.append(char)
+            blank.append(char)
             i += 1
             while i < n:
                 if text[i] == "\\":
-                    out.append(text[i : i + 2])
+                    keep.append(text[i : i + 2])
+                    blank.append("  ")
                     i += 2
                     continue
-                out.append(text[i])
+                keep.append(text[i])
+                blank.append(text[i] if text[i] in '"\n' else " ")
                 i += 1
                 if text[i - 1] == '"':
                     break
             continue
         if text.startswith("//", i):
             while i < n and text[i] != "\n":
-                out.append(" ")
+                keep.append(" ")
+                blank.append(" ")
                 i += 1
             continue
         if text.startswith("/*", i):
             depth = 1
-            out.append("  ")
+            keep.append("  ")
+            blank.append("  ")
             i += 2
             while i < n and depth:
                 if text.startswith("/*", i):
                     depth, i = depth + 1, i + 2
-                    out.append("  ")
+                    keep.append("  ")
+                    blank.append("  ")
                 elif text.startswith("*/", i):
                     depth, i = depth - 1, i + 2
-                    out.append("  ")
+                    keep.append("  ")
+                    blank.append("  ")
                 else:
-                    out.append("\n" if text[i] == "\n" else " ")
+                    keep.append("\n" if text[i] == "\n" else " ")
+                    blank.append("\n" if text[i] == "\n" else " ")
                     i += 1
             continue
-        out.append(char)
+        keep.append(char)
+        blank.append(char)
         i += 1
-    return "".join(out)
+    return "".join(keep), "".join(blank)
 
 
-CFG_TEST = re.compile(r"#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]")
+# A test attribute. `#[cfg(not(test))]` deliberately does not match: it marks the
+# PRODUCTION arm of a cfg split and must survive.
+TEST_ATTR = re.compile(
+    r"^[ \t]*#\[[ \t]*(?:cfg[ \t]*\([ \t]*test[ \t]*\)|test|tokio::test|rstest"
+    r"|async_std::test|proptest)"
+)
+ATTR_OPEN = re.compile(r"^[ \t]*#\[")
 
 
-def strip_cfg_test(text):
-    """Drop `#[cfg(test)]` items. A fixture's resources are not a renderer's."""
+def _after_attributes(line):
+    """Whatever follows the leading `#[..]` attributes on `line`.
+
+    `#[cfg(test)] field: Option<T>,` puts the attribute and the item it decorates
+    on ONE line; without this the item would be looked for on the next line,
+    which is production code.
+    """
+    rest = line
     while True:
-        marker = CFG_TEST.search(text)
-        if not marker:
-            return text
-        i, n = marker.end(), len(text)
-        while i < n and text[i] not in "{;":
+        match = ATTR_OPEN.match(rest)
+        if not match:
+            return rest
+        depth, i = 0, match.end() - 1
+        while i < len(rest):
+            if rest[i] == "[":
+                depth += 1
+            elif rest[i] == "]":
+                depth -= 1
+                if depth == 0:
+                    break
             i += 1
-        if i >= n:
-            return text[: marker.start()]
-        if text[i] == ";":
-            end = i + 1
+        if depth:
+            return ""  # attribute spans lines; the item has not started yet
+        rest = rest[i + 1 :]
+
+
+def strip_cfg_test(keep, blank):
+    """Blank the `#[cfg(test)]` items, and NOTHING else.
+
+    STRUCTURAL, never positional — this is the Python counterpart of
+    `rs_test_context` in `scripts/lib/rust-source-scan.awk`; read that file for
+    the full rationale.
+
+    The previous implementation scanned forward from the attribute to the next
+    `{` or `;` and brace-matched from there. A struct FIELD ends in `,`, so on
+    `#[cfg(test)] dispatch_image_override: Option<String>,` the scan ran past the
+    end of the struct and matched the brace of the NEXT item — deleting the rest
+    of the struct plus an entire production `impl` block. Measured on
+    server/crates/djinn-k8s/src/runtime.rs (which this guard reads: it is the
+    crate that owns job.rs) that ate 91 lines of production code, the whole of
+    `impl KubernetesRuntime`. Nothing in that span happens to declare a
+    `requests:` map TODAY, so the derived coverage set is unchanged — but a Job
+    renderer or a `requests:` map added anywhere in it would have been invisible,
+    and the ClusterQueue coverage guard would have stayed green while an
+    uncovered resource shipped.
+
+    The rule instead: a test attribute ARMS the tracker, and the item it
+    decorates either opens a brace (removed to its matching close) or terminates
+    on its own line (`,` for a field, `;` for a `mod x;`/`use`/`const`/`let`) and
+    only that line goes. Paren depth is carried so a multi-line signature
+    `fn f(\n  a: A,\n) {` still resolves to its block.
+
+    Disarming is EAGER, matching the awk: over-keeping leaves test-only resources
+    in the derived set, which makes the coverage assertion demand MORE coverage
+    and fail loudly. Over-deleting is the silent direction, and it is the one
+    this rewrite closes.
+    """
+    kept = keep.split("\n")
+    code = blank.split("\n")
+    depth, armed, parens = 0, False, 0
+    for index, line in enumerate(code):
+        if depth > 0:
+            kept[index] = ""
+            depth += line.count("{") - line.count("}")
+            if depth < 0:
+                depth = 0
+            continue
+        if TEST_ATTR.search(line):
+            armed, parens = True, 0
+            kept[index] = ""
+            item = _after_attributes(line)
+        elif armed:
+            kept[index] = ""
+            item = _after_attributes(line)
         else:
-            depth = 0
-            while i < n:
-                if text[i] == "{":
-                    depth += 1
-                elif text[i] == "}":
-                    depth -= 1
-                    if depth == 0:
-                        break
-                i += 1
-            end = i + 1
-        removed = text[marker.start() : end]
-        text = text[: marker.start()] + "\n" * removed.count("\n") + text[end:]
+            continue
+        # Stacked attributes, blank lines and (already-blanked) comment lines sit
+        # between the attribute and the item it decorates.
+        if not item.strip():
+            continue
+        parens += item.count("(") - item.count(")")
+        opened = item.count("{") - item.count("}")
+        if opened > 0:
+            depth, armed, parens = opened, False, 0
+            continue
+        if parens > 0:
+            continue  # still inside a multi-line signature
+        armed, parens = False, 0
+    return "\n".join(kept)
+
+
+def _self_test_strip():
+    """Both directions, on fixtures, every run.
+
+    A stripper that silently over-deletes makes every assertion downstream
+    vacuous, and the failure looks exactly like a passing guard. So the guard
+    proves its own stripper before it uses it.
+    """
+
+    def prepared(source):
+        return strip_cfg_test(*strip_comments(source))
+
+    # 1. A test module goes; production AFTER it is still production.
+    out = prepared(
+        "pub fn keep_me() -> Job { todo!() }\n"
+        "#[cfg(test)]\n"
+        "mod tests {\n"
+        "    fn drop_me() { requests: 1 }\n"
+        "}\n"
+        "pub fn after_the_tests() -> Job { todo!() }\n"
+    )
+    assert "keep_me" in out and "after_the_tests" in out, out
+    assert "drop_me" not in out, out
+
+    # 2. THE DEFECT. A `#[cfg(test)]` on a struct FIELD removes the field only —
+    #    not the rest of the struct, and not the impl block behind it.
+    out = prepared(
+        "pub struct Runtime {\n"
+        "    #[cfg(test)]\n"
+        "    dispatch_image_override: Option<String>,\n"
+        "    pending: Arc<Mutex<Pending>>,\n"
+        "}\n"
+        "impl Runtime {\n"
+        '    pub fn requests(&self) -> u32 { requests: 1 }\n'
+        "}\n"
+    )
+    assert "dispatch_image_override" not in out, out
+    assert "pending" in out and "impl Runtime" in out and "pub fn requests" in out, out
+
+    # 2b. Attribute and field on ONE line: the NEXT line is production.
+    out = prepared(
+        "pub struct S {\n"
+        "    #[cfg(test)] override_me: Option<String>,\n"
+        "    keep_this_field: u8,\n"
+        "}\n"
+    )
+    assert "override_me" not in out and "keep_this_field" in out, out
+
+    # 3. A multi-line signature resolves to its block, and code after survives.
+    out = prepared(
+        "#[cfg(test)]\n"
+        "fn fixture(\n"
+        "    a: A,\n"
+        ") {\n"
+        "    let x = 1;\n"
+        "}\n"
+        "pub fn survivor() {}\n"
+    )
+    assert "fixture" not in out and "let x = 1" not in out, out
+    assert "survivor" in out, out
+
+    # 4. `#[cfg(test)] mod x;` takes one line, not a file.
+    out = prepared("#[cfg(test)]\nmod fixtures;\npub fn survivor() {}\n")
+    assert "fixtures" not in out and "survivor" in out, out
+
+    # 5. `#[cfg(not(test))]` is the PRODUCTION arm and must survive intact.
+    out = prepared(
+        "#[cfg(test)]\nlet tag = self.override_tag();\n"
+        "#[cfg(not(test))]\nlet tag: Option<String> = None;\n"
+    )
+    assert "override_tag" not in out, out
+    assert "let tag: Option<String> = None;" in out, out
+
+    # 6. An unbalanced brace inside a STRING inside a test must not extend the
+    #    removal past the test block. This is why the brace count reads the
+    #    string-blanked form.
+    out = prepared(
+        "#[cfg(test)]\n"
+        "mod tests {\n"
+        '    fn f() { println!("{"); }\n'
+        "}\n"
+        "pub fn survivor() -> Job { todo!() }\n"
+    )
+    assert "survivor" in out, out
+
+    # 7. Comment blindness: prose ABOUT `#[cfg(test)]` must not arm the stripper.
+    out = prepared(
+        "// this used to be #[cfg(test)] only\n"
+        "pub fn survivor() -> Job { todo!() }\n"
+    )
+    assert "survivor" in out, out
+
+    # 8. A trailing comment does not launder the code in front of it, and a `//`
+    #    inside a string literal is not a comment.
+    keep, _ = strip_comments('let u = "https://x"; requests: 1; // requests: 2\n')
+    assert 'let u = "https://x"; requests: 1;' in keep, keep
+    assert "requests: 2" not in keep, keep
+
+
+_self_test_strip()
 
 
 # A Job renderer is a function that RETURNS a Job. Nothing here names the four.
@@ -208,6 +418,15 @@ def line_of(text, index):
     return text.count("\n", 0, index) + 1
 
 
+# Two path heuristics, both deliberate, both UNDER-reporting by construction:
+#   * `*/src/**/*.rs` reaches one crate level under $CRATES_ROOT. Every Job
+#     renderer in the workspace lives there today, and a renderer moved outside
+#     it would take `renderer_files` below 4 and fail this extraction loudly
+#     rather than silently shrink the derived set.
+#   * `_tests.rs` files are declared by a parent as `#[cfg(test)] mod x;`, so the
+#     attribute that makes them test code is not IN them and nothing here could
+#     see it (the `force_test=1` case in scripts/lib/rust-source-scan.awk). The
+#     name is the only available signal.
 sources = sorted(
     path for path in crates_root.glob("*/src/**/*.rs") if not path.name.endswith("_tests.rs")
 )
@@ -222,7 +441,7 @@ for path in sources:
     if "requests" not in text and "Job" not in text:
         text = ""
     else:
-        text = strip_cfg_test(strip_comments(text))
+        text = strip_cfg_test(*strip_comments(text))
     prepared[path] = text
 
 renderer_files = [path for path, text in prepared.items() if JOB_BUILDER.search(text)]

--- a/deploy/helm/djinn/tests/pods-resize-rbac.sh
+++ b/deploy/helm/djinn/tests/pods-resize-rbac.sh
@@ -59,6 +59,125 @@ require_tool python3
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
+# ---------------------------------------------------------------------------
+# ONE comment-stripping implementation, shared by BOTH python blocks below.
+#
+# This file used to strip comments for its one BAN and not for any of its
+# PRESENCE assertions, which is the worse half of the pair to skip: a ban that
+# reads a comment merely false-alarms, but a presence assertion that reads a
+# comment goes SILENTLY green after the code it names is deleted. Both blocks
+# now import the same helper so the rule cannot be applied to one assertion and
+# forgotten on the next.
+#
+# It is the Python counterpart of `scripts/lib/rust-source-scan.awk`'s `rs_split`
+# and is kept deliberately small: this file cannot call awk from inside a Python
+# heredoc, and rewriting these guards across languages is a separate job.
+# ---------------------------------------------------------------------------
+cat >"$WORK/rust_source_text.py" <<'PY'
+"""Comment stripping for Rust source-text guards, with its own self-tests."""
+
+
+def strip_rust_comments(text):
+    """Blank out Rust comments, keeping the CODE IN FRONT of a trailing one.
+
+    Byte-for-byte length preserving: comment bodies become spaces (newlines
+    kept), so offsets and line numbers in the result index the original file and
+    a brace scan over the result stays aligned with it.
+
+    Three properties this has to hold, each of which a real guard got wrong:
+
+      * a trailing comment does NOT launder the code before it. `foo(); // ban`
+        is still a call to `foo()`. Dropping the whole line — the cheap fix —
+        would let a banned token be smuggled in behind a `//`.
+      * a `//` INSIDE a string literal is not a comment. Truncating at the `//`
+        of `"https://example"` would blank the rest of a real line of code.
+      * string literals are otherwise kept verbatim, because the tokens these
+        guards match on (`TOKEN_AUDIENCE: &str = "djinn"`) live inside them.
+    """
+    out, i, n = [], 0, len(text)
+    while i < n:
+        char = text[i]
+        # A char literal whose value IS a double quote must not open a phantom
+        # string and swallow the rest of the file. Replaced by a same-length
+        # placeholder so nothing downstream sees the quote.
+        if char == "'":
+            for width in (3, 4):
+                if text[i:i + width] in ("'\"'", "'\\\"'"):
+                    out.append("'" + "q" * (width - 2) + "'")
+                    i += width
+                    break
+            else:
+                out.append(char)
+                i += 1
+            continue
+        if char == '"':
+            out.append(char)
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    out.append(text[i:i + 2])
+                    i += 2
+                    continue
+                out.append(text[i])
+                i += 1
+                if text[i - 1] == '"':
+                    break
+            continue
+        if text.startswith("//", i):
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if text.startswith("/*", i):
+            depth = 1
+            out.append("  ")
+            i += 2
+            while i < n and depth:
+                if text.startswith("/*", i):
+                    depth, i = depth + 1, i + 2
+                    out.append("  ")
+                elif text.startswith("*/", i):
+                    depth, i = depth - 1, i + 2
+                    out.append("  ")
+                else:
+                    out.append("\n" if text[i] == "\n" else " ")
+                    i += 1
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _self_test():
+    """Both directions, on fixtures, every run. A stripper nobody tests is the
+    same silent hazard as a guard nobody mutates."""
+    cases = [
+        # (source, must still contain, must no longer contain)
+        ('let x = 1; // audience: Some(BAD)', 'let x = 1;', 'audience'),
+        ('// audience: Some(BAD)', None, 'audience'),
+        ('    /// audience: Some(BAD)', None, 'audience'),
+        ('/* audience: Some(BAD) */ let y = 2;', 'let y = 2;', 'audience'),
+        ('let u = "https://x/audience"; call();', 'call();', None),
+        ('let q = \'"\'; call();', 'call();', None),
+    ]
+    for source, must_keep, must_drop in cases:
+        result = strip_rust_comments(source)
+        assert len(result) == len(source), (
+            f'strip_rust_comments changed the length of {source!r}: {result!r}')
+        if must_keep is not None:
+            assert must_keep in result, (
+                f'strip_rust_comments ate code: {source!r} -> {result!r}')
+        if must_drop is not None:
+            assert must_drop not in result, (
+                f'strip_rust_comments left a comment behind: {source!r} -> {result!r}')
+    # The string-literal body survives: these guards match tokens inside one.
+    assert '"djinn"' in strip_rust_comments('const A: &str = "djinn"; // note')
+
+
+_self_test()
+PY
+export PYTHONPATH="$WORK${PYTHONPATH:+:$PYTHONPATH}"
+
 helm template pods-resize-rbac "$CHART_DIR" --is-upgrade >"$WORK/render.yaml"
 
 python3 - "$WORK/render.yaml" "$JOB_RS" <<'PY'
@@ -68,6 +187,8 @@ import sys
 from pathlib import Path
 
 import yaml
+
+from rust_source_text import strip_rust_comments
 
 RESIZE = 'pods/resize'
 BINDING_KINDS = ('RoleBinding', 'ClusterRoleBinding')
@@ -104,31 +225,34 @@ def grants_resize(rule):
     return any(resource in (RESIZE, '*', 'pods/*') for resource in resources)
 
 
-def strip_rust_comments(text):
-    return '\n'.join(line for line in text.splitlines() if not line.lstrip().startswith('//'))
-
-
-def pod_spec_block(text):
-    """Return the task-run PodSpec struct literal, comments stripped.
+def pod_spec_block(code):
+    """Return the task-run PodSpec struct literal, out of ALREADY-STRIPPED code.
 
     Scoped by brace matching rather than grepping the whole file so the
     assertion below reads the PodSpec djinn-server actually dispatches, not a
     doc comment, a test fixture, or some other struct that happens to mention
     the field.
+
+    The caller strips comments BEFORE this runs, and that ordering is the point:
+    locating the marker in raw text let a commented-out
+    `// let pod_spec = PodSpec {` earlier in the file capture the whole block
+    scope, and brace-matching over raw text let a `{` inside a doc comment
+    unbalance the count. Either one silently redirects every assertion below to
+    a region of the file that is not the PodSpec.
     """
     marker = 'let pod_spec = PodSpec {'
-    assert marker in text, 'task-run PodSpec literal not found in job.rs'
-    start = text.index(marker)
+    assert marker in code, 'task-run PodSpec literal not found in job.rs'
+    start = code.index(marker)
     cursor = start + len(marker)
     depth = 1
     while depth:
-        assert cursor < len(text), 'unbalanced braces in the task-run PodSpec literal'
-        if text[cursor] == '{':
+        assert cursor < len(code), 'unbalanced braces in the task-run PodSpec literal'
+        if code[cursor] == '{':
             depth += 1
-        elif text[cursor] == '}':
+        elif code[cursor] == '}':
             depth -= 1
         cursor += 1
-    return strip_rust_comments(text[start:cursor])
+    return code[start:cursor]
 
 
 def validate(docs, job_rs):
@@ -201,25 +325,28 @@ def validate(docs, job_rs):
             )
 
     # ---- 3. task-run Pods carry no apiserver credential ----------------------
-    spec = pod_spec_block(job_rs)
+    # EVERY source-text assertion below reads `code`, never `job_rs`. A comment
+    # is prose: it can neither satisfy a presence assertion nor trip a ban.
+    code = strip_rust_comments(job_rs)
+    spec = pod_spec_block(code)
     assert re.search(r'automount_service_account_token:\s*Some\(false\)', spec), (
         'the task-run PodSpec no longer sets automount_service_account_token: Some(false); '
         'the apiserver-capable default ServiceAccount token would be projected into a Pod '
         'running repository-controlled code'
     )
-    stray = re.search(r'automount_service_account_token:\s*(Some\(true\)|None)', strip_rust_comments(job_rs))
+    stray = re.search(r'automount_service_account_token:\s*(Some\(true\)|None)', code)
     assert not stray, (
         f'job.rs sets automount_service_account_token: {stray.group(1)} somewhere; '
         'the task-run Pod must never automount the apiserver token'
     )
-    audience = re.search(r'pub const TOKEN_AUDIENCE: &str = "([^"]*)";', job_rs)
+    audience = re.search(r'pub const TOKEN_AUDIENCE: &str = "([^"]*)";', code)
     assert audience, 'job.rs no longer declares TOKEN_AUDIENCE'
     assert audience.group(1) == EXPECTED_AUDIENCE, (
         f'the task-run projected token audience is {audience.group(1)!r}, expected '
         f'{EXPECTED_AUDIENCE!r}. An apiserver (or empty) audience would make the one token '
         'task-run Pods do hold usable against the apiserver'
     )
-    assert re.search(r'audience:\s*Some\(TOKEN_AUDIENCE\.to_string\(\)\)', job_rs), (
+    assert re.search(r'audience:\s*Some\(TOKEN_AUDIENCE\.to_string\(\)\)', code), (
         'the task-run projected token no longer binds its audience to TOKEN_AUDIENCE'
     )
 
@@ -260,6 +387,21 @@ def expect_rejected(label, mutant_docs, mutant_job, needle):
         print(f'  non-vacuity OK: {label}')
     else:
         raise AssertionError(f'{label}: forbidden configuration was ACCEPTED')
+
+
+def expect_accepted(label, mutant_docs, mutant_job):
+    """The other direction: prose about a token is not the token.
+
+    A guard that only ever proves it REJECTS things drifts into rejecting the
+    comment that explains why the token is wrong. That failure is loud rather
+    than silent, but it is still a guard nobody can edit around, so it gets the
+    same fixture treatment.
+    """
+    try:
+        validate(mutant_docs, mutant_job)
+    except AssertionError as error:
+        raise AssertionError(f'{label}: a COMMENT was read as code: {error}') from None
+    print(f'  comment-blindness OK: {label}')
 
 
 # (a) AC1 — widen the verbs.
@@ -372,6 +514,105 @@ mutant.append({
 })
 expect_rejected('added an unrelated ClusterRoleBinding', mutant, job_rs, 'introduces cluster-scoped RBAC')
 
+# ---------------------------------------------------------------------------
+# (e) COMMENT BLINDNESS, both directions, for every source-text assertion above.
+#
+# A BAN and a PRESENCE assertion need DIFFERENT mutations, and neither proves
+# anything about the other:
+#   * to exercise a PRESENCE arm you REMOVE (or comment out) the required token;
+#   * to exercise a BAN you ADD the banned token while LEAVING the required one
+#     in place — otherwise you are re-testing the presence arm and reporting it
+#     as ban coverage.
+# Both arms appear below for each assertion.
+# ---------------------------------------------------------------------------
+
+# (e1) PRESENCE — the defect this section was written for. Delete the real
+# projected-token binding and leave a doc comment that still mentions it. Read
+# against raw source this stayed GREEN while the invariant was false in
+# production, which is the silent direction.
+expect_rejected(
+    'the audience binding commented out, comment left behind',
+    docs,
+    job_rs.replace('audience: Some(TOKEN_AUDIENCE.to_string()),',
+                   '// audience: Some(TOKEN_AUDIENCE.to_string()),'),
+    'no longer binds its audience to TOKEN_AUDIENCE',
+)
+
+# (e2) PRESENCE — the same for the constant itself.
+expect_rejected(
+    'the TOKEN_AUDIENCE declaration commented out',
+    docs,
+    job_rs.replace('pub const TOKEN_AUDIENCE: &str = "djinn";',
+                   '// pub const TOKEN_AUDIENCE: &str = "djinn";'),
+    'no longer declares TOKEN_AUDIENCE',
+)
+
+# (e3) PRESENCE, false-POSITIVE arm — a commented-out DECOY declaration ahead of
+# the real one must not be the match. Raw-text `re.search` takes the first hit,
+# so this reported an apiserver audience against a healthy file.
+expect_accepted(
+    'a commented-out decoy TOKEN_AUDIENCE ahead of the real one',
+    docs,
+    job_rs.replace('pub const TOKEN_AUDIENCE: &str = "djinn";',
+                   '// pub const TOKEN_AUDIENCE: &str = "kubernetes.default.svc";\n'
+                   'pub const TOKEN_AUDIENCE: &str = "djinn";'),
+)
+
+# (e4) BAN, false-POSITIVE arm — prose explaining why the banned value is wrong
+# must not fire the ban. The required Some(false) is untouched, so this is the
+# ban arm and not the presence arm.
+expect_accepted(
+    'a comment explaining why automount_service_account_token: Some(true) is wrong',
+    docs,
+    job_rs + '\n// never write automount_service_account_token: Some(true) here\n',
+)
+
+# (e5) BAN — a trailing comment must NOT launder the code in front of it.
+# `foo(); // banned` still calls foo(). Dropping the whole line would be the
+# cheap way to strip comments and would smuggle this straight through.
+expect_rejected(
+    'a banned token laundered by a trailing comment',
+    docs,
+    job_rs + '\n    automount_service_account_token: Some(true), // deliberate, honest\n',
+    'somewhere; the task-run Pod must never automount',
+)
+
+# (e6) BAN — a `//` inside a string literal is not a comment. Truncating there
+# would blank the rest of a REAL line of code and hide the token after it.
+expect_rejected(
+    'a banned token after a string literal containing //',
+    docs,
+    job_rs + '\n    let _doc = "https://example.invalid/x"; '
+             'automount_service_account_token: Some(true),\n',
+    'somewhere; the task-run Pod must never automount',
+)
+
+# (e7) SCOPE — `pod_spec_block` located its marker in raw text, so a commented-out
+# `let pod_spec = PodSpec {` earlier in the file captured the block scope and
+# every assertion inside it then read the wrong region.
+DECOY_POD_SPEC = (
+    '    // let pod_spec = PodSpec {\n'
+    '    //     automount_service_account_token: Some(true),\n'
+    '    // };\n'
+)
+expect_accepted(
+    'a commented-out PodSpec literal ahead of the real one',
+    docs,
+    job_rs.replace('    let pod_spec = PodSpec {', DECOY_POD_SPEC + '    let pod_spec = PodSpec {', 1),
+)
+# ...and the same text as CODE is still refused, so (e7) is not just "the guard
+# ignores everything that looks like this".
+expect_rejected(
+    'a second, automounting PodSpec literal ahead of the real one',
+    docs,
+    job_rs.replace('    let pod_spec = PodSpec {',
+                   '    let _decoy = PodSpec {\n'
+                   '        automount_service_account_token: Some(true),\n'
+                   '    };\n'
+                   '    let pod_spec = PodSpec {', 1),
+    'somewhere; the task-run Pod must never automount',
+)
+
 print('PASS: pods/resize is granted once, namespaced, patch-only, and the '
       'task-run ServiceAccount holds no apiserver credential')
 PY
@@ -404,14 +645,21 @@ from pathlib import Path
 
 import yaml
 
+from rust_source_text import strip_rust_comments
+
 render, cutover_rs = (Path(p) for p in sys.argv[1:3])
 docs = [d for d in yaml.safe_load_all(render.read_text(encoding='utf-8')) if isinstance(d, dict)]
-source = cutover_rs.read_text(encoding='utf-8')
+# Same rule as the block above, same helper: a commented-out or decoy constant is
+# prose. Reading the raw file meant a `// pub const RESIZE_RULE_VERB: &str =
+# "get";` above the real declaration decided what this guard compared the render
+# against, and a declaration deleted but left in a comment kept it green.
+raw_source = cutover_rs.read_text(encoding='utf-8')
+source = strip_rust_comments(raw_source)
 failures = []
 
 
-def constant(name):
-    match = re.search(rf'pub const {name}: &str = "([^"]*)";', source)
+def constant(name, text=None):
+    match = re.search(rf'pub const {name}: &str = "([^"]*)";', source if text is None else text)
     assert match, f'{name} is not declared in cutover_preflight.rs'
     return match.group(1)
 
@@ -495,6 +743,33 @@ stripped = [
 ]
 if not check(stripped, triple):
     failures.append('removing the component=taskrun label was not detected')
+
+# Non-vacuity, comment blindness: `constant()` reads a DECLARATION, not prose
+# about one. Both directions, because they fail differently:
+#   * a decoy in a comment ahead of the real declaration must be ignored
+#     (otherwise this guard compares the render against a string nobody ships);
+#   * a declaration that has been deleted and left behind as a comment must NOT
+#     satisfy the lookup (otherwise the guard is green with nothing declared).
+DECOY = ('// pub const RESIZE_RULE_VERB: &str = "get";\n'
+         'pub const RESIZE_RULE_VERB: &str = "patch";')
+decoyed = strip_rust_comments(
+    raw_source.replace('pub const RESIZE_RULE_VERB: &str = "patch";', DECOY, 1))
+if constant('RESIZE_RULE_VERB', decoyed) != triple[2]:
+    failures.append(
+        'a commented-out decoy declaration was read as RESIZE_RULE_VERB; the '
+        'preflight would be compared against a constant the crate does not declare')
+
+commented_out = strip_rust_comments(
+    raw_source.replace('pub const RESIZE_RULE_VERB: &str = "patch";',
+                       '// pub const RESIZE_RULE_VERB: &str = "patch";', 1))
+try:
+    constant('RESIZE_RULE_VERB', commented_out)
+except AssertionError:
+    pass
+else:
+    failures.append(
+        'a commented-out RESIZE_RULE_VERB still satisfied the declaration lookup; '
+        'this check would stay green after the constant was deleted')
 
 if failures:
     for failure in failures:

--- a/deploy/kueue/tests/zero-capture-gate.sh
+++ b/deploy/kueue/tests/zero-capture-gate.sh
@@ -41,7 +41,14 @@ fi
 # an operator can actually run.
 SINGLE_NODE_VALUES="$SCRIPT_DIR/fixtures/single-node-values.yaml"
 [ -f "$SINGLE_NODE_VALUES" ] || fail "single-node values file the runbook cites is missing: $SINGLE_NODE_VALUES"
-grep -Fq 'ReadWriteOnce' "$SINGLE_NODE_VALUES" || fail 'single-node values do not override the chart ReadWriteMany defaults, which no single-node default StorageClass can bind'
+# Anchored on the KEY, not on the bare word. A `grep -Fq 'ReadWriteOnce'`
+# accepts the token in a `#` comment, so deleting every real `accessMode:`
+# override and leaving `# ReadWriteOnce is required on single-node` would keep
+# this green while the values file the runbook cites no longer binds anything.
+# The two checks around this one already exclude `#` in their value class; this
+# one did not.
+grep -Eq '^[[:space:]]*accessMode:[[:space:]]*ReadWriteOnce[[:space:]]*(#.*)?$' "$SINGLE_NODE_VALUES" \
+    || fail 'single-node values do not override the chart ReadWriteMany defaults with an accessMode key, which no single-node default StorageClass can bind'
 if grep -Eq '^[[:space:]]+(server|runtime):[[:space:]]*[^[:space:]#]' "$SINGLE_NODE_VALUES"; then
     fail 'single-node values pin an image tag; the release under test belongs on the command line and in the release record'
 fi

--- a/deploy/runbooks/tests/kueue-cutover-quiesce-rollback.sh
+++ b/deploy/runbooks/tests/kueue-cutover-quiesce-rollback.sh
@@ -187,10 +187,18 @@ validate_exit_codes() {
     'EXIT_LEDGER_UNREADABLE=40'
     'EXIT_API_UNREADABLE=41'
   )
+  # Anchored, and deliberately so: an unanchored `grep -Fq` accepts the
+  # assignment inside a `#` comment. Renumber to
+  # `EXIT_MISSING_RUNTIME_CLASS=11` and leave
+  # `# was EXIT_MISSING_RUNTIME_CLASS=10 before the renumber` and the runbook
+  # now lies to an operator while this contract stays green — the 1j64 shape,
+  # in the silent (presence) direction. This file's own non-vacuity mutant at
+  # `expect_rejected` already uses an anchored `sed`, so it removed the real
+  # line and never exercised the comment case.
   local assignment
   for assignment in "${expected[@]}"; do
-    grep -Fq -- "$assignment" "$script" \
-      || { fail "preflight no longer defines $assignment, but the runbook quotes that code"; return 1; }
+    grep -Eq -- "^[[:space:]]*(readonly[[:space:]]+|declare[[:space:]]+-r[[:space:]]+|export[[:space:]]+)?${assignment}[[:space:]]*(#.*)?$" "$script" \
+      || { fail "preflight no longer defines $assignment as code, but the runbook quotes that code"; return 1; }
   done
 }
 

--- a/scripts/check-capability-boundaries.sh
+++ b/scripts/check-capability-boundaries.sh
@@ -332,20 +332,27 @@ is_in_scope_file() {
     return 0
 }
 
-# is_comment_or_doc returns 0 if the given line is a comment or doc line only.
-is_comment_or_doc() {
-    line=$1
+# Comment handling lives in scripts/lib/rust-source-scan.awk, which strips `//`
+# and `/* */` in a string-literal-aware pass and keeps the code IN FRONT of a
+# trailing comment. The shell predicate this replaced only recognised a comment
+# that STARTED the line, so `let c = Client::new(); // git2::` was reported as a
+# git2 violation — the same prose-trips-a-ban defect that #2871 fixed in
+# `task_run_resize_kind.rs`.
+#
+# `strings=keep` is required here and must not be changed: the matchers for this
+# guard ARE string literals (`Command::new("git")`), so blanking literal bodies
+# would blind it completely.
+SCAN_AWK="$SCRIPT_DIR/lib/rust-source-scan.awk"
+if [ ! -f "$SCAN_AWK" ]; then
+    printf '::error::check-capability-boundaries: missing shared scanner %s\n' "$SCAN_AWK" >&2
+    exit 2
+fi
 
-    # Strip leading whitespace.
-    trimmed=${line#"${line%%[![:space:]]*}"}
-
-    case "$trimmed" in
-        "//"*|"/*"*|"*/"*|"*"*)
-            return 0
-            ;;
-    esac
-
-    return 1
+# Emit `<lineno>:<raw line>` for each match outside comments — the same shape
+# `grep -E -n` produced, so the classification below is unchanged.
+scan_hits() {
+    RS_PATTERN="$PATTERN" awk -f "$SCAN_AWK" -v strings=keep "$1" 2>/dev/null |
+        cut -d: -f2-
 }
 
 # ── Diagnostic helpers ─────────────────────────────────────────────────
@@ -399,9 +406,10 @@ check_files() {
 
         checked=$((checked + 1))
 
-        # Grep the file for capability patterns.  We intentionally do not use
-        # -o so that line numbers remain valid.
-        hits=$(grep -E -n "$PATTERN" "$file" 2>/dev/null || true)
+        # Scan the file for capability patterns, ignoring matches that sit
+        # inside a comment. Output is `<lineno>:<raw line>`, so line numbers
+        # remain valid and the diagnostic shows what the author wrote.
+        hits=$(scan_hits "$file" || true)
         if [ -z "$hits" ]; then
             continue
         fi
@@ -420,10 +428,6 @@ check_files() {
 
             line_no=${hit%%:*}
             line_text=${hit#*:}
-
-            if is_comment_or_doc "$line_text"; then
-                continue
-            fi
 
             # Identify the matcher substring that matched.  We try the obvious
             # literal anchors first; if they fail, fall back to the raw line.

--- a/scripts/check-include-macro.sh
+++ b/scripts/check-include-macro.sh
@@ -99,37 +99,26 @@ fi
 
 # Emit "path:lineno:text" for every offending `include!`.
 #
-# The scanner strips Rust double-quoted string literals (honouring backslash
-# escapes) and `//` line comments before looking for the macro, so neither a
-# mention in a comment nor a `format!("include!(\"{f}\")")` inside a test can
-# trip the guard. The OUT_DIR exemption is evaluated against the ORIGINAL line,
-# because stripping string literals would erase the "OUT_DIR" token it keys on.
+# The scan is delegated to scripts/lib/rust-source-scan.awk, which is shared
+# with every other Rust source-text guard in this directory. It strips Rust
+# double-quoted string literals (honouring backslash escapes), `//` line
+# comments and `/* */` block comments before looking for the macro, so neither
+# a mention in a comment nor a `format!("include!(\"{f}\")")` inside a test can
+# trip the guard — while the code IN FRONT of a trailing comment survives, so
+# `include!("x.rs"); // legacy` is still reported.
+#
+# The OUT_DIR exemption is evaluated against the ORIGINAL line (RS_EXEMPT),
+# because blanking string literals would erase the "OUT_DIR" token it keys on.
+SCAN_AWK="$SCRIPT_DIR/lib/rust-source-scan.awk"
+if [ ! -f "$SCAN_AWK" ]; then
+    echo "::error::check-include-macro: missing shared scanner $SCAN_AWK" >&2
+    exit 2
+fi
+
 scan() {
-    awk '
-        function strip(line,    i, n, c, out, in_str) {
-            n = length(line); i = 1; out = ""; in_str = 0
-            while (i <= n) {
-                c = substr(line, i, 1)
-                if (in_str) {
-                    if (c == "\\") { i += 2; continue }
-                    if (c == "\"") { in_str = 0 }
-                    i++
-                    continue
-                }
-                if (c == "\"") { in_str = 1; i++; continue }
-                if (c == "/" && substr(line, i + 1, 1) == "/") { break }
-                out = out c
-                i++
-            }
-            return out
-        }
-        {
-            # Build-script exemption, checked on the raw line: the path is
-            # computed from OUT_DIR, so no source file exists to be indexed.
-            if ($0 ~ /include![ \t]*\([ \t]*concat!/ && $0 ~ /env![ \t]*\([ \t]*"OUT_DIR"[ \t]*\)/) next
-            if (strip($0) ~ /include![ \t]*\(/) printf "%s:%d:%s\n", FILENAME, FNR, $0
-        }
-    ' "$@"
+    RS_PATTERN='include![ \t]*\(' \
+        RS_EXEMPT='include![ \t]*\([ \t]*concat!.*env![ \t]*\([ \t]*"OUT_DIR"[ \t]*\)' \
+        awk -f "$SCAN_AWK" -v strings=blank "$@"
 }
 
 violations=$(

--- a/scripts/check-raw-sql-boundary.sh
+++ b/scripts/check-raw-sql-boundary.sh
@@ -235,44 +235,38 @@ SQL_PATTERN='(sqlx::query[!(]|sqlx::query_as[!(]|sqlx::query_scalar[!(]|(^|[^a-z
 #     state across lines would let a single mis-parse silence a whole file.
 #   * Raw strings (r#"…"#) are paired by the same quote scan, which is
 #     correct except when a raw body ends in a backslash.
-SQL_SCAN_PROGRAM='
-function strip_string_literals(s,   out, i, n, c) {
-    out = ""
-    i = 1
-    n = length(s)
-    while (i <= n) {
-        c = substr(s, i, 1)
+# ── Comments are prose, not calls ──────────────────────────────────────
+#
+# This guard used to match string-blanked source directly, with no comment
+# handling at all, so a doc comment saying
+#
+#     /// Raw `sqlx::query!` belongs in djinn-db, never here.
+#
+# in any crate outside djinn-db failed the build. That is the same defect
+# #2871 fixed in `task_run_resize_kind.rs`: prose tripping a ban. Comment
+# stripping is delegated to `scripts/lib/rust-source-scan.awk`, which removes
+# `//` and `/* */` in a string-literal-aware pass and — critically — keeps the
+# code IN FRONT of a trailing comment, so `sqlx::query!(..); // fixme` is still
+# a violation.
+#
+# Both limits above are preserved by that scanner and both still over-report
+# rather than under-report: string state resets at every line, and raw strings
+# are paired by the same quote scan.
+SCAN_AWK="$SCRIPT_DIR/lib/rust-source-scan.awk"
+if [ ! -f "$SCAN_AWK" ]; then
+    printf '::error::check-raw-sql-boundary: missing shared scanner %s\n' "$SCAN_AWK" >&2
+    exit 2
+fi
 
-        # A char literal whose value IS a double quote — \047"\047 or the
-        # escaped form \047\"\047 — must not open a phantom string and hide
-        # a real call later on the line.
-        if (c == "\047") {
-            if (substr(s, i, 3) == "\047\"\047") { out = out "\047\047"; i += 3; continue }
-            if (substr(s, i, 4) == "\047\\\"\047") { out = out "\047\047"; i += 4; continue }
-        }
-
-        if (c != "\"") {
-            out = out c
-            i += 1
-            continue
-        }
-
-        # Opening delimiter: keep it, then swallow the body up to the
-        # matching unescaped quote (or end of line).
-        out = out "\"\""
-        i += 1
-        while (i <= n) {
-            c = substr(s, i, 1)
-            if (c == "\\") { i += 2; continue }
-            if (c == "\"") { i += 1; break }
-            i += 1
-        }
-    }
-    return out
+# Emit `<line>:<original line>` — identical to what `grep -E -n` produced.
+#
+# `strings=blank` is the load-bearing option and must not be changed: it erases
+# literal BODIES while keeping the delimiters, so a fixture payload cannot
+# trigger the guard while `sqlx::query(&format!("…"))` still does.
+scan_sql_hits() {
+    RS_PATTERN="$SQL_PATTERN" awk -f "$SCAN_AWK" -v strings=blank "$1" 2>/dev/null |
+        cut -d: -f2-
 }
-
-strip_string_literals($0) ~ pattern { printf "%d:%s\n", FNR, $0 }
-'
 
 check_files() {
     violations=0
@@ -307,9 +301,8 @@ check_files() {
         checked=$((checked + 1))
 
         # Scan the file for sqlx query patterns, ignoring matches whose own
-        # tokens are string-literal data rather than code. Output format is
-        # `<line>:<original line>` — identical to `grep -E -n`.
-        hits=$(awk -v pattern="$SQL_PATTERN" "$SQL_SCAN_PROGRAM" "$file" 2>/dev/null || true)
+        # tokens are string-literal data or comment prose rather than code.
+        hits=$(scan_sql_hits "$file" || true)
         if [ -n "$hits" ]; then
             violations=$((violations + 1))
             printf '::error::Raw sqlx query usage detected outside djinn-db: %s\n' "$file" >&2

--- a/scripts/check-resize-authorization-boundary.sh
+++ b/scripts/check-resize-authorization-boundary.sh
@@ -80,6 +80,24 @@ LauncherAuthorityProtocol
 # Only the module itself must name the types; the test file is free not to.
 TYPED_FILE=server/crates/djinn-coordinator/src/resize_authorization.rs
 
+SCAN_AWK="$SCRIPT_DIR/lib/rust-source-scan.awk"
+if [ ! -f "$SCAN_AWK" ]; then
+    echo "FAIL: missing shared scanner: $SCAN_AWK" >&2
+    exit 2
+fi
+
+# Every text assertion below that is about CODE goes through the shared
+# scanner in scripts/lib/rust-source-scan.awk, which strips comments in a
+# string-literal-aware pass and tracks `#[cfg(test)]` structurally.
+#
+#   rust_hits <file> <ERE> [scope]   -> `<file>:<line>:<text>` per match
+#
+# `strings=blank` erases literal bodies, so a type or symbol named inside a
+# string cannot satisfy a presence assertion either.
+rust_hits() {
+    RS_PATTERN="$2" awk -f "$SCAN_AWK" -v strings=blank -v scope="${3:-any}" "$1" 2>/dev/null
+}
+
 status=0
 
 for file in $GUARDED_FILES; do
@@ -101,12 +119,21 @@ for file in $GUARDED_FILES; do
     done
 done
 
+# Check 3 asks whether the module still names each required type IN CODE.
+#
+# It used to be a bare `grep`, which is the 1j64 defect: `resize_authorization.rs`
+# names both types in doc comments as well as in code (`/// That predicate is
+# [`InvocationLiftDecision`] …`), so deleting every real use would have left the
+# guard green on the prose that describes the use. A PRESENCE assertion is the
+# silent direction — it does not fail, it just stops meaning anything.
 if [ -f "$TYPED_FILE" ]; then
     for type_name in $REQUIRED_TYPES; do
-        if ! grep -n -- "$type_name" "$TYPED_FILE" >/dev/null 2>&1; then
-            echo "FAIL: $TYPED_FILE no longer names '$type_name'." >&2
+        if [ -z "$(rust_hits "$TYPED_FILE" "$type_name")" ]; then
+            echo "FAIL: $TYPED_FILE no longer names '$type_name' in code." >&2
             echo "      The should-we-lift-at-all predicate must be written against" >&2
-            echo "      that type. Removing it satisfies the ban above vacuously." >&2
+            echo "      that type. Removing it satisfies the ban above vacuously," >&2
+            echo "      and a doc comment that merely mentions the type does not" >&2
+            echo "      count -- that is how a presence guard goes quiet." >&2
             status=1
         fi
     done
@@ -120,57 +147,44 @@ fi
 ARMING_SYMBOL="with_resize""_authority"
 ARMING_ROOT=server/src
 
-# A hit counts only if it precedes the file's first UNINDENTED `#[cfg(test)]`.
+# A hit counts only if it is production code: outside every `#[cfg(test)]`
+# block and outside every `#[test]`-attributed item.
 #
-# An unindented `#[cfg(test)]` is a test-MODULE attribute; the indented ones are
-# `#[cfg(test)]` struct fields and statements, which sit in production code and
-# must not truncate the scan. Test modules go at the end of a file in this
-# codebase, so "before the first top-level `#[cfg(test)]`" is exactly "outside
-# every test module" without this script having to parse Rust.
+# THIS USED TO TRUNCATE AT THE FIRST UNINDENTED `#[cfg(test)]`, and that was
+# wrong for a reason worth recording, because the sibling guard
+# `scripts/check-resize-reachability.sh` was taken down by the same idea in a
+# stronger form the same week. The old rationale here read: "test modules go at
+# the end of a file in this codebase, so 'before the first top-level
+# `#[cfg(test)]`' is exactly 'outside every test module'". That convention is
+# not a rule and nothing enforces it. `server/src/server/state/mod.rs` -- the
+# very file this check exists to read -- is 4147 lines with `#[cfg(test)]`
+# FIELD attributes from line 342 onward; requiring the marker to be unindented
+# is the only reason this check ever saw line 540, where the arming actually
+# lives. One production item moved below a test module and the guard would have
+# stopped seeing the composition site: the single place its own purpose
+# requires it to look.
 #
-# The rule is conservative in the safe direction: a caller appearing after one
-# is IGNORED, so the guard can only ever under-count production callers, never
-# over-count them. It can fail spuriously; it cannot pass spuriously.
+# "Fails closed" was the defence, and it is not good enough. A guard that
+# cannot see its subject is not safe, it is decorative: the reachability guard
+# failed closed too, and the effect was that it verified reachability against
+# the first 8% of a file. So the test-context rule is now STRUCTURAL --
+# brace-matched blocks, `#[cfg(test)]` on a field or a `mod x;` correctly
+# treated as introducing no block at all -- and lives in the shared scanner at
+# scripts/lib/rust-source-scan.awk, which is self-tested in both directions by
+# scripts/test-rust-source-scan.sh.
+#
+# A commented-out call is still not a call: the scanner strips comments before
+# matching, so `// .with_resize_authority(x)` does not count. Without that, the
+# named failing mutation "delete the arming" is satisfied by commenting it out
+# and the guard passes on a composition that arms nothing -- which is what the
+# first version of this check actually did.
 arming_callers() {
     [ -d "$ARMING_ROOT" ] || return 0
     find "$ARMING_ROOT" -name '*.rs' -type f 2>/dev/null |
         grep -v -- '_tests\.rs$' |
         grep -v -- '/\.worktrees/' |
         while IFS= read -r file; do
-            awk -v sym="$ARMING_SYMBOL" -v path="$file" '
-                /^#\[cfg\(test\)\]/ { exit }
-                # A commented-out call is not a call. Without this, the named
-                # mutation "delete the arming" is satisfied by commenting it out
-                # and the guard passes on a composition that arms nothing --
-                # which is what the first version of this check actually did.
-                {
-                    raw = $0
-                    code = $0
-                    if (in_block) {
-                        if (match(code, /\*\//)) {
-                            code = substr(code, RSTART + RLENGTH)
-                            in_block = 0
-                        } else {
-                            next
-                        }
-                    }
-                    while (match(code, /\/\*/)) {
-                        head = substr(code, 1, RSTART - 1)
-                        rest = substr(code, RSTART + 2)
-                        if (match(rest, /\*\//)) {
-                            code = head substr(rest, RSTART + RLENGTH)
-                        } else {
-                            code = head
-                            in_block = 1
-                            break
-                        }
-                    }
-                    sub(/\/\/.*/, "", code)
-                    if (index(code, "." sym "(")) {
-                        printf "%s:%d:%s\n", path, NR, raw
-                    }
-                }
-            ' "$file"
+            rust_hits "$file" "\\.$ARMING_SYMBOL\\(" prod
         done
 }
 

--- a/scripts/check-test-global-metrics.sh
+++ b/scripts/check-test-global-metrics.sh
@@ -61,6 +61,11 @@
 
 set -eu
 
+# The shared scanner is resolved from THIS SCRIPT's location, deliberately
+# unlike REPO_ROOT below: the tree being scanned may be a throwaway fixture
+# repo, but the scanner is always the one shipped next to this guard.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
 # Resolve the tree to scan from the CALLER's working directory rather than from
 # this script's own location. CI invokes it from the repo root either way, and
 # deriving it this way is what lets the self-test drive the real guard against a
@@ -115,68 +120,32 @@ whole_file_is_test() {
     return 1
 }
 
+# The tracker described above now lives in scripts/lib/rust-source-scan.awk,
+# shared with every other Rust source-text guard and self-tested in both
+# directions by scripts/test-rust-source-scan.sh.
+#
+# It moved because the copy that used to sit here broke this guard's own
+# documented exemption 2 ("Production code ... is exempt"). An armed
+# `#[cfg(test)]` disarmed only on a line ending in `;`, so the attribute on a
+# struct FIELD -- which ends in `,` -- left the tracker armed until the next
+# line that opened a brace, which is normally the next PRODUCTION function.
+# Measured on a fixture of exactly that shape (a `#[cfg(test)]` field followed
+# by a plain `pub fn`), a production `render()` was reported as a test read.
+# `server/src/server/state/mod.rs` carries that shape from line 342 onward.
+#
+# The shared tracker disarms on any `;`- or `,`-terminated item and carries
+# paren depth, so a multi-line `#[test] async fn foo(\n a: A,\n) {` signature
+# still resolves to its block rather than disarming mid-signature.
+SCAN_AWK="$SCRIPT_DIR/lib/rust-source-scan.awk"
+if [ ! -f "$SCAN_AWK" ]; then
+    echo "::error::check-test-global-metrics: missing shared scanner $SCAN_AWK" >&2
+    exit 2
+fi
+
 scan_test_reads() {
-    awk -v whole_file="${2:-0}" '
-        function strip(line,    i, n, c, out, in_str) {
-            n = length(line); i = 1; out = ""; in_str = 0
-            while (i <= n) {
-                c = substr(line, i, 1)
-                if (in_str) {
-                    if (c == "\\") { i += 2; continue }
-                    if (c == "\"") { in_str = 0 }
-                    i++
-                    continue
-                }
-                if (c == "\"") { in_str = 1; i++; continue }
-                if (c == "/" && substr(line, i + 1, 1) == "/") { break }
-                out = out c
-                i++
-            }
-            return out
-        }
-        function braces(s,    i, n, c, d) {
-            n = length(s); d = 0
-            for (i = 1; i <= n; i++) {
-                c = substr(s, i, 1)
-                if (c == "{") d++
-                else if (c == "}") d--
-            }
-            return d
-        }
-        BEGIN { depth = 0; armed = 0 }
-        {
-            s = strip($0)
-
-            if (whole_file == 1) {
-                if (s ~ /djinn_telemetry::render[ \t]*\(/) print FNR
-                next
-            }
-
-            if (depth > 0) {
-                if (s ~ /djinn_telemetry::render[ \t]*\(/) print FNR
-                depth += braces(s)
-                if (depth <= 0) depth = 0
-                next
-            }
-
-            # A test attribute arms the tracker; the block it introduces starts
-            # at the next line that opens a brace.
-            if (s ~ /^[ \t]*#\[(cfg\(test\)|test|tokio::test|rstest)/ ||
-                s ~ /^[ \t]*#\[tokio::test\(/) {
-                armed = 1
-                next
-            }
-
-            if (armed) {
-                d = braces(s)
-                if (d > 0) { depth = d; armed = 0; next }
-                # `#[cfg(test)] mod foo;` and `#[cfg(test)] use ...;` introduce
-                # no block in this file.
-                if (s ~ /;[ \t]*$/) { armed = 0 }
-                next
-            }
-        }
-    ' "$1"
+    RS_PATTERN='djinn_telemetry::render[ \t]*\(' \
+        awk -f "$SCAN_AWK" -v strings=blank -v scope=test -v force_test="${2:-0}" "$1" |
+        cut -d: -f2
 }
 
 is_exempt() {

--- a/scripts/check_boundaries.py
+++ b/scripts/check_boundaries.py
@@ -27,7 +27,9 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -209,20 +211,64 @@ def check_crate_rule(rule: dict, edges: list[tuple[str, str, str]]) -> list[dict
     return out
 
 
+SCAN_AWK = REPO_ROOT / "scripts" / "lib" / "rust-source-scan.awk"
+
+
+def scan_production_code(paths: list[Path], pattern: str) -> dict[str, list[str]]:
+    """Lines of ``paths`` that match ``pattern`` in PRODUCTION code.
+
+    Delegates to ``scripts/lib/rust-source-scan.awk`` — the same scanner the
+    shell guards in this directory use — rather than adding a fourth private
+    copy of "strip comments and track ``#[cfg(test)]``".
+
+    A file-level rule used to grep raw text, which is a ban with no comment
+    handling: a line like ``// this no longer reaches into djinn_k8s`` in one
+    of the four guarded slot-pool files failed the build. That is the pcod
+    defect (#2871), prose tripping a ban.
+
+    Test code is excluded for the same reason the reachability guards exclude
+    it: a ``#[cfg(test)]`` block that constructs a k8s type for a fixture is
+    not a production layering violation. The exclusion is STRUCTURAL, never
+    "truncate at the first marker" — that heuristic is what made
+    ``check-resize-reachability.sh`` read the first 8% of a 4147-line file.
+
+    Returns ``{relative_path: [raw lines]}``. Raises on any environment
+    failure: a scanner that cannot run must not read as "no violations".
+    """
+    if not paths:
+        return {}
+    if not SCAN_AWK.is_file():
+        _die(f"shared source scanner is missing: {SCAN_AWK}")
+    env = dict(os.environ, RS_PATTERN=pattern)
+    proc = subprocess.run(
+        ["awk", "-f", str(SCAN_AWK), "-v", "strings=blank", "-v", "scope=prod",
+         *(str(p) for p in paths)],
+        capture_output=True, text=True, env=env, check=False,
+    )
+    if proc.returncode != 0:
+        _die(f"source scanner failed (exit {proc.returncode}): {proc.stderr.strip()}")
+    hits: dict[str, list[str]] = {}
+    for line in proc.stdout.splitlines():
+        path, _, rest = line.partition(":")
+        _, _, text = rest.partition(":")
+        rel = Path(path).resolve().relative_to(REPO_ROOT).as_posix()
+        hits.setdefault(rel, []).append(text)
+    return hits
+
+
 def check_file_rule(rule: dict, files: list[Path]) -> list[dict]:
     target_crate = normalise_crate_glob(rule["to_glob"])
-    import_token = re.compile(r"\b" + re.escape(target_crate.replace("-", "_")) + r"\b")
+    token = target_crate.replace("-", "_")
     matchers = [glob_to_regex(g) for g in _expand_braces(rule["from_glob"])]
-    out = []
-    for path in files:
-        rel = path.relative_to(REPO_ROOT).as_posix()
-        if not any(m.match(rel) for m in matchers):
-            continue
-        text = path.read_text(encoding="utf-8", errors="replace")
-        if import_token.search(text):
-            out.append({"rule": rule, "from_key": rel, "to_key": target_crate,
-                        "witness": f"{rel} references `{target_crate.replace('-', '_')}`"})
-    return out
+    scoped = [p for p in files
+              if any(m.match(p.relative_to(REPO_ROOT).as_posix()) for m in matchers)]
+    # POSIX ERE has no `\b`, and `\<`/`\>` are a GNU extension the CI runner's
+    # awk may not have. Spell the word boundary out.
+    boundary = "[^A-Za-z0-9_]"
+    hits = scan_production_code(scoped, f"(^|{boundary}){re.escape(token)}({boundary}|$)")
+    return [{"rule": rule, "from_key": rel, "to_key": target_crate,
+             "witness": f"{rel} references `{token}`"}
+            for rel in sorted(hits)]
 
 
 def render_report(violations: list[dict]) -> str:
@@ -290,8 +336,74 @@ def _self_test() -> int:
     rule = {"name": "x", "from_glob": "**/djinn-a/**", "to_glob": "**/djinn-b/**", "description": "d"}
     assert check_crate_rule(rule, [("djinn-a", "djinn-b", "w")])
     assert not check_crate_rule(rule, [("djinn-a", "djinn-c", "w")])
+    _self_test_file_rule()
     print("self-test: OK")
     return 0
+
+
+def _self_test_file_rule() -> None:
+    """File-level rules: prove the scan fails in BOTH directions.
+
+    A ban that ignores comments and a ban that ignores everything look
+    identical from a green run, so each case below is paired with its
+    opposite. The two traps this is written against:
+
+    * A presence assertion and a ban assertion need DIFFERENT mutations.
+      Here the invariant is a BAN, so the mutation that must be caught is
+      ADDING the forbidden token as real code while leaving the rest alone --
+      not removing something.
+    * A trailing comment must not launder the code in front of it.
+    """
+    import tempfile
+
+    rule = {"name": "x", "description": "d",
+            "from_glob": "**/pool/{actor,handle}.rs", "to_glob": "**/djinn-k8s/**"}
+
+    cases = [
+        # (label, body, expect_violation)
+        ("a comment naming the crate is prose",
+         "// This module no longer reaches into djinn_k8s.\n"
+         "/// See [`djinn_k8s::Pod`] for what we deliberately do not use.\n"
+         "pub fn spawn() {}\n", False),
+        ("a real reference is a violation",
+         "// This module no longer reaches into djinn_k8s.\n"
+         "pub fn spawn(p: djinn_k8s::Pod) {}\n", True),
+        ("a trailing comment does not launder the code in front of it",
+         "pub fn spawn(p: djinn_k8s::Pod) {} // TODO: move behind a port\n", True),
+        ("a reference confined to a #[cfg(test)] block is not production",
+         "pub fn spawn() {}\n\n"
+         "#[cfg(test)]\nmod tests {\n"
+         "    fn fixture() -> djinn_k8s::Pod { todo!() }\n"
+         "}\n", False),
+        # The load-bearing pair for the case above: production code AFTER a
+        # #[cfg(test)] block is still production code. Truncating at the first
+        # marker is what made check-resize-reachability.sh read 8% of a file.
+        ("production code AFTER a #[cfg(test)] block is still scanned",
+         "#[cfg(test)]\nmod tests {\n    fn fixture() {}\n}\n\n"
+         "pub fn spawn(p: djinn_k8s::Pod) {}\n", True),
+        # #[cfg(test)] on a FIELD opens no block and must not swallow the
+        # production function that follows it.
+         ("a #[cfg(test)] field does not hide the next fn",
+         "pub struct S {\n    #[cfg(test)]\n    shim: bool,\n    real: u32,\n}\n\n"
+         "pub fn spawn(p: djinn_k8s::Pod) {}\n", True),
+        ("a substring of a longer crate name is not a reference",
+         "pub fn spawn(p: djinn_k8s_helpers::Pod) {}\n", False),
+    ]
+
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT) as tmp:
+        root = Path(tmp) / "pool"
+        root.mkdir()
+        target = root / "actor.rs"
+        for label, body, expect_violation in cases:
+            target.write_text(body, encoding="utf-8")
+            # glob_to_regex matches repo-relative paths, so build the rule's
+            # matcher against this fixture's real relative path.
+            rel = target.relative_to(REPO_ROOT).as_posix()
+            scoped_rule = dict(rule, from_glob="**/pool/{actor,handle}.rs")
+            found = bool(check_file_rule(scoped_rule, [target]))
+            assert found == expect_violation, (
+                f"file-rule self-test failed: {label} (path {rel}, "
+                f"expected violation={expect_violation}, got {found})")
 
 
 def main() -> int:

--- a/scripts/ci-nextest-plan.test.mjs
+++ b/scripts/ci-nextest-plan.test.mjs
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { readFile, writeFile, mkdtemp, rm, access } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
+import { scriptCode } from './lib/source-text.mjs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -853,9 +854,30 @@ describe('consumer boundary: file-backed filter transport', () => {
   });
 });
 
+// Every assertion in this block reads the workflow as TEXT, so comments are
+// part of what it matches. `workflowCode()` strips them (see
+// scripts/lib/source-text.mjs), because both directions are live here:
+//
+//   * BAN false-positive: the `select(.workflow_run.conclusion` ban below is
+//     quoted verbatim in this file's own explanatory comment. Documenting the
+//     retired anti-pattern in quality-gate.yml would red the build with no
+//     behavioural change.
+//   * PRESENCE false-negative, and this is the failure this block exists to
+//     prevent recurring: delete the `--jq '.conclusion'` / `run_conclusion`
+//     filter, leave it quoted in a comment, and the planner silently
+//     cold-starts again exactly as it did for the runs described above --
+//     while every assertion here stays green.
+//
+// A trailing comment does not launder the code in front of it, and line
+// numbering is preserved, so the multi-line `\s*\n?\s*` anchors below still
+// resolve.
+function workflowCode() {
+  return scriptCode(readFileSync(WORKFLOW, 'utf8'));
+}
+
 describe('workflow static checks', () => {
   it('rejects expanding a filter file into a single argv string', () => {
-    const source = readFileSync(WORKFLOW, 'utf8');
+    const source = workflowCode();
     assert.ok(!source.includes('--filter-expr "$(cat'), 'workflow must not expand a filter file into one argv argument');
     assert.ok(!source.includes("--filter-expr '$(cat"), 'workflow must not expand a filter file into one argv argument');
     // Also reject any --filter-expr line that uses command substitution to read a file.
@@ -892,7 +914,7 @@ describe('workflow static checks', () => {
   // eight shards of ~1458 tests and ran four: 5834 of 11666 tests (50%) never
   // executed, and the run was GREEN.
   it('provisions a server-test matrix at least as wide as the widest possible plan', () => {
-    const source = readFileSync(WORKFLOW, 'utf8');
+    const source = workflowCode();
 
     const serverTest = /^ {2}server-test:$/m.exec(source);
     assert.ok(serverTest, 'server-test job must exist');
@@ -936,7 +958,7 @@ describe('workflow static checks', () => {
   });
 
   it('resolves the timing artifact run conclusion on an endpoint that returns it', () => {
-    const source = readFileSync(WORKFLOW, 'utf8');
+    const source = workflowCode();
     const artifactQuery = /actions\/artifacts\?name=nextest-timing[^\n]*/.exec(source);
     assert.ok(artifactQuery, 'workflow must query the nextest-timing artifact list');
 

--- a/scripts/ci-qa-smoke-workflow.test.mjs
+++ b/scripts/ci-qa-smoke-workflow.test.mjs
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import test from 'node:test';
 
+import { scriptCode } from './lib/source-text.mjs';
+
 const WORKFLOW = resolve('.github/workflows/quality-gate.yml');
 
 // Keep trigger parsing scoped to GitHub event names so later top-level mappings
@@ -126,8 +128,27 @@ function stepName(step) {
   return step.lines[0].text.match(/^ {6}- name:\s*(.+?)\s*$/)?.[1];
 }
 
+// Every source-text assertion in this file goes through `blockCode`, which
+// strips `#` comments (see scripts/lib/source-text.mjs). Two live defects
+// motivated it, one in each direction:
+//
+//   * BAN false-positive: `assertQaJobHasNoLiveDependencies` forbids
+//     /\bkind\b/i, which matches the ordinary English word in a comment
+//     ("this kind of failure"). So does /\bhttps?:\/\//i against any URL in
+//     a comment. Either reds the build with no live dependency added.
+//   * PRESENCE false-negative, the silent one: delete the
+//     `psql … CREATE DATABASE djinn_test_template` step, leave a comment
+//     saying it moved, and this guard stays green while qa-smoke no longer
+//     creates its database.
+//
+// A trailing comment does NOT launder the code in front of it, so
+// `run: make test  # no kubectl needed` is still a `make test` step.
+function blockCode(block) {
+  return scriptCode(block.lines.map(({ text }) => text).join('\n'));
+}
+
 function stepText(step) {
-  return step.lines.map(({ text }) => text).join('\n');
+  return blockCode(step);
 }
 
 function namedStep(job, name) {
@@ -152,7 +173,7 @@ function assertStepOrder(job, names) {
 }
 
 function assertQaJobHasNoLiveDependencies(job) {
-  const source = job.lines.map(({ text }) => text).join('\n');
+  const source = blockCode(job);
   assert.doesNotMatch(source, /\b(?:kubectl|kind|kubernetes|kubeconfig|helm|tilt)\b/i,
     'qa-smoke must not depend on Kubernetes or local-cluster tooling');
   assert.doesNotMatch(source, /\b(?:nightly[-_ ]live|live[-_ ](?:provider|credential|scenario|execution))\b/i,
@@ -208,7 +229,7 @@ test('qa-smoke consumes the routed output and is event-safe', () => {
 test('qa-smoke owns only a restore-only test cache and a disposable database', () => {
   const qa = parseJobs(readFileSync(WORKFLOW, 'utf8')).jobs.get('qa-smoke');
   assert.ok(qa, 'qa-smoke job must exist');
-  const source = qa.lines.map(({ text }) => text).join('\n');
+  const source = blockCode(qa);
 
   assert.match(source, /Swatinem\/rust-cache@v2/, 'qa-smoke must restore Rust build inputs');
   assert.match(source, /^ {10}shared-key:\s*server-test\s*$/m, 'qa-smoke must use the server-test cache family');
@@ -236,7 +257,7 @@ test('qa-smoke owns only a restore-only test cache and a disposable database', (
 test('qa-smoke builds, precompiles, and directly executes in deterministic order', () => {
   const qa = parseJobs(readFileSync(WORKFLOW, 'utf8')).jobs.get('qa-smoke');
   assert.ok(qa, 'qa-smoke job must exist');
-  const source = qa.lines.map(({ text }) => text).join('\n');
+  const source = blockCode(qa);
   assertStepOrder(qa, [
     'Build migrated Postgres template',
     'Build qa runner once',
@@ -292,7 +313,7 @@ test('Quality Gate aggregates qa-smoke results fail-closed', () => {
   assert.ok(gate, 'Quality Gate job must exist');
   assert.ok(jobNeeds(gate).includes('qa-smoke'), 'Quality Gate must depend on qa-smoke');
 
-  const source = gate.lines.map(({ text }) => text).join('\n');
+  const source = blockCode(gate);
   assert.match(source, /^ {10}QA_SMOKE:\s*\$\{\{ needs\.preflight\.outputs\.qaSmoke \}\}:\$\{\{ needs\.qa-smoke\.result \}\}\s*$/m,
     'Quality Gate must pair qa-smoke selection with its result');
   assert.match(source, /if \[ "\$selected" = true \] && \[ "\$result" = success \]; then return; fi/,

--- a/scripts/ci-source-text.test.mjs
+++ b/scripts/ci-source-text.test.mjs
@@ -1,0 +1,108 @@
+// Self-test for scripts/lib/source-text.mjs.
+//
+// Every case is a PAIR. For each thing the stripper must ignore there is an
+// adjacent thing it must still keep, because "strips comments" and "strips
+// everything" are indistinguishable from a green run — and a guard whose
+// stripper returned the empty string would report OK forever.
+//
+// The same reasoning, and the same two traps, as scripts/test-rust-source-scan.sh:
+//
+//   * A PRESENCE assertion and a BAN assertion need DIFFERENT mutations.
+//     Swapping a required token for another valid one exercises the presence
+//     arm and proves nothing about the ban. To test a ban you must ADD the
+//     banned token while LEAVING the required one in place.
+//   * A trailing comment must not launder the code in front of it.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { scriptCode, slashCode } from './lib/source-text.mjs';
+
+test('scriptCode drops comment prose but keeps the code beside it', () => {
+  const yaml = [
+    '      # kubectl is deliberately absent from this job',
+    '      - name: Run tests',
+    '        run: make test  # no kubectl needed here either',
+    '        env:',
+    '          KEY: value # trailing',
+  ].join('\n');
+  const code = scriptCode(yaml);
+
+  // BAN direction: the word only ever appears in prose, so the ban must not
+  // fire. This is the /\bkind\b/i and /https?:\/\// shape that reds the
+  // qa-smoke job on an English sentence.
+  assert.doesNotMatch(code, /kubectl/, 'a comment mentioning kubectl is not a dependency');
+
+  // The load-bearing pair: if the stripper dropped whole lines, `make test`
+  // and `KEY: value` would have gone with the comments.
+  assert.match(code, /run: make test/, 'code before a trailing comment survives');
+  assert.match(code, /KEY: value/, 'a trailing comment does not launder the key');
+  assert.doesNotMatch(code, /trailing/, 'the trailing comment itself is gone');
+});
+
+test('scriptCode adds the ban back when the token is real', () => {
+  // The correct mutation for a BAN: ADD the banned token as real code while
+  // leaving everything else in place. Replacing a required token instead would
+  // exercise the presence arm and prove nothing here.
+  const yaml = [
+    '      # kubectl is deliberately absent from this job',
+    '      - name: Run tests',
+    '        run: kubectl apply -f manifest.yaml',
+  ].join('\n');
+  assert.match(scriptCode(yaml), /kubectl apply/, 'a real invocation is still visible');
+});
+
+test('scriptCode does not treat a # inside a value or a quote as a comment', () => {
+  const yaml = [
+    '        run: psql postgres://user:pw@127.0.0.1:5433/db#frag',
+    '        run: echo "a # b" && kubectl version',
+    "        run: echo 'c # d'",
+    '        run: echo "$#"',
+  ].join('\n');
+  const code = scriptCode(yaml);
+  assert.match(code, /db#frag/, 'a # not preceded by whitespace is not a comment');
+  assert.match(code, /a # b/, 'a # inside a double-quoted scalar is data');
+  assert.match(code, /c # d/, 'a # inside a single-quoted scalar is data');
+  assert.match(code, /kubectl version/, 'a quoted # does not swallow the rest of the line');
+  assert.match(code, /\$#/, 'a shell $# is not a comment');
+});
+
+test('scriptCode preserves the line count', () => {
+  // The guards anchor on `/^ {10}key:/m` and report line numbers. Renumbering
+  // them while fixing comment blindness would be its own defect.
+  const yaml = ['# a', 'b: 1', '', '# c', 'd: 2'].join('\n');
+  assert.equal(scriptCode(yaml).split('\n').length, yaml.split('\n').length);
+});
+
+test('scriptCode makes a commented-out step stop satisfying a presence check', () => {
+  // The 0vku shape: a CI guard passed on a commented-out call, the exact
+  // mutation its acceptance criterion named.
+  const deleted = '        # run: psql -c "CREATE DATABASE djinn_test_template"';
+  const live = '        run: psql -c "CREATE DATABASE djinn_test_template"';
+  assert.doesNotMatch(scriptCode(deleted), /CREATE DATABASE djinn_test_template/);
+  assert.match(scriptCode(live), /CREATE DATABASE djinn_test_template/);
+});
+
+test('slashCode strips // and /* */ without eating strings', () => {
+  const js = [
+    '// banned_call() in a comment',
+    'const url = "https://example.com"; banned_call();',
+    'const t = `a // b`;',
+    '/* banned_call() in a block */',
+    'banned_call(); // trailing banned_call() mention',
+  ].join('\n');
+  const code = slashCode(js);
+
+  // A naive `line.replace(/\/\/.*/, '')` truncates line 2 at `https:` and
+  // silently drops a real violation — a FALSE NEGATIVE created by fixing a
+  // false positive.
+  assert.match(code, /banned_call\(\);\n/, 'the real call after a URL survives');
+  assert.match(code, /a \/\/ b/, 'a // inside a template literal is data');
+  // Line 5 carries one real call AND one mention of the same token in its own
+  // trailing comment: the count proves the stripper kept the code and dropped
+  // the prose, rather than dropping or keeping the whole line.
+  assert.equal((code.match(/banned_call\(\)/g) ?? []).length, 2,
+    'only the two real calls remain; the three comment mentions are gone');
+  assert.equal(slashCode(js).split('\n').length, js.split('\n').length,
+    'line count is preserved');
+});

--- a/scripts/fixtures/resize-cutover-retention/disable-wait-empty-test-only-caller/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-wait-empty-test-only-caller/fixture.json
@@ -1,0 +1,18 @@
+{
+  "asset": "wait-empty",
+  "expect": "reject",
+  "why": "Retirement disguised as reachability. The production teardown no longer waits for the drain, but a `#[cfg(test)]` module calls `wait_empty`, so a whole-file text search still finds it. A reachability check claims something in PRODUCTION calls the asset; a call site under `#[cfg(test)]` proves the API still compiles and nothing more. This is the shape that let `check-resize-reachability.sh` verify reachability against the first 8% of a 4147-line file.",
+  "operations": [
+    {
+      "op": "replace",
+      "path": "server/crates/djinn-agent/src/process.rs",
+      "find": "        child.wait_empty().map_err(LeaseInvocationError::Launcher)?;\n",
+      "with": ""
+    },
+    {
+      "op": "append",
+      "path": "server/crates/djinn-agent/src/process.rs",
+      "text": "\n#[cfg(test)]\nmod retention_fixture_tests {\n    #[test]\n    fn the_drain_api_still_exists() {\n        let mut child = fixture_child();\n        child.wait_empty().map_err(LeaseInvocationError::Launcher).unwrap();\n    }\n}\n"
+    }
+  ]
+}

--- a/scripts/lib/rust-source-scan.awk
+++ b/scripts/lib/rust-source-scan.awk
@@ -1,0 +1,252 @@
+# Shared source-text scanner for Rust guards.
+#
+# WHY THIS FILE EXISTS
+#
+# Four separate guards were defeated in a single day by two defects, and each
+# guard had written its own half-answer to them:
+#
+#   (a) COMMENT BLINDNESS. Matching raw source text conflates code with prose.
+#       It bites in BOTH directions and the direction decides the damage:
+#         * a BAN (`this token must not appear`) FALSE-POSITIVES on a comment
+#           that explains why the token is wrong — `pcod`'s Patch::Apply guard,
+#           fixed in #2871;
+#         * a PRESENCE assertion (`this token must still appear`) FALSE-
+#           NEGATIVES: the comment mentioning the token keeps the guard green
+#           after the real call is deleted — `1j64`'s teardown-trap guard — and
+#           a commented-out call satisfies it outright — `0vku`'s CI guard.
+#       The presence direction is the dangerous one: it is silent.
+#
+#   (b) `#[cfg(test)]` TRUNCATION. `scripts/check-resize-reachability.sh`
+#       stopped scanning at a file's first `#[cfg(test)]` marker. In
+#       `server/src/server/state/mod.rs` that marker is a FIELD attribute on
+#       line 342 of 4147, so the guard read the first 8% of the file and never
+#       saw the composition site it exists to find. The convention it assumed
+#       ("one test module at the bottom") is simply false for that file.
+#
+# So: one implementation, used by every Rust source-text guard, that strips
+# comments without eating the code in front of them and that tracks test
+# context STRUCTURALLY instead of by first-marker.
+#
+# USAGE
+#
+#   awk -f scripts/lib/rust-source-scan.awk \
+#       -v strings=keep|blank -v scope=any|prod|test -v force_test=0|1 \
+#       <file>...
+#
+#   RS_PATTERN   (env, REQUIRED)  ERE matched against the processed line.
+#   RS_EXEMPT    (env, optional)  ERE matched against the RAW line; a matching
+#                                 line is skipped before anything else. Used for
+#                                 exemptions that key on text the processing
+#                                 would erase (e.g. `env!("OUT_DIR")`).
+#
+#   Both patterns come from the environment rather than `-v` on purpose: `-v`
+#   runs backslash-escape processing over its value, so `\(` and `\.` in an ERE
+#   are mangled or undefined. `ENVIRON[]` is byte-exact.
+#
+#   strings=keep   (default) string literals are kept verbatim, so a pattern may
+#                  match inside one. Required by matchers whose token IS a
+#                  literal — `Command::new("git")`.
+#   strings=blank  string BODIES are erased, delimiters kept (`"x"` -> `""`), so
+#                  a literal's contents can never satisfy the pattern while a
+#                  call assembled around one still can:
+#                  `sqlx::query(&format!("..."))` keeps `sqlx::query(`.
+#
+#   scope=any      (default) report every match.
+#   scope=prod     report only matches OUTSIDE test context. This is what a
+#                  reachability/presence guard wants: a call site under
+#                  `#[cfg(test)]` must not count as production reachability.
+#   scope=test     report only matches INSIDE test context.
+#
+#   force_test=1   treat the whole file as test context regardless of structure.
+#                  For files a PARENT declares as `#[cfg(test)] mod x;` — the
+#                  attribute is not in this file, so nothing here can see it.
+#
+# Output, one line per hit:  <file>:<lineno>:<RAW line>
+# The raw line is emitted so diagnostics show what the author actually wrote,
+# comment and all.
+#
+# Exit status is awk's own. A missing RS_PATTERN exits 2.
+#
+# KNOWN LIMITS, both chosen to over-report rather than under-report
+#
+#   * Raw strings (`r#"..."#`) are paired by the same quote scan as ordinary
+#     ones, so a raw body containing an unbalanced `"` mis-pairs. The result is
+#     a line that reads as more code than it is, i.e. a possible false positive.
+#   * Nothing here parses Rust. `scope=prod` can only ever UNDER-report
+#     production hits if the tracker over-estimates test context; the tracker is
+#     therefore written to disarm eagerly (see `rs_test_context`).
+
+# ---------------------------------------------------------------------------
+# Lexer
+# ---------------------------------------------------------------------------
+
+# Split one raw line into two processed forms, left in the globals
+# `_rs_keep` (strings verbatim) and `_rs_blank` (string bodies erased).
+# Comments are removed from both; `/* */` state carries across lines.
+#
+# The code IN FRONT of a trailing comment survives, which is the whole point:
+# `foo(); // Patch::Apply` is still a call to `foo()`, and a guard that dropped
+# the line would launder it.
+function rs_split(line,   i, n, c, nxt, keep, blank) {
+    n = length(line)
+    i = 1
+    keep = ""
+    blank = ""
+    while (i <= n) {
+        c = substr(line, i, 1)
+        nxt = substr(line, i + 1, 1)
+
+        if (_rs_block) {
+            if (c == "*" && nxt == "/") { _rs_block = 0; i += 2 } else { i += 1 }
+            continue
+        }
+
+        # A char literal whose value IS a double quote must not open a phantom
+        # string and swallow the rest of the line. Replaced by a placeholder of
+        # the same shape so nothing downstream sees the quote.
+        if (c == "'") {
+            if (substr(line, i, 3) == "'\"'")   { keep = keep "'q'"; blank = blank "'q'"; i += 3; continue }
+            if (substr(line, i, 4) == "'\\\"'") { keep = keep "'q'"; blank = blank "'q'"; i += 4; continue }
+        }
+
+        if (c == "/" && nxt == "/") break                       # line comment
+        if (c == "/" && nxt == "*") { _rs_block = 1; i += 2; continue }
+
+        if (c == "\"") {
+            keep = keep "\""
+            blank = blank "\"\""
+            i += 1
+            while (i <= n) {
+                c = substr(line, i, 1)
+                if (c == "\\") { keep = keep substr(line, i, 2); i += 2; continue }
+                keep = keep c
+                i += 1
+                if (c == "\"") break
+            }
+            continue
+        }
+
+        keep = keep c
+        blank = blank c
+        i += 1
+    }
+    _rs_keep = keep
+    _rs_blank = blank
+}
+
+function rs_braces(s,   i, n, c, d) {
+    n = length(s); d = 0
+    for (i = 1; i <= n; i++) {
+        c = substr(s, i, 1)
+        if (c == "{") d++
+        else if (c == "}") d--
+    }
+    return d
+}
+
+function rs_parens(s,   i, n, c, d) {
+    n = length(s); d = 0
+    for (i = 1; i <= n; i++) {
+        c = substr(s, i, 1)
+        if (c == "(") d++
+        else if (c == ")") d--
+    }
+    return d
+}
+
+# ---------------------------------------------------------------------------
+# Test-context tracker
+# ---------------------------------------------------------------------------
+
+# Returns 1 if the current line is inside test code. Call it for EVERY line —
+# it is a state machine, and skipping a line loses the state.
+#
+# `s` must be the string-blanked code form, so a brace inside a literal or a
+# comment cannot unbalance the depth count.
+#
+# The rule is structural, never positional. A test attribute ARMS the tracker;
+# the item it decorates then either opens a block (tracked to its matching close
+# brace) or is a single item that ends on its own line. That second case is what
+# the first-marker guards got wrong: `#[cfg(test)]` on a struct FIELD or a `mod
+# x;` declaration introduces no block at all, and treating it as one truncated
+# `state/mod.rs` at line 342 of 4147.
+#
+# Disarming is eager. An over-eager disarm reports a test hit as production,
+# which is visible; an under-eager one silently swallows production code, which
+# is the failure this file exists to prevent.
+function rs_test_context(s,   d) {
+    if (force_test == 1) return 1
+
+    if (_rs_depth > 0) {
+        _rs_depth += rs_braces(s)
+        if (_rs_depth < 0) _rs_depth = 0
+        return 1
+    }
+
+    if (s ~ /^[ \t]*#\[[ \t]*(cfg[ \t]*\([ \t]*test[ \t]*\)|test|tokio::test|rstest|async_std::test|proptest)/) {
+        _rs_armed = 1
+        _rs_parens = 0
+        return 1
+    }
+
+    if (_rs_armed) {
+        # Stacked attributes and blank / comment-only lines sit between the
+        # attribute and the item it decorates.
+        if (s ~ /^[ \t]*#\[/) return 1
+        if (s ~ /^[ \t]*$/) return 1
+
+        _rs_parens += rs_parens(s)
+        d = rs_braces(s)
+        if (d > 0) { _rs_depth = d; _rs_armed = 0; _rs_parens = 0; return 1 }
+
+        # Still inside a multi-line signature -> the item has not started yet.
+        if (_rs_parens > 0) return 1
+
+        # A `;`- or `,`-terminated item: a field, a `mod x;`, a `use`, a const.
+        # It ends here and introduces no block.
+        _rs_armed = 0
+        _rs_parens = 0
+        return 1
+    }
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+BEGIN {
+    RS_PATTERN = ENVIRON["RS_PATTERN"]
+    RS_EXEMPT = ENVIRON["RS_EXEMPT"]
+    if (RS_PATTERN == "") {
+        print "rust-source-scan.awk: RS_PATTERN must be set in the environment" > "/dev/stderr"
+        exit 2
+    }
+    if (strings == "") strings = "keep"
+    if (scope == "") scope = "any"
+    if (strings != "keep" && strings != "blank") {
+        print "rust-source-scan.awk: strings must be keep or blank, got: " strings > "/dev/stderr"
+        exit 2
+    }
+    if (scope != "any" && scope != "prod" && scope != "test") {
+        print "rust-source-scan.awk: scope must be any, prod or test, got: " scope > "/dev/stderr"
+        exit 2
+    }
+}
+
+FNR == 1 { _rs_block = 0; _rs_depth = 0; _rs_armed = 0; _rs_parens = 0 }
+
+{
+    rs_split($0)
+    # Unconditional: the tracker is stateful and must see every line.
+    in_test = rs_test_context(_rs_blank)
+
+    if (scope == "prod" && in_test) next
+    if (scope == "test" && !in_test) next
+    if (RS_EXEMPT != "" && $0 ~ RS_EXEMPT) next
+
+    if ((strings == "blank" ? _rs_blank : _rs_keep) ~ RS_PATTERN) {
+        printf "%s:%d:%s\n", FILENAME, FNR, $0
+    }
+}

--- a/scripts/lib/source-text.mjs
+++ b/scripts/lib/source-text.mjs
@@ -1,0 +1,134 @@
+// Shared source-text helpers for the JavaScript CI guards.
+//
+// WHY THIS FILE EXISTS
+//
+// The `scripts/ci-*.test.mjs` guards assert on workflow YAML as raw text.
+// Comments are text, so every one of those assertions has a defect, and the
+// direction decides the damage:
+//
+//   * a BAN false-POSITIVES on prose. `assertQaJobHasNoLiveDependencies`
+//     forbids /\bkind\b/i in the qa-smoke job; the English word "kind" in a
+//     `#` comment ("this kind of failure") reds the build with no live
+//     dependency added anywhere.
+//   * a PRESENCE assertion false-NEGATIVES, and this is the silent direction.
+//     Delete the `psql … CREATE DATABASE djinn_test_template` step, leave
+//     `# CREATE DATABASE djinn_test_template happens in the compose file now`,
+//     and the guard stays green while the job no longer creates its database.
+//
+// Both shapes have already shipped in this repo in other languages:
+// `1j64`'s teardown-trap guard matched a comment mentioning `trap … EXIT` and
+// stayed green when the real `trap` was deleted; `0vku`'s CI guard passed on a
+// commented-out arming call, the exact mutation its acceptance criterion
+// named. The Rust-side answer lives in `scripts/lib/rust-source-scan.awk` and
+// `server/tests/task_run_resize_kind.rs` (`code_lines` / `rust_code` /
+// `script_code`, PR #2871). This is the same rule for YAML and shell.
+//
+// THE ONE INVARIANT: a trailing comment must not launder the code in front of
+// it. `run: make test  # no kubectl needed` still runs `make test`, so the
+// text before the `#` survives. A helper that dropped the whole line would let
+// any violation be hidden by typing a comment after it.
+
+/**
+ * Remove `#` comments from YAML or shell text.
+ *
+ * A `#` starts a comment only at the start of a line or after whitespace —
+ * that is YAML's own rule, and it is also close enough for the shell inside a
+ * `run: |` block. So `postgres://user:pw@host/db#frag` and `$#` keep their
+ * `#`, while `save-if: false  # restore only` loses the tail and keeps the
+ * key.
+ *
+ * Quoted spans are honoured, so a `#` inside `"a # b"` is data, not a comment.
+ * Line count is preserved: these guards use `/^ {10}key:/m` anchors and
+ * report line numbers, and renumbering them would be its own defect.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function scriptCode(text) {
+  return text
+    .split('\n')
+    .map((line) => stripHashComment(line))
+    .join('\n');
+}
+
+function stripHashComment(line) {
+  let quote = null;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (quote) {
+      // YAML single-quoted scalars escape a quote by doubling it; double-quoted
+      // ones use a backslash. Either way the span continues.
+      if (char === '\\' && quote === '"') {
+        i += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === '#' && (i === 0 || /\s/.test(line[i - 1]))) {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+/**
+ * Remove `//` line comments and `/* *\/` block comments from JavaScript,
+ * TypeScript or Rust text, honouring string literals so a `//` inside
+ * `"https://x"` neither opens a comment nor hides one.
+ *
+ * Same invariant as {@link scriptCode}: the code in front of a trailing
+ * comment survives, and the line count is preserved.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function slashCode(text) {
+  let out = '';
+  let inBlock = false;
+  let quote = null;
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    const next = text[i + 1];
+    if (inBlock) {
+      if (char === '\n') out += '\n';
+      else if (char === '*' && next === '/') {
+        inBlock = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      out += char;
+      if (char === '\\') {
+        out += next ?? '';
+        i += 1;
+      } else if (char === quote || char === '\n') {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      out += char;
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      const end = text.indexOf('\n', i);
+      if (end === -1) break;
+      i = end - 1;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      inBlock = true;
+      i += 1;
+      continue;
+    }
+    out += char;
+  }
+  return out;
+}

--- a/scripts/resize-cutover-retention-manifest.mjs
+++ b/scripts/resize-cutover-retention-manifest.mjs
@@ -42,8 +42,10 @@
 // Exit codes: 0 = every asset retained, 1 = a retirement was detected,
 // 2 = the gate could not run (its own subject is missing).
 
+import { spawnSync } from 'node:child_process';
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { join, extname } from 'node:path';
+import { join, extname, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // ---------------------------------------------------------------------------
 // Paths, spelled once.
@@ -499,6 +501,74 @@ function everyInput() {
     return [...paths].sort();
 }
 
+// ---------------------------------------------------------------------------
+// Production scoping for `reachability`.
+//
+// A `reachability` check asserts that something in PRODUCTION still calls the
+// asset — that is the word its own header uses, and it is the whole difference
+// between this and a `content` check. But it was matching the entire file, so
+// a call moved into a `#[cfg(test)] mod tests` satisfied it. The mutation is
+// exact: delete the production `child.wait_empty()` teardown in
+// `djinn-agent/src/process.rs` and add one inside that file's test module at
+// line 1865, and UNREACHABLE never fires while no shipped code waits for the
+// drain.
+//
+// Test scope is resolved by scripts/lib/rust-source-scan.awk — the same
+// scanner the shell and Python guards use — rather than by a fourth private
+// `#[cfg(test)]` heuristic. It is asked for every line that IS test context
+// (`scope=test` with a match-anything pattern) and those lines are blanked.
+// Line COUNT is preserved so the regexes and any reported offsets still line
+// up, and so a multi-line pattern cannot silently start matching across a
+// removed span.
+//
+// Truncating at the first `#[cfg(test)]` would have been the easy version and
+// is exactly the defect that made `scripts/check-resize-reachability.sh` verify
+// reachability against the first 8% of a 4147-line file.
+// ---------------------------------------------------------------------------
+
+// Resolved from THIS FILE's location, deliberately unlike `--root`: the tree
+// being evaluated may be a throwaway fixture, but the scanner is always the one
+// shipped next to this engine.
+const SCAN_AWK = join(dirname(fileURLToPath(import.meta.url)), 'lib', 'rust-source-scan.awk');
+
+function testLineNumbers(full) {
+    const result = spawnSync(
+        'awk',
+        ['-f', SCAN_AWK, '-v', 'strings=blank', '-v', 'scope=test', full],
+        { encoding: 'utf8', env: { ...process.env, RS_PATTERN: '.' } },
+    );
+    if (result.error || result.status !== 0) {
+        // A scanner that cannot run must never read as "everything is
+        // production" OR as "everything is test": both are silent verdicts.
+        throw new Error(
+            `resize-cutover-retention: source scanner failed for ${full}: `
+            + `${result.error?.message ?? result.stderr?.trim() ?? `exit ${result.status}`}`,
+        );
+    }
+    const lines = new Set();
+    for (const hit of result.stdout.split('\n')) {
+        if (!hit) continue;
+        const n = Number(hit.split(':')[1]);
+        if (Number.isInteger(n)) lines.add(n);
+    }
+    return lines;
+}
+
+function productionCode(full, path, code) {
+    if (extname(path) !== '.rs' || !existsSync(SCAN_AWK)) {
+        if (extname(path) === '.rs') {
+            throw new Error(`resize-cutover-retention: shared source scanner is missing: ${SCAN_AWK}`);
+        }
+        return code;
+    }
+    const testLines = testLineNumbers(full);
+    if (testLines.size === 0) return code;
+    return code
+        .split('\n')
+        .map((line, index) => (testLines.has(index + 1) ? '' : line))
+        .join('\n');
+}
+
 function readSource(root, path) {
     const full = join(root, path);
     if (!existsSync(full)) {
@@ -509,7 +579,8 @@ function readSource(root, path) {
         return { empty: true };
     }
     const raw = readFileSync(full, 'utf8');
-    return { raw, code: stripComments(raw, path) };
+    const code = stripComments(raw, path);
+    return { raw, code, production: productionCode(full, path, code) };
 }
 
 export function evaluate(root) {
@@ -556,9 +627,12 @@ export function evaluate(root) {
                 problems.push(`UNREACHABLE: ${check.path} is gone, so nothing calls into this asset from there.`);
                 continue;
             }
-            if (!check.pattern.test(source.code)) {
+            if (!check.pattern.test(source.production)) {
+                const testOnly = check.pattern.test(source.code);
                 problems.push(
-                    `UNREACHABLE: ${check.path} no longer matches /${check.pattern.source}/. Presence without a caller is retirement with extra steps. Why it is guarded: ${check.why}.`,
+                    testOnly
+                        ? `UNREACHABLE: ${check.path} matches /${check.pattern.source}/ only inside test code. A call site under \`#[cfg(test)]\` proves the API compiles, not that anything shipped calls it. Why it is guarded: ${check.why}.`
+                        : `UNREACHABLE: ${check.path} no longer matches /${check.pattern.source}/. Presence without a caller is retirement with extra steps. Why it is guarded: ${check.why}.`,
                 );
             }
         }

--- a/scripts/test-check-raw-sql-boundary.sh
+++ b/scripts/test-check-raw-sql-boundary.sh
@@ -36,6 +36,11 @@ run_linked_worktree_diff_guard() {
     LINKED_WORKTREE="$LOG_DIR/linked-worktree"
     git -C "$REPO_ROOT" worktree add --detach "$LINKED_WORKTREE" HEAD > "$LOG_DIR/t14_worktree_setup.log" 2>&1
     cp "$GUARD" "$LINKED_WORKTREE/scripts/check-raw-sql-boundary.sh"
+    # The worktree is checked out at HEAD, so it carries the COMMITTED guard and
+    # its committed dependencies. Copy the working-tree scanner alongside the
+    # working-tree guard: otherwise this case silently tests the old pair.
+    mkdir -p "$LINKED_WORKTREE/scripts/lib"
+    cp "$SCRIPT_DIR/lib/rust-source-scan.awk" "$LINKED_WORKTREE/scripts/lib/rust-source-scan.awk"
 
     ORIGIN_MAIN_BEFORE=$(git -C "$REPO_ROOT" rev-parse --verify origin/main^{commit})
     SHALLOW_BEFORE=$(git -C "$REPO_ROOT" rev-parse --is-shallow-repository)
@@ -551,6 +556,59 @@ assert_output_contains "T28 catches the call after an escaped-quote literal" \
     "2:    let label = " "$LOG_DIR/t28_after_literal.log.out"
 assert_output_contains "T28 catches the call after a double-quote char literal" \
     "3:    let ch = " "$LOG_DIR/t28_after_literal.log.out"
+
+# ── T29: prose naming the banned call is not a call ───────────────────
+#
+# The pcod defect (#2871): a comment written to explain WHY a token is wrong
+# fired the ban that forbids it. A rule outside djinn-db is exactly the kind
+# of thing a doc comment says out loud, so this shape is common, not exotic.
+FIXTURE_PROSE="$REPO_ROOT/$FIXTURE_BASE/src/prose_only.rs"
+cat > "$FIXTURE_PROSE" <<'FIXTURE'
+//! Repository access notes.
+//!
+//! Raw `sqlx::query!` and `sqlx::query_as!` belong in djinn-db, never here.
+
+/// Do not reach for sqlx::query_scalar!( in this module; call the repository.
+/*
+ * A block comment mentioning sqlx::query( is prose too.
+ */
+pub async fn count(repo: &Repo) -> u64 {
+    repo.count().await
+}
+FIXTURE
+
+PROSE_PATH="$FIXTURE_BASE/src/prose_only.rs"
+set +e
+run_guard t29_prose "$PROSE_PATH"
+t29_actual=$?
+set -e
+assert_exit "T29 comments naming sqlx calls exit 0" 0 "$t29_actual" "$LOG_DIR/t29_prose.log.out"
+assert_output_lacks "T29 does not flag the prose file" \
+    "$PROSE_PATH" "$LOG_DIR/t29_prose.log.out"
+
+# ── T30: a trailing comment does not launder the code in front of it ───
+#
+# The load-bearing counterpart to T29. If comment stripping were implemented
+# as "drop any line containing //", every violation could be hidden by typing
+# a comment after it. `foo(); // note` is still a call to foo().
+FIXTURE_TRAILING="$REPO_ROOT/$FIXTURE_BASE/src/trailing_comment.rs"
+cat > "$FIXTURE_TRAILING" <<'FIXTURE'
+pub async fn touch(pool: &PgPool) {
+    // sqlx::query("SELECT 1") — this line is prose and must not be reported.
+    sqlx::query("DELETE FROM orders").execute(pool).await.unwrap(); // TODO: move to djinn-db
+}
+FIXTURE
+
+TRAILING_PATH="$FIXTURE_BASE/src/trailing_comment.rs"
+set +e
+run_guard t30_trailing "$TRAILING_PATH"
+t30_actual=$?
+set -e
+assert_exit "T30 code before a trailing comment still exits non-zero" 1 "$t30_actual" "$LOG_DIR/t30_trailing.log.out"
+assert_output_contains "T30 reports the real call on line 3" \
+    "3:    sqlx::query(\"DELETE FROM orders\")" "$LOG_DIR/t30_trailing.log.out"
+assert_output_lacks "T30 does not report the comment on line 2" \
+    "2:    // sqlx::query" "$LOG_DIR/t30_trailing.log.out"
 
 # ── T10: mixed files — violation + clean + djinn-db ───────────────────
 set +e

--- a/scripts/test-check-resize-authorization-boundary.sh
+++ b/scripts/test-check-resize-authorization-boundary.sh
@@ -228,5 +228,58 @@ fn new_inner() {
 EOF
 expect 0 "an indented #[cfg(test)] field does not hide the production caller"
 
+fixture
+# PRODUCTION CODE AFTER A `#[cfg(test)]` BLOCK IS STILL PRODUCTION CODE.
+#
+# The guard used to stop scanning at the first unindented `#[cfg(test)]`, on
+# the stated convention that test modules live at the end of a file. Nothing
+# enforces that convention. This is the shape that convention forbids and the
+# language permits, and it is the exact blind spot that made
+# check-resize-reachability.sh verify reachability against the first 8% of
+# server/src/server/state/mod.rs.
+cat >"$SCRATCH/$ARMING_FILE" <<EOF
+#[cfg(test)]
+mod early_tests {
+    #[test]
+    fn decoy() {
+        let _ = BuildLeaseService::new(repo, cap);
+    }
+}
+
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap).$ARMING_SYMBOL(authority);
+}
+EOF
+expect 0 "a production caller BELOW a #[cfg(test)] module is still found"
+
+fixture
+# The counterpart, so the case above cannot be satisfied by "see everything".
+# Moving the ONLY caller inside that same block must still fail.
+cat >"$SCRATCH/$ARMING_FILE" <<EOF
+#[cfg(test)]
+mod early_tests {
+    #[test]
+    fn decoy() {
+        let _ = BuildLeaseService::new(repo, cap).$ARMING_SYMBOL(authority);
+    }
+}
+
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap);
+}
+EOF
+expect 1 "a caller inside that same #[cfg(test)] module still does not count"
+
+fixture
+# A trailing comment must not launder the code in front of it. `foo(); // x`
+# is still a call to foo(); a stripper that dropped the whole line would let
+# any real arming be hidden by typing a comment after it.
+cat >"$SCRATCH/$ARMING_FILE" <<EOF
+fn new_inner() {
+    let _ = BuildLeaseService::new(repo, cap).$ARMING_SYMBOL(authority); // TODO: revisit
+}
+EOF
+expect 0 "a trailing comment does not launder the arming call in front of it"
+
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/scripts/test-check-test-global-metrics.sh
+++ b/scripts/test-check-test-global-metrics.sh
@@ -162,6 +162,56 @@ git commit -qm "add production readers"
 expect "production readers before and after a test mod are exempt" 0 "$BASE"
 git reset -q --hard HEAD~1
 
+# 5b. A `#[cfg(test)]` attribute on a struct FIELD introduces no block, so the
+#     production function after it is production code. The tracker that used to
+#     live in the guard disarmed only on a line ending in `;`; a field ends in
+#     `,`, so it stayed armed until the next line that opened a brace and
+#     reported this `render()` as a test read. `server/src/server/state/mod.rs`
+#     has exactly this shape from line 342 onward.
+mkdir -p server/src/server
+cat >server/src/server/state.rs <<'EOF'
+pub struct AppState {
+    /// Test-only bypass.
+    #[cfg(test)]
+    test_bypass_persist: bool,
+    real_field: u32,
+}
+
+pub fn health_probe() -> String {
+    djinn_telemetry::render().unwrap_or_default()
+}
+EOF
+git add server/src/server/state.rs
+git commit -qm "add cfg(test) field before a production reader"
+expect "a #[cfg(test)] FIELD does not make the next fn test code" 0 "$BASE"
+git reset -q --hard HEAD~1
+
+# 5c. The counterpart, so 5b cannot be satisfied by "classify nothing as test".
+#     The same file with the reader moved inside a real test module must fail.
+mkdir -p server/src/server
+cat >server/src/server/state.rs <<'EOF'
+pub struct AppState {
+    #[cfg(test)]
+    test_bypass_persist: bool,
+    real_field: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn reads_the_registry(
+        _fixture: u32,
+    ) {
+        let rendered = djinn_telemetry::render().unwrap();
+        assert!(rendered.is_empty());
+    }
+}
+EOF
+git add server/src/server/state.rs
+git commit -qm "add cfg(test) field before a test-module reader"
+expect "a read in a test mod after a #[cfg(test)] field is still caught" 1 "$BASE"
+git reset -q --hard HEAD~1
+
 # 6. The telemetry crate owns the singleton and must be able to test it.
 mkdir -p server/crates/djinn-telemetry/src
 cat >server/crates/djinn-telemetry/src/lib.rs <<'EOF'

--- a/scripts/test-rust-source-scan.sh
+++ b/scripts/test-rust-source-scan.sh
@@ -1,0 +1,280 @@
+#!/bin/sh
+# Self-test for the shared Rust source-text scanner.
+#
+# WHY THIS FILE EXISTS
+#
+# `scripts/lib/rust-source-scan.awk` is now the single comment-stripping and
+# `#[cfg(test)]`-tracking implementation behind five guards. A silent
+# regression in it would take all five down at once, and the failure would be
+# invisible: a guard that stops matching anything still exits 0.
+#
+# So every case below is written as a PAIR. For each thing the scanner must
+# ignore there is an adjacent thing it must still catch, because "ignores
+# comments" and "ignores everything" are indistinguishable from a green run.
+# That pairing is the whole point — the same reasoning as
+# `banned_patch_variant_in` in server/tests/task_run_resize_kind.rs (#2871).
+#
+# Two traps this file is written against:
+#
+#   * A PRESENCE assertion and a BAN assertion need DIFFERENT mutations.
+#     Swapping a required token for another valid one exercises the presence
+#     arm and proves nothing about the ban. To test a ban you must ADD the
+#     banned token while LEAVING the required one in place.
+#   * A trailing comment must not launder the code in front of it.
+#     `foo(); // banned` is still a call to `foo()`.
+#
+# Usage: sh scripts/test-rust-source-scan.sh
+# Exit codes: 0 all cases pass, 1 a case failed.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SCAN="$SCRIPT_DIR/lib/rust-source-scan.awk"
+
+if [ ! -f "$SCAN" ]; then
+    echo "FATAL: shared scanner not found: $SCAN" >&2
+    exit 2
+fi
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/rust-source-scan-selftest.XXXXXX")
+trap 'rm -rf -- "$WORK"' EXIT INT TERM
+
+PASS=0
+FAIL=0
+
+# scan <pattern> [strings] [scope] [force_test] -> matched line numbers, space-separated
+scan() {
+    RS_PATTERN="$1" awk -f "$SCAN" \
+        -v strings="${2:-keep}" \
+        -v scope="${3:-any}" \
+        -v force_test="${4:-0}" \
+        "$WORK/fixture.rs" | cut -d: -f2 | tr '\n' ' ' | sed 's/ $//'
+}
+
+# expect <label> <expected-lines> <pattern> [strings] [scope] [force_test]
+expect() {
+    _label=$1
+    _want=$2
+    shift 2
+    _got=$(scan "$@")
+    if [ "$_got" = "$_want" ]; then
+        PASS=$((PASS + 1))
+        printf '  ok   %s\n' "$_label"
+    else
+        FAIL=$((FAIL + 1))
+        printf '  FAIL %s\n' "$_label" >&2
+        printf '       expected lines [%s], got [%s]\n' "$_want" "$_got" >&2
+    fi
+}
+
+printf 'rust-source-scan self-test\n'
+
+# ── 1. Comments are not code, in BOTH directions ───────────────────────
+#
+# Line 1 is the pcod shape: a comment written to explain why a token is wrong,
+# which tripped the ban that forbids it. Line 5 is its load-bearing pair — if
+# the stripper were "drop any line mentioning the token", line 5 would vanish
+# with line 1 and the guard would be worthless.
+cat >"$WORK/fixture.rs" <<'EOF'
+// Never use Patch::Apply here; it clobbers the whole object.
+/// See [`Patch::Apply`] for why this is wrong.
+/* A block comment naming Patch::Apply is prose too. */
+pub fn patch() {
+    let p = Patch::Apply(body);
+}
+EOF
+expect "a line comment naming the banned token is not a match" "5" 'Patch::Apply'
+
+# ── 2. A trailing comment does not launder the code in front of it ─────
+cat >"$WORK/fixture.rs" <<'EOF'
+// forbidden_call() in a comment
+let x = 1; // forbidden_call()
+forbidden_call(); // TODO: remove
+EOF
+expect "code before a trailing comment is still code" "3" 'forbidden_call\('
+
+# ── 3. A URL in a string literal does not truncate the line ────────────
+#
+# The naive fix for (1) is `sub(/\/\/.*/, "", line)`. That turns
+# `let u = "https://x"; banned();` into `let u = "https:` and drops a real
+# violation — a FALSE NEGATIVE introduced by fixing a false positive.
+cat >"$WORK/fixture.rs" <<'EOF'
+let doc = "https://example.com/api";
+let u = "https://example.com"; banned_call();
+// https://example.com banned_call()
+EOF
+expect "a // inside a string literal does not start a comment" "2" 'banned_call\('
+
+# ── 4. strings=blank hides literal DATA but not calls built around it ──
+#
+# The pair matters: a scanner that detects SQL in source text feeds Rust source
+# to itself AS A STRING, and the guard was matching its own fixtures. But
+# `sqlx::query(&format!("..."))` still has the call outside every literal.
+cat >"$WORK/fixture.rs" <<'EOF'
+let hits = scan_sql("sqlx::query!(\"INSERT INTO t\")");
+sqlx::query(&format!("{SET}owner = $3"));
+EOF
+expect "strings=blank ignores a literal payload" "2" 'sqlx::query[!(]' blank
+expect "strings=keep sees inside the literal" "1 2" 'sqlx::query[!(]' keep
+
+# A char literal holding a double quote must not open a phantom string and
+# swallow the real call after it.
+cat >"$WORK/fixture.rs" <<'EOF'
+let ch = '"'; banned_call();
+let esc = '\"'; banned_call();
+EOF
+expect "a '\"' char literal does not hide the call after it" "1 2" 'banned_call\(' blank
+
+# ── 5. PRODUCTION CODE AFTER A #[cfg(test)] BLOCK IS PRODUCTION CODE ───
+#
+# The check-resize-reachability.sh blind spot. Truncating at the first marker
+# meant the guard read the first 8% of a 4147-line file and never saw the
+# composition site it existed to find.
+cat >"$WORK/fixture.rs" <<'EOF'
+pub fn before() { arm_it(); }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn decoy() { arm_it(); }
+}
+
+pub fn after() { arm_it(); }
+EOF
+expect "production callers on both sides of a test mod are found" "1 9" 'arm_it\(' blank prod
+expect "the caller inside the test mod is excluded" "6" 'arm_it\(' blank test
+
+# ── 6. #[cfg(test)] on a FIELD introduces no block ─────────────────────
+#
+# A field ends in `,`, not `{` or `;`. A tracker that arms on the attribute and
+# waits for the next `{` swallows the following production function whole. This
+# is the live shape in server/src/server/state/mod.rs from line 342.
+cat >"$WORK/fixture.rs" <<'EOF'
+pub struct AppState {
+    /// Test-only bypass.
+    #[cfg(test)]
+    test_bypass: bool,
+    real: u32,
+}
+
+pub fn compose() {
+    arm_it();
+}
+EOF
+expect "a #[cfg(test)] field does not swallow the next fn" "9" 'arm_it\(' blank prod
+expect "and nothing in that file counts as test code" "" 'arm_it\(' blank test
+
+# `#[cfg(test)] mod x;` and `#[cfg(test)] use ...;` open no block either.
+cat >"$WORK/fixture.rs" <<'EOF'
+#[cfg(test)]
+mod slow_tests;
+
+#[cfg(test)]
+use std::io::Write;
+
+pub fn compose() { arm_it(); }
+EOF
+expect "a bodyless #[cfg(test)] item does not swallow the next fn" "7" 'arm_it\(' blank prod
+
+# ── 7. A multi-line test signature still resolves to its block ─────────
+#
+# The mirror hazard of case 6: disarm too eagerly and a `#[tokio::test] async
+# fn foo(\n a: A,\n) {` body is classified as production, so a test-only hit is
+# reported as a production one.
+cat >"$WORK/fixture.rs" <<'EOF'
+#[tokio::test]
+async fn reads(
+    fixture: Fixture,
+    other: Other,
+) {
+    arm_it();
+}
+
+pub fn compose() { arm_it(); }
+EOF
+expect "a multi-line #[test] signature keeps its body in test scope" "9" 'arm_it\(' blank prod
+expect "and the body itself is test scope" "6" 'arm_it\(' blank test
+
+# Stacked attributes between the marker and the item.
+cat >"$WORK/fixture.rs" <<'EOF'
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    fn helper() { arm_it(); }
+}
+
+pub fn compose() { arm_it(); }
+EOF
+expect "stacked attributes do not break the tracker" "7" 'arm_it\(' blank prod
+
+# ── 8. force_test=1 for a module a PARENT declares as #[cfg(test)] ─────
+#
+# The attribute lives in the parent file, so nothing in this file can see it.
+cat >"$WORK/fixture.rs" <<'EOF'
+fn helper() {
+    arm_it();
+}
+EOF
+expect "force_test=1 makes the whole file test scope" "" 'arm_it\(' blank prod 1
+expect "force_test=1 still reports it as a test hit" "2" 'arm_it\(' blank test 1
+
+# ── 9. A commented-out call is not a call ──────────────────────────────
+#
+# The 0vku shape: a CI guard passed on a commented-out arming call, which was
+# the exact mutation its acceptance criterion named.
+cat >"$WORK/fixture.rs" <<'EOF'
+pub fn compose() {
+    // arm_it();
+    let _ = build();
+}
+EOF
+expect "a commented-out call does not satisfy a presence scan" "" 'arm_it\(' blank prod
+
+# ── 10. State resets between files ─────────────────────────────────────
+#
+# An unterminated block comment in one file must not blind the scanner to the
+# next one.
+cat >"$WORK/fixture.rs" <<'EOF'
+pub fn compose() { arm_it(); }
+EOF
+cat >"$WORK/leading.rs" <<'EOF'
+/* unterminated block comment
+EOF
+_got=$(RS_PATTERN='arm_it\(' awk -f "$SCAN" -v strings=blank "$WORK/leading.rs" "$WORK/fixture.rs" | wc -l | tr -d ' ')
+if [ "$_got" = "1" ]; then
+    PASS=$((PASS + 1))
+    printf '  ok   block-comment state resets at each file\n'
+else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL block-comment state resets at each file (got %s hits, want 1)\n' "$_got" >&2
+fi
+
+# ── 11. Misconfiguration is an error, not a silent pass ────────────────
+#
+# A guard whose scanner quietly matched nothing would report OK forever.
+set +e
+awk -f "$SCAN" -v strings=blank "$WORK/fixture.rs" >/dev/null 2>&1
+_rc=$?
+set -e
+if [ "$_rc" -eq 2 ]; then
+    PASS=$((PASS + 1))
+    printf '  ok   a missing RS_PATTERN exits 2 rather than matching nothing\n'
+else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL a missing RS_PATTERN should exit 2, got %s\n' "$_rc" >&2
+fi
+
+set +e
+RS_PATTERN='x' awk -f "$SCAN" -v scope=production "$WORK/fixture.rs" >/dev/null 2>&1
+_rc=$?
+set -e
+if [ "$_rc" -eq 2 ]; then
+    PASS=$((PASS + 1))
+    printf '  ok   an unknown scope exits 2 rather than defaulting\n'
+else
+    FAIL=$((FAIL + 1))
+    printf '  FAIL an unknown scope should exit 2, got %s\n' "$_rc" >&2
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/server/crates/djinn-coordinator/src/tests/boundary.rs
+++ b/server/crates/djinn-coordinator/src/tests/boundary.rs
@@ -1,10 +1,18 @@
 // ─── Boundary checks: orchestration crate dependency invariants ──────────────
 //
 // These tests verify the architectural boundaries established by the Phase 5
-// orchestration split.  They read `Cargo.toml` at compile time via
-// `include_str!` and assert that forbidden dependency edges are absent.
-// If a boundary is violated, the test fails with a clear message explaining
-// which crate depends on which forbidden crate.
+// orchestration split.  The manifest guards read `Cargo.toml` at compile time
+// via `include_str!` and assert that forbidden dependency edges are absent.
+// The source guards walk a crate's `src/` tree and assert that no PRODUCTION
+// file declares a `use` of a forbidden crate — the case a manifest guard
+// cannot see, because a dev-dependency is legitimately importable from
+// `#[cfg(test)]` code in the very same file.
+//
+// The source-scanning primitives live in the "Shared source-guard primitives"
+// section at the bottom of this file and are reused by
+// `raw_signal_bypass_guard.rs`.
+
+use std::path::{Path, PathBuf};
 
 /// `djinn-slot` must NOT depend on `djinn-coordinator` or `djinn-agent`.
 ///
@@ -54,68 +62,20 @@ fn boundary_djinn_coordinator_has_no_agent_dependency() {
 }
 
 /// `djinn-slot` production code must NOT use `djinn-coordinator` types.
-///
-/// This source-level check scans all non-test `.rs` files in `djinn-slot/src/`
-/// for `use djinn_coordinator` imports.  Test-only files (under `tests/` or
-/// containing `#[cfg(test)]`) are excluded.
 #[test]
 fn boundary_djinn_slot_source_has_no_coordinator_import() {
-    let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../djinn-slot/src");
-    let mut offenders = Vec::new();
-    if src_dir.exists() {
-        for entry in walkdir_or_empty(&src_dir) {
-            let path = entry;
-            if !path.ends_with(".rs") {
-                continue;
-            }
-            let rel = path.strip_prefix(&src_dir).unwrap_or(&path);
-            // Skip test-only files
-            if rel.starts_with("tests") || rel.to_string_lossy().contains("test_helper") {
-                continue;
-            }
-            if let Ok(contents) = std::fs::read_to_string(&path)
-                && contents.contains("use djinn_coordinator")
-            {
-                offenders.push(rel.display().to_string());
-            }
-        }
-    }
-    assert!(
-        offenders.is_empty(),
-        "djinn-slot production source must not import djinn_coordinator; offenders: {offenders:?}"
-    );
+    assert_no_production_import("../djinn-slot/src", "djinn_coordinator");
 }
 
 /// `djinn-coordinator` production code must NOT use `djinn_agent` types.
 ///
-/// This source-level check scans all non-test `.rs` files in
-/// `djinn-coordinator/src/` for `use djinn_agent` imports.
+/// `djinn-agent` is a *dev*-dependency of `djinn-coordinator`, so a
+/// `#[cfg(test)]` import compiles and a production one does not.  That makes
+/// this guard's job the narrow one it looks like: catch the moment the edge is
+/// promoted to `[dependencies]` and used, with a message that names the file.
 #[test]
 fn boundary_djinn_coordinator_source_has_no_agent_import() {
-    let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../djinn-coordinator/src");
-    let mut offenders = Vec::new();
-    if src_dir.exists() {
-        for entry in walkdir_or_empty(&src_dir) {
-            let path = entry;
-            if !path.ends_with(".rs") {
-                continue;
-            }
-            let rel = path.strip_prefix(&src_dir).unwrap_or(&path);
-            // Skip test files
-            if rel.starts_with("tests") || rel.to_string_lossy().contains("test_helper") {
-                continue;
-            }
-            if let Ok(contents) = std::fs::read_to_string(&path)
-                && contents.contains("use djinn_agent")
-            {
-                offenders.push(rel.display().to_string());
-            }
-        }
-    }
-    assert!(
-        offenders.is_empty(),
-        "djinn-coordinator production source must not import djinn_agent; offenders: {offenders:?}"
-    );
+    assert_no_production_import("../djinn-coordinator/src", "djinn_agent");
 }
 
 /// `djinn-coordinator` must NOT have a direct `sqlx` dependency.
@@ -155,27 +115,641 @@ fn boundary_djinn_slot_has_no_sqlx_dependency() {
     );
 }
 
-// ── Helper: collect .rs paths from a directory tree ──────────────────────────
+// ── The source guard ─────────────────────────────────────────────────────────
 
-/// Return a vector of `.rs` file paths under `dir`, or an empty vec if the
-/// directory does not exist.  Not recursive beyond what `std::fs` provides
-/// via a simple stack walk.
-fn walkdir_or_empty(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+/// Fail if any production `.rs` file under `relative_src_dir` declares a `use`
+/// of `crate_ident`.
+///
+/// The scanner's own failures are asserted BEFORE the offender list: a file the
+/// scanner cannot resolve is not evidence of a clean tree, and reporting it as
+/// one is how a guard goes quietly dead.
+fn assert_no_production_import(relative_src_dir: &str, crate_ident: &str) {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_src_dir);
+    // Previously this whole scan sat behind `if src_dir.exists()`, so a moved
+    // or renamed crate would have silently emptied the guard.
+    assert!(
+        src_dir.exists(),
+        "{} must exist; a missing tree makes this guard vacuous rather than green",
+        src_dir.display()
+    );
+
+    let mut offenders = Vec::new();
+    let mut problems = Vec::new();
+    for path in rust_files(&src_dir) {
+        let relative = path.strip_prefix(&src_dir).unwrap_or(&path).to_path_buf();
+        if is_test_only_path(&relative) {
+            continue;
+        }
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            problems.push(format!("{}: unreadable", relative.display()));
+            continue;
+        };
+        match production_code(&contents) {
+            Ok(code) => {
+                if declares_use_of_crate(&code, crate_ident) {
+                    offenders.push(relative.display().to_string());
+                }
+            }
+            Err(error) => problems.push(format!("{}: {error}", relative.display())),
+        }
+    }
+    offenders.sort();
+
+    assert!(
+        problems.is_empty(),
+        "the {crate_ident} boundary scanner could not resolve some sources; fix the \
+         scanner rather than the guard: {problems:?}"
+    );
+    assert!(
+        offenders.is_empty(),
+        "{} production source must not import {crate_ident}; offenders: {offenders:?}",
+        relative_src_dir
+            .trim_start_matches("../")
+            .trim_end_matches("/src")
+    );
+}
+
+/// Every `.rs` file under `dir`, recursively.
+fn rust_files(dir: &Path) -> Vec<PathBuf> {
     let mut result = Vec::new();
     let mut stack = vec![dir.to_path_buf()];
     while let Some(current) = stack.pop() {
         let entries = match std::fs::read_dir(&current) {
-            Ok(e) => e,
+            Ok(entries) => entries,
             Err(_) => continue,
         };
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
                 stack.push(path);
-            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
                 result.push(path);
             }
         }
     }
     result
+}
+
+/// Whether `relative` (a path relative to a crate's `src/`) names test-only
+/// source.
+///
+/// `Path::starts_with` — the form this replaced — compares whole COMPONENTS
+/// anchored at the root, so it excluded `src/tests/*` and nothing else.
+/// `src/cargo_warm_base_gc/tests/pressure_execution.rs` is test code that it
+/// missed, and that file imports `djinn_agent_worker`, a dev-dependency.
+fn is_test_only_path(relative: &Path) -> bool {
+    relative
+        .components()
+        .any(|component| component.as_os_str() == "tests")
+        || relative.file_name().is_some_and(|name| {
+            let name = name.to_string_lossy();
+            name == "tests.rs"
+                || name.ends_with("_tests.rs")
+                || name.ends_with("_test.rs")
+                || name.contains("test_helper")
+        })
+}
+
+/// Whether `code` carries a `use` declaration naming exactly `crate_ident`.
+///
+/// `contains("use djinn_agent")` — the form this replaced — also matches
+/// `use djinn_agent_worker::…`, a DIFFERENT crate that djinn-coordinator
+/// legitimately dev-depends on.  The crate name must end on a token boundary
+/// and be introduced by `use`, which covers `use x::…`, `use x::{…}`,
+/// `use x;`, `use x as y;`, `pub use x::…`, and `use ::x::…`.
+///
+/// Known gap: a fully qualified `djinn_agent::Foo` with no `use` declaration is
+/// not matched.  That form cannot compile today (the edge is a dev-dependency,
+/// and `boundary_djinn_coordinator_has_no_agent_dependency` guards the
+/// promotion), so the `use` forms are where this guard adds signal.
+fn declares_use_of_crate(code: &str, crate_ident: &str) -> bool {
+    code.match_indices(crate_ident).any(|(start, _)| {
+        let before = code[..start].chars().next_back();
+        let after = code[start + crate_ident.len()..].chars().next();
+        if before.is_some_and(is_ident_char) || after.is_some_and(is_ident_char) {
+            return false;
+        }
+        // `use ::krate` and `use krate` both reduce to a prefix ending in `use`.
+        let prefix = code[..start].trim_end();
+        let prefix = prefix.strip_suffix("::").unwrap_or(prefix).trim_end();
+        match prefix.strip_suffix("use") {
+            Some(head) => !head.ends_with(is_ident_char),
+            None => false,
+        }
+    })
+}
+
+// ── Shared source-guard primitives ───────────────────────────────────────────
+//
+// A text guard matches against SOURCE, and a comment is not source: it cannot
+// import a crate or call a function.  So a comment must neither trip a ban nor
+// satisfy a presence assertion, and both directions have bitten this repo (see
+// the `code_lines` commentary in `server/tests/task_run_resize_kind.rs`).  A
+// string literal is not source either: `"classify_task_liveness: …"` in a log
+// message is not a call to it.
+//
+// `#[cfg(test)]` code is likewise not production source, and tracking it MUST
+// be structural.  `scripts/check-resize-reachability.sh` truncated its scan at
+// the FIRST `#[cfg(test)]` marker; in `server/src/server/state/mod.rs` that
+// marker is a struct FIELD attribute on line 342 of 4147, so the scan saw 8% of
+// the file and passed.  An attribute on a field (`…,`) or on a declaration
+// (`mod x;`) opens no block at all, and arming a "skip to the next closing
+// brace" on either swallows every line of production code that follows.
+
+const CFG_TEST: &str = "#[cfg(test)]";
+
+/// Keywords introducing an item or statement whose body a `#[cfg(test)]`
+/// attribute gates, once any visibility is stripped.  Anything else an
+/// attribute can precede — a struct field, an enum variant, a match arm — owns
+/// no scope to exclude.
+const ITEM_KEYWORDS: &[&str] = &[
+    "async",
+    "const",
+    "default",
+    "enum",
+    "extern",
+    "fn",
+    "impl",
+    "let",
+    "macro",
+    "macro_rules",
+    "mod",
+    "static",
+    "struct",
+    "trait",
+    "type",
+    "union",
+    "unsafe",
+    "use",
+];
+
+/// `source` reduced to production Rust: comment bodies and literal bodies
+/// blanked, `#[cfg(test)]`-gated items removed.
+///
+/// Removed text is replaced by spaces rather than deleted, so line structure
+/// and offsets survive: a needle can never be manufactured by splicing two
+/// distant lines together, and a trailing comment cannot launder the code in
+/// front of it — `foo(); // banned` still contains a real call to `foo()`.
+///
+/// Returns `Err` when the source cannot be resolved (an unterminated literal, an
+/// unbalanced delimiter, or a `#[cfg(test)]` item with neither a body nor a
+/// terminator).  Callers MUST fail on `Err`: an unscannable file is not a clean
+/// one.
+///
+/// Only the canonical `#[cfg(test)]` spelling is recognized.  `#[cfg(all(test,
+/// …))]` and friends do not appear in the guarded trees; if one is introduced,
+/// its body is scanned as production code, which is the safe direction for a ban
+/// and a visible one for a presence assertion.
+pub(super) fn production_code(source: &str) -> Result<String, String> {
+    strip_cfg_test(&mask_non_code(source)?)
+}
+
+fn is_ident_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// Overwrite `range` with spaces, preserving newlines.
+fn blank(text: &mut [char], range: std::ops::Range<usize>) {
+    for slot in &mut text[range] {
+        if *slot != '\n' {
+            *slot = ' ';
+        }
+    }
+}
+
+/// Blank every comment body and every literal body in `source`.
+///
+/// After this, the remaining `{`, `}`, `#` and `;` characters are all real
+/// tokens, which is what makes the structural `#[cfg(test)]` walk below safe.
+/// A hand-rolled brace counter without this step is exactly what the
+/// `StreamEvent` audit had to replace: one `{` inside a string literal left the
+/// scan unbalanced and an entire test module was audited as production code.
+fn mask_non_code(source: &str) -> Result<String, String> {
+    let chars: Vec<char> = source.chars().collect();
+    let mut out = chars.clone();
+    let mut index = 0;
+    while index < chars.len() {
+        let current = chars[index];
+        let after_ident = index > 0 && is_ident_char(chars[index - 1]);
+
+        if current == '/' && chars.get(index + 1) == Some(&'/') {
+            let start = index;
+            while index < chars.len() && chars[index] != '\n' {
+                index += 1;
+            }
+            blank(&mut out, start..index);
+            continue;
+        }
+        if current == '/' && chars.get(index + 1) == Some(&'*') {
+            let start = index;
+            let mut depth = 0usize;
+            while index + 1 < chars.len() {
+                if chars[index] == '/' && chars[index + 1] == '*' {
+                    depth += 1;
+                    index += 2;
+                } else if chars[index] == '*' && chars[index + 1] == '/' {
+                    depth -= 1;
+                    index += 2;
+                    if depth == 0 {
+                        break;
+                    }
+                } else {
+                    index += 1;
+                }
+            }
+            if depth != 0 {
+                return Err("unterminated block comment".to_owned());
+            }
+            blank(&mut out, start..index);
+            continue;
+        }
+        if !after_ident && let Some((quote, hashes)) = raw_literal_open(&chars, index) {
+            let (close, end) = raw_literal_close(&chars, quote, hashes)?;
+            blank(&mut out, quote + 1..close);
+            index = end;
+            continue;
+        }
+        // `"…"`, `b"…"`, `c"…"`, `b'…'`.
+        let quoted = if current == '"' {
+            Some(index)
+        } else if !after_ident
+            && matches!(
+                (current, chars.get(index + 1).copied()),
+                ('b' | 'c', Some('"')) | ('b', Some('\''))
+            )
+        {
+            Some(index + 1)
+        } else {
+            None
+        };
+        if let Some(open) = quoted {
+            let close = quoted_literal_close(&chars, open)?;
+            blank(&mut out, open + 1..close);
+            index = close + 1;
+            continue;
+        }
+        if current == '\'' {
+            // `'a'` and `'\n'` are literals; `'static` and `'outer:` are not.
+            if chars.get(index + 1) == Some(&'\\') || chars.get(index + 2) == Some(&'\'') {
+                let close = quoted_literal_close(&chars, index)?;
+                blank(&mut out, index + 1..close);
+                index = close + 1;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        index += 1;
+    }
+    Ok(out.into_iter().collect())
+}
+
+/// If a raw literal starts at `start`, its opening quote index and hash count.
+fn raw_literal_open(chars: &[char], start: usize) -> Option<(usize, usize)> {
+    let mut index = start;
+    if matches!(chars.get(index), Some('b' | 'c')) {
+        index += 1;
+    }
+    if chars.get(index) != Some(&'r') {
+        return None;
+    }
+    index += 1;
+    let hashes_start = index;
+    while chars.get(index) == Some(&'#') {
+        index += 1;
+    }
+    // `r#type` is a raw identifier, not a raw string.
+    (chars.get(index) == Some(&'"')).then(|| (index, index - hashes_start))
+}
+
+/// The closing quote index and the index just past the closing hashes.
+fn raw_literal_close(
+    chars: &[char],
+    quote: usize,
+    hashes: usize,
+) -> Result<(usize, usize), String> {
+    let mut index = quote + 1;
+    while index < chars.len() {
+        if chars[index] == '"'
+            && chars[index + 1..]
+                .iter()
+                .take(hashes)
+                .filter(|c| **c == '#')
+                .count()
+                == hashes
+        {
+            return Ok((index, index + 1 + hashes));
+        }
+        index += 1;
+    }
+    Err("unterminated raw literal".to_owned())
+}
+
+/// The closing delimiter index of the escaped literal opened at `open`.
+fn quoted_literal_close(chars: &[char], open: usize) -> Result<usize, String> {
+    let delimiter = chars[open];
+    let mut index = open + 1;
+    while index < chars.len() {
+        match chars[index] {
+            '\\' => index += 2,
+            c if c == delimiter => return Ok(index),
+            _ => index += 1,
+        }
+    }
+    Err(format!("unterminated {delimiter} literal"))
+}
+
+/// Blank every `#[cfg(test)]`-gated item in already-masked source.
+fn strip_cfg_test(masked: &str) -> Result<String, String> {
+    let chars: Vec<char> = masked.chars().collect();
+    let mut out = chars.clone();
+    let marker: Vec<char> = CFG_TEST.chars().collect();
+    let mut index = 0;
+    while index + marker.len() <= chars.len() {
+        if chars[index..index + marker.len()] != marker[..] {
+            index += 1;
+            continue;
+        }
+        let attribute_end = index + marker.len();
+        match gated_region_end(&chars, attribute_end)? {
+            // A gated item: drop the attribute and everything it gates.
+            Some(end) => {
+                blank(&mut out, index..end);
+                index = end;
+            }
+            // A gated field, variant, arm, or statement: there is no scope to
+            // exclude, and everything after it is still production code.
+            None => {
+                blank(&mut out, index..attribute_end);
+                index = attribute_end;
+            }
+        }
+    }
+    Ok(out.into_iter().collect())
+}
+
+/// Where the item gated by a `#[cfg(test)]` ending at `from` stops, or `None`
+/// when the attribute gates something that owns no scope.
+fn gated_region_end(chars: &[char], from: usize) -> Result<Option<usize>, String> {
+    let mut index = skip_whitespace(chars, from);
+    // Attributes stacked on the same item, e.g. `#[cfg(test)] #[derive(Debug)]`.
+    while chars.get(index) == Some(&'#') {
+        let open = skip_whitespace(chars, index + 1);
+        if chars.get(open) != Some(&'[') {
+            break;
+        }
+        index = skip_whitespace(chars, matching_delimiter(chars, open)? + 1);
+    }
+    // A bare gated block: `#[cfg(test)] { true }`.
+    if chars.get(index) == Some(&'{') {
+        return Ok(Some(matching_delimiter(chars, index)? + 1));
+    }
+    let mut keyword = read_ident(chars, index);
+    if keyword == "pub" {
+        index = skip_whitespace(chars, index + keyword.len());
+        if chars.get(index) == Some(&'(') {
+            index = skip_whitespace(chars, matching_delimiter(chars, index)? + 1);
+        }
+        keyword = read_ident(chars, index);
+    }
+    if !ITEM_KEYWORDS.contains(&keyword.as_str()) {
+        return Ok(None);
+    }
+    while index < chars.len() {
+        match chars[index] {
+            // Generic bounds, argument lists, and array types can hold both `;`
+            // and `{`; skipping them balanced keeps the search at item level.
+            '(' | '[' => index = matching_delimiter(chars, index)? + 1,
+            '{' => return Ok(Some(matching_delimiter(chars, index)? + 1)),
+            ';' => return Ok(Some(index + 1)),
+            _ => index += 1,
+        }
+    }
+    Err(format!(
+        "the #[cfg(test)] item at char {from} has neither a body nor a terminator"
+    ))
+}
+
+fn matching_delimiter(chars: &[char], open: usize) -> Result<usize, String> {
+    let mut stack: Vec<char> = Vec::new();
+    for (offset, current) in chars.iter().enumerate().skip(open) {
+        match current {
+            '(' => stack.push(')'),
+            '[' => stack.push(']'),
+            '{' => stack.push('}'),
+            ')' | ']' | '}' => match stack.pop() {
+                Some(expected) if expected == *current => {
+                    if stack.is_empty() {
+                        return Ok(offset);
+                    }
+                }
+                _ => return Err(format!("unbalanced delimiter at char {offset}")),
+            },
+            _ => {}
+        }
+    }
+    Err(format!("unclosed delimiter at char {open}"))
+}
+
+fn skip_whitespace(chars: &[char], from: usize) -> usize {
+    let mut index = from;
+    while chars.get(index).is_some_and(|c| c.is_whitespace()) {
+        index += 1;
+    }
+    index
+}
+
+fn read_ident(chars: &[char], from: usize) -> String {
+    chars
+        .get(from..)
+        .unwrap_or_default()
+        .iter()
+        .take_while(|c| is_ident_char(**c))
+        .collect()
+}
+
+// ── Self-tests for the primitives above ──────────────────────────────────────
+//
+// Without these, "ignores comments" and "ignores everything" are
+// indistinguishable from a green run.
+
+/// The predicate the two source guards are built from.
+fn production_import(source: &str, crate_ident: &str) -> bool {
+    let code = production_code(source).expect("the fixture is scannable");
+    declares_use_of_crate(&code, crate_ident)
+}
+
+#[test]
+fn a_real_production_import_is_an_offence() {
+    assert!(production_import(
+        "use djinn_agent::context::AgentContext;\nfn main() {}\n",
+        "djinn_agent"
+    ));
+    assert!(production_import(
+        "use djinn_agent::{context, roles};\n",
+        "djinn_agent"
+    ));
+    assert!(production_import("use djinn_agent;\n", "djinn_agent"));
+    assert!(production_import(
+        "use djinn_agent as agent;\n",
+        "djinn_agent"
+    ));
+    assert!(production_import(
+        "pub use ::djinn_agent::context;\n",
+        "djinn_agent"
+    ));
+}
+
+#[test]
+fn a_comment_or_a_string_naming_the_import_is_not_an_offence() {
+    assert!(!production_import(
+        "//! Mirrors `use djinn_agent::context;` without the dependency.\n",
+        "djinn_agent"
+    ));
+    assert!(!production_import(
+        "// use djinn_agent::context::AgentContext;\nfn main() {}\n",
+        "djinn_agent"
+    ));
+    assert!(!production_import(
+        "/* use djinn_agent::context; */\nfn main() {}\n",
+        "djinn_agent"
+    ));
+    assert!(!production_import(
+        "const BANNED: &str = \"use djinn_agent::context;\";\n",
+        "djinn_agent"
+    ));
+    assert!(!production_import(
+        "const BANNED: &str = r#\"use djinn_agent::context;\"#;\n",
+        "djinn_agent"
+    ));
+}
+
+#[test]
+fn a_trailing_comment_does_not_launder_the_import_in_front_of_it() {
+    assert!(production_import(
+        "use djinn_agent::context; // test-only, honest\n",
+        "djinn_agent"
+    ));
+}
+
+#[test]
+fn a_sibling_crate_with_a_shared_prefix_is_not_an_offence() {
+    let source = "use djinn_agent_worker::cargo_incremental_prune::WarmWorkPhase;\n";
+    assert!(!production_import(source, "djinn_agent"));
+    assert!(production_import(source, "djinn_agent_worker"));
+}
+
+#[test]
+fn a_cfg_test_import_is_excluded_but_production_code_after_it_is_not() {
+    // The `check-resize-reachability.sh` blind spot: a scan that stops at the
+    // first `#[cfg(test)]` marker never sees anything below it.
+    let gated_only = "\
+#[cfg(test)]
+mod tests {
+    use djinn_agent::context::AgentContext;
+    fn helper() {}
+}
+fn production() {}
+";
+    assert!(!production_import(gated_only, "djinn_agent"));
+
+    let gated_then_production = "\
+#[cfg(test)]
+mod tests {
+    use djinn_slot::SlotHandle;
+}
+use djinn_agent::context::AgentContext;
+fn production() {}
+";
+    assert!(production_import(gated_then_production, "djinn_agent"));
+}
+
+#[test]
+fn a_cfg_test_field_or_declaration_does_not_swallow_the_code_after_it() {
+    let field = "\
+struct Config {
+    #[cfg(test)]
+    test_use_live_credential_resolution: bool,
+    real: bool,
+}
+use djinn_agent::context::AgentContext;
+";
+    assert!(production_import(field, "djinn_agent"));
+
+    let declaration = "\
+#[cfg(test)]
+mod slow_tests;
+use djinn_agent::context::AgentContext;
+";
+    assert!(production_import(declaration, "djinn_agent"));
+
+    let statement = "\
+fn dispatch() {
+    #[cfg(test)]
+    observe_dispatch_cap_count(stage, count);
+    commit();
+}
+use djinn_agent::context::AgentContext;
+";
+    assert!(production_import(statement, "djinn_agent"));
+}
+
+#[test]
+fn braces_inside_literals_do_not_perturb_cfg_test_ranges() {
+    let source = "\
+#[cfg(test)]
+mod tests {
+    const METRIC: &str = \"djinn_taskrun_jobs_started_total{\";
+    const RAW: &str = r#\"#[cfg(test)] mod nested {\"#;
+    const CH: char = '}';
+}
+use djinn_agent::context::AgentContext;
+";
+    assert!(production_import(source, "djinn_agent"));
+}
+
+#[test]
+fn lifetimes_are_not_mistaken_for_character_literals() {
+    let source = "\
+struct Borrowed<'a> { name: &'a str }
+impl<'a> Borrowed<'a> {
+    fn label(&self) -> &'static str { \"x\" }
+}
+use djinn_agent::context::AgentContext;
+";
+    assert!(production_import(source, "djinn_agent"));
+}
+
+#[test]
+fn the_test_only_path_filter_covers_nested_test_trees() {
+    for excluded in [
+        "tests/boundary.rs",
+        "cargo_warm_base_gc/tests/pressure_execution.rs",
+        "dispatch/tests.rs",
+        "resize_lift_tests.rs",
+        "dispatch/admission_test.rs",
+        "test_helpers.rs",
+    ] {
+        assert!(
+            is_test_only_path(Path::new(excluded)),
+            "{excluded} must be treated as test-only"
+        );
+    }
+    for included in [
+        "lib.rs",
+        "dispatch/session_recovery.rs",
+        "cargo_warm_base_gc/pressure.rs",
+        "latest_attempt.rs",
+    ] {
+        assert!(
+            !is_test_only_path(Path::new(included)),
+            "{included} must be treated as production"
+        );
+    }
+}
+
+#[test]
+fn an_unresolvable_source_is_reported_rather_than_reported_clean() {
+    assert!(production_code("const OPEN: &str = \"unterminated;\n").is_err());
+    assert!(production_code("#[cfg(test)]\nmod tests {\n").is_err());
 }

--- a/server/crates/djinn-coordinator/src/tests/raw_signal_bypass_guard.rs
+++ b/server/crates/djinn-coordinator/src/tests/raw_signal_bypass_guard.rs
@@ -6,10 +6,42 @@
 //! code that bypasses the liveness classifier and independently decides from
 //! raw pod phase, in-memory activity, or DB state alone.
 //!
+//! Every assertion here matches against PRODUCTION code only: comment bodies,
+//! literal bodies, and `#[cfg(test)]` items are removed first (see
+//! `boundary::production_code`). Matching the raw file could not do
+//! the job the module header claims. `classify_task_liveness` appears in nine
+//! comments and six `tracing` message literals in the guarded file, and
+//! `Verdict::Live` in another comment, so the entire classifier gate could be
+//! deleted from the stall path with every assertion below still green on the
+//! surviving prose. That is the `1j64` false-negative shape, and it was live
+//! here.
+//!
 //! Companion runbook: `server/docs/operational/raw-signal-bypass-audit.md`
+
+use super::boundary::production_code;
 
 /// Source of the primary session recovery consumers (stall, zombie, idle, kill).
 const SESSION_RECOVERY_SRC: &str = include_str!("../dispatch/session_recovery.rs");
+
+/// `SESSION_RECOVERY_SRC` reduced to production code.
+///
+/// A scanner failure fails the guard rather than reporting a clean file: an
+/// unscannable source is not evidence that the classifier gate is present.
+fn session_recovery_code() -> String {
+    production_code(SESSION_RECOVERY_SRC)
+        .unwrap_or_else(|error| panic!("session_recovery.rs must be scannable: {error}"))
+}
+
+/// Whether `needle` appears in the production code of `source`.
+///
+/// Extracted so the guard's own logic is testable against synthetic input —
+/// otherwise "ignores comments" and "ignores everything" are indistinguishable
+/// from a green run.
+fn production_mentions(source: &str, needle: &str) -> bool {
+    production_code(source)
+        .expect("the fixture is scannable")
+        .contains(needle)
+}
 
 // ── Session recovery classifier integration guards ────────────────────────
 
@@ -18,7 +50,7 @@ const SESSION_RECOVERY_SRC: &str = include_str!("../dispatch/session_recovery.rs
 #[test]
 fn stall_recovery_calls_classifier() {
     assert!(
-        SESSION_RECOVERY_SRC.contains("classify_task_liveness"),
+        session_recovery_code().contains("classify_task_liveness"),
         "session_recovery.rs must call classify_task_liveness for stall recovery"
     );
 }
@@ -27,13 +59,13 @@ fn stall_recovery_calls_classifier() {
 /// reap on the verdict — a `Live` or `Slow` verdict must suppress reap.
 #[test]
 fn zombie_reap_gates_on_classifier_verdict() {
+    let code = session_recovery_code();
     assert!(
-        SESSION_RECOVERY_SRC.contains("Verdict::Live")
-            || SESSION_RECOVERY_SRC.contains("Verdict::Slow"),
+        code.contains("Verdict::Live") || code.contains("Verdict::Slow"),
         "session_recovery.rs zombie reap must gate on Verdict::Live/Verdict::Slow"
     );
     assert!(
-        SESSION_RECOVERY_SRC.contains("LivenessOutcome::KillNoop"),
+        code.contains("LivenessOutcome::KillNoop"),
         "session_recovery.rs zombie reap must check LivenessOutcome::KillNoop for terminal-task races"
     );
 }
@@ -43,12 +75,13 @@ fn zombie_reap_gates_on_classifier_verdict() {
 /// for the board_health and doctor diagnostics surfaces.
 #[test]
 fn kill_paths_persist_liveness_evidence() {
+    let code = session_recovery_code();
     assert!(
-        SESSION_RECOVERY_SRC.contains("LivenessEvidenceSnapshot"),
+        code.contains("LivenessEvidenceSnapshot"),
         "session_recovery.rs must persist LivenessEvidenceSnapshot for kill paths"
     );
     assert!(
-        SESSION_RECOVERY_SRC.contains("LivenessRepository"),
+        code.contains("LivenessRepository"),
         "session_recovery.rs must use LivenessRepository for evidence persistence"
     );
 }
@@ -58,7 +91,7 @@ fn kill_paths_persist_liveness_evidence() {
 #[test]
 fn session_recovery_uses_classifier_result() {
     assert!(
-        SESSION_RECOVERY_SRC.contains("ClassificationResult"),
+        session_recovery_code().contains("ClassificationResult"),
         "session_recovery.rs must use ClassificationResult from the classifier"
     );
 }
@@ -68,7 +101,7 @@ fn session_recovery_uses_classifier_result() {
 #[test]
 fn session_exit_liveness_classification_exists() {
     assert!(
-        SESSION_RECOVERY_SRC.contains("classify_session_exit_liveness"),
+        session_recovery_code().contains("classify_session_exit_liveness"),
         "session_recovery.rs must have classify_session_exit_liveness for exit-time protocol violation detection"
     );
 }
@@ -77,9 +110,172 @@ fn session_exit_liveness_classification_exists() {
 /// enum rather than raw string comparisons on DB fields.
 #[test]
 fn session_recovery_imports_verdict_enum() {
+    let code = session_recovery_code();
     assert!(
-        SESSION_RECOVERY_SRC.contains("super::liveness::")
-            && SESSION_RECOVERY_SRC.contains("Verdict"),
+        code.contains("super::liveness::") && code.contains("Verdict"),
         "session_recovery.rs must import Verdict from the liveness module"
     );
+}
+
+// ── Self-tests: each needle must have a real production occurrence ───────────
+
+/// Every needle above must survive comment, literal, and `#[cfg(test)]`
+/// stripping in the guarded file.
+///
+/// A presence assertion whose needle only ever appeared in prose is already
+/// vacuous, and tightening the matcher would only convert a silent pass into a
+/// silent failure. This names the needles so that regression is loud.
+#[test]
+fn every_guarded_needle_has_a_production_occurrence_today() {
+    let code = session_recovery_code();
+    let missing: Vec<&str> = [
+        "classify_task_liveness",
+        "Verdict::Live",
+        "Verdict::Slow",
+        "LivenessOutcome::KillNoop",
+        "LivenessEvidenceSnapshot",
+        "LivenessRepository",
+        "ClassificationResult",
+        "classify_session_exit_liveness",
+        "super::liveness::",
+    ]
+    .into_iter()
+    .filter(|needle| !code.contains(needle))
+    .collect();
+    assert!(
+        missing.is_empty(),
+        "these guards no longer have a production code occurrence to assert on, so they \
+         are vacuous rather than green: {missing:?}"
+    );
+}
+
+/// The pre-fix guard's exact failure mode, demonstrated against the real file.
+///
+/// Rename every non-comment occurrence of `classify_task_liveness` — the whole
+/// classifier gate, calls and definition alike — and the old
+/// `SESSION_RECOVERY_SRC.contains(…)` assertion still passes on the surviving
+/// comments. The fixed predicate goes false. If this test ever stops holding
+/// because the comments were deleted, the guard is no weaker; it is this
+/// demonstration that has expired.
+#[test]
+fn the_old_whole_file_match_survived_deleting_every_real_call() {
+    const NEEDLE: &str = "classify_task_liveness";
+    let mutated = SESSION_RECOVERY_SRC
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("//") {
+                line.to_owned()
+            } else {
+                line.replace(NEEDLE, "decide_from_raw_signals")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        mutated.contains(NEEDLE),
+        "the demonstration needs at least one comment still naming {NEEDLE}"
+    );
+    assert!(
+        !production_mentions(&mutated, NEEDLE),
+        "the guard must not accept a comment as evidence that {NEEDLE} is called"
+    );
+}
+
+#[test]
+fn a_needle_in_production_code_is_seen() {
+    let source = "\
+async fn recover(&self, task_id: &str) {
+    let classification = self.classify_task_liveness(task_id).await;
+}
+";
+    assert!(production_mentions(source, "classify_task_liveness"));
+}
+
+#[test]
+fn a_needle_only_in_a_comment_or_a_log_message_does_not_satisfy_the_guard() {
+    // These are the exact shapes present in `session_recovery.rs` today.
+    let comment = "\
+async fn recover(&self) {
+    // classify_task_liveness already persisted the KillNoop evidence.
+    self.reap().await;
+}
+";
+    assert!(!production_mentions(comment, "classify_task_liveness"));
+
+    let doc = "\
+/// Runs [`super::liveness::classify`] and returns a `ClassificationResult`.
+async fn recover(&self) {}
+";
+    assert!(!production_mentions(doc, "ClassificationResult"));
+
+    let log = "\
+async fn recover(&self) {
+    tracing::warn!(\"classify_task_liveness: pool query failed\");
+}
+";
+    assert!(!production_mentions(log, "classify_task_liveness"));
+}
+
+#[test]
+fn a_trailing_comment_does_not_launder_the_call_in_front_of_it() {
+    let source = "\
+async fn recover(&self, task_id: &str) {
+    self.classify_task_liveness(task_id).await; // consulted, not trusted
+}
+";
+    assert!(production_mentions(source, "classify_task_liveness"));
+}
+
+#[test]
+fn a_needle_only_inside_a_cfg_test_module_does_not_satisfy_the_guard() {
+    let source = "\
+async fn recover(&self) {
+    self.reap().await;
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn classification() {
+        let result = super::super::liveness::classify(&evidence);
+        assert_eq!(result.verdict, Verdict::Live);
+    }
+}
+";
+    assert!(!production_mentions(source, "Verdict::Live"));
+}
+
+#[test]
+fn production_code_after_a_cfg_test_module_still_counts() {
+    // The `check-resize-reachability.sh` blind spot, in the presence direction:
+    // a scan that stops at the first `#[cfg(test)]` marker reports the real call
+    // below it as missing.
+    let source = "\
+#[cfg(test)]
+mod fixtures {
+    fn evidence() -> LivenessEvidence { LivenessEvidence::default() }
+}
+
+async fn recover(&self, task_id: &str) {
+    let classification = self.classify_task_liveness(task_id).await;
+}
+";
+    assert!(production_mentions(source, "classify_task_liveness"));
+}
+
+#[test]
+fn a_cfg_test_field_does_not_swallow_the_production_call_after_it() {
+    let source = "\
+struct Recovery {
+    #[cfg(test)]
+    test_use_live_credential_resolution: bool,
+    db: Db,
+}
+
+async fn recover(&self, task_id: &str) {
+    let classification = self.classify_task_liveness(task_id).await;
+}
+";
+    assert!(production_mentions(source, "classify_task_liveness"));
 }

--- a/server/crates/djinn-provider/tests/stream_event_consumer_audit.rs
+++ b/server/crates/djinn-provider/tests/stream_event_consumer_audit.rs
@@ -681,7 +681,50 @@ fn checked_in_classification_covers_every_production_stream_event_match() {
     assert!(!FIXTURE.contains("direct_services.rs::invoke_llm#1"));
     assert!(!FIXTURE.contains("direct_services.rs::collect_planner_stream#1"));
     assert!(
-        FIXTURE.contains("no behavioral claim")
-            || include_str!("stream_event_consumer_audit.rs").contains("no behavioral claim")
+        fixture_header_disclaims_behavioral_coverage(FIXTURE),
+        "the fixture's header must tell the next reader that these rows are an \
+         inventory, not coverage; the disclaimer belongs in the file a reader opens"
     );
+}
+
+/// The disclaimer the fixture header must carry, in the words it uses today.
+const FIXTURE_DISCLAIMER: &str = "not a behavioral claim";
+
+/// Whether `fixture`'s leading comment block disclaims behavioral coverage.
+///
+/// The predicate this replaced was
+/// `FIXTURE.contains("no behavioral claim") || include_str!(<this file>)
+/// .contains("no behavioral claim")`. The fixture has never contained that
+/// phrase — it says "not a behavioral claim" — so the left arm was always
+/// false, and the right arm read this test file into itself, where the phrase
+/// occurs twice: in the module doc on line 1 and in the assertion's own string
+/// literal. The assertion was therefore unconditionally true and could never
+/// fail for any state of either file.
+///
+/// The self-read is gone rather than made self-proof: the claim is about the
+/// FIXTURE, and only the fixture should be able to satisfy or break it. The
+/// match is restricted to the leading `#` header so a data row's classification
+/// text cannot stand in for the header a reader actually sees.
+fn fixture_header_disclaims_behavioral_coverage(fixture: &str) -> bool {
+    fixture
+        .lines()
+        .take_while(|line| line.starts_with('#'))
+        .any(|line| line.contains(FIXTURE_DISCLAIMER))
+}
+
+#[test]
+fn the_fixture_disclaimer_guard_reads_the_fixture_header_and_nothing_else() {
+    assert!(fixture_header_disclaims_behavioral_coverage(
+        "# rows are static evidence, not a behavioral claim\nsite\tarms\n"
+    ));
+    // Removing the header line must fail the guard.
+    assert!(!fixture_header_disclaims_behavioral_coverage(
+        "# site identifier\tall StreamEvent arms at this site\nsite\tarms\n"
+    ));
+    // A data row cannot stand in for the header.
+    assert!(!fixture_header_disclaims_behavioral_coverage(
+        "# site identifier\tall StreamEvent arms at this site\nsite\tnot a behavioral claim\n"
+    ));
+    // An empty fixture is not a disclaimed one.
+    assert!(!fixture_header_disclaims_behavioral_coverage(""));
 }

--- a/server/tests/task_run_resize_cycles.rs
+++ b/server/tests/task_run_resize_cycles.rs
@@ -187,6 +187,112 @@ fn read_repo_file(relative: &str) -> String {
         .unwrap_or_else(|error| panic!("read {relative}: {error}"))
 }
 
+/// `text` with whole-line comments removed.
+///
+/// Copied from `server/tests/task_run_resize_kind.rs`, whose doc comment is the
+/// canonical statement of this defect class. These are separate test binaries,
+/// so the helper is duplicated rather than shared. The rule: a comment cannot
+/// call a function, set a variable or arm a workflow step, so it must neither
+/// satisfy a positive assertion nor trip a negative one. Both directions have
+/// bitten this campaign — this suite's own teardown-trap guard matched prose in
+/// a header and stayed green when the real `trap` line was deleted.
+///
+/// Only WHOLE-line comments are dropped, deliberately: a trailing comment must
+/// not be able to launder the code in front of it.
+fn code_lines(text: &str, comment_prefix: &str) -> String {
+    text.lines()
+        .filter(|line| !line.trim_start().starts_with(comment_prefix))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// [`code_lines`] for Rust. Covers `//`, `///` and `//!`.
+fn rust_code(source: &str) -> String {
+    code_lines(source, "//")
+}
+
+/// [`code_lines`] for shell and YAML, which share the `#` comment marker.
+fn script_code(text: &str) -> String {
+    code_lines(text, "#")
+}
+
+// ---------------------------------------------------------------------------
+// The predicates the source gates below rest on.
+//
+// Each is split out from its guard so the guard's logic is testable against
+// synthetic input: otherwise "ignores comments" and "ignores everything" are
+// indistinguishable from a green run. Every needle is assembled at compile time
+// because the subject of these gates is THE FILE THEY LIVE IN — a needle spelled
+// literally on its own assertion line is satisfied by that line and can never
+// fail. The `ban` needles here already used this trick; the `presence` ones did
+// not, which is the defect this split repairs.
+// ---------------------------------------------------------------------------
+
+/// The CODE lines of `source` that name the regular container-status list.
+///
+/// `initContainerStatuses` is deliberately not a match: the forbidden spelling
+/// has a lower-case `c` where that token has a capital one.
+fn regular_status_list_code_lines(source: &str) -> Vec<String> {
+    let needle = concat!("container", "Statuses");
+    rust_code(source)
+        .lines()
+        .filter(|line| line.contains(needle))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Whether `source` confirms a limit through the PRODUCTION reader, in code.
+fn calls_the_production_confirmation_reader(source: &str) -> bool {
+    rust_code(source).contains(concat!("confirm_launcher", "_cpu("))
+}
+
+/// Whether `source` reads `cpu.weight` as a PATH under a cgroup directory.
+fn reads_cpu_weight_as_a_cgroup_path(source: &str) -> bool {
+    rust_code(source).contains(concat!("/cpu", ".weight"))
+}
+
+/// The CODE line, if any, that derives `cpu.weight` from a request value.
+fn cpu_weight_derived_from_a_request(source: &str) -> Option<String> {
+    let needle = concat!("cpu", ".weight");
+    rust_code(source)
+        .lines()
+        .find(|line| line.contains(needle) && line.contains("requests"))
+        .map(str::to_owned)
+}
+
+/// Whether `source` reads the weight at BOTH the node and the launcher.
+///
+/// The two helper names must appear on a line that also names the cgroup file,
+/// so the helpers' own definitions do not satisfy this: only a call that reads
+/// `cpu.weight` through them does.
+fn reads_the_weight_at_both_sites(source: &str) -> bool {
+    let weight = concat!("cpu", ".weight");
+    let code = rust_code(source);
+    let reads: Vec<&str> = code.lines().filter(|line| line.contains(weight)).collect();
+    reads
+        .iter()
+        .any(|line| line.contains(concat!("node", "_read(")))
+        && reads
+            .iter()
+            .any(|line| line.contains(concat!("launcher", "_read(")))
+}
+
+/// Whether `source` parses the NODE's own allocation table.
+fn parses_the_node_allocation_table(source: &str) -> bool {
+    let code = rust_code(source);
+    code.contains(concat!("\"describe\", ", "\"node\""))
+        && code.contains(concat!("Allocated ", "resources"))
+}
+
+/// Whether `source` INVOKES the shared setup script rather than merely naming it.
+///
+/// The predecessor of this predicate was `source.contains(SETUP_SCRIPT)`, which
+/// the constant's own declaration satisfies: it could not fail while the file
+/// compiled.
+fn invokes_the_shared_setup_script(source: &str) -> bool {
+    rust_code(source).contains(concat!(".arg(repo_root().join(SETUP", "_SCRIPT))"))
+}
+
 fn run_setup_script(args: &[&str]) -> Output {
     Command::new("bash")
         .arg(repo_root().join(SETUP_SCRIPT))
@@ -272,8 +378,8 @@ fn guard_the_harness_is_disjoint_and_reuses_the_shared_script() {
     );
     let source = read_repo_file(THIS_FILE);
     assert!(
-        source.contains(SETUP_SCRIPT),
-        "this suite must name the shared setup script"
+        invokes_the_shared_setup_script(&source),
+        "this suite must INVOKE the shared setup script, passing it to a `Command`. Merely NAMING it was the previous assertion, and the constant's own declaration satisfied that unconditionally."
     );
     assert!(
         !repo_root()
@@ -392,15 +498,7 @@ fn guard_the_kubernetes_floor_is_enforced() {
 #[test]
 fn guard_confirmation_never_reads_container_statuses() {
     let source = read_repo_file(THIS_FILE);
-    // Built by concatenation so this guard's own text is not a hit.
-    let needle = concat!("container", "Statuses");
-    let hits: Vec<&str> = source
-        .lines()
-        .filter(|line| line.contains(needle))
-        .filter(|line| !line.trim_start().starts_with("//!"))
-        .filter(|line| !line.trim_start().starts_with("///"))
-        .filter(|line| !line.trim_start().starts_with("//"))
-        .collect();
+    let hits = regular_status_list_code_lines(&source);
     assert_eq!(
         hits.len(),
         1,
@@ -412,8 +510,8 @@ fn guard_confirmation_never_reads_container_statuses() {
         hits[0]
     );
     assert!(
-        source.contains("confirm_launcher_cpu("),
-        "confirmation must go through the PRODUCTION reader, which reads status.initContainerStatuses[name=cgroup-launcher] and nothing else"
+        calls_the_production_confirmation_reader(&source),
+        "confirmation must go through the PRODUCTION reader, which reads the init-container status list and nothing else"
     );
 }
 
@@ -427,7 +525,10 @@ fn guard_confirmation_never_reads_container_statuses() {
 /// checks still exists is an assumption. This guard checks.
 #[test]
 fn guard_the_misleading_status_fixture_still_exists_and_is_run() {
-    let sibling = read_repo_file(PCOD_SUITE);
+    // Both proof names are also spelled in that suite's doc comments, so a raw
+    // `contains` stays green after the tests themselves are deleted. Only the
+    // `fn` definitions count.
+    let sibling = rust_code(&read_repo_file(PCOD_SUITE));
     for proof in [
         "the_misleading_container_status_is_not_confirmation",
         "live_the_absent_init_status_is_not_confirmed",
@@ -437,7 +538,9 @@ fn guard_the_misleading_status_fixture_still_exists_and_is_run() {
             "{PCOD_SUITE} no longer carries `{proof}`. This suite's confirmation reads defer to it for the live half of AC6; if it moved, point this guard at its new home rather than deleting the guard."
         );
     }
-    let workflow = read_repo_file(WORKFLOW);
+    // The workflow's own header comment names that suite too; a commented-out
+    // step must not stand in for an armed one.
+    let workflow = script_code(&read_repo_file(WORKFLOW));
     assert!(
         workflow.contains("task_run_resize_kind"),
         "the live misleading-status fixture is no longer invoked by any lane"
@@ -451,24 +554,16 @@ fn guard_the_misleading_status_fixture_still_exists_and_is_run() {
 fn guard_cpu_weight_is_read_from_the_cgroup_file() {
     let source = read_repo_file(THIS_FILE);
     assert!(
-        source.contains("/cpu.weight"),
-        "cpu.weight must be read as a PATH under a cgroup directory"
+        reads_cpu_weight_as_a_cgroup_path(&source),
+        "the weight must be read as a PATH under a cgroup directory"
     );
-    for line in source.lines() {
-        if !line.contains("cpu.weight") {
-            continue;
-        }
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("//") {
-            continue;
-        }
-        assert!(
-            !line.contains("requests"),
-            "cpu.weight must never be derived from a request value: {line}"
-        );
-    }
+    assert_eq!(
+        cpu_weight_derived_from_a_request(&source),
+        None,
+        "the weight must never be derived from a request value"
+    );
     assert!(
-        source.contains("node_read(") && source.contains("launcher_read("),
+        reads_the_weight_at_both_sites(&source),
         "the weight must be read at BOTH the pod slice (on the node) and the launcher container"
     );
 }
@@ -479,12 +574,8 @@ fn guard_cpu_weight_is_read_from_the_cgroup_file() {
 fn guard_node_allocation_is_read_from_the_node() {
     let source = read_repo_file(THIS_FILE);
     assert!(
-        source.contains("\"describe\", \"node\""),
-        "the Node's own allocated-resources view is what must be read; a sum over Pod specs is the INPUT to that accounting, not the accounting"
-    );
-    assert!(
-        source.contains("Allocated resources"),
-        "the parser must be anchored on the Node's Allocated resources section"
+        parses_the_node_allocation_table(&source),
+        "the Node's own allocated-resources view is what must be read, and the parser must be anchored on that section's heading. A sum over Pod specs is the INPUT to that accounting, not the accounting."
     );
 }
 
@@ -523,7 +614,7 @@ fn guard_the_resize_patch_touches_only_the_launcher_cpu_limit() {
 
     // Strategic, not merge: `Patch::Merge` on this shape answers
     // `limits: Forbidden: resource limits cannot be removed`.
-    let source = read_repo_file(THIS_FILE);
+    let source = rust_code(&read_repo_file(THIS_FILE));
     assert!(
         source.contains("\"strategic\""),
         "the PATCH must be strategic; the initContainers array carries patchMergeKey: name and a JSON-merge body would replace the whole array"
@@ -572,7 +663,9 @@ fn the_no_retirement_gate_passes_and_its_self_test_is_green() {
 /// unconditional teardown.
 #[test]
 fn guard_the_live_lane_is_wired() {
-    let workflow = read_repo_file(WORKFLOW);
+    // Comment-stripped: a step that is commented out arms nothing, and this
+    // workflow's prose already names the job, the suite and the cluster.
+    let workflow = script_code(&read_repo_file(WORKFLOW));
     for needle in [
         "resize-cycles",
         HARNESS_CLUSTER,
@@ -599,11 +692,199 @@ fn guard_the_live_lane_is_wired() {
 
     // The suite's own count of live proofs, so deleting one fails the ordinary
     // PR lane rather than silently shrinking the dispatch lane.
-    let source = read_repo_file(THIS_FILE);
+    let source = rust_code(&read_repo_file(THIS_FILE));
     let live_proofs = source.matches("#[ignore = \"live:").count();
     assert_eq!(
         live_proofs, 1,
         "this suite declares {live_proofs} live proofs; the workflow and this guard both expect 1"
+    );
+}
+
+// ===========================================================================
+// The gates' own self-tests.
+//
+// A source gate that ignores comments and a source gate that ignores everything
+// look identical from a green run. Each predicate above is therefore driven
+// against synthetic input here, in BOTH directions.
+//
+// Two mutations, not one. A PRESENCE assertion is mutated by REMOVING the
+// required call — swapping it for a different valid token proves nothing about a
+// ban. A BAN is mutated by ADDING the banned token while LEAVING the required
+// one in place, or it is the presence arm that goes red and the ban is still
+// untested.
+// ===========================================================================
+
+#[test]
+fn a_whole_line_comment_is_not_code_but_a_trailing_one_does_not_launder_the_line() {
+    assert_eq!(rust_code("a\n// b\n  /// c\n//! d\ne"), "a\ne");
+    assert_eq!(
+        rust_code("call(); // and why"),
+        "call(); // and why",
+        "a trailing comment must NOT drop the code in front of it: `foo(); // banned` still calls foo"
+    );
+    assert_eq!(
+        script_code("run: x\n# note\n  # indented\nrun: y"),
+        "run: x\nrun: y"
+    );
+}
+
+#[test]
+fn the_confirmation_reader_gate_reads_calls_and_not_prose() {
+    let call = concat!("confirm_launcher", "_cpu(parsed, target).unwrap();");
+    assert!(
+        calls_the_production_confirmation_reader(&format!("fn f() {{\n    {call}\n}}\n")),
+        "a real call must satisfy the gate"
+    );
+    assert!(
+        !calls_the_production_confirmation_reader(&format!("fn f() {{\n    // {call}\n}}\n")),
+        "a commented-out call must NOT satisfy the gate; that is how a deleted confirmation stays green"
+    );
+    assert!(
+        !calls_the_production_confirmation_reader(&format!(
+            "//! confirmation goes through {call}\nfn f() {{}}\n"
+        )),
+        "a doc comment naming the reader must NOT satisfy the gate"
+    );
+    assert!(
+        calls_the_production_confirmation_reader(&format!("fn f() {{\n    {call} // AC6\n}}\n")),
+        "a trailing comment must not hide the real call in front of it"
+    );
+}
+
+#[test]
+fn the_regular_status_list_gate_fires_on_code_and_not_on_a_comment() {
+    // The BAN mutation ADDS the forbidden read; the permitted STATUS_LISTS
+    // mention stays exactly where it is, so what goes red can only be the ban.
+    let permitted = concat!(
+        "const STATUS_LISTS: [&str; 2] = [\"initContainer",
+        "Statuses\", \"container",
+        "Statuses\"];"
+    );
+    let offending = concat!("    let s = &pod[\"status\"][\"container", "Statuses\"];");
+
+    assert_eq!(
+        regular_status_list_code_lines(permitted).len(),
+        1,
+        "the permitted constant is one hit"
+    );
+    assert_eq!(
+        regular_status_list_code_lines(&format!("{permitted}\n{offending}\n")).len(),
+        2,
+        "a real read of the regular list must be a SECOND hit, which is what reds the gate"
+    );
+    assert_eq!(
+        regular_status_list_code_lines(&format!("{permitted}\n    // {offending}\n")).len(),
+        1,
+        "a comment naming the forbidden list must not red the gate"
+    );
+    assert_eq!(
+        regular_status_list_code_lines(&format!("{permitted}\n{offending} // stale\n")).len(),
+        2,
+        "a trailing comment must not launder a real read"
+    );
+    assert!(
+        regular_status_list_code_lines(concat!(
+            "let s = &pod[\"status\"][\"initContainer",
+            "Statuses\"];"
+        ))
+        .is_empty(),
+        "the init-container list is the PERMITTED confirmation site and must never be a hit"
+    );
+}
+
+#[test]
+fn the_cpu_weight_gates_read_the_cgroup_file_and_ignore_comments() {
+    let real = concat!(
+        "    let w = node",
+        "_read(node, \"/sys/fs/cgroup/cpu",
+        ".weight\");"
+    );
+    let derived = concat!("    let w = spec.resources.requests.cpu", ".weight;");
+
+    assert!(reads_cpu_weight_as_a_cgroup_path(real));
+    assert!(
+        !reads_cpu_weight_as_a_cgroup_path(&format!("// {real}")),
+        "a commented-out read must not satisfy the path requirement"
+    );
+    assert!(
+        reads_cpu_weight_as_a_cgroup_path(&format!("{real} // AC4")),
+        "a trailing comment must not hide the real read"
+    );
+
+    // The BAN mutation ADDS the request-derived line and KEEPS the cgroup read.
+    assert_eq!(cpu_weight_derived_from_a_request(real), None);
+    assert!(
+        cpu_weight_derived_from_a_request(&format!("{real}\n{derived}\n")).is_some(),
+        "deriving the weight from a request value must be caught even when a real cgroup read is also present"
+    );
+    assert_eq!(
+        cpu_weight_derived_from_a_request(&format!("{real}\n// {derived}\n")),
+        None,
+        "a comment explaining why requests are the wrong source must not red the gate"
+    );
+    assert!(
+        cpu_weight_derived_from_a_request(&format!("{derived} // legacy\n")).is_some(),
+        "a trailing comment must not launder a request-derived weight"
+    );
+}
+
+#[test]
+fn the_both_sites_and_node_table_gates_ignore_comments() {
+    let both = concat!(
+        "    a = node",
+        "_read(n, &format!(\"{slice}/cpu",
+        ".weight\"));\n    b = launcher",
+        "_read(pod, \"/sys/fs/cgroup/cpu",
+        ".weight\");"
+    );
+    assert!(reads_the_weight_at_both_sites(both));
+    assert!(
+        !reads_the_weight_at_both_sites(&both.replace("    b = launcher", "    // b = launcher")),
+        "commenting out the launcher-side read must red the gate"
+    );
+    assert!(
+        !reads_the_weight_at_both_sites(concat!(
+            "fn node",
+            "_read(n: &str, p: &str) -> String {}\nfn launcher",
+            "_read(pod: &str, p: &str) -> String {}"
+        )),
+        "the helpers' own DEFINITIONS must not satisfy the gate; only a call that reads the cgroup file does"
+    );
+
+    let table = concat!(
+        "    let d = kubectl_ok(&[\"describe\", ",
+        "\"node\", node]);\n    if line.starts_with(\"Allocated ",
+        "resources\") {}"
+    );
+    assert!(parses_the_node_allocation_table(table));
+    assert!(
+        !parses_the_node_allocation_table(&table.replace("    if line", "    // if line")),
+        "commenting out the section anchor must red the gate"
+    );
+    assert!(
+        !parses_the_node_allocation_table(concat!(
+            "//! the parser is anchored on the node's Allocated ",
+            "resources section, read via \"describe\", ",
+            "\"node\""
+        )),
+        "a doc comment describing the parser must NOT stand in for the parser"
+    );
+}
+
+#[test]
+fn the_setup_script_gate_wants_an_invocation_not_a_mention() {
+    let naming = "const SETUP_SCRIPT: &str = \"scripts/kind/setup-resize-kind-cluster.sh\";";
+    let invoking = concat!("        .arg(repo_root().join(SETUP", "_SCRIPT))");
+    assert!(
+        !invokes_the_shared_setup_script(naming),
+        "declaring the constant is not invoking the script; this is the assertion that could never fail"
+    );
+    assert!(invokes_the_shared_setup_script(&format!(
+        "{naming}\nfn r() {{\n    Command::new(\"bash\")\n{invoking}\n}}\n"
+    )));
+    assert!(
+        !invokes_the_shared_setup_script(&format!("{naming}\n    // {invoking}")),
+        "a commented-out invocation must not satisfy the gate"
     );
 }
 

--- a/server/tests/task_run_resize_mixed_version.rs
+++ b/server/tests/task_run_resize_mixed_version.rs
@@ -976,33 +976,113 @@ fn this_file() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/task_run_resize_mixed_version.rs")
 }
 
+/// `text` with whole-line comments removed.
+///
+/// Copied from `server/tests/task_run_resize_kind.rs`, whose doc comment is the
+/// canonical statement of this defect class. These are separate test binaries,
+/// so the helper is duplicated rather than shared. A comment cannot call a
+/// function, set a variable or arm a shell step, so it must neither satisfy a
+/// positive assertion nor trip a negative one. Both directions are live here:
+/// the teardown-trap gate below matched the harness script's PROSE, and the
+/// 1.29 ban below sat next to a header paragraph discussing 1.29.
+///
+/// Only WHOLE-line comments are dropped, deliberately: a trailing comment must
+/// not be able to launder the code in front of it.
+fn code_lines(text: &str, comment_prefix: &str) -> String {
+    text.lines()
+        .filter(|line| !line.trim_start().starts_with(comment_prefix))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// [`code_lines`] for Rust. Covers `//`, `///` and `//!`.
+fn rust_code(source: &str) -> String {
+    code_lines(source, "//")
+}
+
+/// [`code_lines`] for shell and YAML, which share the `#` comment marker.
+fn script_code(text: &str) -> String {
+    code_lines(text, "#")
+}
+
+/// Whether `needle` appears in the harness script's CODE rather than its prose.
+///
+/// Split out from its guard so the guard's logic is testable against synthetic
+/// input: otherwise "ignores comments" and "ignores everything" are
+/// indistinguishable from a green run.
+fn shell_code_contains(script: &str, needle: &str) -> bool {
+    script_code(script).contains(needle)
+}
+
+/// Whether the harness script really ARMS the failure-path teardown.
+///
+/// This is the `1j64` defect verbatim: delete the real `trap` line, leave
+/// `# trap cleanup_on_failure EXIT` behind, and a raw `contains` stays green
+/// while a failed `up` leaves a cluster standing.
+fn arms_the_failure_teardown(script: &str) -> bool {
+    shell_code_contains(script, "trap cleanup_on_failure EXIT")
+}
+
+/// Whether the harness script SETS the measured-false 1.29 floor.
+///
+/// The script's header discusses 1.29 at length — it has to, that is where the
+/// correction is recorded. A ban that fires on the paragraph explaining why the
+/// floor moved is a ban that argues against being told why the code is the way
+/// it is.
+fn restores_the_measured_false_floor(script: &str) -> bool {
+    shell_code_contains(script, "MIN_K8S_MINOR=29")
+}
+
+/// Whether this suite READS the one permitted confirmation site.
+///
+/// The needle is assembled at compile time AND required in indexing position,
+/// because the token is spelled in this gate's own doc comment and in its own
+/// failure message. `body.contains("initContainerStatuses")` was satisfied by
+/// those, so it could never fail.
+fn reads_the_init_container_status_list(source: &str) -> bool {
+    rust_code(source).contains(concat!("[\"initContainer", "Statuses\"]"))
+}
+
+/// The forbidden regular-container-status spelling this suite CONSTRUCTS, if any.
+fn regular_status_list_token_in(source: &str) -> Option<String> {
+    let code = rust_code(source);
+    [
+        format!("{}{}", "container", "Statuses"),
+        format!("{}_{}", "container", "statuses"),
+    ]
+    .into_iter()
+    .find(|token| code.contains(token))
+}
+
 /// **AC7, source gate.** No helper in this suite reads the regular-container
 /// status list.
 ///
-/// The forbidden token is ASSEMBLED at run time rather than written out, so this
-/// gate does not trip on itself. `initContainerStatuses` is not a match: the
+/// The forbidden token is ASSEMBLED at compile time rather than written out, so
+/// this gate does not trip on itself. `initContainerStatuses` is not a match: the
 /// forbidden spelling has a lower-case `c` that `initContainerStatuses` does not
 /// contain at that position.
+///
+/// Both halves run over CODE only. The presence half asserted
+/// `body.contains("initContainerStatuses")` against the raw file, which this
+/// paragraph, the assertion's own line and the failure message below each
+/// satisfied on their own — the gate could not fail, so "or this gate guards
+/// nothing" was exactly what it did.
 #[test]
 fn no_helper_in_this_suite_reads_the_regular_container_status_list() {
-    let forbidden = [
-        format!("{}{}", "container", "Statuses"),
-        format!("{}_{}", "container", "statuses"),
-    ];
     let body = std::fs::read_to_string(this_file()).expect("this test file is readable");
     assert!(
-        body.contains("initContainerStatuses"),
-        "the suite must actually name the ONLY confirmation site, or this gate guards nothing",
+        reads_the_init_container_status_list(&body),
+        "the suite must actually READ the ONLY confirmation site, in an indexing expression and \
+         not merely in prose, or this gate guards nothing",
     );
-    for token in forbidden {
-        assert!(
-            !body.contains(&token),
-            "`{token}` appears in this suite. Confirmation for the native sidecar comes ONLY from \
-             status.initContainerStatuses[name={LAUNCHER_CONTAINER_NAME}]; the regular-container \
-             list can carry a matching, stale or misleading entry and reading it is the defect \
-             this gate exists to prevent",
-        );
-    }
+    assert_eq!(
+        regular_status_list_token_in(&body),
+        None,
+        "the forbidden regular-container-status spelling appears in this suite's CODE. \
+         Confirmation for the native sidecar comes ONLY from the init-container status list at \
+         name={LAUNCHER_CONTAINER_NAME}; the regular-container list can carry a matching, stale or \
+         misleading entry and reading it is the defect this gate exists to prevent",
+    );
 }
 
 /// The body of the first `fn <name>` in this file, up to its closing brace at
@@ -1064,11 +1144,20 @@ fn the_managed_fields_read_is_paired_with_show_managed_fields() {
 /// **AC10, hermetic half.** The harness script exists, is disposable, refuses
 /// every sibling's target, pins its context, and cannot have its floor walked
 /// back to the measured-false 1.29.
+///
+/// Every needle below that names shell CODE is matched against
+/// [`script_code`], never the raw file. That script is heavily commented — its
+/// header explains the 1.29 correction, its usage block lists the default
+/// cluster and registry names — so the raw file satisfied most of these
+/// assertions on prose alone. The teardown trap is the sharp case: delete the
+/// real `trap` line, leave `# trap cleanup_on_failure EXIT` behind, and a raw
+/// `contains` reports an armed teardown that does not exist.
 #[test]
 fn the_kind_harness_is_disposable_and_isolated() {
     let script = repo_root().join("scripts/kind/setup-resize-matrix-cluster.sh");
-    let body = std::fs::read_to_string(&script)
+    let raw = std::fs::read_to_string(&script)
         .unwrap_or_else(|error| panic!("{} must exist: {error}", script.display()));
+    let body = script_code(&raw);
 
     assert!(
         body.contains(HARNESS_CLUSTER) && body.contains(HARNESS_REGISTRY),
@@ -1106,9 +1195,9 @@ fn the_kind_harness_is_disposable_and_isolated() {
 
     // The teardown and its proof.
     assert!(
-        body.contains("trap cleanup_on_failure EXIT"),
-        "the failure path must tear the cluster down; without the trap a failed `up` leaves a \
-         cluster behind and the host fills up",
+        arms_the_failure_teardown(&raw),
+        "the failure path must ARM the teardown trap in code; without the trap a failed `up` \
+         leaves a cluster behind and the host fills up",
     );
     assert!(
         body.contains("survived teardown"),
@@ -1125,12 +1214,137 @@ fn the_kind_harness_is_disposable_and_isolated() {
         "the epic's Kubernetes floor is 1.30",
     );
     assert!(
-        !body.contains("MIN_K8S_MINOR=29"),
+        !restores_the_measured_false_floor(&raw),
         "the 1.29 floor was measured false and corrected in #2818; it must not come back",
     );
+    // The one assertion here that is deliberately about PROSE. "Say out loud" is
+    // satisfied by a comment: the point is that a reader of the script learns why
+    // a non-kind API server is refused, and the header comment is a legitimate
+    // place to say it. Matched against the raw file on purpose.
     assert!(
-        body.contains("eks") || body.contains("EKS"),
+        raw.contains("eks") || raw.contains("EKS"),
         "the script must say out loud why a non-kind server is refused",
+    );
+}
+
+// ═══ the gates' own self-tests ═══════════════════════════════════════════════
+//
+// A source gate that ignores comments and a source gate that ignores everything
+// look identical from a green run, so each predicate above is driven against
+// synthetic input in BOTH directions.
+//
+// Two mutations, not one. A PRESENCE gate is mutated by REMOVING the required
+// call; swapping it for a different valid token reds the presence arm and proves
+// nothing about a ban. A BAN is mutated by ADDING the banned token while LEAVING
+// the required one in place.
+
+#[test]
+fn a_whole_line_comment_is_not_code_but_a_trailing_one_does_not_launder_the_line() {
+    assert_eq!(
+        script_code("set -e\n# note\n  # indented\ntrap x EXIT"),
+        "set -e\ntrap x EXIT"
+    );
+    assert_eq!(rust_code("a\n// b\n  /// c\n//! d\ne"), "a\ne");
+    assert_eq!(
+        script_code("trap cleanup_on_failure EXIT  # armed here"),
+        "trap cleanup_on_failure EXIT  # armed here",
+        "a trailing comment must NOT drop the code in front of it",
+    );
+}
+
+#[test]
+fn the_teardown_trap_gate_reads_the_trap_and_not_the_paragraph_about_it() {
+    let armed = "cleanup_on_failure() { :; }\ntrap cleanup_on_failure EXIT\n";
+    assert!(arms_the_failure_teardown(armed));
+    assert!(
+        !arms_the_failure_teardown("cleanup_on_failure() { :; }\n# trap cleanup_on_failure EXIT\n"),
+        "a commented-out trap arms nothing; this is the 1j64 defect verbatim",
+    );
+    assert!(
+        !arms_the_failure_teardown(
+            "# the failure path runs `trap cleanup_on_failure EXIT` before it creates anything\n"
+        ),
+        "prose describing the trap must not stand in for the trap",
+    );
+    assert!(
+        arms_the_failure_teardown("trap cleanup_on_failure EXIT  # before anything is created\n"),
+        "a trailing comment must not hide the real trap in front of it",
+    );
+}
+
+#[test]
+fn the_measured_false_floor_ban_fires_on_an_assignment_and_not_on_the_correction_note() {
+    // The BAN mutation ADDS the 1.29 assignment and LEAVES the 1.30 epic floor
+    // in place, so the only thing that can go red is the ban.
+    let corrected = "# the \"1.29\" older docs carried was measured false (#2818); never restore\n\
+                     # MIN_K8S_MINOR=29 here or anywhere\nEPIC_MIN_K8S_MINOR=30\nMIN_K8S_MINOR=33\n";
+    assert!(
+        !restores_the_measured_false_floor(corrected),
+        "the paragraph recording the correction must not be punished as the defect it warns about",
+    );
+    assert!(
+        restores_the_measured_false_floor(&format!("{corrected}MIN_K8S_MINOR=29\n")),
+        "a real assignment must red the ban even with the epic floor still present",
+    );
+    assert!(
+        restores_the_measured_false_floor("MIN_K8S_MINOR=29  # restored, wrongly\n"),
+        "a trailing comment must not launder a real assignment",
+    );
+    assert!(
+        shell_code_contains(corrected, "EPIC_MIN_K8S_MINOR=30"),
+        "the epic floor is set in code and must still satisfy its own presence gate",
+    );
+}
+
+#[test]
+fn the_confirmation_site_gate_reads_an_indexing_expression_and_not_prose() {
+    let real = concat!(
+        "let raw = pod_json[\"status\"][\"initContainer",
+        "Statuses\"]\n"
+    );
+    assert!(reads_the_init_container_status_list(real));
+    assert!(
+        !reads_the_init_container_status_list(&format!("    // {real}")),
+        "a commented-out read must not satisfy the gate",
+    );
+    assert!(
+        !reads_the_init_container_status_list(concat!(
+            "//! confirmation comes from status.initContainer",
+            "Statuses[name=cgroup-launcher]\n"
+        )),
+        "prose naming the confirmation site must not stand in for reading it",
+    );
+    assert!(
+        reads_the_init_container_status_list(&format!("{} // AC7", real.trim_end())),
+        "a trailing comment must not hide the real read",
+    );
+}
+
+#[test]
+fn the_regular_status_list_ban_fires_on_code_and_not_on_a_comment() {
+    // ADD the forbidden read; the permitted init-container read stays put.
+    let permitted = concat!(
+        "let raw = pod_json[\"status\"][\"initContainer",
+        "Statuses\"];\n"
+    );
+    let offending = concat!("let s = pod_json[\"status\"][\"container", "Statuses\"];\n");
+    assert_eq!(regular_status_list_token_in(permitted), None);
+    assert!(
+        regular_status_list_token_in(&format!("{permitted}{offending}")).is_some(),
+        "a real read of the regular list must red the ban with the permitted read still present",
+    );
+    assert_eq!(
+        regular_status_list_token_in(&format!("{permitted}// {offending}")),
+        None,
+        "a comment explaining why the regular list is forbidden must not red the ban",
+    );
+    assert!(
+        regular_status_list_token_in(&format!("{} // stale\n", offending.trim_end())).is_some(),
+        "a trailing comment must not launder a real read",
+    );
+    assert!(
+        reads_the_init_container_status_list(&format!("{permitted}{offending}")),
+        "the presence arm must still hold under the ban's mutation, or the two arms are confounded",
     );
 }
 

--- a/server/tests/task_run_resize_rollout.rs
+++ b/server/tests/task_run_resize_rollout.rs
@@ -1301,6 +1301,56 @@ fn read(relative: &str) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("reading {path:?}: {error}"))
 }
 
+/// `text` with whole-line comments removed.
+///
+/// Copied from `server/tests/task_run_resize_kind.rs`, whose doc comment is the
+/// canonical statement of this defect class. These are separate test binaries,
+/// so the helper is duplicated rather than shared. A comment cannot construct a
+/// value, call a method or gate a module, so it must neither satisfy a positive
+/// assertion nor trip a negative one — and both directions were live in the
+/// gates below:
+///
+/// * **False negative.** `launcher_owns_leaf_quota` is named twice in comments
+///   in `djinn-k8s/src/launcher.rs` and once in code. `cgroup.kill` and
+///   `wait_empty` are named together in one comment in the cgroup launcher.
+///   Deleting the code left every one of those retention gates green.
+/// * **False positive.** `!driver.contains("kube::")` and
+///   `!driver.contains("#[cfg(test)]")` fired on any comment that so much as
+///   mentioned the thing it was there to forbid.
+///
+/// Only WHOLE-line comments are dropped, deliberately: a trailing comment must
+/// not be able to launder the code in front of it.
+fn code_lines(text: &str, comment_prefix: &str) -> String {
+    text.lines()
+        .filter(|line| !line.trim_start().starts_with(comment_prefix))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// [`code_lines`] for Rust. Covers `//`, `///` and `//!`.
+fn rust_code(source: &str) -> String {
+    code_lines(source, "//")
+}
+
+/// Whether `needle` appears in `source`'s Rust CODE.
+///
+/// Split out from its guards so their logic is testable against synthetic
+/// input: otherwise "ignores comments" and "ignores everything" are
+/// indistinguishable from a green run.
+fn code_contains(source: &str, needle: &str) -> bool {
+    rust_code(source).contains(needle)
+}
+
+/// The retention needles of `retained` that `source` no longer carries in CODE.
+fn retention_needles_missing_from<'a>(source: &str, retained: &[&'a str]) -> Vec<&'a str> {
+    let code = rust_code(source);
+    retained
+        .iter()
+        .copied()
+        .filter(|needle| !code.contains(needle))
+        .collect()
+}
+
 /// **The production composition site.**
 ///
 /// The reachability question this repository keeps losing to is not "does the
@@ -1315,7 +1365,9 @@ fn read(relative: &str) -> String {
 /// path *can* be handed a substitute for the drain fence or the catalog.
 #[test]
 fn the_production_composition_site_wires_only_production_implementations() {
-    let driver = read("server/src/task_run_resize_rollout.rs");
+    // Comment-stripped in both directions: a doc comment must neither wire a
+    // production implementation nor make the constructor conditional.
+    let driver = rust_code(&read("server/src/task_run_resize_rollout.rs"));
     let start = driver
         .find("pub fn production(")
         .expect("the module must expose a production composition site");
@@ -1371,18 +1423,21 @@ fn the_production_composition_site_wires_only_production_implementations() {
 /// substitutable seam.
 #[test]
 fn the_drain_proof_calls_list_nonterminal_resize_from_compiled_server_code() {
+    // The driver's own module docs discuss `list_nonterminal_resize` at length,
+    // so only a call in CODE counts — and the `cfg(test)` ban must not fire on a
+    // comment that merely explains why there is no test-only path.
     let driver = read("server/src/task_run_resize_rollout.rs");
     assert!(
-        driver.contains(".list_nonterminal_resize()"),
+        code_contains(&driver, ".list_nonterminal_resize()"),
         "the drain proof must call the production repository method"
     );
     assert!(
-        !driver.contains("#[cfg(test)]"),
+        !code_contains(&driver, "#[cfg(test)]"),
         "the driver must carry no test-only code path; the drain proof one production \
          caller compiles is the same one the tests drive"
     );
 
-    let lib = read("server/src/lib.rs");
+    let lib = rust_code(&read("server/src/lib.rs"));
     assert!(
         lib.contains("pub mod task_run_resize_rollout;"),
         "the module must be declared in the server crate, unconditionally"
@@ -1397,7 +1452,7 @@ fn the_drain_proof_calls_list_nonterminal_resize_from_compiled_server_code() {
 /// can stand in for the drain fence or the catalog check.
 #[test]
 fn the_driver_exposes_no_seam_for_a_fake_repository() {
-    let driver = read("server/src/task_run_resize_rollout.rs");
+    let driver = rust_code(&read("server/src/task_run_resize_rollout.rs"));
     // Needles are assembled at compile time so this file does not match itself.
     for forbidden in [
         concat!("permits: ", "impl"),
@@ -1417,9 +1472,13 @@ fn the_driver_exposes_no_seam_for_a_fake_repository() {
         "the permit repository must be constructed from the Database, not injected"
     );
 
-    let tests = read("server/tests/task_run_resize_rollout.rs");
+    // Assembled at compile time and comment-stripped: this file reads ITSELF, so
+    // a needle spelled on its own assertion line is satisfied by that line and
+    // can never fail — and the module doc at the top of this file names the
+    // constructor too.
+    let tests = rust_code(&read("server/tests/task_run_resize_rollout.rs"));
     assert!(
-        tests.contains("Database::ephemeral()"),
+        tests.contains(concat!("Database::", "ephemeral()")),
         "these tests must construct a real PgPool"
     );
     for forbidden in [
@@ -1448,7 +1507,7 @@ fn no_blanket_launcher_cpu_clamp_is_reintroduced_and_nothing_is_retired() {
     // The driver renders nothing at all: no manifest type, no resource block,
     // no quantity. It cannot produce a container `limits.cpu` because it never
     // constructs a container.
-    let driver = read("server/src/task_run_resize_rollout.rs");
+    let driver = rust_code(&read("server/src/task_run_resize_rollout.rs"));
     for rendering in [
         "ResourceRequirements",
         "k8s_openapi",
@@ -1476,10 +1535,12 @@ fn no_blanket_launcher_cpu_clamp_is_reintroduced_and_nothing_is_retired() {
         "the registry probe must use the capability owner's client"
     );
 
-    // The `resize-v2`-only condition on the ceiling render is intact.
+    // The `resize-v2`-only condition on the ceiling render is intact. Read from
+    // CODE: that file names `launcher_owns_leaf_quota` twice in comments and
+    // once in the `if`, so a raw `contains` survives deleting the condition.
     let launcher = read("server/crates/djinn-k8s/src/launcher.rs");
     assert!(
-        launcher.contains("launcher_owns_leaf_quota"),
+        code_contains(&launcher, "launcher_owns_leaf_quota"),
         "the ceiling render must still be conditioned on the protocol"
     );
 
@@ -1494,11 +1555,113 @@ fn no_blanket_launcher_cpu_clamp_is_reintroduced_and_nothing_is_retired() {
             "{asset} must not be deleted by this task"
         );
     }
+    // Both of these are named together in ONE comment in that file, explaining
+    // that teardown is best-effort because `cgroup.kill` is asynchronous. That
+    // comment alone satisfied a raw `contains` for both needles, so the
+    // containment retention gate survived deleting the containment.
     let launcher_src = read("server/crates/djinn-cgroup-launcher/src/lib.rs");
-    for retained in ["cgroup.kill", "wait_empty"] {
+    let missing = retention_needles_missing_from(&launcher_src, &["cgroup.kill", "wait_empty"]);
+    assert!(
+        missing.is_empty(),
+        "{missing:?} must not be disabled by this task"
+    );
+}
+
+// ═══ the gates' own self-tests ══════════════════════════════════════════════
+//
+// A source gate that ignores comments and a source gate that ignores everything
+// look identical from a green run, so the predicate the gates above rest on is
+// driven against synthetic input here, in BOTH directions.
+//
+// Two mutations, not one. A PRESENCE gate is mutated by REMOVING the required
+// construct; swapping it for a different valid token reds the presence arm and
+// proves nothing about a ban. A BAN is mutated by ADDING the banned token while
+// LEAVING the required one in place.
+
+#[test]
+fn a_whole_line_comment_is_not_code_but_a_trailing_one_does_not_launder_the_line() {
+    assert_eq!(rust_code("a\n// b\n  /// c\n//! d\ne"), "a\ne");
+    assert_eq!(
+        rust_code("    self.kill(); // `cgroup.kill` is asynchronous"),
+        "    self.kill(); // `cgroup.kill` is asynchronous",
+        "a trailing comment must NOT drop the code in front of it"
+    );
+}
+
+#[test]
+fn a_retention_gate_reads_the_code_it_protects_and_not_the_comment_about_it() {
+    // This is the shape measured in `djinn-cgroup-launcher/src/lib.rs`: one
+    // comment names both retained primitives, and the code names them again.
+    let comment_only = "        // Teardown is best-effort ON PURPOSE. `cgroup.kill` is\n\
+                        // asynchronous, so `wait_empty` can still observe a live pid.\n\
+                        fn teardown(&mut self) {}\n";
+    let with_code = "        // Teardown is best-effort ON PURPOSE. `cgroup.kill` is\n\
+                     // asynchronous, so `wait_empty` can still observe a live pid.\n\
+                     self.fs.write_leaf(leaf.fd, \"cgroup.kill\", \"1\")?;\n\
+                     pub fn wait_empty(&mut self, leaf: &Leaf) {}\n";
+
+    assert!(
+        comment_only.contains("cgroup.kill") && comment_only.contains("wait_empty"),
+        "the raw text a `contains` gate reads is satisfied by the comment alone — this is the \
+         false negative the gate had"
+    );
+    assert_eq!(
+        retention_needles_missing_from(comment_only, &["cgroup.kill", "wait_empty"]),
+        vec!["cgroup.kill", "wait_empty"],
+        "with the code deleted, BOTH retention needles must be reported missing"
+    );
+    assert!(
+        retention_needles_missing_from(with_code, &["cgroup.kill", "wait_empty"]).is_empty(),
+        "the shipped shape — comment and code together — must stay green"
+    );
+    assert!(
+        retention_needles_missing_from(
+            "self.kill_leaf(\"cgroup.kill\"); // retained\npub fn wait_empty() {} // retained",
+            &["cgroup.kill", "wait_empty"]
+        )
+        .is_empty(),
+        "a trailing comment must not launder the code in front of it"
+    );
+}
+
+#[test]
+fn a_reachability_gate_ignores_comments_in_both_directions() {
+    let condition =
+        "    if protocol.launcher_owns_leaf_quota() {\n        render_ceiling();\n    }\n";
+    let prose = "/// ([`LauncherAuthorityProtocol::launcher_owns_leaf_quota`]), so a container\n";
+
+    // FALSE NEGATIVE: prose alone must not satisfy the presence gate.
+    assert!(
+        prose.contains("launcher_owns_leaf_quota"),
+        "the raw text matches"
+    );
+    assert!(
+        !code_contains(prose, "launcher_owns_leaf_quota"),
+        "deleting the `if` and keeping the doc comment must red the gate"
+    );
+    assert!(code_contains(
+        &format!("{prose}{condition}"),
+        "launcher_owns_leaf_quota"
+    ));
+
+    // FALSE POSITIVE: a comment naming a banned construct must not fire the ban,
+    // while the real construct still must. The required call stays in place in
+    // both fixtures so it is only ever the ban that moves.
+    let call = "    let rows = repo.list_nonterminal_resize().await?;\n";
+    let excused = "// This module reaches no `kube::` type of its own and carries no\n\
+                   // #[cfg(test)] path.\n";
+    assert!(
+        code_contains(&format!("{call}{excused}"), ".list_nonterminal_resize()"),
+        "the presence arm must hold under the ban's mutation, or the arms are confounded"
+    );
+    for banned in ["kube::", "#[cfg(test)]"] {
         assert!(
-            launcher_src.contains(retained),
-            "{retained} must not be disabled by this task"
+            !code_contains(&format!("{call}{excused}"), banned),
+            "{banned:?} named only in a comment must not fire the ban"
+        );
+        assert!(
+            code_contains(&format!("{call}{excused}    use {banned}Client;\n"), banned),
+            "{banned:?} in real code must still fire the ban"
         );
     }
 }


### PR DESCRIPTION
Audit of **every source-text guard in the repo** against the two defects that bit four times on 2026-07-30, plus the fixes.

The two defects, restated so the direction is explicit:

**(a) Comment blindness.** Matching source text conflates code with prose.
- A **ban** false-POSITIVES on a comment explaining why the token is wrong (`pcod`, fixed in #2871). Noisy but visible.
- A **presence assertion** false-NEGATIVES: the comment naming the token keeps the guard green after the real call is deleted (`1j64`'s teardown trap), and a commented-out call satisfies it outright (`0vku`). **This is the dangerous direction — it is silent.**

**(b) `#[cfg(test)]` truncation.** `check-resize-reachability.sh` stopped at the first marker; in `server/src/server/state/mod.rs` that marker is a *field* attribute on line 342 of 4147, so the guard read 8% of the file and never saw the composition site it exists to find.

---

## Vacuous guards found — passing for a reason unrelated to what they claim

This is the campaign's signature failure and the most valuable part of the audit. Each was **proven**, not inferred: mutate the real code, run the guard at HEAD, watch it stay green.

| Guard | Why it could never fail |
|---|---|
| `djinn-coordinator/src/tests/boundary.rs` — **both** crate-boundary guards | `if !path.ends_with(".rs") { continue; }`. `Path::ends_with` compares whole path **components**, so it is false for every real file, `!false` is true, and `continue` fires unconditionally. `offenders` was provably always empty. **100% dead.** |
| `stream_event_consumer_audit.rs:683` | `FIXTURE.contains("no behavioral claim") \|\| include_str!("<self>").contains(...)`. The fixture header says *"not a behavioral claim"* — the left disjunct was always false — and the right disjunct reads the test file into itself, where the phrase sits in the module doc comment **and** in the assertion's own string literal. Unconditionally true. |
| `task_run_resize_cycles.rs` — 5 needles | Self-read, needle spelled literally on the assertion line. `Allocated resources` was satisfied by the guard's own *failure message*; `SETUP_SCRIPT` by the `const` **declaration**. |
| `task_run_resize_mixed_version.rs:993` | `body.contains("initContainerStatuses")` with the message *"…or this gate guards nothing"*. It was literally that. Deleting **both** real reads left it green. |
| `task_run_resize_rollout.rs:1422` | `tests.contains("Database::ephemeral()")` — renaming all 14 call sites left it green. |

Each file already assembled its **ban** needles with `concat!`/`format!` for exactly this reason. The trick was never applied to the **presence** needles.

## Live false negatives (guard green, invariant already violable)

- `raw_signal_bypass_guard.rs` — six presence assertions over `dispatch/session_recovery.rs`. `classify_task_liveness` appears in that file's **comments** at lines 1313 and 1324, so deleting the entire classifier gate left all six green. The module header claims it *"prevents merge of code that bypasses the liveness classifier"*.
- `task_run_resize_rollout.rs` — `launcher_owns_leaf_quota`, `cgroup.kill`, `wait_empty` are each named in comments of their production file as well as in code. Delete the code, keep the comment, guard green.
- `task_run_resize_mixed_version.rs` — replacing the real `trap cleanup_on_failure EXIT` with the same text commented out leaves the harness guard green with teardown gone. `1j64` verbatim, in a second file.
- `ci-nextest-plan.test.mjs` — commenting out `if [ "$run_conclusion" != success ]; then` in `quality-gate.yml` left it green. That is the mutation that reintroduces the silent planner cold-start which **ran 4 of 8 shards and passed** (5834 of 11666 tests never executed).
- `resize-cutover-retention-manifest.mjs` — `reachability` claims *"something in PRODUCTION still calls it"* but matched the whole file. Delete the production `child.wait_empty()` teardown and add one in a `#[cfg(test)]` module: **accepted**.
- `pods-resize-rbac.sh` — its ban stripped comments; its `audience:` presence assertion read raw text. Delete the real projected-token binding, leave `// audience: Some(TOKEN_AUDIENCE.to_string())`: **accepted**.
- `deploy/kueue/tests/zero-capture-gate.sh`, `deploy/runbooks/tests/kueue-cutover-quiesce-rollback.sh` — unanchored fixed-string greps over YAML and shell.

## The measured `#[cfg(test)]` blast radius

`strip_cfg_test` in `kueue-topology-render.sh` removed **2145 of 4441 lines (48.3%)** from `server/crates/djinn-k8s/src/runtime.rs`. The first removal anchors on the **field** attribute at line 311 — a field ends in `,`, so the scanner ran forward to the next `{` anywhere in the file (the `{` of `impl KubernetesRuntime`) and brace-matched from there. Removed span 311–455: the struct's remaining field, its closing brace, and the **entire production impl block**. Across `server/crates`: **22 files, 1065 lines of production code eaten**.

The guard's verdict is unchanged *today* — the full extraction was run under both strippers and `renderer_files`, `request_sites` and the derived `cpu`/`memory` keys are identical. That is luck. A resource request added anywhere in `impl KubernetesRuntime` would have been invisible and the ClusterQueue coverage guard would have stayed green while an uncovered resource shipped.

`check-test-global-metrics.sh` broke its **own documented exemption** ("Production code … is exempt") the same way: its tracker disarmed only on `;`, so `#[cfg(test)]` on a field left it armed until the next brace-opening line — normally the next production function. Measured on a fixture of that shape, a production `render()` was reported as a test read.

---

## One shared implementation

`scripts/lib/rust-source-scan.awk` is now the single comment-stripping and `#[cfg(test)]`-tracking scanner, used by **shell, Python and Node**:

- `check-raw-sql-boundary.sh`, `check-capability-boundaries.sh` (git/http/k8s), `check-resize-authorization-boundary.sh`, `check-test-global-metrics.sh`, `check-include-macro.sh`
- `check_boundaries.py` (via `subprocess`)
- `resize-cutover-retention-manifest.mjs` (via `spawnSync`, blanking test lines so line numbers still align)

It strips `//` and `/* */` in a **string-literal-aware** pass, so `"https://x"` neither opens a comment nor hides one — a naive `sub(/\/\/.*/, "")` turns `let u = "https://x"; banned();` into `let u = "https:` and drops a real violation, a false negative created by fixing a false positive. Test context is **structural**: an attribute arms the tracker, and the decorated item either opens a brace-matched block or is a `;`/`,`-terminated item that ends on its own line, with paren depth carried so a multi-line `#[test] async fn foo(\n a: A,\n) {` still resolves to its block.

`scripts/lib/source-text.mjs` is the JavaScript counterpart for YAML and shell, with the same invariant.

Where one implementation was **not** feasible, stated rather than papered over: Rust integration-test binaries and the Python embedded in the deploy contract scripts cannot call awk mid-body, so `code_lines`/`rust_code`/`script_code` are copied from `task_run_resize_kind.rs` (#2871) with the origin cited, and the deploy scripts reimplement `rs_test_context`'s semantics in Python. A `server/tests/common/` module and a cross-language rewrite are both out of scope here.

## Self-tests, in both directions

`scripts/test-rust-source-scan.sh` (20 cases) and `scripts/ci-source-text.test.mjs` (6), both wired into `quality-gate.yml` **before** their consumers — a regression in the shared piece takes five guards down at once and does so silently, because a guard whose scanner matches nothing still exits 0.

Every case is a **pair**: for each thing the scanner must ignore there is an adjacent thing it must still catch, because "ignores comments" and "ignores everything" are indistinguishable from a green run. Included by name:

- **production code AFTER a `#[cfg(test)]` block is still production code**, paired with the same caller *inside* that block still being excluded;
- `#[cfg(test)]` on a struct **field** does not swallow the next function;
- a trailing comment does not launder the code in front of it (`foo(); // banned` is still a call to `foo()`);
- a `//` inside a string literal neither opens nor hides a comment;
- a missing pattern or an unknown scope **exits 2** rather than matching nothing.

Both traps from the brief are respected: bans are mutated by **adding** the banned token while leaving the required one in place (asserted explicitly in the Rust suites, so the two arms cannot be confounded), and no stripper drops a whole line for having a trailing comment.

`check_boundaries.py --self-test` existed and **was never wired into CI** — nothing enforced that an edit to the checker still caught a violation. It now runs before the check.

## Deliberately left alone, with reasons

- **`check-resize-authorization-boundary.sh`'s ban on the retired relation covers comments too.** Documented: *"in code OR in a comment. A comment that names it is a comment that invites a reader to read it."* That is a deliberate, stated policy, not an oversight.
- **`task_run_resize_mixed_version.rs`'s `raw.contains("eks")`.** Its intent is that the script must *say out loud* why a non-kind server is refused. A header comment legitimately satisfies it. Left reading raw text, with a comment explaining why.
- **`resize-cutover-retention-manifest.mjs`'s `stripComments` stays whole-line-only.** Its rationale is written down and still holds for what it guards; widening it would change every `content` check at once for no demonstrated defect. Only the `reachability` arm changed.
- **`kueue-topology-render.sh`'s `_tests.rs` filename filter and `*/src/**` glob.** The first is the `force_test=1` case — those files are declared by a parent as `#[cfg(test)] mod x;`, so the attribute is not *in* them and the name is the only signal. The second under-reports by construction, but every `-> Job` renderer lives under `server/crates/*/src`, and one moved outside drops `renderer_files` below its floor and fails loudly. Its failure direction leaves the guard able to see its subject.
- **`check-file-size.sh`, `check-migrations-immutable.sh`, `check-shared-cache-rollout.sh`.** Not source-text code guards: line counts, filename hashes, Markdown prose contracts.
- **`scripts/check-resize-reachability.sh` — untouched, as instructed.** #2872 merged mid-audit and landed its own inline tracker. It was tested here: it is **correct** on both defect classes (it handles the field case via an item-keyword whitelist). It is the one remaining duplicate implementation. One divergence worth a follow-up: it recognises items by keyword, so an unusual item form falls through to the "field" branch and its body is scanned as production — for a reachability guard that direction counts a test caller as a production one. Consolidating it onto the shared scanner is a natural follow-up now that its PR has landed.

## Notable, reported but not fixed (out of scope for one PR)

- `boundary.rs`'s `declares_use_of_crate` matches `use` forms only; a bare `djinn_agent::Foo` path is not caught. It cannot compile today (dev-only edge) and the limit is documented on the function.
- `djinn-image-controller` contributes **zero** `requests:` sites to `kueue-topology-render.sh`'s derived key set, so the "four renderers" framing overstates coverage — `cpu`/`memory` come entirely from `djinn-k8s`.
- Three `expect_rejected` cases in the same file assert only *that* the render failed, never *why*; a chart syntax error satisfies all three.
- `ci-qa-smoke-workflow.test.mjs`'s `/\bkind\b/i` ban and several `ci-*.test.mjs` presence assertions in other files remain comment-blind; the two highest-value ones are fixed here.

## Verification

All green locally: 20 + 6 shared-scanner cases · `test-check-{raw-sql,include-macro,test-global-metrics,resize-authorization}` + `test-capability-boundaries` · all 9 deploy contract scripts · `kueue-topology-render.sh` + `pods-resize-rbac.sh` · 27 retention-engine cases · `cargo test` for `boundary` (18), `raw_signal_bypass_guard` (14), `stream_event_consumer_audit` (10), `task_run_resize_cycles` (16), `_mixed_version` (22), `_rollout` (20) · `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
