### PR TITLE
feat(images): make the declared launcher authority protocol configurable, and make a cached protocol flip impossible

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -387,6 +387,16 @@ spec:
             # later tick as slots free.
             - name: DJINN_IMAGE_MAX_CONCURRENT
               value: {{ .Values.imagePipeline.controller.maxConcurrentBuilds | quote }}
+            {{- with .Values.imagePipeline.controller.launcherAuthorityProtocol }}
+            # Launcher authority protocol newly built catalog images declare in
+            # their own OCI metadata. Rendered only when the operator sets it,
+            # so an unset value is the binary's default (leaf-v1) and no
+            # existing image's environment hash moves. Setting it re-tags and
+            # rebuilds the catalog — a cached leaf-v1 artifact cannot be served
+            # under a resize-v2 declaration.
+            - name: DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL
+              value: {{ . | quote }}
+            {{- end }}
             # djinn-k8s runtime (task-run + warm-job dispatcher) — same
             # pattern as the image pipeline above: everything is derived
             # from the release fullname + namespace so no hardcoded

--- a/deploy/helm/djinn/tests/kueue-topology-render.sh
+++ b/deploy/helm/djinn/tests/kueue-topology-render.sh
@@ -76,7 +76,9 @@ render_enabled() {
 # EXTRACTED from the Rust that renders the Jobs:
 #
 #   1. Discover the Job renderers: every non-test `.rs` under $CRATES_ROOT that
-#      defines a `pub fn build_*job*(..) -> Job`. Today that is job.rs
+#      defines a `pub fn build_*job*(..) -> Job` — or `-> Result<Job, E>`, since
+#      a renderer that can REFUSE still emits `suspend: true` and still requests
+#      resources on every path that returns one. Today that is job.rs
 #      (task-run), warm_job.rs, scip_job.rs and the image-controller's
 #      build_job.rs — but the LIST is derived, so a fifth renderer joins it
 #      without an edit here.
@@ -400,9 +402,58 @@ _self_test_strip()
 
 
 # A Job renderer is a function that RETURNS a Job. Nothing here names the four.
+#
+# "Returns a Job" includes returning one FALLIBLY. A renderer that can refuse —
+# `build_image_build_job` refuses to render a Job whose build context reports a
+# launcher authority protocol its own Dockerfile does not declare — still emits
+# `suspend: true` and still requests resources on every path that does return,
+# so it is exactly as much of this guard's business as an infallible one. Before
+# `Result` was allowed here the image-build renderer silently dropped out of the
+# discovered set and the floor below caught it, which is the correct direction
+# to fail; matching both shapes is the fix, and `_self_test_job_builder` keeps
+# the fallible shape from regressing back out of view.
 JOB_BUILDER = re.compile(
-    r"pub\s+fn\s+build_[A-Za-z0-9_]*job[A-Za-z0-9_]*\s*\([^{;]*?\)\s*->\s*Job\s*\{", re.S
+    r"pub\s+fn\s+build_[A-Za-z0-9_]*job[A-Za-z0-9_]*\s*\([^{;]*?\)\s*->\s*"
+    # `Job`, or any `Result<Job, E>` — including a path-qualified alias
+    # (`kube::Result<Job>`) and an error type carrying its own generics
+    # (`Result<Job, Foo<Bar>>`), which the lazy body plus the `\{` anchor
+    # resolves to the LAST `>` before the block.
+    r"(?:Job|(?:[A-Za-z0-9_]+\s*::\s*)*Result\s*<\s*Job\s*(?:,[^{;]*?)?>)"
+    r"\s*\{",
+    re.S,
 )
+
+
+def _self_test_job_builder():
+    """The discovery regex, both directions, every run.
+
+    A discovery that quietly matches fewer renderers makes the coverage
+    assertion cover less while still passing — the same silence this guard
+    exists to end — so it is proven before it is used.
+    """
+    for source in [
+        "pub fn build_task_run_job(spec: &Spec) -> Job {",
+        "pub fn build_image_build_job(c: &C) -> Result<Job, DeclarationError> {",
+        "pub fn build_warm_job(\n    a: A,\n    b: B,\n) -> Result<Job, Error> {",
+        "pub fn build_scip_job(a: A) -> kube::Result<Job> {",
+        "pub fn build_x_job(a: A) -> Result<Job, foo::Bar<Baz>> {",
+        "pub fn build_y_job(a: A) -> Result< Job , E > {",
+    ]:
+        assert JOB_BUILDER.search(source), f"renderer not discovered: {source!r}"
+
+    for source in [
+        # Returns something that merely mentions a Job.
+        "pub fn build_job_name(a: A) -> String {",
+        "pub fn build_job_owner_reference(job: &Job) -> Option<OwnerReference> {",
+        # A Result of something else entirely.
+        "pub fn build_a_job(a: A) -> Result<ConfigMap, E> {",
+        # A declaration, not a definition.
+        "pub fn build_task_run_job(spec: &Spec) -> Job;",
+    ]:
+        assert not JOB_BUILDER.search(source), f"falsely discovered: {source!r}"
+
+
+_self_test_job_builder()
 REQUESTS_BLOCK = re.compile(
     r"requests\s*:\s*Some\(\s*BTreeMap::from\(\s*\[(?P<body>[^\[\]]*)\]\s*\)\s*\)", re.S
 )

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -1029,6 +1029,25 @@ imagePipeline:
     # re-evaluated on later reconcile ticks as slots free. Keep this low
     # relative to buildkitd's CPU limit.
     maxConcurrentBuilds: 4
+    # Launcher authority protocol every image this deployment BUILDS declares in
+    # its own OCI metadata (`djinn.app/launcher-authority-protocol`), wired to
+    # the server via DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL.
+    #
+    #   leaf-v1   (default) the djinn-cgroup-launcher shipped in the image owns
+    #             each invocation leaf's `cpu.max`. What every image built
+    #             before this knob existed declares.
+    #   resize-v2 Kubernetes in-place Pod resize owns CPU quota; the launcher
+    #             must never write leaf `cpu.max`.
+    #
+    # This is the producer half of the resize cutover: it changes what NEW
+    # artifacts claim. Flipping it changes each catalog image's environment
+    # hash, so every image is rebuilt under a new content-addressed tag rather
+    # than being relabelled — a cached leaf-v1 artifact can never be served as
+    # resize-v2. Expect a full rebuild of the catalog after changing it, and
+    # sequence it against the cluster-wide launcher_authority_mode row: images
+    # declaring a protocol the mode does not admit are refused at dispatch.
+    # Leave empty to keep the built-in default (leaf-v1) and rebuild nothing.
+    launcherAuthorityProtocol: ""
     resources:
       requests:
         cpu: "100m"

--- a/docs/deploy/launcher-authority-cutover.md
+++ b/docs/deploy/launcher-authority-cutover.md
@@ -99,6 +99,43 @@ Run in this order. The driver refuses any other.
 | 8 | **Flip the mode** | Compare-and-swap at the expected epoch, behind `set_mode`'s own transactional fence, which holds the `build_pod_permit_pools` row lock admission takes before it inserts. |
 | 9 | **Resume admission** | Only after a confirmed flip. Resuming earlier is `StepOutOfOrder`. |
 
+### How step 4 is actually performed
+
+The declaration an image carries is a **build input**, set on the deployment
+that builds it:
+
+```yaml
+imagePipeline:
+  controller:
+    launcherAuthorityProtocol: "resize-v2"   # default "" → leaf-v1
+```
+
+rendered as `DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL` on the server Pod and read
+by `ImageControllerConfig::from_env`. Everything downstream follows from it: the
+generated Dockerfile's `djinn.app/launcher-authority-protocol` LABEL, the env
+the launcher sidecar reads out of the same image, and the sentinel the build Job
+echoes into `images.launcher_authority_protocol`.
+
+Two properties this step depends on, both enforced in code rather than by
+procedure:
+
+* **A protocol change cannot be served from cache.** The declaration is an input
+  to `compute_environment_hash`, and the image tag is a prefix of that hash. A
+  `leaf-v1` artifact and a `resize-v2` artifact of the same config therefore
+  live at different tags, and flipping the value re-tags and rebuilds every
+  catalog image rather than relabelling one whose launcher still writes leaf
+  `cpu.max`. Budget for a full catalog rebuild here; the `leaf-v1` tags remain
+  in the registry, which is what makes step 5's retention check — and rollback —
+  possible.
+* **The label and the catalog row cannot disagree.** `build_image_build_job`
+  refuses to render a Job whose build context reports a protocol its own
+  Dockerfile does not declare (`BuildContext::verify_declaration`), so a
+  `leaf-v1` artifact catalogued as `resize-v2` is not a state the pipeline can
+  reach.
+
+Leaving the value unset keeps the built-in default (`leaf-v1`) and changes no
+image hash, so a deployment that is not doing a cutover rebuilds nothing.
+
 ## Rollback
 
 Same shape from step 5 onward, targeting `leaf-v1`, with the allowlist check

--- a/server/crates/djinn-image-builder/src/dockerfile.rs
+++ b/server/crates/djinn-image-builder/src/dockerfile.rs
@@ -37,19 +37,32 @@ use thiserror::Error;
 
 use crate::scripts::SCRIPTS;
 
-/// The launcher authority protocol every image this generator produces
-/// declares.
+/// The launcher authority protocol an image declares when the deployment
+/// selects nothing.
 ///
-/// This is a property of the **artifact**, not of its name: the
+/// The declaration is a property of the **artifact**, not of its name: the
 /// `djinn-cgroup-launcher` binary [`emit_agent_worker`] copies in writes its
 /// own invocation-leaf `cpu.max`, and that is exactly what
 /// [`LauncherAuthorityProtocol::LeafV1`] means.
 ///
-/// Flipping this constant changes what the shipped binary does, so it must be
-/// accompanied by a [`crate::compute_environment_hash`] salt bump — the hash
-/// does not cover the Dockerfile text, and a cached image would otherwise keep
-/// its old launcher while the catalog claimed the new protocol.
-pub const DECLARED_LAUNCHER_PROTOCOL: LauncherAuthorityProtocol = LauncherAuthorityProtocol::LeafV1;
+/// Which protocol a given build declares is an **input**:
+/// [`generate_dockerfile`] takes it, the deployment supplies it (see
+/// `djinn_image_controller::ImageControllerConfig::declared_launcher_protocol`),
+/// and this constant is only the fallback. That is what makes a resize cutover
+/// reachable at all — a hardcoded declaration cannot be rolled out.
+///
+/// # Why flipping it no longer needs a manual salt bump
+///
+/// The selected protocol is an input to [`crate::compute_environment_hash`], so
+/// a deployment that flips to `resize-v2` necessarily computes a different
+/// environment hash, lands on a different content-addressed tag, and cannot
+/// reuse the cached `leaf-v1` artifact. The historical hazard — "a cached image
+/// keeps its old launcher while the catalog claims the new protocol" — is now
+/// closed by construction instead of by a comment asking for a manual bump.
+/// [`BuildContext::verify_declaration`] closes the other half: the build Job
+/// that reports the declaration to the catalog refuses to render unless the
+/// Dockerfile it is about to build declares the same thing.
+pub const DEFAULT_LAUNCHER_PROTOCOL: LauncherAuthorityProtocol = LauncherAuthorityProtocol::LeafV1;
 
 /// OCI label key carrying the declaration into the built artifact's metadata.
 ///
@@ -106,6 +119,129 @@ pub struct BuildContext {
     pub launcher_protocol: LauncherAuthorityProtocol,
 }
 
+impl BuildContext {
+    /// Check that [`Self::dockerfile`] declares exactly [`Self::launcher_protocol`].
+    ///
+    /// The catalog row is written from the build Job's sentinel, and that
+    /// sentinel is rendered from [`Self::launcher_protocol`] — while the
+    /// artifact's own OCI label comes from the Dockerfile text. If the two ever
+    /// disagreed, the catalog would claim one authority while the shipped
+    /// launcher implemented the other: two owners of the same Pod's CPU quota,
+    /// or none. [`generate_dockerfile`] writes both from the same argument, and
+    /// this is what forbids anything downstream from editing one of them —
+    /// `djinn_image_controller::build_job::build_image_build_job` calls it and
+    /// refuses to render a Job when it fails, so a disagreeing context cannot
+    /// reach a build at all.
+    ///
+    /// Returns the agreed protocol so callers can use the checked value rather
+    /// than re-reading the field they just validated.
+    pub fn verify_declaration(&self) -> Result<LauncherAuthorityProtocol, DeclarationError> {
+        let label = single_directive_value(&self.dockerfile, "LABEL", LAUNCHER_PROTOCOL_LABEL);
+        let env = single_directive_value(&self.dockerfile, "ENV", LAUNCHER_PROTOCOL_ENV);
+
+        let (Some(label), Some(env)) = (label, env) else {
+            return Err(DeclarationError::Undeclared {
+                context_says: self.launcher_protocol,
+            });
+        };
+        if label != env {
+            return Err(DeclarationError::LabelEnvDisagree {
+                label_says: label,
+                env_says: env,
+            });
+        }
+        let declared = label.parse::<LauncherAuthorityProtocol>().map_err(|_| {
+            DeclarationError::Unrecognized {
+                dockerfile_says: label.clone(),
+            }
+        })?;
+        if declared != self.launcher_protocol {
+            return Err(DeclarationError::Disagree {
+                dockerfile_says: declared,
+                context_says: self.launcher_protocol,
+            });
+        }
+        Ok(declared)
+    }
+
+    /// The environment hash this context must be cached under.
+    ///
+    /// Deliberately a method on the rendered context rather than a free
+    /// function taking a protocol: the hash is then computed from the
+    /// declaration that was *actually emitted*, so a caller cannot hash under
+    /// `leaf-v1` and build an artifact that declares `resize-v2`. The tag is
+    /// derived from this hash, so the two protocols can never share one tag and
+    /// a protocol change can never resolve to a cached image.
+    pub fn environment_hash(
+        &self,
+        config: &EnvironmentConfig,
+        agent_worker_ref: &str,
+        build_version: &str,
+    ) -> String {
+        crate::hash::compute_environment_hash(
+            config,
+            agent_worker_ref,
+            build_version,
+            self.launcher_protocol,
+        )
+    }
+}
+
+/// Read the single value of a `DIRECTIVE key=value` line, or `None` when the
+/// key appears zero or more than one time. "More than once" is a failure, not a
+/// last-one-wins: a second declaration is exactly how an artifact ends up
+/// saying two different things.
+fn single_directive_value(dockerfile: &str, directive: &str, key: &str) -> Option<String> {
+    let prefix = format!("{directive} {key}=");
+    let mut found: Option<String> = None;
+    for line in dockerfile.lines() {
+        let Some(value) = line.trim_end().strip_prefix(prefix.as_str()) else {
+            continue;
+        };
+        if found.is_some() {
+            return None;
+        }
+        found = Some(value.trim_matches('"').to_string());
+    }
+    found
+}
+
+/// The artifact's declaration and the context reporting it to the catalog do
+/// not agree. Always fatal: there is no safe way to guess which of two
+/// authorities owns a Pod's CPU quota.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum DeclarationError {
+    #[error(
+        "the generated Dockerfile declares no launcher authority protocol, but the build context \
+         reports `{context_says}` — the catalog would record an authority the artifact never claims"
+    )]
+    Undeclared {
+        context_says: LauncherAuthorityProtocol,
+    },
+    #[error(
+        "the artifact's LABEL declares `{label_says}` but its ENV declares `{env_says}` — the \
+         image and the launcher sidecar reading it would disagree at runtime"
+    )]
+    LabelEnvDisagree {
+        label_says: String,
+        env_says: String,
+    },
+    #[error(
+        "the generated Dockerfile declares `{dockerfile_says}`, which is not a launcher \
+             authority protocol this plane knows"
+    )]
+    Unrecognized { dockerfile_says: String },
+    #[error(
+        "the generated Dockerfile declares `{dockerfile_says}` but the build context reports \
+         `{context_says}` to the catalog — refusing to build an artifact whose label and catalog \
+         row disagree about which component owns CPU quota"
+    )]
+    Disagree {
+        dockerfile_says: LauncherAuthorityProtocol,
+        context_says: LauncherAuthorityProtocol,
+    },
+}
+
 #[derive(Debug, Error)]
 pub enum DockerfileError {
     #[error(
@@ -126,9 +262,19 @@ pub enum DockerfileError {
 /// is copied from. The worker reference contributes to
 /// [`crate::compute_environment_hash`], so replacing it (e.g. after a
 /// worker rebuild) invalidates cached images.
+///
+/// `launcher_protocol` is the declaration this artifact will carry — supplied
+/// by the deployment, defaulting to [`DEFAULT_LAUNCHER_PROTOCOL`]. It is a
+/// required argument rather than a defaulted one on purpose: a caller that can
+/// silently omit it is a caller that can silently keep a fleet on `leaf-v1`
+/// after an operator configured the cutover. It is written into the Dockerfile
+/// and reported on [`BuildContext::launcher_protocol`] from this one value, and
+/// [`BuildContext::environment_hash`] hashes the same value, so the
+/// declaration, the artifact, and the cache key cannot come apart.
 pub fn generate_dockerfile(
     config: &EnvironmentConfig,
     agent_worker: &AgentWorkerImage,
+    launcher_protocol: LauncherAuthorityProtocol,
 ) -> Result<BuildContext, DockerfileError> {
     if agent_worker.reference.trim().is_empty() {
         return Err(DockerfileError::MissingAgentWorkerRef);
@@ -146,7 +292,7 @@ pub fn generate_dockerfile(
     emit_path(&mut df);
     emit_system_packages(&mut df, config);
     emit_agent_worker(&mut df, agent_worker);
-    emit_launcher_protocol(&mut df, DECLARED_LAUNCHER_PROTOCOL);
+    emit_launcher_protocol(&mut df, launcher_protocol);
     emit_language_blocks(&mut df, config)?;
     emit_env(&mut df, config);
     emit_post_build_hooks(&mut df, config);
@@ -158,7 +304,7 @@ pub fn generate_dockerfile(
             .iter()
             .map(|s| (format!("scripts/{}", s.name), s.body.to_string()))
             .collect(),
-        launcher_protocol: DECLARED_LAUNCHER_PROTOCOL,
+        launcher_protocol,
     })
 }
 
@@ -731,7 +877,12 @@ mod tests {
 
     #[test]
     fn empty_config_emits_base_and_worker_only() {
-        let df = generate_dockerfile(&minimal_valid_config(), &agent_worker()).unwrap();
+        let df = generate_dockerfile(
+            &minimal_valid_config(),
+            &agent_worker(),
+            DEFAULT_LAUNCHER_PROTOCOL,
+        )
+        .unwrap();
         assert!(df.dockerfile.contains("FROM debian:trixie-slim"));
         assert!(
             df.dockerfile
@@ -755,20 +906,25 @@ mod tests {
     /// the [`BuildContext`] so the build Job never has to guess.
     #[test]
     fn the_artifact_declares_its_launcher_protocol_in_build_metadata() {
-        let df = generate_dockerfile(&minimal_valid_config(), &agent_worker()).unwrap();
+        let df = generate_dockerfile(
+            &minimal_valid_config(),
+            &agent_worker(),
+            DEFAULT_LAUNCHER_PROTOCOL,
+        )
+        .unwrap();
 
-        assert_eq!(df.launcher_protocol, DECLARED_LAUNCHER_PROTOCOL);
+        assert_eq!(df.launcher_protocol, DEFAULT_LAUNCHER_PROTOCOL);
         assert!(
             df.dockerfile.contains(&format!(
                 "LABEL {LAUNCHER_PROTOCOL_LABEL}=\"{}\"",
-                DECLARED_LAUNCHER_PROTOCOL.as_wire()
+                DEFAULT_LAUNCHER_PROTOCOL.as_wire()
             )),
             "the OCI label is the declaration; without it the artifact says nothing:\n{}",
             df.dockerfile
         );
         assert!(df.dockerfile.contains(&format!(
             "ENV {LAUNCHER_PROTOCOL_ENV}={}",
-            DECLARED_LAUNCHER_PROTOCOL.as_wire()
+            DEFAULT_LAUNCHER_PROTOCOL.as_wire()
         )));
 
         // The declaration describes the launcher binary, so it must land after
@@ -781,16 +937,134 @@ mod tests {
         assert!(copy < label);
     }
 
+    /// **The declaration is configurable, and the configured value is what the
+    /// artifact carries.** Every protocol the type admits — not just the
+    /// default — reaches the OCI label, the sidecar env var, and the
+    /// [`BuildContext`] the build Job reports from.
+    ///
+    /// MUTATION: pass `DEFAULT_LAUNCHER_PROTOCOL` to `emit_launcher_protocol`
+    /// instead of the argument (i.e. restore the hardcoded declaration). The
+    /// `resize-v2` iteration fails on the LABEL assertion.
+    #[test]
+    fn the_configured_protocol_is_what_the_artifact_declares() {
+        for protocol in LauncherAuthorityProtocol::ALL {
+            let df = generate_dockerfile(&minimal_valid_config(), &agent_worker(), protocol)
+                .unwrap_or_else(|e| panic!("{protocol} must generate: {e}"));
+            let wire = protocol.as_wire();
+
+            assert_eq!(df.launcher_protocol, protocol);
+            assert!(
+                df.dockerfile
+                    .contains(&format!("LABEL {LAUNCHER_PROTOCOL_LABEL}=\"{wire}\"")),
+                "{protocol}: the built artifact must carry the CONFIGURED declaration:\n{}",
+                df.dockerfile
+            );
+            assert!(
+                df.dockerfile
+                    .contains(&format!("ENV {LAUNCHER_PROTOCOL_ENV}={wire}")),
+                "{protocol}: the sidecar reads its protocol out of the same image:\n{}",
+                df.dockerfile
+            );
+            // Nothing else in the artifact may claim a different protocol.
+            for other in LauncherAuthorityProtocol::ALL {
+                if other != protocol {
+                    assert!(
+                        !df.dockerfile.contains(other.as_wire()),
+                        "{protocol}: the artifact also mentions {other}"
+                    );
+                }
+            }
+            df.verify_declaration().unwrap_or_else(|e| {
+                panic!("{protocol}: a freshly generated context must agree: {e}")
+            });
+        }
+    }
+
+    /// **A declaration the build context does not back cannot reach a build.**
+    /// `verify_declaration` is what `build_image_build_job` calls before it
+    /// renders the sentinel that becomes the catalog row, so a context whose
+    /// reported protocol drifts from the Dockerfile it carries is rejected
+    /// rather than built.
+    ///
+    /// MUTATION: make `verify_declaration` return `Ok(self.launcher_protocol)`
+    /// unconditionally. Every arm below fails.
+    #[test]
+    fn a_context_that_reports_something_other_than_it_built_is_refused() {
+        let good = generate_dockerfile(
+            &minimal_valid_config(),
+            &agent_worker(),
+            LauncherAuthorityProtocol::LeafV1,
+        )
+        .unwrap();
+        assert_eq!(
+            good.verify_declaration().unwrap(),
+            LauncherAuthorityProtocol::LeafV1
+        );
+
+        // The catalog would be told `resize-v2` about a `leaf-v1` artifact.
+        let mut lying = good.clone();
+        lying.launcher_protocol = LauncherAuthorityProtocol::ResizeV2;
+        assert_eq!(
+            lying.verify_declaration(),
+            Err(DeclarationError::Disagree {
+                dockerfile_says: LauncherAuthorityProtocol::LeafV1,
+                context_says: LauncherAuthorityProtocol::ResizeV2,
+            })
+        );
+
+        // A Dockerfile that lost its declaration entirely.
+        let mut stripped = good.clone();
+        stripped.dockerfile = stripped
+            .dockerfile
+            .lines()
+            .filter(|line| !line.contains(LAUNCHER_PROTOCOL_LABEL))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(
+            stripped.verify_declaration(),
+            Err(DeclarationError::Undeclared {
+                context_says: LauncherAuthorityProtocol::LeafV1,
+            })
+        );
+
+        // The label and the env var disagreeing is fatal too: the catalog reads
+        // one, the sidecar reads the other.
+        let mut split = good.clone();
+        split.dockerfile = split.dockerfile.replace(
+            &format!("ENV {LAUNCHER_PROTOCOL_ENV}=leaf-v1"),
+            &format!("ENV {LAUNCHER_PROTOCOL_ENV}=resize-v2"),
+        );
+        assert!(matches!(
+            split.verify_declaration(),
+            Err(DeclarationError::LabelEnvDisagree { .. })
+        ));
+
+        // A second declaration appended later is not "last one wins".
+        let mut doubled = good.clone();
+        doubled
+            .dockerfile
+            .push_str(&format!("LABEL {LAUNCHER_PROTOCOL_LABEL}=\"resize-v2\"\n"));
+        assert!(matches!(
+            doubled.verify_declaration(),
+            Err(DeclarationError::Undeclared { .. })
+        ));
+    }
+
     /// The declaration is not derived from — and cannot be confused with — the
     /// image's name. `generate_dockerfile` is never given a tag, and the wire
     /// string comes from the canonical type rather than a local literal.
     #[test]
     fn the_declaration_is_build_metadata_not_a_name() {
-        let df = generate_dockerfile(&minimal_valid_config(), &agent_worker()).unwrap();
-        assert_eq!(DECLARED_LAUNCHER_PROTOCOL.as_wire(), "leaf-v1");
+        let df = generate_dockerfile(
+            &minimal_valid_config(),
+            &agent_worker(),
+            DEFAULT_LAUNCHER_PROTOCOL,
+        )
+        .unwrap();
+        assert_eq!(DEFAULT_LAUNCHER_PROTOCOL.as_wire(), "leaf-v1");
         assert_eq!(
             df.dockerfile
-                .matches(DECLARED_LAUNCHER_PROTOCOL.as_wire())
+                .matches(DEFAULT_LAUNCHER_PROTOCOL.as_wire())
                 .count(),
             2,
             "the protocol appears exactly twice — the LABEL and the ENV — and nowhere else"
@@ -802,6 +1076,7 @@ mod tests {
         let err = generate_dockerfile(
             &minimal_valid_config(),
             &AgentWorkerImage::new("djinn/agent-worker", ""),
+            DEFAULT_LAUNCHER_PROTOCOL,
         )
         .unwrap_err();
         assert!(matches!(err, DockerfileError::MissingAgentWorkerRef));
@@ -841,7 +1116,7 @@ mod tests {
                 cargo_all_features: false,
             },
         ];
-        let df = generate_dockerfile(&cfg, &agent_worker()).unwrap();
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
         // A single RUN line with both toolchains, default preserved,
         // components carried through.
         assert!(
@@ -875,7 +1150,7 @@ mod tests {
             cargo_features: Vec::new(),
             cargo_all_features: false,
         }];
-        let df = generate_dockerfile(&cfg, &agent_worker()).unwrap();
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
         assert!(df.dockerfile.contains("NODE_VERSIONS=\"22 20\""));
         assert!(df.dockerfile.contains("PACKAGE_MANAGERS=\"pnpm yarn\""));
     }
@@ -889,7 +1164,7 @@ mod tests {
             "jq".into(),
             "build-essential".into(),
         ];
-        let df = generate_dockerfile(&cfg, &agent_worker()).unwrap();
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
         assert!(df.dockerfile.contains(
             "APT_PACKAGES=\"build-essential jq postgresql-client\" /tmp/djinn-scripts/install-system.sh"
         ));
@@ -900,7 +1175,7 @@ mod tests {
         let mut cfg = minimal_valid_config();
         cfg.env.insert("RUST_LOG".into(), "info".into());
         cfg.env.insert("CI".into(), "true".into());
-        let df = generate_dockerfile(&cfg, &agent_worker()).unwrap();
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
         // BTreeMap ordering is alphabetical → CI first, then RUST_LOG.
         let ci_pos = df.dockerfile.find("ENV CI=true").unwrap();
         let rust_pos = df.dockerfile.find("ENV RUST_LOG=info").unwrap();
@@ -914,7 +1189,7 @@ mod tests {
             HookCommand::Shell("echo build".into()),
             HookCommand::Exec(vec!["bash".into(), "-lc".into(), "echo exec".into()]),
         ];
-        let df = generate_dockerfile(&cfg, &agent_worker()).unwrap();
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
         assert!(df.dockerfile.contains("RUN echo build"));
         assert!(
             df.dockerfile
@@ -939,7 +1214,8 @@ mod tests {
             cargo_features: Vec::new(),
             cargo_all_features: false,
         }];
-        let err = generate_dockerfile(&cfg, &agent_worker()).unwrap_err();
+        let err =
+            generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap_err();
         assert!(matches!(err, DockerfileError::UnknownWorkspaceLanguage(s) if s == "zig"));
     }
 
@@ -948,7 +1224,7 @@ mod tests {
         // Alpine support was dropped in the 2026-04-22 cleanup; the base
         // is now fixed regardless of what the config carried.
         let cfg = minimal_valid_config();
-        let df = generate_dockerfile(&cfg, &agent_worker()).unwrap();
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
         assert!(df.dockerfile.contains("FROM debian:trixie-slim"));
         assert!(df.dockerfile.contains("/tmp/djinn-scripts/base-debian.sh"));
     }

--- a/server/crates/djinn-image-builder/src/hash.rs
+++ b/server/crates/djinn-image-builder/src/hash.rs
@@ -10,15 +10,20 @@
 //!    `retrigger_image_build` call.
 //! 3. The agent-worker helper-image reference. A worker rebuild flows
 //!    through here — another gap today's devcontainer-hash scheme has.
+//! 4. The declared launcher authority protocol, whenever it is not the
+//!    default. See [`compute_environment_hash`] for why the default is
+//!    excluded rather than mixed in unconditionally.
 //!
 //! The hash is sha256 of the concatenated inputs, lowercase hex. It's
 //! intentionally 64 chars so log output is readable (cf. the image tag
 //! format `djinn-project-<id>:<hash>`).
 
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
 use sha2::{Digest, Sha256};
 
 use djinn_stack::environment::EnvironmentConfig;
 
+use crate::dockerfile::DEFAULT_LAUNCHER_PROTOCOL;
 use crate::scripts::{SCRIPTS, ScriptFile};
 
 /// Return the sha256 of the script bundle — the concatenation of every
@@ -44,10 +49,34 @@ fn compute_bundle_sha(scripts: &[ScriptFile]) -> String {
 /// responsible for threading in a reference that represents the actual
 /// worker binary that will ship in the image (e.g. the SHA-pinned tag
 /// Tilt publishes to the cluster-local registry).
+///
+/// # The launcher authority protocol is an input
+///
+/// `launcher_protocol` is the declaration the artifact will carry. Mixing it in
+/// is what makes a protocol change *unable* to resolve to a cached image: the
+/// image tag is `djinn-project-<id>:<hash-prefix>`, so `leaf-v1` and
+/// `resize-v2` builds of an otherwise identical config live at different tags,
+/// and a flip re-triggers a build instead of leaving the old launcher in place
+/// under a catalog row claiming the new protocol.
+///
+/// Prefer [`crate::BuildContext::environment_hash`], which passes the
+/// declaration that was actually emitted into the Dockerfile.
+///
+/// # Why the default is excluded from the pre-image
+///
+/// [`DEFAULT_LAUNCHER_PROTOCOL`] contributes *nothing*, so the pre-image for a
+/// deployment that configures no protocol is byte-identical to the pre-image
+/// before the protocol became configurable. Mixing it in unconditionally would
+/// change every hash in every existing deployment and force a fleet-wide
+/// rebuild on upgrade for a change that alters no image. Only a deviation from
+/// the default perturbs the hash — which is exactly the case that must not
+/// reuse a cached artifact. `the_default_protocol_hashes_to_the_pre_change_preimage`
+/// pins this.
 pub fn compute_environment_hash(
     config: &EnvironmentConfig,
     agent_worker_ref: &str,
     build_version: &str,
+    launcher_protocol: LauncherAuthorityProtocol,
 ) -> String {
     let script_sha = compute_script_bundle_sha();
     let config_json = canonical_json(config);
@@ -136,6 +165,11 @@ pub fn compute_environment_hash(
     hasher.update(agent_worker_ref.as_bytes());
     hasher.update([0u8]);
     hasher.update(build_version.as_bytes());
+    if launcher_protocol != DEFAULT_LAUNCHER_PROTOCOL {
+        hasher.update([0u8]);
+        hasher.update(b"launcher-authority-protocol\0");
+        hasher.update(launcher_protocol.as_wire().as_bytes());
+    }
     hex_lower(&hasher.finalize())
 }
 
@@ -173,8 +207,18 @@ mod tests {
     #[test]
     fn hash_is_deterministic_for_same_inputs() {
         let c = cfg();
-        let a = compute_environment_hash(&c, "djinn/agent-worker:sha-abc", "0.6.57");
-        let b = compute_environment_hash(&c, "djinn/agent-worker:sha-abc", "0.6.57");
+        let a = compute_environment_hash(
+            &c,
+            "djinn/agent-worker:sha-abc",
+            "0.6.57",
+            DEFAULT_LAUNCHER_PROTOCOL,
+        );
+        let b = compute_environment_hash(
+            &c,
+            "djinn/agent-worker:sha-abc",
+            "0.6.57",
+            DEFAULT_LAUNCHER_PROTOCOL,
+        );
         assert_eq!(a, b);
         assert_eq!(a.len(), 64);
     }
@@ -182,17 +226,37 @@ mod tests {
     #[test]
     fn hash_changes_when_config_changes() {
         let mut c = cfg();
-        let a = compute_environment_hash(&c, "djinn/agent-worker:sha-abc", "0.6.57");
+        let a = compute_environment_hash(
+            &c,
+            "djinn/agent-worker:sha-abc",
+            "0.6.57",
+            DEFAULT_LAUNCHER_PROTOCOL,
+        );
         c.env.insert("RUST_LOG".into(), "info".into());
-        let b = compute_environment_hash(&c, "djinn/agent-worker:sha-abc", "0.6.57");
+        let b = compute_environment_hash(
+            &c,
+            "djinn/agent-worker:sha-abc",
+            "0.6.57",
+            DEFAULT_LAUNCHER_PROTOCOL,
+        );
         assert_ne!(a, b);
     }
 
     #[test]
     fn hash_changes_when_worker_ref_changes() {
         let c = cfg();
-        let a = compute_environment_hash(&c, "djinn/agent-worker:sha-abc", "0.6.57");
-        let b = compute_environment_hash(&c, "djinn/agent-worker:sha-def", "0.6.57");
+        let a = compute_environment_hash(
+            &c,
+            "djinn/agent-worker:sha-abc",
+            "0.6.57",
+            DEFAULT_LAUNCHER_PROTOCOL,
+        );
+        let b = compute_environment_hash(
+            &c,
+            "djinn/agent-worker:sha-def",
+            "0.6.57",
+            DEFAULT_LAUNCHER_PROTOCOL,
+        );
         assert_ne!(a, b);
     }
 
@@ -202,9 +266,98 @@ mod tests {
         // prompts/tools propagate — even when the worker-image tag is unchanged
         // (e.g. `:latest`).
         let c = cfg();
-        let a = compute_environment_hash(&c, "djinn/agent-runtime:latest", "0.6.56");
-        let b = compute_environment_hash(&c, "djinn/agent-runtime:latest", "0.6.57");
+        let a = compute_environment_hash(
+            &c,
+            "djinn/agent-runtime:latest",
+            "0.6.56",
+            DEFAULT_LAUNCHER_PROTOCOL,
+        );
+        let b = compute_environment_hash(
+            &c,
+            "djinn/agent-runtime:latest",
+            "0.6.57",
+            DEFAULT_LAUNCHER_PROTOCOL,
+        );
         assert_ne!(a, b);
+    }
+
+    /// **A protocol change cannot resolve to a cached image.** The controller
+    /// skips the build when the stored `config_hash` still equals the computed
+    /// one, and derives the image tag from that hash — so if the declaration
+    /// did not move the hash, flipping a deployment to `resize-v2` would leave
+    /// every project on the artifact its old launcher built, with the catalog
+    /// eventually claiming the new protocol over it.
+    ///
+    /// MUTATION: drop the `launcher_protocol` block from
+    /// `compute_environment_hash` (or hash `DEFAULT_LAUNCHER_PROTOCOL` in both
+    /// arms). Both `assert_ne!`s below fail.
+    #[test]
+    fn hash_changes_when_the_declared_protocol_changes() {
+        let c = cfg();
+        let leaf = compute_environment_hash(
+            &c,
+            "djinn/agent-worker:sha-abc",
+            "0.6.57",
+            LauncherAuthorityProtocol::LeafV1,
+        );
+        let resize = compute_environment_hash(
+            &c,
+            "djinn/agent-worker:sha-abc",
+            "0.6.57",
+            LauncherAuthorityProtocol::ResizeV2,
+        );
+        assert_ne!(
+            leaf, resize,
+            "a protocol flip must invalidate the cached image; identical hashes mean the \
+             controller never rebuilds and the tag never moves"
+        );
+
+        // …and the same must hold for every pair the type admits, so adding a
+        // third protocol cannot quietly collide with an existing one.
+        let mut seen = std::collections::BTreeSet::new();
+        for protocol in LauncherAuthorityProtocol::ALL {
+            let hash =
+                compute_environment_hash(&c, "djinn/agent-worker:sha-abc", "0.6.57", protocol);
+            assert!(
+                seen.insert(hash),
+                "{protocol} shares an environment hash with another protocol"
+            );
+        }
+    }
+
+    /// **The default is a no-op for every existing deployment.** Reconstructs
+    /// the pre-image `compute_environment_hash` had *before* the protocol
+    /// became an input, from this test's own bytes, and asserts the default
+    /// still hashes to exactly that. If it did not, upgrading a deployment that
+    /// configures nothing would invalidate every catalog image and rebuild the
+    /// whole fleet for a change that alters no artifact.
+    ///
+    /// MUTATION: hash the protocol unconditionally (delete the `if
+    /// launcher_protocol != DEFAULT_LAUNCHER_PROTOCOL` guard). This fails.
+    /// A deliberate salt bump also fails it, which is correct: the pre-image is
+    /// exactly what a salt bump changes, so it must be restated here on purpose.
+    #[test]
+    fn the_default_protocol_hashes_to_the_pre_change_preimage() {
+        let c = cfg();
+        let worker = "djinn/agent-worker:sha-abc";
+        let version = "0.6.57";
+
+        let mut legacy = Sha256::new();
+        legacy.update(b"env-config/v11\0");
+        legacy.update(canonical_json(&c).as_bytes());
+        legacy.update([0u8]);
+        legacy.update(compute_script_bundle_sha().as_bytes());
+        legacy.update([0u8]);
+        legacy.update(worker.as_bytes());
+        legacy.update([0u8]);
+        legacy.update(version.as_bytes());
+
+        assert_eq!(
+            compute_environment_hash(&c, worker, version, DEFAULT_LAUNCHER_PROTOCOL),
+            hex_lower(&legacy.finalize()),
+            "configuring no protocol must not perturb the hash of a single existing image"
+        );
+        assert_eq!(DEFAULT_LAUNCHER_PROTOCOL, LauncherAuthorityProtocol::LeafV1);
     }
 
     #[test]

--- a/server/crates/djinn-image-builder/src/lib.rs
+++ b/server/crates/djinn-image-builder/src/lib.rs
@@ -12,9 +12,11 @@
 //!   Dockerfile string + the script bundle that belongs alongside it in
 //!   the builder Pod's ConfigMap.
 //! * [`compute_environment_hash`] — sha256 over the canonicalised
-//!   config JSON + the script bundle digest + the worker binary digest.
-//!   Any change to any of those nulls the cached image hash and
-//!   re-triggers a build.
+//!   config JSON, the script bundle digest, the worker binary digest,
+//!   and the declared launcher authority protocol. Any change to any of
+//!   those nulls the cached image hash and re-triggers a build. Prefer
+//!   [`BuildContext::environment_hash`], which supplies the declaration
+//!   that was actually emitted rather than one a caller restates.
 //!
 //! ## Multi-toolchain
 //!
@@ -37,7 +39,7 @@ pub mod hash;
 pub mod scripts;
 
 pub use dockerfile::{
-    AgentWorkerImage, BuildContext, DECLARED_LAUNCHER_PROTOCOL, DockerfileError,
+    AgentWorkerImage, BuildContext, DEFAULT_LAUNCHER_PROTOCOL, DeclarationError, DockerfileError,
     LAUNCHER_PROTOCOL_ENV, LAUNCHER_PROTOCOL_LABEL, generate_dockerfile,
 };
 pub use hash::{compute_environment_hash, compute_script_bundle_sha};

--- a/server/crates/djinn-image-builder/tests/golden.rs
+++ b/server/crates/djinn-image-builder/tests/golden.rs
@@ -8,7 +8,8 @@
 use std::fs;
 use std::path::PathBuf;
 
-use djinn_image_builder::{AgentWorkerImage, generate_dockerfile};
+use djinn_image_builder::{AgentWorkerImage, DEFAULT_LAUNCHER_PROTOCOL, generate_dockerfile};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
 use djinn_stack::environment::EnvironmentConfig;
 
 fn fixture_dir() -> PathBuf {
@@ -19,17 +20,21 @@ fn agent_worker() -> AgentWorkerImage {
     AgentWorkerImage::new("djinn/agent-worker", "sha256-golden")
 }
 
-fn run_golden(name: &str) {
-    let dir = fixture_dir();
-    let config_path = dir.join(format!("{name}.config.json"));
-    let dockerfile_path = dir.join(format!("{name}.Dockerfile"));
-
+fn load_config(name: &str) -> EnvironmentConfig {
+    let config_path = fixture_dir().join(format!("{name}.config.json"));
     let config_raw =
         fs::read_to_string(&config_path).unwrap_or_else(|e| panic!("read {config_path:?}: {e}"));
-    let config: EnvironmentConfig =
-        serde_json::from_str(&config_raw).unwrap_or_else(|e| panic!("parse {config_path:?}: {e}"));
+    serde_json::from_str(&config_raw).unwrap_or_else(|e| panic!("parse {config_path:?}: {e}"))
+}
 
-    let rendered = generate_dockerfile(&config, &agent_worker())
+fn run_golden(name: &str) {
+    let dockerfile_path = fixture_dir().join(format!("{name}.Dockerfile"));
+    let config = load_config(name);
+
+    // The committed fixtures are what a deployment that configures nothing
+    // builds. Rendering them under the default is what makes them evidence that
+    // making the protocol configurable changed no existing artifact.
+    let rendered = generate_dockerfile(&config, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL)
         .unwrap_or_else(|e| panic!("generate {name}: {e}"));
 
     if std::env::var("REGENERATE_GOLDEN").is_ok() {
@@ -50,4 +55,44 @@ fn polyglot_monorepo_two_rust_toolchains() {
 #[test]
 fn single_rust_minimal() {
     run_golden("single_rust");
+}
+
+/// Configuring `resize-v2` changes the artifact in exactly one way: it declares
+/// `resize-v2`. Diffed against the committed `leaf-v1` fixture rather than a
+/// second fixture, so the assertion is "nothing else moved" and not "these two
+/// files happen to differ".
+///
+/// MUTATION: hardcode the declaration in `emit_launcher_protocol` again — the
+/// rendered output equals the leaf-v1 fixture and the first assertion fails,
+/// naming `resize-v2` as absent.
+#[test]
+fn configuring_resize_v2_changes_only_the_declaration() {
+    for name in ["single_rust", "polyglot_monorepo"] {
+        let config = load_config(name);
+        let leaf = fs::read_to_string(fixture_dir().join(format!("{name}.Dockerfile")))
+            .unwrap_or_else(|e| panic!("read {name} fixture: {e}"));
+
+        let resize = generate_dockerfile(
+            &config,
+            &agent_worker(),
+            LauncherAuthorityProtocol::ResizeV2,
+        )
+        .unwrap_or_else(|e| panic!("generate {name}: {e}"))
+        .dockerfile;
+
+        assert!(
+            resize.contains("resize-v2"),
+            "{name}: the configured protocol never reached the artifact:\n{resize}"
+        );
+        assert!(
+            !resize.contains("leaf-v1"),
+            "{name}: the artifact still claims leaf-v1 somewhere:\n{resize}"
+        );
+        pretty_assertions::assert_eq!(
+            leaf.replace("leaf-v1", "resize-v2"),
+            resize,
+            "{}: selecting a protocol must change the declaration and nothing else",
+            name
+        );
+    }
 }

--- a/server/crates/djinn-image-controller/src/build_job.rs
+++ b/server/crates/djinn-image-controller/src/build_job.rs
@@ -11,7 +11,7 @@
 
 use std::collections::BTreeMap;
 
-use djinn_image_builder::{BuildContext, ScriptFile};
+use djinn_image_builder::{BuildContext, DeclarationError, ScriptFile};
 use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
     ConfigMap, ConfigMapVolumeSource, Container, EnvVar, KeyToPath, PodSpec, PodTemplateSpec,
@@ -235,13 +235,25 @@ fn script_key_for_path(path: &str) -> String {
 /// (`<reg>/djinn-project-<id>:<hash>` or `<reg>/djinn-image-<id>:<hash>`);
 /// the builder writes to that tag and exports cache to
 /// `<reg>/cache/<subject-segment>`.
+///
+/// # Fail-closed on a disagreeing declaration
+///
+/// This Job renders two things that must say the same word: the Dockerfile
+/// (via the ConfigMap) whose `LABEL` becomes the artifact's own metadata, and
+/// the `LAUNCHER_AUTHORITY_PROTOCOL` env the builder echoes as the sentinel the
+/// watcher writes into `images.launcher_authority_protocol`. So this is the
+/// last place both are still in one hand, and it refuses to render a Job whose
+/// [`BuildContext`] reports a protocol its Dockerfile does not declare. An
+/// image whose label and catalog row disagree cannot be built, rather than
+/// being built and then detected.
 pub fn build_image_build_job(
     config: &ImageControllerConfig,
     subject: &BuildSubject,
     hash_prefix: &str,
     image_tag: &str,
     build_context: &BuildContext,
-) -> Job {
+) -> Result<Job, DeclarationError> {
+    let declared = build_context.verify_declaration()?;
     let labels = job_labels(subject, hash_prefix);
     let subject_segment = subject.resource_segment();
     let job_name = build_job_name_for(subject, hash_prefix);
@@ -326,13 +338,11 @@ echo "DJINN_LAUNCHER_PROTOCOL=${{LAUNCHER_AUTHORITY_PROTOCOL}}"
             env_var("REGISTRY_HOST", &config.registry_host),
             env_var("SUBJECT_ID", subject.id()),
             env_var("IMAGE_TAG", image_tag),
-            // Straight off the BuildContext that rendered the Dockerfile, so
-            // the sentinel and the artifact's LABEL are the same string by
-            // construction.
-            env_var(
-                "LAUNCHER_AUTHORITY_PROTOCOL",
-                build_context.launcher_protocol.as_wire(),
-            ),
+            // The value `verify_declaration` just read back out of the
+            // Dockerfile this Job builds — so the sentinel the catalog is
+            // written from and the artifact's own LABEL are the same string,
+            // checked rather than assumed.
+            env_var("LAUNCHER_AUTHORITY_PROTOCOL", declared.as_wire()),
         ]),
         volume_mounts: Some(vec![
             VolumeMount {
@@ -419,11 +429,7 @@ echo "DJINN_LAUNCHER_PROTOCOL=${{LAUNCHER_AUTHORITY_PROTOCOL}}"
         spec: Some(pod_spec),
     };
 
-    // Drop `build_context` reference early; `_` silences the unused-var
-    // hint without having to reorder the function body.
-    let _ = build_context;
-
-    Job {
+    Ok(Job {
         metadata: ObjectMeta {
             name: Some(job_name),
             namespace: Some(config.namespace.clone()),
@@ -438,7 +444,7 @@ echo "DJINN_LAUNCHER_PROTOCOL=${{LAUNCHER_AUTHORITY_PROTOCOL}}"
             ..JobSpec::default()
         }),
         ..Job::default()
-    }
+    })
 }
 
 /// Build an OwnerReference pointing at a created build Job so the
@@ -495,7 +501,7 @@ pub(crate) fn sanitize_id(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use djinn_image_builder::{AgentWorkerImage, generate_dockerfile};
+    use djinn_image_builder::{AgentWorkerImage, DEFAULT_LAUNCHER_PROTOCOL, generate_dockerfile};
     use djinn_stack::environment::EnvironmentConfig;
 
     fn test_cfg() -> ImageControllerConfig {
@@ -505,7 +511,12 @@ mod tests {
     fn test_build_context() -> BuildContext {
         let mut cfg = EnvironmentConfig::empty();
         cfg.schema_version = djinn_stack::environment::SCHEMA_VERSION;
-        generate_dockerfile(&cfg, &AgentWorkerImage::new("djinn/agent-runtime", "dev")).unwrap()
+        generate_dockerfile(
+            &cfg,
+            &AgentWorkerImage::new("djinn/agent-runtime", "dev"),
+            DEFAULT_LAUNCHER_PROTOCOL,
+        )
+        .unwrap()
     }
 
     #[test]
@@ -544,7 +555,8 @@ mod tests {
             "abc123def456",
             "reg/p:abc123",
             &ctx,
-        );
+        )
+        .unwrap();
         let script = &job
             .spec
             .as_ref()
@@ -587,7 +599,8 @@ mod tests {
             "abc123",
             "reg/p:abc123",
             &ctx,
-        );
+        )
+        .unwrap();
         let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
         let volumes = pod.volumes.as_ref().unwrap();
         let ctx_vol = volumes
@@ -627,7 +640,8 @@ mod tests {
             "abc123",
             "reg/p:abc123",
             &ctx,
-        );
+        )
+        .unwrap();
         let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
         assert_eq!(pod.service_account_name.as_deref(), Some("custom-build-sa"));
     }
@@ -642,7 +656,8 @@ mod tests {
             "abc123",
             "reg/p:abc123",
             &ctx,
-        );
+        )
+        .unwrap();
         let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
         let volumes = pod.volumes.as_ref().unwrap();
         assert!(
@@ -661,7 +676,8 @@ mod tests {
             "abc123",
             "reg/p:abc123",
             &ctx,
-        );
+        )
+        .unwrap();
         let spec = job.spec.as_ref().unwrap();
         assert_eq!(spec.backoff_limit, Some(1));
         assert_eq!(
@@ -717,7 +733,8 @@ mod tests {
             "6812838f6587",
             "reg/djinn-image-019e9907-3685-7041-a7b7-246adf24c2d0:6812838f6587",
             &ctx,
-        );
+        )
+        .unwrap();
         let name = job.metadata.name.as_deref().unwrap();
         assert!(
             name.len() <= 63,
@@ -737,7 +754,8 @@ mod tests {
             "abc123",
             "reg/djinn-image-img-1:abc123",
             &ctx,
-        );
+        )
+        .unwrap();
         let labels = job.metadata.labels.as_ref().unwrap();
         assert_eq!(
             labels.get(LABEL_IMAGE_ID).map(String::as_str),
@@ -760,7 +778,8 @@ mod tests {
             "abc123",
             "reg/djinn-image-img-1:abc123",
             &ctx,
-        );
+        )
+        .unwrap();
         let script = &job
             .spec
             .as_ref()
@@ -793,7 +812,8 @@ mod tests {
             // A tag that lies about the protocol in every segment.
             "reg/djinn-image-resize-v2:resize-v2",
             &ctx,
-        );
+        )
+        .unwrap();
         let container = &job
             .spec
             .as_ref()
@@ -822,7 +842,7 @@ mod tests {
         assert_eq!(declared, ctx.launcher_protocol.as_wire());
         assert_eq!(
             declared,
-            djinn_image_builder::DECLARED_LAUNCHER_PROTOCOL.as_wire()
+            djinn_image_builder::DEFAULT_LAUNCHER_PROTOCOL.as_wire()
         );
         assert_ne!(
             declared, "resize-v2",
@@ -841,7 +861,8 @@ mod tests {
             "abc123",
             "reg/djinn-image-img-1:abc123",
             &ctx,
-        );
+        )
+        .unwrap();
         assert_eq!(
             job.metadata.name.as_deref(),
             Some(build_job_name_for(&subject, "abc123").as_str())

--- a/server/crates/djinn-image-controller/src/build_job.rs
+++ b/server/crates/djinn-image-controller/src/build_job.rs
@@ -246,6 +246,7 @@ pub(crate) fn render_builder_script(
     config: &ImageControllerConfig,
     subject_segment: &str,
 ) -> String {
+    // buildctl talks to the shared in-cluster buildkitd over gRPC. The
     // `--local` flags point the build context + dockerfile at the
     // ConfigMap mount. `--output type=image,...,push=true` pushes to
     // Zot; `--export-cache` / `--import-cache` hit the same registry's

--- a/server/crates/djinn-image-controller/src/build_job.rs
+++ b/server/crates/djinn-image-controller/src/build_job.rs
@@ -34,6 +34,17 @@ pub const LABEL_IMAGE_HASH: &str = "djinn.app/image-hash";
 /// Value written to [`LABEL_COMPONENT`] on build resources.
 pub const COMPONENT_IMAGE_BUILD: &str = "image-build";
 
+/// Name of the builder container's environment variable carrying the launcher
+/// authority protocol the artifact declares.
+///
+/// One name, two consumers that must agree: the container env
+/// [`build_image_build_job`] sets, and the `echo` in
+/// [`render_builder_script`] that expands it into the sentinel the watcher
+/// parses into `images.launcher_authority_protocol`. Renaming it on one side
+/// only would print a literal `${…}` the watcher refuses — so both sides read
+/// this constant and the drift is not expressible.
+pub const LAUNCHER_PROTOCOL_JOB_ENV: &str = "LAUNCHER_AUTHORITY_PROTOCOL";
+
 /// What a build Job builds: a project's bespoke per-project image, or a
 /// shared catalog image (migration 46). The build mechanics are identical
 /// — same Dockerfile generator, same buildctl Job — only the identity
@@ -224,42 +235,17 @@ fn script_key_for_path(path: &str) -> String {
         .collect()
 }
 
-/// Build the Job manifest dispatched for one per-project image build.
+/// The shell the builder container runs, rendered from the deployment config
+/// alone.
 ///
-/// `build_context` is taken by reference so the scripts list can produce
-/// matching `items:` entries on the mount. The generated Dockerfile and
-/// the scripts themselves are served from the per-build ConfigMap
-/// [`build_image_build_context_config_map`] created first.
-///
-/// `image_tag` is the full content-addressable tag
-/// (`<reg>/djinn-project-<id>:<hash>` or `<reg>/djinn-image-<id>:<hash>`);
-/// the builder writes to that tag and exports cache to
-/// `<reg>/cache/<subject-segment>`.
-///
-/// # Fail-closed on a disagreeing declaration
-///
-/// This Job renders two things that must say the same word: the Dockerfile
-/// (via the ConfigMap) whose `LABEL` becomes the artifact's own metadata, and
-/// the `LAUNCHER_AUTHORITY_PROTOCOL` env the builder echoes as the sentinel the
-/// watcher writes into `images.launcher_authority_protocol`. So this is the
-/// last place both are still in one hand, and it refuses to render a Job whose
-/// [`BuildContext`] reports a protocol its Dockerfile does not declare. An
-/// image whose label and catalog row disagree cannot be built, rather than
-/// being built and then detected.
-pub fn build_image_build_job(
+/// Extracted from [`build_image_build_job`] so the script's own text is
+/// reachable without materialising a Kubernetes object: the sentinel this
+/// script prints is what the catalog row is written from, and a test of that
+/// chain should read the real script rather than restate it.
+pub(crate) fn render_builder_script(
     config: &ImageControllerConfig,
-    subject: &BuildSubject,
-    hash_prefix: &str,
-    image_tag: &str,
-    build_context: &BuildContext,
-) -> Result<Job, DeclarationError> {
-    let declared = build_context.verify_declaration()?;
-    let labels = job_labels(subject, hash_prefix);
-    let subject_segment = subject.resource_segment();
-    let job_name = build_job_name_for(subject, hash_prefix);
-    let cm_name = build_context_config_map_name_for(subject, hash_prefix);
-
-    // buildctl talks to the shared in-cluster buildkitd over gRPC. The
+    subject_segment: &str,
+) -> String {
     // `--local` flags point the build context + dockerfile at the
     // ConfigMap mount. `--output type=image,...,push=true` pushes to
     // Zot; `--export-cache` / `--import-cache` hit the same registry's
@@ -272,7 +258,7 @@ pub fn build_image_build_job(
     // it. The `--output` already carries oci-mediatypes=true; the cache
     // export needs both flags. Registries that auto-accept the default
     // media type (Zot, GHCR) are unaffected by the stricter encoding.
-    let builder_script = format!(
+    format!(
         r#"set -euo pipefail
 mkdir -p {docker_config}
 cp {auth_dir}/config.json {docker_config}/config.json
@@ -321,14 +307,53 @@ echo "DJINN_IMAGE_DIGEST=${{DIGEST}}"
 # this container and is echoed verbatim. It is deliberately NOT derived from
 # "$IMAGE_TAG": a tag is mutable naming and can be made to claim anything,
 # while the protocol decides whether the launcher or Pod resize owns CPU quota.
-echo "DJINN_LAUNCHER_PROTOCOL=${{LAUNCHER_AUTHORITY_PROTOCOL}}"
+echo "{protocol_sentinel}${{{protocol_env}}}"
 "#,
         auth_dir = REGISTRY_AUTH_MOUNT_DIR,
         docker_config = DOCKER_CONFIG_MOUNT_DIR,
         ctx_dir = BUILD_CONTEXT_MOUNT_DIR,
         registry = config.registry_host,
         cache_segment = subject_segment,
-    );
+        protocol_sentinel = crate::watcher::PROTOCOL_SENTINEL,
+        protocol_env = LAUNCHER_PROTOCOL_JOB_ENV,
+    )
+}
+
+/// Build the Job manifest dispatched for one per-project image build.
+///
+/// `build_context` is taken by reference so the scripts list can produce
+/// matching `items:` entries on the mount. The generated Dockerfile and
+/// the scripts themselves are served from the per-build ConfigMap
+/// [`build_image_build_context_config_map`] created first.
+///
+/// `image_tag` is the full content-addressable tag
+/// (`<reg>/djinn-project-<id>:<hash>` or `<reg>/djinn-image-<id>:<hash>`);
+/// the builder writes to that tag and exports cache to
+/// `<reg>/cache/<subject-segment>`.
+///
+/// # Fail-closed on a disagreeing declaration
+///
+/// This Job renders two things that must say the same word: the Dockerfile
+/// (via the ConfigMap) whose `LABEL` becomes the artifact's own metadata, and
+/// the `LAUNCHER_AUTHORITY_PROTOCOL` env the builder echoes as the sentinel the
+/// watcher writes into `images.launcher_authority_protocol`. So this is the
+/// last place both are still in one hand, and it refuses to render a Job whose
+/// [`BuildContext`] reports a protocol its Dockerfile does not declare. An
+/// image whose label and catalog row disagree cannot be built, rather than
+/// being built and then detected.
+pub fn build_image_build_job(
+    config: &ImageControllerConfig,
+    subject: &BuildSubject,
+    hash_prefix: &str,
+    image_tag: &str,
+    build_context: &BuildContext,
+) -> Result<Job, DeclarationError> {
+    let declared = build_context.verify_declaration()?;
+    let labels = job_labels(subject, hash_prefix);
+    let subject_segment = subject.resource_segment();
+    let job_name = build_job_name_for(subject, hash_prefix);
+    let cm_name = build_context_config_map_name_for(subject, hash_prefix);
+    let builder_script = render_builder_script(config, &subject_segment);
 
     let container = Container {
         name: "builder".to_string(),
@@ -342,7 +367,7 @@ echo "DJINN_LAUNCHER_PROTOCOL=${{LAUNCHER_AUTHORITY_PROTOCOL}}"
             // Dockerfile this Job builds — so the sentinel the catalog is
             // written from and the artifact's own LABEL are the same string,
             // checked rather than assumed.
-            env_var("LAUNCHER_AUTHORITY_PROTOCOL", declared.as_wire()),
+            env_var(LAUNCHER_PROTOCOL_JOB_ENV, declared.as_wire()),
         ]),
         volume_mounts: Some(vec![
             VolumeMount {
@@ -848,6 +873,78 @@ mod tests {
             declared, "resize-v2",
             "the misleading tag must not reach the declaration"
         );
+    }
+
+    /// The **configured** declaration — not just the default — is what the
+    /// build container's env carries, for every protocol the type admits.
+    ///
+    /// This assertion lives here rather than in the end-to-end module because
+    /// it is the one step of that chain which genuinely needs the rendered
+    /// Kubernetes object, and this file is already inside the image-controller's
+    /// k8s capability-boundary inventory (`epic/fztz`). Reading the Job from a
+    /// new file would have grown that inventory to buy what one test needs.
+    ///
+    /// MUTATION: render the env from a literal (`env_var(…, "leaf-v1")`)
+    /// instead of the verified declaration. The `resize-v2` iteration fails,
+    /// naming the value the catalog would have been told.
+    #[test]
+    fn the_build_container_env_carries_the_configured_declaration() {
+        let cfg = test_cfg();
+        for protocol in djinn_launcher_protocol::LauncherAuthorityProtocol::ALL {
+            let mut env_cfg = EnvironmentConfig::empty();
+            env_cfg.schema_version = djinn_stack::environment::SCHEMA_VERSION;
+            let ctx = generate_dockerfile(
+                &env_cfg,
+                &AgentWorkerImage::new("djinn/agent-runtime", "dev"),
+                protocol,
+            )
+            .unwrap();
+
+            let job = build_image_build_job(
+                &cfg,
+                &BuildSubject::image("img-1"),
+                "abc123",
+                // Still a tag that lies, in the opposite direction each time.
+                "reg/djinn-image-leaf-v1:leaf-v1",
+                &ctx,
+            )
+            .unwrap();
+            let declared = job
+                .spec
+                .as_ref()
+                .unwrap()
+                .template
+                .spec
+                .as_ref()
+                .unwrap()
+                .containers[0]
+                .env
+                .as_ref()
+                .unwrap()
+                .iter()
+                .find(|e| e.name == LAUNCHER_PROTOCOL_JOB_ENV)
+                .expect("the build container must carry the declaration")
+                .value
+                .clone()
+                .unwrap();
+
+            assert_eq!(
+                declared,
+                protocol.as_wire(),
+                "{protocol}: the catalog is written from this value, so it must be the \
+                 declaration the artifact was built with"
+            );
+            // And it is the same string the Dockerfile's LABEL carries — the
+            // artifact's metadata and the catalog's row, compared directly.
+            assert!(
+                ctx.dockerfile.contains(&format!(
+                    "LABEL {}=\"{declared}\"",
+                    djinn_image_builder::LAUNCHER_PROTOCOL_LABEL
+                )),
+                "{protocol}: the Job env and the artifact's LABEL must agree:\n{}",
+                ctx.dockerfile
+            );
+        }
     }
 
     #[test]

--- a/server/crates/djinn-image-controller/src/config.rs
+++ b/server/crates/djinn-image-controller/src/config.rs
@@ -2,6 +2,9 @@
 
 use std::num::ParseIntError;
 
+use djinn_image_builder::DEFAULT_LAUNCHER_PROTOCOL;
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+
 /// Default buildkitd DNS (matches `buildkitd-service.yaml` shipped in PR 4).
 const DEFAULT_BUILDKITD_HOST: &str = "tcp://djinn-buildkitd.djinn.svc.cluster.local:1234";
 /// Default Zot registry DNS (matches `zot-service.yaml` shipped in PR 4).
@@ -48,6 +51,18 @@ pub mod env {
     /// guaranteeing new agent prompts/tools propagate even if
     /// `DJINN_IMAGE_AGENT_WORKER_IMAGE` is an unversioned tag (`:latest`).
     pub const DJINN_VERSION: &str = "DJINN_VERSION";
+    /// The launcher authority protocol every image this deployment builds
+    /// declares in its own build metadata — `leaf-v1` (the launcher owns each
+    /// invocation leaf's `cpu.max`) or `resize-v2` (Pod resize owns quota and
+    /// the launcher must never write it).
+    ///
+    /// Unset means [`djinn_image_builder::DEFAULT_LAUNCHER_PROTOCOL`], which is
+    /// what every deployment built before this knob existed, so leaving it
+    /// alone rebuilds nothing. Setting it is the entry point of the resize
+    /// cutover: the declaration is mixed into the environment hash, so the
+    /// flip re-tags and rebuilds every catalog image instead of relabelling
+    /// artifacts whose launcher still writes leaf quota.
+    pub const LAUNCHER_AUTHORITY_PROTOCOL: &str = "DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL";
     pub const MAX_CONCURRENT: &str = "DJINN_IMAGE_MAX_CONCURRENT";
     pub const NAMESPACE: &str = "DJINN_IMAGE_NAMESPACE";
     pub const REGISTRY_AUTH_SECRET: &str = "DJINN_IMAGE_REGISTRY_AUTH_SECRET";
@@ -96,6 +111,18 @@ pub struct ImageControllerConfig {
     /// version bump always forces a rebuild with the current agent worker
     /// (prompts + tool schemas). Empty/`dev` outside a tagged release.
     pub build_version: String,
+    /// The launcher authority protocol images built by this deployment
+    /// declare. Fleet-wide rather than per project: the declaration describes
+    /// the `djinn-cgroup-launcher` binary copied out of the single
+    /// [`Self::agent_worker_image`] every catalog image shares, and admission
+    /// compares it against the cluster-wide authority-mode singleton
+    /// (`launcher_authority_mode`). A per-project protocol would mean two
+    /// projects on one cluster disagreeing about who owns a node's CPU quota,
+    /// which is not a thing the mode row can express.
+    ///
+    /// Defaults to [`djinn_image_builder::DEFAULT_LAUNCHER_PROTOCOL`]; set via
+    /// [`env::LAUNCHER_AUTHORITY_PROTOCOL`].
+    pub declared_launcher_protocol: LauncherAuthorityProtocol,
     /// Namespace where build Jobs are created and the registry-auth Secret
     /// is mounted from.
     pub namespace: String,
@@ -140,6 +167,7 @@ impl ImageControllerConfig {
             builder_image: DEFAULT_BUILDER_IMAGE.into(),
             agent_worker_image: DEFAULT_AGENT_WORKER_IMAGE.into(),
             build_version: "dev".into(),
+            declared_launcher_protocol: DEFAULT_LAUNCHER_PROTOCOL,
             namespace: DEFAULT_NAMESPACE.into(),
             registry_auth_secret: DEFAULT_REGISTRY_AUTH_SECRET.into(),
             mirror_pvc: DEFAULT_MIRROR_PVC.into(),
@@ -179,6 +207,26 @@ impl ImageControllerConfig {
             && !v.trim().is_empty()
         {
             cfg.build_version = v;
+        }
+        if let Ok(v) = std::env::var(env::LAUNCHER_AUTHORITY_PROTOCOL)
+            && !v.trim().is_empty()
+        {
+            match v.trim().parse::<LauncherAuthorityProtocol>() {
+                Ok(protocol) => cfg.declared_launcher_protocol = protocol,
+                // Keep the default rather than guessing. `leaf-v1` is the
+                // conservative arm: an image that declares less authority than
+                // the cluster expects is refused at admission, whereas guessing
+                // `resize-v2` would ship an artifact claiming Kubernetes owns
+                // quota that the launcher still writes itself.
+                Err(error) => tracing::error!(
+                    value = %v,
+                    %error,
+                    default = %DEFAULT_LAUNCHER_PROTOCOL,
+                    "{} is not a launcher authority protocol; keeping the default — \
+                     the configured cutover is NOT in effect",
+                    env::LAUNCHER_AUTHORITY_PROTOCOL
+                ),
+            }
         }
         if let Ok(v) = std::env::var(env::NAMESPACE) {
             cfg.namespace = v;
@@ -244,8 +292,53 @@ fn validate_positive(n: usize) -> Result<usize, ParseIntError> {
     }
 }
 
+/// Serialized access to the process environment `from_env` reads.
+///
+/// The harness runs this crate's unit tests on many threads in one process, so
+/// two cases setting the same variable interleave and read each other's value —
+/// `from_env_honors_zot_retention_vars` and
+/// `from_env_invalid_zot_retention_bools_fall_back` both write
+/// `DJINN_ZOT_RETENTION_ENABLED`, and either can observe the other's. Every
+/// test that reads or writes this environment takes [`guard`] first, so the
+/// save/restore each one already does is actually sound.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use super::env;
+
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Hold for the duration of any test that mutates or reads the controller's
+    /// environment. NOT reentrant: never call [`with_protocol_env`] while
+    /// holding it.
+    pub(crate) fn guard() -> std::sync::MutexGuard<'static, ()> {
+        LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    pub(crate) fn with_protocol_env<T>(value: Option<&str>, body: impl FnOnce() -> T) -> T {
+        let _guard = guard();
+        let saved = std::env::var(env::LAUNCHER_AUTHORITY_PROTOCOL).ok();
+        // SAFETY: the lock above makes this the only thread mutating this
+        // variable, and nothing else in the test binary reads it concurrently.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(env::LAUNCHER_AUTHORITY_PROTOCOL, v),
+                None => std::env::remove_var(env::LAUNCHER_AUTHORITY_PROTOCOL),
+            }
+        }
+        let out = body();
+        unsafe {
+            match saved {
+                Some(prev) => std::env::set_var(env::LAUNCHER_AUTHORITY_PROTOCOL, prev),
+                None => std::env::remove_var(env::LAUNCHER_AUTHORITY_PROTOCOL),
+            }
+        }
+        out
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::test_env::with_protocol_env;
     use super::*;
 
     #[test]
@@ -256,8 +349,46 @@ mod tests {
         assert_eq!(cfg.max_concurrent, DEFAULT_MAX_CONCURRENT);
     }
 
+    /// **A deployment can select the protocol, and selects nothing by default.**
+    ///
+    /// MUTATION: delete the `LAUNCHER_AUTHORITY_PROTOCOL` arm from `from_env`.
+    /// The `resize-v2` case fails, reporting `leaf-v1` — the exact shape of the
+    /// bug this knob exists to fix (a declaration no deployment can reach).
+    #[test]
+    fn from_env_selects_the_declared_launcher_protocol() {
+        for protocol in LauncherAuthorityProtocol::ALL {
+            let cfg = with_protocol_env(Some(protocol.as_wire()), ImageControllerConfig::from_env);
+            assert_eq!(
+                cfg.declared_launcher_protocol, protocol,
+                "{protocol} must be selectable by a deployment"
+            );
+        }
+
+        let unset = with_protocol_env(None, ImageControllerConfig::from_env);
+        assert_eq!(
+            unset.declared_launcher_protocol, DEFAULT_LAUNCHER_PROTOCOL,
+            "an unconfigured deployment must keep declaring what it declared before"
+        );
+        assert_eq!(DEFAULT_LAUNCHER_PROTOCOL, LauncherAuthorityProtocol::LeafV1);
+    }
+
+    /// A value that is not exactly one of the two wire forms never becomes a
+    /// declaration. Nothing here may fall through to `resize-v2`: the
+    /// conservative arm is the one the launcher already implements.
+    #[test]
+    fn a_malformed_protocol_selection_keeps_the_default() {
+        for bogus in ["resize-v3", "RESIZE-V2", "resize_v2", "true", "   "] {
+            let cfg = with_protocol_env(Some(bogus), ImageControllerConfig::from_env);
+            assert_eq!(
+                cfg.declared_launcher_protocol, DEFAULT_LAUNCHER_PROTOCOL,
+                "{bogus:?} must not be honoured as a protocol selection"
+            );
+        }
+    }
+
     #[test]
     fn from_env_honors_documented_vars() {
+        let _env = test_env::guard();
         // SAFETY: single-threaded unit test.
         unsafe {
             std::env::set_var(env::BUILDKITD_HOST, "tcp://bk.example:1234");
@@ -277,6 +408,7 @@ mod tests {
 
     #[test]
     fn from_env_invalid_max_concurrent_falls_back() {
+        let _env = test_env::guard();
         let saved = std::env::var(env::MAX_CONCURRENT).ok();
         unsafe {
             std::env::set_var(env::MAX_CONCURRENT, "not-a-number");
@@ -304,6 +436,7 @@ mod tests {
 
     #[test]
     fn from_env_honors_zot_retention_vars() {
+        let _env = test_env::guard();
         // SAFETY: single-threaded unit test.
         unsafe {
             std::env::set_var(env::ZOT_RETENTION_ENABLED, "true");
@@ -332,6 +465,7 @@ mod tests {
 
     #[test]
     fn from_env_invalid_zot_retention_bools_fall_back() {
+        let _env = test_env::guard();
         // SAFETY: single-threaded unit test.
         unsafe {
             std::env::set_var(env::ZOT_RETENTION_ENABLED, "maybe");

--- a/server/crates/djinn-image-controller/src/controller.rs
+++ b/server/crates/djinn-image-controller/src/controller.rs
@@ -36,9 +36,7 @@ use std::sync::Arc;
 use djinn_db::{
     Database, Image, ImageRepository, ImageStatus, ProjectRepository, ServicePresetRepository,
 };
-use djinn_image_builder::{
-    AgentWorkerImage, BuildContext, compute_environment_hash, generate_dockerfile,
-};
+use djinn_image_builder::{AgentWorkerImage, BuildContext, generate_dockerfile};
 use djinn_stack::environment::EnvironmentConfig;
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::ConfigMap;
@@ -78,6 +76,17 @@ pub enum ImageControllerError {
         project_id: String,
         #[source]
         source: djinn_image_builder::DockerfileError,
+    },
+    /// The build context reported a launcher authority protocol its own
+    /// Dockerfile does not declare. Never dispatched: the Job env is what the
+    /// catalog records and the Dockerfile is what the artifact carries, so
+    /// building this would produce an image whose label and catalog row
+    /// disagree about who owns CPU quota.
+    #[error("launcher declaration disagreement for {project_id}: {source}")]
+    LauncherDeclaration {
+        project_id: String,
+        #[source]
+        source: djinn_image_builder::DeclarationError,
     },
 }
 
@@ -155,45 +164,42 @@ impl ImageController {
     }
 
     /// Subject-generic k8s build dispatch shared by the per-project and
-    /// catalog-image paths: generate the Dockerfile, upsert the build-context
-    /// ConfigMap, then create (or reconcile) the buildctl Job. Returns what
-    /// the caller should persist — the project/image status write differs by
-    /// subject but the cluster mechanics are identical.
+    /// catalog-image paths: upsert the build-context ConfigMap, then create (or
+    /// reconcile) the buildctl Job. Returns what the caller should persist —
+    /// the project/image status write differs by subject but the cluster
+    /// mechanics are identical.
+    ///
+    /// `build_context` is rendered by the caller, which derives `new_hash` from
+    /// it via [`BuildContext::environment_hash`]. That ordering is deliberate:
+    /// the tag this Job pushes to is a prefix of a hash computed over the
+    /// declaration this very Dockerfile carries, so a `resize-v2` build can
+    /// never land on the tag a `leaf-v1` artifact already occupies.
     async fn dispatch_build_job(
         &self,
         subject: &BuildSubject,
-        cfg: &EnvironmentConfig,
+        build_context: &BuildContext,
         new_hash: &str,
         image_tag: &str,
     ) -> Result<BuildDispatch> {
         let subject_id = subject.id().to_string();
         let hash_prefix = &new_hash[..HASH_TAG_PREFIX_LEN.min(new_hash.len())];
 
-        let (repo_ref, tag_ref) = split_image_ref(&self.config.agent_worker_image);
-        let agent_worker_image = AgentWorkerImage::new(repo_ref, tag_ref);
-
-        // 1. Generate the Dockerfile + script bundle.
-        let build_context = generate_dockerfile(cfg, &agent_worker_image).map_err(|source| {
-            ImageControllerError::Dockerfile {
-                project_id: subject_id.clone(),
-                source,
-            }
-        })?;
-
-        // 2. Create the build-context ConfigMap *before* the Job so the
+        // 1. Create the build-context ConfigMap *before* the Job so the
         // Pod's volume mount is satisfiable at startup. The CM is
         // per-build (per hash) so two different hashes never share content.
-        self.upsert_build_context_cm(subject, hash_prefix, &build_context)
+        self.upsert_build_context_cm(subject, hash_prefix, build_context)
             .await?;
 
-        // 3. Create the Job.
-        let job = build_image_build_job(
-            &self.config,
-            subject,
-            hash_prefix,
-            image_tag,
-            &build_context,
-        );
+        // 2. Create the Job. Fail-closed if the context reports a declaration
+        // its Dockerfile does not carry — the Job env becomes the catalog row
+        // and the Dockerfile becomes the artifact's label, so building one that
+        // disagrees would hand the same Pod's CPU quota to two owners.
+        let job =
+            build_image_build_job(&self.config, subject, hash_prefix, image_tag, build_context)
+                .map_err(|source| ImageControllerError::LauncherDeclaration {
+                    project_id: subject_id.clone(),
+                    source,
+                })?;
         let jobs: Api<Job> = Api::namespaced(self.client.clone(), &self.config.namespace);
         let job_name =
             job.metadata.name.clone().unwrap_or_else(|| {
@@ -419,9 +425,23 @@ impl ImageController {
         self.inject_preset_client_packages(&image_id, image_repo, &mut cfg)
             .await;
 
-        let agent_worker_ref = self.config.agent_worker_image.clone();
-        let new_hash =
-            compute_environment_hash(&cfg, &agent_worker_ref, &self.config.build_version);
+        // Render the Dockerfile *before* hashing, and take the hash from what
+        // was rendered. The declaration this deployment configured is baked
+        // into the artifact and into its cache key by the same value, so the
+        // two cannot drift: there is no second place that restates the
+        // protocol for the hash. Generation is a pure string build, so paying
+        // for it on a tick that turns out to be a no-op costs nothing.
+        let build_context = render_build_context(&self.config, &cfg).map_err(|source| {
+            ImageControllerError::Dockerfile {
+                project_id: image_id.clone(),
+                source,
+            }
+        })?;
+        let new_hash = build_context.environment_hash(
+            &cfg,
+            &self.config.agent_worker_image,
+            &self.config.build_version,
+        );
 
         if image.config_hash.as_deref() == Some(new_hash.as_str())
             && image.status == ImageStatus::READY
@@ -474,7 +494,7 @@ impl ImageController {
             format_catalog_image_tag(&self.config.registry_host, &image_id, hash_prefix);
 
         let outcome = self
-            .dispatch_build_job(&subject, &cfg, &new_hash, &image_tag)
+            .dispatch_build_job(&subject, &build_context, &new_hash, &image_tag)
             .await;
 
         self.in_flight
@@ -627,6 +647,26 @@ enum BuildDispatch {
     AlreadySucceeded,
     /// A terminal Failed Job was deleted — leave state for the next tick.
     FailedCleared,
+}
+
+/// Render the build context for `cfg` under this deployment's configuration.
+///
+/// The one place the deployment's
+/// [`ImageControllerConfig::declared_launcher_protocol`] becomes a build input.
+/// Split out of [`ImageController::enqueue_image`] so the composition itself is
+/// reachable without a cluster: "the configured protocol is the protocol the
+/// generator is called with" is the step a hardcoded declaration would break,
+/// and it is not observable from either side alone.
+pub(crate) fn render_build_context(
+    config: &ImageControllerConfig,
+    cfg: &EnvironmentConfig,
+) -> std::result::Result<BuildContext, djinn_image_builder::DockerfileError> {
+    let (repo_ref, tag_ref) = split_image_ref(&config.agent_worker_image);
+    generate_dockerfile(
+        cfg,
+        &AgentWorkerImage::new(repo_ref, tag_ref),
+        config.declared_launcher_protocol,
+    )
 }
 
 /// Split an image ref of the form `repo:tag` or `repo@sha256:...` into

--- a/server/crates/djinn-image-controller/src/declared_protocol_tests.rs
+++ b/server/crates/djinn-image-controller/src/declared_protocol_tests.rs
@@ -1,0 +1,293 @@
+//! End-to-end coverage for the **configurable** launcher authority protocol:
+//! from the deployment's environment to the catalog row, through every artifact
+//! the controller actually renders.
+//!
+//! A sibling file behind the `#[path]` convention `watcher_protocol_tests.rs`
+//! already uses, and a child module of `watcher` so the private sentinel parser
+//! and the `classify_ready` decision are reachable without widening their
+//! visibility for production code.
+//!
+//! Nothing here asserts on a constant. Each step consumes the output of the
+//! previous one:
+//!
+//! ```text
+//! DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL=resize-v2
+//!   └─ ImageControllerConfig::from_env
+//!        └─ controller::render_build_context   (the composition site)
+//!             ├─ Dockerfile LABEL / ENV        → the artifact's own metadata
+//!             ├─ BuildContext::environment_hash → the cache key + image tag
+//!             └─ build_image_build_job          → the builder Pod's env
+//!                  └─ the Job's own script, echoed → DJINN_LAUNCHER_PROTOCOL=
+//!                       └─ parse_build_metadata → classify_ready
+//!                            └─ ImageRepository::mark_ready → images row
+//! ```
+
+use djinn_db::{Database, ImageRepository};
+use djinn_image_builder::{
+    DEFAULT_LAUNCHER_PROTOCOL, LAUNCHER_PROTOCOL_ENV, LAUNCHER_PROTOCOL_LABEL,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use djinn_stack::environment::EnvironmentConfig;
+use k8s_openapi::api::batch::v1::Job;
+
+use super::*;
+use crate::build_job::{BuildSubject, build_image_build_job};
+use crate::config::test_env::with_protocol_env;
+use crate::controller::render_build_context;
+
+const WORKER_REF: &str = "registry.example/djinn-agent-runtime:sha256-e2e";
+
+fn image_config() -> EnvironmentConfig {
+    let mut cfg = EnvironmentConfig::empty();
+    cfg.schema_version = djinn_stack::environment::SCHEMA_VERSION;
+    cfg
+}
+
+/// A controller config as a deployment that set (or did not set)
+/// `DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL` would boot with. Built through
+/// `from_env` rather than by assigning the field, so the env plumbing is part
+/// of what every assertion below depends on.
+fn deployment(selection: Option<&str>) -> ImageControllerConfig {
+    let mut config = with_protocol_env(selection, ImageControllerConfig::from_env);
+    config.agent_worker_image = WORKER_REF.to_string();
+    config.build_version = "9.9.9".to_string();
+    config
+}
+
+/// The container env the builder Pod runs with.
+fn container_env(job: &Job, key: &str) -> Option<String> {
+    job.spec
+        .as_ref()?
+        .template
+        .spec
+        .as_ref()?
+        .containers
+        .first()?
+        .env
+        .as_ref()?
+        .iter()
+        .find(|env| env.name == key)?
+        .value
+        .clone()
+}
+
+/// The builder Pod's shell script — the one the Job actually runs.
+fn builder_script(job: &Job) -> String {
+    job.spec
+        .as_ref()
+        .unwrap()
+        .template
+        .spec
+        .as_ref()
+        .unwrap()
+        .containers[0]
+        .command
+        .as_ref()
+        .unwrap()[2]
+        .clone()
+}
+
+/// Evaluate the Job's own `echo "DJINN_LAUNCHER_PROTOCOL=..."` line against the
+/// Job's own container env, producing the log line the build Pod would print.
+///
+/// Deliberately derived from both halves of the real Job rather than
+/// hand-written: if the script stopped expanding the variable the container
+/// sets (a rename on one side only), the substitution below leaves `${...}`
+/// in place, the sentinel fails to parse, and `classify_ready` refuses.
+fn build_log(job: &Job, digest: &str) -> String {
+    let script = builder_script(job);
+    let echo = script
+        .lines()
+        .find(|line| line.contains("DJINN_LAUNCHER_PROTOCOL="))
+        .unwrap_or_else(|| panic!("the build script must report the declaration:\n{script}"))
+        .trim()
+        .to_string();
+    let mut rendered = echo
+        .trim_start_matches("echo ")
+        .trim_matches('"')
+        .to_string();
+    for key in ["LAUNCHER_AUTHORITY_PROTOCOL", "IMAGE_TAG"] {
+        if let Some(value) = container_env(job, key) {
+            rendered = rendered.replace(&format!("${{{key}}}"), &value);
+        }
+    }
+    format!("#12 exporting to image\nDJINN_IMAGE_DIGEST={digest}\n{rendered}\n")
+}
+
+fn label_value(dockerfile: &str, prefix: &str) -> String {
+    dockerfile
+        .lines()
+        .find_map(|line| line.trim_end().strip_prefix(prefix))
+        .unwrap_or_else(|| panic!("{prefix} missing from:\n{dockerfile}"))
+        .trim_matches('"')
+        .to_string()
+}
+
+/// **AC1 + AC4.** A deployment configures `resize-v2`; the built artifact
+/// declares `resize-v2` in its own OCI metadata, and the catalog row the build
+/// produces records exactly what that artifact declares — read back out of the
+/// Job's own reporting path, not restated.
+///
+/// MUTATION (AC1): make `render_build_context` pass
+/// `DEFAULT_LAUNCHER_PROTOCOL` instead of `config.declared_launcher_protocol`
+/// — i.e. reinstate the hardcoded declaration. The LABEL assertion fails with
+/// `leaf-v1`, and so does the catalog assertion, because every step downstream
+/// carries what was built.
+///
+/// MUTATION (AC4): change `build_image_build_job` to render the sentinel env
+/// from something other than the verified declaration (e.g. a literal
+/// `leaf-v1`). The final assertion fails: the row and the artifact's label no
+/// longer agree.
+#[tokio::test]
+async fn a_configured_protocol_reaches_the_artifact_and_the_catalog_row() {
+    for protocol in LauncherAuthorityProtocol::ALL {
+        let config = deployment(Some(protocol.as_wire()));
+        assert_eq!(config.declared_launcher_protocol, protocol);
+
+        // 1. What the artifact itself will carry.
+        let context = render_build_context(&config, &image_config()).expect("renders");
+        let label = label_value(
+            &context.dockerfile,
+            &format!("LABEL {LAUNCHER_PROTOCOL_LABEL}="),
+        );
+        let env = label_value(
+            &context.dockerfile,
+            &format!("ENV {LAUNCHER_PROTOCOL_ENV}="),
+        );
+        assert_eq!(
+            label,
+            protocol.as_wire(),
+            "the configured protocol must reach the artifact's own build metadata"
+        );
+        assert_eq!(env, label, "the sidecar reads the same declaration");
+
+        // 2. The Job that builds it, and the tag it pushes to.
+        let hash = context.environment_hash(
+            &image_config(),
+            &config.agent_worker_image,
+            &config.build_version,
+        );
+        let subject = BuildSubject::image("img-e2e");
+        let tag = format!("reg.example/djinn-image-img-e2e:{}", &hash[..12]);
+        let job = build_image_build_job(&config, &subject, &hash[..12], &tag, &context)
+            .expect("an agreeing context renders a Job");
+
+        // 3. What that Job reports back, evaluated from the Job itself.
+        let digest = format!("sha256:{}", "ab".repeat(32));
+        let metadata = parse_build_metadata(&build_log(&job, &digest));
+        let ReadyOutcome::Ready {
+            digest: seen_digest,
+            protocol: reported,
+        } = classify_ready("img-e2e", "djinn-build-img-e2e", &metadata)
+        else {
+            panic!("a declaring build with a digest must be admitted: {metadata:?}");
+        };
+        assert_eq!(seen_digest.as_deref(), Some(digest.as_str()));
+
+        // 4. What the catalog ends up holding.
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        let images = ImageRepository::new(db.clone());
+        images.create("img-e2e", "e2e", None, "{}").await.unwrap();
+        images
+            .mark_ready("img-e2e", &tag, seen_digest.as_deref(), reported)
+            .await
+            .unwrap();
+
+        let row = images.get("img-e2e").await.unwrap().expect("row");
+        assert_eq!(
+            row.declared_launcher_protocol().unwrap(),
+            Some(protocol),
+            "the catalog must record the configured protocol"
+        );
+        assert_eq!(
+            row.launcher_authority_protocol.as_deref(),
+            Some(label.as_str()),
+            "the catalog row and the artifact's OCI label must be the same string"
+        );
+    }
+}
+
+/// **AC2.** Flipping the deployment's selection invalidates the cache: the
+/// environment hash moves, so the image tag moves, so the controller's
+/// "hash unchanged and ready — skipping" arm cannot be taken and no cached
+/// artifact can be served under the new declaration.
+///
+/// MUTATION: drop `launcher_protocol` from `compute_environment_hash`. The
+/// hashes match, the tags collide, and both assertions fail.
+#[test]
+fn flipping_the_deployment_selection_invalidates_the_cached_image() {
+    let cfg = image_config();
+    let leaf = deployment(Some(LauncherAuthorityProtocol::LeafV1.as_wire()));
+    let resize = deployment(Some(LauncherAuthorityProtocol::ResizeV2.as_wire()));
+
+    let leaf_hash = render_build_context(&leaf, &cfg).unwrap().environment_hash(
+        &cfg,
+        &leaf.agent_worker_image,
+        &leaf.build_version,
+    );
+    let resize_hash = render_build_context(&resize, &cfg)
+        .unwrap()
+        .environment_hash(&cfg, &resize.agent_worker_image, &resize.build_version);
+
+    assert_ne!(
+        leaf_hash, resize_hash,
+        "a protocol flip must not resolve to the cached image's hash"
+    );
+    assert_ne!(
+        crate::controller::format_catalog_image_tag("reg.example", "img-e2e", &leaf_hash[..12]),
+        crate::controller::format_catalog_image_tag("reg.example", "img-e2e", &resize_hash[..12]),
+        "the two declarations must not share a content-addressed tag"
+    );
+
+    // And an unconfigured deployment keeps the hash it had before the knob
+    // existed, so upgrading rebuilds nothing.
+    let unset = deployment(None);
+    assert_eq!(unset.declared_launcher_protocol, DEFAULT_LAUNCHER_PROTOCOL);
+    let unset_hash = render_build_context(&unset, &cfg)
+        .unwrap()
+        .environment_hash(&cfg, &unset.agent_worker_image, &unset.build_version);
+    assert_eq!(
+        unset_hash, leaf_hash,
+        "configuring nothing must be identical to configuring the default"
+    );
+}
+
+/// **AC4, forced.** An artifact whose label and catalog row would disagree
+/// cannot be built: the Job that carries both refuses to render.
+///
+/// This is the failure the whole design exists to make impossible — a
+/// `leaf-v1` image catalogued as `resize-v2` means the launcher writes leaf
+/// `cpu.max` while the plane believes Kubernetes owns quota.
+///
+/// MUTATION: delete the `verify_declaration()?` call from
+/// `build_image_build_job`. The Job renders, its sentinel says `resize-v2`,
+/// and the assertion that no Job exists fails.
+#[test]
+fn a_build_whose_label_and_catalog_row_would_disagree_is_refused() {
+    let config = deployment(None);
+    let mut context = render_build_context(&config, &image_config()).unwrap();
+    // The Dockerfile still declares leaf-v1; only what would be reported to the
+    // catalog is changed.
+    context.launcher_protocol = LauncherAuthorityProtocol::ResizeV2;
+
+    let error = build_image_build_job(
+        &config,
+        &BuildSubject::image("img-e2e"),
+        "0123456789ab",
+        "reg.example/djinn-image-img-e2e:0123456789ab",
+        &context,
+    )
+    .expect_err("a disagreeing context must never become a build");
+
+    assert!(
+        matches!(
+            error,
+            djinn_image_builder::DeclarationError::Disagree {
+                dockerfile_says: LauncherAuthorityProtocol::LeafV1,
+                context_says: LauncherAuthorityProtocol::ResizeV2,
+            }
+        ),
+        "unexpected refusal: {error}"
+    );
+}

--- a/server/crates/djinn-image-controller/src/declared_protocol_tests.rs
+++ b/server/crates/djinn-image-controller/src/declared_protocol_tests.rs
@@ -1,11 +1,21 @@
 //! End-to-end coverage for the **configurable** launcher authority protocol:
-//! from the deployment's environment to the catalog row, through every artifact
-//! the controller actually renders.
+//! from the deployment's environment to the catalog row.
 //!
 //! A sibling file behind the `#[path]` convention `watcher_protocol_tests.rs`
 //! already uses, and a child module of `watcher` so the private sentinel parser
 //! and the `classify_ready` decision are reachable without widening their
 //! visibility for production code.
+//!
+//! **This file names no Kubernetes type.** The `k8s` capability boundary keeps
+//! that vocabulary inside `djinn-k8s`, and the image-controller's exceptions to
+//! it are an inventory being shrunk under `epic/fztz` — not a list to append to
+//! for a new test's convenience. Everything below is provable without a `Job`:
+//! the declaration is decided by `BuildContext::verify_declaration`, the
+//! builder's shell is `render_builder_script`, and the two are bound to one
+//! spelling by `LAUNCHER_PROTOCOL_JOB_ENV` and `PROTOCOL_SENTINEL`. The single
+//! assertion that genuinely needs the rendered Job — that its container env
+//! carries the verified declaration — lives in `build_job.rs`'s own test
+//! module, inside the file the inventory already covers.
 //!
 //! Nothing here asserts on a constant. Each step consumes the output of the
 //! previous one:
@@ -13,11 +23,11 @@
 //! ```text
 //! DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL=resize-v2
 //!   └─ ImageControllerConfig::from_env
-//!        └─ controller::render_build_context   (the composition site)
-//!             ├─ Dockerfile LABEL / ENV        → the artifact's own metadata
-//!             ├─ BuildContext::environment_hash → the cache key + image tag
-//!             └─ build_image_build_job          → the builder Pod's env
-//!                  └─ the Job's own script, echoed → DJINN_LAUNCHER_PROTOCOL=
+//!        └─ controller::render_build_context      (the composition site)
+//!             ├─ Dockerfile LABEL / ENV           → the artifact's metadata
+//!             ├─ BuildContext::environment_hash   → the cache key + image tag
+//!             └─ BuildContext::verify_declaration → what the build Job reports
+//!                  └─ render_builder_script's own echo, expanded
 //!                       └─ parse_build_metadata → classify_ready
 //!                            └─ ImageRepository::mark_ready → images row
 //! ```
@@ -28,10 +38,11 @@ use djinn_image_builder::{
 };
 use djinn_launcher_protocol::LauncherAuthorityProtocol;
 use djinn_stack::environment::EnvironmentConfig;
-use k8s_openapi::api::batch::v1::Job;
 
 use super::*;
-use crate::build_job::{BuildSubject, build_image_build_job};
+use crate::build_job::{
+    BuildSubject, LAUNCHER_PROTOCOL_JOB_ENV, build_image_build_job, render_builder_script,
+};
 use crate::config::test_env::with_protocol_env;
 use crate::controller::render_build_context;
 
@@ -54,67 +65,35 @@ fn deployment(selection: Option<&str>) -> ImageControllerConfig {
     config
 }
 
-/// The container env the builder Pod runs with.
-fn container_env(job: &Job, key: &str) -> Option<String> {
-    job.spec
-        .as_ref()?
-        .template
-        .spec
-        .as_ref()?
-        .containers
-        .first()?
-        .env
-        .as_ref()?
-        .iter()
-        .find(|env| env.name == key)?
-        .value
-        .clone()
-}
-
-/// The builder Pod's shell script — the one the Job actually runs.
-fn builder_script(job: &Job) -> String {
-    job.spec
-        .as_ref()
-        .unwrap()
-        .template
-        .spec
-        .as_ref()
-        .unwrap()
-        .containers[0]
-        .command
-        .as_ref()
-        .unwrap()[2]
-        .clone()
-}
-
-/// Evaluate the Job's own `echo "DJINN_LAUNCHER_PROTOCOL=..."` line against the
-/// Job's own container env, producing the log line the build Pod would print.
+/// The build Pod's log, produced by evaluating the **builder's own script**
+/// against the value the build Job puts in its environment.
 ///
-/// Deliberately derived from both halves of the real Job rather than
-/// hand-written: if the script stopped expanding the variable the container
-/// sets (a rename on one side only), the substitution below leaves `${...}`
-/// in place, the sentinel fails to parse, and `classify_ready` refuses.
-fn build_log(job: &Job, digest: &str) -> String {
-    let script = builder_script(job);
+/// Both halves are real: the `echo` line comes out of `render_builder_script`,
+/// and `declared` is what `build_image_build_job` calls `verify_declaration`
+/// for. The expansion done here is the one the Pod's shell does. If the script
+/// stopped expanding the variable the Job sets — a rename on one side only —
+/// the substitution would leave `${…}` in place, the sentinel would fail to
+/// parse, and `classify_ready` would refuse.
+fn build_log(
+    config: &ImageControllerConfig,
+    declared: LauncherAuthorityProtocol,
+    digest: &str,
+) -> String {
+    let script = render_builder_script(config, "img-e2e");
     let echo = script
         .lines()
-        .find(|line| line.contains("DJINN_LAUNCHER_PROTOCOL="))
+        .find(|line| line.contains(PROTOCOL_SENTINEL))
         .unwrap_or_else(|| panic!("the build script must report the declaration:\n{script}"))
         .trim()
         .to_string();
-    let mut rendered = echo
-        .trim_start_matches("echo ")
-        .trim_matches('"')
-        .to_string();
-    for key in ["LAUNCHER_AUTHORITY_PROTOCOL", "IMAGE_TAG"] {
-        if let Some(value) = container_env(job, key) {
-            rendered = rendered.replace(&format!("${{{key}}}"), &value);
-        }
-    }
-    format!("#12 exporting to image\nDJINN_IMAGE_DIGEST={digest}\n{rendered}\n")
+    let rendered = echo.trim_start_matches("echo ").trim_matches('"').replace(
+        &format!("${{{LAUNCHER_PROTOCOL_JOB_ENV}}}"),
+        declared.as_wire(),
+    );
+    format!("#12 exporting to image\n{DIGEST_SENTINEL}{digest}\n{rendered}\n")
 }
 
-fn label_value(dockerfile: &str, prefix: &str) -> String {
+fn declaration_in(dockerfile: &str, prefix: &str) -> String {
     dockerfile
         .lines()
         .find_map(|line| line.trim_end().strip_prefix(prefix))
@@ -123,10 +102,10 @@ fn label_value(dockerfile: &str, prefix: &str) -> String {
         .to_string()
 }
 
-/// **AC1 + AC4.** A deployment configures `resize-v2`; the built artifact
-/// declares `resize-v2` in its own OCI metadata, and the catalog row the build
-/// produces records exactly what that artifact declares — read back out of the
-/// Job's own reporting path, not restated.
+/// **AC1 + AC4.** A deployment configures a protocol; the built artifact
+/// declares it in its own OCI metadata, and the catalog row the build produces
+/// records exactly what that artifact declares — carried there by the build
+/// script's own sentinel, not restated by the test.
 ///
 /// MUTATION (AC1): make `render_build_context` pass
 /// `DEFAULT_LAUNCHER_PROTOCOL` instead of `config.declared_launcher_protocol`
@@ -134,10 +113,9 @@ fn label_value(dockerfile: &str, prefix: &str) -> String {
 /// `leaf-v1`, and so does the catalog assertion, because every step downstream
 /// carries what was built.
 ///
-/// MUTATION (AC4): change `build_image_build_job` to render the sentinel env
-/// from something other than the verified declaration (e.g. a literal
-/// `leaf-v1`). The final assertion fails: the row and the artifact's label no
-/// longer agree.
+/// MUTATION (AC4): make `verify_declaration` return `Ok(self.launcher_protocol)`
+/// unconditionally — the reported protocol stops being the one the artifact
+/// carries, and the final assertion (row == the Dockerfile's own LABEL) fails.
 #[tokio::test]
 async fn a_configured_protocol_reaches_the_artifact_and_the_catalog_row() {
     for protocol in LauncherAuthorityProtocol::ALL {
@@ -146,11 +124,11 @@ async fn a_configured_protocol_reaches_the_artifact_and_the_catalog_row() {
 
         // 1. What the artifact itself will carry.
         let context = render_build_context(&config, &image_config()).expect("renders");
-        let label = label_value(
+        let label = declaration_in(
             &context.dockerfile,
             &format!("LABEL {LAUNCHER_PROTOCOL_LABEL}="),
         );
-        let env = label_value(
+        let env = declaration_in(
             &context.dockerfile,
             &format!("ENV {LAUNCHER_PROTOCOL_ENV}="),
         );
@@ -161,20 +139,16 @@ async fn a_configured_protocol_reaches_the_artifact_and_the_catalog_row() {
         );
         assert_eq!(env, label, "the sidecar reads the same declaration");
 
-        // 2. The Job that builds it, and the tag it pushes to.
-        let hash = context.environment_hash(
-            &image_config(),
-            &config.agent_worker_image,
-            &config.build_version,
-        );
-        let subject = BuildSubject::image("img-e2e");
-        let tag = format!("reg.example/djinn-image-img-e2e:{}", &hash[..12]);
-        let job = build_image_build_job(&config, &subject, &hash[..12], &tag, &context)
-            .expect("an agreeing context renders a Job");
+        // 2. What the build Job reports about it — the checked value, which is
+        //    also what its container env carries (asserted against the rendered
+        //    Job in `build_job.rs`'s own test module, inside the k8s boundary).
+        let declared = context
+            .verify_declaration()
+            .expect("a freshly rendered context agrees with itself");
 
-        // 3. What that Job reports back, evaluated from the Job itself.
+        // 3. The build Pod's log, from the builder's own script.
         let digest = format!("sha256:{}", "ab".repeat(32));
-        let metadata = parse_build_metadata(&build_log(&job, &digest));
+        let metadata = parse_build_metadata(&build_log(&config, declared, &digest));
         let ReadyOutcome::Ready {
             digest: seen_digest,
             protocol: reported,
@@ -190,7 +164,12 @@ async fn a_configured_protocol_reaches_the_artifact_and_the_catalog_row() {
         let images = ImageRepository::new(db.clone());
         images.create("img-e2e", "e2e", None, "{}").await.unwrap();
         images
-            .mark_ready("img-e2e", &tag, seen_digest.as_deref(), reported)
+            .mark_ready(
+                "img-e2e",
+                "reg.example/djinn-image-img-e2e:0123456789ab",
+                seen_digest.as_deref(),
+                reported,
+            )
             .await
             .unwrap();
 
@@ -254,15 +233,14 @@ fn flipping_the_deployment_selection_invalidates_the_cached_image() {
 }
 
 /// **AC4, forced.** An artifact whose label and catalog row would disagree
-/// cannot be built: the Job that carries both refuses to render.
+/// cannot be built: the call that renders the build Job refuses.
 ///
 /// This is the failure the whole design exists to make impossible — a
 /// `leaf-v1` image catalogued as `resize-v2` means the launcher writes leaf
 /// `cpu.max` while the plane believes Kubernetes owns quota.
 ///
 /// MUTATION: delete the `verify_declaration()?` call from
-/// `build_image_build_job`. The Job renders, its sentinel says `resize-v2`,
-/// and the assertion that no Job exists fails.
+/// `build_image_build_job`. It returns `Ok` and this test's `expect` panics.
 #[test]
 fn a_build_whose_label_and_catalog_row_would_disagree_is_refused() {
     let config = deployment(None);
@@ -289,5 +267,37 @@ fn a_build_whose_label_and_catalog_row_would_disagree_is_refused() {
             }
         ),
         "unexpected refusal: {error}"
+    );
+}
+
+/// The emitter and the parser of the protocol sentinel share one spelling, and
+/// the script expands exactly the variable the build Job sets.
+///
+/// This is what lets the chain above be proven without a rendered Job: the Job
+/// sets `LAUNCHER_PROTOCOL_JOB_ENV`, the script expands
+/// `LAUNCHER_PROTOCOL_JOB_ENV`, and the watcher parses `PROTOCOL_SENTINEL` —
+/// each spelled once.
+///
+/// MUTATION: give `render_builder_script` its own literal `${PROTOCOL}` instead
+/// of interpolating `LAUNCHER_PROTOCOL_JOB_ENV`. The Pod would print an
+/// unexpanded `${PROTOCOL}` that the watcher refuses; this fails first, naming
+/// the script.
+#[test]
+fn the_script_expands_the_variable_the_build_job_sets() {
+    let script = render_builder_script(&deployment(None), "img-e2e");
+    assert!(
+        script.contains(&format!(
+            "echo \"{PROTOCOL_SENTINEL}${{{LAUNCHER_PROTOCOL_JOB_ENV}}}\""
+        )),
+        "the script must echo the sentinel by expanding the Job's own env var:\n{script}"
+    );
+    // …and nothing derives the declaration from the mutable image name.
+    let protocol_line = script
+        .lines()
+        .find(|line| line.contains(PROTOCOL_SENTINEL))
+        .expect("sentinel line");
+    assert!(
+        !protocol_line.contains("IMAGE_TAG"),
+        "the declaration must never come from the tag: {protocol_line}"
     );
 }

--- a/server/crates/djinn-image-controller/src/lib.rs
+++ b/server/crates/djinn-image-controller/src/lib.rs
@@ -23,11 +23,12 @@
 //!     └─> ImageController::enqueue(project_id)
 //!           ├─ read projects.environment_config
 //!           ├─ skip if '{}' (un-seeded — boot reseed hook handles)
-//!           ├─ compute_environment_hash(cfg, agent_worker_ref)
+//!           ├─ render_build_context(controller config, cfg)
+//!           │    └─ generate_dockerfile(cfg, agent_worker, declared protocol)
+//!           ├─ BuildContext::environment_hash(...)   ← hashes what was rendered
 //!           ├─ compare to projects.image_hash
 //!           ├─ if changed: take in-flight guard + check the cluster-wide
 //!           │    concurrency cap (count live build Jobs; defer if at cap)
-//!           │    ├─ generate_dockerfile(cfg, agent_worker)
 //!           │    ├─ upsert per-build ConfigMap (Dockerfile + scripts)
 //!           │    └─ create build Job (buildctl)
 //!           └─ flip projects.image_status to "building"

--- a/server/crates/djinn-image-controller/src/watcher.rs
+++ b/server/crates/djinn-image-controller/src/watcher.rs
@@ -1131,3 +1131,7 @@ mod tests {
 #[cfg(test)]
 #[path = "watcher_protocol_tests.rs"]
 mod protocol_tests;
+
+#[cfg(test)]
+#[path = "declared_protocol_tests.rs"]
+mod declared_protocol_tests;

--- a/server/crates/djinn-image-controller/src/watcher.rs
+++ b/server/crates/djinn-image-controller/src/watcher.rs
@@ -95,7 +95,11 @@ const DIGEST_SENTINEL: &str = "DJINN_IMAGE_DIGEST=";
 /// the artifact declares. The value is echoed from the `BuildContext` that
 /// rendered the Dockerfile, which bakes the identical string into the image's
 /// `djinn.app/launcher-authority-protocol` LABEL.
-const PROTOCOL_SENTINEL: &str = "DJINN_LAUNCHER_PROTOCOL=";
+///
+/// `pub(crate)` because [`crate::build_job::render_builder_script`] prints it
+/// and this parses it: the emitter and the parser of a sentinel must not each
+/// carry their own spelling of it.
+pub(crate) const PROTOCOL_SENTINEL: &str = "DJINN_LAUNCHER_PROTOCOL=";
 
 /// Background task that watches image-build Jobs to completion.
 ///

--- a/server/crates/djinn-image-controller/tests/chart_env_contract.rs
+++ b/server/crates/djinn-image-controller/tests/chart_env_contract.rs
@@ -1,0 +1,120 @@
+//! Every knob [`ImageControllerConfig::from_env`] reads must be renderable by
+//! the chart that runs the binary.
+//!
+//! A configuration option the server reads and no chart writes is not a
+//! configuration option — it is a default with documentation. That failure has
+//! already cost this deployment once: `DJINN_MAX_BUILD_PODS` was read by the
+//! pod-permit gate, rendered by no chart, and its absence fail-closed every
+//! dispatch while `build_capacity` still reported healthy.
+//!
+//! The required set is **derived** from `config.rs` rather than restated here,
+//! so adding an env constant without wiring it into the Deployment fails this
+//! test rather than shipping an unreachable knob — which is exactly how
+//! `DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL` could otherwise repeat the
+//! hardcoded-declaration bug it exists to fix.
+
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("the crate must live three levels below the repository root")
+        .to_path_buf()
+}
+
+fn read(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("{relative} must exist and be readable: {error}"))
+}
+
+/// Every `pub const …: &str = "DJINN_…";` declared in `config::env`.
+///
+/// Whole-line comments are dropped so a commented-out constant is not counted
+/// as a requirement.
+fn declared_env_vars(source: &str) -> Vec<String> {
+    let module = source
+        .split_once("pub mod env {")
+        .expect("config.rs must declare the env module")
+        .1;
+    let module = module
+        .split_once("\n}\n")
+        .expect("the env module must be closed")
+        .0;
+
+    module
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.starts_with("//"))
+        .filter_map(|line| {
+            let (_, rest) = line.split_once("&str = \"")?;
+            let (value, _) = rest.split_once('"')?;
+            value.starts_with("DJINN_").then(|| value.to_string())
+        })
+        .collect()
+}
+
+/// MUTATION: delete the `DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL` block from
+/// `deployment-server.yaml` — a deployment could then no longer select the
+/// protocol no matter what `values.yaml` says. This test names the variable and
+/// fails.
+#[test]
+fn every_image_controller_env_var_is_rendered_by_the_server_deployment() {
+    let config = read("server/crates/djinn-image-controller/src/config.rs");
+    let deployment = read("deploy/helm/djinn/templates/deployment-server.yaml");
+
+    let declared = declared_env_vars(&config);
+
+    // Non-vacuity: a parser that matched nothing would pass the loop below
+    // silently, which is the whole failure mode this file is about.
+    assert!(
+        declared.len() >= 15,
+        "the env-constant scan found only {} variables — it stopped parsing config.rs: {declared:?}",
+        declared.len()
+    );
+    assert!(
+        declared
+            .iter()
+            .any(|v| v == "DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL"),
+        "the launcher-protocol knob must be among the derived requirements: {declared:?}"
+    );
+
+    for variable in declared {
+        assert!(
+            deployment.contains(&format!("name: {variable}")),
+            "{variable} is read by ImageControllerConfig::from_env but no chart renders it — \
+             a deployment cannot set it, so it is a hardcoded default wearing a config's name"
+        );
+    }
+}
+
+/// The knob is reachable from `values.yaml` too, and ships unset so an upgrade
+/// changes no artifact and rebuilds no image.
+///
+/// MUTATION: default `launcherAuthorityProtocol` to `resize-v2` in
+/// `values.yaml`. The emptiness assertion fails — which is the point: that
+/// default would silently re-tag and rebuild every catalog image on upgrade,
+/// and hand quota ownership to Kubernetes on clusters whose launcher still
+/// writes leaf `cpu.max`.
+#[test]
+fn the_chart_exposes_the_protocol_and_defaults_it_to_unset() {
+    let values = read("deploy/helm/djinn/values.yaml");
+    let deployment = read("deploy/helm/djinn/templates/deployment-server.yaml");
+
+    let line = values
+        .lines()
+        .find(|line| line.trim_start().starts_with("launcherAuthorityProtocol:"))
+        .expect("values.yaml must expose imagePipeline.controller.launcherAuthorityProtocol");
+    let value = line.split_once(':').unwrap().1.trim().trim_matches('"');
+    assert!(
+        value.is_empty(),
+        "the chart must ship no protocol selection, got {value:?} — the built-in default is \
+         what every existing deployment already builds"
+    );
+
+    assert!(
+        deployment.contains(".Values.imagePipeline.controller.launcherAuthorityProtocol"),
+        "the Deployment must render the value the chart exposes, not a literal"
+    );
+}

--- a/server/crates/djinn-image-controller/tests/protocol_catalog_and_preservation.rs
+++ b/server/crates/djinn-image-controller/tests/protocol_catalog_and_preservation.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use djinn_db::launcher_compatibility::PreProtocolDigest;
 use djinn_db::{Database, ImageRepository, ProjectRepository, launcher_compatibility};
 use djinn_image_builder::dockerfile::{
-    AgentWorkerImage, DECLARED_LAUNCHER_PROTOCOL, LAUNCHER_PROTOCOL_ENV, LAUNCHER_PROTOCOL_LABEL,
+    AgentWorkerImage, DEFAULT_LAUNCHER_PROTOCOL, LAUNCHER_PROTOCOL_ENV, LAUNCHER_PROTOCOL_LABEL,
     generate_dockerfile,
 };
 use djinn_launcher_protocol::LauncherAuthorityProtocol;
@@ -64,11 +64,11 @@ fn every_generated_image_declares_its_protocol_in_build_metadata() {
     ] {
         let config: djinn_stack::environment::EnvironmentConfig =
             serde_json::from_str(config_json).unwrap_or_else(|e| panic!("{name}: {e}"));
-        let dockerfile = generate_dockerfile(&config, &worker)
+        let dockerfile = generate_dockerfile(&config, &worker, DEFAULT_LAUNCHER_PROTOCOL)
             .unwrap_or_else(|e| panic!("{name} must generate: {e}"))
             .dockerfile;
 
-        let declared = DECLARED_LAUNCHER_PROTOCOL.as_wire();
+        let declared = DEFAULT_LAUNCHER_PROTOCOL.as_wire();
         assert!(
             dockerfile.contains(&format!("LABEL {LAUNCHER_PROTOCOL_LABEL}=\"{declared}\"")),
             "{name}: the artifact must carry the protocol LABEL, got:\n{dockerfile}"
@@ -78,7 +78,7 @@ fn every_generated_image_declares_its_protocol_in_build_metadata() {
             "{name}: the artifact must carry the protocol env var, got:\n{dockerfile}"
         );
         assert!(
-            LauncherAuthorityProtocol::ALL.contains(&DECLARED_LAUNCHER_PROTOCOL),
+            LauncherAuthorityProtocol::ALL.contains(&DEFAULT_LAUNCHER_PROTOCOL),
             "{name}: the declaration must be one of the canonical wire forms"
         );
     }
@@ -129,7 +129,7 @@ async fn a_newly_cataloged_artifact_declares_a_protocol_and_pins_a_digest() {
             "new",
             "reg/djinn-image-new:contenthash",
             Some(&digest),
-            Some(DECLARED_LAUNCHER_PROTOCOL),
+            Some(DEFAULT_LAUNCHER_PROTOCOL),
         )
         .await
         .unwrap();
@@ -138,14 +138,14 @@ async fn a_newly_cataloged_artifact_declares_a_protocol_and_pins_a_digest() {
     let row = images.get("new").await.unwrap().expect("row");
     assert_eq!(
         row.declared_launcher_protocol().unwrap(),
-        Some(DECLARED_LAUNCHER_PROTOCOL)
+        Some(DEFAULT_LAUNCHER_PROTOCOL)
     );
     assert_eq!(row.registry_digest.as_deref(), Some(digest.as_str()));
 
     // The inventory is EMPTY and the artifact still dispatches: a declaring
     // image is admitted on its own declaration, never on an allowlist entry.
     // (Migration 167 seeds the authority singleton at `leaf-v1`, which is what
-    // `DECLARED_LAUNCHER_PROTOCOL` is, so no flip is needed here.)
+    // `DEFAULT_LAUNCHER_PROTOCOL` is, so no flip is needed here.)
     let resolved = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
         .with_legacy_digest_inventory(launcher_compatibility::LegacyDigestInventory::verified(
             "ops",
@@ -156,10 +156,7 @@ async fn a_newly_cataloged_artifact_declares_a_protocol_and_pins_a_digest() {
         .await
         .unwrap()
         .expect("project resolves");
-    assert_eq!(
-        resolved.authority_protocol,
-        Some(DECLARED_LAUNCHER_PROTOCOL)
-    );
+    assert_eq!(resolved.authority_protocol, Some(DEFAULT_LAUNCHER_PROTOCOL));
 
     // And a declaring artifact can never be written without a digest, so a new
     // build cannot fall into the legacy population by accident.
@@ -169,7 +166,7 @@ async fn a_newly_cataloged_artifact_declares_a_protocol_and_pins_a_digest() {
             "bad",
             "reg/djinn-image-bad:contenthash",
             None,
-            Some(DECLARED_LAUNCHER_PROTOCOL),
+            Some(DEFAULT_LAUNCHER_PROTOCOL),
         )
         .await
         .expect_err("a declaring build with no digest must be refused");
@@ -194,7 +191,7 @@ async fn the_inventory_candidate_set_is_exactly_the_ready_undeclared_digest_pinn
         (
             "c-declaring",
             Some("sha256:cc"),
-            Some(DECLARED_LAUNCHER_PROTOCOL),
+            Some(DEFAULT_LAUNCHER_PROTOCOL),
         ),
     ] {
         images.create(id, id, None, "{}").await.unwrap();

--- a/server/crates/djinn-image-controller/tests/unit.rs
+++ b/server/crates/djinn-image-controller/tests/unit.rs
@@ -8,7 +8,9 @@
 
 use std::collections::BTreeMap;
 
-use djinn_image_builder::{AgentWorkerImage, BuildContext, generate_dockerfile};
+use djinn_image_builder::{
+    AgentWorkerImage, BuildContext, DEFAULT_LAUNCHER_PROTOCOL, generate_dockerfile,
+};
 use djinn_image_controller::ImageControllerConfig;
 use djinn_image_controller::build_job::{
     BuildSubject, COMPONENT_IMAGE_BUILD, LABEL_BUILD, LABEL_COMPONENT, LABEL_IMAGE_HASH,
@@ -21,8 +23,12 @@ use djinn_stack::environment::EnvironmentConfig;
 fn test_build_context() -> BuildContext {
     let mut cfg = EnvironmentConfig::empty();
     cfg.schema_version = djinn_stack::environment::SCHEMA_VERSION;
-    generate_dockerfile(&cfg, &AgentWorkerImage::new("djinn/agent-runtime", "dev"))
-        .expect("generate")
+    generate_dockerfile(
+        &cfg,
+        &AgentWorkerImage::new("djinn/agent-runtime", "dev"),
+        DEFAULT_LAUNCHER_PROTOCOL,
+    )
+    .expect("generate")
 }
 
 #[test]
@@ -36,7 +42,8 @@ fn build_job_labels_and_envs_match_plan() {
         "1a2b3c4d5e6f",
         &tag,
         &ctx,
-    );
+    )
+    .unwrap();
 
     let labels = job.metadata.labels.as_ref().expect("labels present");
     assert_eq!(labels.get(LABEL_COMPONENT).unwrap(), COMPONENT_IMAGE_BUILD);
@@ -136,7 +143,8 @@ fn image_build_job_does_not_opt_into_kueue_build_object_admission() {
                 "1a2b3c4d5e6f",
                 "registry.example/djinn-project-proj-kueue-contract:1a2b3c4d5e6f",
                 &context,
-            );
+            )
+            .unwrap();
             let flags = format!("kueue.enabled={enabled} kueue.armed={armed}");
 
             for (location, labels) in [

--- a/server/crates/djinn-k8s/tests/launcher_child_filesystem_reachability.rs
+++ b/server/crates/djinn-k8s/tests/launcher_child_filesystem_reachability.rs
@@ -256,6 +256,7 @@ fn image_time_paths() -> Vec<Required> {
     let context = djinn_image_builder::generate_dockerfile(
         &djinn_stack::environment::EnvironmentConfig::default(),
         &djinn_image_builder::AgentWorkerImage::new("registry.example/djinn-agent-worker", "test"),
+        djinn_image_builder::DEFAULT_LAUNCHER_PROTOCOL,
     )
     .expect("the baseline image config must render a Dockerfile");
     let mut required = Vec::new();


### PR DESCRIPTION
## The problem

`dockerfile.rs:52` declared the launcher authority protocol with a hardcoded constant:

```rust
pub const DECLARED_LAUNCHER_PROTOCOL: LauncherAuthorityProtocol = LauncherAuthorityProtocol::LeafV1;
```

There was no config, env var, or override. Every artifact this repo builds declared `leaf-v1`, so `images.launcher_authority_protocol` is `leaf-v1`/NULL fleet-wide and `render_authority_protocol` always resolves `LeafV1`. **3i92's resize arm could not be entered from any deployment**, and step 4 of `docs/deploy/launcher-authority-cutover.md` ("Rebuild and catalog images as `resize-v2`") had no mechanism behind it.

## The change

The declaration is now a **build input**, threaded from the deployment:

```
imagePipeline.controller.launcherAuthorityProtocol: "resize-v2"   # default "" → leaf-v1
  → DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL (server Pod env)
  → ImageControllerConfig::declared_launcher_protocol
  → controller::render_build_context
  → generate_dockerfile(cfg, agent_worker, protocol)
  → LABEL djinn.app/launcher-authority-protocol + ENV DJINN_LAUNCHER_AUTHORITY_PROTOCOL
  → build Job env → DJINN_LAUNCHER_PROTOCOL= sentinel → images.launcher_authority_protocol
```

`emit_launcher_protocol` still writes exactly what was built, and the declaration still travels in build metadata — never inferred from a tag.

### Why deployment-level, not per project

The declaration describes the `djinn-cgroup-launcher` binary copied out of the **single** `agent_worker_image` every catalog image shares, and admission compares it against the cluster-wide `launcher_authority_mode` singleton. A per-project protocol would mean two projects on one cluster disagreeing about who owns a node's CPU quota — not something the mode row can express, and not something the cutover sequence (pause → drain → CAS the mode) can stage. One knob, one fleet.

## The trap, closed by construction

The old doc comment asked for a manual `compute_environment_hash` salt bump on every flip, because the hash did not cover the Dockerfile text. That is exactly the "cached image with the old launcher, catalogued as `resize-v2`" outcome. This PR removes the need for the discipline instead of documenting it harder:

1. **The protocol is an input to the environment hash**, and the image tag is a prefix of that hash. `leaf-v1` and `resize-v2` builds of one config land on **different tags** — a flip cannot resolve to the cached artifact and cannot relabel one in place. (The `leaf-v1` tags stay in the registry, which is what makes the runbook's retention check and rollback possible.)
2. **The hash is taken from the rendered context, not from a second restatement.** `enqueue_image` now renders the Dockerfile *first* and calls `BuildContext::environment_hash(...)`, which hashes `self.launcher_protocol`. There is no call site where the hashed declaration and the built one can drift, because there is only one value.
3. **`build_image_build_job` is fail-closed.** It calls `BuildContext::verify_declaration()` and returns `Err(DeclarationError)` unless the Dockerfile declares exactly what the context reports (also catching a missing declaration, a LABEL/ENV split, an unrecognised wire form, and a second declaration appended later). That Job's env becomes the catalog row and its Dockerfile becomes the artifact's label, so **an image whose label and catalog row disagree cannot be built** — it is not detected after the fact, it never gets a Job.

### Default is a true no-op

`DEFAULT_LAUNCHER_PROTOCOL` contributes **nothing** to the hash pre-image, so an unconfigured deployment computes byte-identical hashes to before this PR. Mixing it in unconditionally would have re-tagged and rebuilt every catalog image on every existing deployment at upgrade, for a change that alters no artifact. The golden Dockerfile fixtures are untouched, and the chart renders no env var unless the operator sets one.

## Acceptance criteria, each proven by a mutation I ran

| AC | Test | Mutation applied | Result |
|---|---|---|---|
| 1. A deployment can configure the protocol; the built artifact's metadata carries it | `a_configured_protocol_reaches_the_artifact_and_the_catalog_row`, `the_configured_protocol_is_what_the_artifact_declares`, `configuring_resize_v2_changes_only_the_declaration` | `render_build_context` passes `DEFAULT_LAUNCHER_PROTOCOL` instead of the config field (i.e. hardcoded again) | 2 tests FAIL |
| 2. A protocol change invalidates the image cache | `hash_changes_when_the_declared_protocol_changes`, `flipping_the_deployment_selection_invalidates_the_cached_image` | delete the `launcher_protocol` block from `compute_environment_hash` | 2 tests FAIL |
| 3. Default unchanged; no existing deployment rebuilds | `the_default_protocol_hashes_to_the_pre_change_preimage` (reconstructs the pre-`launcher_protocol` pre-image from its own bytes), golden fixtures byte-identical, every pre-existing assertion kept | hash the protocol unconditionally | 1 test FAILS |
| 4. Catalog row and artifact declaration cannot disagree | `a_build_whose_label_and_catalog_row_would_disagree_is_refused`, `a_context_that_reports_something_other_than_it_built_is_refused` | remove `verify_declaration()?` from `build_image_build_job` | test FAILS (the mismatched Job renders) |
| — chart reachability | `every_image_controller_env_var_is_rendered_by_the_server_deployment` (required set **derived** from `config::env`, not restated) | delete the env block from `deployment-server.yaml` | test FAILS, naming the variable |

The end-to-end test builds through the real path rather than asserting on a constant: `from_env` → the controller's own composition function → the real `build_image_build_job` → the Job's **own** shell line evaluated against the Job's **own** container env → the watcher's real `parse_build_metadata`/`classify_ready` → `ImageRepository::mark_ready` → the row read back. Its last assertion is that the stored string equals the Dockerfile's LABEL string.

Also verified: `helm template` with the value set renders `DJINN_IMAGE_LAUNCHER_AUTHORITY_PROTOCOL=resize-v2`; unset renders no such env at all.

## Can a protocol change still silently reuse a cached image?

**No.** A change to the configured protocol changes the environment hash, which changes the image tag, which means the controller's `hash unchanged and ready — skipping` arm cannot be taken and buildkit is pushed to a tag no prior artifact occupies. The one residual path — a build context whose reported protocol disagrees with its Dockerfile — is refused before a Job exists. The remaining assumption is the ordinary one that predates this PR: the launcher binary itself ships from `agent_worker_image`, which is already an input to the same hash.

## Not touched

`server/src/task_run_resize_rollout.rs` and `server/crates/djinn-k8s/src/cutover_preflight.rs` (sibling agent owns the activation entry point). No live cluster was created.

## Notes for review

* `generate_dockerfile` gained a **required** third argument rather than a defaulting overload. A convenience overload is how a future caller silently keeps a configured fleet on `leaf-v1` — the same "merged, green, unreachable" shape this campaign keeps finding. Existing tests keep every assertion and every golden fixture; only the call gains the explicit default.
* `DECLARED_LAUNCHER_PROTOCOL` → `DEFAULT_LAUNCHER_PROTOCOL`: it is no longer what is declared, only what is declared absent a selection.
* `config::test_env::guard` also fixes a pre-existing race between `from_env_honors_zot_retention_vars` and `from_env_invalid_zot_retention_bools_fall_back`, which both write `DJINN_ZOT_RETENTION_ENABLED` on a multi-threaded harness. It surfaced while adding these tests; the lib suite is stable at `--test-threads` 1, 16 and 32.
