### PR TITLE
feat(3i92): give the launcher-authority cutover an operator entry point

### DIFF
--- a/deploy/cutover/authority-cutover.sh
+++ b/deploy/cutover/authority-cutover.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# THE OPERATOR ENTRY POINT for proposal 3i92's launcher-authority cutover.
+#
+# WHY THIS EXISTS
+# ---------------
+# `ResizeRollout` (server/src/task_run_resize_rollout.rs) has encoded the whole
+# fenced transition — the ordering, both drain checks, the compare-and-swap, the
+# reverse that can refuse itself — since task `eeky`. Until this script and
+# `server/src/bin/authority_cutover.rs` landed, `ResizeRollout::production` had
+# ZERO callers in any binary: the staged activation was a library with tests
+# that nobody could run. This is what an operator types.
+#
+# WHY IT DELEGATES TO THE PREFLIGHT WRAPPER
+# -----------------------------------------
+# The flip is gated on `djinn_k8s::cutover_preflight::run`, whose Rust half
+# re-renders the task-run Job from `DJINN_K8S_*`. Those variables must come from
+# the RENDERED djinn-server container, not from the operator's shell — otherwise
+# the credential-boundary and launcher-ceiling classes are judged against
+# whatever happens to be exported. `deploy/preflight/cutover-preflight.sh`
+# already renders the chart, extracts that environment and re-execs under
+# `env -i`. So this script does not repeat any of it: it points
+# CUTOVER_PREFLIGHT_BIN at the `authority-cutover` binary and hands over.
+#
+# The consequence is the point: the gate the deploy lane runs and the gate the
+# flip runs are the same gate, over the same render, under the same environment.
+#
+# USAGE
+#   DJINN_CUTOVER_DIRECTION=activate \
+#   DJINN_CUTOVER_PLAN=/path/plan.json \
+#   DJINN_CUTOVER_AUTHORITY_MODE=resize-v2 \
+#   DJINN_DATABASE_URL=postgres://... \
+#     deploy/cutover/authority-cutover.sh deploy/helm/djinn --values prod-values.yaml
+#
+#   # and the reverse
+#   DJINN_CUTOVER_DIRECTION=rollback DJINN_CUTOVER_AUTHORITY_MODE=leaf-v1 ...
+#
+# Exit status: 0 the mode flipped and admission resumed; 1 blocked (the mode did
+# NOT move, and admission is left paused whenever the block came at or after the
+# pause step — the binary says which); 2 unevaluable, nothing attempted.
+#
+# Environment:
+#   DJINN_CUTOVER_DIRECTION        activate | rollback (required, never defaulted)
+#   DJINN_CUTOVER_PLAN             retained set, probe, expected epoch, registry URL
+#   DJINN_CUTOVER_AUTHORITY_MODE   must name the mode the direction targets
+#   DJINN_DATABASE_URL             required — the fence, catalog and singleton live there
+#   DJINN_CUTOVER_OBSERVATIONS     JSON bundle of catalog images / live births
+#   DJINN_CUTOVER_PAUSED_BY        recorded on the pause row (default: authority-cutover)
+#   AUTHORITY_CUTOVER_BIN          path to the binary (default: build it)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PREFLIGHT="$REPO_DIR/deploy/preflight/cutover-preflight.sh"
+
+die() {
+  printf 'authority-cutover: %s\n' "$1" >&2
+  exit 2
+}
+
+usage() {
+  cat <<'EOF'
+usage: authority-cutover.sh <chart-dir> [helm template args...]
+
+Runs proposal 3i92's fenced launcher-authority cutover, or its reverse, through
+ResizeRollout::production. The flip is gated on the REAL deploy preflight over
+the same render this script hands the binary.
+
+  DJINN_CUTOVER_DIRECTION=activate DJINN_CUTOVER_PLAN=plan.json \
+  DJINN_CUTOVER_AUTHORITY_MODE=resize-v2 DJINN_DATABASE_URL=postgres://... \
+    deploy/cutover/authority-cutover.sh deploy/helm/djinn
+
+Exit 0 flipped, 1 blocked (mode unchanged), 2 unevaluable.
+EOF
+}
+
+case "${1:-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  '')
+    usage >&2
+    die "a chart directory is required"
+    ;;
+esac
+
+[ -f "$PREFLIGHT" ] || die "preflight wrapper not found at $PREFLIGHT"
+
+# Refused HERE as well as in the binary. The binary's refusal is the enforcement
+# — it is what a caller bypassing this script still hits — but an operator who
+# forgot the direction should not first watch a chart render.
+[ -n "${DJINN_CUTOVER_DIRECTION:-}" ] || die "DJINN_CUTOVER_DIRECTION is not set (activate|rollback)"
+[ -n "${DJINN_CUTOVER_PLAN:-}" ] || die "DJINN_CUTOVER_PLAN is not set"
+[ -f "${DJINN_CUTOVER_PLAN}" ] || die "DJINN_CUTOVER_PLAN does not exist: $DJINN_CUTOVER_PLAN"
+[ -n "${DJINN_DATABASE_URL:-}" ] || die "DJINN_DATABASE_URL is not set"
+
+BIN="${AUTHORITY_CUTOVER_BIN:-}"
+if [ -z "$BIN" ]; then
+  BIN="${CARGO_TARGET_DIR:-$REPO_DIR/server/target}/debug/authority-cutover"
+  if [ ! -x "$BIN" ]; then
+    command -v cargo >/dev/null 2>&1 ||
+      die "authority-cutover binary missing ($BIN) and cargo is unavailable to build it"
+    # Built from `server/` for the reason cutover-preflight.sh documents: CI sets
+    # a RELATIVE CARGO_BUILD_BUILD_DIR that cargo resolves against the process
+    # CWD, so building from the repo root rebuilds the whole chain off a cold
+    # cache.
+    (cd "$REPO_DIR/server" && cargo build -p djinn-server --bin authority-cutover) >&2
+  fi
+fi
+[ -x "$BIN" ] || die "authority-cutover binary is not executable: $BIN"
+
+# Hand over. From here the preflight wrapper owns the render, the DJINN_K8S_*
+# extraction and the `env -i` re-exec; the binary it runs is ours.
+CUTOVER_PREFLIGHT_BIN="$BIN" exec "$PREFLIGHT" "$@"

--- a/deploy/preflight/cutover-preflight.sh
+++ b/deploy/preflight/cutover-preflight.sh
@@ -220,12 +220,19 @@ done <"$WORK/env.nul"
 [ "${#pairs[@]}" -gt 0 ] || die "no DJINN_K8S_* environment was extracted from the render"
 
 # `env -i` is the point: the verdict must depend on the RENDER, never on the
-# DJINN_K8S_* variables exported in the operator's shell. The four names below
-# are forwarded explicitly because they describe the CUTOVER, not the render —
-# which mode we are flipping to, where the durable fence lives, and where the
+# DJINN_K8S_* variables exported in the operator's shell. The names below are
+# forwarded explicitly because they describe the CUTOVER, not the render — which
+# mode we are flipping to, where the durable fence lives, and where the
 # cluster/registry observations are.
+#
+# The DIRECTION/PLAN/PAUSED_BY trio is read only by `authority-cutover`, which
+# deploy/cutover/authority-cutover.sh runs THROUGH this script by pointing
+# CUTOVER_PREFLIGHT_BIN at it. Doing the cutover that way is deliberate: the flip
+# and the deploy gate then judge the same render under the same extracted
+# environment, which is the only way the preflight verdict is about the flip.
 forward=()
 for name in DJINN_CUTOVER_AUTHORITY_MODE DJINN_CUTOVER_OBSERVATIONS DJINN_DATABASE_URL \
+  DJINN_CUTOVER_DIRECTION DJINN_CUTOVER_PLAN DJINN_CUTOVER_PAUSED_BY \
   DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_PUBLIC_KEY \
   DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_SIGNATURE; do
   if [ -n "${!name:-}" ]; then

--- a/docs/deploy/launcher-authority-cutover.md
+++ b/docs/deploy/launcher-authority-cutover.md
@@ -10,10 +10,83 @@ reverse has to be able to refuse itself.
 > **This document is not the enforcement.** The ordering below is enforced by
 > `ResizeRollout` in `server/src/task_run_resize_rollout.rs`: every step
 > declares the steps that must already have run, the journal records only steps
-> that actually completed, and calling the flip before the drain proof returns
-> `StepOutOfOrder`. If this file and that module ever disagree, the module is
-> right. What this file adds is the *operator* half — what you run, what you
-> retain, and what to do when it blocks.
+> that actually completed, and calling the flip before the drain proof — or
+> before the preflight — returns `StepOutOfOrder`. If this file and that module
+> ever disagree, the module is right. What this file adds is the *operator*
+> half — what you run, what you retain, and what to do when it blocks.
+
+---
+
+## What you run
+
+```bash
+# forward: leaf-v1 -> resize-v2
+DJINN_CUTOVER_DIRECTION=activate \
+DJINN_CUTOVER_AUTHORITY_MODE=resize-v2 \
+DJINN_CUTOVER_PLAN=/path/to/plan.json \
+DJINN_DATABASE_URL=postgres://... \
+DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY=/path/to/legacy-digests.json \
+DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_PUBLIC_KEY=<base64> \
+DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_SIGNATURE=<base64> \
+  deploy/cutover/authority-cutover.sh deploy/helm/djinn --values prod-values.yaml
+
+# reverse: resize-v2 -> leaf-v1
+DJINN_CUTOVER_DIRECTION=rollback \
+DJINN_CUTOVER_AUTHORITY_MODE=leaf-v1 \
+  ... same variables ...
+  deploy/cutover/authority-cutover.sh deploy/helm/djinn --values prod-values.yaml
+```
+
+**Exit status:** `0` the mode flipped and admission resumed; `1` blocked — the
+mode did **not** move, and the driver says whether admission is left paused;
+`2` unevaluable — a missing plan, an unreadable render, a probe image that is
+not in the catalog. Nothing was attempted.
+
+The wrapper delegates to `deploy/preflight/cutover-preflight.sh`, pointing
+`CUTOVER_PREFLIGHT_BIN` at the `authority-cutover` binary. That is not a
+shortcut: it is what makes the flip and the deploy gate render the same chart,
+extract the same `DJINN_K8S_*` out of the same rendered `djinn-server`
+container, and re-exec under the same `env -i`. A preflight verdict produced
+under the operator's shell would not be a verdict about the deployment.
+
+### The plan file
+
+Everything one cutover run needs that a render cannot contain. Unknown keys are
+rejected, an empty `retained` set is rejected (proving the pullability of
+nothing is not evidence), and `role` is parsed, never defaulted.
+
+```json
+{
+  "expected_epoch": 3,
+  "registry_base_url": "https://ghcr.io",
+  "reason": "3i92 launcher authority cutover",
+  "probe_task_run_id": "019fc000-0000-7000-8000-000000000001",
+  "probe_image_id": "i1",
+  "retained": [
+    {
+      "image_id": "i1",
+      "repository": "djinnos/djinn-image-i1",
+      "digest": "sha256:<64 hex>",
+      "role": "resize-v2-current"
+    },
+    {
+      "image_id": "i1",
+      "repository": "djinnos/djinn-image-i1",
+      "digest": "sha256:<64 hex>",
+      "role": "leaf-v1-rollback"
+    }
+  ]
+}
+```
+
+`role` is one of `legacy-no-handshake`, `leaf-v1-rollback`,
+`resize-v2-current`. `probe_image_id` must name a real, `ready`, selected
+catalog row — the pause step proves itself by dispatching it, and a synthesised
+image would prove the pause against a path no task run takes.
+
+`expected_epoch` is read first (see "What you need before you start", item 3):
+every flip is a compare-and-swap against it, so a second operator moving the
+mode under you is a conflict, not a silent overwrite.
 
 ---
 
@@ -96,8 +169,9 @@ Run in this order. The driver refuses any other.
 | 5 | **Verify retention** | Every retained digest is fetched from the registry and its content hashes to the recorded digest. |
 | 6 | **Pause admission** | The pause is written **and then disbelieved**: a probe dispatch is issued through the same path a task run takes and must be refused. A pause row with no wired refusal blocks the cutover here rather than passing it. |
 | 7 | **Prove the drain** | **Zero live task-run Pods** and **zero nonterminal resize/lease rows**. Both. See below. |
-| 8 | **Flip the mode** | Compare-and-swap at the expected epoch, behind `set_mode`'s own transactional fence, which holds the `build_pod_permit_pools` row lock admission takes before it inserts. |
-| 9 | **Resume admission** | Only after a confirmed flip. Resuming earlier is `StepOutOfOrder`. |
+| 8 | **Clear the preflight** | `djinn_k8s::cutover_preflight::run` — the same validator `deploy/preflight/cutover-preflight.sh` runs, over the same render, assembled by the same module — must come back clean **for the mode being flipped to**, having actually evaluated its six classes. A clean verdict from zero evaluated classes blocks here. This step runs *after* the drain proof, not before, because the preflight judges the drain fence too and that fence is never empty on a live deployment. |
+| 9 | **Flip the mode** | Compare-and-swap at the expected epoch, behind `set_mode`'s own transactional fence, which holds the `build_pod_permit_pools` row lock admission takes before it inserts. Requires steps 6, 7 **and** 8 in the journal; reaching it without any of them is `StepOutOfOrder`. |
+| 10 | **Resume admission** | Only after a confirmed flip. Resuming earlier is `StepOutOfOrder`. |
 
 ## Rollback
 
@@ -110,8 +184,9 @@ dispatch, and they dispatch only because the signed inventory vouches for them.
 3. Validate the catalog against `leaf-v1`.
 4. Pause admission (proven by a refused dispatch).
 5. Prove the drain.
-6. Flip to `leaf-v1`.
-7. Resume admission.
+6. Clear the preflight, **against `leaf-v1`**.
+7. Flip to `leaf-v1`.
+8. Resume admission.
 
 **Rollback is blocked, and admission is left paused, when any of the first three
 fail.** Concretely: the signed allowlist file is absent; a retained digest is no
@@ -119,6 +194,13 @@ longer pullable; a catalog row has been repointed to a digest the signed
 document does not vouch for. In each case the mode does not move, admission is
 not resumed, and no Pod is started. Do not "unblock" it by relaxing a check —
 restore the artifact or re-sign the inventory.
+
+"Admission is left paused" is reported from the **production dispatch-pause
+predicate**, not from how far the run got. Steps 1-3 run before the rollback's
+own pause step, so a rollback blocked there has an empty journal — and it will
+still say `admission=PAUSED` if a half-finished forward cutover left a pause
+behind, which is exactly when you need to know. An unreadable pause state is
+reported as paused.
 
 ---
 
@@ -154,6 +236,19 @@ not a substitute for the first: it reports counts, and it is blind to Pods.
 
 ## Preflight
 
+The driver runs `djinn_k8s::cutover_preflight::run` itself, at step 8, and
+refuses to flip when it blocks. Running it standalone first is still worth it:
+it is the same verdict, minutes earlier, without pausing anything.
+
+```bash
+DJINN_CUTOVER_AUTHORITY_MODE=resize-v2 DJINN_DATABASE_URL=postgres://... \
+  deploy/preflight/cutover-preflight.sh deploy/helm/djinn --values prod-values.yaml
+```
+
+Expect `drain-fence` to be the one class that blocks a standalone run against a
+live deployment — the drain is not empty until admission has been paused, which
+is why the flip's own preflight runs *after* the drain proof and not before.
+
 ```bash
 # Retention, against a disposable registry:2 (isolated name and port, deleted
 # on exit pass or fail).
@@ -161,7 +256,12 @@ bash deploy/preflight/tests/task-run-resize-rollout.sh
 
 # The workflow itself, against real PostgreSQL.
 cd server && cargo test -p djinn-server --test task_run_resize_rollout
+# The operator entry point, end to end through ResizeRollout::production.
+cd server && cargo test -p djinn-server --test authority_cutover
 cd server && cargo test -p djinn-db  --test image_legacy_digest_allowlist
+
+# The entry point is still reachable from a binary.
+sh scripts/check-resize-reachability.sh
 ```
 
 ---

--- a/scripts/check-resize-reachability.sh
+++ b/scripts/check-resize-reachability.sh
@@ -51,12 +51,20 @@ cd "$ROOT"
 
 # symbol|extended-regex for a call site|file must also mention this token
 #
-# `0ppk-3` added the last two. Before it, `list_nonterminal_resize` had ZERO
-# callers of ANY kind outside one repository test — the read the whole external
-# reconciler exists to perform, merged and unreachable — and
-# `task_run_resize_reconcile::spawn` is the seam that makes a dead worker's
-# stranded Pod somebody's problem at all. Both are exactly the shape this guard
-# exists to catch.
+# `0ppk-3` added `list_nonterminal_resize` and `task_run_resize_reconcile::spawn`.
+# Before it, `list_nonterminal_resize` had ZERO callers of ANY kind outside one
+# repository test — the read the whole external reconciler exists to perform,
+# merged and unreachable — and `task_run_resize_reconcile::spawn` is the seam
+# that makes a dead worker's stranded Pod somebody's problem at all. Both are
+# exactly the shape this guard exists to catch.
+#
+# `ResizeRollout::production` is the last entry, and it was in the same state:
+# the staged activation this whole proposal is FOR, composed correctly, tested
+# thoroughly, and callable by nobody. Its only reference outside its own module
+# was a test asserting the constructor existed. The composition anchors below
+# pin the two halves that make it reachable — the driver that calls it and the
+# binary that calls the driver — because a production caller inside a function
+# no `main` reaches is still zero reachability.
 GUARDED_SYMBOLS="
 TaskRunResizeBootstrap::bootstrap|\.bootstrap\(|TaskRunResizeBootstrap
 DispatchGate::admit|\.admit\(|DispatchGate
@@ -64,6 +72,7 @@ BuildPodPermitRepository::acquire|\.acquire\(|BuildPodPermitRepository
 BuildPodPermitRepository::capture_resize_identity|\.capture_resize_identity\(|BuildPodPermitRepository
 BuildPodPermitRepository::list_nonterminal_resize|\.list_nonterminal_resize\(|BuildPodPermitRepository
 task_run_resize_reconcile::spawn|task_run_resize_reconcile::spawn\(|become_leader
+ResizeRollout::production|ResizeRollout::production\(|ResizeRollout
 "
 
 # file|extended-regex|why this anchor exists
@@ -75,6 +84,12 @@ server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs|bind_build_pod_pe
 server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs|admit_task_run_dispatch\(|the dispatch seam must gate stdio attach on the birth downsize
 server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs|record_dispatch_started\(|the dispatch site must report itself so the gate's absence is observable
 server/src/server/state/mod.rs|task_run_resize_reconcile::spawn\(self\.clone\(\)\)|the resize reconciler must be armed from become_leader, or a worker death strands its Pod forever
+server/src/bin/authority_cutover.rs|let report = run\(|the operator binary must call the cutover driver, or ResizeRollout::production sits inside a function no main reaches
+server/Cargo.toml|^name = .authority-cutover.$|the operator entry point must be a declared binary target; a src/bin file cargo does not build is not an entry point
+server/src/authority_cutover.rs|rollout\.activate\(&plan\)|the driver must run the forward sequence through ResizeRollout, not through set_mode
+server/src/authority_cutover.rs|rollout\.rollback\(&plan\)|the driver must run the reverse sequence through ResizeRollout, not through set_mode
+server/src/task_run_resize_rollout.rs|self\.clear_preflight\(LauncherAuthorityProtocol::ResizeV2\)|the forward cutover must run the real preflight before the flip
+server/src/task_run_resize_rollout.rs|self\.clear_preflight\(LauncherAuthorityProtocol::LeafV1\)|the reverse cutover must run the real preflight before the flip
 "
 
 status=0

--- a/scripts/test-check-resize-reachability.sh
+++ b/scripts/test-check-resize-reachability.sh
@@ -38,6 +38,10 @@ STATE=server/src/server/state/mod.rs
 BRIDGE=server/src/task_run_resize_bootstrap.rs
 SEAM=server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
 RECONCILE=server/src/task_run_resize_reconcile.rs
+CUTOVER=server/src/authority_cutover.rs
+CUTOVER_BIN=server/src/bin/authority_cutover.rs
+ROLLOUT=server/src/task_run_resize_rollout.rs
+MANIFEST=server/Cargo.toml
 
 cleanup() {
     rm -rf -- "$SCRATCH" 2>/dev/null || true
@@ -176,12 +180,65 @@ async fn execute_runtime_report_phase() {
 EOF
 }
 
+write_cutover() {
+    mkdir -p -- "$SCRATCH/$(dirname "$CUTOVER")"
+    cat >"$SCRATCH/$CUTOVER" <<'EOF'
+// Operator cutover driver fixture: the ONLY production caller of
+// ResizeRollout::production, running both sequences through ResizeRollout.
+use crate::task_run_resize_rollout::{ResizeRollout, RolloutPlan};
+
+pub async fn run(db: Database, request: &CutoverRequest) -> Result<(), CutoverFailure> {
+    let rollout = ResizeRollout::production(db, events, runtime, url, paused_by, &sources)?;
+    let outcome = match request.direction {
+        CutoverDirection::Activate => rollout.activate(&plan).await,
+        CutoverDirection::Rollback => rollout.rollback(&plan).await,
+    };
+}
+EOF
+
+    mkdir -p -- "$SCRATCH/$(dirname "$CUTOVER_BIN")"
+    cat >"$SCRATCH/$CUTOVER_BIN" <<'EOF'
+// Operator binary fixture.
+use djinn_server::authority_cutover::{CutoverFailure, CutoverRequest, run};
+
+async fn drive() -> Result<(), CutoverFailure> {
+    let report = run(db, events, runtime, &request).await?;
+    Ok(())
+}
+EOF
+
+    mkdir -p -- "$SCRATCH/$(dirname "$ROLLOUT")"
+    cat >"$SCRATCH/$ROLLOUT" <<'EOF'
+// Rollout fixture: the preflight gates both flips.
+impl ResizeRollout {
+    pub async fn activate(&self, plan: &RolloutPlan<'_>) -> Result<i64, RolloutBlocked> {
+        self.prove_drained().await?;
+        self.clear_preflight(LauncherAuthorityProtocol::ResizeV2).await?;
+        self.flip_authority_mode(plan.expected_epoch, LauncherAuthorityProtocol::ResizeV2).await
+    }
+    pub async fn rollback(&self, plan: &RolloutPlan<'_>) -> Result<i64, RolloutBlocked> {
+        self.prove_drained().await?;
+        self.clear_preflight(LauncherAuthorityProtocol::LeafV1).await?;
+        self.flip_authority_mode(plan.expected_epoch, LauncherAuthorityProtocol::LeafV1).await
+    }
+}
+EOF
+
+    mkdir -p -- "$SCRATCH/$(dirname "$MANIFEST")"
+    cat >"$SCRATCH/$MANIFEST" <<'EOF'
+[[bin]]
+name = "authority-cutover"
+path = "src/bin/authority_cutover.rs"
+EOF
+}
+
 fixture() {
     rm -rf -- "$SCRATCH"
     write_state
     write_bridge
     write_seam
     write_reconcile
+    write_cutover
 }
 
 run_guard() {
@@ -357,6 +414,93 @@ mv "$SCRATCH/.tmp" "$SCRATCH/$STATE"
 expect_fail_naming \
     "a spawn that survives only inside a #[cfg(test)] mod does not count" \
     "task_run_resize_reconcile::spawn has ZERO production callers"
+
+# 15. THE `eeky-2` NAMED MUTATION: delete the ResizeRollout::production call.
+#     This is verbatim the state main was in before the operator entry point
+#     landed — the staged activation composed, tested, and callable by nobody.
+fixture
+grep -v 'ResizeRollout::production(' "$SCRATCH/$CUTOVER" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$CUTOVER"
+expect_fail_naming \
+    "deleting the ResizeRollout::production call fails, naming the symbol" \
+    "ResizeRollout::production has ZERO production callers"
+
+# 16. The call survives only inside a `#[cfg(test)]` module — which is where it
+#     effectively lived before, as an assertion that the constructor existed.
+fixture
+cat >"$SCRATCH/$CUTOVER" <<'EOF'
+// Driver fixture with the composition demoted to a test.
+use crate::task_run_resize_rollout::{ResizeRollout, RolloutPlan};
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn the_constructor_exists() {
+        let rollout = ResizeRollout::production(db, events, runtime, url, paused_by, &sources);
+        rollout.activate(&plan);
+        rollout.rollback(&plan);
+    }
+}
+EOF
+expect_fail_naming \
+    "a ResizeRollout::production call that survives only in #[cfg(test)] does not count" \
+    "ResizeRollout::production has ZERO production callers"
+
+# 17. The driver exists and calls `production`, but no binary calls the driver.
+#     Reachable-looking code inside a function no `main` reaches.
+fixture
+grep -v 'let report = run(' "$SCRATCH/$CUTOVER_BIN" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$CUTOVER_BIN"
+expect_fail_naming \
+    "a cutover driver no binary calls fails on the composition anchor" \
+    "let report = run"
+
+# 18. The binary source exists but cargo does not build it. A file under
+#     `src/bin/` that is not a declared target ships nothing.
+fixture
+grep -v 'authority-cutover' "$SCRATCH/$MANIFEST" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$MANIFEST"
+expect_fail_naming \
+    "an undeclared binary target fails on the manifest anchor" \
+    "authority-cutover"
+
+# 19. The driver runs the sequences through something other than ResizeRollout —
+#     `set_mode` directly, say, which has its own fence but refuses with a bare
+#     census and names no row.
+fixture
+grep -v 'rollout.activate(&plan)' "$SCRATCH/$CUTOVER" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$CUTOVER"
+expect_fail_naming \
+    "a driver that does not run activate through ResizeRollout fails the anchor" \
+    "must run the forward sequence through ResizeRollout"
+
+# 19b. …and the reverse, guarded separately: rollback is the path that must never
+#      start an incompatible Pod, and `set_mode` alone refuses with a bare census.
+fixture
+grep -v 'rollout.rollback(&plan)' "$SCRATCH/$CUTOVER" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$CUTOVER"
+expect_fail_naming \
+    "a driver that does not run rollback through ResizeRollout fails the anchor" \
+    "must run the reverse sequence through ResizeRollout"
+
+# 20. The forward flip stops running the preflight. The gate would still exist,
+#     still be tested, and gate nothing.
+fixture
+grep -v 'clear_preflight(LauncherAuthorityProtocol::ResizeV2)' "$SCRATCH/$ROLLOUT" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$ROLLOUT"
+expect_fail_naming \
+    "dropping the forward preflight call fails the anchor" \
+    "clear_preflight"
+
+# 21. …and the reverse flip likewise. Rollback is the path that must never start
+#     an incompatible Pod, so its gate is guarded separately rather than assumed
+#     to travel with the forward one.
+fixture
+grep -v 'clear_preflight(LauncherAuthorityProtocol::LeafV1)' "$SCRATCH/$ROLLOUT" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$ROLLOUT"
+expect_fail_naming \
+    "dropping the reverse preflight call fails the anchor" \
+    "clear_preflight"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,6 +29,12 @@ doctest = false
 name = "export-usage-schema"
 path = "src/bin/export_usage_schema.rs"
 
+# The operator entry point for proposal 3i92's launcher-authority cutover.
+# `deploy/cutover/authority-cutover.sh` builds and execs it.
+[[bin]]
+name = "authority-cutover"
+path = "src/bin/authority_cutover.rs"
+
 [features]
 default = []
 qdrant = ["djinn-db/qdrant"]

--- a/server/crates/djinn-k8s/Cargo.toml
+++ b/server/crates/djinn-k8s/Cargo.toml
@@ -9,9 +9,10 @@ doctest = false
 
 [features]
 default = []
-# Exposes cluster-free `Pod` fixtures (`pod_resize_fixture`) to downstream test
-# targets. Kept behind a feature so production binaries never link them.
-test-support = []
+# Exposes cluster-free `Pod` fixtures (`pod_resize_fixture`) and the recording
+# in-process apiserver (`runtime_fixture`) to downstream test targets. Kept
+# behind a feature so production binaries never link them.
+test-support = ["dep:tower", "dep:http", "dep:http-body-util"]
 
 [dependencies]
 djinn-cgroup-launcher = { path = "../djinn-cgroup-launcher" }
@@ -41,6 +42,13 @@ time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
 tokio = { version = "1", features = ["rt", "sync", "macros", "time", "net", "io-util", "process"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v7"] }
+# `runtime_fixture` only. Optional regular dependencies rather than dev-only
+# ones, because a dev-dependency is absent when this crate is compiled as a
+# dependency of `djinn-server`'s test binary with `test-support` enabled — the
+# same reason `server/Cargo.toml` carries `tower` as an optional dependency.
+tower = { version = "0.5", features = ["util"], optional = true }
+http = { version = "1", optional = true }
+http-body-util = { version = "0.1", optional = true }
 workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/server/crates/djinn-k8s/src/bin/cutover-preflight.rs
+++ b/server/crates/djinn-k8s/src/bin/cutover-preflight.rs
@@ -7,13 +7,18 @@
 //!
 //! # What it assembles
 //!
+//! The assembly itself lives in [`djinn_k8s::cutover_preflight_driver`], not in
+//! this file, because `djinn-server`'s authority-cutover driver runs the same
+//! preflight before it flips the authority mode and must not assemble a
+//! *different* one. What that module gathers:
+//!
 //! * **The Helm surface** — the `pods/resize` Role rule, the task-run
 //!   ServiceAccount and every RoleBinding — comes from a LIVE `helm template`
 //!   render, converted to JSON and passed as `argv[1]`.
 //!   `deploy/preflight/cutover-preflight.sh` produces it.
 //! * **The Rust surface** — `automountServiceAccountToken`, the projected token
-//!   audience and the launcher sidecar's CPU ceiling — is rendered here, in
-//!   process, by the same [`djinn_k8s::job::build_task_run_job`] +
+//!   audience and the launcher sidecar's CPU ceiling — is rendered in process by
+//!   the same [`djinn_k8s::job::build_task_run_job`] +
 //!   [`djinn_k8s::launcher::apply_launcher_authority_protocol`] pair dispatch
 //!   uses. Helm never sees those fields, so a Helm-only preflight would declare
 //!   a credential boundary it had not looked at.
@@ -23,10 +28,10 @@
 //!   database was unreachable" and "nothing is in flight" are the two answers a
 //!   cutover must never confuse.
 //! * **The signed legacy-digest inventory** is resolved by
-//!   [`LegacyDigestInventory::from_env`] — the production resolver, with its
-//!   own fail-closed `Unusable` arm. It is deliberately NOT taken from the
-//!   observation bundle: a file that could declare itself verified is not an
-//!   inventory.
+//!   [`djinn_db::launcher_compatibility::LegacyDigestInventory::from_env`] — the
+//!   production resolver, with its own fail-closed `Unusable` arm. It is
+//!   deliberately NOT taken from the observation bundle: a file that could
+//!   declare itself verified is not an inventory.
 //! * **Catalog images and live birth observations** come from the JSON bundle
 //!   at `DJINN_CUTOVER_OBSERVATIONS`. These are cluster/registry facts a render
 //!   cannot contain. An absent bundle means an empty catalog and no births —
@@ -54,66 +59,15 @@
 //!   `1` so a harness error is never read as a clean or a blocked verdict.
 
 use std::process::ExitCode;
-use std::str::FromStr;
 
-use djinn_cgroup_launcher::LauncherAuthorityProtocol;
-use djinn_db::launcher_compatibility::LegacyDigestInventory;
-use djinn_db::{BuildPodPermitRepository, Database, DatabaseConnectConfig, PostgresDatabaseConfig};
-use djinn_k8s::config::KubernetesConfig;
-use djinn_k8s::cutover_preflight::{
-    BirthObservation, CatalogImage, CutoverPreflightInput, DrainFenceObservation,
-    observe_drain_fence, run, summarize,
+use djinn_k8s::cutover_preflight_driver::{
+    DrainFenceSource, PreflightSources, RenderedCutoverPreflight, authority_mode_from_env,
 };
-use djinn_k8s::job::build_task_run_job;
-use djinn_k8s::launcher::apply_launcher_authority_protocol;
-use k8s_openapi::api::core::v1::Pod;
-use serde::Deserialize;
-use serde_json::Value;
-
-/// Cluster/registry observations a render cannot contain.
-#[derive(Debug, Default, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct Observations {
-    #[serde(default)]
-    catalog: Vec<WireCatalogImage>,
-    #[serde(default)]
-    births: Vec<WireBirth>,
-    #[serde(default)]
-    live_task_run_pods: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct WireCatalogImage {
-    pull_ref: String,
-    /// `"leaf-v1"`, `"resize-v2"`, or absent for a pre-handshake image.
-    #[serde(default)]
-    declared: Option<String>,
-    #[serde(default)]
-    digest: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct WireBirth {
-    pod: Pod,
-    target_cpu: String,
-}
-
-/// Placeholders for the task-run Job render.
-///
-/// None of the three participate in any property this preflight judges: the
-/// credential boundary and the launcher ceiling are functions of the config and
-/// the authority protocol, not of which task run happens to be dispatching.
-/// Naming them here rather than reading them from somewhere makes the render
-/// reproducible, which is what lets the wrapper's fixture diff be exact.
-const PREFLIGHT_PROJECT: &str = "cutover-preflight";
-const PREFLIGHT_SECRET: &str = "cutover-preflight-secret";
-const PREFLIGHT_IMAGE: &str = "ghcr.io/djinnos/cutover-preflight:preflight";
 
 #[allow(clippy::print_stdout, clippy::print_stderr)]
-fn main() -> ExitCode {
-    match drive() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> ExitCode {
+    match drive().await {
         Ok(true) => ExitCode::SUCCESS,
         Ok(false) => ExitCode::FAILURE,
         Err(message) => {
@@ -124,7 +78,7 @@ fn main() -> ExitCode {
 }
 
 #[allow(clippy::print_stdout, clippy::print_stderr)]
-fn drive() -> Result<bool, String> {
+async fn drive() -> Result<bool, String> {
     let path = std::env::args().nth(1).ok_or_else(|| {
         "usage: cutover-preflight <rendered-manifests.json>  (the wrapper \
          deploy/preflight/cutover-preflight.sh produces the file)"
@@ -140,218 +94,33 @@ fn drive() -> Result<bool, String> {
         return Ok(true);
     }
 
-    let manifests = load_manifests(&path)?;
-    let mode = authority_mode()?;
-    let observations = load_observations()?;
+    let mode = authority_mode_from_env()?;
+    let preflight = RenderedCutoverPreflight::load(
+        &PreflightSources::from_env(path),
+        DrainFenceSource::from_database_url_env(),
+    )?;
+    // This binary reads no apiserver of its own; the Pod half of the fence comes
+    // from the observation bundle. `djinn-server`'s cutover driver enumerates it
+    // live and passes it here instead.
+    let judgement = preflight.judge(mode, &[]).await?;
+    let summary = &judgement.summary;
 
-    let config = KubernetesConfig::from_env();
-    // `build_task_run_job` asserts this pairing. It is `render-gate`'s subject,
-    // not this one's, so refuse to evaluate rather than panic in a deploy step.
-    if config.cgroup_launcher_mode.renders_sidecar() && !config.task_run_cgroup_writable_enabled {
-        return Err(
-            "the rendered config arms the cgroup launcher without the task-run RuntimeClass; \
-             deploy/preflight/render-gate.sh is the gate for that pairing and refuses it already"
-                .to_string(),
+    if judgement.is_clear() {
+        println!(
+            "cutover-preflight: CLEAR {summary} evaluated={}",
+            judgement.evaluated_classes().join(",")
         );
+        return Ok(true);
     }
-    let mut job = build_task_run_job(
-        &config,
-        &uuid::Uuid::nil(),
-        PREFLIGHT_PROJECT,
-        PREFLIGHT_SECRET,
-        PREFLIGHT_IMAGE,
-        &[],
-        None,
-        false,
-        None,
+
+    eprintln!("cutover-preflight: BLOCKED {summary}");
+    for defect in judgement.blocking_defects() {
+        eprintln!("cutover-preflight: DEFECT {defect}");
+    }
+    eprintln!(
+        "cutover-preflight: BLOCKED classes={} defects={}",
+        judgement.blocking_classes().join(","),
+        judgement.blocking_defects().len()
     );
-    // The same post-render seam dispatch uses. Its refusals ARE ceiling
-    // defects, so they are folded into the report instead of aborting: an
-    // operator needs every blocking reason in one run, not the first one.
-    let applied = apply_launcher_authority_protocol(&mut job, config.cgroup_launcher_mode, mode);
-
-    // The production resolver, not the bundle: an inventory that could be
-    // handed to the gate by the thing being gated is not an inventory.
-    let inventory = LegacyDigestInventory::from_env();
-    let catalog = observations
-        .catalog
-        .into_iter()
-        .map(|image| {
-            let declared = match image.declared.as_deref() {
-                None => None,
-                Some(raw) => Some(
-                    LauncherAuthorityProtocol::from_str(raw)
-                        .map_err(|error| format!("catalog image {:?}: {error}", image.pull_ref))?,
-                ),
-            };
-            Ok(CatalogImage {
-                pull_ref: image.pull_ref,
-                declared,
-                digest: image.digest,
-            })
-        })
-        .collect::<Result<Vec<_>, String>>()?;
-    let births: Vec<BirthObservation> = observations
-        .births
-        .into_iter()
-        .map(|birth| BirthObservation {
-            pod: birth.pod,
-            target_cpu: birth.target_cpu,
-        })
-        .collect();
-    let drain = drain_fence(observations.live_task_run_pods);
-
-    let input = CutoverPreflightInput {
-        manifests: &manifests,
-        task_run_job: &job,
-        authority_mode: mode,
-        catalog: &catalog,
-        legacy_digest_inventory: &inventory,
-        births: &births,
-        drain: &drain,
-    };
-    let summary = summarize(&input);
-
-    let mut blocked = false;
-    if let Err(error) = applied {
-        // Emitted with the same class prefix the validator uses, so the shell
-        // contract asserts one vocabulary rather than two.
-        eprintln!(
-            "cutover-preflight: DEFECT launcher-cpu-ceiling the dispatch render refused to apply \
-             the {mode} authority protocol: RenderValidationError::{error:?}: {error}"
-        );
-        blocked = true;
-    }
-    match run(&input) {
-        Ok(report) if !blocked => {
-            println!(
-                "cutover-preflight: CLEAR {summary} evaluated={}",
-                report
-                    .evaluated()
-                    .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join(",")
-            );
-            Ok(true)
-        }
-        Ok(_) => {
-            eprintln!("cutover-preflight: BLOCKED {summary} classes=launcher-cpu-ceiling");
-            Ok(false)
-        }
-        Err(refusal) => {
-            eprintln!("cutover-preflight: BLOCKED {summary}");
-            for defect in refusal.defects() {
-                eprintln!(
-                    "cutover-preflight: DEFECT {} {}",
-                    defect.class(),
-                    defect.detail()
-                );
-            }
-            let mut classes: Vec<String> =
-                refusal.classes().iter().map(ToString::to_string).collect();
-            if blocked {
-                classes.push("launcher-cpu-ceiling".to_string());
-                classes.sort();
-                classes.dedup();
-            }
-            eprintln!(
-                "cutover-preflight: BLOCKED classes={} defects={}",
-                classes.join(","),
-                refusal.defects().len()
-            );
-            Ok(false)
-        }
-    }
-}
-
-/// The render, as a flat list of documents.
-///
-/// JSON rather than YAML because `serde_yaml` is a dev-dependency of this
-/// crate; the wrapper converts with the same `python3`/PyYAML pair
-/// `render-gate.sh` already requires. A single document, a JSON array, and a
-/// `{"items": [...]}` list are all accepted, because all three are shapes
-/// `helm template` output legitimately reduces to.
-fn load_manifests(path: &str) -> Result<Vec<Value>, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|error| format!("cannot read rendered manifests {path}: {error}"))?;
-    let parsed: Value = serde_json::from_str(&raw)
-        .map_err(|error| format!("rendered manifests {path} are not valid JSON: {error}"))?;
-    let documents = match parsed {
-        Value::Array(documents) => documents,
-        Value::Object(ref map) if map.contains_key("items") => map["items"]
-            .as_array()
-            .cloned()
-            .ok_or_else(|| format!("{path}: `items` is not an array"))?,
-        other => vec![other],
-    };
-    if documents.is_empty() {
-        return Err(format!(
-            "{path} contains no documents; an empty render would pass every render-derived check \
-             vacuously"
-        ));
-    }
-    Ok(documents)
-}
-
-/// The protocol the deployment is being flipped to. Fail-closed on a malformed
-/// value; absent means the pre-cutover status quo, which is `leaf-v1`.
-fn authority_mode() -> Result<LauncherAuthorityProtocol, String> {
-    match std::env::var("DJINN_CUTOVER_AUTHORITY_MODE") {
-        Err(_) => Ok(LauncherAuthorityProtocol::LeafV1),
-        Ok(raw) if raw.trim().is_empty() => Ok(LauncherAuthorityProtocol::LeafV1),
-        Ok(raw) => LauncherAuthorityProtocol::from_str(raw.trim())
-            .map_err(|error| format!("DJINN_CUTOVER_AUTHORITY_MODE: {error}")),
-    }
-}
-
-fn load_observations() -> Result<Observations, String> {
-    let Ok(path) = std::env::var("DJINN_CUTOVER_OBSERVATIONS") else {
-        return Ok(Observations::default());
-    };
-    if path.trim().is_empty() {
-        return Ok(Observations::default());
-    }
-    let raw = std::fs::read_to_string(&path)
-        .map_err(|error| format!("cannot read observations {path}: {error}"))?;
-    serde_json::from_str(&raw).map_err(|error| format!("observations {path} are invalid: {error}"))
-}
-
-/// Read the durable half of the drain fence with the production query, or
-/// report it unobservable. Never reports an empty fence it did not read.
-fn drain_fence(live_task_run_pods: Vec<String>) -> DrainFenceObservation {
-    let Ok(url) = std::env::var("DJINN_DATABASE_URL") else {
-        return DrainFenceObservation::unobservable(
-            "DJINN_DATABASE_URL is not set, so the nonterminal resize/lease rows could not be read",
-        );
-    };
-    let runtime = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(runtime) => runtime,
-        Err(error) => {
-            return DrainFenceObservation::unobservable(format!("no tokio runtime: {error}"));
-        }
-    };
-    // The pool is built INSIDE `block_on`. `PgPool` spawns its own reaper task
-    // at construction, so `sqlx` panics with "this functionality requires a
-    // Tokio context" if it is created outside a runtime — and a panic in a
-    // deploy gate is an exit 101 that reads as neither a clean nor a blocked
-    // verdict. Caught by `deploy/preflight/tests/cutover-preflight.sh` the
-    // first time the lane ran it with a real `DJINN_DATABASE_URL`.
-    runtime.block_on(async move {
-        let database = match Database::open_with_config(DatabaseConnectConfig::Postgres(
-            PostgresDatabaseConfig { url },
-        )) {
-            Ok(database) => database,
-            Err(error) => {
-                return DrainFenceObservation::unobservable(format!(
-                    "cannot open DJINN_DATABASE_URL: {error}"
-                ));
-            }
-        };
-        let permits = BuildPodPermitRepository::new(database);
-        observe_drain_fence(&permits, live_task_run_pods).await
-    })
+    Ok(false)
 }

--- a/server/crates/djinn-k8s/src/cutover_preflight_driver.rs
+++ b/server/crates/djinn-k8s/src/cutover_preflight_driver.rs
@@ -1,0 +1,432 @@
+//! Assembling a REAL [`crate::cutover_preflight`] input, once, for every caller
+//! that needs a verdict (proposal `3i92`).
+//!
+//! # Why this is a library module and not two copies
+//!
+//! [`crate::cutover_preflight::run`] judges an input it does not assemble. The
+//! assembly — a live `helm template` render, the Rust-rendered task-run Job, the
+//! signed inventory resolved from the deployment's environment, the durable
+//! drain fence read with the production query — used to live entirely inside
+//! `bin/cutover-preflight.rs`, which meant a *second* caller could only get a
+//! verdict by rebuilding it.
+//!
+//! There is now a second caller: `djinn-server`'s authority-cutover driver runs
+//! this preflight and refuses to flip the authority mode when it blocks. A
+//! preflight the flip assembles differently from the one the deploy gate
+//! assembles is not the same preflight, so both go through [`RenderedCutoverPreflight`].
+//!
+//! # What a caller must supply, and what it must not
+//!
+//! It supplies the *render* (as JSON documents) and the cluster/registry
+//! observations a render cannot contain. It does **not** supply the signed
+//! legacy-digest inventory or the drain fence: the inventory comes from
+//! [`LegacyDigestInventory::from_env`], the production resolver, and the fence
+//! comes from [`observe_drain_fence`] over the production
+//! `list_nonterminal_resize` query. A gate whose evidence can be handed to it by
+//! the thing being gated is not a gate.
+
+use std::str::FromStr;
+
+use djinn_cgroup_launcher::LauncherAuthorityProtocol;
+use djinn_db::launcher_compatibility::LegacyDigestInventory;
+use djinn_db::{BuildPodPermitRepository, Database, DatabaseConnectConfig, PostgresDatabaseConfig};
+use k8s_openapi::api::core::v1::Pod;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::config::KubernetesConfig;
+use crate::cutover_preflight::{
+    BirthObservation, Blocked, CatalogImage, CutoverPreflightInput, DefectClass,
+    DrainFenceObservation, observe_drain_fence, run, summarize,
+};
+use crate::job::build_task_run_job;
+use crate::launcher::apply_launcher_authority_protocol;
+
+/// Cluster/registry observations a render cannot contain.
+///
+/// Deserialized from the `DJINN_CUTOVER_OBSERVATIONS` bundle. `deny_unknown_fields`
+/// is deliberate: a typo'd key that silently produced an empty catalog would
+/// make the catalog class pass vacuously.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Observations {
+    #[serde(default)]
+    catalog: Vec<WireCatalogImage>,
+    #[serde(default)]
+    births: Vec<WireBirth>,
+    #[serde(default)]
+    live_task_run_pods: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireCatalogImage {
+    pull_ref: String,
+    /// `"leaf-v1"`, `"resize-v2"`, or absent for a pre-handshake image.
+    #[serde(default)]
+    declared: Option<String>,
+    #[serde(default)]
+    digest: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireBirth {
+    pod: Pod,
+    target_cpu: String,
+}
+
+/// Placeholders for the task-run Job render.
+///
+/// None of the three participate in any property this preflight judges: the
+/// credential boundary and the launcher ceiling are functions of the config and
+/// the authority protocol, not of which task run happens to be dispatching.
+/// Naming them here rather than reading them from somewhere makes the render
+/// reproducible, which is what lets the wrapper's fixture diff be exact.
+const PREFLIGHT_PROJECT: &str = "cutover-preflight";
+const PREFLIGHT_SECRET: &str = "cutover-preflight-secret";
+const PREFLIGHT_IMAGE: &str = "ghcr.io/djinnos/cutover-preflight:preflight";
+
+/// Where the caller's half of the evidence lives on disk.
+#[derive(Clone, Debug)]
+pub struct PreflightSources {
+    /// A LIVE `helm template` render, converted to JSON. A single document, a
+    /// JSON array and a `{"items": [...]}` list are all accepted.
+    pub manifests_path: String,
+    /// The `DJINN_CUTOVER_OBSERVATIONS` bundle, when one is configured.
+    pub observations_path: Option<String>,
+}
+
+impl PreflightSources {
+    /// The sources a deploy step is given: the render as `argv[1]`, the bundle
+    /// from `DJINN_CUTOVER_OBSERVATIONS`.
+    #[must_use]
+    pub fn from_env(manifests_path: impl Into<String>) -> Self {
+        let observations_path = std::env::var("DJINN_CUTOVER_OBSERVATIONS")
+            .ok()
+            .filter(|path| !path.trim().is_empty());
+        Self {
+            manifests_path: manifests_path.into(),
+            observations_path,
+        }
+    }
+}
+
+/// Where the durable half of the drain fence comes from.
+///
+/// Two variants and no third, because "the database was unreachable" and
+/// "nothing is in flight" are the two answers a cutover must never confuse. An
+/// [`Self::Unobservable`] fence is a *defect*, not an empty one.
+pub enum DrainFenceSource {
+    /// The production `list_nonterminal_resize` query, against a live pool.
+    Repository(BuildPodPermitRepository),
+    /// The fence could not be read. Fails closed.
+    Unobservable(String),
+}
+
+impl DrainFenceSource {
+    /// Open `DJINN_DATABASE_URL`, or report the fence unobservable.
+    ///
+    /// # Panics
+    ///
+    /// Must be called from inside a Tokio runtime: `PgPool` spawns its own
+    /// reaper task at construction, and `sqlx` panics with "this functionality
+    /// requires a Tokio context" otherwise — a panic in a deploy gate is an
+    /// exit 101 that reads as neither a clean nor a blocked verdict. Caught by
+    /// `deploy/preflight/tests/cutover-preflight.sh` the first time the lane ran
+    /// it with a real `DJINN_DATABASE_URL`.
+    #[must_use]
+    pub fn from_database_url_env() -> Self {
+        let Ok(url) = std::env::var("DJINN_DATABASE_URL") else {
+            return Self::Unobservable(
+                "DJINN_DATABASE_URL is not set, so the nonterminal resize/lease rows could not be \
+                 read"
+                    .to_string(),
+            );
+        };
+        match Database::open_with_config(DatabaseConnectConfig::Postgres(PostgresDatabaseConfig {
+            url,
+        })) {
+            Ok(database) => Self::Repository(BuildPodPermitRepository::new(database)),
+            Err(error) => Self::Unobservable(format!("cannot open DJINN_DATABASE_URL: {error}")),
+        }
+    }
+}
+
+/// A loaded, judgeable preflight.
+///
+/// Loading is separated from judging so a caller that must *not* proceed on an
+/// unreadable render finds out before it has paused admission or moved anything.
+pub struct RenderedCutoverPreflight {
+    manifests: Vec<Value>,
+    catalog: Vec<CatalogImage>,
+    births: Vec<BirthObservation>,
+    bundle_live_pods: Vec<String>,
+    permits: DrainFenceSource,
+}
+
+impl RenderedCutoverPreflight {
+    /// Read the render and the observation bundle.
+    ///
+    /// # Errors
+    ///
+    /// The render is missing, unparseable or empty; the bundle is invalid; a
+    /// catalog row declares a protocol that is not one of the two wire forms.
+    /// Every one of these is *unevaluable*, never "clean".
+    pub fn load(sources: &PreflightSources, permits: DrainFenceSource) -> Result<Self, String> {
+        let manifests = load_manifests(&sources.manifests_path)?;
+        let observations = load_observations(sources.observations_path.as_deref())?;
+        let catalog = observations
+            .catalog
+            .into_iter()
+            .map(|image| {
+                let declared = match image.declared.as_deref() {
+                    None => None,
+                    Some(raw) => {
+                        Some(LauncherAuthorityProtocol::from_str(raw).map_err(|error| {
+                            format!("catalog image {:?}: {error}", image.pull_ref)
+                        })?)
+                    }
+                };
+                Ok(CatalogImage {
+                    pull_ref: image.pull_ref,
+                    declared,
+                    digest: image.digest,
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        let births = observations
+            .births
+            .into_iter()
+            .map(|birth| BirthObservation {
+                pod: birth.pod,
+                target_cpu: birth.target_cpu,
+            })
+            .collect();
+        Ok(Self {
+            manifests,
+            catalog,
+            births,
+            bundle_live_pods: observations.live_task_run_pods,
+            permits,
+        })
+    }
+
+    /// Assemble the input and hand it to [`run`].
+    ///
+    /// `additional_live_pods` is the apiserver half of the drain fence for
+    /// callers that can enumerate it themselves (the server-side cutover driver
+    /// does; a deploy step reads it from the bundle). It is UNIONED with the
+    /// bundle's list rather than replacing it, so neither source can launder the
+    /// other's non-empty answer into an empty fence.
+    ///
+    /// # Errors
+    ///
+    /// Unevaluable: the rendered config arms the cgroup launcher without the
+    /// task-run RuntimeClass, which is `render-gate`'s subject and refuses
+    /// there. Distinct from a blocked verdict, which is carried inside
+    /// [`Judgement`].
+    pub async fn judge(
+        &self,
+        mode: LauncherAuthorityProtocol,
+        additional_live_pods: &[String],
+    ) -> Result<Judgement, String> {
+        let config = KubernetesConfig::from_env();
+        // `build_task_run_job` asserts this pairing. It is `render-gate`'s
+        // subject, not this one's, so refuse to evaluate rather than panic in a
+        // deploy step.
+        if config.cgroup_launcher_mode.renders_sidecar() && !config.task_run_cgroup_writable_enabled
+        {
+            return Err(
+                "the rendered config arms the cgroup launcher without the task-run RuntimeClass; \
+                 deploy/preflight/render-gate.sh is the gate for that pairing and refuses it \
+                 already"
+                    .to_string(),
+            );
+        }
+        let mut job = build_task_run_job(
+            &config,
+            &uuid::Uuid::nil(),
+            PREFLIGHT_PROJECT,
+            PREFLIGHT_SECRET,
+            PREFLIGHT_IMAGE,
+            &[],
+            None,
+            false,
+            None,
+        );
+        // The same post-render seam dispatch uses. Its refusals ARE ceiling
+        // defects, so they are folded into the report instead of aborting: an
+        // operator needs every blocking reason in one run, not the first one.
+        let ceiling_render_error =
+            apply_launcher_authority_protocol(&mut job, config.cgroup_launcher_mode, mode)
+                .err()
+                .map(|error| {
+                    format!(
+                        "the dispatch render refused to apply the {mode} authority protocol: \
+                         RenderValidationError::{error:?}: {error}"
+                    )
+                });
+
+        // The production resolver, not the bundle: an inventory that could be
+        // handed to the gate by the thing being gated is not an inventory.
+        let inventory = LegacyDigestInventory::from_env();
+
+        let mut live_pods = self.bundle_live_pods.clone();
+        live_pods.extend(additional_live_pods.iter().cloned());
+        live_pods.sort();
+        live_pods.dedup();
+        let drain = match &self.permits {
+            DrainFenceSource::Repository(permits) => observe_drain_fence(permits, live_pods).await,
+            DrainFenceSource::Unobservable(reason) => {
+                DrainFenceObservation::unobservable(reason.clone())
+            }
+        };
+
+        let input = CutoverPreflightInput {
+            manifests: &self.manifests,
+            task_run_job: &job,
+            authority_mode: mode,
+            catalog: &self.catalog,
+            legacy_digest_inventory: &inventory,
+            births: &self.births,
+            drain: &drain,
+        };
+        let summary = summarize(&input);
+        let verdict = run(&input);
+        Ok(Judgement {
+            summary,
+            ceiling_render_error,
+            verdict,
+        })
+    }
+}
+
+/// What the preflight decided about one deployment, at one mode.
+///
+/// Carries `ceiling_render_error` separately from `verdict` because the render
+/// seam's own refusal is not produced by [`run`] — it is produced by the same
+/// `apply_launcher_authority_protocol` call dispatch makes, and it belongs to
+/// the `launcher-cpu-ceiling` class.
+pub struct Judgement {
+    /// One-line description of what was judged, for the operator's log.
+    pub summary: String,
+    /// The dispatch render refused to apply the protocol. Blocking.
+    pub ceiling_render_error: Option<String>,
+    /// [`run`]'s own verdict.
+    pub verdict: Result<crate::cutover_preflight::Report, Blocked>,
+}
+
+impl Judgement {
+    /// May the cutover proceed?
+    ///
+    /// Both halves must be clean. A caller that consulted only `verdict` would
+    /// flip a deployment whose dispatch render cannot apply the protocol it is
+    /// being flipped to.
+    #[must_use]
+    pub fn is_clear(&self) -> bool {
+        self.ceiling_render_error.is_none() && self.verdict.is_ok()
+    }
+
+    /// Every blocking class, sorted and deduped, as stable labels.
+    #[must_use]
+    pub fn blocking_classes(&self) -> Vec<String> {
+        let mut classes: Vec<String> = match &self.verdict {
+            Ok(_) => Vec::new(),
+            Err(blocked) => blocked.classes().iter().map(ToString::to_string).collect(),
+        };
+        if self.ceiling_render_error.is_some() {
+            classes.push(DefectClass::LauncherCpuCeiling.as_str().to_string());
+        }
+        classes.sort();
+        classes.dedup();
+        classes
+    }
+
+    /// Every blocking reason as `class detail`, in class order.
+    #[must_use]
+    pub fn blocking_defects(&self) -> Vec<String> {
+        let mut lines: Vec<String> = Vec::new();
+        if let Some(detail) = &self.ceiling_render_error {
+            lines.push(format!("{} {detail}", DefectClass::LauncherCpuCeiling));
+        }
+        if let Err(blocked) = &self.verdict {
+            lines.extend(
+                blocked
+                    .defects()
+                    .iter()
+                    .map(|defect| format!("{} {}", defect.class(), defect.detail())),
+            );
+        }
+        lines
+    }
+
+    /// The classes [`run`] actually evaluated, as stable labels. Empty when the
+    /// verdict is blocked — "no defects" and "no checks ran" must stay
+    /// distinguishable.
+    #[must_use]
+    pub fn evaluated_classes(&self) -> Vec<String> {
+        match &self.verdict {
+            Ok(report) => report.evaluated().iter().map(ToString::to_string).collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+}
+
+/// The render, as a flat list of documents.
+///
+/// JSON rather than YAML because `serde_yaml` is a dev-dependency of this
+/// crate; the wrapper converts with the same `python3`/PyYAML pair
+/// `render-gate.sh` already requires. A single document, a JSON array, and a
+/// `{"items": [...]}` list are all accepted, because all three are shapes
+/// `helm template` output legitimately reduces to.
+fn load_manifests(path: &str) -> Result<Vec<Value>, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("cannot read rendered manifests {path}: {error}"))?;
+    let parsed: Value = serde_json::from_str(&raw)
+        .map_err(|error| format!("rendered manifests {path} are not valid JSON: {error}"))?;
+    let documents = match parsed {
+        Value::Array(documents) => documents,
+        Value::Object(ref map) if map.contains_key("items") => map["items"]
+            .as_array()
+            .cloned()
+            .ok_or_else(|| format!("{path}: `items` is not an array"))?,
+        other => vec![other],
+    };
+    if documents.is_empty() {
+        return Err(format!(
+            "{path} contains no documents; an empty render would pass every render-derived check \
+             vacuously"
+        ));
+    }
+    Ok(documents)
+}
+
+fn load_observations(path: Option<&str>) -> Result<Observations, String> {
+    let Some(path) = path else {
+        return Ok(Observations::default());
+    };
+    if path.trim().is_empty() {
+        return Ok(Observations::default());
+    }
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("cannot read observations {path}: {error}"))?;
+    serde_json::from_str(&raw).map_err(|error| format!("observations {path} are invalid: {error}"))
+}
+
+/// The protocol the deployment is being flipped to. Fail-closed on a malformed
+/// value; absent means the pre-cutover status quo, which is `leaf-v1`.
+///
+/// # Errors
+///
+/// `DJINN_CUTOVER_AUTHORITY_MODE` holds something that is not a launcher
+/// authority protocol. Defaulting it would answer a question about `resize-v2`
+/// readiness with a `leaf-v1` verdict.
+pub fn authority_mode_from_env() -> Result<LauncherAuthorityProtocol, String> {
+    match std::env::var("DJINN_CUTOVER_AUTHORITY_MODE") {
+        Err(_) => Ok(LauncherAuthorityProtocol::LeafV1),
+        Ok(raw) if raw.trim().is_empty() => Ok(LauncherAuthorityProtocol::LeafV1),
+        Ok(raw) => LauncherAuthorityProtocol::from_str(raw.trim())
+            .map_err(|error| format!("DJINN_CUTOVER_AUTHORITY_MODE: {error}")),
+    }
+}

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod build_resources;
 pub mod config;
 pub mod cutover_preflight;
+pub mod cutover_preflight_driver;
 pub mod env_config;
 pub mod graph_warmer;
 pub mod graph_warmer_candidates;
@@ -31,6 +32,14 @@ pub mod pod_resize_fixture;
 pub mod private_dep_config;
 pub mod runtime;
 mod runtime_eviction;
+/// A `KubernetesRuntime` over an in-process apiserver that records every
+/// request.
+///
+/// Gated exactly like [`pod_resize_fixture`], and for the same reason: a
+/// `djinn-server` test that must prove "zero Pod creations" has to observe the
+/// WIRE, and `deny.toml` bans a direct `kube` dependency outside this crate.
+#[cfg(any(test, feature = "test-support"))]
+pub mod runtime_fixture;
 pub mod scip_job;
 pub mod scip_schedule;
 pub mod secret;

--- a/server/crates/djinn-k8s/src/runtime_fixture.rs
+++ b/server/crates/djinn-k8s/src/runtime_fixture.rs
@@ -1,0 +1,196 @@
+//! A [`KubernetesRuntime`] bound to an in-process apiserver that records every
+//! request it is given.
+//!
+//! # Why this exists
+//!
+//! `ResizeRollout::production` composes `KubernetesTaskRunPodPlane`, which is
+//! built from a `KubernetesRuntime`. Every *other* `KubernetesRuntime`
+//! constructor resolves through `kube::Client::try_default()` — the ambient
+//! kubeconfig — so a test that wanted to drive the production composition either
+//! touched whatever cluster the developer's context happens to point at, or
+//! stopped short of the production composition and drove a stand-in instead.
+//! That second option is how this epic shipped eight pieces of merged, green,
+//! unreachable work.
+//!
+//! [`KubernetesRuntime::from_client`] is the seam that makes neither necessary,
+//! and this module supplies the client. The transport is a `tower` service, so
+//! the Kubernetes half of the stack under test — `Api::namespaced`, the URL the
+//! lister builds, the deserialization of the response — is entirely real.
+//!
+//! # What the recorder is FOR
+//!
+//! "No Pod was created" is a claim about the wire, not about an intent field. A
+//! test asserts it by reading [`RecordedApiserver::mutations`] and finding it
+//! empty: every non-`GET` this fixture observes is recorded with its method and
+//! path *before* the fixture refuses it, so a driver that tried to create a Pod
+//! and got a `403` is still visible as an attempt.
+
+use std::sync::{Arc, Mutex};
+
+use djinn_supervisor::ConnectionRegistry;
+
+use crate::config::KubernetesConfig;
+use crate::runtime::KubernetesRuntime;
+
+/// One request the in-process apiserver observed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordedRequest {
+    /// `GET`, `POST`, `PATCH`, `DELETE`, …
+    pub method: String,
+    /// The request path, without the query string.
+    pub path: String,
+    /// The request body, as UTF-8 (lossy).
+    pub body: String,
+}
+
+/// Everything the in-process apiserver was asked to do, in issue order.
+#[derive(Clone)]
+pub struct RecordedApiserver(Arc<Mutex<Vec<RecordedRequest>>>);
+
+impl RecordedApiserver {
+    /// Every request, in issue order.
+    #[must_use]
+    pub fn all(&self) -> Vec<RecordedRequest> {
+        self.0.lock().expect("recorder poisoned").clone()
+    }
+
+    /// Every request that was not a read.
+    ///
+    /// A cutover that refuses must leave this empty: it is the assertion that
+    /// nothing was created, patched or deleted, made against the wire rather
+    /// than against a counter the code under test increments itself.
+    #[must_use]
+    pub fn mutations(&self) -> Vec<RecordedRequest> {
+        self.all()
+            .into_iter()
+            .filter(|request| request.method != "GET")
+            .collect()
+    }
+
+    /// Every attempt to CREATE a workload — a `POST` to a Pod or Job
+    /// collection.
+    #[must_use]
+    pub fn workload_creations(&self) -> Vec<RecordedRequest> {
+        self.all()
+            .into_iter()
+            .filter(|request| {
+                request.method == "POST"
+                    && (request.path.ends_with("/pods") || request.path.ends_with("/jobs"))
+            })
+            .collect()
+    }
+}
+
+/// A runtime over an apiserver that holds **no** task-run Jobs and **no** Pods.
+///
+/// Reads are answered with genuinely empty typed lists, so
+/// `KubernetesRuntime::list_taskrun_jobs` and the resize surface's Pod reads
+/// both succeed and both return nothing. Writes are recorded and then refused
+/// with `403`, because nothing in a cutover is allowed to create a workload and
+/// a fixture that quietly accepted one would hide exactly that.
+#[must_use]
+pub fn empty_task_run_cluster(namespace: &str) -> (Arc<KubernetesRuntime>, RecordedApiserver) {
+    let mut config = KubernetesConfig::from_env();
+    config.namespace = namespace.to_owned();
+    let recorder = RecordedApiserver(Arc::new(Mutex::new(Vec::new())));
+    let client = recording_client(&recorder, namespace);
+    (
+        Arc::new(KubernetesRuntime::from_client(
+            client,
+            config,
+            Arc::new(ConnectionRegistry::new()),
+        )),
+        recorder,
+    )
+}
+
+/// Build a client whose every request lands in `recorder`.
+fn recording_client(recorder: &RecordedApiserver, namespace: &str) -> kube::Client {
+    use http::Response;
+    use http_body_util::BodyExt as _;
+    use kube::client::Body;
+    use tower::service_fn;
+
+    let captured = recorder.clone();
+    kube::Client::new(
+        service_fn(move |request: http::Request<Body>| {
+            let captured = captured.clone();
+            async move {
+                let method = request.method().to_string();
+                let path = request.uri().path().to_string();
+                let body = request
+                    .into_body()
+                    .collect()
+                    .await
+                    .expect("collect kube request")
+                    .to_bytes();
+                captured
+                    .0
+                    .lock()
+                    .expect("recorder poisoned")
+                    .push(RecordedRequest {
+                        method: method.clone(),
+                        path: path.clone(),
+                        body: String::from_utf8_lossy(&body).into_owned(),
+                    });
+
+                let (status, payload) = if method != "GET" {
+                    (
+                        403,
+                        serde_json::json!({
+                            "kind": "Status",
+                            "apiVersion": "v1",
+                            "status": "Failure",
+                            "message": format!("{method} {path} is forbidden in this fixture"),
+                            "reason": "Forbidden",
+                            "code": 403,
+                        }),
+                    )
+                } else if path.contains("/jobs") {
+                    (
+                        200,
+                        serde_json::json!({
+                            "apiVersion": "batch/v1",
+                            "kind": "JobList",
+                            "metadata": { "resourceVersion": "1" },
+                            "items": [],
+                        }),
+                    )
+                } else if path.contains("/pods") {
+                    (
+                        200,
+                        serde_json::json!({
+                            "apiVersion": "v1",
+                            "kind": "PodList",
+                            "metadata": { "resourceVersion": "1" },
+                            "items": [],
+                        }),
+                    )
+                } else {
+                    (
+                        404,
+                        serde_json::json!({
+                            "kind": "Status",
+                            "apiVersion": "v1",
+                            "status": "Failure",
+                            "message": format!("{path} is not served by this fixture"),
+                            "reason": "NotFound",
+                            "code": 404,
+                        }),
+                    )
+                };
+
+                Ok::<_, std::io::Error>(
+                    Response::builder()
+                        .status(status)
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::to_vec(&payload).expect("fixture payload serializes"),
+                        ))
+                        .expect("fixture response builds"),
+                )
+            }
+        }),
+        namespace.to_owned(),
+    )
+}

--- a/server/crates/djinn-k8s/tests/cutover_preflight.rs
+++ b/server/crates/djinn-k8s/tests/cutover_preflight.rs
@@ -1504,22 +1504,69 @@ fn the_cutover_preflight_lane_is_wired_and_cannot_silently_skip() {
     );
 }
 
-/// **AC1.** `run` is the production entry point, and the driver binary calls
-/// exactly it — no second rule to drift from.
+/// Source text with `//`-comments and doc comments removed.
+///
+/// Every assertion below is about what the code DOES, and this file's prose
+/// discusses `run(&input)` and `cutover_preflight_driver` at length. Matching a
+/// comment would let the assembly be deleted while the guard stayed green,
+/// which is the failure mode the whole suite exists to prevent.
+fn rust_code(source: &str) -> String {
+    source
+        .lines()
+        .map(|line| match line.find("//") {
+            Some(index) => &line[..index],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// **AC1.** `run` is the production entry point, and there is exactly ONE
+/// assembly that feeds it.
+///
+/// The assembly used to live inside `bin/cutover-preflight.rs`. It now lives in
+/// `cutover_preflight_driver`, because `djinn-server`'s authority-cutover driver
+/// runs this same preflight before it flips the authority mode, and a preflight
+/// the flip assembles differently from the one the deploy gate assembles is not
+/// the same preflight. So the guard is in three parts: the module calls `run`,
+/// the binary reaches the module, and neither holds a second copy.
 #[test]
 fn the_deploy_driver_calls_the_production_run() {
-    let driver = std::fs::read_to_string(
-        repo_root().join("server/crates/djinn-k8s/src/bin/cutover-preflight.rs"),
-    )
-    .expect("the driver source is readable");
-    assert!(
-        driver.contains("djinn_k8s::cutover_preflight::"),
-        "the driver must import the production validator"
+    let module = rust_code(
+        &std::fs::read_to_string(
+            repo_root().join("server/crates/djinn-k8s/src/cutover_preflight_driver.rs"),
+        )
+        .expect("the assembly module is readable"),
     );
     assert!(
-        driver.contains("run(&input)"),
-        "the driver must call the production `run`"
+        module.contains("crate::cutover_preflight::"),
+        "the assembly must import the production validator"
     );
+    assert!(
+        module.contains("run(&input)"),
+        "the assembly must call the production `run`"
+    );
+
+    let driver = rust_code(
+        &std::fs::read_to_string(
+            repo_root().join("server/crates/djinn-k8s/src/bin/cutover-preflight.rs"),
+        )
+        .expect("the driver source is readable"),
+    );
+    assert!(
+        driver.contains("djinn_k8s::cutover_preflight_driver::"),
+        "the driver must reach the validator through the shared assembly"
+    );
+    assert!(
+        driver.contains(".judge("),
+        "the driver must actually ask for a verdict"
+    );
+    assert!(
+        !driver.contains("CutoverPreflightInput"),
+        "a second input assembly in the binary is exactly the drift this module was extracted to \
+         prevent"
+    );
+
     assert_eq!(
         DefectClass::ALL.len(),
         6,

--- a/server/src/authority_cutover.rs
+++ b/server/src/authority_cutover.rs
@@ -1,0 +1,400 @@
+//! **The operator entry point for the launcher-authority cutover** (proposal
+//! `3i92`, epic `xowm`, task `eeky`).
+//!
+//! # Why this module exists
+//!
+//! [`crate::task_run_resize_rollout::ResizeRollout`] encodes the whole fenced
+//! transition — the ordering, the two drain checks, the compare-and-swap, the
+//! reverse that can refuse itself — and until this module landed
+//! `ResizeRollout::production` had **zero callers in any binary**. The staged
+//! activation existed as a library with tests and could not be run by anyone.
+//! That is not a smaller problem than a bug; it is the problem this epic keeps
+//! rediscovering, and `scripts/check-resize-reachability.sh` now guards this
+//! call site the way it guards the others.
+//!
+//! # Why a `bin/`, and not an admin MCP tool
+//!
+//! Three properties decided it, and each of them an MCP tool fails:
+//!
+//! 1. **The verdict must depend on the RENDER, not on the operator's shell.**
+//!    The preflight's Rust half re-renders the task-run Job from `DJINN_K8S_*`,
+//!    so those variables have to come from the *rendered* `djinn-server`
+//!    container. `deploy/preflight/cutover-preflight.sh` already extracts them
+//!    and re-execs under `env -i`; running the cutover through that same
+//!    wrapper is what makes the flip and the deploy gate answer the same
+//!    question. A tool executing inside a running `djinn-server` reads that
+//!    server's environment — which is the *old* deployment's, and the whole
+//!    point of step 3 is that the new server is deployed while the mode has not
+//!    moved.
+//! 2. **Step 3 deploys a new server; steps 4-9 must survive it.** An entry
+//!    point hosted by the process being replaced cannot run a sequence that
+//!    replaces it.
+//! 3. **The refusal is the product.** The exit codes are the contract a deploy
+//!    lane reads — `0` flipped, `1` blocked, `2` unevaluable — the same triple
+//!    `cutover-preflight` and `render-gate` already speak.
+//!
+//! # What an operator runs
+//!
+//! ```text
+//! DJINN_CUTOVER_DIRECTION=activate \
+//! DJINN_CUTOVER_PLAN=/path/to/plan.json \
+//! DJINN_CUTOVER_AUTHORITY_MODE=resize-v2 \
+//! DJINN_DATABASE_URL=postgres://... \
+//!   deploy/cutover/authority-cutover.sh deploy/helm/djinn --values prod-values.yaml
+//! ```
+//!
+//! and to reverse it, `DJINN_CUTOVER_DIRECTION=rollback` with
+//! `DJINN_CUTOVER_AUTHORITY_MODE=leaf-v1`. See
+//! `docs/deploy/launcher-authority-cutover.md`.
+
+use std::sync::Arc;
+
+use djinn_core::events::EventBus;
+use djinn_db::Database;
+use djinn_k8s::cutover_preflight_driver::PreflightSources;
+use djinn_k8s::runtime::KubernetesRuntime;
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use serde::Deserialize;
+
+use crate::task_run_resize_rollout::{
+    AdmissionControl as _, DispatchProbe, DurableAdmissionControl, ResizeRollout, RetainedArtifact,
+    RetentionRole, RolloutBlocked, RolloutPlan, RolloutStep,
+};
+
+/// Which way the cutover goes.
+///
+/// Parsed, never defaulted. A missing or malformed direction is refused: an
+/// operator who meant `rollback` and got `activate` because a variable was
+/// unset would flip a deployment the wrong way at 03:00.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CutoverDirection {
+    /// `leaf-v1` → `resize-v2`.
+    Activate,
+    /// `resize-v2` → `leaf-v1`.
+    Rollback,
+}
+
+impl CutoverDirection {
+    /// Parse a wire value.
+    ///
+    /// # Errors
+    ///
+    /// Anything but `activate` or `rollback`.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        match raw.trim() {
+            "activate" => Ok(Self::Activate),
+            "rollback" => Ok(Self::Rollback),
+            other => Err(format!(
+                "DJINN_CUTOVER_DIRECTION must be `activate` or `rollback`, got {other:?}"
+            )),
+        }
+    }
+
+    /// The authority mode this direction targets.
+    #[must_use]
+    pub const fn target(self) -> LauncherAuthorityProtocol {
+        match self {
+            Self::Activate => LauncherAuthorityProtocol::ResizeV2,
+            Self::Rollback => LauncherAuthorityProtocol::LeafV1,
+        }
+    }
+
+    /// Stable label for logs and the exit-status contract.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Activate => "activate",
+            Self::Rollback => "rollback",
+        }
+    }
+}
+
+/// The operator's plan file: everything one cutover run needs that a render
+/// cannot contain.
+///
+/// `deny_unknown_fields` because a typo'd `retained` key that silently produced
+/// an empty retained set would make step 5 pass vacuously — a cutover proving
+/// retention of nothing.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CutoverPlanDocument {
+    /// The authority epoch this cutover was planned against. Every flip is a
+    /// compare-and-swap against it.
+    pub expected_epoch: i64,
+    /// OCI registry base URL, e.g. `https://ghcr.io`.
+    pub registry_base_url: String,
+    /// Operator-facing pause reason, written onto the durable pause row.
+    pub reason: String,
+    /// The task-run id the pause proves itself against by attempting a
+    /// dispatch. A real id, so the probe travels the path a task run takes.
+    pub probe_task_run_id: String,
+    /// `images.id` of the catalog row the probe dispatch would run.
+    pub probe_image_id: String,
+    /// Every artifact whose continued pullability this cutover depends on.
+    pub retained: Vec<RetainedArtifactDocument>,
+}
+
+/// One retained artifact, as the plan file spells it.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RetainedArtifactDocument {
+    /// `images.id`, for the operator's report.
+    pub image_id: String,
+    /// The registry repository path, e.g. `djinnos/djinn-image-i1`.
+    pub repository: String,
+    /// The immutable manifest digest the catalog records.
+    pub digest: String,
+    /// `legacy-no-handshake`, `leaf-v1-rollback` or `resize-v2-current`.
+    pub role: String,
+}
+
+impl RetainedArtifactDocument {
+    /// Convert to the driver's type.
+    ///
+    /// # Errors
+    ///
+    /// The role is not one of the three. Parsed, never defaulted: a typo that
+    /// silently became `ResizeV2Current` would misreport what a blocked
+    /// retention check was protecting.
+    pub fn parse(&self) -> Result<RetainedArtifact, String> {
+        let role = match self.role.trim() {
+            "legacy-no-handshake" => RetentionRole::LegacyNoHandshake,
+            "leaf-v1-rollback" => RetentionRole::LeafV1Rollback,
+            "resize-v2-current" => RetentionRole::ResizeV2Current,
+            other => {
+                return Err(format!(
+                    "retained artifact {}: role must be one of legacy-no-handshake, \
+                     leaf-v1-rollback, resize-v2-current; got {other:?}",
+                    self.image_id
+                ));
+            }
+        };
+        Ok(RetainedArtifact {
+            image_id: self.image_id.clone(),
+            repository: self.repository.clone(),
+            digest: self.digest.clone(),
+            role,
+        })
+    }
+}
+
+impl CutoverPlanDocument {
+    /// Read and parse a plan file.
+    ///
+    /// # Errors
+    ///
+    /// The file is missing, is not JSON, carries an unknown key, or names a
+    /// role that is not one of the three.
+    pub fn load(path: &str) -> Result<Self, String> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|error| format!("cannot read cutover plan {path}: {error}"))?;
+        let document: Self = serde_json::from_str(&raw)
+            .map_err(|error| format!("cutover plan {path} is invalid: {error}"))?;
+        if document.retained.is_empty() {
+            return Err(format!(
+                "cutover plan {path} retains nothing; step 5 would prove the pullability of an \
+                 empty set, which is not evidence that anything is still runnable"
+            ));
+        }
+        for artifact in &document.retained {
+            artifact.parse()?;
+        }
+        Ok(document)
+    }
+}
+
+/// One whole cutover request.
+pub struct CutoverRequest {
+    /// Which way.
+    pub direction: CutoverDirection,
+    /// A LIVE `helm template` render, converted to JSON.
+    pub rendered_manifests_path: String,
+    /// The parsed plan.
+    pub plan: CutoverPlanDocument,
+    /// Recorded on the durable pause row this cutover writes.
+    pub paused_by: String,
+}
+
+impl CutoverRequest {
+    /// Assemble a request from the environment the wrapper hands the binary,
+    /// plus the render it passes as `argv[1]`.
+    ///
+    /// # Errors
+    ///
+    /// A missing or malformed `DJINN_CUTOVER_DIRECTION`, a missing
+    /// `DJINN_CUTOVER_PLAN`, or an unusable plan file.
+    pub fn from_env(rendered_manifests_path: impl Into<String>) -> Result<Self, String> {
+        let direction = CutoverDirection::parse(
+            &std::env::var("DJINN_CUTOVER_DIRECTION")
+                .map_err(|_| "DJINN_CUTOVER_DIRECTION is not set".to_string())?,
+        )?;
+        let plan_path = std::env::var("DJINN_CUTOVER_PLAN")
+            .map_err(|_| "DJINN_CUTOVER_PLAN is not set".to_string())?;
+        Ok(Self {
+            direction,
+            rendered_manifests_path: rendered_manifests_path.into(),
+            plan: CutoverPlanDocument::load(&plan_path)?,
+            paused_by: std::env::var("DJINN_CUTOVER_PAUSED_BY")
+                .unwrap_or_else(|_| "authority-cutover".to_string()),
+        })
+    }
+}
+
+/// What one cutover run did.
+pub struct CutoverReport {
+    /// The steps that actually completed, in the order they completed.
+    pub journal: Vec<RolloutStep>,
+    /// The authority epoch after the flip.
+    pub epoch: i64,
+    /// Pods created between the pause and the resume. Structurally zero; read
+    /// back and reported so its absence is observable rather than assumed.
+    pub dispatches_admitted_while_paused: u64,
+}
+
+/// Why a cutover run did not complete.
+#[derive(Debug, thiserror::Error)]
+pub enum CutoverFailure {
+    /// The request, the plan or the preflight sources could not be assembled.
+    /// Nothing was attempted.
+    #[error("the cutover could not be evaluated: {0}")]
+    Unevaluable(String),
+    /// The rollout refused, at the step named by `journal`'s tail.
+    #[error("the cutover was blocked: {blocked}")]
+    Blocked {
+        /// The block.
+        #[source]
+        blocked: RolloutBlocked,
+        /// How far it got. Steps that returned an error never appear here.
+        journal: Vec<RolloutStep>,
+        /// Whether admission is left paused, evaluated against the SAME durable
+        /// predicate the coordinator's dispatch loop guards on — not inferred
+        /// from the journal. A rollback that blocks before its own pause step
+        /// still has to report a pause an earlier operator left behind, and a
+        /// journal cannot know about one.
+        admission_left_paused: bool,
+    },
+}
+
+impl CutoverFailure {
+    /// The exit status a deploy lane reads: `1` blocked, `2` unevaluable.
+    #[must_use]
+    pub const fn exit_code(&self) -> u8 {
+        match self {
+            Self::Blocked { .. } => 1,
+            Self::Unevaluable(_) => 2,
+        }
+    }
+}
+
+/// **Run one cutover, forward or reverse.**
+///
+/// This is the function the binary's `main` is a shell around, and the function
+/// the integration suite drives. It composes
+/// [`ResizeRollout::production`] — the real dispatch-pause state and the
+/// coordinator's own refusal predicate, the real apiserver-backed Pod plane, a
+/// real HTTP registry probe, and the real deploy-time preflight over the
+/// render — and then calls [`ResizeRollout::activate`] or
+/// [`ResizeRollout::rollback`]. It re-implements no step and skips none: the
+/// ordering, both drain checks and the preflight gate all belong to
+/// `ResizeRollout`, and this function cannot reach past them.
+///
+/// # Errors
+///
+/// [`CutoverFailure::Unevaluable`] when the rollout could not even be composed
+/// (an unreadable render, an unresolvable probe image), and
+/// [`CutoverFailure::Blocked`] carrying the refusal and the journal. In every
+/// blocked case the authority mode is unchanged, and for every block at or
+/// after the pause, admission is left paused — `rollback`'s allowlist and
+/// retention checks run before the pause precisely so a rollback that cannot
+/// find its artifacts blocks without having touched anything.
+pub async fn run(
+    db: Database,
+    events: EventBus,
+    runtime: Arc<KubernetesRuntime>,
+    request: &CutoverRequest,
+) -> Result<CutoverReport, CutoverFailure> {
+    let retained = request
+        .plan
+        .retained
+        .iter()
+        .map(RetainedArtifactDocument::parse)
+        .collect::<Result<Vec<_>, String>>()
+        .map_err(CutoverFailure::Unevaluable)?;
+
+    let sources = PreflightSources::from_env(request.rendered_manifests_path.clone());
+    let rollout = ResizeRollout::production(
+        db.clone(),
+        events.clone(),
+        runtime,
+        &request.plan.registry_base_url,
+        &request.paused_by,
+        &sources,
+    )
+    .map_err(CutoverFailure::Unevaluable)?;
+
+    // The probe is a REAL catalog row, resolved through the production
+    // accessor. A synthesised `Image` would let the pause step prove itself
+    // against an artifact no project can dispatch, which is not the path a task
+    // run takes.
+    let image = djinn_db::ImageRepository::new(db.clone())
+        .get(&request.plan.probe_image_id)
+        .await
+        .map_err(|error| {
+            CutoverFailure::Unevaluable(format!(
+                "cannot read probe image {}: {error}",
+                request.plan.probe_image_id
+            ))
+        })?
+        .ok_or_else(|| {
+            CutoverFailure::Unevaluable(format!(
+                "probe image {} is not in the catalog; the pause step proves itself by \
+                 dispatching it",
+                request.plan.probe_image_id
+            ))
+        })?;
+
+    let plan = RolloutPlan {
+        retained: &retained,
+        probe: DispatchProbe {
+            task_run_id: request.plan.probe_task_run_id.clone(),
+            image,
+        },
+        expected_epoch: request.plan.expected_epoch,
+        reason: &request.plan.reason,
+    };
+
+    let outcome = match request.direction {
+        CutoverDirection::Activate => rollout.activate(&plan).await,
+        CutoverDirection::Rollback => rollout.rollback(&plan).await,
+    };
+
+    match outcome {
+        Ok(epoch) => Ok(CutoverReport {
+            journal: rollout.journal(),
+            epoch,
+            dispatches_admitted_while_paused: rollout.dispatches_admitted_while_paused(),
+        }),
+        Err(blocked) => {
+            // Read the production dispatch-pause predicate, not the journal:
+            // `rollback`'s allowlist and retention checks run BEFORE its own
+            // pause step, so a rollback blocked there has an empty journal and
+            // may still be sitting on a pause a previous, half-finished cutover
+            // left behind. Reporting "untouched" there would tell an operator
+            // that dispatch had resumed when it had not.
+            //
+            // Unreadable is reported as PAUSED. The alternative — reporting
+            // "not paused" because the read failed — is the one answer that
+            // could make somebody stop looking.
+            let admission_left_paused =
+                DurableAdmissionControl::new(db, events, &request.paused_by)
+                    .dispatch_is_paused()
+                    .await
+                    .unwrap_or(true);
+            Err(CutoverFailure::Blocked {
+                blocked,
+                journal: rollout.journal(),
+                admission_left_paused,
+            })
+        }
+    }
+}

--- a/server/src/bin/authority_cutover.rs
+++ b/server/src/bin/authority_cutover.rs
@@ -1,0 +1,176 @@
+//! **`authority-cutover`** — run the launcher-authority cutover, or its reverse.
+//!
+//! A thin shell over [`djinn_server::authority_cutover::run`], mirroring
+//! `djinn-k8s`'s `bin/cutover-preflight.rs`: it parses nothing it can delegate,
+//! decides nothing, and holds no copy of any rule. Everything the cutover
+//! *does* — the step ordering, both drain checks, the real deploy-time
+//! preflight, the compare-and-swap and the reverse that can refuse itself —
+//! belongs to `ResizeRollout`, which this binary composes through
+//! `ResizeRollout::production` and cannot reach past.
+//!
+//! # Invocation
+//!
+//! `argv[1]` is a LIVE `helm template` render converted to JSON, exactly as
+//! `cutover-preflight` takes it, because the preflight this binary runs judges
+//! that render. `deploy/cutover/authority-cutover.sh` produces it and re-execs
+//! this binary under `env -i` with the rendered `DJINN_K8S_*` — so the verdict
+//! depends on the deployment, never on the operator's shell.
+//!
+//! ```text
+//! DJINN_CUTOVER_DIRECTION=activate|rollback   which way (required, never defaulted)
+//! DJINN_CUTOVER_PLAN=<plan.json>              retained set, probe, epoch, registry (required)
+//! DJINN_CUTOVER_AUTHORITY_MODE=<mode>         the mode the preflight judges (must match direction)
+//! DJINN_DATABASE_URL=<postgres url>           the durable half of everything (required)
+//! DJINN_CUTOVER_OBSERVATIONS=<bundle.json>    catalog/birth observations for the preflight
+//! DJINN_CUTOVER_PAUSED_BY=<name>              recorded on the pause row
+//! ```
+//!
+//! # Exit status
+//!
+//! The same triple `cutover-preflight` and `render-gate` speak, so one deploy
+//! lane reads all three the same way:
+//!
+//! * `0` — the mode flipped and admission resumed.
+//! * `1` — blocked. The mode did not move. Admission is left paused whenever
+//!   the block happened at or after the pause step, and the binary says which.
+//! * `2` — unevaluable: a missing plan, an unreadable render, a probe image
+//!   that is not in the catalog. Nothing was attempted.
+
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use djinn_server::authority_cutover::{CutoverFailure, CutoverRequest, run};
+
+#[allow(clippy::print_stdout, clippy::print_stderr)]
+#[tokio::main]
+async fn main() -> ExitCode {
+    match drive().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(failure) => ExitCode::from(report(&failure)),
+    }
+}
+
+/// Print the failure the way a deploy lane greps it, and return its exit code.
+#[allow(clippy::print_stderr)]
+fn report(failure: &CutoverFailure) -> u8 {
+    match failure {
+        CutoverFailure::Unevaluable(reason) => {
+            eprintln!("authority-cutover: UNEVALUABLE {reason}");
+        }
+        CutoverFailure::Blocked {
+            blocked,
+            journal,
+            admission_left_paused,
+        } => {
+            eprintln!("authority-cutover: BLOCKED {blocked}");
+            eprintln!(
+                "authority-cutover: completed={}",
+                journal
+                    .iter()
+                    .map(|step| format!("{step:?}"))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+            eprintln!(
+                "authority-cutover: authority-mode=unchanged admission={}",
+                if *admission_left_paused {
+                    "PAUSED — resume it deliberately once the block is resolved"
+                } else {
+                    "untouched"
+                }
+            );
+        }
+    }
+    failure.exit_code()
+}
+
+#[allow(clippy::print_stdout, clippy::print_stderr)]
+async fn drive() -> Result<(), CutoverFailure> {
+    let path = std::env::args()
+        .nth(1)
+        .ok_or_else(|| CutoverFailure::Unevaluable(USAGE.to_string()))?;
+    if path == "-h" || path == "--help" {
+        println!("{USAGE}");
+        return Ok(());
+    }
+
+    let request = CutoverRequest::from_env(path).map_err(CutoverFailure::Unevaluable)?;
+
+    // The preflight judges the mode named by `DJINN_CUTOVER_AUTHORITY_MODE`,
+    // and the flip targets the mode named by `DJINN_CUTOVER_DIRECTION`. If
+    // those two disagree the operator would get a `resize-v2` readiness verdict
+    // stamped on a `leaf-v1` flip, so the disagreement is refused rather than
+    // reconciled by preferring one of them.
+    let judged = djinn_k8s::cutover_preflight_driver::authority_mode_from_env()
+        .map_err(CutoverFailure::Unevaluable)?;
+    if judged != request.direction.target() {
+        return Err(CutoverFailure::Unevaluable(format!(
+            "DJINN_CUTOVER_AUTHORITY_MODE={} judges a different mode than \
+             DJINN_CUTOVER_DIRECTION={} targets ({}); the preflight verdict would not be about \
+             the flip",
+            judged.as_wire(),
+            request.direction.as_str(),
+            request.direction.target().as_wire(),
+        )));
+    }
+
+    let url = std::env::var("DJINN_DATABASE_URL").map_err(|_| {
+        CutoverFailure::Unevaluable(
+            "DJINN_DATABASE_URL is not set; the drain fence, the catalog and the authority \
+             singleton all live there"
+                .to_string(),
+        )
+    })?;
+    let db = djinn_db::Database::open_with_config(djinn_db::DatabaseConnectConfig::Postgres(
+        djinn_db::PostgresDatabaseConfig { url },
+    ))
+    .map_err(|error| {
+        CutoverFailure::Unevaluable(format!("cannot open DJINN_DATABASE_URL: {error}"))
+    })?;
+
+    // The runtime is built from the ambient cluster configuration — the
+    // in-cluster ServiceAccount, or the operator's kubeconfig — which is the
+    // cluster whose Pods the drain proof must not find.
+    let runtime = djinn_k8s::runtime::KubernetesRuntime::new(
+        djinn_k8s::config::KubernetesConfig::from_env(),
+        Arc::new(djinn_supervisor::ConnectionRegistry::new()),
+    )
+    .await
+    .map_err(|error| CutoverFailure::Unevaluable(format!("cannot reach the apiserver: {error}")))?;
+
+    // The pause this cutover writes is a durable row; the bus is how repositories
+    // announce it to in-process subscribers, of which a one-shot deploy binary
+    // has none. A sink, not a stub: nothing in the cutover reads an event back.
+    let (tx, _rx) = tokio::sync::broadcast::channel(16);
+    let report = run(
+        db,
+        djinn_server::events::event_bus_for(&tx),
+        Arc::new(runtime),
+        &request,
+    )
+    .await?;
+
+    println!(
+        "authority-cutover: FLIPPED direction={} epoch={} completed={}",
+        request.direction.as_str(),
+        report.epoch,
+        report
+            .journal
+            .iter()
+            .map(|step| format!("{step:?}"))
+            .collect::<Vec<_>>()
+            .join(","),
+    );
+    println!(
+        "authority-cutover: pods-created-while-paused={}",
+        report.dispatches_admitted_while_paused
+    );
+    Ok(())
+}
+
+const USAGE: &str = "usage: authority-cutover <rendered-manifests.json>\n\
+     env: DJINN_CUTOVER_DIRECTION={activate|rollback} DJINN_CUTOVER_PLAN=<plan.json>\n\
+     \x20    DJINN_CUTOVER_AUTHORITY_MODE={leaf-v1|resize-v2} DJINN_DATABASE_URL=<postgres url>\n\
+     \x20    [DJINN_CUTOVER_OBSERVATIONS=<bundle.json>] [DJINN_CUTOVER_PAUSED_BY=<name>]\n\
+     exit: 0 flipped, 1 blocked, 2 unevaluable\n\
+     prefer the wrapper: deploy/cutover/authority-cutover.sh <chart-dir> [helm args...]";

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod admin;
 pub mod allocator;
+pub mod authority_cutover;
 pub mod codex_keepalive;
 pub mod db;
 pub mod error;

--- a/server/src/task_run_resize_rollout.rs
+++ b/server/src/task_run_resize_rollout.rs
@@ -59,6 +59,22 @@
 //! merely violate a runbook. The journal is the assertion surface: a test reads
 //! the observed sequence, not a checklist.
 //!
+//! # The preflight gates the flip, structurally
+//!
+//! [`RolloutStep::AuthorityModeFlipped`] lists [`RolloutStep::PreflightCleared`]
+//! among its prerequisites, and [`RolloutStep::PreflightCleared`] is journaled
+//! only when the REAL `djinn_k8s::cutover_preflight::run` — over a live
+//! `helm template` render, the production task-run Job render, the
+//! environment-resolved signed inventory and the production
+//! `list_nonterminal_resize` query — comes back clean having actually evaluated
+//! its classes. Deleting the [`ResizeRollout::clear_preflight`] call from
+//! [`ResizeRollout::activate`] does not produce an ungated flip; it produces
+//! [`RolloutBlocked::StepOutOfOrder`].
+//!
+//! It sits after the drain proof rather than at the front because the preflight
+//! judges the drain fence too, and at the front of a live deployment that fence
+//! is never empty.
+//!
 //! # There is no state with two quota authorities, or none
 //!
 //! [`ResizeRollout::attempt_dispatch`] is the single admission path this module
@@ -132,6 +148,9 @@ pub enum RolloutStep {
     AdmissionPaused,
     /// Zero live task-run Pods and zero nonterminal resize/lease rows.
     DrainProven,
+    /// The deploy-time preflight returned a clean verdict for the target mode,
+    /// having actually evaluated its classes.
+    PreflightCleared,
     /// The authority mode compare-and-swap committed behind its own fence.
     AuthorityModeFlipped,
     /// Admission is resumed. Only reachable after a confirmed flip.
@@ -142,8 +161,14 @@ impl RolloutStep {
     /// The steps that must already have run before this one may.
     ///
     /// This is the ordering itself, in one place. `AdmissionResumed` requires
-    /// `AuthorityModeFlipped` and `AuthorityModeFlipped` requires `DrainProven`
-    /// — the two reorderings the cutover has to make impossible.
+    /// `AuthorityModeFlipped`, and `AuthorityModeFlipped` requires
+    /// `DrainProven` **and** `PreflightCleared` — the three reorderings the
+    /// cutover has to make impossible.
+    ///
+    /// `PreflightCleared` sits *after* `DrainProven` rather than at the front
+    /// because the preflight judges the drain fence too, and at the front of a
+    /// live deployment that fence is never empty. Placing it here is what makes
+    /// it a gate on the flip rather than a gate on the operator's day.
     const fn prerequisites(self) -> &'static [Self] {
         match self {
             Self::CatalogMutationFrozen => &[],
@@ -155,7 +180,12 @@ impl RolloutStep {
             Self::RetentionVerified => &[],
             Self::AdmissionPaused => &[Self::RetentionVerified],
             Self::DrainProven => &[Self::AdmissionPaused],
-            Self::AuthorityModeFlipped => &[Self::AdmissionPaused, Self::DrainProven],
+            Self::PreflightCleared => &[Self::AdmissionPaused, Self::DrainProven],
+            Self::AuthorityModeFlipped => &[
+                Self::AdmissionPaused,
+                Self::DrainProven,
+                Self::PreflightCleared,
+            ],
             Self::AdmissionResumed => &[Self::AuthorityModeFlipped],
         }
     }
@@ -235,10 +265,26 @@ pub enum RolloutBlocked {
     #[error("{} dispatch-eligible catalog image(s) are incompatible with the authority mode", .0.len())]
     CatalogIncompatible(Vec<CatalogDefect>),
     /// Task-run Pods are still live. PostgreSQL cannot see these.
-    #[error("{} task-run Pod(s) are still live", .0.len())]
+    ///
+    /// Rendered by identity — Pod name, Pod UID, task run — because the next
+    /// thing an operator does with this is a UID-fenced delete, and a count
+    /// tells them nothing to fence against.
+    #[error("{} task-run Pod(s) are still live: {}", .0.len(), render_live_pods(.0))]
     LiveTaskRunPods(Vec<LiveTaskRunPod>),
     /// Permits still owe a resize/lease decision, named individually.
-    #[error("{} permit(s) are in a nonterminal resize state", .0.len())]
+    ///
+    /// **Rendered by identity, not as a census.** This is the whole reason the
+    /// cutover reads `list_nonterminal_resize` instead of leaning on
+    /// [`LauncherAuthorityModeRepository::set_mode`]'s own fence: `set_mode`
+    /// refuses with per-dimension COUNTS, and a `Display` that printed
+    /// `.0.len()` here would throw away the difference at exactly the moment an
+    /// operator reads it. Carrying the rows in the struct and hiding them in the
+    /// message is the same failure as not carrying them.
+    #[error(
+        "{} permit(s) are in a nonterminal resize state: {}",
+        .0.len(),
+        render_nonterminal_rows(.0)
+    )]
     NonterminalResizeRows(Vec<NonterminalResizeRow>),
     /// The apiserver could not be enumerated. Never read as zero Pods.
     #[error("the task-run Pod census is unavailable: {0}")]
@@ -290,6 +336,63 @@ pub enum RolloutBlocked {
     /// back the row it wrote, it dispatches and requires a refusal.
     #[error("admission was paused but a dispatch attempt was still admitted")]
     AdmissionPauseIneffective,
+    /// The deploy-time preflight refused the target mode.
+    ///
+    /// Carries every defect, not just the first: an operator fixing one at a
+    /// time across six deploy windows is how a cutover window is lost.
+    #[error("the cutover preflight refused {}: {}", .classes.join(","), .defects.join("; "))]
+    PreflightRefused {
+        /// The blocking defect classes, sorted and deduplicated.
+        classes: Vec<String>,
+        /// Every blocking reason, as `class detail`.
+        defects: Vec<String>,
+    },
+    /// The preflight could not be evaluated at all — an unreadable render, a
+    /// config `render-gate` already refuses. Never read as a clean verdict.
+    #[error("the cutover preflight could not be evaluated: {0}")]
+    PreflightUnevaluable(String),
+    /// The preflight returned no defects **and** evaluated no classes.
+    ///
+    /// "No defects" and "no checks ran" are the two answers a gate must never
+    /// confuse, and this is the arm that keeps them apart: a preflight that
+    /// silently stopped evaluating would otherwise report the cleanest verdict
+    /// in the system.
+    #[error(
+        "the cutover preflight evaluated zero classes; a clean verdict from no checks is not a clean verdict"
+    )]
+    PreflightVacuous,
+}
+
+/// `task_run_id=state pod_uid=…` for every blocking permit.
+///
+/// The three fields an operator needs at 03:00: which run, what it still owes,
+/// and which Pod identity the drop would be fenced against.
+fn render_nonterminal_rows(rows: &[NonterminalResizeRow]) -> String {
+    rows.iter()
+        .map(|row| {
+            format!(
+                "task_run_id={} state={} pod_uid={}",
+                row.task_run_id,
+                row.state,
+                row.pod_uid.as_deref().unwrap_or("<none>")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// `pod=… uid=… task_run_id=…` for every live Pod, so the UID-fenced delete an
+/// operator is about to issue has something to fence against.
+fn render_live_pods(pods: &[LiveTaskRunPod]) -> String {
+    pods.iter()
+        .map(|pod| {
+            format!(
+                "pod={} pod_uid={} task_run_id={}",
+                pod.pod_name, pod.pod_uid, pod.task_run_id
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 /// One dispatch-eligible catalog row that may not run under the mode.
@@ -461,6 +564,49 @@ pub trait TaskRunPodPlane: Send + Sync {
     async fn live_task_run_pods(&self) -> Result<Vec<LiveTaskRunPod>, String>;
 }
 
+/// What the deploy-time preflight decided.
+///
+/// Three variants, not two. A preflight that could not run is not a preflight
+/// that passed, and a preflight that ran no checks is not a preflight that
+/// found nothing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PreflightVerdict {
+    /// Clean, having evaluated the named classes.
+    Clear {
+        /// The defect classes actually evaluated, as stable labels.
+        evaluated: Vec<String>,
+    },
+    /// Blocked, naming every defect.
+    Blocked {
+        /// The blocking classes, sorted and deduplicated.
+        classes: Vec<String>,
+        /// Every blocking reason, as `class detail`.
+        defects: Vec<String>,
+    },
+    /// The preflight could not be evaluated at all.
+    Unevaluable(String),
+}
+
+/// The deploy-time cutover preflight, as the flip consults it.
+///
+/// The production implementation is [`DeployRenderPreflight`], which runs
+/// `djinn_k8s::cutover_preflight::run` over a live `helm template` render — the
+/// same validator `deploy/preflight/cutover-preflight.sh` runs, assembled by the
+/// same code. There is no second copy of any rule, and no arm in which this
+/// module decides a class for itself.
+#[async_trait]
+pub trait CutoverPreflight: Send + Sync {
+    /// Judge the deployment against the mode it is being flipped to.
+    ///
+    /// `live_task_run_pods` is the apiserver half of the drain fence, supplied
+    /// by the caller because the preflight does not talk to a cluster.
+    async fn evaluate(
+        &self,
+        mode: LauncherAuthorityProtocol,
+        live_task_run_pods: &[String],
+    ) -> PreflightVerdict;
+}
+
 /// A read of an OCI registry manifest.
 ///
 /// The check built on this compares the SHA-256 of the **returned bytes**
@@ -554,6 +700,7 @@ pub struct ResizeRollout {
     admission: std::sync::Arc<dyn AdmissionControl>,
     pods: std::sync::Arc<dyn TaskRunPodPlane>,
     registry: std::sync::Arc<dyn RegistryProbe>,
+    preflight: std::sync::Arc<dyn CutoverPreflight>,
     journal: Mutex<Vec<RolloutStep>>,
     dispatches_admitted_while_paused: AtomicU64,
 }
@@ -569,6 +716,7 @@ impl ResizeRollout {
         admission: std::sync::Arc<dyn AdmissionControl>,
         pods: std::sync::Arc<dyn TaskRunPodPlane>,
         registry: std::sync::Arc<dyn RegistryProbe>,
+        preflight: std::sync::Arc<dyn CutoverPreflight>,
     ) -> Self {
         Self {
             permits: BuildPodPermitRepository::new(db.clone()),
@@ -578,6 +726,7 @@ impl ResizeRollout {
             admission,
             pods,
             registry,
+            preflight,
             journal: Mutex::new(Vec::new()),
             dispatches_admitted_while_paused: AtomicU64::new(0),
         }
@@ -951,6 +1100,70 @@ impl ResizeRollout {
         Ok(())
     }
 
+    /// **Step 6b.** Run the deploy-time preflight against the mode being
+    /// flipped to, and refuse the cutover unless it comes back clean.
+    ///
+    /// # Why this is a step and not a call inside the flip
+    ///
+    /// Because the ordering is the enforcement. [`RolloutStep::AuthorityModeFlipped`]
+    /// lists [`RolloutStep::PreflightCleared`] among its prerequisites, and
+    /// [`Self::guard`] refuses a step whose prerequisites are not in the
+    /// journal — so a flip that never ran the preflight is
+    /// [`RolloutBlocked::StepOutOfOrder`] rather than a flip that happened to
+    /// skip a check. Deleting the call below does not make the flip permissive;
+    /// it makes the flip impossible.
+    ///
+    /// The live-Pod census is re-read here and handed to the preflight, so the
+    /// preflight's own drain-fence class is judged against the apiserver rather
+    /// than against whatever the observation bundle claimed.
+    ///
+    /// # Errors
+    ///
+    /// [`RolloutBlocked::PreflightRefused`] naming every defect,
+    /// [`RolloutBlocked::PreflightUnevaluable`], [`RolloutBlocked::PreflightVacuous`],
+    /// or [`RolloutBlocked::PodCensusUnavailable`] when the apiserver half
+    /// cannot be read. None of them is ever "clean".
+    pub async fn clear_preflight(
+        &self,
+        mode: LauncherAuthorityProtocol,
+    ) -> Result<Vec<String>, RolloutBlocked> {
+        self.guard(RolloutStep::PreflightCleared)?;
+        let live: Vec<String> = self
+            .pods
+            .live_task_run_pods()
+            .await
+            .map_err(RolloutBlocked::PodCensusUnavailable)?
+            .into_iter()
+            .map(|pod| pod.task_run_id)
+            .collect();
+        match self.preflight.evaluate(mode, &live).await {
+            PreflightVerdict::Clear { evaluated } if evaluated.is_empty() => {
+                warn!("task_run_resize_rollout: the preflight returned clean with zero classes");
+                Err(RolloutBlocked::PreflightVacuous)
+            }
+            PreflightVerdict::Clear { evaluated } => {
+                self.record(RolloutStep::PreflightCleared);
+                info!(
+                    mode = mode.as_wire(),
+                    evaluated = evaluated.join(","),
+                    "task_run_resize_rollout: cutover preflight clear"
+                );
+                Ok(evaluated)
+            }
+            PreflightVerdict::Blocked { classes, defects } => {
+                warn!(
+                    mode = mode.as_wire(),
+                    classes = classes.join(","),
+                    "task_run_resize_rollout: cutover preflight refused the flip"
+                );
+                Err(RolloutBlocked::PreflightRefused { classes, defects })
+            }
+            PreflightVerdict::Unevaluable(reason) => {
+                Err(RolloutBlocked::PreflightUnevaluable(reason))
+            }
+        }
+    }
+
     /// **Step 7.** Flip the authority mode, behind the drain proof and behind
     /// `set_mode`'s own transactional fence.
     ///
@@ -1040,6 +1253,8 @@ impl ResizeRollout {
         self.verify_retention(plan.retained).await?;
         self.pause_admission(plan.reason, &plan.probe).await?;
         self.prove_drained().await?;
+        self.clear_preflight(LauncherAuthorityProtocol::ResizeV2)
+            .await?;
         let epoch = self
             .flip_authority_mode(plan.expected_epoch, LauncherAuthorityProtocol::ResizeV2)
             .await?;
@@ -1073,6 +1288,8 @@ impl ResizeRollout {
             .await?;
         self.pause_admission(plan.reason, &plan.probe).await?;
         self.prove_drained().await?;
+        self.clear_preflight(LauncherAuthorityProtocol::LeafV1)
+            .await?;
         let epoch = self
             .flip_authority_mode(plan.expected_epoch, LauncherAuthorityProtocol::LeafV1)
             .await?;
@@ -1356,37 +1573,102 @@ impl TaskRunPodPlane for KubernetesTaskRunPodPlane {
     }
 }
 
+/// The deploy-time preflight, bound to a live `helm template` render.
+///
+/// # Why it delegates rather than re-implements
+///
+/// The whole rule lives in `djinn_k8s::cutover_preflight::run`, and the
+/// assembly of its input lives in `djinn_k8s::cutover_preflight_driver` — the
+/// same module `bin/cutover-preflight.rs` uses. This type adds no check, reads
+/// no manifest field of its own and names no Kubernetes type. If it did, the
+/// gate the deploy step runs and the gate the flip runs could disagree, and the
+/// one that disagreed would be the one nobody was watching.
+pub struct DeployRenderPreflight {
+    inner: djinn_k8s::cutover_preflight_driver::RenderedCutoverPreflight,
+}
+
+impl DeployRenderPreflight {
+    /// Read the render and the observation bundle, and bind the durable half of
+    /// the drain fence to `db`.
+    ///
+    /// # Errors
+    ///
+    /// The render is missing, unparseable or empty, or the observation bundle
+    /// is invalid. Every one of these refuses the cutover before it has paused
+    /// admission or moved anything.
+    pub fn load(
+        sources: &djinn_k8s::cutover_preflight_driver::PreflightSources,
+        db: Database,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            inner: djinn_k8s::cutover_preflight_driver::RenderedCutoverPreflight::load(
+                sources,
+                djinn_k8s::cutover_preflight_driver::DrainFenceSource::Repository(
+                    BuildPodPermitRepository::new(db),
+                ),
+            )?,
+        })
+    }
+}
+
+#[async_trait]
+impl CutoverPreflight for DeployRenderPreflight {
+    async fn evaluate(
+        &self,
+        mode: LauncherAuthorityProtocol,
+        live_task_run_pods: &[String],
+    ) -> PreflightVerdict {
+        match self.inner.judge(mode, live_task_run_pods).await {
+            Err(reason) => PreflightVerdict::Unevaluable(reason),
+            Ok(judgement) if judgement.is_clear() => PreflightVerdict::Clear {
+                evaluated: judgement.evaluated_classes(),
+            },
+            Ok(judgement) => PreflightVerdict::Blocked {
+                classes: judgement.blocking_classes(),
+                defects: judgement.blocking_defects(),
+            },
+        }
+    }
+}
+
 impl ResizeRollout {
     /// **The production composition site.**
     ///
     /// Every seam gets its real implementation: the durable dispatch-pause
     /// state and the coordinator's own refusal predicate, the live apiserver,
-    /// and an HTTP registry. The three repositories are built from `db` inside
-    /// [`Self::new`] and cannot be passed in.
+    /// an HTTP registry, and the deploy-time preflight over a live render. The
+    /// three repositories are built from `db` inside [`Self::new`] and cannot be
+    /// passed in.
     ///
     /// Nothing here is conditional, feature-gated or test-only. A cutover
     /// driven through this constructor is the same code path the tests drive,
-    /// with the two seams that need a cluster and a registry pointed at a real
+    /// with the seams that need a cluster and a registry pointed at a real
     /// cluster and a real registry.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// The rendered manifests or the observation bundle could not be read. A
+    /// cutover whose preflight cannot even be assembled must not start.
     pub fn production(
         db: Database,
         events: djinn_core::events::EventBus,
         runtime: std::sync::Arc<djinn_k8s::runtime::KubernetesRuntime>,
         registry_base_url: &str,
         paused_by: &str,
-    ) -> Self {
-        Self::new(
+        preflight_sources: &djinn_k8s::cutover_preflight_driver::PreflightSources,
+    ) -> Result<Self, String> {
+        Ok(Self::new(
             db.clone(),
             // Read from the deployment's environment at process start. A
             // restart re-reads the document; nothing re-reads it in-process,
             // because an allowlist that can change under a running cutover is
             // not an allowlist.
             LegacyDigestInventory::process().clone(),
-            std::sync::Arc::new(DurableAdmissionControl::new(db, events, paused_by)),
+            std::sync::Arc::new(DurableAdmissionControl::new(db.clone(), events, paused_by)),
             std::sync::Arc::new(KubernetesTaskRunPodPlane::new(runtime)),
             std::sync::Arc::new(HttpRegistryProbe::new(registry_base_url)),
-        )
+            std::sync::Arc::new(DeployRenderPreflight::load(preflight_sources, db)?),
+        ))
     }
 }
 

--- a/server/tests/authority_cutover.rs
+++ b/server/tests/authority_cutover.rs
@@ -1,0 +1,981 @@
+//! **The operator entry point, driven end to end** (proposal `3i92`, task
+//! `eeky-2`).
+//!
+//! # What is real here
+//!
+//! | thing under test | fixture |
+//! |---|---|
+//! | the composition | **`ResizeRollout::production`** — the real one. Not `ResizeRollout::new` with stand-ins: every test below goes through `djinn_server::authority_cutover::run`, which is the function `bin/authority_cutover.rs`'s `main` is a shell around. |
+//! | the drain fence, the catalog, the signed allowlist, the authority singleton | **real PostgreSQL**, via `Database::ephemeral()`. |
+//! | admission pause | **`DurableAdmissionControl`** — the real `dispatch_pauses` state, read back through the coordinator's own refusal predicate. |
+//! | retention | **a real HTTP round trip** to a real OCI-manifest endpoint on a real TCP socket, whose response body is hashed. |
+//! | the preflight | **`djinn_k8s::cutover_preflight::run`**, assembled by the same `cutover_preflight_driver` module `bin/cutover-preflight.rs` uses, over a rendered-manifest document on disk. |
+//! | the Pod plane | **`KubernetesTaskRunPodPlane`** over a real `kube::Client` whose transport is in-process and records every request. `list_taskrun_jobs`, the URL it builds and the response it deserializes are all production code. |
+//!
+//! # Why the apiserver is in-process and not a cluster
+//!
+//! Every `KubernetesRuntime` constructor but `from_client` resolves through
+//! `kube::Client::try_default()` — the ambient kubeconfig, which on a developer
+//! machine is the live production cluster. Composing the production Pod plane
+//! against that would silently touch production. So the client is built by
+//! `djinn_k8s::runtime_fixture`, which fakes the transport and nothing above
+//! it, and the recorder it hands back is how "zero Pod creations" is asserted:
+//! against the WIRE, not against a counter the code under test increments.
+//!
+//! # The governing question
+//!
+//! "What stays green if the body does nothing?" Every criterion below is
+//! asserted against the durable authority row, the durable pause predicate and
+//! the recorded requests — never against a returned `Err` alone. An error
+//! returned *after* a flip satisfies an `Err`-only assertion and fails every
+//! assertion in this file.
+
+use std::sync::Arc;
+use std::sync::{LazyLock, Mutex};
+
+use djinn_db::launcher_compatibility::LegacyDigestInventory;
+use djinn_db::{
+    AcquireBuildPodPermitResult, BuildPodPermitRepository, BuildPodResizeIdentity,
+    CaptureBuildPodResizeIdentityResult, Database, DispatchPauseRepository, ImageRepository,
+    LauncherAuthorityModeRepository, SetLauncherAuthorityModeResult,
+};
+use djinn_k8s::runtime_fixture::{RecordedApiserver, empty_task_run_cluster};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use djinn_server::authority_cutover::{
+    CutoverDirection, CutoverFailure, CutoverPlanDocument, CutoverRequest,
+    RetainedArtifactDocument, run,
+};
+use djinn_server::task_run_resize_rollout::{
+    AdmissionControl as _, DurableAdmissionControl, RolloutBlocked, RolloutStep,
+};
+use ring::signature::KeyPair as _;
+use serde_json::{Value, json};
+
+const LEAF: LauncherAuthorityProtocol = LauncherAuthorityProtocol::LeafV1;
+const RESIZE: LauncherAuthorityProtocol = LauncherAuthorityProtocol::ResizeV2;
+
+/// One task carries every fixture task run. `tasks.id` is `varchar(36)`.
+const EEKY_TASK_ID: &str = "eeky2-task";
+
+// ═══ process-wide environment ═══════════════════════════════════════════════
+
+/// The signed legacy-digest inventory this binary runs under.
+///
+/// `ResizeRollout::production` resolves it through
+/// `LegacyDigestInventory::process()`, a `OnceLock` over the environment, so it
+/// is fixed for the life of the process and cannot be varied per test. Every
+/// test here therefore runs under the SAME verified, empty inventory — which is
+/// the honest configuration for a catalog whose every row declares a protocol,
+/// and is what makes the allowlist step pass on its own evidence rather than
+/// because nothing checked it.
+///
+/// Written and installed exactly once, before the first `process()` call, and
+/// asserted to have produced a `Verified` inventory: an `Unconfigured` one would
+/// block every cutover below at step 1b for a reason unrelated to what each
+/// test is about.
+struct CutoverEnvironment {
+    scratch: std::path::PathBuf,
+}
+
+static ENVIRONMENT: LazyLock<CutoverEnvironment> = LazyLock::new(|| {
+    let scratch = std::env::temp_dir().join(format!("eeky2-{}", uuid::Uuid::now_v7().simple()));
+    std::fs::create_dir_all(&scratch).expect("scratch directory");
+
+    let rng = ring::rand::SystemRandom::new();
+    let pkcs8 = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    let key = ring::signature::Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap();
+    let document = serde_json::to_vec(&json!({
+        "schema_version": 1,
+        "issuer": "platform-ops",
+        "issued_at": "2026-07-31T00:00:00Z",
+        "digests": [],
+    }))
+    .unwrap();
+    let path = scratch.join("legacy-digests.json");
+    std::fs::write(&path, &document).expect("write the signed document");
+
+    // SAFETY: this runs exactly once, inside a `LazyLock`, before anything in
+    // this binary reads the inventory environment — `LegacyDigestInventory::process()`
+    // is forced below, inside the same initializer, so no later test can observe
+    // a half-installed environment.
+    unsafe {
+        std::env::set_var("DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY", &path);
+        std::env::set_var(
+            "DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_PUBLIC_KEY",
+            b64(key.public_key().as_ref()),
+        );
+        std::env::set_var(
+            "DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_SIGNATURE",
+            b64(key.sign(&document).as_ref()),
+        );
+    }
+
+    assert!(
+        matches!(
+            LegacyDigestInventory::process(),
+            LegacyDigestInventory::Verified { .. }
+        ),
+        "the process inventory must be signature-verified, or every cutover below blocks at the \
+         allowlist step for a reason no test in this file is about"
+    );
+    CutoverEnvironment { scratch }
+});
+
+fn b64(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// A path under this binary's scratch directory, unique per caller.
+fn scratch_file(name: &str) -> std::path::PathBuf {
+    ENVIRONMENT
+        .scratch
+        .join(format!("{}-{name}", uuid::Uuid::now_v7().simple()))
+}
+
+// ═══ the rendered manifest surface ══════════════════════════════════════════
+
+/// A render that satisfies both render-derived preflight classes.
+///
+/// It is deliberately minimal rather than a `helm template` of the shipped
+/// chart: whether the CHART satisfies the preflight is `djinn-k8s`'s
+/// `tests/cutover_preflight.rs` question, asked there against a live render.
+/// What these tests ask is whether the CUTOVER DRIVER refuses when the
+/// preflight refuses, and for that the render has to be something a test can
+/// mutate by exactly one field.
+///
+/// * a namespaced `Role` granting the exact `("", pods/resize, patch)` triple;
+/// * a `ServiceAccount` labelled `app.kubernetes.io/component: taskrun`, so the
+///   binding check has an identity to look for instead of matching nothing;
+/// * no `RoleBinding` naming it.
+fn clean_render() -> Vec<Value> {
+    vec![
+        json!({
+            "apiVersion": "rbac.authorization.k8s.io/v1",
+            "kind": "Role",
+            "metadata": { "name": "djinn-controller", "namespace": "djinn" },
+            "rules": [
+                {
+                    "apiGroups": [""],
+                    "resources": ["pods", "pods/resize"],
+                    "verbs": ["get", "list", "patch"],
+                },
+            ],
+        }),
+        json!({
+            "apiVersion": "v1",
+            "kind": "ServiceAccount",
+            "metadata": {
+                "name": "djinn-taskrun",
+                "namespace": "djinn",
+                "labels": { "app.kubernetes.io/component": "taskrun" },
+            },
+        }),
+    ]
+}
+
+/// **THE MUTATION for the preflight criterion.** One field: the `pods/resize`
+/// resource, removed from the only rule that grants it.
+///
+/// Everything else — the same Role, the same verbs, the same apiGroup, the same
+/// ServiceAccount — is byte-identical to [`clean_render`]. Without the
+/// subresource the lift is a 403 and every brokered build silently runs at the
+/// unleased floor, which is exactly the class `pods-resize-rbac` exists to
+/// catch.
+fn render_without_the_resize_grant() -> Vec<Value> {
+    let mut documents = clean_render();
+    documents[0]["rules"][0]["resources"] = json!(["pods"]);
+    documents
+}
+
+/// Write a render where the driver expects to find one, and return the path.
+fn write_render(documents: &[Value]) -> String {
+    let path = scratch_file("render.json");
+    std::fs::write(&path, serde_json::to_vec(documents).unwrap()).expect("write the render");
+    path.to_string_lossy().into_owned()
+}
+
+// ═══ seeding ════════════════════════════════════════════════════════════════
+
+async fn assert_real_postgres(db: &Database) {
+    db.ensure_initialized()
+        .await
+        .expect("the ephemeral database must materialize");
+    let version: String = sqlx::query_scalar("SELECT version()")
+        .fetch_one(db.pool())
+        .await
+        .expect("the fence, catalog and authority properties are PostgreSQL properties");
+    assert!(
+        version.starts_with("PostgreSQL"),
+        "these tests must run against real PostgreSQL, got {version:?}"
+    );
+}
+
+fn digest(seed: char) -> String {
+    format!("sha256:{}", seed.to_string().repeat(64))
+}
+
+/// Seed `users -> projects -> tasks -> task_runs`, so real permit rows can
+/// exist. `build_pod_permits.task_run_id` is a restricted foreign key.
+async fn seed_project_and_run(db: &Database, task_run_id: &str) {
+    db.ensure_initialized().await.unwrap();
+    let pool = db.pool();
+    sqlx::query(
+        "INSERT INTO users (id, github_id, github_login) \
+         VALUES ('00000000-0000-7000-8000-0000000000e2', 9000000239, 'eeky2-cutover') \
+         ON CONFLICT DO NOTHING",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO projects (id, name, github_owner, github_repo) \
+         VALUES ('eeky2-project', 'eeky2-project', 'djinnos', 'eeky') ON CONFLICT DO NOTHING",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO tasks \
+         (id, project_id, short_id, title, description, design, labels, acceptance_criteria, \
+          memory_refs, created_by_user_id) \
+         VALUES ($1, 'eeky2-project', $2, 't', 'd', 'g', '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, \
+                 '00000000-0000-7000-8000-0000000000e2') ON CONFLICT DO NOTHING",
+    )
+    .bind(EEKY_TASK_ID)
+    .bind("eeky2")
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO task_runs (id, project_id, task_id, trigger_type, status) \
+         VALUES ($1, 'eeky2-project', $2, 'manual', 'running') ON CONFLICT DO NOTHING",
+    )
+    .bind(task_run_id)
+    .bind(EEKY_TASK_ID)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Register a `ready` catalog image declaring `declared`, and select it.
+///
+/// The declaration is a parameter because the catalog a cutover validates is
+/// the catalog for the mode it is moving TO: a forward cutover validates
+/// `resize-v2` rows, and a rollback validates `leaf-v1` ones. Seeding one
+/// declaration for both would make the rollback tests block on a catalog
+/// mismatch and never reach the property they are about.
+async fn seed_selected_image(
+    db: &Database,
+    id: &str,
+    digest: &str,
+    declared: LauncherAuthorityProtocol,
+) {
+    let repo = ImageRepository::new(db.clone());
+    repo.create(id, id, None, "{}").await.unwrap();
+    repo.mark_ready(id, &format!("reg/{id}:tag"), Some(digest), Some(declared))
+        .await
+        .unwrap();
+    sqlx::query("UPDATE projects SET selected_image_id = $1 WHERE id = 'eeky2-project'")
+        .bind(id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    assert!(
+        repo.get(id).await.unwrap().is_some(),
+        "the catalog row the probe dispatch resolves must exist"
+    );
+}
+
+/// Drive a permit into a nonterminal resize state through production repository
+/// methods only, so the row is exactly what production writes.
+async fn seed_nonterminal_resize_row(db: &Database, task_run_id: &str) -> String {
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let AcquireBuildPodPermitResult::Acquired { row, .. } = permits.acquire(task_run_id, 8).await
+    else {
+        panic!("the permit pool must admit the fixture run");
+    };
+    permits
+        .bind_or_refresh_job_uid(
+            task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            "job-uid-eeky2",
+        )
+        .await
+        .map(|_| ())
+        .unwrap_or_else(|error| panic!("binding a Job UID must succeed: {error}"));
+    let pod_uid = format!("uid-{task_run_id}");
+    let captured = permits
+        .capture_resize_identity(
+            task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            &BuildPodResizeIdentity {
+                pod_namespace: "djinn".into(),
+                pod_name: "taskrun-eeky2".into(),
+                pod_uid: pod_uid.clone(),
+                launcher_container_name: "cgroup-launcher".into(),
+                launcher_container_id: "containerd://eeky2".into(),
+                image_digest: digest('a'),
+                observed_launcher_protocol: RESIZE.as_wire().into(),
+                effective_launcher_protocol: RESIZE.as_wire().into(),
+                admitted_cpu_millicores: 4000,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        captured,
+        CaptureBuildPodResizeIdentityResult::Captured(_)
+    ));
+    pod_uid
+}
+
+/// Read the durable authority row, so "the mode did not move" is asserted
+/// against PostgreSQL rather than against the driver's own memory.
+async fn authority(db: &Database) -> (LauncherAuthorityProtocol, i64) {
+    let row = LauncherAuthorityModeRepository::new(db.clone())
+        .read()
+        .await
+        .unwrap()
+        .expect("migration 167 seeds the singleton");
+    (row.mode, row.epoch)
+}
+
+/// The production dispatch-pause predicate — the expression the coordinator's
+/// dispatch loop guards on, not a read of the `dispatch_pauses` row.
+async fn dispatch_is_paused(db: &Database) -> bool {
+    DurableAdmissionControl::new(db.clone(), djinn_core::events::EventBus::noop(), "eeky2")
+        .dispatch_is_paused()
+        .await
+        .expect("the pause state must be readable")
+}
+
+// ═══ the registry ═══════════════════════════════════════════════════════════
+
+/// A real OCI-manifest endpoint on a real TCP socket. Deleting an entry here is
+/// a genuine "the artifact is no longer pullable", not a flag flip.
+struct LocalRegistry {
+    manifests: Arc<Mutex<std::collections::HashMap<String, Vec<u8>>>>,
+    base_url: String,
+}
+
+impl LocalRegistry {
+    async fn start() -> Self {
+        let manifests: Arc<Mutex<std::collections::HashMap<String, Vec<u8>>>> =
+            Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let state = Arc::clone(&manifests);
+        let app = axum::Router::new().route(
+            "/v2/{repository}/manifests/{reference}",
+            axum::routing::get(
+                move |axum::extract::Path((repository, reference)): axum::extract::Path<(
+                    String,
+                    String,
+                )>| {
+                    let state = Arc::clone(&state);
+                    async move {
+                        let key = format!("{repository}/{reference}");
+                        match state.lock().unwrap().get(&key).cloned() {
+                            Some(bytes) => (axum::http::StatusCode::OK, bytes),
+                            None => (axum::http::StatusCode::NOT_FOUND, Vec::new()),
+                        }
+                    }
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self {
+            manifests,
+            base_url,
+        }
+    }
+
+    fn push(&self, repository: &str, body: &[u8]) -> String {
+        use sha2::{Digest as _, Sha256};
+        let digest = format!("sha256:{:x}", Sha256::digest(body));
+        self.manifests
+            .lock()
+            .unwrap()
+            .insert(format!("{repository}/{digest}"), body.to_vec());
+        digest
+    }
+
+    fn delete(&self, repository: &str, reference: &str) {
+        self.manifests
+            .lock()
+            .unwrap()
+            .remove(&format!("{repository}/{reference}"));
+    }
+}
+
+// ═══ the request ════════════════════════════════════════════════════════════
+
+/// Build the request the binary would build, without going through the
+/// environment: `CutoverRequest::from_env` is exercised separately by
+/// [`the_request_refuses_a_missing_or_malformed_direction`], and every test
+/// below needs its own render path in the same process.
+fn request(
+    direction: CutoverDirection,
+    render: &str,
+    registry_base_url: &str,
+    expected_epoch: i64,
+    retained: Vec<RetainedArtifactDocument>,
+    probe_image_id: &str,
+    probe_task_run_id: &str,
+) -> CutoverRequest {
+    let plan_path = scratch_file("plan.json");
+    std::fs::write(
+        &plan_path,
+        serde_json::to_vec(&json!({
+            "expected_epoch": expected_epoch,
+            "registry_base_url": registry_base_url,
+            "reason": "eeky-2 cutover",
+            "probe_task_run_id": probe_task_run_id,
+            "probe_image_id": probe_image_id,
+            "retained": retained
+                .iter()
+                .map(|artifact| json!({
+                    "image_id": artifact.image_id,
+                    "repository": artifact.repository,
+                    "digest": artifact.digest,
+                    "role": artifact.role,
+                }))
+                .collect::<Vec<_>>(),
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    CutoverRequest {
+        direction,
+        rendered_manifests_path: render.to_owned(),
+        plan: CutoverPlanDocument::load(&plan_path.to_string_lossy()).expect("a valid plan"),
+        paused_by: "eeky2-cutover".into(),
+    }
+}
+
+fn retained(
+    image_id: &str,
+    repository: &str,
+    digest: &str,
+    role: &str,
+) -> RetainedArtifactDocument {
+    RetainedArtifactDocument {
+        image_id: image_id.into(),
+        repository: repository.into(),
+        digest: digest.into(),
+        role: role.into(),
+    }
+}
+
+/// A fresh, seeded database plus the in-process apiserver and registry.
+struct Deployment {
+    db: Database,
+    runtime: Arc<djinn_k8s::runtime::KubernetesRuntime>,
+    apiserver: RecordedApiserver,
+    registry: LocalRegistry,
+    current_digest: String,
+}
+
+impl Deployment {
+    async fn start(task_run_id: &str, declared: LauncherAuthorityProtocol) -> Self {
+        LazyLock::force(&ENVIRONMENT);
+        let db = Database::ephemeral().await.unwrap();
+        assert_real_postgres(&db).await;
+        seed_project_and_run(&db, task_run_id).await;
+        let registry = LocalRegistry::start().await;
+        let current_digest = registry.push(
+            "djinn-image-modern",
+            br#"{"schemaVersion":2,"role":"resize-v2"}"#,
+        );
+        seed_selected_image(&db, "modern", &current_digest, declared).await;
+        let (runtime, apiserver) = empty_task_run_cluster("djinn");
+        Self {
+            db,
+            runtime,
+            apiserver,
+            registry,
+            current_digest,
+        }
+    }
+
+    fn retained_current(&self) -> RetainedArtifactDocument {
+        retained(
+            "modern",
+            "djinn-image-modern",
+            &self.current_digest,
+            "resize-v2-current",
+        )
+    }
+
+    async fn run(&self, request: &CutoverRequest) -> Result<Vec<RolloutStep>, CutoverFailure> {
+        run(
+            self.db.clone(),
+            djinn_core::events::EventBus::noop(),
+            Arc::clone(&self.runtime),
+            request,
+        )
+        .await
+        .map(|report| {
+            assert_eq!(
+                report.dispatches_admitted_while_paused, 0,
+                "no Pod may be created between the pause and the resume"
+            );
+            report.journal
+        })
+    }
+}
+
+// ═══ AC1 — the entry point reaches ResizeRollout::production ════════════════
+
+/// **The whole forward cutover, through the operator entry point.**
+///
+/// This is the baseline every "blocked" criterion below is measured against: it
+/// proves the path can actually reach the flip, so a later test that observes an
+/// unmoved mode is observing the refusal and not a path that never worked.
+///
+/// It also proves the apiserver recorder is LIVE — the drain proof and the
+/// preflight both enumerate task-run Jobs — which is what makes
+/// `workload_creations().is_empty()` a real assertion in the rollback criterion
+/// rather than an assertion about a dead fixture.
+#[tokio::test]
+async fn the_operator_entry_point_runs_the_whole_forward_cutover() {
+    let deployment = Deployment::start("019fc000-1111-7000-8000-000000000001", RESIZE).await;
+    let render = write_render(&clean_render());
+    let request = request(
+        CutoverDirection::Activate,
+        &render,
+        &deployment.registry.base_url,
+        0,
+        vec![deployment.retained_current()],
+        "modern",
+        "019fc000-1111-7000-8000-000000000002",
+    );
+
+    let journal = deployment.run(&request).await.expect("a clean cutover");
+    assert_eq!(
+        journal,
+        vec![
+            RolloutStep::CatalogMutationFrozen,
+            RolloutStep::LegacyInventorySigned,
+            RolloutStep::ProtocolAwareServerDeployed,
+            RolloutStep::CatalogRebuiltAsResizeV2,
+            RolloutStep::RetentionVerified,
+            RolloutStep::AdmissionPaused,
+            RolloutStep::DrainProven,
+            RolloutStep::PreflightCleared,
+            RolloutStep::AuthorityModeFlipped,
+            RolloutStep::AdmissionResumed,
+        ],
+        "the observed sequence is the assertion"
+    );
+    assert_eq!(authority(&deployment.db).await, (RESIZE, 1));
+    assert!(
+        !dispatch_is_paused(&deployment.db).await,
+        "a completed cutover resumes admission"
+    );
+
+    // The apiserver was really read — twice, once for the drain proof and once
+    // for the preflight's own Pod half — and nothing was created.
+    let reads = deployment.apiserver.all();
+    assert!(
+        reads.len() >= 2 && reads.iter().all(|request| request.method == "GET"),
+        "the drain proof and the preflight must both enumerate task-run Jobs, and neither may \
+         write: {reads:?}"
+    );
+    assert!(deployment.apiserver.workload_creations().is_empty());
+}
+
+// ═══ AC2 — a failing preflight blocks the FLIP ══════════════════════════════
+
+/// **A real preflight defect blocks the flip, and the mode does not move.**
+///
+/// The mutation is one field of the render — `pods/resize` removed from the one
+/// Role rule that grants it — against a render that is otherwise byte-identical
+/// to the one
+/// [`the_operator_entry_point_runs_the_whole_forward_cutover`] flips under. So
+/// the difference between "flipped" and "blocked" is that field and nothing
+/// else.
+///
+/// # What stays green if the body does nothing
+///
+/// Nothing. Asserting only that an error came back would be satisfied by an
+/// error returned *after* the flip, so the assertion is on the durable
+/// authority row: mode `leaf-v1`, epoch `0`, unchanged. And the journal is read
+/// too, because a flip that happened and was then rolled back by some later arm
+/// would also leave the row looking untouched — `AuthorityModeFlipped` is
+/// journaled only by a committed compare-and-swap, and it must be absent.
+#[tokio::test]
+async fn a_failing_preflight_blocks_the_flip_and_the_authority_row_does_not_move() {
+    let deployment = Deployment::start("019fc000-2222-7000-8000-000000000001", RESIZE).await;
+    let render = write_render(&render_without_the_resize_grant());
+    let request = request(
+        CutoverDirection::Activate,
+        &render,
+        &deployment.registry.base_url,
+        0,
+        vec![deployment.retained_current()],
+        "modern",
+        "019fc000-2222-7000-8000-000000000002",
+    );
+
+    let failure = deployment
+        .run(&request)
+        .await
+        .expect_err("a render with no pods/resize grant must not flip the authority mode");
+    let CutoverFailure::Blocked {
+        blocked,
+        journal,
+        admission_left_paused,
+    } = failure
+    else {
+        panic!("expected a blocked cutover, got {failure:?}");
+    };
+
+    let RolloutBlocked::PreflightRefused { classes, defects } = &blocked else {
+        panic!("expected the preflight to be what refused, got {blocked:?}");
+    };
+    assert!(
+        classes.iter().any(|class| class == "pods-resize-rbac"),
+        "the refusal must name the class the mutation created: {classes:?}"
+    );
+    assert!(
+        defects
+            .iter()
+            .any(|defect| defect.contains("pods/resize") && defect.contains("Role")),
+        "the refusal must be the validator's own words, not a restatement: {defects:?}"
+    );
+
+    // THE ASSERTIONS THAT MATTER.
+    assert_eq!(
+        authority(&deployment.db).await,
+        (LEAF, 0),
+        "a blocked preflight must leave the durable authority row exactly as it was"
+    );
+    assert!(
+        !journal.contains(&RolloutStep::PreflightCleared),
+        "a blocked preflight must not journal a cleared step: {journal:?}"
+    );
+    assert!(
+        !journal.contains(&RolloutStep::AuthorityModeFlipped),
+        "the flip must never have committed: {journal:?}"
+    );
+    assert!(
+        journal.contains(&RolloutStep::DrainProven),
+        "the cutover must have got as far as the drain proof, or this test would pass for the \
+         wrong reason: {journal:?}"
+    );
+
+    // Admission is left paused — read from the production predicate, not the
+    // journal — because `resume_admission` is unreachable without a flip.
+    assert!(admission_left_paused);
+    assert!(dispatch_is_paused(&deployment.db).await);
+    assert!(deployment.apiserver.workload_creations().is_empty());
+}
+
+// ═══ AC3 — a nonterminal row blocks the flip, BY NAME ═══════════════════════
+
+/// **The refusal names the row, and `set_mode` alone could not.**
+///
+/// The criterion's named mutation is "route through `set_mode` directly and this
+/// test must fail". That mutation is not described here, it is *executed*: the
+/// second half of this test calls `LauncherAuthorityModeRepository::set_mode`
+/// against the same database, in the same seeded state, and asserts that its
+/// refusal — which is also correct, and also fail-closed — carries no
+/// `task_run_id`, no lifecycle state and no `pod_uid`. A driver wired to
+/// `set_mode` would produce that refusal and fail the assertions above.
+#[tokio::test]
+async fn a_nonterminal_resize_row_blocks_the_flip_and_the_refusal_names_it() {
+    let task_run_id = "019fc000-3333-7000-8000-000000000001";
+    let deployment = Deployment::start(task_run_id, RESIZE).await;
+    let pod_uid = seed_nonterminal_resize_row(&deployment.db, task_run_id).await;
+    let render = write_render(&clean_render());
+    let request = request(
+        CutoverDirection::Activate,
+        &render,
+        &deployment.registry.base_url,
+        0,
+        vec![deployment.retained_current()],
+        "modern",
+        "019fc000-3333-7000-8000-000000000002",
+    );
+
+    let failure = deployment
+        .run(&request)
+        .await
+        .expect_err("a permit that still owes a resize decision must block the flip");
+    let CutoverFailure::Blocked {
+        blocked, journal, ..
+    } = failure
+    else {
+        panic!("expected a blocked cutover, got {failure:?}");
+    };
+
+    let RolloutBlocked::NonterminalResizeRows(rows) = &blocked else {
+        panic!(
+            "the block must come from `list_nonterminal_resize`, which returns ROWS. \
+             `set_mode`'s own fence would produce AuthorityDrainRefused with a census — that is \
+             the mutation this test exists to catch. Got {blocked:?}"
+        );
+    };
+    assert_eq!(rows.len(), 1, "{rows:?}");
+    assert_eq!(rows[0].task_run_id, task_run_id);
+    assert_eq!(rows[0].state, "BirthConfirmed", "{rows:?}");
+    assert_eq!(rows[0].pod_uid.as_deref(), Some(pod_uid.as_str()));
+
+    // The operator-facing rendering carries all three, not a count.
+    let rendered = blocked.to_string();
+    for needle in [task_run_id, "BirthConfirmed", pod_uid.as_str()] {
+        assert!(
+            rendered.contains(needle),
+            "the refusal an operator reads must contain {needle:?}: {rendered}"
+        );
+    }
+
+    assert_eq!(
+        authority(&deployment.db).await,
+        (LEAF, 0),
+        "the mode must not have moved"
+    );
+    assert!(!journal.contains(&RolloutStep::DrainProven));
+    assert!(!journal.contains(&RolloutStep::AuthorityModeFlipped));
+
+    // ── THE NAMED MUTATION, EXECUTED ────────────────────────────────────────
+    //
+    // Same database, same seeded row. `set_mode` refuses too — it is not
+    // permissive — but it refuses with per-dimension COUNTS. A driver wired to
+    // it would satisfy an `Err`-only assertion and fail every assertion above.
+    let direct = LauncherAuthorityModeRepository::new(deployment.db.clone())
+        .set_mode(0, RESIZE)
+        .await;
+    let SetLauncherAuthorityModeResult::DrainNotEmpty { drain, .. } = direct else {
+        panic!("set_mode must refuse the same seeded state, got {direct:?}");
+    };
+    let census = format!("{drain:?}");
+    for needle in [task_run_id, pod_uid.as_str()] {
+        assert!(
+            !census.contains(needle),
+            "set_mode's census must NOT name {needle:?} — that is why the driver goes through \
+             ResizeRollout: {census}"
+        );
+    }
+    assert_eq!(
+        authority(&deployment.db).await,
+        (LEAF, 0),
+        "and set_mode's own fence held too"
+    );
+}
+
+// ═══ AC4 — rollback refuses, admission stays paused, no Pod starts ══════════
+
+/// **A missing artifact blocks the rollback with zero Pod creations.**
+///
+/// Two runs, and the first is what makes the second mean anything:
+///
+/// 1. **control** — every retained digest is pullable, so the rollback runs to
+///    completion and moves the mode `resize-v2` → `leaf-v1`. The apiserver
+///    recorder ends up non-empty, proving the fixture observes traffic.
+/// 2. **mutation** — one manifest is deleted from the registry and nothing else
+///    changes. The rollback must refuse with the mode still `resize-v2`, the
+///    epoch unmoved, admission still paused, and **zero** creations on the wire.
+///
+/// # What stays green if the body does nothing
+///
+/// An `Err`-only assertion passes if the mode flips first and the error arrives
+/// afterwards, and it passes if a Pod was started on the way. So neither is
+/// asserted by absence of an `Ok`: the mode and the epoch are read back out of
+/// PostgreSQL, the pause is read through the coordinator's own predicate, and
+/// the Pod count is read off the recorded requests.
+#[tokio::test]
+async fn a_missing_artifact_blocks_the_rollback_leaving_admission_paused_and_no_pod_started() {
+    // ── 1. CONTROL ──────────────────────────────────────────────────────────
+    let control = Deployment::start("019fc000-4444-7000-8000-000000000001", LEAF).await;
+    arm_at_resize_v2(&control.db).await;
+    let legacy = control.registry.push(
+        "djinn-image-legacy",
+        br#"{"schemaVersion":2,"role":"leaf-v1"}"#,
+    );
+    let render = write_render(&clean_render());
+    let control_request = request(
+        CutoverDirection::Rollback,
+        &render,
+        &control.registry.base_url,
+        // `arm_at_resize_v2` moved the singleton to epoch 1; every flip is a
+        // compare-and-swap against the epoch it was planned at.
+        1,
+        vec![
+            control.retained_current(),
+            retained("modern", "djinn-image-legacy", &legacy, "leaf-v1-rollback"),
+        ],
+        "modern",
+        "019fc000-4444-7000-8000-000000000002",
+    );
+    let journal = control
+        .run(&control_request)
+        .await
+        .expect("a rollback whose artifacts are all pullable must complete");
+    assert!(journal.contains(&RolloutStep::AuthorityModeFlipped));
+    assert_eq!(
+        authority(&control.db).await,
+        (LEAF, 2),
+        "the control must really have moved the mode, or the mutation below proves nothing"
+    );
+    assert!(
+        !control.apiserver.all().is_empty(),
+        "the apiserver recorder must observe the control run, or 'zero creations' below is an \
+         assertion about a dead fixture"
+    );
+    assert!(control.apiserver.workload_creations().is_empty());
+
+    // ── 2. MUTATION: delete one manifest, change nothing else ───────────────
+    let broken = Deployment::start("019fc000-5555-7000-8000-000000000001", LEAF).await;
+    arm_at_resize_v2(&broken.db).await;
+    // An operator arrives at a rollback with admission ALREADY paused, which is
+    // the state a half-finished forward cutover leaves behind. The criterion is
+    // that the rollback leaves it that way.
+    DispatchPauseRepository::new(broken.db.clone(), djinn_core::events::EventBus::noop())
+        .pause(
+            djinn_db::DispatchPauseTarget::global(),
+            djinn_core::models::DispatchPause {
+                paused_by: "the operator who started the forward cutover".into(),
+                paused_at: "2026-07-31T00:00:00Z".into(),
+                reason: "forward cutover blocked".into(),
+                expires_at: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(dispatch_is_paused(&broken.db).await);
+
+    let rollback_digest = broken.registry.push(
+        "djinn-image-legacy",
+        br#"{"schemaVersion":2,"role":"leaf-v1"}"#,
+    );
+    let broken_request = request(
+        CutoverDirection::Rollback,
+        &render,
+        &broken.registry.base_url,
+        1,
+        vec![
+            broken.retained_current(),
+            retained(
+                "modern",
+                "djinn-image-legacy",
+                &rollback_digest,
+                "leaf-v1-rollback",
+            ),
+        ],
+        "modern",
+        "019fc000-5555-7000-8000-000000000002",
+    );
+    broken
+        .registry
+        .delete("djinn-image-legacy", &rollback_digest);
+
+    let failure = broken
+        .run(&broken_request)
+        .await
+        .expect_err("a rollback whose leaf-v1 artifact is gone must refuse");
+    let CutoverFailure::Blocked {
+        blocked,
+        journal,
+        admission_left_paused,
+    } = failure
+    else {
+        panic!("expected a blocked rollback, got {failure:?}");
+    };
+    let RolloutBlocked::RetentionUnprovable { digest, .. } = &blocked else {
+        panic!("expected retention to be what refused, got {blocked:?}");
+    };
+    assert_eq!(digest, &rollback_digest);
+
+    // THE ASSERTIONS THAT MATTER.
+    assert_eq!(
+        authority(&broken.db).await,
+        (RESIZE, 1),
+        "a blocked rollback must leave the mode and the epoch exactly as they were"
+    );
+    assert!(
+        !journal.contains(&RolloutStep::AuthorityModeFlipped),
+        "{journal:?}"
+    );
+    assert!(
+        admission_left_paused && dispatch_is_paused(&broken.db).await,
+        "a blocked rollback must never resume admission"
+    );
+    assert!(
+        broken.apiserver.workload_creations().is_empty(),
+        "no Pod may be started under an artifact set the rollback could not prove: {:?}",
+        broken.apiserver.all()
+    );
+    assert!(
+        broken.apiserver.mutations().is_empty(),
+        "and nothing may be patched or deleted either: {:?}",
+        broken.apiserver.mutations()
+    );
+}
+
+/// Move a drained deployment to `resize-v2` so a rollback has somewhere to come
+/// back from. Setup only — the property under test is what the DRIVER does next.
+async fn arm_at_resize_v2(db: &Database) {
+    let result = LauncherAuthorityModeRepository::new(db.clone())
+        .set_mode(0, RESIZE)
+        .await;
+    assert!(
+        matches!(result, SetLauncherAuthorityModeResult::Flipped { .. }),
+        "the fixture must start from resize-v2, got {result:?}"
+    );
+}
+
+// ═══ the request surface ════════════════════════════════════════════════════
+
+/// The direction is parsed, never defaulted, and the plan must retain something.
+#[test]
+fn the_request_refuses_a_missing_or_malformed_direction() {
+    assert_eq!(
+        CutoverDirection::parse("activate").unwrap(),
+        CutoverDirection::Activate
+    );
+    assert_eq!(
+        CutoverDirection::parse("rollback").unwrap(),
+        CutoverDirection::Rollback
+    );
+    assert_eq!(CutoverDirection::Activate.target(), RESIZE);
+    assert_eq!(CutoverDirection::Rollback.target(), LEAF);
+    for bogus in ["", "Activate", "roll-back", "resize-v2", "yes"] {
+        assert!(
+            CutoverDirection::parse(bogus).is_err(),
+            "{bogus:?} must not be read as a direction"
+        );
+    }
+
+    LazyLock::force(&ENVIRONMENT);
+    let empty = scratch_file("empty-plan.json");
+    std::fs::write(
+        &empty,
+        br#"{"expected_epoch":0,"registry_base_url":"http://r","reason":"r",
+             "probe_task_run_id":"t","probe_image_id":"i","retained":[]}"#,
+    )
+    .unwrap();
+    let error = CutoverPlanDocument::load(&empty.to_string_lossy())
+        .expect_err("a plan that retains nothing proves the pullability of nothing");
+    assert!(error.contains("retains nothing"), "{error}");
+
+    let bad_role = scratch_file("bad-role-plan.json");
+    std::fs::write(
+        &bad_role,
+        br#"{"expected_epoch":0,"registry_base_url":"http://r","reason":"r",
+             "probe_task_run_id":"t","probe_image_id":"i",
+             "retained":[{"image_id":"i","repository":"r","digest":"sha256:x","role":"current"}]}"#,
+    )
+    .unwrap();
+    assert!(
+        CutoverPlanDocument::load(&bad_role.to_string_lossy())
+            .expect_err("an unknown retention role must be refused, not defaulted")
+            .contains("role must be one of")
+    );
+}

--- a/server/tests/task_run_resize_mixed_version.rs
+++ b/server/tests/task_run_resize_mixed_version.rs
@@ -126,8 +126,9 @@ use djinn_k8s::launcher::{
 use djinn_k8s::pod_resize::{CpuLimit, build_resize_patch};
 use djinn_launcher_protocol::{LEAF_V1_WIRE, LauncherAuthorityProtocol, RESIZE_V2_WIRE};
 use djinn_server::task_run_resize_rollout::{
-    DispatchProbe, DurableAdmissionControl, LiveTaskRunPod, RegistryProbe, ResizeRollout,
-    RolloutBlocked, RolloutStep, TaskRunPodPlane,
+    CutoverPreflight, DispatchProbe, DurableAdmissionControl, LiveTaskRunPod,
+    PreflightVerdict as RolloutPreflightVerdict, RegistryProbe, ResizeRollout, RolloutBlocked,
+    RolloutStep, TaskRunPodPlane,
 };
 use serde_json::{Value, json};
 
@@ -2798,8 +2799,42 @@ fn cutover_rollout(db: &Database, pods: Arc<dyn TaskRunPodPlane>) -> ResizeRollo
         )),
         pods,
         Arc::new(UnreachedRegistry),
+        // The gate this suite drives for real is the SHELL one —
+        // `deploy/preflight/cutover-preflight.sh`, run as a subprocess against a
+        // live helm render, whose verdict `gated_flip` refuses on. What the
+        // rollout's own seam adds here is the ORDERING: `PreflightCleared` is a
+        // prerequisite of `AuthorityModeFlipped`, so a flip that skipped
+        // `clear_preflight` is `StepOutOfOrder` rather than an ungated flip.
+        Arc::new(AlwaysClearPreflight),
     )
 }
+
+/// A preflight seam that clears, so the journal ordering is exercised while the
+/// real verdict comes from the shell gate this suite runs as a subprocess.
+struct AlwaysClearPreflight;
+
+#[async_trait]
+impl CutoverPreflight for AlwaysClearPreflight {
+    async fn evaluate(
+        &self,
+        _mode: LauncherAuthorityProtocol,
+        _live_task_run_pods: &[String],
+    ) -> RolloutPreflightVerdict {
+        RolloutPreflightVerdict::Clear {
+            evaluated: DEPLOY_GATE_CLASSES.iter().map(|c| (*c).to_string()).collect(),
+        }
+    }
+}
+
+/// The six classes `djinn_k8s::cutover_preflight::run` evaluates.
+const DEPLOY_GATE_CLASSES: &[&str] = &[
+    "birth-confirmation",
+    "catalog-protocol",
+    "credential-boundary",
+    "drain-fence",
+    "launcher-cpu-ceiling",
+    "pods-resize-rbac",
+];
 
 /// A catalog row the probe dispatch can name, written by the production
 /// `ImageRepository`.
@@ -3071,6 +3106,10 @@ async fn neither_flip_proceeds_with_a_live_permit_row() {
             .prove_drained()
             .await
             .expect("a drained snapshot must prove");
+        rollout
+            .clear_preflight(target)
+            .await
+            .expect("the preflight gate must clear before the flip is reachable");
         let flipped = rollout
             .flip_authority_mode(epoch, target)
             .await
@@ -3086,6 +3125,7 @@ async fn neither_flip_proceeds_with_a_live_permit_row() {
                 RolloutStep::RetentionVerified,
                 RolloutStep::AdmissionPaused,
                 RolloutStep::DrainProven,
+                RolloutStep::PreflightCleared,
                 RolloutStep::AuthorityModeFlipped,
                 RolloutStep::AdmissionResumed,
             ],
@@ -3564,6 +3604,12 @@ async fn gated_flip(
         .prove_drained()
         .await
         .map_err(|blocked| format!("the drain proof refused: {blocked}"))?;
+    // The rollout's own preflight step, so the flip below is reachable at all:
+    // `AuthorityModeFlipped` lists `PreflightCleared` among its prerequisites.
+    rollout
+        .clear_preflight(target)
+        .await
+        .map_err(|blocked| format!("the rollout preflight gate refused: {blocked}"))?;
     rollout
         .flip_authority_mode(expected_epoch, target)
         .await

--- a/server/tests/task_run_resize_mixed_version.rs
+++ b/server/tests/task_run_resize_mixed_version.rs
@@ -2821,7 +2821,10 @@ impl CutoverPreflight for AlwaysClearPreflight {
         _live_task_run_pods: &[String],
     ) -> RolloutPreflightVerdict {
         RolloutPreflightVerdict::Clear {
-            evaluated: DEPLOY_GATE_CLASSES.iter().map(|c| (*c).to_string()).collect(),
+            evaluated: DEPLOY_GATE_CLASSES
+                .iter()
+                .map(|c| (*c).to_string())
+                .collect(),
         }
     }
 }

--- a/server/tests/task_run_resize_rollout.rs
+++ b/server/tests/task_run_resize_rollout.rs
@@ -42,10 +42,10 @@ use djinn_db::{
 };
 use djinn_launcher_protocol::LauncherAuthorityProtocol;
 use djinn_server::task_run_resize_rollout::{
-    AdmissionControl, CatalogDefectReason, CatalogVerdict, DispatchOutcome, DispatchProbe,
-    DurableAdmissionControl, HttpRegistryProbe, LiveTaskRunPod, RegistryProbe, ResizeRollout,
-    RetainedArtifact, RetentionRole, RolloutBlocked, RolloutPlan, RolloutStep, TaskRunPodPlane,
-    classify_catalog_image,
+    AdmissionControl, CatalogDefectReason, CatalogVerdict, CutoverPreflight, DispatchOutcome,
+    DispatchProbe, DurableAdmissionControl, HttpRegistryProbe, LiveTaskRunPod, PreflightVerdict,
+    RegistryProbe, ResizeRollout, RetainedArtifact, RetentionRole, RolloutBlocked, RolloutPlan,
+    RolloutStep, TaskRunPodPlane, classify_catalog_image,
 };
 use ring::signature::KeyPair as _;
 
@@ -308,6 +308,60 @@ impl TaskRunPodPlane for RecordingPodPlane {
     }
 }
 
+// ── the preflight seam ──────────────────────────────────────────────────────
+
+/// A preflight whose verdict is chosen by the test, recording every call.
+///
+/// The REAL preflight — `djinn_k8s::cutover_preflight::run` over a live
+/// `helm template` render — is driven end to end through
+/// `ResizeRollout::production` in `tests/authority_cutover.rs`. What this
+/// fixture is for is the *ordering* property: that a blocked preflight leaves
+/// the mode untouched and that the flip is unreachable without it. Both of
+/// those are properties of the journal, not of any rule inside the preflight.
+struct RecordingPreflight {
+    verdict: Mutex<PreflightVerdict>,
+    calls: AtomicU64,
+}
+
+impl RecordingPreflight {
+    /// Clean, with every class evaluated.
+    fn clear() -> Arc<Self> {
+        Arc::new(Self {
+            verdict: Mutex::new(PreflightVerdict::Clear {
+                evaluated: vec![
+                    "birth-confirmation".into(),
+                    "catalog-protocol".into(),
+                    "credential-boundary".into(),
+                    "drain-fence".into(),
+                    "launcher-cpu-ceiling".into(),
+                    "pods-resize-rbac".into(),
+                ],
+            }),
+            calls: AtomicU64::new(0),
+        })
+    }
+
+    fn set(&self, verdict: PreflightVerdict) {
+        *self.verdict.lock().unwrap() = verdict;
+    }
+
+    fn calls(&self) -> u64 {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl CutoverPreflight for RecordingPreflight {
+    async fn evaluate(
+        &self,
+        _mode: LauncherAuthorityProtocol,
+        _live_task_run_pods: &[String],
+    ) -> PreflightVerdict {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.verdict.lock().unwrap().clone()
+    }
+}
+
 // ── the registry ────────────────────────────────────────────────────────────
 
 /// A real OCI-manifest endpoint on a real TCP socket.
@@ -478,6 +532,7 @@ async fn retention_is_proven_by_a_registry_round_trip_not_by_a_stored_column() {
         durable_admission(&db),
         RecordingPodPlane::drained(),
         registry.probe(),
+        RecordingPreflight::clear(),
     );
     let retained = vec![RetainedArtifact {
         image_id: "legacy".into(),
@@ -544,6 +599,7 @@ async fn catalog_metadata_is_validated_against_the_mode_and_not_only_the_declara
         durable_admission(&db),
         RecordingPodPlane::drained(),
         Arc::new(UnusedRegistry),
+        RecordingPreflight::clear(),
     );
 
     // Under `leaf-v1`: an allowlisted no-handshake digest maps to leaf
@@ -593,6 +649,7 @@ async fn a_declaration_is_admitted_only_by_the_mode_that_matches_it() {
         durable_admission(&db),
         RecordingPodPlane::drained(),
         Arc::new(UnusedRegistry),
+        RecordingPreflight::clear(),
     );
 
     assert_eq!(
@@ -688,6 +745,7 @@ async fn the_admission_pause_is_proven_by_a_refused_dispatch() {
         durable_admission(&db),
         Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
         Arc::new(UnusedRegistry),
+        RecordingPreflight::clear(),
     );
 
     // Positive control: unpaused, the same dispatch creates a Pod. Without this
@@ -752,6 +810,7 @@ async fn a_pause_row_without_a_wired_refusal_blocks_the_cutover() {
         Arc::clone(&broken) as Arc<dyn AdmissionControl>,
         Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
         Arc::new(UnusedRegistry),
+        RecordingPreflight::clear(),
     );
 
     rollout.verify_retention(&[]).await.unwrap();
@@ -800,6 +859,7 @@ async fn armed_at_the_flip(
         durable_admission(db),
         Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
         Arc::new(UnusedRegistry),
+        RecordingPreflight::clear(),
     );
     rollout.verify_retention(&[]).await.unwrap();
     rollout
@@ -919,6 +979,7 @@ async fn a_drained_snapshot_flips_forward_and_back() {
     )
     .await;
     forward.prove_drained().await.unwrap();
+    forward.clear_preflight(RESIZE).await.unwrap();
     assert_eq!(forward.flip_authority_mode(0, RESIZE).await, Ok(1));
     forward.resume_admission().await.unwrap();
     assert_eq!(authority(&db).await, (RESIZE, 1));
@@ -931,6 +992,7 @@ async fn a_drained_snapshot_flips_forward_and_back() {
     )
     .await;
     back.prove_drained().await.unwrap();
+    back.clear_preflight(LEAF).await.unwrap();
     assert_eq!(back.flip_authority_mode(1, LEAF).await, Ok(2));
     back.resume_admission().await.unwrap();
     assert_eq!(authority(&db).await, (LEAF, 2));
@@ -999,6 +1061,7 @@ async fn rollback_is_blocked_and_leaves_admission_paused() {
             durable_admission(&db),
             Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
             registry.probe(),
+            RecordingPreflight::clear(),
         );
         let plan = RolloutPlan {
             retained: &[RetainedArtifact {
@@ -1087,6 +1150,7 @@ async fn the_forward_cutover_records_the_specced_step_sequence() {
         durable_admission(&db),
         Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
         registry.probe(),
+        RecordingPreflight::clear(),
     );
     let plan = RolloutPlan {
         retained: &[RetainedArtifact {
@@ -1111,6 +1175,7 @@ async fn the_forward_cutover_records_the_specced_step_sequence() {
             RolloutStep::RetentionVerified,
             RolloutStep::AdmissionPaused,
             RolloutStep::DrainProven,
+            RolloutStep::PreflightCleared,
             RolloutStep::AuthorityModeFlipped,
             RolloutStep::AdmissionResumed,
         ],
@@ -1173,9 +1238,136 @@ async fn the_flip_cannot_precede_the_drain_and_the_resume_cannot_precede_the_fli
     );
     assert_eq!(rollout.dispatches_admitted_while_paused(), 0);
 
-    // In order, both succeed.
+    // REORDERING 3 — flip with the drain proven but the preflight never run.
+    // The gate is the prerequisite graph, not a call somebody remembered to
+    // make: deleting `clear_preflight` from `activate` does not produce an
+    // ungated flip, it produces this.
+    assert_eq!(
+        rollout.flip_authority_mode(0, RESIZE).await,
+        Err(RolloutBlocked::StepOutOfOrder {
+            step: RolloutStep::AuthorityModeFlipped,
+            missing: RolloutStep::PreflightCleared
+        })
+    );
+    assert_eq!(
+        authority(&db).await,
+        (LEAF, 0),
+        "the mode must not have moved"
+    );
+
+    // In order, all three succeed.
+    rollout.clear_preflight(RESIZE).await.unwrap();
     assert_eq!(rollout.flip_authority_mode(0, RESIZE).await, Ok(1));
     rollout.resume_admission().await.unwrap();
+}
+
+/// **A blocked preflight blocks the FLIP, not just the call.**
+///
+/// The seam here is injected, so what this proves is the *ordering* half: a
+/// refusal leaves the durable mode and the epoch exactly where they were, and
+/// leaves admission paused, because `resume_admission` requires a journaled
+/// flip and the flip requires a journaled preflight. The half this cannot prove
+/// — that the preflight production composes is the real one — is proven in
+/// `tests/authority_cutover.rs`, which drives
+/// `djinn_k8s::cutover_preflight::run` over a live render through
+/// `ResizeRollout::production`.
+#[tokio::test]
+async fn a_blocked_preflight_leaves_the_mode_and_the_epoch_where_they_were() {
+    let db = Database::ephemeral().await.unwrap();
+    assert_real_postgres(&db).await;
+    seed_project_and_run(&db, "019fb854-cccc-7000-8000-000000000001").await;
+    let image = seed_image(&db, "legacy", Some(&digest('a')), None).await;
+
+    let pods = RecordingPodPlane::drained();
+    let preflight = RecordingPreflight::clear();
+    let rollout = ResizeRollout::new(
+        db.clone(),
+        signed_inventory(&[digest('a')]),
+        durable_admission(&db),
+        Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
+        Arc::new(UnusedRegistry),
+        Arc::clone(&preflight) as Arc<dyn CutoverPreflight>,
+    );
+    rollout.verify_retention(&[]).await.unwrap();
+    rollout
+        .pause_admission("eeky cutover", &probe_for(&image))
+        .await
+        .unwrap();
+    rollout.prove_drained().await.unwrap();
+
+    for (case, verdict) in [
+        (
+            "blocked",
+            PreflightVerdict::Blocked {
+                classes: vec!["pods-resize-rbac".into()],
+                defects: vec!["pods-resize-rbac no Role grants the exact triple".into()],
+            },
+        ),
+        (
+            "unevaluable",
+            PreflightVerdict::Unevaluable("the render could not be read".into()),
+        ),
+        // "No defects" and "no checks ran" must not be the same verdict. A
+        // preflight that quietly stopped evaluating would otherwise return the
+        // cleanest answer in the system.
+        (
+            "vacuous",
+            PreflightVerdict::Clear {
+                evaluated: Vec::new(),
+            },
+        ),
+    ] {
+        preflight.set(verdict);
+        let calls_before = preflight.calls();
+        let blocked = rollout
+            .clear_preflight(RESIZE)
+            .await
+            .expect_err("a non-clean preflight must block");
+        assert!(
+            matches!(
+                blocked,
+                RolloutBlocked::PreflightRefused { .. }
+                    | RolloutBlocked::PreflightUnevaluable(_)
+                    | RolloutBlocked::PreflightVacuous
+            ),
+            "{case}: {blocked:?}"
+        );
+        assert_eq!(
+            preflight.calls(),
+            calls_before + 1,
+            "{case}: the preflight must actually have been consulted"
+        );
+        assert!(
+            !rollout.journal().contains(&RolloutStep::PreflightCleared),
+            "{case}: a blocked preflight must not journal a cleared step"
+        );
+
+        // THE ASSERTION THAT MATTERS: not that an error came back, but that the
+        // durable authority row is untouched. An error returned *after* a flip
+        // would satisfy the first and fail this.
+        assert_eq!(
+            authority(&db).await,
+            (LEAF, 0),
+            "{case}: the mode and the epoch must not have moved"
+        );
+        assert_eq!(
+            rollout
+                .attempt_dispatch("019fb854-cccc-7000-8000-000000000002", &image)
+                .await,
+            DispatchOutcome::RefusedByAdmissionPause,
+            "{case}: admission must be left paused"
+        );
+        assert_eq!(pods.pod_creations(), 0, "{case}");
+    }
+
+    // And with the flip still unreachable, so is the resume.
+    assert_eq!(
+        rollout.resume_admission().await,
+        Err(RolloutBlocked::StepOutOfOrder {
+            step: RolloutStep::AdmissionResumed,
+            missing: RolloutStep::AuthorityModeFlipped
+        })
+    );
 }
 
 /// A step cannot run twice, so a replayed cutover cannot launder a fence.
@@ -1189,6 +1381,7 @@ async fn no_step_runs_twice() {
         durable_admission(&db),
         RecordingPodPlane::drained(),
         Arc::new(UnusedRegistry),
+        RecordingPreflight::clear(),
     );
     rollout.freeze_catalog_mutation().unwrap();
     assert_eq!(
@@ -1219,6 +1412,7 @@ async fn no_pod_ever_has_two_quota_authorities_or_none() {
         durable_admission(&db),
         Arc::clone(&pods) as Arc<dyn TaskRunPodPlane>,
         Arc::new(UnusedRegistry),
+        RecordingPreflight::clear(),
     );
 
     // ── mode `leaf-v1` ───────────────────────────────────────────────────
@@ -1380,6 +1574,12 @@ fn the_production_composition_site_wires_only_production_implementations() {
         "KubernetesTaskRunPodPlane::new",
         "HttpRegistryProbe::new",
         "LegacyDigestInventory::process()",
+        // The preflight the flip is gated on must be the REAL one, assembled
+        // from a live render by the same module `bin/cutover-preflight.rs`
+        // uses. A production constructor that accepted an
+        // `Arc<dyn CutoverPreflight>` would be a seam through which a fake
+        // verdict could reach the flip.
+        "DeployRenderPreflight::load",
         "Self::new(",
     ] {
         assert!(


### PR DESCRIPTION
## The problem

`ResizeRollout::production` had **zero callers in any binary**. Proposal `3i92`'s staged activation was composed, tested, documented — and runnable by nobody. Its only reference outside its own module was a test asserting the constructor existed.

Worse, `ResizeRollout::activate` / `rollback` **never consulted the preflight**. "The preflight gates the flip" was true of a test-local helper (`gated_flip` in `task_run_resize_mixed_version.rs`), not of production.

This PR is the operator entry point, and it makes the preflight gate structural.

## What an operator now types

```bash
# activate: leaf-v1 -> resize-v2
DJINN_CUTOVER_DIRECTION=activate \
DJINN_CUTOVER_AUTHORITY_MODE=resize-v2 \
DJINN_CUTOVER_PLAN=/path/to/plan.json \
DJINN_DATABASE_URL=postgres://... \
DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY=/path/to/legacy-digests.json \
DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_PUBLIC_KEY=<base64> \
DJINN_LEGACY_LAUNCHER_DIGEST_INVENTORY_SIGNATURE=<base64> \
  deploy/cutover/authority-cutover.sh deploy/helm/djinn --values prod-values.yaml

# roll back: resize-v2 -> leaf-v1
DJINN_CUTOVER_DIRECTION=rollback DJINN_CUTOVER_AUTHORITY_MODE=leaf-v1 ... same command
```

`0` flipped · `1` blocked (mode unchanged; it says whether admission is left paused) · `2` unevaluable, nothing attempted — the same triple `cutover-preflight` and `render-gate` already speak.

## The surface, and why

**A `bin/` driver, not an admin MCP tool.** Three properties decided it, and an MCP tool fails each:

1. **The verdict must depend on the RENDER, not on the process reading it.** The preflight's Rust half re-renders the task-run Job from `DJINN_K8S_*`, which has to come from the *rendered* `djinn-server` container. `deploy/cutover/authority-cutover.sh` delegates to `deploy/preflight/cutover-preflight.sh` with `CUTOVER_PREFLIGHT_BIN` pointed at the cutover binary — so the flip and the deploy gate render the same chart, extract the same environment, and re-exec under the same `env -i`. A tool inside a running server reads that server's environment, which is the **old** deployment's; step 3 of the runbook exists precisely because the new server is deployed while the mode has not moved.
2. **Step 3 deploys a new server and steps 4-10 must survive it.** An entry point hosted by the process being replaced cannot run a sequence that replaces it.
3. **The refusal is the product.** Exit codes are what a deploy lane reads.

## The preflight gate is structural, not a call somebody remembered

`RolloutStep::PreflightCleared` is now a prerequisite of `AuthorityModeFlipped`. Deleting `clear_preflight` from `activate` does not produce an ungated flip — it produces `StepOutOfOrder`. It sits *after* the drain proof because the preflight judges the drain fence too, and on a live deployment that fence is never empty before admission is paused.

`djinn_k8s::cutover_preflight_driver` extracts the input assembly out of `bin/cutover-preflight.rs`, so the gate the deploy lane runs and the gate the flip runs are **one assembly over one validator**. The binary's output and its 0/1/2 exit contract are byte-compatible; `deploy/preflight/tests/cutover-preflight.sh` passes 14/14 unchanged, and all 18 helm-backed proofs in `tests/cutover_preflight.rs` still pass.

## Two real defects found on the way

* **`RolloutBlocked::NonterminalResizeRows` carried the rows and rendered `.0.len()`.** The struct had `task_run_id`/`state`/`pod_uid`; the operator read `1 permit(s) are in a nonterminal resize state`. Carrying rows and hiding them in the message is the same failure as not carrying them. Both it and `LiveTaskRunPods` now render by identity. **AC3 caught this — it was red until it was fixed.**
* **`rollback` blocks *before* its own pause step**, so a journal-derived "admission left paused" reported `untouched` while a half-finished forward cutover's pause was still live. It is now read from the production dispatch-pause predicate — the expression the coordinator's dispatch loop guards on — and an unreadable state reports PAUSED.

## Acceptance criteria — every mutation was RUN, not described

| AC | Assertion | Mutation | Result |
|---|---|---|---|
| 1 | `ResizeRollout::production` has a production caller | delete the call | `check-resize-reachability.sh` fails naming the symbol; self-test grew 8 cases (22 total) |
| 2 | a failing preflight blocks the **flip** | (a) let a `Blocked` verdict through `clear_preflight`; (b) un-break the render | both -> cutover completes -> **RED** |
| 3 | refusal names `task_run_id`/`state`/`pod_uid` | make `prove_drained` stop reading rows | **RED**. The named `set_mode` mutation is *executed inline*: `set_mode` is called on the same seeded state and its census asserted **not** to contain either identity |
| 4 | rollback refuses, admission stays paused, zero Pod creations | make retention a no-op | **RED** |

AC1's guard also pins five composition anchors: the driver calls `production`, the binary calls the driver, `[[bin]]` declares the target, both sequences go through `ResizeRollout`, and *both* flips call the preflight. The `#[cfg(test)]` structural tracking recently added to that script is preserved and re-proven (cases 13/14 still pass).

## What is real in `tests/authority_cutover.rs`

Everything goes through `authority_cutover::run` — the function the binary's `main` is a shell around — which composes `ResizeRollout::production`. Real PostgreSQL, real `DurableAdmissionControl` read through the coordinator's own predicate, real HTTP round trips to a real OCI-manifest socket, the real `djinn_k8s::cutover_preflight::run`, and the real `KubernetesTaskRunPodPlane`.

**No cluster is touched.** Every `KubernetesRuntime` constructor but `from_client` resolves through `kube::Client::try_default()` — the ambient kubeconfig, which on this machine is live EKS. So `djinn_k8s::runtime_fixture` (test-support, gated exactly like `pod_resize_fixture`) supplies a client whose *transport* is a `tower` service and nothing else: `Api::namespaced`, the URL the lister builds, and the deserialization are all production code. "Zero Pod creations" is asserted against the recorded **wire**, not against a counter the code under test increments.

AC4 runs a **control** first — a rollback whose artifacts are all pullable, which completes and moves the mode — so the mutation's "the mode did not move" and "the recorder saw no creations" are not assertions about a path that never worked or a fixture that was dead.

## Runbook

`docs/deploy/launcher-authority-cutover.md` is updated to match, not the other way round: the command, the plan-file schema, the new step 8, the corrected rollback semantics, and a note that a standalone preflight run against a live deployment will legitimately block on `drain-fence`.

## Verification run locally

- `cargo test -p djinn-server --test authority_cutover` — 5/5
- `cargo test -p djinn-server --test task_run_resize_{rollout,mixed_version,cycles,faults,recovery,dispatch_seam}` — all green
- `cargo test -p djinn-k8s` (356 lib) + `--test cutover_preflight -- --ignored` (18 helm-backed) — all green
- `deploy/preflight/tests/cutover-preflight.sh` — 14/14
- `scripts/test-check-resize-reachability.sh` — 22/22
- `check-{resize-reachability,resize-cutover-retention,resize-authorization-boundary,http,k8s,git,raw-sql,include-macro,test-global-metrics}` — OK
- `scripts/test-deploy-contracts.sh` — 9/9
- `cargo clippy --workspace --all-targets` clean · `cargo fmt --check` clean · `cargo hakari verify` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
