### PR TITLE
fix(deploy): graph-warm is not a cache warm — the SCIP Job split has no chart surface and has never run

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -478,6 +478,30 @@ spec:
               value: {{ .Values.scipCache.maxBytes | int64 | quote }}
             - name: DJINN_SCIP_CACHE_MAX_IDLE_HOURS
               value: {{ .Values.scipCache.maxIdleHours | quote }}
+            # Standalone SCIP-index Job. `DJINN_K8S_SCIP_INDEX_ENABLED` is the
+            # ONLY thing that decides whether that Job is ever created
+            # (`djinn_k8s::scip_schedule::ScipIndexScheduler::enabled`, read per
+            # tick), and it defaults to false in the binary. Rendering it
+            # explicitly — even as "false" — is what makes it an operator lever:
+            # before this block the chart set no value for it anywhere, so the
+            # Job split shipped green and never ran once, and every graph-warm
+            # paid the full inline SCIP index it exists to remove.
+            #
+            # Listed in `djinn_k8s::config::FAIL_CLOSED_ARMING_SWITCHES`, whose
+            # members this chart is required to render — see
+            # deploy/helm/djinn/tests/scip-index-arming-render.sh.
+            - name: DJINN_K8S_SCIP_INDEX_ENABLED
+              value: {{ .Values.scipIndex.enabled | quote }}
+            - name: DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS
+              value: {{ .Values.scipIndex.intervalSeconds | int64 | quote }}
+            - name: DJINN_K8S_SCIP_QUIESCENCE_SECONDS
+              value: {{ .Values.scipIndex.quiescenceSeconds | int64 | quote }}
+            # Read by the warm Pod, not by this one: the server projects it onto
+            # every warm Job it renders (`djinn_k8s::warm_job`), and
+            # `djinn_graph::semantic_index_claim` reads it there. A value the
+            # server never parses is a value no warm Pod can ever be given.
+            - name: DJINN_K8S_SCIP_CLAIM_WAIT_SECONDS
+              value: {{ .Values.scipIndex.claimWaitSeconds | int64 | quote }}
             # Per-invocation CPU lease. `required` renders the cgroup-launcher
             # sidecar onto every task-run Pod; `disabled` is an explicit local
             # development compatibility profile that renders no launcher surface.

--- a/deploy/helm/djinn/tests/scip-index-arming-render.sh
+++ b/deploy/helm/djinn/tests/scip-index-arming-render.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Every fail-closed arming switch the server binary reads MUST have a chart
+# surface, and the standalone SCIP-index Job's cadence knobs must render as
+# values the server can parse.
+#
+# # Why this test exists
+#
+# PR #2697 split the semantic (SCIP) index out of the graph-warm Job so a warm
+# would stop paying for it. `DJINN_K8S_SCIP_INDEX_ENABLED` was made the per-tick
+# arming switch precisely so that arming would be "a config flip, not a
+# redeploy" — and then no chart, no values file and no deploy script ever set
+# it. The feature shipped, every test stayed green, and it created zero Jobs in
+# production while `kueue-topology.yaml` went on rendering a `-scip` LocalQueue
+# to admit Jobs nothing could create. Every graph-warm kept paying the full
+# inline index: 3644s of a measured 5442s warm.
+#
+# The required env set is READ OUT OF THE RUST SOURCE
+# (`djinn_k8s::config::FAIL_CLOSED_ARMING_SWITCHES`), never enumerated here. A
+# new arming switch added to that list without a chart surface fails this test;
+# deleting an existing switch's env block from deployment-server.yaml fails it
+# too; renaming or deleting the list itself fails it, because a parse that finds
+# no switches is treated as a broken contract rather than a satisfied one. A
+# test with the names hard-coded here would have gone on passing through exactly
+# the defect it exists to catch.
+#
+# Usage: bash deploy/helm/djinn/tests/scip-index-arming-render.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CHART_DIR/../../.." && pwd)"
+CONFIG_RS="$REPO_ROOT/server/crates/djinn-k8s/src/config.rs"
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "FAIL: required test tool '$1' is not installed" >&2
+        exit 1
+    }
+}
+
+require_tool helm
+require_tool python3
+
+[ -f "$CONFIG_RS" ] || {
+    echo "FAIL: cannot read the arming-switch source of truth: $CONFIG_RS" >&2
+    exit 1
+}
+
+TMPDIR_RENDER=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_RENDER"' EXIT
+
+render() {
+    local output=$1
+    shift
+    helm template scip-index-arming-test "$CHART_DIR" \
+        --is-upgrade \
+        --show-only templates/deployment-server.yaml "$@" >"$output"
+}
+
+# Assert that every switch named in FAIL_CLOSED_ARMING_SWITCHES is rendered onto
+# the server Deployment with a non-empty value.
+assert_every_arming_switch_is_rendered() {
+    local manifest=$1
+    python3 - "$CONFIG_RS" "$manifest" <<'PY'
+import re
+import sys
+
+config_rs, manifest = sys.argv[1:]
+source = open(config_rs, encoding="utf-8").read()
+
+block = re.search(
+    r"pub const FAIL_CLOSED_ARMING_SWITCHES\s*:\s*&\[ArmingSwitch\]\s*=\s*&\[(.*?)\n\];",
+    source,
+    re.S,
+)
+assert block, (
+    "FAIL_CLOSED_ARMING_SWITCHES was not found in "
+    f"{config_rs}. If it was renamed or moved, point this test at the new "
+    "source of truth — an unparsed list must never read as an empty one."
+)
+switches = re.findall(r'env\s*:\s*"([^"]+)"', block.group(1))
+assert switches, (
+    "FAIL_CLOSED_ARMING_SWITCHES parsed to zero entries; the contract this "
+    "test enforces would be vacuous"
+)
+
+rendered = open(manifest, encoding="utf-8").read().splitlines()
+
+
+def env_value(name):
+    for index, line in enumerate(rendered):
+        if re.match(rf"^\s*- name: {re.escape(name)}$", line):
+            match = re.match(r"^\s*value: (.+)$", rendered[index + 1])
+            assert match, f"{name} is rendered with no literal value"
+            return match.group(1).strip().strip('"')
+    return None
+
+
+missing = [name for name in switches if env_value(name) is None]
+assert not missing, (
+    "these fail-closed arming switches have NO surface on the server "
+    f"Deployment: {missing}. An unset fail-closed switch is not a disabled "
+    "feature, it is an unreachable one: there is no supported way to turn it "
+    "on and the deployment looks healthy while the code path never runs."
+)
+for name in switches:
+    value = env_value(name)
+    assert value != "", f"{name} renders an empty value, which the server cannot parse"
+
+print(f"checked {len(switches)} fail-closed arming switch(es): {', '.join(switches)}")
+PY
+}
+
+assert_env_values() {
+    local manifest=$1
+    shift
+    python3 - "$manifest" "$@" <<'PY'
+import re
+import sys
+
+manifest, *pairs = sys.argv[1:]
+lines = open(manifest, encoding="utf-8").read().splitlines()
+
+
+def env_value(name):
+    for index, line in enumerate(lines):
+        if re.match(rf"^\s*- name: {re.escape(name)}$", line):
+            match = re.match(r"^\s*value: (.+)$", lines[index + 1])
+            assert match, f"{name} has no rendered value"
+            value = match.group(1)
+            assert value.startswith('"') and value.endswith('"'), (
+                f"{name} must render as a quoted literal, got {value!r}"
+            )
+            return value.strip('"')
+    raise AssertionError(f"{name} is not rendered onto the server Deployment")
+
+
+for pair in pairs:
+    name, expected = pair.split("=", 1)
+    actual = env_value(name)
+    assert actual == expected, f"{name}: expected {expected!r}, got {actual!r}"
+    if expected in ("true", "false"):
+        continue
+    # Helm decodes YAML numbers as float64, so a bare `| quote` renders 10800
+    # as "10800" but a larger default as scientific notation the server's
+    # `parse::<u64>()` rejects — and a rejected value is silently replaced by
+    # the built-in default, i.e. a knob that reads as wired but is not.
+    assert re.fullmatch(r"[0-9]+", actual), (
+        f"{name} must render as a decimal integer, got {actual!r}"
+    )
+PY
+}
+
+expect_rejected() {
+    local name=$1
+    shift
+    echo "=== invalid $name ==="
+    if render "$TMPDIR_RENDER/$name.yaml" "$@" 2>&1; then
+        echo "FAIL: invalid scipIndex scenario '$name' rendered successfully" >&2
+        exit 1
+    fi
+}
+
+echo "=== every fail-closed arming switch has a chart surface ==="
+render "$TMPDIR_RENDER/defaults.yaml"
+assert_every_arming_switch_is_rendered "$TMPDIR_RENDER/defaults.yaml"
+
+echo "=== shipped defaults render the SCIP Job disarmed, explicitly ==="
+assert_env_values "$TMPDIR_RENDER/defaults.yaml" \
+    DJINN_K8S_SCIP_INDEX_ENABLED=false \
+    DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS=10800 \
+    DJINN_K8S_SCIP_QUIESCENCE_SECONDS=3523 \
+    DJINN_K8S_SCIP_CLAIM_WAIT_SECONDS=900
+
+echo "=== an operator can arm it and retune every gate ==="
+render "$TMPDIR_RENDER/armed.yaml" \
+    --set scipIndex.enabled=true \
+    --set scipIndex.intervalSeconds=3600 \
+    --set scipIndex.quiescenceSeconds=0 \
+    --set scipIndex.claimWaitSeconds=0
+assert_env_values "$TMPDIR_RENDER/armed.yaml" \
+    DJINN_K8S_SCIP_INDEX_ENABLED=true \
+    DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS=3600 \
+    DJINN_K8S_SCIP_QUIESCENCE_SECONDS=0 \
+    DJINN_K8S_SCIP_CLAIM_WAIT_SECONDS=0
+
+expect_rejected negative-interval --set scipIndex.intervalSeconds=-1
+expect_rejected negative-quiescence --set scipIndex.quiescenceSeconds=-1
+expect_rejected negative-claim-wait --set scipIndex.claimWaitSeconds=-1
+expect_rejected noninteger-enabled --set-string scipIndex.enabled=yes
+expect_rejected unknown-key --set scipIndex.enable=true
+
+echo "=== All SCIP-index arming Helm render tests passed ==="

--- a/deploy/helm/djinn/values.schema.json
+++ b/deploy/helm/djinn/values.schema.json
@@ -29,6 +29,22 @@
         "maxIdleHours": { "type": "integer", "minimum": 0 }
       }
     },
+    "scipIndex": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "intervalSeconds",
+        "quiescenceSeconds",
+        "claimWaitSeconds"
+      ],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "intervalSeconds": { "type": "integer", "minimum": 1 },
+        "quiescenceSeconds": { "type": "integer", "minimum": 0 },
+        "claimWaitSeconds": { "type": "integer", "minimum": 0 }
+      }
+    },
     "kueue": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -67,6 +67,46 @@ scipCache:
   maxIdleHours: 168
 
 # -----------------------------------------------------------------------------
+# Standalone SCIP-index Job
+# -----------------------------------------------------------------------------
+# PR #2697 split the semantic (SCIP) index out of the graph-warm Job into its
+# own Job so a warm would find the index already computed and only warm the
+# cargo/build cache. `enabled` below is the ONLY thing that decides whether that
+# Job is ever created (`djinn_k8s::scip_schedule::ScipIndexScheduler::enabled`,
+# read per tick from `DJINN_K8S_SCIP_INDEX_ENABLED`, default false).
+#
+# Until this block existed the chart rendered NO env var for it, so the switch
+# had no operator surface at all: the split shipped, stayed green, and never
+# ran once in production. Every warm therefore paid the full inline index —
+# measured 2026-07-27 at 3644s of a 5442s warm, i.e. 67% of the warm's wall
+# clock was the phase the split exists to remove. The chart even renders a
+# `<fullname>-scip` LocalQueue (templates/kueue-topology.yaml) to admit Jobs
+# that nothing could create.
+#
+# Arming this creates an additional Pod sized by `resources.scip` — a 16Gi
+# memory limit against a measured ~10 GB peak. Read the cadence gates in
+# `djinn_k8s::scip_schedule::decide` before arming: the Job is additionally
+# skipped while a warm Job is in flight and while the head has not stood still
+# for `quiescenceSeconds`, so on a repository that merges more often than it
+# indexes, arming it costs a Pod and returns little.
+scipIndex:
+  # Master arming switch. False renders the switch explicitly OFF — which is
+  # the point: an env var rendered as "false" is a lever an operator can find
+  # and flip; an absent one is a feature nobody can reach.
+  enabled: false
+  # Cadence floor between dispatches, in seconds. Default 3h.
+  intervalSeconds: 10800
+  # How long the repository head must have stood still before an index is worth
+  # producing, in seconds. Default 3523 — the measured SCIP phase cost. The
+  # cache key folds in source hashes, so an index produced at a head that then
+  # moves serves nobody. 0 disables the gate.
+  quiescenceSeconds: 3523
+  # How long a warm Pod waits for another Pod's in-flight index of the same
+  # tree before indexing inline itself, in seconds. Projected onto every warm
+  # Pod as DJINN_SCIP_CLAIM_WAIT_SECONDS. 0 disables waiting.
+  claimWaitSeconds: 900
+
+# -----------------------------------------------------------------------------
 # Kueue prerequisite topology
 # -----------------------------------------------------------------------------
 # The exact pods quota for Kueue's inert prerequisite queues; task-run and warm

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -19,6 +19,53 @@ use crate::launcher::CgroupLauncherMode;
 /// followed by the whole warm.
 pub const MEASURED_FULL_WARM_SECONDS: i64 = 5_442;
 
+/// One operator lever whose default is OFF, so an unset environment variable
+/// leaves the feature permanently inert.
+///
+/// The `armed` probe is what makes membership checkable rather than declared:
+/// [`fail_closed_arming_switches_are_all_off_by_default`] reads it against
+/// [`KubernetesConfig::for_testing`], so a switch listed here that is actually
+/// on by default fails the build instead of quietly overstating the contract.
+#[derive(Clone, Copy, Debug)]
+pub struct ArmingSwitch {
+    /// Environment variable the server reads to arm the feature.
+    pub env: &'static str,
+    /// Reads the armed state this switch controls out of a config.
+    pub armed: fn(&KubernetesConfig) -> bool,
+}
+
+/// Every environment variable whose ABSENCE silently disables a whole feature.
+///
+/// # Why this list exists as data
+///
+/// A fail-closed switch that no chart renders is not a disabled feature, it is
+/// an unreachable one — there is no supported way to turn it on, and the
+/// deployment looks healthy while the code path never executes. That is exactly
+/// what happened to the standalone SCIP-index Job: PR #2697 split the semantic
+/// index out of the graph-warm Job specifically so a warm would stop paying for
+/// it, `DJINN_K8S_SCIP_INDEX_ENABLED` was made the per-tick arming switch so
+/// that "arming is a config flip, not a redeploy" — and then no chart, no values
+/// file and no deploy script ever set it. The split shipped, stayed green, and
+/// never created a single Job in production, while `kueue-topology.yaml` went on
+/// rendering a `-scip` LocalQueue to admit Jobs nothing could create. Every warm
+/// kept paying the full inline index: 3644s of a measured 5442s warm.
+///
+/// `deploy/helm/djinn/tests/scip-index-arming-render.sh` derives its required
+/// env set from THIS list and fails when the server Deployment does not render
+/// a member. Adding a switch here without a chart surface fails that test;
+/// deleting the chart surface of an existing one fails it too. The list is the
+/// contract, the chart is the obligation.
+pub const FAIL_CLOSED_ARMING_SWITCHES: &[ArmingSwitch] = &[
+    ArmingSwitch {
+        env: "DJINN_K8S_SCIP_INDEX_ENABLED",
+        armed: |cfg: &KubernetesConfig| cfg.scip_index_enabled,
+    },
+    ArmingSwitch {
+        env: "DJINN_KUEUE_ARMED",
+        armed: |cfg: &KubernetesConfig| cfg.kueue_armed,
+    },
+];
+
 /// Configuration for `KubernetesRuntime`.
 ///
 /// Loaded once at djinn-server boot and cloned into the runtime. Fields
@@ -945,5 +992,54 @@ pub(crate) mod tests {
             cfg.warm_job_timeout_seconds,
             MEASURED_FULL_WARM_SECONDS,
         );
+    }
+
+    /// Membership in [`FAIL_CLOSED_ARMING_SWITCHES`] has to be *true*, not
+    /// merely asserted: the chart-render obligation the list creates is only
+    /// justified for a switch that is genuinely off until something sets it.
+    ///
+    /// A switch that is on by default needs no chart surface to be reachable,
+    /// so listing it here would inflate the contract with an entry whose
+    /// absence from the chart costs nothing — and the next reader would trust
+    /// the list less. Probing the config is what keeps the list honest.
+    #[test]
+    fn fail_closed_arming_switches_are_all_off_by_default() {
+        let cfg = KubernetesConfig::for_testing();
+        assert!(
+            !FAIL_CLOSED_ARMING_SWITCHES.is_empty(),
+            "the fail-closed arming-switch list is empty; the chart-render \
+             contract in deploy/helm/djinn/tests/scip-index-arming-render.sh \
+             would then assert nothing at all"
+        );
+        for switch in FAIL_CLOSED_ARMING_SWITCHES {
+            assert!(
+                !(switch.armed)(&cfg),
+                "{} is listed as a FAIL-CLOSED arming switch but the shipped \
+                 default already has its feature armed. Either the default \
+                 changed (and the switch no longer needs a chart surface to be \
+                 reachable), or the probe reads the wrong field.",
+                switch.env,
+            );
+        }
+    }
+
+    /// Duplicate entries would let one charted switch satisfy the render
+    /// contract twice while a second, genuinely unrendered switch hid behind
+    /// the same name.
+    #[test]
+    fn fail_closed_arming_switches_are_uniquely_named() {
+        let mut seen = std::collections::BTreeSet::new();
+        for switch in FAIL_CLOSED_ARMING_SWITCHES {
+            assert!(
+                switch.env.starts_with("DJINN_"),
+                "{} does not look like a djinn env var",
+                switch.env
+            );
+            assert!(
+                seen.insert(switch.env),
+                "{} is listed twice in FAIL_CLOSED_ARMING_SWITCHES",
+                switch.env
+            );
+        }
     }
 }


### PR DESCRIPTION
## Why a graph-warm Job takes ~45–90 minutes

**It is not a cache warm.** It is a full cargo compile *plus* a full semantic index, and the Job split that was supposed to remove the second half has never run in production.

### The mechanism, from the code

1. `warm_job.rs:214` — the warm Pod's command is `exec djinn-agent-worker warm-graph <project>`. That subcommand runs **two** phases (`main.rs:3941` → `warm_cargo_and_continue`):
   * `warm_cargo_target_base` (`main.rs:1323`) — `cargo clippy --all-targets` + `cargo test --no-run --all-targets` over the whole workspace (`cargo_cache_policy.rs::build_warm_commands`);
   * then `run_warm_graph_command` → `ensure_canonical_graph` → `run_indexers_already_locked` (`canonical_graph.rs:1131`) — the `rust-analyzer scip` fan-out, **inline, in the warm Pod**.
2. The renderer's own measurement (`warm_job.rs:427`, `config.rs::MEASURED_FULL_WARM_SECONDS`): a complete production warm on 2026-07-27 spent **1798s in cargo and 3644s in the graph phase — 5442s end to end**. Two thirds of a warm is the phase the split exists to remove.
3. PR #2697 created `scip_job.rs` + `scip_schedule.rs` to move that phase into its own Job. Whether that Job is ever created is decided per tick by `scip_index_enabled` (`config.rs:503`, default **false**), read from `DJINN_K8S_SCIP_INDEX_ENABLED`.
4. **No chart, values file, or deploy script has ever set that variable.** Before this PR it appeared in exactly four Rust files and nowhere else in the repo — while `templates/kueue-topology.yaml:164` renders a `<fullname>-scip` LocalQueue to admit Jobs nothing can create, and `values.yaml` documents arming as reaching "the task-run, warm and standalone-**SCIP** renderers".

So in production the SCIP Job has never been dispatched, `semantic_index_claim` always resolves to `Held` immediately (there is no other indexer to wait for), and **100% of SCIP work happens inline in the warm.** The owner's premise — "SCIP indexing runs as a separate Job, so graph-warm should be warming the cargo cache only" — is the design; it is not what is deployed.

### The 17-minute gap is not a Pod restart

`warm_job.rs:419` sets `backoff_limit: Some(0)`. A warm Job gets exactly one Pod: if it fails, the Job goes `Failed` with `active=0`. The observation had `active=1` at 23:12, which is inconsistent with "the first Pod died and was retried". The gap is queueing:

* `warm_job.rs:422` sets `suspend: config.kueue_job_suspend()` — **when Kueue is armed the Job is created suspended and no Pod object exists at all until Kueue admits it** against a `kueue.buildPods: 3` quota (`values.yaml:94`). A 17-minute wait for one of three build slots, behind a warm that holds its slot for its whole cargo phase, is unremarkable; or
* the Pod was created and sat `Pending` on 4 CPU / warm-memory requests on a single node (`status.startTime` is only stamped once the kubelet acknowledges a bound Pod).

Either way: ~17 min queued + ~17 min running = a *normal* warm caught at t+17 of a ~90-minute run, not an anomaly. Commands to settle which, next time, are below.

## What this PR changes

It makes the lever reachable and makes the whole class of defect fail CI.

* `scipIndex.{enabled,intervalSeconds,quiescenceSeconds,claimWaitSeconds}` in `values.yaml` / `values.schema.json`, rendered onto the server Deployment. `enabled` ships **false** — this PR makes the switch findable and flippable; it does not arm a 16Gi Pod on anyone's cluster (see "what I did not do").
* `claimWaitSeconds` was equally unsettable: the server projects it onto every warm Pod as `DJINN_SCIP_CLAIM_WAIT_SECONDS` (`warm_job.rs:249`), and a value the server never parses is a value no warm Pod can be given.
* `djinn_k8s::config::FAIL_CLOSED_ARMING_SWITCHES` — every env var whose *absence* silently disables a feature, each paired with a probe reading the armed state out of a config.
* `deploy/helm/djinn/tests/scip-index-arming-render.sh` — globbed by `scripts/test-helm-chart-contracts.sh`, so CI runs it. It **derives its required env set from the Rust list** instead of hard-coding names; a hard-coded test would have passed through this exact defect.

### ACs, each with the mutation that fails it

| Assertion | Mutation that makes it fail |
| --- | --- |
| Every `FAIL_CLOSED_ARMING_SWITCHES` member is rendered on the server Deployment | Rename/delete an env block in `deployment-server.yaml` → **verified: fails, naming the missing switch**; revert → PASS |
| The list is a real contract, not a claim | Delete or rename `FAIL_CLOSED_ARMING_SWITCHES` → the parse finds zero entries and the test **fails** rather than vacuously passing |
| A listed switch is genuinely fail-closed | Flip its shipped default to armed → `fail_closed_arming_switches_are_all_off_by_default` fails |
| An operator can actually set the knobs | Drop `scipIndex` from `values.yaml` → render fails; make a knob render as float64 sci-notation → the decimal-integer assertion fails |
| Bad operator input fails the render, not the runtime | Remove the schema bounds → the five `expect_rejected` scenarios render successfully and the test fails |

## What I deliberately did NOT do

**I did not arm SCIP dispatch**, and arming it is not the fix for warm duration on this repo:

* `scip_schedule::decide` skips while a **warm Job is in flight**, and a warm is near-continuous here (`mirror_fetcher` triggers every 60s; the warm debounce collapses every window at its 900s cap — documented as dead at `scip_schedule.rs:12`), so the standalone Job would rarely get a window;
* it also requires the head to have stood still for `quiescenceSeconds` (3523s). But a warm dispatches on *every* head advance and takes ~90 min, so by the time a head has been still for 59 minutes the warm for that head has already indexed it. **The SCIP Job cannot front-run a warm under the current scheduler** — it can only produce artifacts for trees the warm already covered. This is consistent with the 2026-07-28 measurement where the Job indexed `server` in 2811s at rev `95dc2969` and the warm 104 minutes later ran at `068b947f`, missed the content-keyed cache entirely, and re-indexed inline.

Making the split actually pay off means changing *when* SCIP is dispatched (e.g. dispatch on head-advance immediately ahead of a warm, and have the warm wait on that claim), which is a scheduling change with production impact and belongs in its own task. It is also gated on production disk state I cannot see (the node is at ~82%, with a recurring `cargo-target-runs` pattern), so I am not making it blind.

## Capture this on the next warm run

```bash
NS=djinn
J=$(kubectl -n $NS get job -l djinn.app/component=graph-warm \
      --sort-by=.metadata.creationTimestamp -o name | tail -1)

# 1. Was the 17-minute gap admission, or scheduling? These three settle it.
kubectl -n $NS get $J -o jsonpath='{.spec.suspend}{"\n"}{.spec.backoffLimit}{"\n"}'
kubectl -n $NS get workload -o custom-columns=\
NAME:.metadata.name,ADMITTED:.status.conditions[?(@.type==\"Admitted\")].lastTransitionTime
kubectl -n $NS get pod -l job-name=${J#job.batch/} \
  -o custom-columns=NAME:.metadata.name,CREATED:.metadata.creationTimestamp,\
START:.status.startTime,PHASE:.status.phase
# creationTimestamp == Job creation + late startTime  => Pending on scheduling
# no Pod until admission                              => Kueue queue wait
kubectl -n $NS get events --field-selector involvedObject.name=${J#job.batch/}

# 2. Prove the split is inert (expected: empty output).
kubectl -n $NS get job -l djinn.app/scip-index=true
kubectl -n $NS get deploy djinn-server \
  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="DJINN_K8S_SCIP_INDEX_ENABLED")]}{"\n"}'

# 3. Attribute the warm's wall clock to a phase — the effect, not a label.
P=$(kubectl -n $NS get pod -l job-name=${J#job.batch/} -o name | head -1)
kubectl -n $NS logs $P --tail=-1 > /tmp/warm.log
grep -E 'cargo warm: resolved per-step budgets|cargo warm: warm target base compile complete' /tmp/warm.log
grep -E 'ensure_canonical_graph: build pipeline complete' /tmp/warm.log   # carries indexers_ms
grep -E 'semantic index claim' /tmp/warm.log                              # expect: NO holder, ever
grep -c 'SCIP cache hit — skipping indexer invocation' /tmp/warm.log      # expect: 0 for `server`
grep -E 'cargo warm: warm-base convergence delta' /tmp/warm.log           # test_unit_delta ≥ 0 across cycles
grep -E 'cargo warm: skipping warm-base sweep|sweep_decision' /tmp/warm.log
```

Read them together: `indexers_ms ≈ 3.6e6` with **zero** `SCIP cache hit` lines confirms the diagnosis (the warm indexed everything itself). A `sweep_decision=skipped_truncated` plus a negative `test_unit_delta` would instead point at the separate warm-base convergence failure mode. `elapsed_ms` on the cargo completion line minus `indexers_ms` splits the ~90 minutes cleanly between the two phases.
