### PR TITLE
fix(build-lease): retire leases whose Job finished, sweep queued rows, and give operators a way out

### DIFF
--- a/deploy/kueue/preflight.sh
+++ b/deploy/kueue/preflight.sh
@@ -307,7 +307,11 @@ if [ -n "$lease_rows" ]; then
         printf 'DIAGNOSTICS: OCCUPYING rows (they hold capacity, and a revert that resumes over them double-books it):\n%s\n' "$occupying" >&2
     fi
     fail "$EXIT_NONTERMINAL_LEASES" \
-        "$(refusal): the drain fence does not hold — build_leases carries nonterminal rows. Every row must reach state 'terminal' first; on a revert, stale occupying rows must be explicitly cleared before dispatch resumes, or the restored ledger admits against capacity it believes is already taken."
+        "$(refusal): the drain fence does not hold — build_leases carries nonterminal rows. Every row must reach state 'terminal' first; on a revert, stale occupying rows must be explicitly cleared before dispatch resumes, or the restored ledger admits against capacity it believes is already taken.
+REMEDY: a lease whose owning Job has reached a terminal condition, or whose Job is gone, is retired automatically by the server's reclamation sweep within one settle window (default 300s) — wait before intervening. If a row survives that, clear it explicitly:
+  djinn-server build-lease list
+  djinn-server build-lease clear --lease <consumer_kind>:<consumer_id>
+Do NOT hand-write an UPDATE against build_leases: 'clear' takes the ledger's advisory lock and records terminal_reason='operator_cleared', so the intervention is auditable and cannot race a live grant."
 fi
 printf 'PASS: zero nonterminal build_leases rows\n'
 

--- a/scripts/check-resize-reachability.sh
+++ b/scripts/check-resize-reachability.sh
@@ -73,6 +73,10 @@ BuildPodPermitRepository::capture_resize_identity|\.capture_resize_identity\(|Bu
 BuildPodPermitRepository::list_nonterminal_resize|\.list_nonterminal_resize\(|BuildPodPermitRepository
 task_run_resize_reconcile::spawn|task_run_resize_reconcile::spawn\(|become_leader
 ResizeRollout::production|ResizeRollout::production\(|ResizeRollout
+BuildLeaseRepository::list_nonterminal_with_settlement|\.list_nonterminal_with_settlement\(|BuildLeaseRepository
+BuildLeaseRepository::list_nonterminal|\.list_nonterminal\(|BuildLeaseRepository
+BuildLeaseRepository::clear_for_operator|\.clear_for_operator\(|BuildLeaseRepository
+BuildLeaseService::expire_deadlines|\.expire_deadlines\(\)|build_lease
 "
 
 # file|extended-regex|why this anchor exists
@@ -90,6 +94,10 @@ server/src/authority_cutover.rs|rollout\.activate\(&plan\)|the driver must run t
 server/src/authority_cutover.rs|rollout\.rollback\(&plan\)|the driver must run the reverse sequence through ResizeRollout, not through set_mode
 server/src/task_run_resize_rollout.rs|self\.clear_preflight\(LauncherAuthorityProtocol::ResizeV2\)|the forward cutover must run the real preflight before the flip
 server/src/task_run_resize_rollout.rs|self\.clear_preflight\(LauncherAuthorityProtocol::LeafV1\)|the reverse cutover must run the real preflight before the flip
+server/src/server/state/mod.rs|BuildLeaseReclaimer::new\(|the build-lease reclaimer must be constructed at the composition root
+server/src/server/state/mod.rs|reclaimer\.reclaim\(\)\.await|the reclaimer must be DRIVEN on the periodic tick, not merely constructed; a startup-only reaper never sees a worker that dies at minute 40
+server/src/server/state/mod.rs|cap_refresh_lease\.expire_deadlines\(\)\.await|queue and launch deadlines must be swept periodically -- expire_deadlines had ZERO production callers, which is why a queued build lease was immortal whenever no other lease was being drained
+server/src/admin.rs|AdminCommand::BuildLease|the operator surface preflight.sh promises must be dispatched from run_admin_command, or its refusal message names a remedy that does not exist
 "
 
 status=0

--- a/scripts/test-check-resize-reachability.sh
+++ b/scripts/test-check-resize-reachability.sh
@@ -82,6 +82,21 @@ fn agent_context() {
 pub async fn become_leader(&self) {
     crate::task_run_resize_reconcile::spawn(self.clone());
 }
+// The build-lease maintenance tick. The reclaimer must be CONSTRUCTED and
+// DRIVEN, and the deadline sweep must actually run: a reaper that is built and
+// never ticked is the exact shape this guard exists to catch.
+fn initialize_graph_warmer(&self) {
+    let lease_reclaimer = warmer.workload_inventory().map(|inventory| {
+        Arc::new(BuildLeaseReclaimer::new(repo, inventory))
+    });
+    let cap_refresh_lease = self.inner.build_lease.clone();
+    tokio::spawn(async move {
+        loop {
+            cap_refresh_lease.expire_deadlines().await;
+            let report = reclaimer.reclaim().await;
+        }
+    });
+}
 EOF
 }
 
@@ -115,6 +130,21 @@ fn agent_context() {
 }
 pub async fn become_leader(&self) {
     crate::task_run_resize_reconcile::spawn(self.clone());
+}
+// The build-lease maintenance tick. The reclaimer must be CONSTRUCTED and
+// DRIVEN, and the deadline sweep must actually run: a reaper that is built and
+// never ticked is the exact shape this guard exists to catch.
+fn initialize_graph_warmer(&self) {
+    let lease_reclaimer = warmer.workload_inventory().map(|inventory| {
+        Arc::new(BuildLeaseReclaimer::new(repo, inventory))
+    });
+    let cap_refresh_lease = self.inner.build_lease.clone();
+    tokio::spawn(async move {
+        loop {
+            cap_refresh_lease.expire_deadlines().await;
+            let report = reclaimer.reclaim().await;
+        }
+    });
 }
 EOF
 }
@@ -232,6 +262,46 @@ path = "src/bin/authority_cutover.rs"
 EOF
 }
 
+# The build-lease reclamation sweep and its operator surface.
+#
+# Both were merged in a state this guard is FOR: the reclaimer could not see the
+# populations it existed to retire, and the operator remedy `preflight.sh`
+# promises ("stale rows must be explicitly cleared") existed in no CLI at all,
+# so production was unwedged twice on 2026-07-30 by a hand-written SQL UPDATE.
+write_build_lease() {
+    mkdir -p -- "$SCRATCH/server/crates/djinn-coordinator/src"
+    cat >"$SCRATCH/server/crates/djinn-coordinator/src/build_lease_reclaim.rs" <<'EOF'
+// Reclaimer fixture: the sweep must read the NONTERMINAL population, so a
+// `queued` row -- the one state with no other reaper -- is reachable at all.
+use djinn_db::BuildLeaseRepository;
+
+impl BuildLeaseReclaimer {
+    pub async fn reclaim(&self) -> BuildLeaseReclaimReport {
+        let rows = self.repository.list_nonterminal_with_settlement(secs).await;
+    }
+}
+EOF
+    mkdir -p -- "$SCRATCH/server/src"
+    cat >"$SCRATCH/server/src/admin.rs" <<'EOF'
+// Operator surface fixture.
+use djinn_db::BuildLeaseRepository;
+
+pub async fn run_admin_command(db: &Database, command: AdminCommand) {
+    match command {
+        AdminCommand::BuildLease { action } => {
+            run_build_lease_action(&BuildLeaseRepository::new(db.clone()), action).await
+        }
+    }
+}
+async fn run_build_lease_action(repository: &BuildLeaseRepository, action: BuildLeaseAction) {
+    match action {
+        BuildLeaseAction::List => repository.list_nonterminal().await,
+        BuildLeaseAction::Clear { leases } => repository.clear_for_operator(&keys).await,
+    }
+}
+EOF
+}
+
 fixture() {
     rm -rf -- "$SCRATCH"
     write_state
@@ -239,6 +309,7 @@ fixture() {
     write_seam
     write_reconcile
     write_cutover
+    write_build_lease
 }
 
 run_guard() {
@@ -501,6 +572,56 @@ mv "$SCRATCH/.tmp" "$SCRATCH/$ROLLOUT"
 expect_fail_naming \
     "dropping the reverse preflight call fails the anchor" \
     "clear_preflight"
+
+# 22. The build-lease reclaimer is CONSTRUCTED but never driven. This is the
+#     shape the campaign keeps finding: a reaper wired and never spawned, or
+#     spawned and never ticked. It looks identical to a working one until a
+#     stranded lease holds the cap for an hour.
+fixture
+grep -v 'reclaimer.reclaim().await' "$SCRATCH/$STATE" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$STATE"
+expect_fail_naming \
+    "a reclaimer that is built but never driven fails the anchor" \
+    "reclaimer"
+
+# 23. The periodic deadline sweep is dropped. `expire_deadlines` had ZERO
+#     production callers until 2026-07-30, which is why a `queued` build lease
+#     was immortal whenever no other lease happened to be draining.
+fixture
+grep -v 'cap_refresh_lease.expire_deadlines().await' "$SCRATCH/$STATE" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/$STATE"
+expect_fail_naming \
+    "dropping the periodic deadline sweep fails, naming the symbol" \
+    "BuildLeaseService::expire_deadlines has ZERO production callers"
+
+# 24. The sweep narrows back to the occupying population, so a `queued` row is
+#     invisible again and no reaper anywhere can retire it.
+fixture
+grep -v 'list_nonterminal_with_settlement' \
+    "$SCRATCH/server/crates/djinn-coordinator/src/build_lease_reclaim.rs" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/server/crates/djinn-coordinator/src/build_lease_reclaim.rs"
+expect_fail_naming \
+    "a sweep that stops reading the nonterminal population fails, naming the symbol" \
+    "BuildLeaseRepository::list_nonterminal_with_settlement has ZERO production callers"
+
+# 25. The operator escape hatch is defined but no longer dispatched from
+#     `run_admin_command`, so `preflight.sh` again names a remedy that does not
+#     exist and SQL is the only way out.
+fixture
+grep -v 'AdminCommand::BuildLease' "$SCRATCH/server/src/admin.rs" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/server/src/admin.rs"
+expect_fail_naming \
+    "an operator subcommand nothing dispatches fails the anchor" \
+    "AdminCommand::BuildLease"
+
+# 26. …and the clear itself, which is the only thing that retires a row a proof
+#     cannot reach.
+fixture
+grep -v 'clear_for_operator' "$SCRATCH/server/src/admin.rs" >"$SCRATCH/.tmp"
+mv "$SCRATCH/.tmp" "$SCRATCH/server/src/admin.rs"
+expect_fail_naming \
+    "an operator clear with no production caller fails, naming the symbol" \
+    "BuildLeaseRepository::clear_for_operator has ZERO production callers"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/server/crates/djinn-coordinator/src/build_lease.rs
+++ b/server/crates/djinn-coordinator/src/build_lease.rs
@@ -997,6 +997,17 @@ fn terminal_result(row: &BuildLeaseRow) -> LeaseResult {
         // retires the spent row on the next `queue`); warm and invocation
         // owners re-enter under a fresh identity.
         BuildLeaseTerminalReason::ReclaimedAbsent => LeaseResult::LeaseUnavailable,
+        // Same conclusion, different evidence: the object still EXISTS but has
+        // reached a terminal condition, so nothing will run under it again and
+        // its holder is equally gone. A finished Job lingers for its whole
+        // `ttlSecondsAfterFinished`, which is why this needed a proof of its
+        // own rather than waiting for the absence one to become true.
+        BuildLeaseTerminalReason::ReclaimedFinished => LeaseResult::LeaseUnavailable,
+        // An operator retired this row by hand. The lease is over by decree
+        // rather than by proof, and the owner -- if one somehow still exists --
+        // must mint a fresh attempt exactly as it would after a reclamation
+        // rather than adopt a lease a human has declared dead.
+        BuildLeaseTerminalReason::OperatorCleared => LeaseResult::LeaseUnavailable,
     }
 }
 fn status(row: &BuildLeaseRow) -> LeaseStatus {

--- a/server/crates/djinn-coordinator/src/build_lease_reclaim.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_reclaim.rs
@@ -11,8 +11,9 @@
 //!   `Launching`/`Bound`/`Active`/`Suspect` and returns `None` for everything
 //!   else, so a `granted` row is invisible to `reconcile_durable_warm_leases`;
 //! * `BuildLeaseService::expire_deadlines` — the one thing that would move
-//!   `granted` to the recoverable `suspect` — has no production caller at all,
-//!   and even when called it only exchanges one occupying state for another.
+//!   `granted` to the recoverable `suspect` — had no production caller at all
+//!   until 2026-07-30 (see "The `queued` row nothing could see" below), and
+//!   even now it only exchanges one occupying state for another.
 //!
 //! Neither gap is a deadline problem, which is why this module reads no
 //! deadline. (#2605 fixed a real defect one layer over: the shared column list
@@ -90,14 +91,68 @@
 //! Retiring the legacy rows is the point. Leaving them would strand the
 //! cutover's own leftovers against a production reference cap of 3, which is
 //! the outage shape this module was written to end.
+//!
+//! # Presence is not liveness (2026-07-30, v0.7.31)
+//!
+//! Everything above proves a lease ownerless by showing its object is GONE.
+//! That is a strictly weaker proof than it reads as, and the gap is an hour
+//! wide.
+//!
+//! Production, single-node k3s, dispatch paused, every task-run Job at
+//! `Complete` (`succeeded=1`, conditions `Suspended → SuccessCriteriaMet →
+//! Complete`, zero Pods): three `task_invocation` rows sat in `launching`, plus
+//! one in `queued`. They survived ~7 minutes of polling, a full `djinn-server`
+//! rollout restart, and every owning Job reaching a terminal condition. Both
+//! incidents that day were ended by a hand-written SQL `UPDATE`.
+//!
+//! The mechanism is that a finished Job does not disappear. Task-run Jobs carry
+//! `ttlSecondsAfterFinished: 3600`, so for a full hour after the work ends the
+//! object is still listed — and this sweep collapsed the authoritative LIST to
+//! a set of NAMES (`records.into_iter().map(|record| record.name)`), discarding
+//! the `terminal` flag `job_record` had already computed for every one of them.
+//! A listed name short-circuited to "still live". Meanwhile no other path can
+//! retire the row either: `release`/`cancel` need the dead worker's fencing
+//! token, and `abandon_queued` refuses anything past `queued`.
+//!
+//! That also explains the one row that DID clear earlier the same day, which is
+//! the most informative fact in the report: its Job's TTL had already fired, so
+//! the object was genuinely absent and the old proof applied. The difference
+//! between the row that healed and the four that did not was never the lease —
+//! it was whether Kubernetes had gotten around to deleting the Job.
+//!
+//! So the LIST now keeps the terminal flag, and a listed-but-terminal object is
+//! [`OwnerlessProof::ObjectFinished`]. This is still observable state, never
+//! elapsed time: a Job with no terminal condition is live work at any age, and
+//! a degraded API server still yields no proof at all.
+//!
+//! # The `queued` row nothing could see
+//!
+//! The fourth stranded row was `queued`, and it was unreachable by every reaper
+//! in the process for a different reason: `queued` holds no capacity, so it is
+//! not in `OCCUPYING`, so the sweep's own listing filtered it out. The only
+//! thing that retires a queued row is `expire_queued_tx`, which runs INSIDE
+//! `grant_next` — i.e. only when some other lease is being drained. With
+//! dispatch paused, nothing calls `grant_next`, and the row is immortal.
+//! `BuildLeaseRepository::expire_deadlines`, the one method that sweeps queue
+//! deadlines on their own, had no production caller anywhere in the workspace.
+//!
+//! `deploy/kueue/preflight.sh` fences the authority cutover on `state <>
+//! 'terminal'`, which counts `queued`, so that row blocked the cutover
+//! indefinitely while every occupancy-shaped reconciler reported clean.
+//!
+//! The sweep is therefore over NONTERMINAL rows, and the periodic loop that
+//! drives it now also calls `expire_deadlines`. Widening the sweep to `queued`
+//! makes the absence proof vacuous for one population — a `graph_warm` lease
+//! POSTs its Job only AFTER it is granted, so a queued warm lease has no object
+//! and never did — which [`object_predates_lease`] excludes explicitly.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use djinn_db::{
-    BuildLeaseConsumerKind, BuildLeaseRepository, BuildLeaseRow, ReclaimAbsentBuildLeaseInput,
-    ReclaimAbsentBuildLeaseOutcome,
+    BuildLeaseConsumerKind, BuildLeaseRepository, BuildLeaseRow, BuildLeaseState,
+    BuildLeaseTerminalReason, ReclaimAbsentBuildLeaseInput, ReclaimAbsentBuildLeaseOutcome,
 };
 use djinn_k8s::{
     ObjectPresence, WorkloadInventory, WorkloadObjectKind, deterministic_warm_job_name,
@@ -118,8 +173,10 @@ const MAX_NAMED_FAILURES: usize = 5;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BuildLeaseReclaimReport {
-    /// Occupying leases the pass examined.
-    pub occupying: usize,
+    /// Nonterminal leases the pass examined. Named for what it counts: the
+    /// sweep covers `queued` as well as the five occupying states, because
+    /// `queued` was the one population no reaper could see.
+    pub examined: usize,
     /// Leases whose object was proven absent, plus the `task_dispatch` leases
     /// whose owning admission generation is proven terminal. Both are the
     /// "this lease has no owner" population; see `ownerless_dispatch` for the
@@ -130,6 +187,11 @@ pub struct BuildLeaseReclaimReport {
     /// population that produced a total dispatch outage while every
     /// Kubernetes-shaped reconciler reported success.
     pub ownerless_dispatch: usize,
+    /// Leases retired because their Kubernetes object still EXISTS but has
+    /// reached a terminal condition. Reported separately because this is the
+    /// population no absence proof could ever see, and the one that stranded
+    /// three `launching` rows behind three `Complete` Jobs in production.
+    pub finished_object: usize,
     /// Leases retired by this pass.
     pub reclaimed: usize,
     /// Leases that changed after their absence proof and were left alone.
@@ -184,12 +246,17 @@ pub fn lease_object_name(row: &BuildLeaseRow) -> Option<String> {
     }
 }
 
-/// Why one settled occupying lease may be retired.
+/// Why one settled nonterminal lease may be retired.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OwnerlessProof {
     /// The authoritative LIST and an independent GET both say the object this
     /// lease committed to does not exist.
     ObjectAbsent,
+    /// The object EXISTS and has reached a terminal condition (`Complete` or
+    /// `Failed`). Nothing will run under it again, so the holder that would
+    /// have released this lease is gone — and the object's continued existence
+    /// for its `ttlSecondsAfterFinished` is not evidence to the contrary.
+    ObjectFinished,
     /// The lease is a `task_dispatch` row, and the pre-create dispatch
     /// reservation that was its only possible acquirer no longer exists (Kueue
     /// cutover, o53p). No owner can exist, so this is legacy capacity to
@@ -203,6 +270,41 @@ impl OwnerlessProof {
     /// cut-over was given a sweep of its own.
     fn is_dispatch(self) -> bool {
         matches!(self, Self::DispatchAuthorityDeleted)
+    }
+
+    /// The reason stamped on the retired row, so the ledger records WHICH proof
+    /// ended the lease rather than flattening every reclamation into one word.
+    fn terminal_reason(self) -> BuildLeaseTerminalReason {
+        match self {
+            Self::ObjectAbsent | Self::DispatchAuthorityDeleted => {
+                BuildLeaseTerminalReason::ReclaimedAbsent
+            }
+            Self::ObjectFinished => BuildLeaseTerminalReason::ReclaimedFinished,
+        }
+    }
+}
+
+/// Whether this lease's Kubernetes object is guaranteed to ALREADY EXIST, so
+/// that "no such object" is evidence of a dead owner rather than of an object
+/// that was never going to exist yet.
+///
+/// This is the guard that keeps the absence proof from becoming vacuous now
+/// that the sweep also sees `queued` rows:
+///
+/// * a `task_invocation` lease is asked for from INSIDE a running task-run pod,
+///   so its Job predates the lease in every nonterminal state — absence is real
+///   evidence even while the lease is still queued;
+/// * a `graph_warm` lease is what AUTHORIZES the warm Job POST, so a `queued`
+///   warm lease has no object yet and never did. Probing for it would find
+///   nothing and retire a legitimately queued warm request — one that may sit
+///   untouched behind a full cap for hours, so no settle window saves it.
+///   Only its queue deadline may retire it.
+fn object_predates_lease(row: &BuildLeaseRow) -> bool {
+    match row.key.consumer_kind {
+        BuildLeaseConsumerKind::TaskInvocation => true,
+        BuildLeaseConsumerKind::GraphWarm | BuildLeaseConsumerKind::TaskDispatch => {
+            row.state != BuildLeaseState::Queued
+        }
     }
 }
 
@@ -249,7 +351,7 @@ impl BuildLeaseReclaimer {
     async fn ownerless_proof(
         &self,
         row: &BuildLeaseRow,
-        listed_names: &HashSet<String>,
+        listed: &HashMap<String, bool>,
     ) -> Option<OwnerlessProof> {
         if row.key.consumer_kind == BuildLeaseConsumerKind::TaskDispatch {
             // See the module docs. Nothing constructs `LeaseIdentity::TaskDispatch`
@@ -259,9 +361,18 @@ impl BuildLeaseReclaimer {
             // being true.
             return Some(OwnerlessProof::DispatchAuthorityDeleted);
         }
-        let object_name = lease_object_name(row)?;
-        if listed_names.contains(&object_name) {
+        if !object_predates_lease(row) {
             return None;
+        }
+        let object_name = lease_object_name(row)?;
+        if let Some(&terminal) = listed.get(&object_name) {
+            // The object is here. Whether that means its owner is ALIVE is the
+            // entire question, and for an hour after a task-run Job completes
+            // the answer is no: the Job lingers for its `ttlSecondsAfterFinished`
+            // while the worker that would have sent `release_lease` is gone.
+            // Reading presence as liveness is what stranded three `launching`
+            // rows behind three `Complete` Jobs in production.
+            return terminal.then_some(OwnerlessProof::ObjectFinished);
         }
         (self
             .inventory
@@ -283,8 +394,17 @@ impl BuildLeaseReclaimer {
 
         // An unusable listing is a pass-level blocker: without an authoritative
         // namespace view nothing below is evidence of anything.
-        let listed_names: HashSet<String> = match self.inventory.list().await {
-            Ok(records) => records.into_iter().map(|record| record.name).collect(),
+        //
+        // Each listed object is kept WITH its terminal flag. Collapsing this to
+        // a set of names — which is what it used to be — throws away the only
+        // evidence that separates "this Job is running" from "this Job finished
+        // and is waiting out its TTL", and the second is exactly when a lease
+        // needs retiring.
+        let listed: HashMap<String, bool> = match self.inventory.list().await {
+            Ok(records) => records
+                .into_iter()
+                .map(|record| (record.name, record.terminal))
+                .collect(),
             Err(error) => {
                 report.blockers.push(error);
                 return report;
@@ -293,7 +413,7 @@ impl BuildLeaseReclaimer {
 
         let rows = match self
             .repository
-            .list_occupying_with_settlement(self.settle_window.as_secs() as i64)
+            .list_nonterminal_with_settlement(self.settle_window.as_secs() as i64)
             .await
         {
             Ok(rows) => rows,
@@ -302,19 +422,22 @@ impl BuildLeaseReclaimer {
                 return report;
             }
         };
-        report.occupying = rows.len();
+        report.examined = rows.len();
 
         for (row, settled) in rows {
             let lease = format!("{:?}/{}", row.key.consumer_kind, row.key.consumer_id);
             if !settled {
                 continue;
             }
-            let Some(proof) = self.ownerless_proof(&row, &listed_names).await else {
+            let Some(proof) = self.ownerless_proof(&row, &listed).await else {
                 continue;
             };
             report.absent += 1;
             if proof.is_dispatch() {
                 report.ownerless_dispatch += 1;
+            }
+            if proof == OwnerlessProof::ObjectFinished {
+                report.finished_object += 1;
             }
             let input = ReclaimAbsentBuildLeaseInput {
                 key: row.key.clone(),
@@ -323,6 +446,7 @@ impl BuildLeaseReclaimer {
                 observed_fencing_token: row.fencing_token,
                 observed_bound_pod_uid: row.bound_pod_uid.clone(),
                 observed_updated_at: row.updated_at.clone(),
+                terminal_reason: proof.terminal_reason(),
             };
             match self.repository.reclaim_absent_object(&input).await {
                 Ok(ReclaimAbsentBuildLeaseOutcome::Reclaimed(_)) => {

--- a/server/crates/djinn-coordinator/src/build_lease_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_reclaim_tests.rs
@@ -282,7 +282,11 @@ async fn abandoned_grant_wedges_the_cap_until_its_absent_object_is_proven() {
         "failures: {:?}",
         report.failures
     );
-    assert_eq!(report.occupying, 1);
+    // Two nonterminal rows: the phantom `granted` occupant and the `live` warm
+    // still queued behind it. The sweep examines both and retires only the one
+    // it has a proof about — a queued warm has no object to prove anything
+    // with.
+    assert_eq!(report.examined, 2);
     assert_eq!(report.absent, 1);
     assert_eq!(report.reclaimed, 1);
     assert_eq!(report.fenced, 0);
@@ -351,7 +355,7 @@ async fn reclamation_reads_no_deadline_and_retires_bounded_and_unbounded_leases_
         "blockers: {:?}",
         report.blockers
     );
-    assert_eq!(report.occupying, 2);
+    assert_eq!(report.examined, 2);
     assert_eq!(
         report.reclaimed, 2,
         "an unexpired deadline is not a reason to keep a phantom lease, and an \
@@ -379,7 +383,7 @@ async fn a_lease_whose_object_still_exists_is_never_retired() {
     )
     .reclaim()
     .await;
-    assert_eq!(report.occupying, 1);
+    assert_eq!(report.examined, 1);
     assert_eq!(report.absent, 0, "the object was listed; nothing is absent");
     assert_eq!(report.reclaimed, 0);
     assert_eq!(
@@ -403,7 +407,7 @@ async fn an_uncertain_probe_is_never_proof_of_absence() {
     let report = reclaimer(&repository, NamespaceInventory::uncertain())
         .reclaim()
         .await;
-    assert_eq!(report.occupying, 1);
+    assert_eq!(report.examined, 1);
     assert_eq!(report.absent, 0, "`Uncertain` is never proof");
     assert_eq!(report.reclaimed, 0);
     assert_eq!(
@@ -471,7 +475,7 @@ async fn an_unsettled_lease_is_not_judged_by_a_listing_it_could_predate() {
     )
     .reclaim()
     .await;
-    assert_eq!(report.occupying, 1);
+    assert_eq!(report.examined, 1);
     assert_eq!(report.absent, 0);
     assert_eq!(report.reclaimed, 0);
 }
@@ -503,6 +507,7 @@ async fn evidence_that_predates_a_holder_acknowledgement_is_fenced() {
             observed_fencing_token: observed.fencing_token,
             observed_bound_pod_uid: observed.bound_pod_uid.clone(),
             observed_updated_at: observed.updated_at.clone(),
+            terminal_reason: djinn_db::BuildLeaseTerminalReason::ReclaimedAbsent,
         })
         .await
         .unwrap();
@@ -679,5 +684,335 @@ fn no_dispatch_lease_can_ever_be_acquired_again() {
          grounds that no acquirer exists. Replace `DispatchAuthorityDeleted` \
          with a real ownership proof BEFORE landing this:\n{}",
         offenders.join("\n")
+    );
+}
+
+// =============================================================================
+// Presence is not liveness (2026-07-30, v0.7.31)
+// =============================================================================
+//
+// Production, dispatch paused, every task-run Job at `Complete` with zero Pods:
+// three `task_invocation` rows stuck in `launching` and one in `queued`. They
+// outlived ~7 minutes of polling, a full `djinn-server` rollout restart, and
+// every owning Job reaching a terminal condition, and were ended by a
+// hand-written SQL `UPDATE` against production. Twice that day.
+//
+// Nothing below writes a lease row by hand. Every stranded row is produced by
+// `BuildLeaseService` against a real `BuildLeaseRepository`, exactly as a worker
+// that dies mid-invocation leaves one.
+
+use djinn_supervisor::services::TaskInvocationLeaseIdentity;
+
+const TASK: &str = "019fba8a-a25e-77c3-a38f-b74943e79893";
+const RUN: &str = "019fba9a-5992-7083-9beb-641f878200e1";
+
+fn invocation(invocation_id: &str) -> LeaseIdentity {
+    LeaseIdentity::TaskInvocation(TaskInvocationLeaseIdentity {
+        task_id: TASK.into(),
+        task_run_id: RUN.into(),
+        invocation_id: invocation_id.into(),
+    })
+}
+
+fn invocation_request(invocation_id: &str) -> LeaseQueueRequest {
+    LeaseQueueRequest {
+        identity: invocation(invocation_id),
+        // Deliberately far in the future on BOTH edges. Every assertion below
+        // must hold for a lease that is nowhere near any deadline, because the
+        // fix must be an observable-state proof and not a timeout in disguise.
+        deadlines: LeaseDeadlines {
+            queue_deadline_ms: 100 + 7_200_000,
+            launch_deadline_ms: 100 + 7_200_000,
+        },
+    }
+}
+
+/// The durable key `BuildLeaseService` composes for an invocation identity: the
+/// invocation id alone is the consumer id, while the task and run live in the
+/// immutable identity that `lease_object_name` reads.
+fn invocation_key(invocation_id: &str) -> BuildLeaseKey {
+    BuildLeaseKey {
+        consumer_kind: BuildLeaseConsumerKind::TaskInvocation,
+        consumer_id: invocation_id.to_owned(),
+    }
+}
+
+/// The name of the task-run Job that owns every invocation lease here.
+fn owning_job_name() -> String {
+    djinn_k8s::taskrun_job_name(RUN)
+}
+
+impl NamespaceInventory {
+    /// A namespace holding Jobs that have reached a terminal condition — the
+    /// shape a completed task-run leaves behind for its whole
+    /// `ttlSecondsAfterFinished`, which is 3600s.
+    fn holding_finished(names: &[&str]) -> Self {
+        let mut inventory = Self::holding(names);
+        for record in inventory.records.get_mut() {
+            record.terminal = true;
+        }
+        inventory
+    }
+}
+
+/// Drive a `task_invocation` lease to `launching` — granted, acknowledged, and
+/// then abandoned because the worker holding it died.
+async fn launching_invocation(service: &Arc<BuildLeaseService>, invocation_id: &str) {
+    let queued = service.queue(invocation_request(invocation_id)).await;
+    let LeaseResult::Granted(grant) = queued else {
+        panic!("a queue against a free cap must grant: {queued:?}");
+    };
+    // `grant` is the worker acknowledging the slot: `granted` → `launching`.
+    // This is the last thing the dead worker ever did.
+    assert!(matches!(
+        service
+            .grant(LeaseGrantRequest {
+                identity: invocation(invocation_id),
+                fencing_token: grant.fencing_token,
+            })
+            .await,
+        LeaseResult::Status(_)
+    ));
+}
+
+/// **The production incident, verbatim.**
+///
+/// A `task_invocation` lease sits in `launching`. Its owning task-run Job is
+/// still LISTED — it completed, and Kubernetes keeps a finished Job for its
+/// `ttlSecondsAfterFinished` — but it has reached a terminal condition and has
+/// no Pods. The worker that would have sent `release_lease` is gone.
+///
+/// The mutation this fails on: collapse the LIST back to a set of names
+/// (`records.into_iter().map(|record| record.name)`) and the terminal flag is
+/// gone, the object reads as live, and the lease is never retired. That one
+/// `.map` is the whole defect.
+#[tokio::test]
+async fn a_lease_whose_job_completed_is_retired_even_though_the_job_still_exists() {
+    let (service, repository) = service(1).await;
+    launching_invocation(&service, "inv-1").await;
+    assert_eq!(
+        repository
+            .get(&invocation_key("inv-1"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Launching,
+        "the lease must be stranded in `launching`, the production state"
+    );
+
+    // The namespace still holds the Job. It is Complete.
+    let job = owning_job_name();
+    let report = reclaimer(&repository, NamespaceInventory::holding_finished(&[&job]))
+        .reclaim()
+        .await;
+
+    assert!(
+        report.blockers.is_empty(),
+        "blockers: {:?}",
+        report.blockers
+    );
+    assert!(
+        report.failures.is_empty(),
+        "failures: {:?}",
+        report.failures
+    );
+    assert_eq!(
+        report.finished_object, 1,
+        "the proof must be `the object finished`, not `the object is absent` — \
+         the Job is right there in the listing"
+    );
+    assert_eq!(report.reclaimed, 1);
+
+    let row = repository
+        .get(&invocation_key("inv-1"))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.state, BuildLeaseState::Terminal);
+    assert_eq!(
+        row.terminal_reason.as_deref(),
+        Some("reclaimed_finished"),
+        "an operator triaging the ledger must be able to tell `its Job was \
+         collected` from `its Job finished and nobody released`"
+    );
+
+    // And the capacity is genuinely back: a fresh invocation is granted.
+    assert!(
+        matches!(
+            service.queue(invocation_request("inv-2")).await,
+            LeaseResult::Granted(_)
+        ),
+        "retiring the stranded lease must actually free the slot it held"
+    );
+}
+
+/// The other direction, and the one that matters more: a Job that is listed and
+/// has NOT reached a terminal condition is live work, and no proof retires it.
+///
+/// Releasing capacity out from under a running compile is strictly worse than
+/// leaking it. The mutation this fails on: treat every listed object as
+/// finished, or derive `terminal` from the `succeeded`/`failed` Pod counters.
+#[tokio::test]
+async fn a_lease_whose_job_is_still_running_is_never_retired() {
+    let (service, repository) = service(1).await;
+    launching_invocation(&service, "inv-1").await;
+
+    let job = owning_job_name();
+    // `holding` builds records with `terminal: false` — a live Job.
+    let report = reclaimer(&repository, NamespaceInventory::holding(&[&job]))
+        .reclaim()
+        .await;
+
+    assert_eq!(report.examined, 1, "the sweep must have seen the lease");
+    assert_eq!(report.absent, 0);
+    assert_eq!(report.finished_object, 0);
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(
+        repository
+            .get(&invocation_key("inv-1"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Launching,
+        "a live holder must keep its lease"
+    );
+}
+
+/// A degraded API server proves nothing, and that must stay true on the new
+/// path too: an `Uncertain` probe against a Job that is not in the listing
+/// leaves the lease exactly where it is.
+#[tokio::test]
+async fn an_unanswerable_probe_never_retires_an_invocation_lease() {
+    let (service, repository) = service(1).await;
+    launching_invocation(&service, "inv-1").await;
+
+    let report = reclaimer(&repository, NamespaceInventory::uncertain())
+        .reclaim()
+        .await;
+
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(
+        repository
+            .get(&invocation_key("inv-1"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Launching
+    );
+}
+
+/// **The fourth stranded row.**
+///
+/// A `queued` lease holds no capacity, so it is not in `OCCUPYING`, so the
+/// sweep's own listing used to filter it out — and the only other thing that
+/// retires a queued row is `expire_queued_tx` inside `grant_next`, which never
+/// runs while dispatch is paused. `preflight.sh` fences the cutover on
+/// `state <> 'terminal'`, so this row blocked the cutover with no code path
+/// anywhere able to clear it.
+///
+/// The mutation this fails on: narrow the sweep back to occupying states only.
+#[tokio::test]
+async fn a_queued_invocation_lease_whose_task_run_finished_is_retired() {
+    let (service, repository) = service(1).await;
+    // Fill the cap so the second invocation is QUEUED rather than granted.
+    launching_invocation(&service, "inv-holder").await;
+    assert!(
+        matches!(
+            service.queue(invocation_request("inv-queued")).await,
+            LeaseResult::Queued(_)
+        ),
+        "the second invocation must queue behind the full cap"
+    );
+    assert_eq!(
+        repository
+            .get(&invocation_key("inv-queued"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Queued
+    );
+
+    // Both leases belong to the same task-run, whose Job has completed.
+    let job = owning_job_name();
+    let report = reclaimer(&repository, NamespaceInventory::holding_finished(&[&job]))
+        .reclaim()
+        .await;
+
+    assert_eq!(
+        report.examined, 2,
+        "the sweep must examine the `queued` row, not just the occupying one"
+    );
+    assert_eq!(report.reclaimed, 2);
+    assert_eq!(
+        repository
+            .get(&invocation_key("inv-queued"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Terminal,
+        "a queued row whose task-run provably finished must reach terminal \
+         without a human writing SQL"
+    );
+}
+
+/// The guard that keeps widening the sweep to `queued` from making the absence
+/// proof vacuous.
+///
+/// A `graph_warm` lease is what AUTHORIZES the warm Job POST, so a queued warm
+/// lease has no Kubernetes object and never did. Probing for it finds nothing —
+/// and a warm request can legitimately sit untouched behind a full cap for
+/// hours, so no settle window rescues it either. Retiring it would silently
+/// cancel a queued warm.
+///
+/// The mutation this fails on: delete `object_predates_lease`, or make it
+/// return `true` unconditionally.
+#[tokio::test]
+async fn a_queued_warm_lease_is_never_retired_on_an_object_proof() {
+    let (service, repository) = service(1).await;
+    // `holder` occupies the cap; `waiting` queues behind it and stays queued.
+    let granted = service.queue(queue_request("holder")).await;
+    let LeaseResult::Granted(grant) = granted else {
+        panic!("the first queue against a free cap must grant: {granted:?}");
+    };
+    assert!(matches!(
+        service
+            .grant(LeaseGrantRequest {
+                identity: warm("holder"),
+                fencing_token: grant.fencing_token,
+            })
+            .await,
+        LeaseResult::Status(_)
+    ));
+    assert!(matches!(
+        service.queue(queue_request("waiting")).await,
+        LeaseResult::Queued(_)
+    ));
+
+    // An EMPTY namespace: the strongest possible absence evidence. The queued
+    // warm still must not be touched, because its object was never going to
+    // exist yet.
+    let report = reclaimer(&repository, NamespaceInventory::empty())
+        .reclaim()
+        .await;
+
+    assert_eq!(
+        repository
+            .get(&key("waiting"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Queued,
+        "a queued warm lease has no object yet; absence is not evidence about it"
+    );
+    assert!(
+        report.examined >= 2,
+        "the queued warm must still be EXAMINED — it is skipped by proof, not by \
+         being invisible: {report:?}"
     );
 }

--- a/server/crates/djinn-db/src/repositories/build_lease.rs
+++ b/server/crates/djinn-db/src/repositories/build_lease.rs
@@ -11,6 +11,23 @@ use crate::{Database, Error as DbError, Result as DbResult};
 
 const OCCUPYING: [&str; 5] = ["granted", "launching", "bound", "active", "suspect"];
 
+/// Every state that is not `terminal`.
+///
+/// Wider than [`OCCUPYING`] by exactly one state, `queued`, and the difference
+/// is load-bearing. A `queued` row holds no capacity, so nothing that reasons
+/// about occupancy has any cause to look at it — which is how a queued row
+/// became the one population with NO reaper at all. `deploy/kueue/preflight.sh`
+/// fences the authority cutover on `state <> 'terminal'`, so such a row blocks
+/// the cutover indefinitely while every occupancy-shaped sweep reports clean.
+const NONTERMINAL: [&str; 6] = [
+    "queued",
+    "granted",
+    "launching",
+    "bound",
+    "active",
+    "suspect",
+];
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BuildLeaseConsumerKind {
@@ -103,6 +120,16 @@ pub enum BuildLeaseTerminalReason {
     Released,
     DeadlineExpired,
     ReclaimedAbsent,
+    /// The reclaimer retired this lease because the Kubernetes object it
+    /// committed to still EXISTS but has reached a terminal condition
+    /// (`Complete`/`Failed`). Distinct from [`Self::ReclaimedAbsent`] so an
+    /// operator reading the ledger can tell "its Job was garbage-collected"
+    /// apart from "its Job finished and its holder never released".
+    ReclaimedFinished,
+    /// An operator retired this lease explicitly, via
+    /// `djinn-server build-lease clear`. Distinct from every automatic reason
+    /// so a human intervention is never mistaken for the reclaimer working.
+    OperatorCleared,
 }
 impl BuildLeaseTerminalReason {
     #[must_use]
@@ -113,6 +140,8 @@ impl BuildLeaseTerminalReason {
             Self::Released => "released",
             Self::DeadlineExpired => "deadline_expired",
             Self::ReclaimedAbsent => "reclaimed_absent",
+            Self::ReclaimedFinished => "reclaimed_finished",
+            Self::OperatorCleared => "operator_cleared",
         }
     }
     /// Parse a stored reason. `None` covers both a NULL column and a value
@@ -125,6 +154,8 @@ impl BuildLeaseTerminalReason {
             "released" => Some(Self::Released),
             "deadline_expired" => Some(Self::DeadlineExpired),
             "reclaimed_absent" => Some(Self::ReclaimedAbsent),
+            "reclaimed_finished" => Some(Self::ReclaimedFinished),
+            "operator_cleared" => Some(Self::OperatorCleared),
             _ => None,
         }
     }
@@ -226,6 +257,11 @@ pub struct ReclaimAbsentBuildLeaseInput {
     pub observed_fencing_token: Option<i64>,
     pub observed_bound_pod_uid: Option<String>,
     pub observed_updated_at: String,
+    /// Why this lease is being retired, recorded on the row. The caller owns
+    /// the proof, so the caller names it: an operator triaging a stale ledger
+    /// reads this column, and "the Job was collected" and "the Job finished
+    /// and nobody released" call for different follow-up.
+    pub terminal_reason: BuildLeaseTerminalReason,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -735,13 +771,18 @@ impl BuildLeaseRepository {
             .collect()
     }
 
-    /// Every currently occupying lease, each paired with whether it has been
+    /// Every currently nonterminal lease, each paired with whether it has been
     /// untouched for at least `settle_seconds`.
     ///
     /// Read-only and lock-free: reclamation gathers evidence from this listing
     /// and then fences its write on the row's `updated_at`, so a lease that
     /// moves between the listing and the write is rejected rather than raced.
-    pub async fn list_occupying_with_settlement(
+    ///
+    /// Scoped to [`NONTERMINAL`] rather than [`OCCUPYING`] on purpose: the
+    /// reclaimer is the ledger's only self-healing path, and the fence that
+    /// blocks the authority cutover counts every nonterminal row. A sweep that
+    /// could not even SEE a `queued` row could never retire one.
+    pub async fn list_nonterminal_with_settlement(
         &self,
         settle_seconds: i64,
     ) -> DbResult<Vec<(BuildLeaseRow, bool)>> {
@@ -755,7 +796,7 @@ impl BuildLeaseRepository {
             "SELECT {COLS}, (updated_at <= now() - make_interval(secs => $2)) AS settled \
              FROM build_leases WHERE state = ANY($1) ORDER BY enqueue_sequence"
         ))
-        .bind(OCCUPYING.as_slice())
+        .bind(NONTERMINAL.as_slice())
         .bind(settle_seconds as f64)
         .fetch_all(self.db.pool())
         .await?;
@@ -788,9 +829,14 @@ impl BuildLeaseRepository {
         &self,
         input: &ReclaimAbsentBuildLeaseInput,
     ) -> DbResult<ReclaimAbsentBuildLeaseOutcome> {
-        if !OCCUPYING.contains(&state_str(input.observed_state)) {
+        if !NONTERMINAL.contains(&state_str(input.observed_state)) {
             return Err(DbError::InvalidData(
-                "reclamation evidence must describe an occupying build lease state".into(),
+                "reclamation evidence must describe a nonterminal build lease state".into(),
+            ));
+        }
+        if input.terminal_reason == BuildLeaseTerminalReason::OperatorCleared {
+            return Err(DbError::InvalidData(
+                "operator_cleared is not a reclamation proof; use clear_for_operator".into(),
             ));
         }
         self.db.ensure_initialized().await?;
@@ -826,13 +872,70 @@ impl BuildLeaseRepository {
         ))
         .bind(input.key.consumer_kind.as_str())
         .bind(&input.key.consumer_id)
-        .bind(BuildLeaseTerminalReason::ReclaimedAbsent.as_str())
+        .bind(input.terminal_reason.as_str())
         .fetch_one(&mut *tx)
         .await?;
         tx.commit().await?;
         Ok(ReclaimAbsentBuildLeaseOutcome::Reclaimed(
             reclaimed.try_into()?,
         ))
+    }
+
+    /// Every nonterminal lease, oldest first. The operator read behind
+    /// `djinn-server build-lease list`.
+    pub async fn list_nonterminal(&self) -> DbResult<Vec<BuildLeaseRow>> {
+        self.db.ensure_initialized().await?;
+        sqlx::query_as::<_, DbRow>(&format!(
+            "SELECT {COLS} FROM build_leases WHERE state = ANY($1) ORDER BY enqueue_sequence"
+        ))
+        .bind(NONTERMINAL.as_slice())
+        .fetch_all(self.db.pool())
+        .await?
+        .into_iter()
+        .map(TryInto::try_into)
+        .collect()
+    }
+
+    /// Retire nonterminal leases on an operator's explicit instruction.
+    ///
+    /// This is the sanctioned answer to `preflight.sh`'s "stale occupying rows
+    /// must be explicitly cleared", which until now named a remedy that did not
+    /// exist in any CLI, MCP tool, or admin route — leaving a hand-written SQL
+    /// `UPDATE` against production as the only way out.
+    ///
+    /// Deliberately UNFENCED on Kubernetes evidence, and deliberately NOT
+    /// reachable from any automatic path: it takes the same advisory lock as
+    /// every other mutation, refuses rows that are already terminal, and stamps
+    /// [`BuildLeaseTerminalReason::OperatorCleared`] so the ledger records that
+    /// a human, not a proof, ended these leases. `keys` is explicit — there is
+    /// no "clear everything" spelling here, because the caller that wants one
+    /// can list first and pass what it read.
+    pub async fn clear_for_operator(&self, keys: &[BuildLeaseKey]) -> DbResult<Vec<BuildLeaseRow>> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        lock(&mut tx).await?;
+        let mut cleared = Vec::new();
+        for key in keys {
+            let Some(row) = fetch(&mut tx, key, true).await? else {
+                continue;
+            };
+            if row.state == BuildLeaseState::Terminal {
+                continue;
+            }
+            let updated = sqlx::query_as::<_, DbRow>(&format!(
+                "UPDATE build_leases SET state='terminal',terminal_reason=$3,\
+                 terminal_at=now(),updated_at=now() WHERE consumer_kind=$1 AND consumer_id=$2 \
+                 RETURNING {COLS}"
+            ))
+            .bind(key.consumer_kind.as_str())
+            .bind(&key.consumer_id)
+            .bind(BuildLeaseTerminalReason::OperatorCleared.as_str())
+            .fetch_one(&mut *tx)
+            .await?;
+            cleared.push(updated.try_into()?);
+        }
+        tx.commit().await?;
+        Ok(cleared)
     }
 
     async fn terminal(

--- a/server/crates/djinn-db/src/repositories/build_lease_tests.rs
+++ b/server/crates/djinn-db/src/repositories/build_lease_tests.rs
@@ -292,6 +292,8 @@ async fn a_spent_task_dispatch_attempt_is_retired_rather_than_replayed_forever()
     for (task_id, reason) in [
         ("expired-task", BuildLeaseTerminalReason::DeadlineExpired),
         ("reclaimed-task", BuildLeaseTerminalReason::ReclaimedAbsent),
+        ("finished-task", BuildLeaseTerminalReason::ReclaimedFinished),
+        ("operator-task", BuildLeaseTerminalReason::OperatorCleared),
         ("abandoned-task", BuildLeaseTerminalReason::Abandoned),
         ("released-task", BuildLeaseTerminalReason::Released),
         ("cancelled-task", BuildLeaseTerminalReason::Cancelled),
@@ -327,11 +329,44 @@ async fn a_spent_task_dispatch_attempt_is_retired_rather_than_replayed_forever()
                         observed_fencing_token: granted.fencing_token,
                         observed_bound_pod_uid: granted.bound_pod_uid.clone(),
                         observed_updated_at: granted.updated_at.clone(),
+                        terminal_reason: BuildLeaseTerminalReason::ReclaimedAbsent,
                     })
                     .await
                     .unwrap(),
                     ReclaimAbsentBuildLeaseOutcome::Reclaimed(_)
                 ));
+            }
+            // The object still EXISTS but reached a terminal condition — the
+            // proof that ends a lease whose Job is Complete but still inside
+            // its `ttlSecondsAfterFinished` window.
+            BuildLeaseTerminalReason::ReclaimedFinished => {
+                repo.queue(&request).await.unwrap();
+                let granted = grant(&repo, 1).await;
+                assert!(matches!(
+                    repo.reclaim_absent_object(&ReclaimAbsentBuildLeaseInput {
+                        key: request.key.clone(),
+                        observed_state: granted.state,
+                        observed_immutable_identity: granted.immutable_identity.clone(),
+                        observed_fencing_token: granted.fencing_token,
+                        observed_bound_pod_uid: granted.bound_pod_uid.clone(),
+                        observed_updated_at: granted.updated_at.clone(),
+                        terminal_reason: BuildLeaseTerminalReason::ReclaimedFinished,
+                    })
+                    .await
+                    .unwrap(),
+                    ReclaimAbsentBuildLeaseOutcome::Reclaimed(_)
+                ));
+            }
+            // The operator escape hatch `preflight.sh` promises.
+            BuildLeaseTerminalReason::OperatorCleared => {
+                repo.queue(&request).await.unwrap();
+                assert_eq!(
+                    repo.clear_for_operator(std::slice::from_ref(&request.key))
+                        .await
+                        .unwrap()
+                        .len(),
+                    1
+                );
             }
             BuildLeaseTerminalReason::Abandoned => {
                 repo.queue(&request).await.unwrap();

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -92,9 +92,10 @@ pub use scip_schedule::{
 pub use token_review::TokenReviewer;
 pub use warm_job::{build_leased_warm_job, build_warm_job, warm_job_name};
 pub use workload_inventory::{
-    KubeWorkloadInventory, LABEL_ADMISSION_DOMAIN, LABEL_ADMISSION_GENERATION,
-    LABEL_ADMISSION_WORK_ID, ObjectPresence, UidGetResult, WorkloadInventory, WorkloadObjectKind,
-    WorkloadRecord, has_canonical_warm_signature,
+    JOB_CONDITION_COMPLETE, JOB_CONDITION_FAILED, KubeWorkloadInventory, LABEL_ADMISSION_DOMAIN,
+    LABEL_ADMISSION_GENERATION, LABEL_ADMISSION_WORK_ID, ObjectPresence, UidGetResult,
+    WorkloadInventory, WorkloadObjectKind, WorkloadRecord, has_canonical_warm_signature,
+    job_reached_terminal_condition,
 };
 
 /// Re-exported `kube::Client` type so non-owner callers can name the

--- a/server/crates/djinn-k8s/src/workload_inventory.rs
+++ b/server/crates/djinn-k8s/src/workload_inventory.rs
@@ -38,6 +38,14 @@ pub struct WorkloadRecord {
     pub name: String,
     pub uid: Option<String>,
     pub labels: BTreeMap<String, String>,
+    /// The object exists but has reached a terminal condition: nothing will run
+    /// under it again. See [`job_reached_terminal_condition`].
+    ///
+    /// This is the distinction between "the object is here" and "its holder is
+    /// alive", and conflating them is what stranded build leases in production:
+    /// a task-run Job stays listed for its whole `ttlSecondsAfterFinished`
+    /// (3600s) after it completes, so a reader that treats mere presence as
+    /// liveness sees a live owner for an hour after the owner died.
     pub terminal: bool,
     pub images: Vec<String>,
     pub commands: Vec<String>,
@@ -156,12 +164,52 @@ fn containers(spec: Option<&k8s_openapi::api::core::v1::PodSpec>) -> (Vec<String
     }
     (images, commands)
 }
+/// Condition Kubernetes sets, exactly once and permanently, on a Job whose
+/// completions have all succeeded.
+pub const JOB_CONDITION_COMPLETE: &str = "Complete";
+/// Condition Kubernetes sets, exactly once and permanently, on a Job that
+/// exhausted its backoff limit or active deadline.
+pub const JOB_CONDITION_FAILED: &str = "Failed";
+
+/// Whether a Job has reached a TERMINAL condition — nothing will run under it
+/// again, ever.
+///
+/// # Why the conditions and not the `succeeded`/`failed` counters
+///
+/// The counters are a per-Pod tally, and a tally is not a lifecycle. A nonzero
+/// `succeeded` on a Job with `completions: N` means one Pod finished while the
+/// rest are still running; a nonzero `failed` on a Job with a nonzero
+/// `backoffLimit` means a Pod died and a replacement is about to be created.
+/// Either read would call a Job terminal while its work is live — and the only
+/// consumer of this flag retires the build lease that work is holding, so a
+/// false positive releases capacity out from under a running compile.
+///
+/// The conditions carry no such ambiguity: the Job controller sets `Complete`
+/// or `Failed` only when it has stopped managing Pods for this Job.
+///
+/// `SuccessCriteriaMet` and `FailureTarget` are deliberately NOT terminal.
+/// They are the intermediate conditions the controller sets first, while it is
+/// still tearing down Pods; production's own trace for a finished task-run Job
+/// reads `Suspended → SuccessCriteriaMet → Complete`, so treating
+/// `SuccessCriteriaMet` as terminal would fire during teardown rather than
+/// after it.
+#[must_use]
+pub fn job_reached_terminal_condition(
+    status: Option<&k8s_openapi::api::batch::v1::JobStatus>,
+) -> bool {
+    status.is_some_and(|status| {
+        status.conditions.iter().flatten().any(|condition| {
+            matches!(
+                condition.type_.as_str(),
+                JOB_CONDITION_COMPLETE | JOB_CONDITION_FAILED
+            ) && condition.status.eq_ignore_ascii_case("True")
+        })
+    })
+}
+
 fn job_record(j: Job) -> Option<WorkloadRecord> {
     let (images, commands) = containers(j.spec.as_ref().and_then(|s| s.template.spec.as_ref()));
-    let terminal = j
-        .status
-        .as_ref()
-        .is_some_and(|s| s.succeeded.unwrap_or(0) > 0 || s.failed.unwrap_or(0) > 0);
+    let terminal = job_reached_terminal_condition(j.status.as_ref());
     Some(WorkloadRecord {
         kind: WorkloadObjectKind::Job,
         name: j.metadata.name?,
@@ -580,6 +628,149 @@ impl WorkloadWatch for KubeWorkloadWatch {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod job_terminal_condition_tests {
+    use super::*;
+    use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
+
+    fn condition(kind: &str, status: &str) -> JobCondition {
+        JobCondition {
+            type_: kind.to_owned(),
+            status: status.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn status(conditions: Vec<JobCondition>) -> JobStatus {
+        JobStatus {
+            conditions: Some(conditions),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_job_with_no_status_is_not_terminal() {
+        assert!(!job_reached_terminal_condition(None));
+    }
+
+    #[test]
+    fn a_running_job_is_not_terminal() {
+        let running = JobStatus {
+            active: Some(1),
+            ..Default::default()
+        };
+        assert!(!job_reached_terminal_condition(Some(&running)));
+    }
+
+    #[test]
+    fn a_complete_job_is_terminal() {
+        assert!(job_reached_terminal_condition(Some(&status(vec![
+            condition("Complete", "True")
+        ]))));
+    }
+
+    #[test]
+    fn a_failed_job_is_terminal() {
+        assert!(job_reached_terminal_condition(Some(&status(vec![
+            condition("Failed", "True")
+        ]))));
+    }
+
+    /// A condition that is present but FALSE is not that condition. A reader
+    /// that checked only for the type would call every suspended Job complete.
+    #[test]
+    fn a_complete_condition_that_is_false_is_not_terminal() {
+        assert!(!job_reached_terminal_condition(Some(&status(vec![
+            condition("Complete", "False")
+        ]))));
+    }
+
+    /// The exact production trace: `Suspended → SuccessCriteriaMet → Complete`.
+    ///
+    /// `SuccessCriteriaMet` is the INTERMEDIATE condition the Job controller
+    /// sets while it is still tearing Pods down. Treating it as terminal would
+    /// retire the build lease of a Job whose Pod is still being killed, which
+    /// is releasing capacity out from under running work.
+    #[test]
+    fn success_criteria_met_alone_is_not_terminal() {
+        assert!(!job_reached_terminal_condition(Some(&status(vec![
+            condition("Suspended", "False"),
+            condition("SuccessCriteriaMet", "True"),
+        ]))));
+        assert!(
+            job_reached_terminal_condition(Some(&status(vec![
+                condition("Suspended", "False"),
+                condition("SuccessCriteriaMet", "True"),
+                condition("Complete", "True"),
+            ]))),
+            "the same Job one condition later IS terminal"
+        );
+    }
+
+    /// `FailureTarget` is `SuccessCriteriaMet`'s mirror on the failure path and
+    /// is equally intermediate.
+    #[test]
+    fn failure_target_alone_is_not_terminal() {
+        assert!(!job_reached_terminal_condition(Some(&status(vec![
+            condition("FailureTarget", "True")
+        ]))));
+    }
+
+    /// The mutation guard for the derivation itself.
+    ///
+    /// This is precisely the shape the previous counter-based reading got
+    /// wrong: a Job with `completions: 3` reports `succeeded: 1` while two Pods
+    /// are still running, and one with a nonzero `backoffLimit` reports
+    /// `failed: 1` while a replacement Pod is being created. Reverting
+    /// `job_reached_terminal_condition` to `succeeded > 0 || failed > 0` makes
+    /// both of these read as terminal and fails here.
+    #[test]
+    fn the_pod_counters_alone_never_make_a_job_terminal() {
+        let partial_success = JobStatus {
+            succeeded: Some(1),
+            active: Some(2),
+            ..Default::default()
+        };
+        assert!(
+            !job_reached_terminal_condition(Some(&partial_success)),
+            "one succeeded Pod out of several is not a finished Job"
+        );
+
+        let retrying = JobStatus {
+            failed: Some(1),
+            active: Some(1),
+            ..Default::default()
+        };
+        assert!(
+            !job_reached_terminal_condition(Some(&retrying)),
+            "a failed Pod inside the backoff limit is not a finished Job"
+        );
+    }
+
+    /// The whole point of the flag, stated as the production fact: a Job that
+    /// has completed is still LISTED for its `ttlSecondsAfterFinished`, and the
+    /// record must say so.
+    #[test]
+    fn a_completed_job_record_is_listed_and_flagged_terminal() {
+        let job = Job {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("djinn-taskrun-abc".to_owned()),
+                uid: Some("uid-1".to_owned()),
+                ..Default::default()
+            },
+            spec: None,
+            status: Some(status(vec![condition("Complete", "True")])),
+        };
+        let record = job_record(job).expect("a named Job yields a record");
+        assert_eq!(record.name, "djinn-taskrun-abc");
+        assert!(
+            record.terminal,
+            "a Complete Job is still listed; the record is what carries the fact \
+             that its holder is gone"
+        );
     }
 }
 

--- a/server/src/admin.rs
+++ b/server/src/admin.rs
@@ -34,7 +34,8 @@ use std::sync::Arc;
 
 use djinn_coordinator::invocation_lease_control::{ControlError, InvocationLeaseControl};
 use djinn_db::{
-    Database, InvocationLeaseAuthorityRepository, InvocationLeaseAuthorityRow, InvocationLeaseMode,
+    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseRow, Database,
+    InvocationLeaseAuthorityRepository, InvocationLeaseAuthorityRow, InvocationLeaseMode,
 };
 
 /// Top-level operator admin commands.
@@ -44,6 +45,42 @@ pub enum AdminCommand {
     Epoch {
         #[command(subcommand)]
         action: EpochAction,
+    },
+    /// Build-lease ledger operator commands.
+    BuildLease {
+        #[command(subcommand)]
+        action: BuildLeaseAction,
+    },
+}
+
+/// Build-lease ledger operator actions.
+///
+/// `deploy/kueue/preflight.sh` refuses the authority cutover (exit 30) while
+/// any nonterminal `build_leases` row exists, and its refusal message says
+/// stale rows "must be explicitly cleared". Until this subtree existed nothing
+/// could clear them — no CLI, no MCP tool, no admin route — so the only way
+/// past that gate was a hand-written SQL `UPDATE` against production, which
+/// happened twice on 2026-07-30.
+///
+/// This is the last resort, not the first. The reclaimer retires an ownerless
+/// lease on its own within one settle window; `clear` exists for the case where
+/// an operator has looked and decided, and it stamps `operator_cleared` so the
+/// ledger never confuses a human decision with a proof.
+#[derive(clap::Subcommand, Debug)]
+pub enum BuildLeaseAction {
+    /// List every nonterminal row — exactly the population the cutover
+    /// preflight counts.
+    List,
+    /// Retire named nonterminal rows.
+    ///
+    /// Each `--lease` is `<consumer_kind>:<consumer_id>`. Naming them
+    /// individually is deliberate: an operator who wants everything runs
+    /// `list` first and passes what they read, so a clear is always against a
+    /// population they actually saw.
+    Clear {
+        /// Repeatable. `task_invocation:019fba8a-…`.
+        #[arg(long = "lease", required = true)]
+        leases: Vec<String>,
     },
 }
 
@@ -107,7 +144,97 @@ pub async fn run_admin_command(db: &Database, command: AdminCommand) -> Result<S
     let control = InvocationLeaseControl::new(repo);
     match command {
         AdminCommand::Epoch { action } => run_epoch_action(&control, action).await,
+        AdminCommand::BuildLease { action } => {
+            run_build_lease_action(&BuildLeaseRepository::new(db.clone()), action).await
+        }
     }
+}
+
+/// Parse `<consumer_kind>:<consumer_id>` into a ledger key.
+///
+/// The kind is validated against the closed enum rather than passed through, so
+/// a typo is refused before it can silently match nothing and be reported as a
+/// successful clear of zero rows.
+fn parse_lease_key(raw: &str) -> Result<BuildLeaseKey, String> {
+    let (kind, id) = raw
+        .split_once(':')
+        .ok_or_else(|| format!("`{raw}` is not `<consumer_kind>:<consumer_id>`"))?;
+    let consumer_kind = match kind {
+        "task_invocation" => BuildLeaseConsumerKind::TaskInvocation,
+        "graph_warm" => BuildLeaseConsumerKind::GraphWarm,
+        "task_dispatch" => BuildLeaseConsumerKind::TaskDispatch,
+        other => {
+            return Err(format!(
+                "unknown consumer kind `{other}`; expected one of \
+                 task_invocation, graph_warm, task_dispatch"
+            ));
+        }
+    };
+    if id.is_empty() {
+        return Err(format!("`{raw}` has an empty consumer id"));
+    }
+    Ok(BuildLeaseKey {
+        consumer_kind,
+        consumer_id: id.to_owned(),
+    })
+}
+
+async fn run_build_lease_action(
+    repository: &BuildLeaseRepository,
+    action: BuildLeaseAction,
+) -> Result<String, String> {
+    match action {
+        BuildLeaseAction::List => {
+            let rows = repository
+                .list_nonterminal()
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(render_leases("nonterminal build leases", &rows))
+        }
+        BuildLeaseAction::Clear { leases } => {
+            let keys = leases
+                .iter()
+                .map(|raw| parse_lease_key(raw))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("clear: {e}"))?;
+            let cleared = repository
+                .clear_for_operator(&keys)
+                .await
+                .map_err(|e| format!("clear: {e}"))?;
+            // A row that was already terminal, or that does not exist, is
+            // skipped rather than failed — but it is NOT reported as cleared.
+            // An operator who asked for four and is told two must go look at
+            // the other two instead of believing the ledger is drained.
+            let mut out = format!(
+                "clear: {} of {} requested lease(s) retired\n",
+                cleared.len(),
+                keys.len()
+            );
+            out.push_str(&render_leases("retired", &cleared));
+            Ok(out)
+        }
+    }
+}
+
+fn render_leases(heading: &str, rows: &[BuildLeaseRow]) -> String {
+    if rows.is_empty() {
+        return format!("{heading}: <none>");
+    }
+    let mut out = format!("{heading}: {}\n", rows.len());
+    for row in rows {
+        let _ = writeln!(
+            out,
+            "{}:{}  state={:?} identity={} granted_at={} updated_at={}",
+            row.key.consumer_kind.as_str(),
+            row.key.consumer_id,
+            row.state,
+            row.immutable_identity,
+            row.granted_at.as_deref().unwrap_or("<never>"),
+            row.updated_at,
+        );
+    }
+    out.truncate(out.trim_end().len());
+    out
 }
 
 async fn run_epoch_action(
@@ -288,6 +415,118 @@ mod tests {
                  rendered: {rendered}"
             );
         }
+    }
+
+    /// **An operator can clear a stuck build lease without writing SQL.**
+    ///
+    /// `deploy/kueue/preflight.sh` refuses the authority cutover (exit 30) while
+    /// any nonterminal `build_leases` row exists, and its message says stale
+    /// rows "must be explicitly cleared" — a remedy that, until this subtree,
+    /// existed in no CLI, MCP tool, or admin route. Production was unwedged
+    /// twice on 2026-07-30 by a hand-written `UPDATE`.
+    ///
+    /// Driven through `run_build_lease_action`, the exact path `main` takes,
+    /// against a real Postgres ledger whose row is created by the production
+    /// repository. The mutation this fails on is the obvious one: a `clear`
+    /// whose body does nothing leaves the row nonterminal and the final `list`
+    /// non-empty.
+    #[tokio::test]
+    async fn an_operator_can_list_and_clear_a_stuck_build_lease() {
+        use djinn_db::{BuildLeaseState, QueueBuildLeaseInput, QueueBuildLeaseResult};
+
+        let db = Database::open_in_memory().expect("test database");
+        let repository = BuildLeaseRepository::new(db);
+        let key = BuildLeaseKey {
+            consumer_kind: BuildLeaseConsumerKind::TaskInvocation,
+            consumer_id: "019fba8a-a25e-77c3-a38f-b74943e79893".to_owned(),
+        };
+
+        // The row is minted by the production queue path, not hand-written.
+        let queued = repository
+            .queue(&QueueBuildLeaseInput {
+                key: key.clone(),
+                immutable_identity: "task:t:019fba9a-5992-7083-9beb-641f878200e1:inv".to_owned(),
+                queue_deadline: None,
+                launch_deadline: None,
+                weight: 1,
+            })
+            .await
+            .expect("queue a lease");
+        assert!(matches!(queued, QueueBuildLeaseResult::Queued { .. }));
+
+        // `list` shows it, and shows enough to act on.
+        let rendered = run_build_lease_action(&repository, BuildLeaseAction::List)
+            .await
+            .expect("list");
+        assert!(rendered.contains(&key.consumer_id), "{rendered}");
+        assert!(rendered.contains("task_invocation"), "{rendered}");
+
+        // A typo is refused rather than reported as a successful clear of zero.
+        let error = run_build_lease_action(
+            &repository,
+            BuildLeaseAction::Clear {
+                leases: vec!["task_invocatoin:whatever".to_owned()],
+            },
+        )
+        .await
+        .expect_err("an unknown consumer kind must be refused");
+        assert!(error.contains("unknown consumer kind"), "{error}");
+        assert_eq!(
+            repository
+                .get(&key)
+                .await
+                .expect("read")
+                .expect("row")
+                .state,
+            BuildLeaseState::Queued,
+            "a refused clear must not mutate the ledger"
+        );
+
+        // And the real thing.
+        let rendered = run_build_lease_action(
+            &repository,
+            BuildLeaseAction::Clear {
+                leases: vec![format!("task_invocation:{}", key.consumer_id)],
+            },
+        )
+        .await
+        .expect("clear");
+        assert!(rendered.contains("1 of 1"), "{rendered}");
+
+        let row = repository.get(&key).await.expect("read").expect("row");
+        assert_eq!(
+            row.state,
+            BuildLeaseState::Terminal,
+            "the operator command must actually retire the row — this is the \
+             whole point, and the SQL UPDATE it replaces"
+        );
+        assert_eq!(
+            row.terminal_reason.as_deref(),
+            Some("operator_cleared"),
+            "a human intervention must never be recorded as the reclaimer \
+             having proven something"
+        );
+
+        // The cutover fence now reads clean.
+        let rendered = run_build_lease_action(&repository, BuildLeaseAction::List)
+            .await
+            .expect("list");
+        assert!(
+            rendered.contains("<none>"),
+            "preflight.sh counts exactly this population: {rendered}"
+        );
+
+        // Clearing again is idempotent and reports honestly: nothing was
+        // retired, because there was nothing left to retire.
+        let rendered = run_build_lease_action(
+            &repository,
+            BuildLeaseAction::Clear {
+                leases: vec![format!("task_invocation:{}", key.consumer_id)],
+            },
+        )
+        .await
+        .expect("repeat clear");
+        assert!(rendered.contains("0 of 1"), "{rendered}");
     }
 
     /// An operator error is a non-zero exit with an actionable message, not a

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -1017,6 +1017,17 @@ impl AppState {
                             // change is an incident control, and the whole
                             // point of it is that the board unwedges now.
                             cap_refresh_lease.refresh_epoch_cap().await;
+                            // Sweep queue and launch deadlines. Until 2026-07-30
+                            // this had NO production caller at all: the only
+                            // thing that expired a queued lease was
+                            // `expire_queued_tx` inside `grant_next`, so a
+                            // `queued` row survived indefinitely whenever no
+                            // OTHER lease was being drained — which is exactly
+                            // the state a paused board is in. It also moves a
+                            // `granted`/`launching` row past its launch deadline
+                            // to `suspect`, where the reclaimer's object proof
+                            // can reach it.
+                            cap_refresh_lease.expire_deadlines().await;
                             recovery_warmer.reconcile_durable_warm_leases().await;
                             let Some(reclaimer) = lease_reclaimer.as_ref() else {
                                 continue;
@@ -1028,15 +1039,16 @@ impl AppState {
                                 || !report.blockers.is_empty()
                             {
                                 tracing::warn!(
-                                    occupying = report.occupying,
+                                    examined = report.examined,
                                     absent = report.absent,
                                     ownerless_dispatch = report.ownerless_dispatch,
+                                    finished_object = report.finished_object,
                                     reclaimed = report.reclaimed,
                                     fenced = report.fenced,
                                     failures = report.failure_count,
                                     named_failures = ?report.failures,
                                     blockers = ?report.blockers,
-                                    "build_lease: reclamation pass over occupying leases"
+                                    "build_lease: reclamation pass over nonterminal leases"
                                 );
                             }
                         }


### PR DESCRIPTION
## The root cause is not the one the report assumed

The report's hypothesis was a missing or startup-only reaper. **`BuildLeaseReclaimer` already existed, was already composed at the production site, and was already spawned on a 30s tick.** It was not startup-only. The reachability guard confirms this on `main`.

It simply could not see either stranded population, for two unrelated reasons.

### 1. Presence was read as liveness — the three `launching` rows

The reclaimer's only Kubernetes proof was object **absence**. `reclaim()` collapsed the authoritative LIST to a set of names:

```rust
let listed_names: HashSet<String> = match self.inventory.list().await {
    Ok(records) => records.into_iter().map(|record| record.name).collect(),
```

`job_record` had already computed a `terminal` flag for every one of those records. That `.map` threw it away, and `WorkloadRecord.terminal` turned out to have **zero production consumers anywhere in the workspace** — collected evidence, never read.

Task-run Jobs carry `ttlSecondsAfterFinished: 3600` (`djinn-k8s/src/job.rs:633`). A `Complete` Job therefore stays listed for a full hour after its Pod is gone. During that hour `listed_names.contains(&object_name)` short-circuited `ownerless_proof` to `None` — "still live" — and nothing else could retire the row either: `release`/`cancel` require the dead worker's fencing token, and `abandon_queued` refuses anything past `queued`.

**This also answers the question the report flagged as most informative.** The single row that *did* clear earlier that day had outlived its Job's TTL, so the object was genuinely absent and the old proof applied. The difference between the row that healed and the four that did not was never a property of the lease — it was whether Kubernetes had gotten around to deleting the Job yet.

### 2. `queued` rows were outside every reaper — the fourth row

A `queued` row holds no capacity, so it is not in `OCCUPYING`, so `list_occupying_with_settlement` filtered it out before any proof was considered. The only thing that retires a queued row is `expire_queued_tx`, which runs **inside `grant_next`** — i.e. only when some *other* lease is being drained. With dispatch paused, `grant_next` is never called and the row is immortal.

`BuildLeaseRepository::expire_deadlines`, the one method that sweeps queue deadlines independently, had **no production caller anywhere** (tests only). The module's own docs said so and the observation had never been acted on.

`preflight.sh` fences on `state <> 'terminal'`, which counts `queued` — so that row blocked the cutover while every occupancy-shaped reconciler reported clean.

## The fix

| | |
|---|---|
| `job_reached_terminal_condition` | Derives `WorkloadRecord.terminal` from the Job's `Complete`/`Failed` **conditions**, not the `succeeded`/`failed` Pod counters. `SuccessCriteriaMet` and `FailureTarget` are intermediate and excluded — production's own trace is `Suspended → SuccessCriteriaMet → Complete`. |
| `OwnerlessProof::ObjectFinished` | The LIST keeps its terminal flag; a listed-but-terminal object is a proof. Observable state, never elapsed time: a Job with no terminal condition is live work at any age, and `Uncertain` still proves nothing. |
| `list_nonterminal_with_settlement` | The sweep covers nonterminal rows, so `queued` is reachable. |
| `object_predates_lease` | Keeps that widening from making the absence proof vacuous. A `graph_warm` lease *authorizes* its Job POST, so a queued warm lease has no object and never did — retiring it would silently cancel a queued warm that may legitimately wait hours behind a full cap. |
| `expire_deadlines` | Called on the same periodic tick. Also moves a `granted`/`launching` row past its launch deadline to `suspect`, where the object proof can reach it. |
| `djinn-server build-lease {list,clear}` | The operator path `preflight.sh` already promised. |

**Bounded in time:** a lease whose Job reached a terminal condition or vanished reaches `terminal` within one settle window (300s) plus one 30s tick. No human action.

**Never terminalises a live holder:** fenced on observable state only. A Job with no terminal condition is left alone regardless of age; a degraded API server yields `Uncertain` and retires nothing; and the durable write remains a compare-and-set on the full observed identity, so a holder that acknowledges between proof and write fences the reclamation.

## Can an operator now clear a stuck lease without SQL? Yes

Verified against the **real linked binary**, not just the library:

```
$ djinn-server build-lease --help
Commands:
  list   List every nonterminal row — exactly the population the cutover preflight counts
  clear  Retire named nonterminal rows
```

`clear` takes the ledger's advisory lock, refuses rows that are already terminal, validates the consumer kind against the closed enum (a typo is an error, not a silent clear of zero), and stamps `terminal_reason='operator_cleared'` — so a human decision is never recorded as if the reclaimer had proven something. `preflight.sh`'s refusal message now names the command and explicitly tells the operator **not** to hand-write an UPDATE.

## Every AC names a mutation that fails it — all four were run

| Mutation | Result |
|---|---|
| Discard the terminal flag (restore `.map(\|r\| r.name)`) | 2 tests fail |
| Delete `object_predates_lease` | 2 tests fail |
| Narrow the sweep back to `OCCUPYING` | 3 tests fail |
| Revert `terminal` to `succeeded > 0 \|\| failed > 0` | 5 tests fail |

Tests run against **real Postgres** (`Database::open_in_memory`). Every stranded row is produced by the production `BuildLeaseService` — nothing is hand-written into the ledger — and there is no `Fake`/`Mock` repository for the thing under test. No `KubernetesRuntime` is constructed anywhere; the inventory seam is driven directly.

## Reachability is asserted, not assumed

`scripts/check-resize-reachability.sh` gains 4 production-caller claims and 4 composition anchors, so the reclaimer being **driven** (not merely constructed), the periodic `expire_deadlines` call, and the operator subcommand's dispatch from `run_admin_command` are all checked against production source with `#[cfg(test)]` tracked structurally.

Those entries would have passed vacuously against the guard's synthetic fixture, so `test-check-resize-reachability.sh` gains the subjects **and 5 negative cases** proving each new claim fires: a reclaimer built but never driven, the deadline sweep dropped, the sweep narrowed off the nonterminal population, the subcommand undispatched, and `clear_for_operator` with no production caller. **27 passed, 0 failed.**

## Verification

- `djinn-coordinator --lib`: 2027 passed
- `djinn-db --lib`: 1207 passed
- `djinn-k8s --lib`: 365 passed
- `djinn-server --lib admin::`: 3 passed
- `djinn-agent --test build_lease_shared_consumers`: 3 passed
- `deploy/kueue/tests/preflight.sh`: full hermetic contract passes (the `queued-lease-only` and `occupying-lease` exit-30 cases still fire)
- `check-raw-sql-boundary.sh`, `check-k8s-boundary.sh`, `check-resize-reachability.sh`: clean
- `cargo clippy --all-targets` on all four touched crates: clean
- No migration added — this is a behaviour fix over the existing schema, so the contiguity constraint is untouched.

## Follow-up worth filing separately

Two new `BuildLeaseTerminalReason` variants were added (`ReclaimedFinished`, `OperatorCleared`). The enum's exhaustive-match design did exactly what its doc comment promised: adding them was a **compile error** at the one mapping site in `build_lease.rs` rather than a silent fall-through into `LeaseUnavailable` — which is the defect that doc comment was written about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
