### PR TITLE
fix(cutover): install a rustls CryptoProvider before the authority cutover talks TLS

### DIFF
--- a/server/src/bin/authority_cutover.rs
+++ b/server/src/bin/authority_cutover.rs
@@ -44,6 +44,34 @@ use djinn_server::authority_cutover::{CutoverFailure, CutoverRequest, run};
 #[allow(clippy::print_stdout, clippy::print_stderr)]
 #[tokio::main]
 async fn main() -> ExitCode {
+    // rustls 0.23 requires an explicit process-level CryptoProvider before any
+    // TLS use, exactly as `server/src/main.rs` installs one for the server.
+    // This binary needs it for the same reason: it talks TLS to the apiserver
+    // (kube client) and to the OCI registry (retention probe, step 5).
+    //
+    // Without it the process panics — not returns UNEVALUABLE, PANICS — on the
+    // first handshake, before any cutover step runs. Observed in production on
+    // 2026-08-01 attempting the 3i92 activation:
+    //
+    //   Could not automatically determine the process-level CryptoProvider
+    //   from Rustls crate features.
+    //
+    // A panic here is worse than a refusal: the wrapper's documented contract
+    // is 0 flipped / 1 blocked / 2 unevaluable, and a panic exits 101, which no
+    // deploy lane classifies. `djinn-k8s`'s kind/kueue/pod-resize test harnesses
+    // already carry this same install for the same reason; the operator entry
+    // point was the one caller that never got it.
+    if rustls::crypto::ring::default_provider()
+        .install_default()
+        .is_err()
+    {
+        eprintln!(
+            "authority-cutover: UNEVALUABLE a rustls CryptoProvider was already installed by \
+             another component; refusing rather than running against an unknown TLS provider"
+        );
+        return ExitCode::from(2);
+    }
+
     match drive().await {
         Ok(()) => ExitCode::SUCCESS,
         Err(failure) => ExitCode::from(report(&failure)),


### PR DESCRIPTION
## What happened

`authority-cutover` — proposal 3i92's operator entry point — **panics** on its first TLS handshake, before any rollout step executes:

```
thread 'main' panicked at rustls-0.23.42/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

Found on 2026-08-01 running the real cutover against the production VPS. This is the first time the binary has been executed against a live cluster, which is why it had not surfaced: `ResizeRollout::production` had no callers in any binary until this entry point landed.

## Why it matters more than a missing line

The wrapper's documented contract is `0` flipped / `1` blocked / `2` unevaluable, and `deploy/preflight/cutover-preflight.sh` classifies on that. **A panic exits 101**, which no deploy lane maps to anything — so a tool whose entire design is "refuse legibly" instead produced a stack trace and an unclassifiable exit code.

The binary needs TLS for two things the cutover cannot skip:
- the kube client (apiserver census, drain proof)
- the OCI registry round trip in step 5, which proves retained artifacts are still pullable

## Why the fix looks like this

`server/src/main.rs:127` already installs `rustls::crypto::ring::default_provider()` for the server, and djinn-k8s's `kind_smoke`, `kueue_cluster_harness` and `pod_resize_kind` harnesses each carry the same install with a comment naming this exact panic. The operator binary was the one caller that never got it.

Uses `install_default()` rather than `get_or_install_from_crate_features()` deliberately: if another component already installed a provider, this returns **`2` (unevaluable)** with an explanatory message rather than silently running the cutover against an unknown TLS stack. That matches the "never guess, refuse" posture of every other gate in this tool.

## Verification

Not a unit test — the proof is the operation itself. With this fix, the same invocation that previously exited 101 proceeded through all ten steps against production:

```
authority-cutover: FLIPPED direction=activate epoch=1
completed=CatalogMutationFrozen,LegacyInventorySigned,ProtocolAwareServerDeployed,
          CatalogRebuiltAsResizeV2,RetentionVerified,AdmissionPaused,DrainProven,
          PreflightCleared,AuthorityModeFlipped,AdmissionResumed
pods-created-while-paused=0
```

Before the fix, `completed=` was empty and the process died with SIGABRT-style output. After it, the gates that *should* refuse still refused correctly on the way there — an unsigned legacy inventory blocked at `LegacyInventorySigned`, and a live task-run Pod blocked at `DrainProven` — so this change removes a crash without weakening a single check.

## Scope

One file, one guard clause. No rollout logic, no gate, no ordering touched.