### PR TITLE
fix(coordinator): stop spawn_failed sessions manufacturing planner remediations

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/cycling_intervention.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/cycling_intervention.rs
@@ -39,15 +39,15 @@ pub(crate) const STREAK_INTERVENTION_THRESHOLD: u32 = 4;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PriorSessionDisposition {
     /// The run reached its own terminal decision — it submitted, completed,
-    /// was reopened by a reviewer, crashed, or failed to spawn. Trigger B's
-    /// premise ("each run finishes and the task lands right back where it
-    /// was") holds for this reappearance.
+    /// was reopened by a reviewer, or crashed mid-run. Trigger B's premise
+    /// ("each run finishes and the task lands right back where it was") holds
+    /// for this reappearance.
     Concluded,
-    /// The session was cancelled or reclaimed by the platform before the run
-    /// could conclude (attempt outcome `cancelled` / `timed_out` /
-    /// `interrupted` — see
-    /// [`TaskAttemptOutcome::is_cancelled_or_reclaimed`](djinn_core::models::task_attempt::TaskAttemptOutcome::is_cancelled_or_reclaimed)).
-    CancelledOrReclaimed,
+    /// The session was cancelled, reclaimed, or never created at all, so the
+    /// run never reached its own terminal decision (attempt outcome
+    /// `cancelled` / `timed_out` / `interrupted` / `spawn_failed` — see
+    /// [`TaskAttemptOutcome::never_concluded`](djinn_core::models::task_attempt::TaskAttemptOutcome::never_concluded)).
+    NeverConcluded,
 }
 
 impl PriorSessionDisposition {
@@ -56,7 +56,7 @@ impl PriorSessionDisposition {
     /// never silently disarm trigger B for a genuine review-cycle livelock.
     pub(crate) fn from_attempt_outcome(outcome: &str) -> Self {
         match outcome.parse::<djinn_core::models::task_attempt::TaskAttemptOutcome>() {
-            Ok(parsed) if parsed.is_cancelled_or_reclaimed() => Self::CancelledOrReclaimed,
+            Ok(parsed) if parsed.never_concluded() => Self::NeverConcluded,
             _ => Self::Concluded,
         }
     }
@@ -72,15 +72,22 @@ impl PriorSessionDisposition {
 ///   problems, already bounded by the breaker/failover and the cooldown
 ///   ladder, not task-shape problems a Planner can fix. Trigger D
 ///   (`maybe_escalate_provider_failure_streak`) owns that class.
-/// - `prior_session` excludes reappearances whose prior session was CANCELLED
-///   or reclaimed before the run could conclude. Trigger B asserts, in its own
-///   user-facing reason, that "each run finishes and the task lands right back
-///   where it was" — an infrastructure cancellation makes that false, and it is
-///   no evidence whatsoever that the task's scope or acceptance criteria are
-///   wrong. Task 7mq0 (2026-07-28) rode four consecutive `session cancelled` +
-///   coordinator-recovery cycles into this gate; the Planner it summoned had no
-///   lever but reshaping the work, so an infra timeout permanently narrowed a
-///   healthy task. Coordinator stall kills keep their own truthful escalation
+/// - `prior_session` excludes reappearances whose prior session was CANCELLED,
+///   reclaimed, or never created before the run could conclude. Trigger B
+///   asserts, in its own user-facing reason, that "each run finishes and the
+///   task lands right back where it was" — an infrastructure cancellation makes
+///   that false, and it is no evidence whatsoever that the task's scope or
+///   acceptance criteria are wrong. Task 7mq0 (2026-07-28) rode four
+///   consecutive `session cancelled` + coordinator-recovery cycles into this
+///   gate; the Planner it summoned had no lever but reshaping the work, so an
+///   infra timeout permanently narrowed a healthy task. On 2026-08-01 a
+///   launcher protocol mismatch (`resize-v2` catalog vs `leaf-v1` server) made
+///   `resolve_dispatch_image` refuse every dispatch at `runtime.prepare`, and
+///   four `spawn_failed` streaks minted four planner remediations for tasks
+///   that had never been given a turn — a `spawn_failed` session was never
+///   created at all, which is strictly LESS evidence of task-level
+///   non-convergence than an `interrupted` run that at least started.
+///   Coordinator stall kills keep their own truthful escalation
 ///   (`STALL_CANCEL_ESCALATION_THRESHOLD` in `session_recovery`).
 /// - worker/reviewer roles only: a planner-role task must never escalate to
 ///   another Planner (recursive intervention), and lead/architect loops have
@@ -90,6 +97,13 @@ impl PriorSessionDisposition {
 /// t9wi/32bk wedge) is untouched: those runs terminalize their attempts
 /// `completed` / `submitted` / `reopened`, which classify as
 /// [`PriorSessionDisposition::Concluded`].
+///
+/// MIXED STREAKS: `prior_session` describes the MOST RECENT same-role attempt
+/// only (`CoordinatorActor::latest_attempt_strike_decision` reads the newest
+/// non-guard row). A streak that mixes infra and concluded outcomes therefore
+/// arms iff its newest attempt concluded — unchanged from how the
+/// cancelled/timed_out/interrupted exclusion has always behaved, and the reason
+/// text emitted by `maybe_intervene_on_cycling_task` says exactly that.
 pub(crate) fn should_route_cycling_intervention(
     role: &str,
     next_streak: u32,
@@ -109,7 +123,7 @@ mod tests {
 
     #[test]
     fn trigger_b_gate_arms_on_clean_same_role_streak_only() {
-        use PriorSessionDisposition::{CancelledOrReclaimed, Concluded};
+        use PriorSessionDisposition::{Concluded, NeverConcluded};
 
         // The review-cycle livelock shape: reviewer-role reappearances with no
         // provider failure, streak at the threshold → arm the Planner route.
@@ -149,19 +163,20 @@ mod tests {
             Concluded
         ));
 
-        // A cancelled / infrastructure-reclaimed session never finished, so the
-        // reappearance says nothing about the task's shape either (task 7mq0).
+        // A cancelled / reclaimed / never-created session never finished, so the
+        // reappearance says nothing about the task's shape either (task 7mq0,
+        // and the 2026-08-01 `spawn_failed` remediation storm).
         assert!(!should_route_cycling_intervention(
             "worker",
             STREAK_INTERVENTION_THRESHOLD,
             false,
-            CancelledOrReclaimed
+            NeverConcluded
         ));
         assert!(!should_route_cycling_intervention(
             "worker",
             STREAK_INTERVENTION_THRESHOLD + 6,
             false,
-            CancelledOrReclaimed
+            NeverConcluded
         ));
 
         // Planner-role tasks must never recursively escalate to a Planner.
@@ -184,20 +199,21 @@ mod tests {
 
     /// The disposition is derived from the session's terminal `task_attempts`
     /// outcome — the only signal the gate is allowed to use. A run that reached
-    /// its own terminal decision (including a genuine crash or a spawn failure)
-    /// stays `Concluded`; only cancellation/reclamation disarms trigger B. An
-    /// unknown outcome string fails CLOSED so vocabulary drift cannot silently
-    /// disable the escalation.
+    /// its own terminal decision (including a genuine mid-run crash) stays
+    /// `Concluded`; cancellation, reclamation, and a session that was never
+    /// created (`spawn_failed`) disarm trigger B. An unknown outcome string
+    /// fails CLOSED so vocabulary drift cannot silently disable the escalation.
     #[test]
-    fn prior_session_disposition_only_excludes_cancelled_or_reclaimed_outcomes() {
+    fn prior_session_disposition_excludes_every_never_concluded_outcome() {
         for outcome in [
-            "cancelled",   // session cancellation token fired (task 7mq0)
-            "timed_out",   // coordinator stall kill reclaimed a live session
-            "interrupted", // deploy/rollout/reap environmental interruption
+            "cancelled",    // session cancellation token fired (task 7mq0)
+            "timed_out",    // coordinator stall kill reclaimed a live session
+            "interrupted",  // deploy/rollout/reap environmental interruption
+            "spawn_failed", // no session ever created (2026-08-01 protocol mismatch)
         ] {
             assert_eq!(
                 PriorSessionDisposition::from_attempt_outcome(outcome),
-                PriorSessionDisposition::CancelledOrReclaimed,
+                PriorSessionDisposition::NeverConcluded,
                 "`{outcome}` must not count as a concluded run"
             );
         }
@@ -209,7 +225,6 @@ mod tests {
             "force_closed",
             "loop_guard_tripped",
             "crashed",
-            "spawn_failed",
             "pending",
             "not_a_real_outcome",
         ] {

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -573,11 +573,13 @@ impl CoordinatorActor {
     /// the Planner for the same decompose / rescope / close decision instead.
     ///
     /// The premise is that the RUNS CONCLUDE and the task still does not move.
-    /// A session cancelled by infrastructure never concluded, says nothing about
-    /// the task's scope, and must not reach here — see
-    /// [`PriorSessionDisposition`]. The reason emitted below therefore names the
-    /// terminal `task_attempts` outcomes actually observed instead of asserting
-    /// completion the coordinator never checked (task 7mq0, 2026-07-28).
+    /// A session cancelled by infrastructure — or, after the 2026-08-01
+    /// launcher-protocol outage, one that `spawn_failed` before any session
+    /// existed — never concluded, says nothing about the task's scope, and must
+    /// not reach here; see [`PriorSessionDisposition`]. The reason emitted below
+    /// therefore names the terminal `task_attempts` outcomes actually observed
+    /// instead of asserting completion the coordinator never checked (task 7mq0,
+    /// 2026-07-28).
     ///
     /// Shares all of trigger A's machinery — second-strike terminal park,
     /// reopen-count-keyed idempotency marker (stable across a review-cycle
@@ -603,10 +605,13 @@ impl CoordinatorActor {
                 .to_owned()
         } else {
             format!(
-                "Observed session outcomes for `{role}`, newest first: {}. Sessions cancelled or \
-                 reclaimed by infrastructure (`cancelled` / `timed_out` / `interrupted`) do NOT \
-                 advance this streak, so every run counted above reached its own terminal \
-                 decision and the task still landed right back where it was.",
+                "Observed session outcomes for `{role}`, newest first: {}. This escalation arms \
+                 only when the MOST RECENT run reached its own terminal decision: a session \
+                 cancelled, reclaimed, or never created by infrastructure (`cancelled` / \
+                 `timed_out` / `interrupted` / `spawn_failed`) can never arm it, so the newest \
+                 outcome above is a decision the run itself made and the task still landed right \
+                 back where it was. Any infrastructure outcome listed after it is shown for \
+                 context only and is not evidence about this task.",
                 observed.join(", ")
             )
         };

--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -1112,6 +1112,225 @@ async fn completed_same_role_redispatches_still_route_the_cycling_planner_interv
     );
 }
 
+/// Regression for the 2026-08-01 launcher-protocol outage. The catalog image
+/// declared `resize-v2` while the server still ran `leaf-v1`, so
+/// `resolve_dispatch_image` refused EVERY dispatch at `runtime.prepare`: no
+/// session row, no pod, no turn. Within two minutes four healthy tasks
+/// (`cfxt`, `skf0`, `zd7p`, `q8i4`) had each accumulated four `spawn_failed`
+/// attempts and trigger B minted four Planner remediations (`sy3z`, `2so0`,
+/// `kol2`, `orh8`) claiming they were "cycling without converging" — tasks that
+/// had never been given a turn.
+///
+/// A `spawn_failed` attempt is strictly LESS evidence of task-level
+/// non-convergence than the `interrupted` outcome trigger B already excludes:
+/// an interrupted session at least started running.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawn_failed_sessions_do_not_route_the_cycling_planner_intervention() {
+    let mut harness = InterventionChaosHarness::new(0).await;
+    let role = "worker";
+
+    assert_eq!(
+        STREAK_INTERVENTION_THRESHOLD, 4,
+        "the 2026-08-01 regression is pinned to the production threshold"
+    );
+
+    // Exactly the outage shape: four same-role redispatches, each explained by
+    // a dispatch that died before any session existed.
+    let (handled, task) = harness
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::SpawnFailed,
+            STREAK_INTERVENTION_THRESHOLD,
+        )
+        .await;
+
+    assert!(
+        !handled,
+        "four spawn_failed dispatches must NOT route a Planner intervention — no \
+         session was ever created, so the streak is no evidence about the task's scope"
+    );
+    assert_eq!(
+        task.status, "open",
+        "the source task must stay dispatchable, not be handed to a Planner"
+    );
+    harness.assert_planner_marker_count(0).await;
+    // The load-bearing side effect: no remediation review task row exists.
+    harness.assert_open_planner_review_count(0).await;
+
+    // The 60s-and-up dispatch backoff is deliberately UNCHANGED: a genuinely
+    // unlaunchable task should still be throttled, it just must not manufacture
+    // Planner work.
+    harness
+        .assert_same_role_backoff_after_reappearance(STREAK_INTERVENTION_THRESHOLD)
+        .await;
+
+    // Well past the threshold the exclusion still holds — it is not a
+    // one-cycle grace period the next spawn failure walks straight through.
+    let (still_excluded, still_open) = harness
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::SpawnFailed,
+            3,
+        )
+        .await;
+    assert!(
+        !still_excluded,
+        "the spawn-failure exclusion must not decay as the streak grows"
+    );
+    assert_eq!(still_open.status, "open");
+    harness.assert_planner_marker_count(0).await;
+    harness.assert_open_planner_review_count(0).await;
+}
+
+/// The other half of the spawn_failed contract: a streak of genuine reviewer
+/// rejections (`reopened` — the run concluded and a reviewer sent it back) MUST
+/// still mint the remediation. Proves the fix narrows the gate rather than
+/// disabling trigger B.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rejected_same_role_redispatches_still_route_the_cycling_planner_intervention() {
+    let mut harness = InterventionChaosHarness::new(0).await;
+    let role = "worker";
+
+    let (below_handled, below) = harness
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::Reopened,
+            STREAK_INTERVENTION_THRESHOLD - 1,
+        )
+        .await;
+    assert!(!below_handled, "below threshold only seeds backoff");
+    assert_eq!(below.status, "open");
+    harness.assert_open_planner_review_count(0).await;
+
+    let (handled, routed) = harness
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::Reopened,
+            1,
+        )
+        .await;
+    assert!(
+        handled,
+        "four rejected same-role redispatches must still route the Planner \
+         intervention — excluding spawn_failed must not disable the escalation"
+    );
+    assert_eq!(routed.status, "open", "the source task stays open");
+    harness.assert_planner_marker_count(1).await;
+    harness.assert_open_planner_review_count(1).await;
+
+    let description = harness
+        .open_planner_intervention_reviews()
+        .await
+        .first()
+        .map(|review| review.description.clone())
+        .expect("trigger B must create a Planner remediation review task");
+    assert!(
+        description.contains(
+            "Observed session outcomes for `worker`, newest first: \
+             reopened, reopened, reopened, reopened"
+        ),
+        "the reason must report the session outcomes it counted, got: {description}"
+    );
+    // The narration must not lie in the other direction either: now that
+    // `spawn_failed` cannot arm this escalation, the enumerated exclusion set
+    // has to name it.
+    assert!(
+        description.contains("`cancelled` / `timed_out` / `interrupted` / `spawn_failed`"),
+        "the reason must enumerate spawn_failed among the outcomes that cannot arm \
+         this escalation, got: {description}"
+    );
+}
+
+/// A streak that MIXES infra and concluded outcomes.
+///
+/// Rule (unchanged by this fix, and identical to how the
+/// cancelled/timed_out/interrupted exclusion has always behaved): the gate
+/// reads the MOST RECENT same-role attempt only, so a mixed streak arms iff its
+/// newest attempt concluded on its own. Both directions are pinned here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mixed_streak_arms_only_when_the_newest_attempt_concluded() {
+    let role = "worker";
+
+    // Direction 1 — newest attempt is a real rejection: 2 spawn_failed then 2
+    // reopened. The task DID get its turn most recently and still did not move,
+    // so the escalation is legitimate and must fire.
+    let mut newest_concluded = InterventionChaosHarness::new(0).await;
+    newest_concluded
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::SpawnFailed,
+            2,
+        )
+        .await;
+    // `task_attempts.created_at` is millisecond-resolution and the read orders
+    // by it descending; separate the phases so "newest" is unambiguous.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let (handled, task) = newest_concluded
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::Reopened,
+            2,
+        )
+        .await;
+    assert!(
+        handled,
+        "a mixed streak whose newest attempt concluded must still route the \
+         Planner intervention"
+    );
+    assert_eq!(task.status, "open");
+    newest_concluded.assert_open_planner_review_count(1).await;
+    let description = newest_concluded
+        .open_planner_intervention_reviews()
+        .await
+        .first()
+        .map(|review| review.description.clone())
+        .expect("trigger B must create a Planner remediation review task");
+    assert!(
+        description.contains(
+            "Observed session outcomes for `worker`, newest first: \
+             reopened, reopened, spawn_failed, spawn_failed"
+        ),
+        "the reason must show the mixed evidence verbatim, got: {description}"
+    );
+    assert!(
+        description.contains("arms only when the MOST RECENT run reached its own terminal"),
+        "the reason must state the newest-attempt rule it actually applied, got: {description}"
+    );
+
+    // Direction 2 — same mix, opposite order: 2 reopened then 2 spawn_failed.
+    // The most recent dispatch never produced a session, so the reappearance is
+    // not evidence about the task and must not mint a remediation.
+    let mut newest_spawn_failed = InterventionChaosHarness::new(0).await;
+    newest_spawn_failed
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::Reopened,
+            2,
+        )
+        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let (mixed_handled, mixed_task) = newest_spawn_failed
+        .dispatch_same_role_reappearances_after_sessions(
+            role,
+            djinn_core::models::TaskAttemptOutcome::SpawnFailed,
+            2,
+        )
+        .await;
+    assert!(
+        !mixed_handled,
+        "a mixed streak whose newest attempt never produced a session must NOT \
+         route a Planner intervention"
+    );
+    assert_eq!(mixed_task.status, "open");
+    newest_spawn_failed.assert_planner_marker_count(0).await;
+    newest_spawn_failed
+        .assert_open_planner_review_count(0)
+        .await;
+    newest_spawn_failed
+        .assert_same_role_backoff_after_reappearance(STREAK_INTERVENTION_THRESHOLD)
+        .await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn below_threshold_does_not_intervene() {
     let db = test_helpers::create_test_db();

--- a/server/crates/djinn-core/src/models/task_attempt.rs
+++ b/server/crates/djinn-core/src/models/task_attempt.rs
@@ -133,9 +133,9 @@ impl TaskAttemptOutcome {
         matches!(self, Self::Interrupted)
     }
 
-    /// True if this terminal outcome proves the session was CANCELLED or
-    /// reclaimed by the platform before the agent's run could conclude, rather
-    /// than the run reaching its own terminal decision.
+    /// True if this terminal outcome proves the agent's run never reached its
+    /// own terminal decision — the platform cancelled it, reclaimed it, or
+    /// never created the session at all.
     ///
     /// - `Cancelled` — the session's cancellation token fired (operator, host,
     ///   arbiter, or the session cap); the supervisor reports
@@ -143,21 +143,35 @@ impl TaskAttemptOutcome {
     ///   releases the task back to `open` / `needs_task_review`.
     /// - `TimedOut` — a coordinator stall kill reclaimed a live session.
     /// - `Interrupted` — an environmental deploy/rollout/reap interruption.
+    /// - `SpawnFailed` — the dispatch died at `runtime.prepare`: no session row,
+    ///   no pod, no turn. Strictly LESS evidence about the task than an
+    ///   `Interrupted` run, which at least started executing.
     ///
     /// This is deliberately NARROWER than [`is_infra`](Self::is_infra): a
-    /// `Crashed` or `SpawnFailed` attempt did reach its own terminal decision
-    /// (it is a genuine failure of the run) and is therefore excluded here.
+    /// `Crashed` attempt DID run and reach its own terminal decision (a genuine
+    /// failure of the run) and is therefore excluded here.
     ///
     /// Used by the coordinator's cycling gate (trigger B), whose whole premise
     /// is "each run FINISHES and the task lands right back where it was". A
-    /// cancelled session never finished, so it is no evidence at all about the
-    /// task's scope or acceptance criteria and must not arm a Planner
-    /// remediation (task 7mq0, 2026-07-28: four ~10-minute worker sessions in a
-    /// row ended `session cancelled` + coordinator recovery, trigger B fired on
-    /// the fourth, and the Planner — with no lever but reshaping the work —
-    /// force-closed a healthy task and replaced it with narrower ones).
-    pub fn is_cancelled_or_reclaimed(&self) -> bool {
-        matches!(self, Self::Cancelled | Self::TimedOut | Self::Interrupted)
+    /// session that never concluded is no evidence at all about the task's scope
+    /// or acceptance criteria and must not arm a Planner remediation:
+    ///
+    /// - task 7mq0 (2026-07-28): four ~10-minute worker sessions in a row ended
+    ///   `session cancelled` + coordinator recovery, trigger B fired on the
+    ///   fourth, and the Planner — with no lever but reshaping the work —
+    ///   force-closed a healthy task and replaced it with narrower ones.
+    /// - 2026-08-01: the catalog image declared launcher protocol `resize-v2`
+    ///   while the server still ran `leaf-v1`, so `resolve_dispatch_image`
+    ///   refused every dispatch at `runtime.prepare`. Four healthy tasks
+    ///   (`cfxt`, `skf0`, `zd7p`, `q8i4`) accumulated four `spawn_failed`
+    ///   attempts each and, inside two minutes, summoned four planner
+    ///   remediations (`sy3z`, `2so0`, `kol2`, `orh8`) for "cycling without
+    ///   converging" — without ever having been given a turn.
+    pub fn never_concluded(&self) -> bool {
+        matches!(
+            self,
+            Self::Cancelled | Self::TimedOut | Self::Interrupted | Self::SpawnFailed
+        )
     }
 
     /// Lifecycle rank used for forward-only ordering.


### PR DESCRIPTION
## The incident

On **2026-08-01** the catalog image declared launcher protocol `resize-v2` while the server still ran `leaf-v1`. `resolve_dispatch_image` refused **every** dispatch at `runtime.prepare`: no session rows, no pods, no turns. Within two minutes the coordinator opened four planner-remediation review tasks — `sy3z`, `2so0`, `kol2`, `orh8` — against four healthy tasks `cfxt`, `skf0`, `zd7p`, `q8i4`, each reading:

> Task is cycling without converging: 4 consecutive `worker` redispatches without the task changing status ... Observed session outcomes for `worker`, newest first: spawn_failed, spawn_failed, spawn_failed, spawn_failed. Sessions cancelled or reclaimed by infrastructure (`cancelled` / `timed_out` / `interrupted`) do NOT advance this streak, so every run counted above reached its own terminal decision and the task still landed right back where it was.

The last sentence is false for the outcome that actually fired. These tasks were escalated for failing to converge without ever having been given a turn — and a Planner handed that loop has no lever but decompose / rescope / close. This is the same failure mode as task `7mq0` (2026-07-28), one outcome later.

## The reasoning

Trigger B's premise is "the RUNS CONCLUDE and the task still does not move". The gate already excludes `cancelled`, `timed_out` and `interrupted` for exactly that reason. `spawn_failed` belongs in that set: **the session was never created at all**, which is strictly *less* evidence of task-level non-convergence than an `interrupted` session that at least started running. `crashed` deliberately stays in the concluded set — a crash means the run happened and died on its own.

## Changes

| File | Change |
|---|---|
| `djinn-core/src/models/task_attempt.rs` | `is_cancelled_or_reclaimed` → **`never_concluded`**, now including `SpawnFailed`. The predicate has exactly one production caller (the trigger-B gate), so the rename keeps the name true to the concept rather than leaving a stale `cancelled_or_reclaimed` label over a set that includes a never-created session. |
| `djinn-coordinator/src/dispatch/cycling_intervention.rs` | `PriorSessionDisposition::CancelledOrReclaimed` → `NeverConcluded`; docs record the outage. Gate expression itself is untouched. |
| `djinn-coordinator/src/dispatch/retry.rs` | Narration fix (below). |
| `djinn-coordinator/src/tests/intervention.rs` | Three new tests. |

### Narration

The reason text **enumerates the excluded outcomes in prose**, so leaving it alone would have made it lie in the other direction. It now reads:

> ... This escalation arms only when the MOST RECENT run reached its own terminal decision: a session cancelled, reclaimed, or never created by infrastructure (`cancelled` / `timed_out` / `interrupted` / `spawn_failed`) can never arm it, so the newest outcome above is a decision the run itself made and the task still landed right back where it was. Any infrastructure outcome listed after it is shown for context only and is not evidence about this task.

The old wording ("do NOT advance this streak") was independently inaccurate: infra outcomes *do* advance `dispatch_failure_streak`, they just cannot arm this escalation. The new wording states what the code actually does.

## The mixed-streak rule

**A mixed streak arms iff its NEWEST same-role attempt concluded on its own.** `latest_attempt_strike_decision` reads a single row — the newest non-guard `task_attempts` row for the role — so the disposition has always described the most recent attempt only. This is unchanged from how the `cancelled`/`timed_out`/`interrupted` exclusion has behaved since `7mq0`; making `spawn_failed` stricter would have made two members of the same set behave differently. Both directions are pinned by test:

- 2 `spawn_failed` then 2 `reopened` (newest concluded) → **remediation fires**. The task got its turn most recently and still did not move.
- 2 `reopened` then 2 `spawn_failed` (newest never ran) → **no remediation**.

## Sibling predicate: the 60s backoff — deliberately NOT changed

`CoordinatorActor: repeated task failure — backing off dispatch` (`streak=2..3`, `cooldown_secs=60`, `throttle=false`) is **not a different predicate**. It is the *same* counter (`dispatch_failure_streak`) in the *same* `ReappearingDispatch::SameRoleFailure` arm, with a different consumer: the Planner route is gated by `should_route_cycling_intervention`, the streak-persist + cooldown is not. The observed `cooldown_secs=60` is `dispatch_cooldown_for_failure(_, had_provider_failure=false)` → the flat `DISPATCH_COOLDOWN` floor.

Decision: **leave it.** A 60s cooldown on a task that genuinely cannot be launched is correct backpressure — it stops the dispatcher spinning on a broken image without destroying anything. Manufacturing Planner work does destroy something. Because the change is confined to the gate, the backoff is untouched by construction, and `spawn_failed_sessions_do_not_route_the_cycling_planner_intervention` asserts `assert_same_role_backoff_after_reappearance(4)` so a future "fix" that silently drops the backpressure goes red.

Also left alone (see residual risk): the environmental exemption one branch up, which grants a *total* pass (no streak, no cooldown). It requires `outcome == "interrupted"` **plus** a structured environmental-evidence JSON; promoting `spawn_failed` into it would remove the backpressure above.

## Mutation table

Every mutation was applied to the tree, run, observed red, and reverted. Suite: `cargo nextest run -p djinn-coordinator` filtered to the 7 relevant tests (3 new, 4 incumbent).

| # | Mutation | Predicted red | Actual |
|---|---|---|---|
| **Baseline** | none | — | **7 passed, 0 failed** |
| **M1** | Revert the fix: drop `Self::SpawnFailed` from `never_concluded()` | the 2 spawn_failed tests + the unit classifier | **4 passed, 3 failed** — `spawn_failed_sessions_do_not_route…`, `mixed_streak_arms_only_when_the_newest_attempt_concluded`, `prior_session_disposition_excludes_every_never_concluded_outcome`. `rejected_…` and `completed_…` stayed green. |
| **M2** | Over-exclude: add `Self::Reopened` to `never_concluded()` (the fix accidentally swallowing real rejections) | the "must still fire" tests | **4 passed, 3 failed** — `rejected_same_role_redispatches_still_route…`, `mixed_streak…` (direction 1), `prior_session_disposition…`. `spawn_failed_…`, `cancelled_…`, `completed_…` stayed green. |
| **M3** | Narration only: remove `` / `spawn_failed` `` from the reason string, code unchanged | the narration assertion | **6 passed, 1 failed** — `rejected_same_role_redispatches_still_route…` only. |
| **M4** | Alternative impl: filter `spawn_failed` rows out of `latest_attempt_strike_decision` instead of classifying them | the newest-attempt rule | **5 passed, 2 failed** — `spawn_failed_sessions_do_not_route…` (no attempt found → falls back to `Concluded` → arms) and `mixed_streak…`. `rejected_…` stayed green. |

M1 proves the fix is what stops the remediation. M2 proves the escalation is not disabled. M3 proves the narration is pinned. M4 proves the mixed test pins the newest-attempt rule rather than accepting any implementation that happens to swallow spawn failures.

All three new tests assert the **observable side effect** — `assert_open_planner_review_count`, i.e. whether a remediation review task row exists in the DB — not a log line or a returned enum.

## Verification

- `cargo nextest run -p djinn-coordinator` → **2041 passed, 0 failed**
- `cargo nextest run -p djinn-core -p djinn-coordinator --no-fail-fast` → 2368 passed, 2 failed; both failures are `cargo_target_runs` fixture tests, **pre-existing on a clean `origin/main` tree** (verified by stashing this diff and re-running: same 2 red) and unrelated to this change.
- `cargo fmt --check` clean; `cargo clippy -p djinn-core -p djinn-coordinator --all-targets -- -D warnings` clean.

## Residual risk (not addressed here — out of scope)

The terminal close at `MAX_DISPATCH_FAILURES` consumes the same `dispatch_failure_streak` and is **not** gated by the disposition, so a long enough spawn-failure outage would still force-close healthy tasks at streak 10. This is equally true today for `cancelled`, and fixing it means touching the escalation ladder. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
