### PR TITLE
fix(dispatch): acquire the build-pod permit after the task_runs row exists

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -961,12 +961,81 @@ struct AcquiredBuildPodPermit {
     fencing_token: i64,
 }
 
+/// Create the durable `task_runs` row this dispatch will be recorded against,
+/// **before** the build-pod permit whose foreign key points at it.
+///
+/// # The ordering this exists to fix
+///
+/// `build_pod_permits.task_run_id` is `REFERENCES task_runs(id)` (migration
+/// 162), and [`acquire_build_pod_permit`] must run before the Job POST. Until
+/// this function existed, nothing on the host created the parent row: the only
+/// production creator was the in-pod supervisor's `create_task_run` RPC, which
+/// travels over a stdio channel [`attach_and_await_terminal_report`] has not
+/// opened yet — a Pod schedule, image pull and handshake later.
+///
+/// So every permit insert on a fresh dispatch referenced a parent that did not
+/// exist. This was never a race. It was strictly sequential and strictly
+/// backwards, and it failed on *every* dispatch, not some of them.
+///
+/// `BuildPodPermitRepository::acquire` collapses all errors into `Unavailable`
+/// to fail closed, so the foreign-key violation surfaced as "no permit" rather
+/// than as anything nameable. Under `leaf-v1` that was invisible —
+/// [`admit_task_run_dispatch`]'s `permit.is_none()` arm returns `Ok(())` for
+/// leaf. Under `resize-v2` the same arm refuses the dispatch, which is why the
+/// launcher-authority cutover looked like it broke dispatch when all it did was
+/// stop masking this.
+///
+/// The row created here is the one the worker would have created anyway: same
+/// host-minted id, same `starting` status, same `catalog_image_id` binding. The
+/// worker's RPC now adopts it.
+async fn ensure_durable_task_run_row(
+    app_state: &AgentContext,
+    spec: &TaskRunSpec,
+) -> anyhow::Result<()> {
+    let created = TaskRunRepository::new(app_state.db.clone())
+        .create_for_dispatch(djinn_db::CreateTaskRunParams {
+            id: &spec.task_run_id,
+            project_id: &spec.project_id,
+            task_id: &spec.task_id,
+            trigger_type: spec.trigger.as_str(),
+            // Byte-identical to what the in-pod supervisor sends: the run is
+            // visible to the UI and to the host-side pre-session liveness
+            // deadline from dispatch, and flips to `running` when the first
+            // reply-loop session is created.
+            status: Some(TaskRunStatus::Starting.as_str()),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: spec
+                .resume_lifecycle_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.dispatch_group_id.as_deref()),
+        })
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "supervisor dispatch: could not create the durable task_runs row for task-run \
+                 {}: {error}; refusing to dispatch a run that has no durable identity to \
+                 fence, record a terminal status against, or reap",
+                spec.task_run_id
+            )
+        })?;
+    tracing::debug!(
+        task_run_id = %spec.task_run_id,
+        created,
+        "supervisor dispatch: durable task_runs row ready before permit acquisition"
+    );
+    Ok(())
+}
+
 /// Acquire the durable `build_pod_permits` row for this dispatch, **before**
 /// the Job that it fences exists.
 ///
-/// Ordering is load-bearing: the permit's `fencing_token` is what every later
-/// durable write is checked against, so a row created after the Job could not
-/// fence the window in which the Job already has a Pod.
+/// Ordering is load-bearing in both directions. The permit's `fencing_token` is
+/// what every later durable write is checked against, so a row created after the
+/// Job could not fence the window in which the Job already has a Pod — and the
+/// permit's own `task_run_id` is a foreign key, so [`ensure_durable_task_run_row`]
+/// has to have run before this. Calling this first is what made every
+/// `resize-v2` dispatch fail closed.
 ///
 /// Returns `None` when this context composes no resize stack at all (an in-pod
 /// worker, a test that dispatches no Job) or when the pool could not answer.
@@ -979,10 +1048,16 @@ struct AcquiredBuildPodPermit {
 /// resize lifecycle that reclaims a permit (lift, drop, quarantine, release)
 /// belongs to `0ppk-3`'s reconciler. Until that lands, rows accumulate in
 /// `job_created` / `birth_confirmed`, which is why
-/// [`BUILD_POD_PERMIT_LIMIT_DEFAULT`] is sized not to bind and why a `PoolFull`
-/// result is a warning rather than a refusal for `leaf-v1` — the arm every Pod
-/// on the current fleet takes. A ceiling that both accumulates and fails closed
-/// is how `DJINN_MAX_BUILD_PODS` wedged the whole cluster.
+/// [`BUILD_POD_PERMIT_LIMIT_DEFAULT`] is sized not to bind. A ceiling that both
+/// accumulates and fails closed is how `DJINN_MAX_BUILD_PODS` wedged the whole
+/// cluster.
+///
+/// A `PoolFull` result is still only a warning *here*; whether it refuses is
+/// [`admit_task_run_dispatch`]'s call, and it refuses for `resize-v2`. The
+/// version of this note that said "a warning rather than a refusal for
+/// `leaf-v1` — the arm every Pod on the current fleet takes" was true when it
+/// was written and stopped being true at the `resize-v2` cutover. Do not read
+/// the fleet's current protocol out of a comment.
 async fn acquire_build_pod_permit(
     app_state: &AgentContext,
     spec: &TaskRunSpec,
@@ -1169,14 +1244,27 @@ pub async fn execute_runtime_report_phase(
     app_state: &AgentContext,
     kill: &CancellationToken,
 ) -> anyhow::Result<RuntimeExecutionOutcome> {
+    // The durable `task_runs` row is created BEFORE the permit, because the
+    // permit's `task_run_id` is a foreign key onto it and the in-pod supervisor
+    // cannot create it until a Pod boot later. See
+    // `ensure_durable_task_run_row`.
+    ensure_durable_task_run_row(app_state, spec).await?;
     // The durable permit is acquired BEFORE the Job exists: its fencing token is
     // what every later resize write is checked against, and a row minted after
     // the Pod could not fence the window it is supposed to own.
     let permit = acquire_build_pod_permit(app_state, spec).await;
-    let handle = runtime
-        .prepare(spec, credentials)
-        .await
-        .map_err(|e| anyhow::anyhow!("runtime.prepare failed: {e}"))?;
+    let handle = match runtime.prepare(spec, credentials).await {
+        Ok(handle) => handle,
+        Err(error) => {
+            // The `task_runs` row above outlives a failed Job POST. Before that
+            // row was created on this side of the boot there was nothing here to
+            // terminalize, and leaving it `starting` would strand it until the
+            // coordinator's stale sweep.
+            reap_orphan_task_run(app_state, &spec.task_run_id, TaskRunStatus::Failed).await;
+            teardown_cargo_target_run_dir(app_state, &spec.task_run_id).await;
+            return Err(anyhow::anyhow!("runtime.prepare failed: {error}"));
+        }
+    };
     // The JOB uid the create above confirmed. Not a Pod UID — `prepare` never
     // waits for a Pod and never sees one.
     let job_uid_bound = match permit.as_ref() {

--- a/server/crates/djinn-db/src/repositories/build_pod_permit.rs
+++ b/server/crates/djinn-db/src/repositories/build_pod_permit.rs
@@ -305,7 +305,17 @@ impl BuildPodPermitRepository {
         match self.acquire_inner(task_run_id, limit).await {
             Ok(result) => result,
             Err(error) => {
-                tracing::warn!(error = %error, "build pod permit acquisition unavailable");
+                // `Unavailable` is deliberately undifferentiated so this API
+                // fails closed, which means this log line is the *only* place
+                // the actual cause is ever named. It carries `task_run_id`
+                // because without it a foreign-key violation here is
+                // indistinguishable from a pool outage at the other end of the
+                // dispatch log.
+                tracing::warn!(
+                    task_run_id,
+                    error = %error,
+                    "build pod permit acquisition unavailable"
+                );
                 AcquireBuildPodPermitResult::Unavailable
             }
         }

--- a/server/crates/djinn-db/src/repositories/task_run.rs
+++ b/server/crates/djinn-db/src/repositories/task_run.rs
@@ -34,6 +34,34 @@ pub enum TerminalStatusAcceptance {
     Rejected,
 }
 
+/// The one dispatch-time `task_runs` insert, shared by every creator.
+///
+/// It is a constant rather than a third copy because of what the copies get
+/// wrong: `catalog_image_id` has to be snapshotted from the project inside the
+/// same statement. Omitting that binding in one creator already left every real
+/// dispatch with a NULL catalog image and failed the final-verification
+/// completion boundary closed.
+///
+/// Runtime query (not the macro): `catalog_image_id` evolves with the task-run
+/// schema and must not require regenerating sqlx offline metadata.
+pub(crate) const INSERT_TASK_RUN_SQL: &str = "INSERT INTO task_runs
+                (id, project_id, task_id, trigger_type, status, workspace_path, mirror_ref, dispatch_group_id, catalog_image_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
+                (SELECT selected_image_id FROM projects WHERE id = $2))";
+
+/// The clause that turns [`INSERT_TASK_RUN_SQL`] into an adoption of a row that
+/// is already there.
+///
+/// Dispatch creates the `task_runs` row on the host, before the build-pod
+/// permit whose foreign key points at it. The in-pod supervisor's
+/// `create_task_run` RPC then arrives for the same id a Pod boot later and must
+/// adopt that row rather than collide with it.
+///
+/// This is not a licence to create one run twice: run ids are uuid-v7, minted
+/// once per dispatch, and every adopting creator re-reads the row it found and
+/// refuses one that belongs to a different task.
+pub(crate) const ADOPT_EXISTING_TASK_RUN: &str = " ON CONFLICT (id) DO NOTHING";
+
 impl TaskRunRepository {
     pub fn new(db: Database) -> Self {
         Self { db }
@@ -47,24 +75,17 @@ impl TaskRunRepository {
             Uuid::parse_str(group_id)
                 .map_err(|_| DbError::InvalidData("dispatch_group_id must be a UUID".to_owned()))?;
         }
-        // Runtime query: `catalog_image_id` evolves with the task-run schema
-        // and must not require regenerating sqlx offline metadata.
-        sqlx::query(
-            "INSERT INTO task_runs
-                (id, project_id, task_id, trigger_type, status, workspace_path, mirror_ref, dispatch_group_id, catalog_image_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
-                (SELECT selected_image_id FROM projects WHERE id = $2))",
-        )
-        .bind(params.id)
-        .bind(params.project_id)
-        .bind(params.task_id)
-        .bind(params.trigger_type)
-        .bind(status)
-        .bind(params.workspace_path)
-        .bind(params.mirror_ref)
-        .bind(params.dispatch_group_id)
-        .execute(self.db.pool())
-        .await?;
+        sqlx::query(INSERT_TASK_RUN_SQL)
+            .bind(params.id)
+            .bind(params.project_id)
+            .bind(params.task_id)
+            .bind(params.trigger_type)
+            .bind(status)
+            .bind(params.workspace_path)
+            .bind(params.mirror_ref)
+            .bind(params.dispatch_group_id)
+            .execute(self.db.pool())
+            .await?;
 
         let run = sqlx::query_as!(
             TaskRunRecord,
@@ -78,6 +99,47 @@ impl TaskRunRepository {
         .await?;
 
         Ok(run)
+    }
+
+    /// Create the dispatch-time `task_runs` row if it is not already there.
+    /// Returns `true` when this call inserted it.
+    ///
+    /// # Why the host calls this before it acquires a build-pod permit
+    ///
+    /// `build_pod_permits.task_run_id` is `REFERENCES task_runs(id)` (migration
+    /// 162). The permit must be acquired before the Job POST — its fencing
+    /// token is what every later resize write is checked against, so a permit
+    /// minted after the Pod could not fence the window it owns. The in-pod
+    /// supervisor's `create_task_run` RPC cannot satisfy that foreign key at
+    /// that point: it travels over a stdio channel that does not exist until a
+    /// Pod schedule, image pull and handshake later.
+    ///
+    /// So the parent row is created here, on the host, at dispatch. The row is
+    /// the same one the worker would have created — same id, same `starting`
+    /// status, same `catalog_image_id` binding — only earlier, which is where
+    /// the ordering was wrong.
+    pub async fn create_for_dispatch(&self, params: CreateTaskRunParams<'_>) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+
+        let status = params.status.unwrap_or("running");
+        if let Some(group_id) = params.dispatch_group_id {
+            Uuid::parse_str(group_id)
+                .map_err(|_| DbError::InvalidData("dispatch_group_id must be a UUID".to_owned()))?;
+        }
+        let inserted = sqlx::query(&format!("{INSERT_TASK_RUN_SQL}{ADOPT_EXISTING_TASK_RUN}"))
+            .bind(params.id)
+            .bind(params.project_id)
+            .bind(params.task_id)
+            .bind(params.trigger_type)
+            .bind(status)
+            .bind(params.workspace_path)
+            .bind(params.mirror_ref)
+            .bind(params.dispatch_group_id)
+            .execute(self.db.pool())
+            .await?
+            .rows_affected();
+
+        Ok(inserted == 1)
     }
 
     /// Immutable catalog image selected at dispatch. NULL is a legacy or

--- a/server/crates/djinn-db/src/repositories/task_run_outcome.rs
+++ b/server/crates/djinn-db/src/repositories/task_run_outcome.rs
@@ -119,25 +119,36 @@ impl TaskRunOutcomeRepository {
         }
         let mut tx = self.db.pool().begin().await?;
         // Catalog authorization is bound at dispatch, never re-selected from a
-        // mutable project at read time. This per-attempt insert must therefore
-        // bind `catalog_image_id` with exactly the same semantics as
-        // [`crate::repositories::task_run::TaskRunRepository::create`]: the
-        // project's currently selected image, snapshotted inside this
-        // transaction so a rolled-back run leaves no partial binding. Omitting
-        // it left every real dispatch with a NULL binding, which fails the
-        // final-verification completion boundary closed.
+        // mutable project at read time. This per-attempt insert therefore binds
+        // `catalog_image_id` through the shared
+        // [`crate::repositories::task_run::INSERT_TASK_RUN_SQL`]: the project's
+        // currently selected image, snapshotted inside this transaction so a
+        // rolled-back run leaves no partial binding. Omitting it left every real
+        // dispatch with a NULL binding, which fails the final-verification
+        // completion boundary closed.
         //
-        // Runtime query (not the macro): `catalog_image_id` evolves with the
-        // task-run schema and must not require regenerating sqlx offline
-        // metadata.
-        sqlx::query(
-            "INSERT INTO task_runs
-                (id, project_id, task_id, trigger_type, status, workspace_path, mirror_ref, dispatch_group_id, catalog_image_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
-                (SELECT selected_image_id FROM projects WHERE id = $2))",
-        )
-            .bind(params.id).bind(params.project_id).bind(params.task_id).bind(params.trigger_type)
-            .bind(status).bind(params.workspace_path).bind(params.mirror_ref).bind(params.dispatch_group_id).execute(&mut *tx).await?;
+        // The insert ADOPTS an existing row. By the time the in-pod supervisor
+        // sends this RPC the host has already created the `task_runs` row at
+        // dispatch, because the run's build-pod permit has a foreign key onto
+        // it and had to be acquired before the Job POST. A plain insert here
+        // would now be a duplicate-key failure on every dispatch. The
+        // `catalog_image_id` binding is unchanged by that: the host's insert
+        // used this same statement, so the column is bound either way.
+        sqlx::query(&format!(
+            "{}{}",
+            crate::repositories::task_run::INSERT_TASK_RUN_SQL,
+            crate::repositories::task_run::ADOPT_EXISTING_TASK_RUN
+        ))
+        .bind(params.id)
+        .bind(params.project_id)
+        .bind(params.task_id)
+        .bind(params.trigger_type)
+        .bind(status)
+        .bind(params.workspace_path)
+        .bind(params.mirror_ref)
+        .bind(params.dispatch_group_id)
+        .execute(&mut *tx)
+        .await?;
         let attempt: Option<(String, Option<String>, i32)> = sqlx::query_as(
             "SELECT task_id, task_run_id, attempt_seq FROM task_attempts WHERE id = $1 FOR UPDATE",
         )
@@ -162,8 +173,18 @@ impl TaskRunOutcomeRepository {
             .await?;
         sqlx::query("INSERT INTO task_run_outcome_facts (task_run_id, attempt_seq, outcome) VALUES ($1, $2, 'observed')")
             .bind(params.id).bind(attempt_seq).execute(&mut *tx).await?;
-        let run = sqlx::query_as("SELECT id, project_id, task_id, trigger_type, status, started_at, ended_at, workspace_path, mirror_ref, dispatch_group_id FROM task_runs WHERE id = $1")
+        let run: djinn_core::models::TaskRunRecord = sqlx::query_as("SELECT id, project_id, task_id, trigger_type, status, started_at, ended_at, workspace_path, mirror_ref, dispatch_group_id FROM task_runs WHERE id = $1")
             .bind(params.id).fetch_one(&mut *tx).await?;
+        // The insert above adopts an existing row instead of colliding with it,
+        // so re-read what it adopted. A run id already bound to a different task
+        // or project must still fail, and inside this transaction the failure
+        // rolls the attempt association back with it. This is the integrity the
+        // duplicate-key error used to provide for free.
+        if run.task_id != params.task_id || run.project_id != params.project_id {
+            return Err(DbError::InvalidData(
+                "task run id is already bound to a different task".into(),
+            ));
+        }
         tx.commit().await?;
         Ok(run)
     }
@@ -841,6 +862,173 @@ mod tests {
                 .is_none(),
             "the rejected transaction must leave no task-run row, bound or otherwise"
         );
+    }
+
+    /// Dispatch creates the `task_runs` row on the host so the run's build-pod
+    /// permit has a foreign-key parent. The in-pod supervisor's
+    /// `create_task_run` RPC then arrives for the same id and must ADOPT that
+    /// row.
+    ///
+    /// This is the other half of the ordering fix, and it is the half that
+    /// breaks loudly: without the adoption clause this call is a duplicate-key
+    /// violation on the primary key, and every dispatch fails at the worker's
+    /// first RPC instead of at the permit.
+    ///
+    /// Mutation: delete `ADOPT_EXISTING_TASK_RUN` from the insert in
+    /// `create_run_for_attempt` and this test fails on the `expect` below with a
+    /// unique-violation.
+    #[tokio::test]
+    async fn the_in_pod_rpc_adopts_the_task_runs_row_dispatch_already_created() {
+        let db = Database::open_in_memory().unwrap();
+        let (project_id, task_id) = create_task(&db).await;
+        let runs = crate::repositories::task_run::TaskRunRepository::new(db.clone());
+
+        // A selected catalog image, so the binding the shared insert snapshots
+        // can be observed rather than assumed.
+        let images = crate::repositories::image::ImageRepository::new(db.clone());
+        let image_id = format!(
+            "catalog-{}",
+            &uuid::Uuid::now_v7().simple().to_string()[..16]
+        );
+        images.create(&image_id, "adopt", None, "{}").await.unwrap();
+        images
+            .set_project_image(&project_id, Some(&image_id))
+            .await
+            .unwrap();
+
+        let attempt = TaskAttemptRepository::new(db.clone())
+            .create_or_get_pending(CreateTaskAttemptParams {
+                id: &uuid::Uuid::now_v7().to_string(),
+                task_id: &task_id,
+                role: "worker",
+                dispatch_key: "adopt-host-created-row",
+                session_id: None,
+                attempt_seq: None,
+                dispatch_owner_incarnation_id: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .unwrap();
+
+        let run_id = uuid::Uuid::now_v7().to_string();
+        let params = || CreateTaskRunParams {
+            id: &run_id,
+            project_id: &project_id,
+            task_id: &task_id,
+            trigger_type: TaskRunTrigger::NewTask.as_str(),
+            status: Some("starting"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        };
+
+        // ── the host, at dispatch ──
+        assert!(
+            runs.create_for_dispatch(params()).await.unwrap(),
+            "the first dispatch-time call creates the row"
+        );
+        assert!(
+            !runs.create_for_dispatch(params()).await.unwrap(),
+            "a redispatch of the same run id adopts rather than duplicating"
+        );
+
+        // ── the in-pod supervisor, one Pod boot later ──
+        TaskRunOutcomeRepository::new(db.clone())
+            .create_run_for_attempt(params(), &attempt.id)
+            .await
+            .expect("the in-pod RPC must adopt the row dispatch created, not collide with it");
+
+        let rows: i64 = sqlx::query_scalar("SELECT count(*)::bigint FROM task_runs WHERE id = $1")
+            .bind(&run_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(rows, 1, "exactly one durable run row, created once");
+
+        // The catalog binding is what a naive `ON CONFLICT DO NOTHING` on a
+        // creator that omitted the column would silently leave NULL, which fails
+        // the final-verification completion boundary closed.
+        assert_eq!(
+            runs.catalog_image_id(&run_id).await.unwrap().as_deref(),
+            Some(image_id.as_str()),
+            "the adopted row still carries the catalog image bound at dispatch"
+        );
+
+        // Adoption must not skip the association work the RPC is actually for.
+        let bound: Option<String> =
+            sqlx::query_scalar("SELECT task_run_id FROM task_attempts WHERE id = $1")
+                .bind(&attempt.id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(bound.as_deref(), Some(run_id.as_str()));
+        assert!(
+            TaskRunOutcomeRepository::new(db.clone())
+                .get_for_attempt(&attempt.id)
+                .await
+                .unwrap()
+                .is_some(),
+            "the outcome fact is still recorded for an adopted run"
+        );
+    }
+
+    /// A run id already bound to a different task must still be refused. The
+    /// adoption clause removed the duplicate-key error that used to provide
+    /// this, so the repository re-reads the row it adopted.
+    ///
+    /// Mutation: delete the `run.task_id != params.task_id` guard from
+    /// `create_run_for_attempt` and this test's `expect_err` fails.
+    #[tokio::test]
+    async fn adoption_refuses_a_run_id_that_belongs_to_a_different_task() {
+        let db = Database::open_in_memory().unwrap();
+        let (project_id, task_id) = create_task(&db).await;
+        let (_other_project_id, other_task_id) = create_task(&db).await;
+        let runs = crate::repositories::task_run::TaskRunRepository::new(db.clone());
+
+        let run_id = uuid::Uuid::now_v7().to_string();
+        runs.create_for_dispatch(CreateTaskRunParams {
+            id: &run_id,
+            project_id: &project_id,
+            task_id: &task_id,
+            trigger_type: TaskRunTrigger::NewTask.as_str(),
+            status: Some("starting"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .unwrap();
+
+        let attempt = TaskAttemptRepository::new(db.clone())
+            .create_or_get_pending(CreateTaskAttemptParams {
+                id: &uuid::Uuid::now_v7().to_string(),
+                task_id: &other_task_id,
+                role: "worker",
+                dispatch_key: "adopt-wrong-task",
+                session_id: None,
+                attempt_seq: None,
+                dispatch_owner_incarnation_id: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .unwrap();
+
+        TaskRunOutcomeRepository::new(db.clone())
+            .create_run_for_attempt(
+                CreateTaskRunParams {
+                    id: &run_id,
+                    project_id: &project_id,
+                    task_id: &other_task_id,
+                    trigger_type: TaskRunTrigger::NewTask.as_str(),
+                    status: Some("starting"),
+                    workspace_path: None,
+                    mirror_ref: None,
+                    dispatch_group_id: None,
+                },
+                &attempt.id,
+            )
+            .await
+            .expect_err("a run id bound to another task must not be adopted");
     }
 }
 

--- a/server/tests/task_run_resize_dispatch_seam.rs
+++ b/server/tests/task_run_resize_dispatch_seam.rs
@@ -43,9 +43,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 use djinn_core::clock::{Clock, SystemClock};
 use djinn_db::{
-    BuildPodPermitRepository, BuildPodPermitState, CreateTaskRunParams, Database,
-    EffectiveCreatorProvenance, ProjectRepository, TaskRepository, TaskRunRepository,
-    UserRepository,
+    BuildPodPermitRepository, BuildPodPermitState, CreateTaskAttemptParams, CreateTaskRunParams,
+    Database, EffectiveCreatorProvenance, ProjectRepository, TaskAttemptRepository, TaskRepository,
+    TaskRunRepository, UserRepository,
 };
 use djinn_k8s::pod_resize::{CpuLimit, PodResizeError};
 use djinn_k8s::pod_resize_fixture::StoredTaskRunPod;
@@ -121,6 +121,21 @@ struct RecordingRuntime {
     protocol: Option<LauncherAuthorityProtocol>,
     attaches: Arc<AtomicUsize>,
     teardowns: Arc<AtomicUsize>,
+    /// When set, `prepare` reads the durable state of this dispatch **at the
+    /// instant of the Job POST** and parks it in `at_job_post`.
+    probe: Option<Database>,
+    at_job_post: Arc<std::sync::Mutex<Option<DurableStateAtJobPost>>>,
+}
+
+/// What the database held for one dispatch at the moment its Job was POSTed.
+///
+/// Both counts are ordering facts, not liveness facts: the Job POST is the
+/// point after which a Pod can exist, so anything that has to fence that Pod
+/// must already be durable here.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DurableStateAtJobPost {
+    task_run_status: Option<String>,
+    build_pod_permits: i64,
 }
 
 impl RecordingRuntime {
@@ -130,6 +145,26 @@ impl RecordingRuntime {
             protocol,
             attaches: Arc::new(AtomicUsize::new(0)),
             teardowns: Arc::new(AtomicUsize::new(0)),
+            probe: None,
+            at_job_post: Arc::new(std::sync::Mutex::new(None)),
+        })
+    }
+
+    /// Same runtime, but it reads the durable ordering out of `db` inside
+    /// `prepare`. Asserting after the seam returns cannot distinguish "created
+    /// before the Job" from "created after it"; this can.
+    fn observing(
+        db: &Database,
+        job_uid: Option<&str>,
+        protocol: Option<LauncherAuthorityProtocol>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            job_uid: job_uid.map(ToOwned::to_owned),
+            protocol,
+            attaches: Arc::new(AtomicUsize::new(0)),
+            teardowns: Arc::new(AtomicUsize::new(0)),
+            probe: Some(db.clone()),
+            at_job_post: Arc::new(std::sync::Mutex::new(None)),
         })
     }
 
@@ -140,6 +175,14 @@ impl RecordingRuntime {
     fn teardowns(&self) -> usize {
         self.teardowns.load(Ordering::SeqCst)
     }
+
+    fn durable_state_at_job_post(&self) -> DurableStateAtJobPost {
+        self.at_job_post
+            .lock()
+            .expect("job-post observation mutex")
+            .clone()
+            .expect("prepare must have run and recorded the durable state")
+    }
 }
 
 #[async_trait]
@@ -149,6 +192,27 @@ impl SessionRuntime for RecordingRuntime {
         spec: &TaskRunSpec,
         _credentials: &ResolvedCredentials,
     ) -> Result<RunHandle, RuntimeError> {
+        if let Some(db) = self.probe.as_ref() {
+            db.ensure_initialized().await.expect("probe db");
+            let task_run_status: Option<String> =
+                sqlx::query_scalar("SELECT status FROM task_runs WHERE id = $1")
+                    .bind(&spec.task_run_id)
+                    .fetch_optional(db.pool())
+                    .await
+                    .expect("read task_runs at job post");
+            let build_pod_permits: i64 = sqlx::query_scalar(
+                "SELECT count(*)::bigint FROM build_pod_permits WHERE task_run_id = $1",
+            )
+            .bind(&spec.task_run_id)
+            .fetch_one(db.pool())
+            .await
+            .expect("count build_pod_permits at job post");
+            *self.at_job_post.lock().expect("job-post observation mutex") =
+                Some(DurableStateAtJobPost {
+                    task_run_status,
+                    build_pod_permits,
+                });
+        }
         Ok(RunHandle {
             task_run_id: spec.task_run_id.clone(),
             container_id: None,
@@ -192,7 +256,9 @@ struct Seeded {
     spec: TaskRunSpec,
 }
 
-async fn seed(db: &Database, suffix: &str) -> Seeded {
+/// Seed only the rows that exist before dispatch begins: a user, a project and
+/// a task.
+async fn seed_task(db: &Database, suffix: &str) -> djinn_core::models::Task {
     let user = UserRepository::new(db.clone())
         .upsert_from_github(
             i64::try_from(uuid::Uuid::now_v7().as_u128() % 8_000_000_000_000_000_000)
@@ -211,7 +277,7 @@ async fn seed(db: &Database, suffix: &str) -> Seeded {
         )
         .await
         .expect("seed project");
-    let task = TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+    TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
         .create_in_project_with_provenance(
             &project.id,
             None,
@@ -226,12 +292,21 @@ async fn seed(db: &Database, suffix: &str) -> Seeded {
             None,
         )
         .await
-        .expect("seed task");
+        .expect("seed task")
+}
+
+/// A run that already has its durable `task_runs` row when the seam is entered.
+///
+/// This is **not** the shape production dispatch presents — see
+/// [`seed_as_dispatch_does`] — but it is the right fixture for every assertion
+/// about what the resize stack does once a permit can be acquired at all.
+async fn seed(db: &Database, suffix: &str) -> Seeded {
+    let task = seed_task(db, suffix).await;
     let task_run_id = uuid::Uuid::now_v7().to_string();
     TaskRunRepository::new(db.clone())
         .create(CreateTaskRunParams {
             id: &task_run_id,
-            project_id: &project.id,
+            project_id: &task.project_id,
             task_id: &task.id,
             trigger_type: "manual",
             status: Some("running"),
@@ -241,11 +316,57 @@ async fn seed(db: &Database, suffix: &str) -> Seeded {
         })
         .await
         .expect("seed task run");
-    let spec = TaskRunSpec {
+    Seeded {
+        spec: spec_for(&task, task_run_id, None),
+        task,
+    }
+}
+
+/// The shape production dispatch actually presents to the seam.
+///
+/// `dispatch_task_runtime` mints a fresh uuid-v7 `task_run_id`, allocates the
+/// `task_attempts` row for it, and enters `execute_runtime_report_phase`. It
+/// does **not** create the `task_runs` row: until this fix, nothing on the host
+/// did, and the only production creator was the in-pod supervisor's
+/// `create_task_run` RPC — which cannot land until a Pod boot later.
+///
+/// Every other fixture in this file pre-seeds that row, which is precisely why
+/// the whole file stayed green while every `resize-v2` dispatch in production
+/// failed closed on a foreign-key violation it could not report.
+async fn seed_as_dispatch_does(db: &Database, suffix: &str) -> Seeded {
+    let task = seed_task(db, suffix).await;
+    let task_run_id = uuid::Uuid::now_v7().to_string();
+    let attempt_id = uuid::Uuid::now_v7().to_string();
+    let dispatch_key = format!("task-run:{task_run_id}");
+    let attempt = TaskAttemptRepository::new(db.clone())
+        .create_or_get_pending(CreateTaskAttemptParams {
+            id: &attempt_id,
+            task_id: &task.id,
+            role: "worker",
+            dispatch_key: &dispatch_key,
+            session_id: None,
+            attempt_seq: None,
+            dispatch_owner_incarnation_id: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed the exact attempt dispatch allocates");
+    Seeded {
+        spec: spec_for(&task, task_run_id, Some(attempt.id)),
+        task,
+    }
+}
+
+fn spec_for(
+    task: &djinn_core::models::Task,
+    task_run_id: String,
+    task_attempt_id: Option<String>,
+) -> TaskRunSpec {
+    TaskRunSpec {
         task_run_id,
-        task_attempt_id: None,
+        task_attempt_id,
         task_id: task.id.clone(),
-        project_id: project.id.clone(),
+        project_id: task.project_id.clone(),
         trigger: djinn_core::models::TaskRunTrigger::NewTask,
         base_branch: "main".to_owned(),
         task_branch: "djinn/resize-seam".to_owned(),
@@ -259,8 +380,7 @@ async fn seed(db: &Database, suffix: &str) -> Seeded {
         commit_author_email: None,
         resume_lifecycle_metadata: None,
         is_evidence_spike: false,
-    };
-    Seeded { task, spec }
+    }
 }
 
 /// The production `AgentContext` — built by `AppState::agent_context()`, the
@@ -614,6 +734,194 @@ async fn a_leaf_v1_dispatch_issues_no_resize_and_captures_no_identity() {
     );
     assert_eq!(row.state, BuildPodPermitState::JobCreated);
     assert_eq!(bridge.gate().dispatches_before_birth_confirmation(), 0);
+}
+
+// ── The dispatch-time ordering of `task_runs` and `build_pod_permits` ──────
+
+/// **The regression.** A dispatch entering the seam the way production enters
+/// it — fresh uuid-v7 run id, `task_attempts` row allocated, **no `task_runs`
+/// row yet** — must still end up with a durable permit row.
+///
+/// `build_pod_permits.task_run_id` is `REFERENCES task_runs(id)`. Before this
+/// fix nothing on the host created that parent, so `acquire` violated the
+/// foreign key, `BuildPodPermitRepository::acquire` collapsed the violation into
+/// `Unavailable` to fail closed, and `admit_task_run_dispatch` refused every
+/// `resize-v2` render with "holds no durable build-pod permit". Production had
+/// zero rows in `build_pod_permits`.
+///
+/// What stays green if the body does nothing? Nothing. This asserts the ROW, in
+/// the real table, behind the real foreign key. Delete the
+/// `ensure_durable_task_run_row` call from `execute_runtime_report_phase` and
+/// the permit lookup below returns `None` — there is no row at all, exactly as
+/// in production.
+#[tokio::test]
+async fn the_seam_acquires_a_permit_for_a_dispatch_that_has_no_task_runs_row_yet() {
+    const POD_UID: &str = "pod-uid-fk";
+    const JOB_UID: &str = "job-uid-fk";
+
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed_as_dispatch_does(&db, "fk").await;
+
+    // The premise of the whole test: production's parent row is genuinely absent
+    // when the seam is entered. If a future refactor makes some earlier step
+    // create it, this assertion fails rather than letting the test go vacuous.
+    let before: i64 = sqlx::query_scalar("SELECT count(*)::bigint FROM task_runs WHERE id = $1")
+        .bind(&seeded.spec.task_run_id)
+        .fetch_one(db.pool())
+        .await
+        .expect("count task_runs before dispatch");
+    assert_eq!(
+        before, 0,
+        "production enters this seam with no task_runs row; a fixture that pre-seeds one \
+         is measuring itself"
+    );
+
+    let cluster = StoredTaskRunPod::resize_v2(POD_UID, RENDERED_CEILING);
+    let bridge = bridge_for(&db, &cluster, CONFIRMING_BUDGET);
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::new(Some(JOB_UID), Some(LauncherAuthorityProtocol::ResizeV2));
+
+    drive_seam(runtime.clone(), &seeded, &context)
+        .await
+        .expect("a resize-v2 dispatch with no pre-existing task_runs row is admitted");
+
+    let row = BuildPodPermitRepository::new(db.clone())
+        .active(&seeded.spec.task_run_id)
+        .await
+        .expect("read permit")
+        .expect(
+            "the seam must have acquired a permit; a None here is the production failure — \
+             the foreign key onto task_runs had no parent to point at",
+        );
+    assert_eq!(row.state, BuildPodPermitState::BirthConfirmed);
+    assert_eq!(row.job_uid.as_deref(), Some(JOB_UID));
+    assert_eq!(runtime.attaches(), 1, "the worker session started");
+
+    // The parent the foreign key points at is the run's own row, not some other
+    // dispatch's, and the host terminalizes the row it created rather than
+    // leaving it live for the stale sweep.
+    let (task_id, status): (String, String) =
+        sqlx::query_as("SELECT task_id, status FROM task_runs WHERE id = $1")
+            .bind(&seeded.spec.task_run_id)
+            .fetch_one(db.pool())
+            .await
+            .expect("the durable task_runs row exists after dispatch");
+    assert_eq!(task_id, seeded.task.id);
+    assert!(
+        matches!(status.as_str(), "completed" | "failed" | "interrupted"),
+        "the host reaps the run row it created; found {status}"
+    );
+}
+
+/// **The ordering.** Both durable rows must exist at the instant the Job is
+/// POSTed, because the Job POST is the point after which a Pod can exist.
+///
+/// Asserting after the seam returns proves only that the rows were written at
+/// some point. This reads them from inside `SessionRuntime::prepare`, which is
+/// the Job POST itself, so it can tell "before" from "after".
+///
+/// Two named mutations make it red, and they are the two orderings that matter:
+///
+/// * move `ensure_durable_task_run_row` to after `runtime.prepare` — the
+///   `task_runs` count at the Job POST is 0, and the permit is gone with it;
+/// * move `acquire_build_pod_permit` to after `runtime.prepare` — the permit
+///   count at the Job POST is 0, which is the fencing violation the permit's
+///   own doc comment forbids.
+#[tokio::test]
+async fn both_durable_rows_exist_before_the_job_that_they_fence_is_posted() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed_as_dispatch_does(&db, "order").await;
+    let cluster = StoredTaskRunPod::resize_v2("pod-uid-order", RENDERED_CEILING);
+    let bridge = bridge_for(&db, &cluster, CONFIRMING_BUDGET);
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::observing(
+        &db,
+        Some("job-uid-order"),
+        Some(LauncherAuthorityProtocol::ResizeV2),
+    );
+
+    drive_seam(runtime.clone(), &seeded, &context)
+        .await
+        .expect("a healthy resize-v2 dispatch is admitted");
+
+    assert_eq!(
+        runtime.durable_state_at_job_post(),
+        DurableStateAtJobPost {
+            // `starting`, not merely present: the host creates the row in the
+            // same pre-session state the in-pod supervisor would have.
+            task_run_status: Some("starting".to_owned()),
+            build_pod_permits: 1,
+        },
+        "the task_runs row and the permit that references it must both be durable \
+         before the Job POST, not after it"
+    );
+}
+
+/// **The guard is not weakened.** With the ordering fixed, a `resize-v2` render
+/// that genuinely cannot obtain a permit must still refuse to start a worker
+/// session.
+///
+/// Two components writing one leaf's `cpu.max`, or none, is the exact hazard
+/// `3i92` exists to prevent, so "no permit" must stay fatal for `resize-v2`. The
+/// permit is made genuinely unobtainable by removing the global pool row that
+/// `acquire` locks first — a real repository failure, not a stubbed result.
+///
+/// Change `admit_task_run_dispatch`'s `permit.is_none()` arm to return `Ok(())`
+/// unconditionally instead of bailing for non-leaf, and `attaches()` below goes
+/// to 1.
+#[tokio::test]
+async fn a_resize_v2_render_still_refuses_when_no_permit_can_be_obtained() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed_as_dispatch_does(&db, "nopermit").await;
+    BuildPodPermitRepository::new(db.clone())
+        .delete_global_pool_for_test()
+        .await
+        .expect("remove the pool row acquire locks first");
+
+    let cluster = StoredTaskRunPod::resize_v2("pod-uid-nopermit", RENDERED_CEILING);
+    let bridge = bridge_for(&db, &cluster, CONFIRMING_BUDGET);
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::new(
+        Some("job-uid-nopermit"),
+        Some(LauncherAuthorityProtocol::ResizeV2),
+    );
+
+    let error = drive_seam(runtime.clone(), &seeded, &context)
+        .await
+        .expect_err("a resize-v2 render with no permit must not dispatch");
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("holds no durable build-pod permit"),
+        "the refusal must name the missing permit, not some downstream symptom: {rendered}"
+    );
+
+    assert_eq!(
+        runtime.attaches(),
+        0,
+        "no worker session may start with no resize identity: {rendered}"
+    );
+    assert_eq!(runtime.teardowns(), 1, "the refused run is torn down");
+    assert_eq!(cluster.resize_patches(), 0, "nothing was resized");
+    assert!(
+        BuildPodPermitRepository::new(db.clone())
+            .active(&seeded.spec.task_run_id)
+            .await
+            .expect("read permit")
+            .is_none(),
+        "no permit was acquired, so the refusal is the real one and not a stubbed result"
+    );
+
+    // The run row the host created is terminalized rather than stranded
+    // `starting` — before dispatch created it, this path had nothing to reap.
+    let status: String = sqlx::query_scalar("SELECT status FROM task_runs WHERE id = $1")
+        .bind(&seeded.spec.task_run_id)
+        .fetch_one(db.pool())
+        .await
+        .expect("the durable task_runs row exists");
+    assert_eq!(
+        status, "failed",
+        "a refused dispatch must not leave its run row live forever"
+    );
 }
 
 /// The bootstrap type is still constructible and still composes — a compile-time


### PR DESCRIPTION
## Production evidence

Since the launcher-authority cutover to `resize-v2` (2026-08-01T14:26:36Z, epoch 1), a large fraction of dispatches fail. The server log:

```
supervisor dispatch: task-run 019fbdb8-ae0c-7221-9aaf-fc2f4a0b4cb4 rendered `resize-v2`
but holds no durable build-pod permit, so no resize identity can be captured for it;
refusing to start the worker session
```

One step back, the permit acquisition returned `Unavailable`, and the cause was:

```
build pod permit acquisition unavailable
error: database error: error returned from database: insert or update on table
"build_pod_permits" violates foreign key constraint "fk_build_pod_permits_task_run"
```

`SELECT count(*) FROM build_pod_permits` = **0** in production. Not "few". Zero. The relation has never held a row.

The cost is not just a refused dispatch. The Job POST has already happened by the time the birth gate refuses, so the Pod boots and the worker runs on regardless — the host walks away in seconds and the orphaned pod keeps working. Two runs in one half-hour window burned ~20 minutes each and produced 4,000–5,600 output tokens of real work that was then torn down and discarded.

## The ordering: a strict bug, not a race

`task_runs` has exactly one production writer, and it is on the wrong side of the Pod boot:

| # | step | where |
|---|---|---|
| 1 | `task_run_id = Uuid::now_v7()` — fresh every dispatch | `supervisor_runner.rs:1534` |
| 2 | `task_attempts` row allocated | `supervisor_runner.rs:1540` |
| 3 | **`acquire_build_pod_permit`** → `INSERT INTO build_pod_permits (task_run_id)` | `supervisor_runner.rs:1175` |
| 4 | `runtime.prepare` → the Job POST | `supervisor_runner.rs:1176` |
| 5 | birth gate, then `attach_stdio` | `supervisor_runner.rs:1190`, `:1297` |
| — | *…Pod schedule, image pull, container start, RPC handshake…* | |
| 6 | **`INSERT INTO task_runs` + commit** | `task_run_outcome.rs:134`, via the in-pod `create_task_run` RPC |

Step 6 is the only production creator of the FK parent for step 3, and it is separated from it by a full Pod boot. Nothing was ever concurrent here — this is sequential and backwards, and it failed on **every** dispatch, not some of them.

There is no path where the row pre-exists: `task_run_id` is minted fresh per dispatch, retries and resumes mint a new one (`resume_lifecycle_metadata` carries only the incarnation and group ids), the attempt row dedups on a `dispatch_key` that embeds the fresh uuid, and `acquire`'s idempotent branch requires a pre-existing permit keyed by that same fresh uuid.

## Why the intermittency is not evidence of a race

`launcher_authority_protocol` is a property of the **image** (`images.launcher_authority_protocol`, resolved through `ProjectRepository::resolve_dispatch_image`), not of the moment. `admit_task_run_dispatch`'s `permit.is_none()` arm returns `Ok(())` when `launcher_owns_leaf_quota()` and bails otherwise. So:

- a project whose selected image declares `resize-v2` fails **100%** of the time;
- a project still on a `leaf-v1` or declared-nothing image succeeds **100%** of the time, dispatching ungoverned exactly as before.

The `completed: 3, failed: 4, interrupted: 3, running: 2` split tracks which image each project selected. It is deterministic, and it needs no race to explain.

## Why leaf-v1 masked it, and why the comment said so

The doc comment at `supervisor_runner.rs:975-985` justified treating a missing permit as a warning because that is the arm "`leaf-v1` — the arm every Pod on the current fleet takes". That was true when written. The fleet is now `resize-v2`, so the arm every Pod takes is the one that refuses. **The failure path was always broken; only its consequence changed.** That comment is corrected in this PR, with a note not to read the fleet's current protocol out of a comment.

Why no test caught it: every permit fixture seeds a `task_runs` row first — including `server/tests/task_run_resize_dispatch_seam.rs`'s own `seed()`, the file whose entire stated purpose is to enter the production seam with no test shim. It seeded the one row production does not have.

## The fix

Ordering only. The foreign key, the fail-closed error collapse, and the `resize-v2` refusal are all untouched.

- **`TaskRunRepository::create_for_dispatch`** — idempotent insert of the dispatch-time `task_runs` row. The insert SQL is now one shared `INSERT_TASK_RUN_SQL` const so the `catalog_image_id` binding cannot drift between creators (omitting it in one creator has already caused a NULL-binding outage once).
- **`ensure_durable_task_run_row`** — called at the top of `execute_runtime_report_phase`, before `acquire_build_pod_permit`. It writes the row the worker would have written anyway: same host-minted id, same `starting` status, same catalog binding.
- **`create_run_for_attempt` now adopts** (`ON CONFLICT (id) DO NOTHING`) instead of colliding. Without this, every dispatch would fail at the worker's *first* RPC. The duplicate-key protection adoption gives up is restored explicitly: the repository re-reads the row it adopted and refuses one bound to a different task or project, inside the same transaction that does the attempt association.
- **Reap on the `runtime.prepare` failure path.** The run row now outlives a failed Job POST, so that path terminalizes it rather than stranding it `starting` until the stale sweep.
- **Secondary, diagnosability.** `acquire` deliberately collapses every error into `Unavailable` to fail closed, which means its `warn!` is the only place the real cause is ever named — it now carries `task_run_id`. That is what made an FK violation indistinguishable from a pool outage at the other end of the dispatch log. The enum is deliberately left undifferentiated; fail-closed is correct.

What was explicitly **not** done: the FK is not dropped or weakened, the `resize-v2` refusal is not made non-fatal (two components writing one leaf's `cpu.max`, or none, is the exact hazard 3i92 exists to prevent), and no retry loop was added — the ordering is sequential-and-wrong, so a retry would have papered over it.

## Mutation table

Every claim has a named mutation. Each was applied, run, observed red, and reverted.

| # | Mutation | Test that goes red | Result |
|---|---|---|---|
| M1 | Delete the `ensure_durable_task_run_row` call from `execute_runtime_report_phase` | all three new seam tests | **7 passed / 3 failed** — permit lookup returns `None`, exactly as in production |
| M2 | Move `acquire_build_pod_permit` to *after* `runtime.prepare` | `both_durable_rows_exist_before_the_job_that_they_fence_is_posted` only | **9 passed / 1 failed** — `build_pod_permits: 0` observed at the Job POST |
| M3 | Weaken `admit_task_run_dispatch`'s `permit.is_none()` arm to `return Ok(())` unconditionally | `a_resize_v2_render_still_refuses_when_no_permit_can_be_obtained` only | **9 passed / 1 failed** — `attaches()` climbs to 1 |
| M4 | Drop `ADOPT_EXISTING_TASK_RUN` from `create_run_for_attempt` | `the_in_pod_rpc_adopts_the_task_runs_row_dispatch_already_created` | **4 passed / 1 failed** — Postgres 23505 `task_runs_pkey` |
| M5 | Drop the adoption integrity guard | `adoption_refuses_a_run_id_that_belongs_to_a_different_task` | **4 passed / 1 failed** — a run id bound to another task is silently adopted |

M2 is the one that matters for non-vacuity of the ordering claim: it leaves the regression test (M1's target) **green** while turning the ordering test red, so the two tests are not restatements of each other. The ordering assertion is read from *inside* `SessionRuntime::prepare` — the Job POST itself — because asserting after the seam returns can only prove the rows were written eventually, never that they were written first.

The new tests assert **rows in the real tables behind the real foreign key**, not that a function returned `Ok`. `the_seam_acquires_a_permit_for_a_dispatch_that_has_no_task_runs_row_yet` also asserts up front that the parent row is genuinely absent when the seam is entered, so a future refactor that pre-seeds it fails the test rather than quietly making it vacuous.

## Test results

- `task_run_resize_dispatch_seam`: **10/10** (7 pre-existing + 3 new)
- `djinn-db` + `djinn-agent`: **3159/3159**
- `djinn-server`: **759/759**
- `djinn-coordinator` + `djinn-supervisor` + `djinn-agent-worker`: **2644/2644**
- `cargo fmt --check` clean; clippy clean for `djinn-db`, `djinn-agent`, `djinn-server` (`--all-targets`)

One `djinn-db doctor_finding` test failed in a fail-fast run and passed in isolation and on a full `--no-fail-fast` rerun. It touches neither `task_runs` nor permits — a known parallelism flake, unrelated.

## Reviewer note: one interaction I checked and deliberately left alone

The coordinator's startup stale-run reaper (`STARTUP_TASK_RUN_THRESHOLD_SECS = 10`) reaps `starting`/`running` rows older than 10s at boot. The `starting` row now exists from dispatch rather than from Pod boot, which widens its exposure by the boot duration.

I judged this acceptable rather than mitigating it, on two grounds: a legitimately live run *already* holds `starting` for up to the 480s pre-session deadline, so the reaper already had to tolerate a long legitimate `starting` window; and the reaper's premise — host process gone, therefore stdio channel gone, therefore run orphaned — holds for a pre-boot run just as it does for a booted one. Flagging it explicitly so the call is reviewed rather than assumed.

Two consequences worth knowing, both improvements: the stuck-task reaper's `cluster_witness_for_task` derives Job names from non-terminal `task_runs` rows, so it now has a witness during the pre-boot window where it previously returned `NotApplicable` and permitted a reap; and `board_health_kueue_admission`'s `without_task_run` counter will fall toward zero, since migration 165's premise was precisely this missing row.
