### PR TITLE
fix(board-health): decode the now-nullable liveness session_id as Option

### DIFF
--- a/server/crates/djinn-db/src/repositories/task/board_health.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health.rs
@@ -160,7 +160,7 @@ pub(super) async fn liveness_outcomes_section(pool: &sqlx::PgPool) -> serde_json
                 "outcome_reason": row.get::<Option<String>, _>("outcome_reason"),
                 "created_at":     row.get::<String, _>("created_at"),
                 "task_id":        row.get::<Option<String>, _>("task_id"),
-                "session_id":     row.get::<String, _>("session_id"),
+                "session_id":     row.get::<Option<String>, _>("session_id"),
             })
         })
         .collect();
@@ -202,7 +202,7 @@ pub(super) async fn protocol_violations_section(pool: &sqlx::PgPool) -> serde_js
                 "outcome_reason": row.get::<Option<String>, _>("outcome_reason"),
                 "created_at":     row.get::<String, _>("created_at"),
                 "task_id":        row.get::<Option<String>, _>("task_id"),
-                "session_id":     row.get::<String, _>("session_id"),
+                "session_id":     row.get::<Option<String>, _>("session_id"),
                 "task_short_id":  row.get::<Option<String>, _>("task_short_id"),
                 "task_title":     row.get::<Option<String>, _>("task_title"),
                 "task_status":    row.get::<Option<String>, _>("task_status"),


### PR DESCRIPTION
## Production down on v0.7.33

`board_health` panicked. The panic killed the tokio worker holding the `CoordinatorActor` mailbox, so every later send failed with `actor channel closed` and **dispatch stopped entirely** — with `skf0` sitting `open` and ready the whole time.

```
thread 'tokio-rt-worker' panicked at
  crates/djinn-db/src/repositories/task/board_health.rs:163:39:
called `Result::unwrap()` on an `Err` value:
  ColumnDecode { index: "session_id", source: UnexpectedNullError }
```

**It looked healthy while dead.** The incarnation-lease renewal runs on a separate task and kept logging `CoordinatorActor: renewed coordinator incarnation lease` every 60s throughout. The only visible symptom was a `WARN` from an unrelated component (`board_health: mismatch refresh trigger failed`), and dispatch silently attempting nothing — no deferral, no backoff, no error.

## Cause: a nullable migration whose readers were never updated

Migration 163 did `ALTER COLUMN session_id DROP NOT NULL` on `liveness_evidence`, guarded by `CHECK (session_id IS NOT NULL OR task_id IS NOT NULL)` — task-scoped evidence is legitimately session-less.

The schema has permitted NULL since then. Nothing ever **wrote** one until #2883 landed the optional `LivenessEvidenceSnapshot.session_id`. The first two NULL rows in production (2 of 8667) were both written at `2026-08-01T16:30:24Z` by the execution-state orphan reclaim, recording `dead_reclaimed` for two tasks whose Jobs had already terminated:

```
dead | dead_reclaimed | 019fb0b6-61e3-... (zd7p) | 2026-08-01T16:30:24.497Z
dead | dead_reclaimed | 019fb2cc-d26c-... (skf0) | 2026-08-01T16:30:24.334Z
```

The next `board_health` read panicked on them.

## The fix

Both call sites (lines 163 and 205) decoded `session_id` as non-nullable `String`, while **every** neighbouring nullable column already used `Option<String>` — `outcome_kind`, `outcome_reason`, `task_id`, `task_short_id`, `task_title`, `task_status`. Only `session_id` was missed when the column became nullable.

Two lines, `String` → `Option<String>`. No query, no schema, no behaviour change; the JSON simply carries `null` where it previously could not exist.

## Why this wasn't caught

The failure needs three things to coincide: a nullable column, a writer that finally exercises the NULL, and a reader that assumes non-null. #2883 supplied the second, ~3 hours after merging, when an unrelated reaper happened to record task-only evidence. No test covers a `liveness_evidence` row with a NULL `session_id` reaching `board_health`.

A regression is worth adding — a `board_health` call over a task-only evidence row must not panic — and I've left that out of this PR deliberately to keep the hotfix minimal while production is down. Filing it as follow-up.