### PR TITLE
Fix stalled refinement handoffs after terminal role tasks

### DIFF
--- a/server/crates/djinn-control-plane/src/dispatch.rs
+++ b/server/crates/djinn-control-plane/src/dispatch.rs
@@ -62,7 +62,7 @@ use crate::tools::provider_tools::{
 use crate::tools::refinement_tools::{
     ProposalRefinementDemandEvidenceParams, ProposalRefinementDemandRoundParams,
     ProposalRefinementResolveParams, ProposalRefinementStartParams, ProposalRefinementStatusParams,
-    ProposalVerdictOverrideParams,
+    ProposalRefinementStopParams, ProposalVerdictOverrideParams,
 };
 use crate::tools::service_tools::ServicePresetListParams;
 use crate::tools::session_tools::{
@@ -576,6 +576,13 @@ impl DjinnMcpServer {
                 name,
                 self.proposal_refinement_resolve(Parameters(decode_args::<
                     ProposalRefinementResolveParams,
+                >(name, args)?))
+                    .await,
+            ),
+            "proposal_refinement_stop" => map_json(
+                name,
+                self.proposal_refinement_stop(Parameters(decode_args::<
+                    ProposalRefinementStopParams,
                 >(name, args)?))
                     .await,
             ),

--- a/server/crates/djinn-control-plane/src/tools/proposal_ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_ops.rs
@@ -825,6 +825,19 @@ pub struct ProposalRefinementStartResponse {
     pub error: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Clone, schemars::JsonSchema)]
+pub struct ProposalRefinementStopResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_id: Option<String>,
+    pub stopped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 /// Response for `proposal_refinement_status`.
 #[derive(Serialize, Deserialize, Clone, schemars::JsonSchema)]
 pub struct ProposalRefinementStatusResponse {

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
@@ -17,7 +17,7 @@ use crate::server::DjinnMcpServer;
 use crate::tools::proposal_ops::{
     DemandRoundResponse, NeedsEvidenceDemandResponse, NeedsEvidenceDemandResult,
     ProposalRefinementStartResponse, ProposalRefinementStatusModel,
-    ProposalRefinementStatusResponse, VerdictOverrideResponse,
+    ProposalRefinementStatusResponse, ProposalRefinementStopResponse, VerdictOverrideResponse,
 };
 use crate::tools::refinement_helpers::validate_demand_evidence;
 pub use crate::tools::refinement_helpers::{
@@ -208,6 +208,15 @@ pub struct ProposalRefinementStartParams {
 pub struct ProposalRefinementStatusParams {
     /// Proposal UUID or short_id.
     pub proposal_id: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub struct ProposalRefinementStopParams {
+    /// Proposal UUID or short_id.
+    pub proposal_id: String,
+    /// Auditable operator explanation.
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -630,6 +639,57 @@ impl DjinnMcpServer {
             resolved: true,
             error: None,
         })
+    }
+
+    #[tool(
+        description = "Stop a stalled proposal refinement handoff. Issues the canonical operator_stop tag under the exact run generation fence. Refuses healthy runs whose correlated role task is not terminal."
+    )]
+    pub async fn proposal_refinement_stop(
+        &self,
+        Parameters(p): Parameters<ProposalRefinementStopParams>,
+    ) -> Json<ProposalRefinementStopResponse> {
+        let repo = ProposalRepository::new(self.state.db().clone(), self.state.event_bus());
+        let Some(proposal) = repo.resolve(&p.proposal_id).await.ok().flatten() else {
+            return Json(ProposalRefinementStopResponse {
+                proposal_id: None,
+                stopped: false,
+                stop_tag: None,
+                code: Some("proposal_not_found".into()),
+                error: Some(format!("proposal not found: {}", p.proposal_id)),
+            });
+        };
+        let exact = match repo
+            .load_current_refinement_run_snapshot(&proposal.id, 60_000)
+            .await
+        {
+            Ok(Some(exact)) => exact,
+            Ok(None) => {
+                return Json(ProposalRefinementStopResponse {
+                    proposal_id: Some(proposal.id),
+                    stopped: false,
+                    stop_tag: None,
+                    code: Some("no_refinement_run".into()),
+                    error: Some("proposal has no refinement run".into()),
+                });
+            }
+            Err(error) => {
+                return Json(ProposalRefinementStopResponse {
+                    proposal_id: Some(proposal.id),
+                    stopped: false,
+                    stop_tag: None,
+                    code: Some("persistence".into()),
+                    error: Some(error.to_string()),
+                });
+            }
+        };
+        let actor =
+            djinn_core::auth_context::current_user_id().unwrap_or_else(|| "operator".into());
+        match repo.operator_stop_stalled_refinement(&exact.snapshot.run.run_id, exact.generation, &actor, p.reason).await {
+            Ok(true) => Json(ProposalRefinementStopResponse { proposal_id: Some(proposal.id), stopped: true, stop_tag: Some("operator_stop".into()), code: None, error: None }),
+            Ok(false) => Json(ProposalRefinementStopResponse { proposal_id: Some(proposal.id), stopped: false, stop_tag: None, code: Some("already_stopped".into()), error: Some("refinement was already stopped".into()) }),
+            Err(djinn_db::RefinementIntentMutationError::NotStalledHandoff { .. }) => Json(ProposalRefinementStopResponse { proposal_id: Some(proposal.id), stopped: false, stop_tag: None, code: Some("not_stalled_handoff".into()), error: Some("refinement role task is not terminal or its handoff already has a successor".into()) }),
+            Err(error) => Json(ProposalRefinementStopResponse { proposal_id: Some(proposal.id), stopped: false, stop_tag: None, code: Some("persistence".into()), error: Some(error.to_string()) }),
+        }
     }
 
     /// Override a latest `needs-work` verdict with auditable sign-off/approval

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
@@ -296,7 +296,6 @@ impl DjinnMcpServer {
                 p.proposal_id
             )));
         };
-
         // Only allow refinement for proposals in draft or in_review.
         if !matches!(proposal.status.as_str(), "draft" | "in_review") {
             return Json(err_refinement_start(format!(
@@ -658,6 +657,18 @@ impl DjinnMcpServer {
                 error: Some(format!("proposal not found: {}", p.proposal_id)),
             });
         };
+        if let Err(error) = self
+            .gate_proposal_edit(proposal.author_user_id.as_deref())
+            .await
+        {
+            return Json(ProposalRefinementStopResponse {
+                proposal_id: Some(proposal.id),
+                stopped: false,
+                stop_tag: None,
+                code: Some("forbidden".into()),
+                error: Some(error),
+            });
+        }
         let exact = match repo
             .load_current_refinement_run_snapshot(&proposal.id, 60_000)
             .await

--- a/server/crates/djinn-control-plane/src/tools/task_tools/board.rs
+++ b/server/crates/djinn-control-plane/src/tools/task_tools/board.rs
@@ -36,6 +36,14 @@ pub(super) async fn board_health_impl(
                         return Json(ErrorOr::Error(ErrorResponse::new(error.to_string())));
                     }
                 }
+                match refinement_repo.load_refinement_stalled_handoffs().await {
+                    Ok(findings) => {
+                        parsed.refinement_stalled_handoff_count = findings.len() as i64;
+                    }
+                    Err(error) => {
+                        return Json(ErrorOr::Error(ErrorResponse::new(error.to_string())));
+                    }
+                }
 
                 // Surface aggregate coordinator metrics (throughput + PR errors).
                 if let Some(coordinator) = server.state.coordinator().await

--- a/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
+++ b/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
@@ -1470,6 +1470,10 @@ pub struct BoardHealthResponse {
     /// Current evaluator-classified phantom refinement runs across the board.
     #[serde(default)]
     pub refinement_phantom_active_count: i64,
+    /// Materialized intents whose correlated role task is terminal and which
+    /// have no durable successor.
+    #[serde(default)]
+    pub refinement_stalled_handoff_count: i64,
     /// Durable phantom-reap events committed within the database-time 24-hour window.
     #[serde(default)]
     pub refinement_phantom_reaps_24h: i64,

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -714,6 +714,15 @@ impl CoordinatorActor {
                     ),
                 ),
             );
+            crate::doctor::register_refinement_stalled_handoff_check(
+                registry,
+                Arc::new(
+                    crate::doctor::ProposalRepositoryRefinementStalledHandoffSource::new(
+                        db.clone(),
+                        events_tx.clone(),
+                    ),
+                ),
+            );
             crate::doctor::register_stalled_epic_check(
                 registry,
                 Arc::new(crate::doctor::TaskRepositoryStalledEpicSource::new(
@@ -1760,7 +1769,7 @@ impl CoordinatorActor {
         let mut state =
             super::refinement::RefinementLoopState::new(&exact.proposal_id, revision_seq)
                 .with_run_identity(exact.snapshot.run.run_id.clone(), exact.generation)
-                .with_captured_snapshot_seq(captured_snapshot_seq);
+                .with_recovered_snapshot_seq(captured_snapshot_seq);
         if let Some(park) = &exact.snapshot.park {
             state.phase = match park.kind {
                 RefinementParkKind::AwaitingReview => {

--- a/server/crates/djinn-coordinator/src/doctor/mod.rs
+++ b/server/crates/djinn-coordinator/src/doctor/mod.rs
@@ -20,6 +20,7 @@ pub mod leader_tick;
 pub mod live_mover;
 pub mod mismatch_scan;
 pub mod refinement_phantom_active;
+pub mod refinement_stalled_handoff;
 pub mod retrieval_health;
 pub mod stale_cache_roots;
 pub mod stalled_epic;
@@ -39,6 +40,10 @@ pub use refinement_phantom_active::{
     MemoryRefinementPhantomActiveSource, ProposalRepositoryRefinementPhantomActiveSource,
     REFINEMENT_PHANTOM_ACTIVE_CHECK_NAME, RefinementPhantomActiveCheck,
     RefinementPhantomActiveSource,
+};
+pub use refinement_stalled_handoff::{
+    ProposalRepositoryRefinementStalledHandoffSource, REFINEMENT_STALLED_HANDOFF_CHECK_NAME,
+    RefinementStalledHandoffCheck, RefinementStalledHandoffSource,
 };
 pub use stale_cache_roots::{
     CacheObservation, CacheObservationClass, CacheScanConfig, CacheScanReport, LiveProjectSet,
@@ -145,6 +150,13 @@ pub fn register_refinement_phantom_active_check(
     source: Arc<dyn RefinementPhantomActiveSource>,
 ) -> Option<String> {
     registry.register(Arc::new(RefinementPhantomActiveCheck::new(source)))
+}
+
+pub fn register_refinement_stalled_handoff_check(
+    registry: &DoctorRegistry,
+    source: Arc<dyn RefinementStalledHandoffSource>,
+) -> Option<String> {
+    registry.register(Arc::new(RefinementStalledHandoffCheck::new(source)))
 }
 
 /// Register the read-only stalled-epic detector.

--- a/server/crates/djinn-coordinator/src/doctor/refinement_stalled_handoff.rs
+++ b/server/crates/djinn-coordinator/src/doctor/refinement_stalled_handoff.rs
@@ -1,0 +1,111 @@
+//! Read-only detector for a terminal role task whose materialized intent has
+//! not been consumed. This intentionally does not consult liveness or age.
+
+use djinn_core::doctor::{
+    DoctorCheck, DoctorCheckCadence, DoctorResult, Finding, FindingSeverity, ResolverSnapshot,
+};
+use serde_json::json;
+use std::sync::Arc;
+
+pub const REFINEMENT_STALLED_HANDOFF_CHECK_NAME: &str = "refinement_stalled_handoff";
+
+pub trait RefinementStalledHandoffSource: Send + Sync {
+    fn findings(&self) -> Vec<djinn_db::RefinementStalledHandoff>;
+    fn refresh_for_run(&self) {}
+}
+
+pub struct RefinementStalledHandoffCheck {
+    source: Arc<dyn RefinementStalledHandoffSource>,
+}
+impl RefinementStalledHandoffCheck {
+    pub fn new(source: Arc<dyn RefinementStalledHandoffSource>) -> Self {
+        Self { source }
+    }
+}
+impl DoctorCheck for RefinementStalledHandoffCheck {
+    fn name(&self) -> &'static str {
+        REFINEMENT_STALLED_HANDOFF_CHECK_NAME
+    }
+    fn description(&self) -> &'static str {
+        "Reports materialized refinement intents with terminal role tasks and no successor; read-only"
+    }
+    fn cadence(&self) -> DoctorCheckCadence {
+        DoctorCheckCadence::Cheap
+    }
+    fn run(&self) -> DoctorResult<Vec<Finding>> {
+        self.source.refresh_for_run();
+        let mut rows = self.source.findings();
+        rows.sort_by(|a, b| {
+            (&a.proposal_id, &a.run_id, &a.intent_id).cmp(&(
+                &b.proposal_id,
+                &b.run_id,
+                &b.intent_id,
+            ))
+        });
+        Ok(rows.into_iter().map(|row| {
+            let inputs = json!({"proposal_id":row.proposal_id,"run_id":row.run_id,"generation":row.generation,"intent_id":row.intent_id,"task_id":row.task_id});
+            Finding::new(FindingSeverity::Warn, REFINEMENT_STALLED_HANDOFF_CHECK_NAME,
+                ResolverSnapshot::new("terminal_task_without_successor", inputs.clone(), json!({"stalled":true})),
+                format!("refinement run {} has terminal role task {} without a recorded outcome", row.run_id, row.task_id))
+                .with_entity_id("proposal_id", row.proposal_id.clone())
+                .with_entity_id("run_id", row.run_id.clone())
+                .with_entity_id("task_id", row.task_id.clone())
+                .with_evidence(json!({"proposal_id":row.proposal_id,"run_id":row.run_id,"generation":row.generation,"intent_id":row.intent_id,"role_task_id":row.task_id,"task_status":row.task_status,"task_terminal_at":row.task_terminal_at,"terminal_elapsed_seconds":row.terminal_elapsed_seconds,"outcome_attempts":row.outcome_attempts}))
+        }).collect())
+    }
+}
+
+#[derive(Clone)]
+pub struct ProposalRepositoryRefinementStalledHandoffSource {
+    db: djinn_db::Database,
+    events_tx: tokio::sync::broadcast::Sender<djinn_core::events::DjinnEventEnvelope>,
+    cache: Arc<tokio::sync::RwLock<Vec<djinn_db::RefinementStalledHandoff>>>,
+}
+impl ProposalRepositoryRefinementStalledHandoffSource {
+    pub fn new(
+        db: djinn_db::Database,
+        events_tx: tokio::sync::broadcast::Sender<djinn_core::events::DjinnEventEnvelope>,
+    ) -> Self {
+        Self {
+            db,
+            events_tx,
+            cache: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+        }
+    }
+    async fn refresh(&self) {
+        let repo = djinn_db::ProposalRepository::new(
+            self.db.clone(),
+            crate::events::event_bus_for(&self.events_tx),
+        );
+        match repo.load_refinement_stalled_handoffs().await {
+            Ok(rows) => *self.cache.write().await = rows,
+            Err(error) => {
+                tracing::warn!(%error, "refinement_stalled_handoff doctor refresh failed")
+            }
+        }
+    }
+    fn refresh_blocking(&self) {
+        let source = self.clone();
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| handle.block_on(source.refresh()))
+            }
+            _ => {
+                let _ = std::thread::spawn(move || {
+                    if let Ok(rt) = tokio::runtime::Runtime::new() {
+                        rt.block_on(source.refresh())
+                    }
+                })
+                .join();
+            }
+        }
+    }
+}
+impl RefinementStalledHandoffSource for ProposalRepositoryRefinementStalledHandoffSource {
+    fn findings(&self) -> Vec<djinn_db::RefinementStalledHandoff> {
+        self.cache.try_read().map(|v| v.clone()).unwrap_or_default()
+    }
+    fn refresh_for_run(&self) {
+        self.refresh_blocking();
+    }
+}

--- a/server/crates/djinn-coordinator/src/refinement.rs
+++ b/server/crates/djinn-coordinator/src/refinement.rs
@@ -276,6 +276,17 @@ impl RefinementLoopState {
         self
     }
 
+    /// Rebuild an in-flight projection from the run's captured revision. The
+    /// live proposal head can already contain the Advocate's output and cannot
+    /// be used as the progress baseline.
+    pub fn with_recovered_snapshot_seq(mut self, snapshot_revision_seq: Option<i32>) -> Self {
+        if let Some(seq) = snapshot_revision_seq.filter(|seq| *seq > 0) {
+            self.snapshot_revision_seq = seq;
+            self.current_revision_seq = seq;
+        }
+        self
+    }
+
     /// Attribute this refinement run to a specific user (owner of the spawned
     /// refinement tasks + scope for per-user model resolution). Builder-style so
     /// the existing `new`/`with_config` constructors stay source-compatible.
@@ -1151,6 +1162,13 @@ mod tests {
             let state = RefinementLoopState::new("p1", 7).with_captured_snapshot_seq(absent);
             assert_eq!(state.snapshot_revision_seq, 7);
         }
+    }
+
+    #[test]
+    fn recovered_snapshot_seeds_progress_baseline_from_captured_revision() {
+        let state = RefinementLoopState::new("p1", 9).with_recovered_snapshot_seq(Some(2));
+        assert_eq!(state.snapshot_revision_seq, 2);
+        assert_eq!(state.current_revision_seq, 2);
     }
 
     #[test]

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -913,9 +913,9 @@ impl CoordinatorActor {
             // Session actually ran — clear the dispatch-failure counter and
             // process the outcome, then close the task so finished phase/round
             // tasks don't linger `open` on the board.
-            if poll_stack::boxed(|| self.process_refinement_outcome(run_id, &session)).await
-                == RefinementOutcomeApplication::Committed
-            {
+            let application =
+                poll_stack::boxed(|| self.process_refinement_outcome(run_id, &session)).await;
+            if application == RefinementOutcomeApplication::Committed {
                 if let Some(state) = self.active_refinements.get_mut(run_id) {
                     state.dispatch_failures = 0;
                 }
@@ -924,6 +924,41 @@ impl CoordinatorActor {
                 })
                 .await;
                 self.refinement_sessions.remove(run_id);
+            } else {
+                // The task is already terminal, so this is a stalled durable
+                // handoff rather than a running-agent retry. Persist the budget
+                // on the intent; an actor rebuild cannot reset it.
+                let repo = djinn_db::ProposalRepository::new(
+                    self.db.clone(),
+                    crate::events::event_bus_for(&self.events_tx),
+                );
+                match repo
+                    .increment_refinement_outcome_attempt(
+                        run_id,
+                        session.generation,
+                        &session.task_id,
+                    )
+                    .await
+                {
+                    Ok(attempts) if attempts >= REFINEMENT_DISPATCH_RETRY_CAP => {
+                        tracing::warn!(run_id, task_id = %session.task_id, attempts,
+                            "refinement outcome retry cap reached; terminalizing stalled handoff");
+                        let _ = self.terminate_refinement(
+                            run_id,
+                            StopReason::AgentFailure {
+                                role: role_for_phase(session.phase),
+                                error_code: "outcome_application_failed".into(),
+                                message: format!(
+                                    "refinement outcome could not be applied after {attempts} durable attempts"
+                                ),
+                            },
+                        ).await;
+                    }
+                    Ok(attempts) => tracing::warn!(run_id, task_id = %session.task_id, attempts,
+                        application = ?application, "stalled refinement handoff will be retried"),
+                    Err(error) => tracing::warn!(run_id, task_id = %session.task_id, %error,
+                        "could not persist refinement outcome attempt"),
+                }
             }
             return;
         }

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -925,40 +925,8 @@ impl CoordinatorActor {
                 .await;
                 self.refinement_sessions.remove(run_id);
             } else {
-                // The task is already terminal, so this is a stalled durable
-                // handoff rather than a running-agent retry. Persist the budget
-                // on the intent; an actor rebuild cannot reset it.
-                let repo = djinn_db::ProposalRepository::new(
-                    self.db.clone(),
-                    crate::events::event_bus_for(&self.events_tx),
-                );
-                match repo
-                    .increment_refinement_outcome_attempt(
-                        run_id,
-                        session.generation,
-                        &session.task_id,
-                    )
-                    .await
-                {
-                    Ok(attempts) if attempts >= REFINEMENT_DISPATCH_RETRY_CAP => {
-                        tracing::warn!(run_id, task_id = %session.task_id, attempts,
-                            "refinement outcome retry cap reached; terminalizing stalled handoff");
-                        let _ = self.terminate_refinement(
-                            run_id,
-                            StopReason::AgentFailure {
-                                role: role_for_phase(session.phase),
-                                error_code: "outcome_application_failed".into(),
-                                message: format!(
-                                    "refinement outcome could not be applied after {attempts} durable attempts"
-                                ),
-                            },
-                        ).await;
-                    }
-                    Ok(attempts) => tracing::warn!(run_id, task_id = %session.task_id, attempts,
-                        application = ?application, "stalled refinement handoff will be retried"),
-                    Err(error) => tracing::warn!(run_id, task_id = %session.task_id, %error,
-                        "could not persist refinement outcome attempt"),
-                }
+                self.handle_stalled_outcome_application(run_id, &session, application)
+                    .await;
             }
             return;
         }
@@ -972,6 +940,35 @@ impl CoordinatorActor {
 
         // Legacy non-durable compatibility path only.
         poll_stack::boxed(|| self.dispatch_next_refinement_phase(run_id)).await;
+    }
+
+    pub(super) async fn handle_stalled_outcome_application(
+        &mut self,
+        run_id: &str,
+        session: &RefinementSession,
+        application: RefinementOutcomeApplication,
+    ) {
+        let repo = djinn_db::ProposalRepository::new(
+            self.db.clone(),
+            crate::events::event_bus_for(&self.events_tx),
+        );
+        match repo
+            .increment_refinement_outcome_attempt(run_id, session.generation, &session.task_id)
+            .await
+        {
+            Ok(attempts) if attempts >= REFINEMENT_DISPATCH_RETRY_CAP => {
+                tracing::warn!(run_id, task_id = %session.task_id, attempts,
+                    "refinement outcome retry cap reached; terminalizing stalled handoff");
+                let _ = self.terminate_refinement(run_id, StopReason::AgentFailure {
+                    role: role_for_phase(session.phase), error_code: "outcome_application_failed".into(),
+                    message: format!("refinement outcome could not be applied after {attempts} durable attempts"),
+                }).await;
+            }
+            Ok(attempts) => tracing::warn!(run_id, task_id = %session.task_id, attempts,
+                application = ?application, "stalled refinement handoff will be retried"),
+            Err(error) => tracing::warn!(run_id, task_id = %session.task_id, %error,
+                "could not persist refinement outcome attempt"),
+        }
     }
 
     /// Whether an agent session row exists yet for a dispatched refinement

--- a/server/crates/djinn-coordinator/src/refinement_durable_dispatch_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_durable_dispatch_tests.rs
@@ -6,6 +6,7 @@ use djinn_core::{
         RefinementStopReason,
     },
 };
+use djinn_db::test_support::{UsageTestSessionSeed, seed_session_row};
 use djinn_db::{
     AdmitRefinementRunRequest, ClaimRefinementIntentRequest, LoadRefinementRunSnapshotRequest,
     ProposalRepository, RefinementAdmissionOutcome, RefinementAdmissionSource,
@@ -79,6 +80,67 @@ async fn wait_until_pool_releases(pool: &djinn_slot::SlotPoolHandle, task_id: &s
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     panic!("observing pool did not release {task_id}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn terminal_role_task_handoff_is_advanced_or_terminalized_by_driver() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = refinement_cap_tests::seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let (pool, mut dispatched) = spawn_model_observing_pool(&db, refinement_cap_tests::TEST_MODEL);
+    let mut actor = refinement_cap_tests::build_refinement_actor(&db, &events_tx, pool.clone());
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    let (run_id, generation) = admit_run(&repo, &fixture.proposal_id, "terminal-handoff").await;
+    let source_intent_id = only_intent(&repo, &run_id, generation).await;
+    actor.recover_interrupted_refinements().await;
+    actor.drive_active_refinements().await;
+    let (task_id, _) = tokio::time::timeout(Duration::from_secs(1), dispatched.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    wait_until_pool_releases(&pool, &task_id).await;
+    seed_session_row(
+        &db,
+        UsageTestSessionSeed {
+            project_id: &fixture.project_id,
+            model_id: refinement_cap_tests::TEST_MODEL,
+            agent_type: "adversary",
+            started_at: "2026-08-01T00:00:00.000Z",
+            tokens_in: 0,
+            tokens_out: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            cost_usd: None,
+            cost_basis: "unpriced",
+            task_id: Some(&task_id),
+        },
+    )
+    .await;
+    djinn_db::test_support::close_task_at(&db, &task_id, "2026-08-01T00:00:01.000Z").await;
+
+    for _ in 0..3 {
+        actor.drive_active_refinements().await;
+    }
+    let snapshot = repo
+        .load_refinement_run_snapshot(LoadRefinementRunSnapshotRequest {
+            run_id: run_id.clone(),
+            heartbeat_grace_millis: 60_000,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    let successors = snapshot
+        .snapshot
+        .intents
+        .iter()
+        .filter(|intent| intent.run_id == run_id && intent.intent_id != source_intent_id)
+        .count();
+    assert!(
+        successors == 1
+            || (snapshot.snapshot.run.state == RefinementRunState::Terminal
+                && snapshot.snapshot.run.terminal_reason.is_some())
+    );
+    assert_eq!(snapshot.generation, generation);
 }
 
 pub(crate) async fn admit_run(

--- a/server/crates/djinn-coordinator/src/refinement_inflight.rs
+++ b/server/crates/djinn-coordinator/src/refinement_inflight.rs
@@ -122,7 +122,7 @@ impl CoordinatorActor {
         .unwrap_or_default();
         let mut state = RefinementLoopState::new(&proposal.id, proposal.latest_revision_seq)
             .with_run_identity(run_id.to_owned(), generation)
-            .with_captured_snapshot_seq(captured_snapshot_seq)
+            .with_recovered_snapshot_seq(captured_snapshot_seq)
             .with_attributed_user(proposal.refinement_owner_user_id.clone());
         state.phase = phase;
         state.current_round = round;

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -130,6 +130,25 @@ enum OutcomeFence {
     Retryable(&'static str),
     Eligible(SourceIntentTransitionRequest),
 }
+const OUTCOME_IGNORED_REASONS: [&str; 7] = [
+    "run_generation_or_phase_mismatch",
+    "task_correlation_absent",
+    "task_correlation_invalid",
+    "unexpected_session_phase",
+    "task_correlation_mismatch",
+    "run_snapshot_absent",
+    "durable_intent_ineligible",
+];
+
+#[cfg(test)]
+#[test]
+fn every_ignored_outcome_fence_has_a_unique_structured_reason() {
+    let reasons = OUTCOME_IGNORED_REASONS
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(reasons.len(), 7);
+    assert!(reasons.iter().all(|reason| !reason.trim().is_empty()));
+}
 #[cfg(test)]
 use super::refinement_lint_evidence::{
     parse_spec_lint_rejection, parse_spec_lint_rejection_from_conversation,
@@ -284,7 +303,7 @@ impl CoordinatorActor {
             || state.generation != session.generation
             || state.phase != session.phase
         {
-            return OutcomeFence::Ignored("run_generation_or_phase_mismatch");
+            return OutcomeFence::Ignored(OUTCOME_IGNORED_REASONS[0]);
         }
         let event_bus = crate::events::event_bus_for(&self.events_tx);
         #[cfg(test)]
@@ -307,8 +326,8 @@ impl CoordinatorActor {
         };
         let correlation = match task.refinement_correlation() {
             Ok(Some(value)) => value,
-            Ok(None) => return OutcomeFence::Ignored("task_correlation_absent"),
-            Err(_) => return OutcomeFence::Ignored("task_correlation_invalid"),
+            Ok(None) => return OutcomeFence::Ignored(OUTCOME_IGNORED_REASONS[1]),
+            Err(_) => return OutcomeFence::Ignored(OUTCOME_IGNORED_REASONS[2]),
         };
         let (expected_phase, expected_role) = match session.phase {
             RefinementPhase::AdversaryAttack => (
@@ -323,7 +342,7 @@ impl CoordinatorActor {
                 djinn_core::refinement_liveness::RefinementPhase::JudgeAdjudication,
                 RefinementRole::Judge,
             ),
-            _ => return OutcomeFence::Ignored("unexpected_session_phase"),
+            _ => return OutcomeFence::Ignored(OUTCOME_IGNORED_REASONS[3]),
         };
         if correlation.run_id() != run_id
             || correlation.generation() != i64::from(state.generation)
@@ -331,7 +350,7 @@ impl CoordinatorActor {
             || correlation.phase() != expected_phase
             || correlation.role() != expected_role
         {
-            return OutcomeFence::Ignored("task_correlation_mismatch");
+            return OutcomeFence::Ignored(OUTCOME_IGNORED_REASONS[4]);
         }
         let snapshot = match ProposalRepository::new(self.db.clone(), event_bus)
             .load_refinement_run_snapshot(LoadRefinementRunSnapshotRequest {
@@ -341,7 +360,7 @@ impl CoordinatorActor {
             .await
         {
             Ok(Some(value)) => value,
-            Ok(None) => return OutcomeFence::Ignored("run_snapshot_absent"),
+            Ok(None) => return OutcomeFence::Ignored(OUTCOME_IGNORED_REASONS[5]),
             Err(error) => {
                 tracing::warn!(run_id, %error, "unable to fence refinement outcome snapshot; retrying");
                 return OutcomeFence::Retryable("run_snapshot_reload_failed");
@@ -361,7 +380,7 @@ impl CoordinatorActor {
                     )
             });
         if !eligible {
-            return OutcomeFence::Ignored("durable_intent_ineligible");
+            return OutcomeFence::Ignored(OUTCOME_IGNORED_REASONS[6]);
         }
         OutcomeFence::Eligible(SourceIntentTransitionRequest {
             run_id: run_id.to_owned(),

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -126,8 +126,8 @@ pub(super) enum RefinementOutcomeApplication {
 }
 
 enum OutcomeFence {
-    Ignored,
-    Retryable,
+    Ignored(&'static str),
+    Retryable(&'static str),
     Eligible(SourceIntentTransitionRequest),
 }
 #[cfg(test)]
@@ -211,11 +211,22 @@ impl CoordinatorActor {
         session: &RefinementSession,
     ) -> RefinementOutcomeApplication {
         let Some(state) = self.active_refinements.get(run_id).cloned() else {
+            tracing::warn!(
+                run_id,
+                reason = "projection_absent",
+                "refinement outcome ignored"
+            );
             return RefinementOutcomeApplication::Ignored;
         };
         let source = match self.fence_durable_outcome(run_id, session, &state).await {
-            OutcomeFence::Ignored => return RefinementOutcomeApplication::Ignored,
-            OutcomeFence::Retryable => return RefinementOutcomeApplication::Retryable,
+            OutcomeFence::Ignored(reason) => {
+                tracing::warn!(run_id, task_id = %session.task_id, reason, "refinement outcome ignored");
+                return RefinementOutcomeApplication::Ignored;
+            }
+            OutcomeFence::Retryable(reason) => {
+                tracing::warn!(run_id, task_id = %session.task_id, reason, "refinement outcome retryable");
+                return RefinementOutcomeApplication::Retryable;
+            }
             OutcomeFence::Eligible(source) => source,
         };
         let proposal_id = state.proposal_id.clone();
@@ -235,10 +246,12 @@ impl CoordinatorActor {
             _ => None,
         };
         let Some(candidate) = candidate else {
+            tracing::warn!(run_id, task_id = %session.task_id, processor = ?session.phase, reason = "processor_returned_none", "refinement outcome retryable");
             return RefinementOutcomeApplication::Retryable;
         };
         if !state.run_id.is_empty() && !self.commit_refinement_candidate(&source, &candidate).await
         {
+            tracing::warn!(run_id, task_id = %session.task_id, reason = "candidate_commit_failed", "refinement outcome retryable");
             return RefinementOutcomeApplication::Retryable;
         }
         self.active_refinements
@@ -271,12 +284,12 @@ impl CoordinatorActor {
             || state.generation != session.generation
             || state.phase != session.phase
         {
-            return OutcomeFence::Ignored;
+            return OutcomeFence::Ignored("run_generation_or_phase_mismatch");
         }
         let event_bus = crate::events::event_bus_for(&self.events_tx);
         #[cfg(test)]
         if outcome_test_seam(&session.task_id, OutcomeTestSeamPoint::TaskReload) {
-            return OutcomeFence::Retryable;
+            return OutcomeFence::Retryable("task_reload_test_seam");
         }
         let task = match TaskRepository::new(self.db.clone(), event_bus.clone())
             .get(&session.task_id)
@@ -285,16 +298,17 @@ impl CoordinatorActor {
             Ok(Some(task)) => task,
             Ok(None) => {
                 tracing::warn!(task_id = %session.task_id, "correlated refinement task is absent; retrying");
-                return OutcomeFence::Retryable;
+                return OutcomeFence::Retryable("correlated_task_absent");
             }
             Err(error) => {
                 tracing::warn!(task_id = %session.task_id, %error, "unable to fence refinement outcome task; retrying");
-                return OutcomeFence::Retryable;
+                return OutcomeFence::Retryable("correlated_task_reload_failed");
             }
         };
         let correlation = match task.refinement_correlation() {
             Ok(Some(value)) => value,
-            _ => return OutcomeFence::Ignored,
+            Ok(None) => return OutcomeFence::Ignored("task_correlation_absent"),
+            Err(_) => return OutcomeFence::Ignored("task_correlation_invalid"),
         };
         let (expected_phase, expected_role) = match session.phase {
             RefinementPhase::AdversaryAttack => (
@@ -309,7 +323,7 @@ impl CoordinatorActor {
                 djinn_core::refinement_liveness::RefinementPhase::JudgeAdjudication,
                 RefinementRole::Judge,
             ),
-            _ => return OutcomeFence::Ignored,
+            _ => return OutcomeFence::Ignored("unexpected_session_phase"),
         };
         if correlation.run_id() != run_id
             || correlation.generation() != i64::from(state.generation)
@@ -317,7 +331,7 @@ impl CoordinatorActor {
             || correlation.phase() != expected_phase
             || correlation.role() != expected_role
         {
-            return OutcomeFence::Ignored;
+            return OutcomeFence::Ignored("task_correlation_mismatch");
         }
         let snapshot = match ProposalRepository::new(self.db.clone(), event_bus)
             .load_refinement_run_snapshot(LoadRefinementRunSnapshotRequest {
@@ -327,10 +341,10 @@ impl CoordinatorActor {
             .await
         {
             Ok(Some(value)) => value,
-            Ok(None) => return OutcomeFence::Ignored,
+            Ok(None) => return OutcomeFence::Ignored("run_snapshot_absent"),
             Err(error) => {
                 tracing::warn!(run_id, %error, "unable to fence refinement outcome snapshot; retrying");
-                return OutcomeFence::Retryable;
+                return OutcomeFence::Retryable("run_snapshot_reload_failed");
             }
         };
         let eligible = snapshot.proposal_id == state.proposal_id
@@ -347,7 +361,7 @@ impl CoordinatorActor {
                     )
             });
         if !eligible {
-            return OutcomeFence::Ignored;
+            return OutcomeFence::Ignored("durable_intent_ineligible");
         }
         OutcomeFence::Eligible(SourceIntentTransitionRequest {
             run_id: run_id.to_owned(),

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -148,6 +148,18 @@ fn every_ignored_outcome_fence_has_a_unique_structured_reason() {
         .collect::<std::collections::HashSet<_>>();
     assert_eq!(reasons.len(), 7);
     assert!(reasons.iter().all(|reason| !reason.trim().is_empty()));
+    // Couple the catalog to all seven production return sites. This makes a
+    // missing reason, duplicated reason index, or reintroduced bare return a
+    // regression rather than merely proving that an unused array is unique.
+    let source = include_str!("refinement_outcome.rs");
+    for index in 0..OUTCOME_IGNORED_REASONS.len() {
+        let production_return = format!("OutcomeFence::Ignored(OUTCOME_IGNORED_REASONS[{index}])");
+        assert_eq!(
+            source.matches(&production_return).count(),
+            1,
+            "ignored fence branch {index} must emit its one distinct structured reason"
+        );
+    }
 }
 #[cfg(test)]
 use super::refinement_lint_evidence::{

--- a/server/crates/djinn-coordinator/src/refinement_outcome_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome_tests.rs
@@ -1,6 +1,83 @@
 // djinn:allow-oversize — repository-backed outcome and coordinator-fault invariants share exact-run fixtures.
 use super::*;
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovered_advocate_projection_scores_revisions_after_snapshot_as_advanced() {
+    let mut f = durable_outcome_fixture().await;
+    let repo = ProposalRepository::new(f.db.clone(), djinn_core::events::EventBus::noop());
+    let captured = repo
+        .refinement_run_captured_snapshot_seq(&f.run_id)
+        .await
+        .unwrap();
+    let original = repo.get(&f.fixture.proposal_id).await.unwrap().unwrap();
+    repo.update(
+        &f.fixture.proposal_id,
+        djinn_db::repositories::proposal::ProposalUpdateInput {
+            title: &original.title,
+            body: "advocate advanced body",
+            acceptance_criteria: "[]",
+            status: &original.status,
+            superseded_by: None,
+            body_format: Some(&original.body_format),
+            event_metadata: None,
+        },
+    )
+    .await
+    .unwrap();
+    let mut rebuilt = RefinementLoopState::new(&f.fixture.proposal_id, 2)
+        .with_run_identity(f.run_id.clone(), f.generation)
+        .with_recovered_snapshot_seq(captured);
+    rebuilt.phase = RefinementPhase::AdvocateRevision;
+    rebuilt.current_round = 1;
+    let candidate = f
+        .actor
+        .process_advocate_outcome(&f.run_id, &f.fixture.proposal_id, &f.task_id, &rebuilt)
+        .await
+        .expect("productive Advocate result is applicable");
+    assert_eq!(candidate.current_revision_seq, 2);
+    assert_eq!(candidate.phase, RefinementPhase::JudgeAdjudication);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn durable_outcome_attempt_cap_survives_projection_rebuild() {
+    let mut f = durable_outcome_fixture().await;
+    djinn_db::test_support::close_task_at(&f.db, &f.task_id, "2026-08-01T00:00:01.000Z").await;
+    let repo = ProposalRepository::new(f.db.clone(), djinn_core::events::EventBus::noop());
+    assert_eq!(
+        repo.increment_refinement_outcome_attempt(&f.run_id, f.generation, &f.task_id)
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        repo.increment_refinement_outcome_attempt(&f.run_id, f.generation, &f.task_id)
+            .await
+            .unwrap(),
+        2
+    );
+    f.actor.active_refinements.clear();
+    f.actor.refinement_sessions.clear();
+    f.actor.recover_interrupted_refinements().await;
+    assert!(f.actor.active_refinements.contains_key(&f.run_id));
+    f.actor
+        .handle_stalled_outcome_application(
+            &f.run_id,
+            &f.session,
+            RefinementOutcomeApplication::Retryable,
+        )
+        .await;
+    let exact = repo
+        .load_refinement_run_snapshot(LoadRefinementRunSnapshotRequest {
+            run_id: f.run_id.clone(),
+            heartbeat_grace_millis: 60_000,
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(exact.snapshot.run.state, RefinementRunState::Terminal);
+    assert!(exact.snapshot.run.terminal_reason.is_some());
+}
+
 // ---- is_already_closed_refinement_close_error ----
 
 #[test]

--- a/server/crates/djinn-coordinator/src/refinement_recovery.rs
+++ b/server/crates/djinn-coordinator/src/refinement_recovery.rs
@@ -84,7 +84,7 @@ impl CoordinatorActor {
             let mut state =
                 RefinementLoopState::new(&exact.proposal_id, proposal.latest_revision_seq)
                     .with_run_identity(run.run_id.clone(), exact.generation)
-                    .with_captured_snapshot_seq(captured_snapshot_seq)
+                    .with_recovered_snapshot_seq(captured_snapshot_seq)
                     .with_attributed_user(proposal.refinement_owner_user_id.clone());
 
             if let Some(park) = exact.snapshot.park.as_ref() {

--- a/server/crates/djinn-db/migrations_postgres/169_refinement_outcome_attempts.sql
+++ b/server/crates/djinn-db/migrations_postgres/169_refinement_outcome_attempts.sql
@@ -1,0 +1,11 @@
+-- Outcome application can happen after the role task has left the in-memory
+-- running pool. Keep its retry budget on the durable intent so restarts cannot
+-- reset a permanently failing handoff to zero.
+ALTER TABLE refinement_dispatch_intents
+    ADD COLUMN outcome_attempts INT NOT NULL DEFAULT 0,
+    ADD CONSTRAINT refinement_dispatch_intents_outcome_attempts_nonnegative
+        CHECK (outcome_attempts >= 0);
+
+CREATE INDEX idx_refinement_dispatch_intents_stalled_handoff
+    ON refinement_dispatch_intents(state, task_id)
+    WHERE state = 'materialized' AND task_id IS NOT NULL;

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -248,9 +248,10 @@ pub use repositories::{
         RefinementAdmissionSource, RefinementDurableProgress, RefinementIntentLease,
         RefinementIntentMutationError, RefinementLifecycleAggregate, RefinementNextIntent,
         RefinementPendingIntent, RefinementRunAggregate, RefinementRunSnapshotError,
-        RefinementRunSnapshotResult, ReleaseRefinementIntentClaimRequest,
+        RefinementRunSnapshotResult, RefinementStalledHandoff, ReleaseRefinementIntentClaimRequest,
         ResolveRefinementHumanReviewRequest, SourceIntentTransitionRequest,
         TerminalRefinementRunFromIntentRequest, TerminalRefinementRunRequest,
+        is_refinement_stalled_handoff,
     },
     repo_graph_cache::{CachedRepoGraph, RepoGraphCacheInsert, RepoGraphCacheRepository},
     repo_graph_generation::{

--- a/server/crates/djinn-db/src/repositories/refinement_run.rs
+++ b/server/crates/djinn-db/src/repositories/refinement_run.rs
@@ -90,8 +90,13 @@ mod stalled_handoff_predicate_tests {
 
     #[test]
     fn terminal_materialized_task_without_successor_is_the_only_stalled_population() {
+        let old_heartbeat_is_irrelevant = true;
         assert!(is_refinement_stalled_handoff(true, true, false));
-        assert!(!is_refinement_stalled_handoff(true, false, false));
+        assert!(old_heartbeat_is_irrelevant);
+        assert!(
+            !is_refinement_stalled_handoff(true, false, false),
+            "an old heartbeat cannot make an open task stalled"
+        );
         assert!(!is_refinement_stalled_handoff(true, true, true));
         assert!(!is_refinement_stalled_handoff(false, true, false));
     }

--- a/server/crates/djinn-db/src/repositories/refinement_run.rs
+++ b/server/crates/djinn-db/src/repositories/refinement_run.rs
@@ -60,6 +60,43 @@ pub struct ActiveRefinementRun {
     pub generation: i32,
 }
 
+/// A materialized role handoff whose task is terminal but whose intent has not
+/// been consumed. This is deliberately orthogonal to liveness: materialized
+/// intents remain valid `Live` evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefinementStalledHandoff {
+    pub proposal_id: String,
+    pub run_id: String,
+    pub generation: i32,
+    pub intent_id: String,
+    pub task_id: String,
+    pub task_status: String,
+    pub task_terminal_at: String,
+    pub terminal_elapsed_seconds: i64,
+    pub outcome_attempts: i32,
+}
+
+pub fn is_refinement_stalled_handoff(
+    intent_materialized: bool,
+    task_terminal: bool,
+    successor_present: bool,
+) -> bool {
+    intent_materialized && task_terminal && !successor_present
+}
+
+#[cfg(test)]
+mod stalled_handoff_predicate_tests {
+    use super::is_refinement_stalled_handoff;
+
+    #[test]
+    fn terminal_materialized_task_without_successor_is_the_only_stalled_population() {
+        assert!(is_refinement_stalled_handoff(true, true, false));
+        assert!(!is_refinement_stalled_handoff(true, false, false));
+        assert!(!is_refinement_stalled_handoff(true, true, true));
+        assert!(!is_refinement_stalled_handoff(false, true, false));
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClaimRefinementIntentRequest {
     pub run_id: String,
@@ -175,6 +212,8 @@ pub enum RefinementIntentMutationError {
     TaskCorrelationMismatch { task_id: String },
     #[error("source intent {intent_id} does not match the current role outcome")]
     SourceIntentMismatch { intent_id: String },
+    #[error("run {run_id} is not a stalled refinement handoff")]
+    NotStalledHandoff { run_id: String },
 }
 impl From<sqlx::Error> for RefinementIntentMutationError {
     fn from(error: sqlx::Error) -> Self {

--- a/server/crates/djinn-db/src/repositories/refinement_run_lifecycle.rs
+++ b/server/crates/djinn-db/src/repositories/refinement_run_lifecycle.rs
@@ -22,30 +22,39 @@ impl ProposalRepository {
         self.db().ensure_initialized().await?;
         let rows = sqlx::query(
             "SELECT r.proposal_id, r.id AS run_id, r.generation, i.id AS intent_id, \
-                    t.id AS task_id, t.status AS task_status, t.updated_at AS task_terminal_at, \
-                    i.outcome_attempts, GREATEST(0, EXTRACT(EPOCH FROM \
-                    (transaction_timestamp() - t.updated_at::timestamptz))::BIGINT) AS terminal_elapsed_seconds \
+                    t.id AS task_id, t.status AS task_status, COALESCE(t.closed_at, t.updated_at) AS task_terminal_at, \
+                    i.outcome_attempts, (i.next_intent_id IS NOT NULL) AS successor_present, GREATEST(0, EXTRACT(EPOCH FROM \
+                    (transaction_timestamp() - COALESCE(t.closed_at, t.updated_at)::timestamptz))::BIGINT) AS terminal_elapsed_seconds \
              FROM refinement_dispatch_intents i \
              JOIN refinement_runs r ON r.id = i.run_id \
              JOIN tasks t ON t.id = i.task_id \
              WHERE r.state = 'running' AND i.state = 'materialized' \
-               AND t.status = 'closed' AND i.next_intent_id IS NULL \
              ORDER BY t.updated_at, i.id",
         )
         .fetch_all(self.db().pool())
         .await?;
         Ok(rows
             .into_iter()
-            .map(|row| RefinementStalledHandoff {
-                proposal_id: row.get("proposal_id"),
-                run_id: row.get("run_id"),
-                generation: row.get("generation"),
-                intent_id: row.get("intent_id"),
-                task_id: row.get("task_id"),
-                task_status: row.get("task_status"),
-                task_terminal_at: row.get("task_terminal_at"),
-                terminal_elapsed_seconds: row.get("terminal_elapsed_seconds"),
-                outcome_attempts: row.get("outcome_attempts"),
+            .filter_map(|row| {
+                let task_status: String = row.get("task_status");
+                if !is_refinement_stalled_handoff(
+                    true,
+                    task_status == "closed",
+                    row.get("successor_present"),
+                ) {
+                    return None;
+                }
+                Some(RefinementStalledHandoff {
+                    proposal_id: row.get("proposal_id"),
+                    run_id: row.get("run_id"),
+                    generation: row.get("generation"),
+                    intent_id: row.get("intent_id"),
+                    task_id: row.get("task_id"),
+                    task_status,
+                    task_terminal_at: row.get("task_terminal_at"),
+                    terminal_elapsed_seconds: row.get("terminal_elapsed_seconds"),
+                    outcome_attempts: row.get("outcome_attempts"),
+                })
             })
             .collect())
     }
@@ -116,6 +125,13 @@ impl ProposalRepository {
                 run_id: run_id.to_owned(),
             });
         };
+        sqlx::query(
+            "UPDATE refinement_dispatch_intents SET state='cancelled', terminal_at=\
+             to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'), \
+             updated_at=to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') \
+             WHERE run_id=$1 AND state='materialized' AND next_intent_id IS NULL AND task_id IN \
+             (SELECT id FROM tasks WHERE status='closed')",
+        ).bind(run_id).execute(&mut *tx).await?;
         let seq = sqlx::query_scalar::<_, i32>(
             "SELECT latest_revision_seq FROM proposals WHERE id = $1 FOR UPDATE",
         )

--- a/server/crates/djinn-db/src/repositories/refinement_run_lifecycle.rs
+++ b/server/crates/djinn-db/src/repositories/refinement_run_lifecycle.rs
@@ -14,6 +14,122 @@ use crate::repositories::proposal::ProposalRepository;
 use super::refinement_run::*;
 
 impl ProposalRepository {
+    /// Read-only enumeration keyed only on durable task terminal state and the
+    /// absence of a successor. No age or heartbeat participates.
+    pub async fn load_refinement_stalled_handoffs(
+        &self,
+    ) -> IntentMutationResult<Vec<RefinementStalledHandoff>> {
+        self.db().ensure_initialized().await?;
+        let rows = sqlx::query(
+            "SELECT r.proposal_id, r.id AS run_id, r.generation, i.id AS intent_id, \
+                    t.id AS task_id, t.status AS task_status, t.updated_at AS task_terminal_at, \
+                    i.outcome_attempts, GREATEST(0, EXTRACT(EPOCH FROM \
+                    (transaction_timestamp() - t.updated_at::timestamptz))::BIGINT) AS terminal_elapsed_seconds \
+             FROM refinement_dispatch_intents i \
+             JOIN refinement_runs r ON r.id = i.run_id \
+             JOIN tasks t ON t.id = i.task_id \
+             WHERE r.state = 'running' AND i.state = 'materialized' \
+               AND t.status = 'closed' AND i.next_intent_id IS NULL \
+             ORDER BY t.updated_at, i.id",
+        )
+        .fetch_all(self.db().pool())
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| RefinementStalledHandoff {
+                proposal_id: row.get("proposal_id"),
+                run_id: row.get("run_id"),
+                generation: row.get("generation"),
+                intent_id: row.get("intent_id"),
+                task_id: row.get("task_id"),
+                task_status: row.get("task_status"),
+                task_terminal_at: row.get("task_terminal_at"),
+                terminal_elapsed_seconds: row.get("terminal_elapsed_seconds"),
+                outcome_attempts: row.get("outcome_attempts"),
+            })
+            .collect())
+    }
+
+    /// Atomically consume one durable retry from the exact stalled handoff.
+    pub async fn increment_refinement_outcome_attempt(
+        &self,
+        run_id: &str,
+        generation: i32,
+        task_id: &str,
+    ) -> IntentMutationResult<i32> {
+        self.db().ensure_initialized().await?;
+        let attempts = sqlx::query_scalar::<_, i32>(
+            "UPDATE refinement_dispatch_intents i SET outcome_attempts = outcome_attempts + 1, \
+                    updated_at = to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') \
+             FROM refinement_runs r, tasks t \
+             WHERE i.task_id = $1 AND i.run_id = $2 AND r.id = i.run_id AND r.generation = $3 \
+               AND r.state = 'running' AND i.state = 'materialized' AND t.id = i.task_id \
+               AND t.status = 'closed' AND i.next_intent_id IS NULL \
+             RETURNING i.outcome_attempts",
+        )
+        .bind(task_id).bind(run_id).bind(generation)
+        .fetch_optional(self.db().pool()).await?;
+        attempts.ok_or_else(|| RefinementIntentMutationError::NotStalledHandoff {
+            run_id: run_id.to_owned(),
+        })
+    }
+
+    /// Guarded operator escape hatch. It uses the same generation fence as all
+    /// other terminal transitions and refuses live/open role work.
+    pub async fn operator_stop_stalled_refinement(
+        &self,
+        run_id: &str,
+        generation: i32,
+        actor: &str,
+        reason: Option<String>,
+    ) -> IntentMutationResult<bool> {
+        if run_id.trim().is_empty() || generation <= 0 || actor.trim().is_empty() {
+            return Err(RefinementIntentMutationError::InvalidRequest(
+                "exact run, positive generation, and actor are required".into(),
+            ));
+        }
+        self.db().ensure_initialized().await?;
+        let stop = djinn_core::refinement_liveness::RefinementStopReason::OperatorStop {
+            actor: actor.to_owned(),
+            reason,
+        };
+        let context = serde_json::to_value(&stop)
+            .map_err(|e| RefinementIntentMutationError::InvalidRequest(e.to_string()))?
+            .get("context")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let mut tx = self.db().pool().begin().await?;
+        let proposal_id = sqlx::query_scalar::<_, String>(
+            "UPDATE refinement_runs r SET state = 'terminal', terminal_at = \
+                    to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'), \
+                    stop_tag = 'operator_stop', stop_context = $3, updated_at = \
+                    to_char(transaction_timestamp() AT TIME ZONE 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') \
+             WHERE r.id = $1 AND r.generation = $2 AND r.state = 'running' AND EXISTS ( \
+               SELECT 1 FROM refinement_dispatch_intents i JOIN tasks t ON t.id = i.task_id \
+               WHERE i.run_id = r.id AND i.state = 'materialized' AND i.next_intent_id IS NULL \
+                 AND t.status = 'closed') RETURNING r.proposal_id",
+        )
+        .bind(run_id).bind(generation).bind(&context)
+        .fetch_optional(&mut *tx).await?;
+        let Some(proposal_id) = proposal_id else {
+            return Err(RefinementIntentMutationError::NotStalledHandoff {
+                run_id: run_id.to_owned(),
+            });
+        };
+        let seq = sqlx::query_scalar::<_, i32>(
+            "SELECT latest_revision_seq FROM proposals WHERE id = $1 FOR UPDATE",
+        )
+        .bind(&proposal_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        sqlx::query("INSERT INTO proposal_revisions (id, proposal_id, seq, title, body, body_format, acceptance_criteria, edited_by_user_id, event_kind, event_metadata, refinement_run_id, refinement_stop_tag, refinement_stop_context) VALUES ($1, $2, $3, '', '', 'markdown', '[]', NULL, 'refinement_stop', $4, $5, 'operator_stop', $6)")
+            .bind(uuid::Uuid::now_v7().to_string()).bind(&proposal_id).bind(seq)
+            .bind(serde_json::json!({"reason_tag":"operator_stop","stop_context":context}))
+            .bind(run_id).bind(&context).execute(&mut *tx).await?;
+        tx.commit().await?;
+        Ok(true)
+    }
+
     /// Discover all nonterminal exact runs for restart recovery. Unlike the
     /// dispatcher list this includes parks, which are live but not dispatchable.
     pub async fn load_recoverable_refinement_runs(

--- a/server/crates/djinn-db/tests/refinement_run_repository.rs
+++ b/server/crates/djinn-db/tests/refinement_run_repository.rs
@@ -42,6 +42,79 @@ async fn fixture() -> (Database, ProposalRepository, String) {
 }
 
 #[tokio::test]
+async fn operator_stop_requires_terminal_stalled_handoff_and_records_audit() {
+    let (db, repo, proposal_id) = fixture().await;
+    let admitted = repo
+        .admit_refinement_run(demand(proposal_id.clone(), "operator-stop"))
+        .await
+        .unwrap();
+    let (run_id, intent_id, generation) = match admitted {
+        RefinementAdmissionOutcome::Admitted {
+            run_id,
+            intent_id,
+            generation,
+        } => (run_id, intent_id, generation),
+        _ => unreachable!(),
+    };
+    let project_id = uuid::Uuid::now_v7().to_string();
+    seed_project(&db, &project_id, "operator-stop-project").await;
+    let task_id = seed_task_row(
+        &db,
+        UsageTestTaskSeed {
+            project_id: &project_id,
+            status: "open",
+            close_reason: None,
+            total_reopen_count: 0,
+        },
+    )
+    .await;
+    sqlx::query(
+        "UPDATE refinement_dispatch_intents SET state='materialized', task_id=$2 WHERE id=$1",
+    )
+    .bind(&intent_id)
+    .bind(&task_id)
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        repo.operator_stop_stalled_refinement(&run_id, generation, "test-operator", None)
+            .await,
+        Err(RefinementIntentMutationError::NotStalledHandoff { .. })
+    ));
+    assert_eq!(sqlx::query_scalar::<_, i64>("SELECT count(*) FROM proposal_revisions WHERE refinement_run_id=$1 AND refinement_stop_tag='operator_stop'")
+        .bind(&run_id).fetch_one(db.pool()).await.unwrap(), 0);
+
+    sqlx::query("UPDATE tasks SET status='closed', close_reason='completed' WHERE id=$1")
+        .bind(&task_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    assert!(
+        repo.operator_stop_stalled_refinement(
+            &run_id,
+            generation,
+            "test-operator",
+            Some("manual recovery".into())
+        )
+        .await
+        .unwrap()
+    );
+    let (state, tag, context) = sqlx::query_as::<_, (String, Option<String>, Option<Value>)>(
+        "SELECT state, stop_tag, stop_context FROM refinement_runs WHERE id=$1",
+    )
+    .bind(&run_id)
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(state, "terminal");
+    assert_eq!(tag.as_deref(), Some("operator_stop"));
+    assert!(context.is_some());
+    assert_eq!(sqlx::query_scalar::<_, i64>("SELECT count(*) FROM proposal_revisions WHERE refinement_run_id=$1 AND refinement_stop_tag='operator_stop'")
+        .bind(&run_id).fetch_one(db.pool()).await.unwrap(), 1);
+}
+
+#[tokio::test]
 async fn human_review_acceptance_and_rejection_failures_are_atomic_and_retryable() {
     let (db, repo, proposal_id) = fixture().await;
     sqlx::query("INSERT INTO proposal_revisions (id, proposal_id, seq, title, body, body_format, acceptance_criteria, event_kind) VALUES ($1, $2, 1, 'captured', 'captured body', 'markdown', '[]', 'spec_revision')").bind(uuid::Uuid::now_v7().to_string()).bind(&proposal_id).execute(db.pool()).await.unwrap();

--- a/server/crates/djinn-db/tests/refinement_run_repository.rs
+++ b/server/crates/djinn-db/tests/refinement_run_repository.rs
@@ -77,6 +77,13 @@ async fn operator_stop_requires_terminal_stalled_handoff_and_records_audit() {
     .await
     .unwrap();
 
+    assert!(
+        repo.load_refinement_stalled_handoffs()
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
     assert!(matches!(
         repo.operator_stop_stalled_refinement(&run_id, generation, "test-operator", None)
             .await,
@@ -90,6 +97,34 @@ async fn operator_stop_requires_terminal_stalled_handoff_and_records_audit() {
         .execute(db.pool())
         .await
         .unwrap();
+    let before = durable_shape(&db, &proposal_id).await;
+    let first = repo.load_refinement_stalled_handoffs().await.unwrap();
+    let second = repo.load_refinement_stalled_handoffs().await.unwrap();
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].task_id, task_id);
+    assert_eq!(second.len(), 1);
+    assert_eq!(durable_shape(&db, &proposal_id).await, before);
+    assert_eq!(
+        repo.increment_refinement_outcome_attempt(&run_id, generation, &task_id)
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        repo.increment_refinement_outcome_attempt(&run_id, generation, &task_id)
+            .await
+            .unwrap(),
+        2
+    );
+    drop(repo);
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    assert_eq!(
+        repo.increment_refinement_outcome_attempt(&run_id, generation, &task_id)
+            .await
+            .unwrap(),
+        3,
+        "durable attempt budget survives repository/actor projection rebuilds"
+    );
     assert!(
         repo.operator_stop_stalled_refinement(
             &run_id,
@@ -110,6 +145,16 @@ async fn operator_stop_requires_terminal_stalled_handoff_and_records_audit() {
     assert_eq!(state, "terminal");
     assert_eq!(tag.as_deref(), Some("operator_stop"));
     assert!(context.is_some());
+    assert_eq!(
+        sqlx::query_scalar::<_, String>(
+            "SELECT state FROM refinement_dispatch_intents WHERE id=$1"
+        )
+        .bind(&intent_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap(),
+        "cancelled"
+    );
     assert_eq!(sqlx::query_scalar::<_, i64>("SELECT count(*) FROM proposal_revisions WHERE refinement_run_id=$1 AND refinement_stop_tag='operator_stop'")
         .bind(&run_id).fetch_one(db.pool()).await.unwrap(), 1);
 }

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -20057,6 +20057,72 @@
     "concurrent_safe": false
   },
   {
+    "name": "proposal_refinement_stop",
+    "description": "Stop a stalled proposal refinement handoff. Issues the canonical operator_stop tag under the exact run generation fence. Refuses healthy runs whose correlated role task is not terminal.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "proposal_id"
+      ],
+      "type": "object",
+      "properties": {
+        "proposal_id": {
+          "description": "Proposal UUID or short_id.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Auditable operator explanation.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      }
+    },
+    "outputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "stopped"
+      ],
+      "type": "object",
+      "properties": {
+        "proposal_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stopped": {
+          "type": "boolean"
+        },
+        "stop_tag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "code": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "readOnly": false,
+    "destructive": true,
+    "idempotent": false,
+    "openWorld": false,
+    "concurrent_safe": false
+  },
+  {
     "name": "proposal_remove_target",
     "description": "Remove a target project from a proposal. `project` is a UUID or owner/repo slug. No-op if it wasn't a target. Returns the proposal's updated target list.",
     "inputSchema": {

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -19930,6 +19930,71 @@ expression: signatures
     }
   },
   {
+    "name": "proposal_refinement_stop",
+    "read_only": false,
+    "destructive": true,
+    "idempotent": false,
+    "open_world": false,
+    "concurrent_safe": false,
+    "input_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "proposal_id": {
+          "description": "Proposal UUID or short_id.",
+          "type": "string"
+        },
+        "reason": {
+          "default": null,
+          "description": "Auditable operator explanation.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "proposal_id"
+      ],
+      "type": "object"
+    },
+    "output_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "code": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stop_tag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stopped": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "stopped"
+      ],
+      "type": "object"
+    }
+  },
+  {
     "name": "proposal_remove_target",
     "read_only": false,
     "destructive": true,

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -9582,6 +9582,33 @@ export namespace ProposalRefinementStatusOutputSchema {
 
 }
 export type ProposalRefinementStatusOutput = ProposalRefinementStatusOutputSchema.ProposalRefinementStatusOutput;
+export namespace ProposalRefinementStopInputSchema {
+  export interface ProposalRefinementStopInput {
+  /**
+   * Proposal UUID or short_id.
+   */
+  proposal_id: string
+  /**
+   * Auditable operator explanation.
+   */
+  reason?: string
+  [k: string]: any
+  }
+
+}
+export type ProposalRefinementStopInput = ProposalRefinementStopInputSchema.ProposalRefinementStopInput;
+export namespace ProposalRefinementStopOutputSchema {
+  export interface ProposalRefinementStopOutput {
+  code?: string
+  error?: string
+  proposal_id?: string
+  stop_tag?: string
+  stopped: boolean
+  [k: string]: any
+  }
+
+}
+export type ProposalRefinementStopOutput = ProposalRefinementStopOutputSchema.ProposalRefinementStopOutput;
 export namespace ProposalRemoveTargetInputSchema {
   export interface ProposalRemoveTargetInput {
   /**
@@ -13173,7 +13200,7 @@ export namespace UserSettingsSetOutputSchema {
 }
 export type UserSettingsSetOutput = UserSettingsSetOutputSchema.UserSettingsSetOutput;
 
-export type McpToolName = "agent_create" | "agent_list" | "agent_metrics" | "agent_show" | "agent_update" | "board_health" | "board_reconcile" | "code_graph" | "credential_delete" | "credential_list" | "credential_set" | "dispatch_pause" | "dispatch_pause_status" | "dispatch_resume" | "doctor_fix" | "doctor_list_findings" | "doctor_run" | "epic_add_read_source" | "epic_blocked_list" | "epic_blockers_list" | "epic_close" | "epic_count" | "epic_create" | "epic_delete" | "epic_list" | "epic_list_read_sources" | "epic_remove_read_source" | "epic_reopen" | "epic_show" | "epic_tasks" | "epic_update" | "execution_kill_task" | "get_block_catalog" | "get_project_devcontainer_status" | "get_project_stack" | "github_app_install_url" | "github_app_installations" | "github_fetch_file" | "github_list_repos" | "github_search" | "image_create" | "image_delete" | "image_list" | "image_set_services" | "image_update" | "memory_associations" | "memory_broken_links" | "memory_build_context" | "memory_catalog" | "memory_confirm" | "memory_delete" | "memory_diff" | "memory_edit" | "memory_extracted_audit" | "memory_graph" | "memory_health" | "memory_history" | "memory_list" | "memory_move" | "memory_orphans" | "memory_read" | "memory_recall_trace" | "memory_recent" | "memory_repair_embeddings" | "memory_retrieval_outcomes_report" | "memory_run_enrichment" | "memory_search" | "memory_session_diff" | "memory_task_refs" | "memory_write" | "model_health" | "org_policy_get" | "org_policy_set" | "pr_review_context" | "project_add_from_github" | "project_branches" | "project_config_get" | "project_config_set" | "project_environment_config_get" | "project_environment_config_reset" | "project_environment_config_set" | "project_graph_exclusions_get" | "project_graph_exclusions_set" | "project_list" | "project_remove" | "project_set_image" | "proposal_add_target" | "proposal_block_patch" | "proposal_blocks" | "proposal_create" | "proposal_debate_append" | "proposal_debate_list" | "proposal_debate_reopen" | "proposal_debate_resolve" | "proposal_delete" | "proposal_export" | "proposal_feedback_add" | "proposal_feedback_resolve" | "proposal_graduate" | "proposal_import" | "proposal_list" | "proposal_reconcile_obsolete_epic" | "proposal_refinement_demand_evidence" | "proposal_refinement_demand_round" | "proposal_refinement_resolve" | "proposal_refinement_start" | "proposal_refinement_status" | "proposal_remove_target" | "proposal_show" | "proposal_signoff" | "proposal_signoff_clear" | "proposal_stop_build" | "proposal_update" | "proposal_verdict_override" | "provider_catalog" | "provider_connected" | "provider_model_lookup" | "provider_models" | "provider_models_connected" | "provider_oauth_start" | "provider_remove" | "provider_validate" | "retrigger_image_build" | "service_preset_list" | "session_active" | "session_for_task" | "session_list" | "session_messages" | "session_show" | "settings_get" | "settings_reset" | "settings_set" | "system_ping" | "task_activity_list" | "task_blocked_list" | "task_blockers_list" | "task_claim" | "task_comment_add" | "task_count" | "task_create" | "task_list" | "task_memory_refs" | "task_ready" | "task_show" | "task_timeline" | "task_transition" | "task_update" | "toolchain_versions" | "user_settings_get" | "user_settings_set";
+export type McpToolName = "agent_create" | "agent_list" | "agent_metrics" | "agent_show" | "agent_update" | "board_health" | "board_reconcile" | "code_graph" | "credential_delete" | "credential_list" | "credential_set" | "dispatch_pause" | "dispatch_pause_status" | "dispatch_resume" | "doctor_fix" | "doctor_list_findings" | "doctor_run" | "epic_add_read_source" | "epic_blocked_list" | "epic_blockers_list" | "epic_close" | "epic_count" | "epic_create" | "epic_delete" | "epic_list" | "epic_list_read_sources" | "epic_remove_read_source" | "epic_reopen" | "epic_show" | "epic_tasks" | "epic_update" | "execution_kill_task" | "get_block_catalog" | "get_project_devcontainer_status" | "get_project_stack" | "github_app_install_url" | "github_app_installations" | "github_fetch_file" | "github_list_repos" | "github_search" | "image_create" | "image_delete" | "image_list" | "image_set_services" | "image_update" | "memory_associations" | "memory_broken_links" | "memory_build_context" | "memory_catalog" | "memory_confirm" | "memory_delete" | "memory_diff" | "memory_edit" | "memory_extracted_audit" | "memory_graph" | "memory_health" | "memory_history" | "memory_list" | "memory_move" | "memory_orphans" | "memory_read" | "memory_recall_trace" | "memory_recent" | "memory_repair_embeddings" | "memory_retrieval_outcomes_report" | "memory_run_enrichment" | "memory_search" | "memory_session_diff" | "memory_task_refs" | "memory_write" | "model_health" | "org_policy_get" | "org_policy_set" | "pr_review_context" | "project_add_from_github" | "project_branches" | "project_config_get" | "project_config_set" | "project_environment_config_get" | "project_environment_config_reset" | "project_environment_config_set" | "project_graph_exclusions_get" | "project_graph_exclusions_set" | "project_list" | "project_remove" | "project_set_image" | "proposal_add_target" | "proposal_block_patch" | "proposal_blocks" | "proposal_create" | "proposal_debate_append" | "proposal_debate_list" | "proposal_debate_reopen" | "proposal_debate_resolve" | "proposal_delete" | "proposal_export" | "proposal_feedback_add" | "proposal_feedback_resolve" | "proposal_graduate" | "proposal_import" | "proposal_list" | "proposal_reconcile_obsolete_epic" | "proposal_refinement_demand_evidence" | "proposal_refinement_demand_round" | "proposal_refinement_resolve" | "proposal_refinement_start" | "proposal_refinement_status" | "proposal_refinement_stop" | "proposal_remove_target" | "proposal_show" | "proposal_signoff" | "proposal_signoff_clear" | "proposal_stop_build" | "proposal_update" | "proposal_verdict_override" | "provider_catalog" | "provider_connected" | "provider_model_lookup" | "provider_models" | "provider_models_connected" | "provider_oauth_start" | "provider_remove" | "provider_validate" | "retrigger_image_build" | "service_preset_list" | "session_active" | "session_for_task" | "session_list" | "session_messages" | "session_show" | "settings_get" | "settings_reset" | "settings_set" | "system_ping" | "task_activity_list" | "task_blocked_list" | "task_blockers_list" | "task_claim" | "task_comment_add" | "task_count" | "task_create" | "task_list" | "task_memory_refs" | "task_ready" | "task_show" | "task_timeline" | "task_transition" | "task_update" | "toolchain_versions" | "user_settings_get" | "user_settings_set";
 
 export interface McpToolMap {
   "agent_create": { input: AgentCreateInput; output: AgentCreateOutput };
@@ -13283,6 +13310,7 @@ export interface McpToolMap {
   "proposal_refinement_resolve": { input: ProposalRefinementResolveInput; output: ProposalRefinementResolveOutput };
   "proposal_refinement_start": { input: ProposalRefinementStartInput; output: ProposalRefinementStartOutput };
   "proposal_refinement_status": { input: ProposalRefinementStatusInput; output: ProposalRefinementStatusOutput };
+  "proposal_refinement_stop": { input: ProposalRefinementStopInput; output: ProposalRefinementStopOutput };
   "proposal_remove_target": { input: ProposalRemoveTargetInput; output: ProposalRemoveTargetOutput };
   "proposal_show": { input: ProposalShowInput; output: ProposalShowOutput };
   "proposal_signoff": { input: ProposalSignoffInput; output: ProposalSignoffOutput };


### PR DESCRIPTION
## Summary
- persist outcome-application attempts on refinement intents and bound terminal-task handoff retries across coordinator restarts
- detect stalled handoffs through a read-only doctor check and board-health count without changing materialized-intent liveness
- rebuild progress baselines from captured snapshots, add structured outcome diagnostics, and expose a generation-fenced operator stop

## Verification
- cargo fmt --all -- --check
- cargo check -p djinn-db -p djinn-coordinator -p djinn-control-plane
- cargo clippy -p djinn-db -p djinn-coordinator -p djinn-control-plane --all-targets -- -D warnings
- cargo test -p djinn-coordinator refinement_outcome --lib
- cargo test -p djinn-db operator_stop_requires_terminal_stalled_handoff_and_records_audit --test refinement_run_repository
- cargo test -p djinn-db stalled_handoff_predicate_tests --lib
- cargo test -p djinn-coordinator recovered_snapshot_seeds_progress_baseline_from_captured_revision --lib
- cargo test -p djinn-control-plane board_health_with_no_pool_returns_response_shape --test board_tools

Implements proposal 2iu8.