### PR TITLE
fix(resize): a refused closing lift must return the launcher to its birth limit, not strand it lifted

### DIFF
--- a/server/crates/djinn-coordinator/src/resize_lift.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift.rs
@@ -59,6 +59,42 @@
 //! list, so this module cannot invent one. A lift that could not be confirmed
 //! must never leave a row claiming `lifted` — the drop reconciler (`0ppk-3`) is
 //! what returns the Pod to its birth limit, and it reads `drop_required`.
+//!
+//! # …and when even THAT write is refused, the lift is undone on the wire
+//!
+//! `→ drop_required` is itself a compare-and-swap, and it can lose. Measured in
+//! production on 2026-08-01, 2m42s after a lift failure at 19:18:13.470Z:
+//!
+//! ```text
+//! permit row : state=birth_confirmed  resize_invocation_id=019fbec3-2047-…  admitted=4000
+//! live Pod   : SPEC   init cgroup-launcher limits.cpu = "4"
+//!              STATUS init cgroup-launcher limits.cpu = "4"
+//! ```
+//!
+//! The 4000m PATCH had already landed AND been status-confirmed; the closing
+//! `lift_applying → lifted` CAS was refused because the in-process 30s drop
+//! reconciler had walked the same row `lift_applying → drop_required →
+//! drop_applying → birth_confirmed` underneath it; and the fallback
+//! `lift_applying → drop_required` was refused for the same reason and then
+//! **only logged**. The ledger said birth-clamped, the kubelet said 4 cores, and
+//! nothing reconciled it: `strandedness()` classifies `birth_confirmed` with a
+//! live owner as `Live` and deliberately will not touch it. Eleven lift failures
+//! in one session — roughly 26% of lifts — all of this shape.
+//!
+//! So a refused closing transition **actuates**. [`ResizeLift::require_drop`]
+//! re-reads the durable row, and when the ledger is not claiming a lift for this
+//! Pod it returns the launcher to [`BIRTH_CPU_MILLICORES`] with a real,
+//! status-confirmed PATCH. The invariant that restores is the one the log line
+//! `resize lift did not take; degrading unleased` has always implied and never
+//! enforced: **the launcher's actual limit may not exceed what the ledger says
+//! was admitted for it.**
+//!
+//! It has to be safe under the very race that produced the defect, because the
+//! competing actor is a reconciler ticking every 30 seconds against the same
+//! row. So the fallback re-reads before acting, refuses to touch a row another
+//! driver owns or one that durably records a lift, treats "already back at
+//! birth" as success with **zero** PATCHes, and fences the Pod UID on every
+//! observation.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -86,6 +122,18 @@ pub const LIFT_CONFIRMATION_BUDGET: Duration = Duration::from_secs(30);
 
 /// Interval between confirmation observations.
 pub const LIFT_CONFIRMATION_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// The CPU limit every `resize-v2` launcher sidecar is downsized to before its
+/// worker session may dispatch — and therefore the limit a lift that could not
+/// be recorded has to put back.
+///
+/// Restated from `djinn_server::task_run_resize_bootstrap::BIRTH_CPU_MILLICORES`
+/// rather than imported, because `djinn-server` depends on this crate and not
+/// the other way round. It is NOT a second source of truth: that module carries
+/// a `const _: () = assert!(…)` against this constant, so the two numbers
+/// drifting apart is a build failure rather than a Pod left holding CPU its
+/// ledger does not admit.
+pub const BIRTH_CPU_MILLICORES: u64 = 250;
 
 /// The two apiserver operations a lift performs.
 ///
@@ -155,6 +203,29 @@ enum SurfaceSource {
     Ambient(tokio::sync::OnceCell<Arc<dyn LauncherResizeSurface>>),
     /// Supplied by the caller. Fixtures use this.
     Fixed(Arc<dyn LauncherResizeSurface>),
+}
+
+/// What the durable permit row claims about a launcher's CPU limit, re-read at
+/// the moment a losing lift has to decide whether to undo itself.
+///
+/// The whole point of this type is that the answer is NOT "what state did this
+/// invocation leave the row in" — by the time it is consulted, the row has
+/// demonstrably moved under us.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LedgerClaim {
+    /// The row durably records a lift for this Pod. The launcher holding the
+    /// admitted ceiling is exactly what the ledger says, so nothing is owed.
+    Lifted,
+    /// Another invocation, or another Pod's permit, owns this lifecycle. It
+    /// settles its own row; a PATCH from here would clamp somebody else's lift.
+    OwnedByAnotherDriver,
+    /// The ledger claims the birth clamp. A launcher above it is a strand.
+    ///
+    /// `state` is the row's state as re-read, carried so a failed actuation can
+    /// still attempt the durable hand-off to the drop reconciler from the state
+    /// the row is *actually* in. `None` means no row was readable at all, and
+    /// therefore no hand-off is possible.
+    BirthClamped { state: Option<BuildPodPermitState> },
 }
 
 /// The status-confirmed, UID/restart/protocol-fenced lift.
@@ -296,24 +367,301 @@ impl ResizeLift {
         }
     }
 
-    /// Best-effort `→ drop_required`.
+    /// `→ drop_required`, and — when that write is refused — the PATCH that
+    /// makes the refusal true anyway.
     ///
-    /// The lift has already failed by the time this runs, so its own failure
-    /// cannot change the reason the caller sees — the Pod is left holding a
-    /// limit nobody granted a lease for either way, and a reconciler that finds
-    /// a stranded `lift_applying` row treats it the same as `drop_required`.
-    /// What must not happen is the failure being swallowed silently, so it is
-    /// logged at `error`.
-    async fn require_drop(&self, intent: &PodResizeIntent, from: BuildPodPermitState) {
-        if let Err(failure) = self
+    /// The lift has already failed by the time this runs, so nothing here can
+    /// change the reason the caller sees. What it *does* change is whether the
+    /// Pod agrees with the ledger.
+    ///
+    /// When the compare-and-swap lands, the row durably owes a drop and the
+    /// external drop reconciler owns it from there — `drop_required` is
+    /// classified `DropOwed`, which is a state it acts on unconditionally. That
+    /// path is unchanged.
+    ///
+    /// When the compare-and-swap is **refused**, this invocation has lost the
+    /// row to another actor and has no ledger edge left to write. Before this
+    /// slice that was the end of it: an `error!` line and a Pod still holding
+    /// the full lifted limit, with the row back at `birth_confirmed` where
+    /// `strandedness()` classifies a live owner as `Live` and skips it forever.
+    /// See this module's header for the production measurement. So the refusal
+    /// is now actuated instead of narrated.
+    ///
+    /// `surface` is `None` only on the one path that failed *because* no
+    /// apiserver surface could be resolved — there is nothing to PATCH through
+    /// and, having never reached the wire, nothing to undo.
+    async fn require_drop(
+        &self,
+        surface: Option<&Arc<dyn LauncherResizeSurface>>,
+        intent: &PodResizeIntent,
+        from: BuildPodPermitState,
+    ) {
+        let Err(failure) = self
             .transition(intent, from, BuildPodPermitState::DropRequired)
             .await
-        {
+        else {
+            return;
+        };
+        tracing::error!(
+            task_run_id = %intent.task_run_id,
+            permit_id = %intent.permit_id,
+            detail = %failure.detail,
+            "resize lift: could not mark the permit drop-required after a failed lift; \
+             returning the launcher to its birth limit directly"
+        );
+        let Some(surface) = surface else {
             tracing::error!(
                 task_run_id = %intent.task_run_id,
                 permit_id = %intent.permit_id,
-                detail = %failure.detail,
-                "resize lift: could not mark the permit drop-required after a failed lift"
+                "resize lift: no apiserver surface to return the launcher through; the \
+                 lift never reached the wire, so there is nothing to undo"
+            );
+            return;
+        };
+        self.return_to_birth_limit(surface, intent).await;
+    }
+
+    /// What the durable row currently claims about this Pod's launcher limit.
+    ///
+    /// Re-read, never inferred from the state this invocation last saw: by the
+    /// time this runs the row has demonstrably moved under us at least once.
+    async fn ledger_claim(&self, intent: &PodResizeIntent) -> LedgerClaim {
+        let row = match self.permits.active(&intent.task_run_id).await {
+            Ok(Some(row)) => row,
+            // No capacity-active permit at all. Nothing durable governs this
+            // Pod any more, so no row is claiming the ceiling and nothing will
+            // ever reconcile a limit left on it. The birth clamp is the honest
+            // reading — and the UID fence at the observation is what keeps that
+            // from becoming a PATCH addressed to somebody else's Pod.
+            Ok(None) => return LedgerClaim::BirthClamped { state: None },
+            Err(error) => {
+                tracing::warn!(
+                    task_run_id = %intent.task_run_id,
+                    %error,
+                    "resize lift: durable permit unreadable while undoing a lift; the lift \
+                     is unrecorded either way, so the launcher is returned to birth"
+                );
+                return LedgerClaim::BirthClamped { state: None };
+            }
+        };
+        // The row must still govern the object this intent was captured
+        // against. A permit whose identity names another Pod UID is not a
+        // ledger entry about our launcher at all.
+        if row.resize_identity.as_ref().map(|id| id.pod_uid.as_str())
+            != Some(intent.pod_uid.as_str())
+        {
+            return LedgerClaim::OwnedByAnotherDriver;
+        }
+        match row.state {
+            // The ledger records a lift. The Pod holding the ceiling is exactly
+            // what the row admits, so the invariant already holds and taking it
+            // away would strand whoever earned it.
+            BuildPodPermitState::Lifted => LedgerClaim::Lifted,
+            // Another invocation is mid-lift on this row. It owns the outcome,
+            // it will settle its own row, and a PATCH from here would clamp a
+            // lift that is still being driven.
+            BuildPodPermitState::LiftApplying
+                if row.resize_invocation_id.as_deref() != Some(intent.invocation_id.as_str()) =>
+            {
+                LedgerClaim::OwnedByAnotherDriver
+            }
+            state => LedgerClaim::BirthClamped { state: Some(state) },
+        }
+    }
+
+    /// Undo a lift the ledger refused to record: PATCH the launcher back to
+    /// [`BIRTH_CPU_MILLICORES`] and confirm it through the init-container
+    /// status.
+    ///
+    /// # Safe under the concurrent reconciler
+    ///
+    /// Three properties, each of which the tests name a mutation for:
+    ///
+    /// 1. **Re-read before acting.** [`Self::ledger_claim`] decides from the
+    ///    row as it is *now*, so a row another driver owns, or one that durably
+    ///    records a lift, is left alone.
+    /// 2. **Already-at-birth is success, not failure.** The first observation
+    ///    reads the launcher's persisted `limits.cpu`; if it is already at or
+    ///    below the birth clamp, somebody else got there first and this path
+    ///    returns having issued **zero** PATCHes.
+    /// 3. **The UID fence on every pass.** The observation is re-fenced before
+    ///    each attempt, so a Pod deleted and recreated under the same name is
+    ///    never the object that gets clamped.
+    ///
+    /// Deliberately NOT fenced on the launcher's `containerID` or its declared
+    /// protocol, unlike a lift. Both of those exist to stop a *grant* being
+    /// reasoned about a cgroup that is gone; a restarted launcher comes back
+    /// holding whatever `spec.initContainers[..].limits.cpu` the failed lift
+    /// left behind, so returning that spec to birth is still exactly right and
+    /// refusing to would leave the strand in place.
+    async fn return_to_birth_limit(
+        &self,
+        surface: &Arc<dyn LauncherResizeSurface>,
+        intent: &PodResizeIntent,
+    ) {
+        let state = match self.ledger_claim(intent).await {
+            LedgerClaim::Lifted => {
+                tracing::info!(
+                    task_run_id = %intent.task_run_id,
+                    pod_uid = %intent.pod_uid,
+                    "resize lift: the permit durably records a lift for this Pod; the \
+                     launcher's limit is admitted and is not returned"
+                );
+                return;
+            }
+            LedgerClaim::OwnedByAnotherDriver => {
+                tracing::info!(
+                    task_run_id = %intent.task_run_id,
+                    pod_uid = %intent.pod_uid,
+                    "resize lift: another driver owns this permit's resize lifecycle; not \
+                     patching"
+                );
+                return;
+            }
+            LedgerClaim::BirthClamped { state } => state,
+        };
+
+        let deadline = tokio::time::Instant::now() + self.budget;
+        let mut patched = false;
+        loop {
+            let observed = match surface.observe_launcher(&intent.task_run_id).await {
+                Ok(Some(observed)) => observed,
+                // No Pod carries the label. Nothing holds the lifted limit.
+                Ok(None) => {
+                    tracing::info!(
+                        task_run_id = %intent.task_run_id,
+                        pod_uid = %intent.pod_uid,
+                        "resize lift: no Pod carries the label; the lifted limit is moot"
+                    );
+                    return;
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        task_run_id = %intent.task_run_id,
+                        %error,
+                        "resize lift: apiserver did not answer while returning the \
+                         launcher to its birth limit"
+                    );
+                    if !self.wait_for_retry(deadline).await {
+                        return self
+                            .strand_alarm(intent, state, "the apiserver never answered")
+                            .await;
+                    }
+                    continue;
+                }
+            };
+            // THE UID FENCE. A Pod recreated under the same name belongs to
+            // whoever created it; our lift is not on it and must not be undone
+            // there.
+            if observed.pod_uid != intent.pod_uid {
+                tracing::info!(
+                    task_run_id = %intent.task_run_id,
+                    permit_pod_uid = %intent.pod_uid,
+                    live_pod_uid = %observed.pod_uid,
+                    "resize lift: the Pod was recreated under the same name; the lifted \
+                     limit went with the object that held it"
+                );
+                return;
+            }
+            // ALREADY BACK AT BIRTH. Somebody else — the drop reconciler, most
+            // likely the very actor that took this row away — got there first.
+            // That is success, and it must cost zero PATCHes: re-PATCHing a
+            // launcher that is already clamped is how an idempotent fallback
+            // turns into a second writer fighting the first.
+            if !patched
+                && observed
+                    .admitted_cpu_millicores
+                    .is_some_and(|millicores| millicores <= BIRTH_CPU_MILLICORES)
+            {
+                tracing::info!(
+                    task_run_id = %intent.task_run_id,
+                    pod_uid = %intent.pod_uid,
+                    "resize lift: the launcher is already at its birth limit; nothing to \
+                     return"
+                );
+                return;
+            }
+
+            patched = true;
+            match surface
+                .resize_launcher_cpu(&observed.pod_name, BIRTH_CPU_MILLICORES)
+                .await
+            {
+                // `resize_launcher_cpu` confirms through
+                // `status.initContainerStatuses`, so `Ok` is the kubelet's
+                // answer and not the apiserver's acknowledgement.
+                Ok(()) => {
+                    tracing::warn!(
+                        task_run_id = %intent.task_run_id,
+                        pod_uid = %intent.pod_uid,
+                        birth_millicores = BIRTH_CPU_MILLICORES,
+                        "resize lift: the ledger refused to record this lift, so the \
+                         launcher was returned to its birth limit"
+                    );
+                    return;
+                }
+                Err(error) => {
+                    if !is_retryable(&error) {
+                        return self.strand_alarm(intent, state, &error.to_string()).await;
+                    }
+                    if !self.wait_for_retry(deadline).await {
+                        return self.strand_alarm(intent, state, &error.to_string()).await;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Sleep one poll interval if the budget allows it. `false` means the
+    /// budget is gone and the caller must settle.
+    async fn wait_for_retry(&self, deadline: tokio::time::Instant) -> bool {
+        if tokio::time::Instant::now() + self.poll_interval >= deadline {
+            return false;
+        }
+        tokio::time::sleep(self.poll_interval).await;
+        true
+    }
+
+    /// The launcher could not be returned. Say so loudly, and — if the row is
+    /// still one this invocation can move — leave a `drop_required` behind so
+    /// the external reconciler has a state it will actually act on.
+    ///
+    /// `state` is the row's re-read state at the moment the fallback started,
+    /// and `None` means there was no readable row to move. This is best-effort
+    /// on top of best-effort: an unreachable apiserver is exactly the condition
+    /// under which the durable hand-off is the only remaining lever.
+    async fn strand_alarm(
+        &self,
+        intent: &PodResizeIntent,
+        state: Option<BuildPodPermitState>,
+        detail: &str,
+    ) {
+        tracing::error!(
+            task_run_id = %intent.task_run_id,
+            permit_id = %intent.permit_id,
+            pod_uid = %intent.pod_uid,
+            admitted_cpu_millicores = intent.admitted_cpu_millicores,
+            detail,
+            "resize lift: THE LAUNCHER IS STRANDED ABOVE ITS LEDGER — the lift could \
+             neither be recorded nor undone"
+        );
+        let Some(state) = state else { return };
+        if let Ok(TransitionBuildPodResizeLifecycleResult::Transitioned(_)) = self
+            .permits
+            .transition_resize_lifecycle(
+                &intent.task_run_id,
+                &intent.permit_id,
+                intent.fencing_token,
+                &intent.pod_uid,
+                Some(&intent.invocation_id),
+                state,
+                BuildPodPermitState::DropRequired,
+            )
+            .await
+        {
+            tracing::warn!(
+                task_run_id = %intent.task_run_id,
+                "resize lift: handed the stranded launcher to the drop reconciler"
             );
         }
     }
@@ -489,7 +837,7 @@ impl PodResizeApplier for ResizeLift {
         let surface = match self.surface().await {
             Ok(surface) => surface,
             Err(failure) => {
-                self.require_drop(intent, entered).await;
+                self.require_drop(None, intent, entered).await;
                 return Err(failure);
             }
         };
@@ -511,14 +859,14 @@ impl PodResizeApplier for ResizeLift {
                     // dropped back to the birth limit by the reconciler, and
                     // a lease granted against it would be a lease for CPU
                     // that is about to be taken away.
-                    self.require_drop(intent, BuildPodPermitState::LiftApplying)
+                    self.require_drop(Some(&surface), intent, BuildPodPermitState::LiftApplying)
                         .await;
                     return Err(failure);
                 }
                 Ok(())
             }
             Err(failure) => {
-                self.require_drop(intent, entered).await;
+                self.require_drop(Some(&surface), intent, entered).await;
                 Err(failure)
             }
         }

--- a/server/crates/djinn-coordinator/src/resize_lift_tests.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift_tests.rs
@@ -26,6 +26,7 @@
 //! everything.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -33,6 +34,7 @@ use djinn_db::{
     AcquireBuildPodPermitResult, BuildLeaseRepository, BuildPodPermitRepository,
     BuildPodPermitState, BuildPodResizeIdentity, CaptureBuildPodResizeIdentityResult, Database,
     InvocationLeaseAuthorityRepository, InvocationLeaseMode,
+    TransitionBuildPodResizeLifecycleResult,
 };
 use djinn_k8s::pod_resize::PodResizeError;
 use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
@@ -148,6 +150,25 @@ impl Fixture {
     /// hand-written — so a fence comparison cannot pass because a test typed the
     /// same string twice.
     async fn armed(pod: StoredTaskRunPod, budget: Duration) -> Self {
+        Self::armed_with(pod, budget, |pod, _| Arc::new(FixtureSurface(pod.clone()))).await
+    }
+
+    /// The same composition, with the lift's apiserver surface built by the
+    /// caller from the fixture Pod **and the live permit repository**.
+    ///
+    /// That second argument is what lets a test inject the concurrent drop
+    /// reconciler: the race that produced this module's production strand is a
+    /// second actor writing the SAME durable row while the lift's PATCH is in
+    /// flight, and it cannot be modelled by a surface that only knows about
+    /// Kubernetes.
+    async fn armed_with(
+        pod: StoredTaskRunPod,
+        budget: Duration,
+        surface: impl FnOnce(
+            &StoredTaskRunPod,
+            &Arc<BuildPodPermitRepository>,
+        ) -> Arc<dyn LauncherResizeSurface>,
+    ) -> Self {
         let db = Database::open_in_memory().unwrap();
         db.ensure_initialized().await.unwrap();
         seed_task_run(&db, RUN).await;
@@ -170,11 +191,8 @@ impl Fixture {
             "resize-lift-tests",
         ));
         let applier = Arc::new(RecordingApplier {
-            inner: ResizeLift::with_surface(
-                Arc::clone(&permits),
-                Arc::new(FixtureSurface(pod.clone())),
-            )
-            .with_wait(budget, Duration::from_millis(1)),
+            inner: ResizeLift::with_surface(Arc::clone(&permits), surface(&pod, &permits))
+                .with_wait(budget, Duration::from_millis(1)),
             intents: std::sync::Mutex::new(Vec::new()),
         });
         let authority = Arc::new(ResizeAuthority::new(
@@ -1055,5 +1073,361 @@ async fn an_intent_above_its_own_ceiling_still_patches_at_the_ceiling() {
         fixture.pod.launcher_status_cpu().as_deref(),
         Some(format!("{ADMITTED_CEILING}m").as_str()),
         "and the launcher ends up holding the CEILING, not the forged 9999m"
+    );
+}
+
+// ── The refused CLOSING transition: a lift the ledger will not record must not
+//    stay physically in place ──────────────────────────────────────────────
+
+/// What the concurrent drop reconciler does to the row it steals, injected at
+/// the exact instant production put it: after the lift's PATCH has landed and
+/// been status-confirmed, before the closing `lift_applying -> lifted` CAS.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Steal {
+    /// The production shape, measured 2026-08-01. The reconciler walked the row
+    /// `lift_applying -> drop_required -> drop_applying -> birth_confirmed` and
+    /// the Pod was **never** returned: ledger says birth-clamped, kubelet says
+    /// the full ceiling, and `strandedness()` classifies `birth_confirmed` with
+    /// a live owner as `Live` so nothing ever comes back for it.
+    LedgerOnly,
+    /// The same walk, but the reconciler really did PATCH the launcher home
+    /// first. The losing lift must recognise that and do nothing.
+    LedgerAndPod,
+    /// Another actor recorded the very lift this invocation was about to
+    /// record. The ledger now admits the ceiling, so the launcher holding it is
+    /// correct and must not be clamped.
+    RecordLifted,
+}
+
+/// A surface that is the production one plus one concurrent durable writer.
+///
+/// It adds no Kubernetes rules of its own — every observation and every PATCH
+/// goes through [`StoredTaskRunPod`], i.e. the production
+/// `observe_launcher_sidecar` / `PodResizeClient` / `confirm_launcher_cpu`. The
+/// only thing it injects is the second writer on `build_pod_permits`, which is
+/// exactly what the real reconciler is.
+struct ReconcilerRacesTheLift {
+    pod: StoredTaskRunPod,
+    permits: Arc<BuildPodPermitRepository>,
+    steal: Steal,
+    fired: AtomicBool,
+    /// How many PATCH bodies had been sent when the steal completed, so a test
+    /// can count what the FALLBACK sent rather than what the whole lift sent.
+    patches_at_steal: AtomicUsize,
+}
+
+impl ReconcilerRacesTheLift {
+    fn new(pod: &StoredTaskRunPod, permits: &Arc<BuildPodPermitRepository>, steal: Steal) -> Self {
+        Self {
+            pod: pod.clone(),
+            permits: Arc::clone(permits),
+            steal,
+            fired: AtomicBool::new(false),
+            patches_at_steal: AtomicUsize::new(0),
+        }
+    }
+
+    /// The reconciler's own durable moves, made through the SAME repository
+    /// method the reconciler uses, so migration 164's legal-edge trigger has to
+    /// accept every one of them.
+    async fn steal_the_row(&self) {
+        let row = self
+            .permits
+            .active(RUN)
+            .await
+            .expect("the permit is readable")
+            .expect("the permit exists");
+        assert_eq!(
+            row.state,
+            BuildPodPermitState::LiftApplying,
+            "the steal has to land while the lift owns the row, or it is not the race"
+        );
+        let identity = row
+            .resize_identity
+            .clone()
+            .expect("a lifting row has a captured identity");
+        let walk: &[(BuildPodPermitState, BuildPodPermitState)] = match self.steal {
+            Steal::LedgerOnly | Steal::LedgerAndPod => &[
+                (
+                    BuildPodPermitState::LiftApplying,
+                    BuildPodPermitState::DropRequired,
+                ),
+                (
+                    BuildPodPermitState::DropRequired,
+                    BuildPodPermitState::DropApplying,
+                ),
+                (
+                    BuildPodPermitState::DropApplying,
+                    BuildPodPermitState::BirthConfirmed,
+                ),
+            ],
+            Steal::RecordLifted => &[(
+                BuildPodPermitState::LiftApplying,
+                BuildPodPermitState::Lifted,
+            )],
+        };
+        for (from, to) in walk {
+            if *to == BuildPodPermitState::BirthConfirmed && self.steal == Steal::LedgerAndPod {
+                // A real drop settles `drop_applying -> birth_confirmed` only
+                // after 250m is confirmed off the init-container status.
+                self.pod
+                    .resize_launcher_cpu(&identity.pod_name, BIRTH_MILLICORES)
+                    .await
+                    .expect("the reconciler's drop confirms on a healthy node");
+            }
+            let moved = self
+                .permits
+                .transition_resize_lifecycle(
+                    RUN,
+                    &row.permit_id,
+                    row.fencing_token,
+                    &identity.pod_uid,
+                    row.resize_invocation_id.as_deref(),
+                    *from,
+                    *to,
+                )
+                .await
+                .expect("the lifecycle is writable");
+            assert!(
+                matches!(
+                    moved,
+                    TransitionBuildPodResizeLifecycleResult::Transitioned(_)
+                ),
+                "the reconciler's {from:?} -> {to:?} move must land: {moved:?}"
+            );
+        }
+    }
+
+    /// Every PATCH body issued AFTER the row was stolen — i.e. the fallback's.
+    fn fallback_patches(&self) -> Vec<u64> {
+        let at_steal = self.patches_at_steal.load(Ordering::SeqCst);
+        let mut bodies = self.pod.patched_cpu_millicores();
+        bodies.split_off(at_steal)
+    }
+}
+
+#[async_trait]
+impl LauncherResizeSurface for ReconcilerRacesTheLift {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.pod.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        let result = self
+            .pod
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await;
+        if result.is_ok() && !self.fired.swap(true, Ordering::SeqCst) {
+            self.steal_the_row().await;
+            self.patches_at_steal
+                .store(self.pod.patched_cpu_millicores().len(), Ordering::SeqCst);
+        }
+        result
+    }
+}
+
+/// The racing surface, kept so a test can ask what the FALLBACK patched.
+type Racer = Arc<ReconcilerRacesTheLift>;
+
+/// Build the racing composition. Returns the fixture and the racer, because the
+/// fixture only keeps the surface as a `dyn` trait object.
+async fn racing_fixture(steal: Steal) -> (Fixture, Racer) {
+    let pod = healthy_pod();
+    let cell: Arc<std::sync::Mutex<Option<Racer>>> = Arc::new(std::sync::Mutex::new(None));
+    let captured = Arc::clone(&cell);
+    let fixture = Fixture::armed_with(pod, NO_WAIT, move |pod, permits| {
+        let racer = Arc::new(ReconcilerRacesTheLift::new(pod, permits, steal));
+        *captured.lock().expect("cell") = Some(Arc::clone(&racer));
+        racer as Arc<dyn LauncherResizeSurface>
+    })
+    .await;
+    let racer = cell.lock().expect("cell").clone().expect("surface built");
+    (fixture, racer)
+}
+
+/// **THE DEFECT.** A lift whose closing CAS is refused leaves the launcher at
+/// its BIRTH clamp, not at the lifted value.
+///
+/// Asserted on `status.initContainerStatuses` — the only field that can confirm
+/// a resize — and on the PATCH body the fallback actually put on the wire.
+/// Never on a log line: the shipped code already logged, and logging is
+/// precisely what left 4 unleased cores on eleven Pods in one session.
+///
+/// NAMED FAILING MUTATION: in `ResizeLift::require_drop`, delete the
+/// `self.return_to_birth_limit(surface, intent).await` call and keep the
+/// `error!` — i.e. restore the shipped behaviour. The launcher then reads
+/// `2500m` against a `birth_confirmed` row, which is the production
+/// ledger-vs-kubelet divergence reproduced exactly.
+#[tokio::test]
+async fn a_refused_closing_transition_returns_the_launcher_to_its_birth_limit() {
+    let (fixture, _racer) = racing_fixture(Steal::LedgerOnly).await;
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{BIRTH_MILLICORES}m").as_str()),
+        "precondition: the launcher sits at its birth limit before the lift"
+    );
+
+    let result = fixture.lift().await;
+
+    assert_eq!(
+        result,
+        LeaseResult::DegradedUnleased {
+            reason: DegradedUnleasedReason::LiftLifecycleUnwritable
+        },
+        "an unrecordable lift still degrades unleased: {result:?}"
+    );
+    // The ledger is where the concurrent reconciler left it: birth-clamped.
+    assert_eq!(
+        fixture.permit_state().await,
+        BuildPodPermitState::BirthConfirmed,
+        "the row is the one `strandedness()` classifies `Live` and never revisits"
+    );
+    // THE INVARIANT. The Pod agrees with that row.
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{BIRTH_MILLICORES}m").as_str()),
+        "the launcher must be back at its BIRTH clamp; anything else is the \
+         production strand — a ledger saying birth_confirmed over a kubelet \
+         holding the full ceiling"
+    );
+    let bodies = fixture.pod.patched_cpu_millicores();
+    assert_eq!(
+        bodies.last().copied(),
+        Some(BIRTH_MILLICORES),
+        "and it got there through a real PATCH, not a log line; bodies: {bodies:?}"
+    );
+    assert!(
+        bodies.contains(&ADMITTED_CEILING),
+        "non-vacuity: the lift really did raise the launcher first, so the \
+         fallback had something to undo; bodies: {bodies:?}"
+    );
+}
+
+/// **IDEMPOTENCY UNDER THE CONCURRENT RECONCILER.** If the actor that took the
+/// row also returned the launcher to its birth limit, the losing lift's
+/// fallback succeeds having issued **zero** further PATCHes.
+///
+/// "Someone else already returned it to birth" is success, not failure, and not
+/// a second writer fighting the first.
+///
+/// NAMED FAILING MUTATION: in `ResizeLift::return_to_birth_limit`, delete the
+/// `if !patched && observed.admitted_cpu_millicores.is_some_and(|m| m <=
+/// BIRTH_CPU_MILLICORES)` short-circuit. The fallback then re-PATCHes an
+/// already-clamped launcher and this test counts one fallback body instead of
+/// none.
+#[tokio::test]
+async fn a_launcher_another_actor_already_returned_is_not_patched_again() {
+    let (fixture, racer) = racing_fixture(Steal::LedgerAndPod).await;
+
+    let result = fixture.lift().await;
+
+    assert_eq!(
+        result,
+        LeaseResult::DegradedUnleased {
+            reason: DegradedUnleasedReason::LiftLifecycleUnwritable
+        },
+        "the losing lift still degrades unleased rather than erroring: {result:?}"
+    );
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{BIRTH_MILLICORES}m").as_str()),
+        "the launcher is at its birth limit — put there by the OTHER actor"
+    );
+    assert_eq!(
+        racer.fallback_patches(),
+        Vec::<u64>::new(),
+        "and the fallback added nothing: a launcher already at birth needs no \
+         second writer"
+    );
+}
+
+/// **THE FALLBACK NEVER CLAMPS AN ADMITTED LIFT.** If the row durably records
+/// `lifted` for this Pod, the ledger admits the ceiling the launcher is holding
+/// — the invariant already holds, and taking the CPU away would strand whoever
+/// earned it.
+///
+/// NAMED FAILING MUTATION: in `ResizeLift::ledger_claim`, delete the
+/// `BuildPodPermitState::Lifted => LedgerClaim::Lifted` arm so `Lifted` falls
+/// through to `BirthClamped`. The fallback then PATCHes a launcher whose own
+/// ledger admits the ceiling, and the last two assertions below fail.
+#[tokio::test]
+async fn a_permit_that_durably_records_a_lift_is_never_clamped_by_the_fallback() {
+    let (fixture, racer) = racing_fixture(Steal::RecordLifted).await;
+
+    let result = fixture.lift().await;
+
+    assert_eq!(
+        result,
+        LeaseResult::DegradedUnleased {
+            reason: DegradedUnleasedReason::LiftLifecycleUnwritable
+        },
+        "this invocation still lost the CAS and must not report a grant: {result:?}"
+    );
+    assert_eq!(
+        fixture.permit_state().await,
+        BuildPodPermitState::Lifted,
+        "the ledger admits the ceiling"
+    );
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{ADMITTED_CEILING}m").as_str()),
+        "so the launcher keeps it — the invariant is `limit <= admitted`, not \
+         `always drop`"
+    );
+    assert_eq!(
+        racer.fallback_patches(),
+        Vec::<u64>::new(),
+        "and the fallback issued no PATCH at all"
+    );
+}
+
+/// **THE HAPPY PATH IS UNTOUCHED.** A lift that confirms and records ends
+/// holding its ceiling, with no birth-limit body anywhere on the wire.
+///
+/// This is the regression guard for the fix itself: a fallback that also ran on
+/// success would silently undo every healthy lift in the fleet, and every
+/// existing assertion about `lifted` would still pass on the DURABLE row while
+/// the Pod sat back at 250m.
+///
+/// NAMED FAILING MUTATION: in `ResizeLift::apply`, move the
+/// `self.require_drop(Some(&surface), intent, BuildPodPermitState::LiftApplying)`
+/// call out of the `if let Err(failure) = …` guard so it runs on every
+/// confirmed lift. `require_drop`'s CAS is then refused (the row reads
+/// `lifted`), the fallback runs, and — pairing it with the `ledger_claim`
+/// mutation above — a `250m` body appears and the launcher's init status reads
+/// `250m`.
+#[tokio::test]
+async fn a_confirmed_lift_is_left_at_its_ceiling_with_no_drop_patch() {
+    let fixture = Fixture::armed(healthy_pod(), NO_WAIT).await;
+
+    let result = fixture.lift().await;
+
+    assert!(
+        matches!(result, LeaseResult::Status(_)),
+        "the happy path still grants: {result:?}"
+    );
+    assert_eq!(
+        fixture.permit_state().await,
+        BuildPodPermitState::Lifted,
+        "and still records `lifted`"
+    );
+    assert_eq!(
+        fixture.pod.launcher_status_cpu().as_deref(),
+        Some(format!("{ADMITTED_CEILING}m").as_str()),
+        "the launcher holds its ceiling"
+    );
+    let bodies = fixture.pod.patched_cpu_millicores();
+    assert_eq!(
+        bodies,
+        vec![ADMITTED_CEILING],
+        "exactly ONE body, at the ceiling: no fallback ran, so no birth-limit \
+         PATCH exists; bodies: {bodies:?}"
     );
 }

--- a/server/src/task_run_resize_bootstrap.rs
+++ b/server/src/task_run_resize_bootstrap.rs
@@ -111,6 +111,14 @@ use tracing::{info, warn};
 /// ceiling; that lifecycle belongs to `0ppk`.
 pub const BIRTH_CPU_MILLICORES: u64 = 250;
 
+/// The coordinator's losing-lift fallback — `ResizeLift::return_to_birth_limit`,
+/// the path that undoes a lift the ledger refused to record — PATCHes the
+/// launcher back to this same number, and it cannot import the constant:
+/// `djinn-server` depends on `djinn-coordinator`, not the other way round. Tying
+/// the two together here makes a drift a **build failure** rather than a Pod left
+/// holding CPU its ledger does not admit.
+const _: () = assert!(BIRTH_CPU_MILLICORES == djinn_coordinator::resize_lift::BIRTH_CPU_MILLICORES);
+
 /// The Postgres SQLSTATE for a unique-violation. It is the *only* signal that
 /// distinguishes "another permit already owns this Pod UID" from "the database
 /// did not answer", and those two must not be conflated: the first is a


### PR DESCRIPTION
## The measured divergence

A losing lift stranded the Pod at 4 cores, ungoverned. Measured live in production on 2026-08-01, 2m42s after a lift failure at 19:18:13.470Z:

```
permit row : state=birth_confirmed   resize_invocation_id=019fbec3-2047-...   admitted=4000
live Pod   : SPEC   init cgroup-launcher limits.cpu = "4"
             STATUS init cgroup-launcher limits.cpu = "4"
```

The ledger said birth-clamped. The kubelet said 4 cores. And it stayed that way until the task run went terminal.

**Eleven lift failures in one session, all this same shape — roughly 26% of lifts.**

### How the Pod gets there

1. `patch_and_confirm` returns `Ok` — the 4000m PATCH **has already landed AND been status-confirmed on the Pod**.
2. The `LiftApplying -> Lifted` CAS is refused: `permit ... refused the LiftApplying -> Lifted transition; another actor owns this lifecycle`, surfacing as `LiftLifecycleUnwritable` and `resize lift did not take; degrading unleased`.
3. The fallback `require_drop` is refused too — and it **only logged**. It never issued a PATCH.

The competing actor is the in-process 30s drop reconciler, not a second server pod. It walked the same row `lift_applying -> drop_required -> drop_applying -> birth_confirmed` underneath the lift, which is exactly why both of the lift's remaining CAS edges were refused and why the row ends at `birth_confirmed` still carrying the lift's `resize_invocation_id`.

Nothing reconciles it afterwards: `strandedness()` returns `Live` for `birth_confirmed` with a live owner (`task_run_resize_reconcile.rs:517-536`), so the reconciler deliberately will not touch it.

`degrading unleased` was a misleading name. It did not degrade the Pod to its birth clamp; it left it at full limit with no lease governing it.

## The fix

A refused closing transition now **actuates**.

`ResizeLift::require_drop` keeps its existing behaviour when the `-> drop_required` CAS lands — the row durably owes a drop and the external reconciler owns it, unchanged. When the CAS is **refused**, the invocation has lost the row and has no ledger edge left to write, so it undoes its own lift on the wire:

- `ledger_claim` **re-reads** the durable permit row and decides what the ledger currently claims about this launcher's limit:
  - `Lifted` for our Pod UID → the ledger admits the ceiling, the invariant already holds, **nothing is done**.
  - `LiftApplying` owned by another invocation, or a row whose identity names a different Pod UID → **another driver owns it**, nothing is done.
  - anything else (`birth_confirmed`, our own `lift_applying`, `drop_*`, `quarantined`, or no readable row) → the ledger claims the birth clamp, and a launcher above it is a strand.
- `return_to_birth_limit` then observes with a **Pod UID fence**, and:
  - if the launcher's persisted `limits.cpu` is already at or below `BIRTH_CPU_MILLICORES`, someone else got there first — that is **success with zero PATCHes**;
  - otherwise it PATCHes to `BIRTH_CPU_MILLICORES` and confirms through `status.initContainerStatuses` (`resize_launcher_cpu`'s own confirmation rule — `Ok` is the kubelet's answer, not the apiserver's acknowledgement), retrying only the retryable `NotConfirmed` shapes within the existing confirmation budget.
- If it still cannot settle, `strand_alarm` logs at `ERROR` with `THE LAUNCHER IS STRANDED ABOVE ITS LEDGER` and, from the state the row is *actually* in, attempts the durable hand-off to `drop_required` so the reconciler has a state it will act on (`DropOwed`).

The reason the caller sees is unchanged — the lift still degrades unleased with its original settled reason. The only thing that changed is whether the Pod agrees with the ledger.

**The invariant restored:** the Pod's actual cgroup-launcher limit must not exceed what the ledger says was admitted for it.

### Safety under the concurrent reconciler

The fallback can itself race, so it is built to be idempotent under concurrent ownership:

- **Re-read before acting.** Nothing is decided from the state this invocation last saw; by the time the fallback runs the row has demonstrably moved at least once.
- **"Someone else already returned it to birth" is success.** The check is on the launcher's own observed limit, before any PATCH of ours, so a reconciler that already dropped the Pod costs us zero writes rather than a second writer fighting the first.
- **Never clamp an admitted lift.** A row that durably records `lifted`, or one owned by another in-flight invocation, is left alone.
- **UID fence on every observation.** A Pod deleted and recreated under the same name is never the object that gets clamped.

Deliberately *not* fenced on the launcher's `containerID` or declared protocol, unlike a lift: those exist to stop a **grant** being reasoned about a cgroup that is gone, whereas a restarted launcher comes back holding whatever `spec.initContainers[..].limits.cpu` the failed lift left behind — so returning that spec to birth is still exactly right, and refusing to would leave the strand in place.

### Scope

`server/src/task_run_resize_reconcile.rs` is **untouched** and no migration is added — the reconciler-side grace is a separate change. The two fixes are complementary: that one reduces how often this race occurs, this one makes the losing path safe when it still does.

One line outside the coordinator: `BIRTH_CPU_MILLICORES` is restated in `resize_lift.rs` because `djinn-server` depends on `djinn-coordinator` and not the reverse, and `task_run_resize_bootstrap.rs` gains a `const _: () = assert!(...)` tying the two together — so drift between them is a **build failure** rather than a Pod left holding CPU its ledger does not admit.

## Mutation table

Every claim has a named mutation that was applied, run, observed red, and reverted. Baseline: `26 tests run: 26 passed` for `-p djinn-coordinator -E 'test(/resize/)'`; full crate `2050 tests run: 2050 passed`.

| # | Claim | Named mutation | Result |
|---|---|---|---|
| 1 | A lift whose closing CAS is refused leaves the launcher at the **birth clamp**, not at the lifted value | In `require_drop`, delete the `self.return_to_birth_limit(surface, intent).await` call and keep the `error!` — i.e. restore the shipped behaviour | **RED**, 14 passed / 1 failed. `a_refused_closing_transition_returns_the_launcher_to_its_birth_limit`: `left: Some("2500m")  right: Some("250m")` — the production ledger-vs-kubelet divergence, reproduced |
| 2 | The fallback is **idempotent**: if another actor already returned the launcher to birth, it succeeds without a second PATCH | In `return_to_birth_limit`, delete the `if !patched && observed.admitted_cpu_millicores.is_some_and(\|m\| m <= BIRTH_CPU_MILLICORES)` short-circuit | **RED**, 14 passed / 1 failed. `a_launcher_another_actor_already_returned_is_not_patched_again`: `left: [250]  right: []` — a redundant body on the wire |
| 3 | The fallback **never clamps an admitted lift** | In `ledger_claim`, delete the `BuildPodPermitState::Lifted => LedgerClaim::Lifted` arm so `Lifted` falls through to `BirthClamped` | **RED**, 14 passed / 1 failed. `a_permit_that_durably_records_a_lift_is_never_clamped_by_the_fallback`: `left: Some("250m")  right: Some("2500m")` |
| 4 | A **normal successful lift is unchanged** | In `apply`, move the `require_drop(...)` call out of the `if let Err(failure) = ...` guard so it runs on every confirmed lift, paired with mutation 3 | **RED**, 9 passed / 6 failed, including `a_confirmed_lift_is_left_at_its_ceiling_with_no_drop_patch` (`left: Some("250m")  right: Some("2500m")`) and the four pre-existing happy-path tests |

Every assertion reads either `status.initContainerStatuses` — the only field that can confirm a resize — or the PATCH bodies actually sent, parsed back through `CpuLimit`. **None reads a log line**, which matters here: the shipped code already logged, and logging is precisely what left 4 unleased cores on eleven Pods in one session.

### How the race is reproduced in the tests

`ReconcilerRacesTheLift` is the production surface plus **one concurrent durable writer**. Every observation and PATCH still goes through `StoredTaskRunPod`, i.e. the production `observe_launcher_sidecar` / `PodResizeClient` / `confirm_launcher_cpu`. The only thing injected is the second writer on `build_pod_permits`, made through the same `transition_resize_lifecycle` method the reconciler uses — so migration 164's legal-edge trigger has to accept every move — fired at the exact instant production put it: after the lift's PATCH has landed and been status-confirmed, before the closing CAS.

Three steal variants: `LedgerOnly` (the production shape — the row walks home, the Pod never does), `LedgerAndPod` (the reconciler really did drop it first), `RecordLifted` (another actor recorded the very lift this invocation was about to record).

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy -p djinn-coordinator --all-targets` — clean
- `cargo clippy -p djinn-server --all-targets` — clean
- `cargo nextest run -p djinn-coordinator` — **2050 tests run: 2050 passed, 0 skipped**
- `cargo nextest run -p djinn-server -E 'test(/resize/)'` — 42 passed / 1 failed. The one failure, `djinn-server::authority_cutover a_nonterminal_resize_row_blocks_the_flip_and_the_refusal_names_it`, was **verified pre-existing**: it fails identically on the unmodified tree with these changes stashed. The only change to `djinn-server` here is a compile-time `assert!`, which cannot affect runtime.

No cluster was touched and no kubectl context was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
