### PR TITLE
fix(resize-kind): make the 40-cycle proof runnable — the namespace owner collided at install

### DIFF
--- a/scripts/kind/setup-resize-kind-cluster.sh
+++ b/scripts/kind/setup-resize-kind-cluster.sh
@@ -151,6 +151,12 @@ CONTAINERD_VERSION_LIB="$REPO_ROOT/deploy/node/k3s/containerd-config-version.sh"
 PREREQS_CHART="$REPO_ROOT/deploy/helm/djinn-prereqs"
 PREREQS_RELEASE="djinn-prereqs"
 PREREQS_NAMESPACE="kueue-system"
+# The throwaway object step 4a admits to prove the Kueue webhook is serving. Its
+# own name: it is created and deleted seconds apart, and must never be mistaken
+# for the chart's `djinn-kueue` ResourceFlavor.
+WEBHOOK_PROBE_FLAVOR="djinn-resize-harness-webhook-probe"
+WEBHOOK_PROBE_ATTEMPTS="${DJINN_RESIZE_HARNESS_WEBHOOK_ATTEMPTS:-90}"
+WEBHOOK_PROBE_INTERVAL_SECONDS=2
 CHART="$REPO_ROOT/deploy/helm/djinn"
 RELEASE="djinn"
 NAMESPACE="djinn"
@@ -651,7 +657,129 @@ info "installing pinned Kueue prerequisite ${PREREQS_RELEASE} (Kueue 0.19.0, DRA
     --namespace "$PREREQS_NAMESPACE" --create-namespace \
     --wait --timeout "${INSTALL_TIMEOUT_SECONDS}s"
 
-# 5. The djinn chart, ARMED.
+# 4a. `--wait` is necessary and NOT sufficient. It returns when the controller's
+# Pod reports Ready, and "Ready" is a strictly weaker fact than "the webhook is
+# serving": kueue answers its readiness probe on the health port before the
+# webhook server has bound :9443. Installing the djinn chart inside that window
+# fails on whichever webhook the API server reaches first — observed twice while
+# verifying this script, roughly one bring-up in two:
+#
+#   Error: failed to create resource: Internal error occurred: conversion webhook
+#   for kueue.x-k8s.io/v1beta1, Kind=ClusterQueue failed: Post
+#   "https://djinn-prereqs-kueue-webhook-service.kueue-system.svc:443/convert?
+#   timeout=30s": dial tcp 10.96.219.155:443: connect: connection refused
+#
+#   Error: ... failed calling webhook "mresourceflavor.kb.io" ... connection refused
+#
+# Both are the same fact and both land in the same place the namespace collision
+# did: the bring-up step, with zero test assertions executed. So this is a
+# MEASUREMENT rather than a sleep or a condition read off the Deployment. It
+# creates a throwaway `v1beta1` ResourceFlavor, which the API server can only
+# admit by calling BOTH the conversion webhook (v1beta1 is not the storage
+# version) and `mresourceflavor.kb.io`, on the same :9443 the chart's topology
+# needs. When that round trip succeeds, the webhook is serving.
+info 'waiting for the Kueue webhook to actually serve (Pod Ready is a weaker fact)'
+webhook_probe_apply() {
+    "${KUBECTL[@]}" apply -f - 2>&1 <<EOF
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: ${WEBHOOK_PROBE_FLAVOR}
+EOF
+}
+webhook_serving=false
+webhook_last_output=""
+webhook_attempt=0
+while [ "$webhook_attempt" -lt "$WEBHOOK_PROBE_ATTEMPTS" ]; do
+    webhook_attempt=$((webhook_attempt + 1))
+    if webhook_last_output=$(webhook_probe_apply); then
+        webhook_serving=true
+        break
+    fi
+    sleep "$WEBHOOK_PROBE_INTERVAL_SECONDS"
+done
+"${KUBECTL[@]}" delete resourceflavor "$WEBHOOK_PROBE_FLAVOR" --ignore-not-found >/dev/null 2>&1 || true
+[ "$webhook_serving" = true ] || fail 1 \
+    "the Kueue webhook never served after ${webhook_attempt} attempts over $((WEBHOOK_PROBE_ATTEMPTS * WEBHOOK_PROBE_INTERVAL_SECONDS))s, so the djinn chart's queue topology cannot be applied. Last error:
+${webhook_last_output}"
+info "Kueue webhook is serving (admitted the probe ResourceFlavor on attempt ${webhook_attempt})"
+
+# 5. WHO OWNS THE `djinn` NAMESPACE.
+#
+# The chart does — and this block exists so that helm agrees with it. Read this
+# before touching either the `kubectl apply` or the helm flags below; the two are
+# one mechanism and changing either alone reintroduces a wedge that produces ZERO
+# test assertions.
+#
+# `$VALUES_FILE` sets `namespace.create: true` (the chart default), so
+# `deploy/helm/djinn/templates/namespace.yaml` renders a Namespace object as part
+# of the release, and it is that object that carries `djinn.io/kueue-managed`.
+# The label is not decoration: Kueue captures Jobs ONLY in a namespace carrying
+# it, and the chart refuses to arm without it. So the chart must stay the thing
+# that applies it.
+#
+# Helm 3 then boxes this in from both sides, and BOTH sides were observed:
+#
+#   * `--create-namespace` (what this script used to pass) makes helm create the
+#     namespace itself, out-of-band, with no release ownership metadata. The
+#     release's own rendered Namespace is then a second create of the same
+#     object:
+#
+#         Release "djinn" does not exist. Installing it now.
+#         Error: 1 error occurred:
+#           * namespaces "djinn" already exists
+#
+#     That is verbatim what killed the first-ever dispatch of
+#     `.github/workflows/resize-kind.yml` — both jobs, at this step, with zero
+#     test assertions executed. `--take-ownership` does NOT rescue it: it relaxes
+#     the ownership CHECK, not the create.
+#
+#   * Dropping the flag and letting the chart render the namespace unaided fails
+#     one step earlier, because helm stores the release record IN the release
+#     namespace and needs it to exist before any manifest is applied:
+#
+#         Error: create: failed to create: namespaces "djinn" not found
+#
+# The way through is helm's own documented resource-adoption contract: a
+# pre-existing object carrying the managed-by label and the two `meta.helm.sh`
+# annotations is ADOPTED into the release instead of being created. So this
+# script creates an EMPTY namespace shell stamped with exactly those three keys
+# and nothing else, and the chart's Namespace object — labels, `djinn.io/
+# kueue-managed` and all — lands on top of it as a release-owned update. Ownership
+# ends where it started: with the chart. Verified against helm 3.21.3 (what the
+# workflow's `get-helm-3` installs) and helm 4.2.1.
+#
+# Omit any of the three keys and helm 3 names the missing one:
+#
+#     Error: Unable to continue with install: Namespace "djinn" in namespace ""
+#     exists and cannot be imported into the current release: invalid ownership
+#     metadata; label validation error: missing key
+#     "app.kubernetes.io/managed-by": must be set to "Helm"; ...
+#
+# The prerequisite install above KEEPS `--create-namespace` for the mirror-image
+# reason: `djinn-prereqs` renders no Namespace object, so there helm is the only
+# candidate owner and `kueue-system` would otherwise never exist.
+#
+# The alternative — pre-creating the namespace with `--set namespace.create=false`
+# — is rejected on purpose. The chart `fail`s that render outright while armed,
+# and silencing THAT with `kueue.namespaceLabelledExternally=true` would arm this
+# cluster down a different branch than production, with `djinn.io/kueue-managed`
+# applied by this script instead of by the chart. The proof would stop exercising
+# the thing it exists to exercise.
+info "creating the ${NAMESPACE} namespace shell for helm to adopt into release ${RELEASE}"
+"${KUBECTL[@]}" apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: ${RELEASE}
+    meta.helm.sh/release-namespace: ${NAMESPACE}
+EOF
+
+# 6. The djinn chart, ARMED.
 #
 # Deliberately NOT `--wait`. The harness proves a resize contract, not a running
 # Djinn: the server image tag in the values file resolves to nothing here and
@@ -659,11 +787,22 @@ info "installing pinned Kueue prerequisite ${PREREQS_RELEASE} (Kueue 0.19.0, DRA
 # time out on a state that is by design.
 info "installing djinn chart release ${RELEASE} (RuntimeClass + cgroup launcher armed)"
 "${HELM[@]}" upgrade --install "$RELEASE" "$CHART" \
-    --namespace "$NAMESPACE" --create-namespace \
+    --namespace "$NAMESPACE" \
     --values "$VALUES_FILE" \
     --set kueue.enabled=true --set kueue.armed=true
 
-# 6. Report what the API server actually holds. Printed, not asserted: the
+# The adoption actually happened. This is a BRING-UP precondition, not a
+# restatement of the resize contract: if the chart's Namespace object did not
+# land on the shell above, `djinn.io/kueue-managed` is absent, Kueue captures
+# nothing, every suspended Job hangs forever, and the Rust suite reports it as
+# "no Pod reached Running" — a scheduling story for a labelling fault. Fail here,
+# where the cause is still legible.
+kueue_managed=$("${KUBECTL[@]}" get namespace "$NAMESPACE" \
+    -o 'jsonpath={.metadata.labels.djinn\.io/kueue-managed}')
+[ "$kueue_managed" = true ] || fail 1 \
+    "namespace ${NAMESPACE} is not labelled djinn.io/kueue-managed=true after the armed install (read back: '${kueue_managed}'). The chart's Namespace object did not adopt the shell this script created, so nothing would ever unsuspend a captured Job."
+
+# 7. Report what the API server actually holds. Printed, not asserted: the
 # assertions live in server/tests/task_run_resize_kind.rs, and duplicating them
 # here in a weaker form would invite someone to trust the weaker copy.
 info 'cluster state:'


### PR DESCRIPTION
## This lane had never completed a run

`.github/workflows/resize-kind.yml` — the live half of the in-place resize proof
for 3i92, including task 1j64's 40-cycle lift/drop proof — had **never executed a
single test assertion in CI** since it landed (#2862). It is
`workflow_dispatch`-only, and until its first dispatch
`gh api .../workflows/324611988/runs --jq .total_count` returned `0`.

That first-ever dispatch (run `30720369261`, `--ref main`) died in **both** jobs at
the step **"Bring up the disposable cluster"**:

```
>>> installing djinn chart release djinn (RuntimeClass + cgroup launcher armed)
Release "djinn" does not exist. Installing it now.
Error: 1 error occurred:
	* namespaces "djinn" already exists
INFO: harness failed (status 1); tearing the disposable cluster down
```

Both jobs — `Disposable resize-proof cluster` and `Repeated lift/drop cycle
invariants` — share one bring-up script, `scripts/kind/setup-resize-kind-cluster.sh`,
so a single defect killed both. Zero assertions ran.

## Root cause: two actors both created the `djinn` namespace

`scripts/kind/setup-resize-kind-cluster.sh:662` (pre-fix) installed the chart with
`--create-namespace`, while its values fixture
`deploy/helm/djinn/tests/fixtures/kueue-governor-values.yaml:23-24` sets
`namespace.create: true`, so `deploy/helm/djinn/templates/namespace.yaml:20`
renders a `Namespace` object too. Helm 3 creates the namespace out-of-band first,
without release ownership metadata, and the release's own rendered `Namespace` is
then a second create of the same object — `AlreadyExists`.

It is **helm-version-dependent**, which is why it survived review: helm 4 adopts
the pre-created namespace and installs cleanly; helm 3 fails. The workflow
installs helm with `get-helm-3`. Reproduced locally verbatim against helm 3.21.3.

## What changed

`scripts/kind/setup-resize-kind-cluster.sh` only. No Rust, no chart, no workflow.

**1. One namespace owner: the chart.** The harness now creates an *empty*
namespace shell carrying exactly helm's three documented adoption keys
(`app.kubernetes.io/managed-by: Helm`, `meta.helm.sh/release-name`,
`meta.helm.sh/release-namespace`) and drops `--create-namespace`. Helm adopts the
shell into the release, and the chart's own `Namespace` object lands on top,
applying `djinn.io/kueue-managed`. The chart stays the labeller — which is what
the fixture and the production arming path both require.

The alternatives were tried and rejected **on evidence**, not on taste:

- *Just drop `--create-namespace`* fails one step **earlier**, because helm 3
  stores the release record **in** the release namespace:
  `Error: create: failed to create: namespaces "djinn" not found`.
- *`--take-ownership`* does **not** rescue `--create-namespace`. It relaxes the
  ownership *check*, not the create — same `AlreadyExists`.
- *Pre-create with `--set namespace.create=false`* makes the chart `fail` the
  render outright while armed, and silencing that with
  `kueue.namespaceLabelledExternally=true` would arm this cluster down a
  **different branch than production**, with `djinn.io/kueue-managed` applied by
  the harness instead of by the chart. The proof would stop exercising the thing
  it exists to exercise.

The prerequisite install keeps `--create-namespace`: `djinn-prereqs` renders no
`Namespace`, so there helm is the only candidate owner.

A post-install readback now **fails the bring-up** if the namespace is not
labelled `djinn.io/kueue-managed=true`, so a future regression cannot present in
the Rust suite as "no Pod reached Running" — a scheduling story for a labelling
fault.

**2. A second bring-up defect, found while verifying.** Once the namespace
collision was gone, roughly one bring-up in two failed at the *same step*:

```
Error: failed to create resource: Internal error occurred: conversion webhook for
kueue.x-k8s.io/v1beta1, Kind=ClusterQueue failed: Post "https://djinn-prereqs-kueue-
webhook-service.kueue-system.svc:443/convert?timeout=30s": dial tcp 10.96.219.155:443:
connect: connection refused
```

The prerequisite install's `--wait` returns when the Kueue controller Pod reports
*Ready*, which is strictly weaker than "the webhook is serving" — kueue answers
its readiness probe before the webhook server has bound `:9443`. The harness now
**measures** it: it creates and deletes a throwaway `v1beta1` ResourceFlavor,
which the API server can only admit by calling both the conversion webhook and
`mresourceflavor.kb.io` on that same port. Left unfixed, this alone would have
kept the lane from reaching the cycles about half the time.

## Yes — the 40 cycles were observed to run

Against a local disposable kind cluster (`kindest/node:v1.35.0`, K8s 1.35,
`pods/resize` present) brought up by the fixed script under helm 3.21.3, invoked
exactly as the workflow does (`DJINN_TEST_RESIZE_CYCLES=1 cargo test -p
djinn-server --test task_run_resize_cycles -- --ignored --test-threads=1
--nocapture`):

```
>>> before: qos=Burstable node allocated cpu=2550m
>>> before: pod slice cpu.weight=41 launcher cpu.weight=11
>>> 10 cycles complete
>>> 20 cycles complete
>>> 30 cycles complete
>>> 40 cycles complete
>>> 40 complete cycles: 250m <-> 2000m, 40 lift and 40 drop confirmations
>>> unmoved across all of them: requests, allocatedResources, QoS class, node
    allocated cpu, and both cgroup weight files

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 16 filtered out;
finished in 252.73s
```

40 complete cycles, 80 status-confirmed resizes, 250m ↔ 2000m.

Then repeated as one uninterrupted sequence against the **committed** script —
`down` → `up` → 40 cycles → `down`, nothing pre-warmed:

```
########## UP (helm v3.21.3) ##########
>>> waiting for the Kueue webhook to actually serve (Pod Ready is a weaker fact)
>>> Kueue webhook is serving (admitted the probe ResourceFlavor on attempt 1)
>>> creating the djinn namespace shell for helm to adopt into release djinn
namespace/djinn created
>>> installing djinn chart release djinn (RuntimeClass + cgroup launcher armed)
Release "djinn" does not exist. Installing it now.
STATUS: deployed
djinn djinn.io/kueue-managed=true
UP EXIT: 0
########## 40 CYCLES ##########
>>> 40 complete cycles: 250m <-> 2000m, 40 lift and 40 drop confirmations
test result: ok. 1 passed; 0 failed; ... finished in 170.31s
CYCLES EXIT: 0
########## DOWN (post) ##########
PASS: cluster djinn-resize-1j64 and registry djinn-resize-1j64-registry are gone
```

## What the proof asserts per cycle

Confirmation comes from `status.initContainerStatuses[name=cgroup-launcher]`, in
parsed millicores, and from nowhere else
(`server/tests/task_run_resize_cycles.rs:1189-1204` and `:1540-1571`) — never from
the `spec`, never from the PATCH response, never from an HTTP 200. It also
requires `has_resize_pending_condition` to be false and cross-checks the
production `confirm_launcher_cpu` reader against the object the apiserver
returned.

That distinction is not theoretical. Mid-run, this cluster reported:

```
djinn-taskrun-…-4qgcc  spec=250m  status=2
```

— the spec already back at the birth limit while the launcher's init-container
status still carried the 2000m lift. Reading `spec` would have confirmed resizes
that had not happened.

Per cycle it further asserts the launcher's container id and restart count are
unchanged (an in-place resize, not a restart), that the QoS class and every
container's `resources.requests` are byte-identical, and that the Node's allocated
CPU **requests** did not move while its allocated **limits** did — the witness
that something actually resized, so the invariants cannot hold vacuously.

## Verification performed

- Reproduced the original failure verbatim under helm 3.21.3 (what `get-helm-3`
  installs today).
- Full `up` end-to-end under helm 3.21.3 — green.
- The adoption path also verified under helm 4.2.1, so the fix is not
  helm-3-only.
- The 40-cycle live proof, twice: **40/40 passed** (252.73s, then 170.31s on a
  clean `down`→`up`→cycles→`down` sequence against the committed script).
- The webhook retry loop's own mechanics, both arms, with a stubbed probe:
  retries to success on attempt 3, and exhausts its budget carrying the last
  error into the failure message.
- `scripts/kind/setup-resize-kind-cluster.sh selftest` — PASS.
- `cargo test -p djinn-server --test task_run_resize_cycles` — 16 passed.
- `cargo test -p djinn-server --test task_run_resize_kind` — 10 passed.
- `node --test scripts/test-resize-cutover-retention.mjs` — 27/27.
- `./scripts/check-resize-cutover-retention.sh` — OK (9 protected assets retained).
- `cargo fmt --check` — clean.

The local kind cluster used the harness's own distinctive name
(`djinn-resize-1j64`) on an isolated `KUBECONFIG`, and was deleted afterwards. No
kubectl context change; no production cluster touched.

## Corrections and things worth knowing

- **The proof itself is not new-born.** The authoring agent's scratchpad shows a
  green local 40/40 run on 2026-07-31 before the suite landed (and a preceding
  red one that caught a launcher restart at cycle 16 — the restart the
  `prepare_holding_job` comment describes). What had never run is the **CI lane**.
- `scripts/kind/setup-kueue-cluster.sh:579` and `deploy/kueue/zero-capture-gate.sh:239`
  install the same chart with the same `--create-namespace` + `namespace.create: true`
  combination, so both are latently broken under helm 3 on a fresh cluster. Not
  touched here — they belong to other lanes (fbiy-C1, tv9g).
- The documented production install (`docs/deploy/vps.md:326`, `README.md:117`,
  `server/docker/README.md:112`) is the same combination. It only bites on a
  *first* install into an empty cluster: `--create-namespace` is install-only, so
  established releases upgrade fine. (Note this contradicts the premise that
  vpsdeploy sets `namespace.create: false` — no values file in this repo sets it
  to false; every one of them leaves it `true`.)
- The workflow installs helm unpinned via `get-helm-3`. Pinning it, as the
  `local-dev-contracts` lane does with `azure/setup-helm@v4`, would make this
  class of divergence reproducible rather than latent.
- `guard_the_cycle_count_is_a_named_constant_of_at_least_forty` proves the
  constant is 40 and proves nothing ran. The cheap strengthening — noted, **not**
  built here — is a fixture-driven test of `launcher_status` against a Pod JSON
  where `spec` already shows the lifted limit while `status.initContainerStatuses`
  still shows the birth limit, asserting the reader returns the birth limit. That
  converts a source-spelling gate into a behavioural one with no cluster.
