### PR TITLE
fix(resize): the birth gate must not count Kueue queue time against the launcher

### DIFF
--- a/server/crates/djinn-k8s/src/pod_resize_fixture.rs
+++ b/server/crates/djinn-k8s/src/pod_resize_fixture.rs
@@ -33,7 +33,9 @@ use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use serde_json::{Value, json};
 
 use crate::pod_resize::{CpuLimit, PodResizeApi, PodResizeClient, PodResizeError};
-use crate::runtime::{LauncherObservationError, ObservedLauncherSidecar, observe_launcher_sidecar};
+use crate::runtime::{
+    JobAdmission, LauncherObservationError, ObservedLauncherSidecar, observe_launcher_sidecar,
+};
 
 /// Whether the fixture kubelet actuates an accepted resize into
 /// `status.initContainerStatuses`.
@@ -106,6 +108,17 @@ impl ApiFault {
 
 struct ClusterState {
     pod: Option<Pod>,
+    /// Whether the Job that would create [`Self::pod`] is still suspended in the
+    /// Kueue admission queue.
+    ///
+    /// This is not decoration next to `pod: None`. A suspended Job and a Job
+    /// whose Pod is merely slow both present as "no Pod" to an observer of Pods;
+    /// only this field tells them apart, and telling them apart is the entire
+    /// subject of the birth-gate budget.
+    job_suspended: bool,
+    /// The Pod the Job controller will create the moment Kueue admits it.
+    /// `None` once it has been handed over to [`Self::pod`].
+    pod_on_admission: Option<Pod>,
     actuation: Actuation,
     resize_patches: usize,
     deletes: Vec<(String, String)>,
@@ -131,6 +144,8 @@ impl StoredTaskRunPod {
         Self {
             state: Arc::new(Mutex::new(ClusterState {
                 pod: Some(pod),
+                job_suspended: false,
+                pod_on_admission: None,
                 actuation: Actuation::Actuates,
                 resize_patches: 0,
                 deletes: Vec::new(),
@@ -194,6 +209,55 @@ impl StoredTaskRunPod {
                 Some("containerd://launcher")
             )]),
         ))
+    }
+
+    /// Hold this Pod's Job in the Kueue admission queue.
+    ///
+    /// `spec.suspend: true`, so the Job controller has created nothing: the
+    /// cluster serves **no Pod** until [`Self::kueue_admits`] is called. This is
+    /// the production shape of `ClusterQueue djinn-kueue: admitted=3 pending=5`
+    /// — a Job that exists, is accounted for, and has no launcher to govern.
+    #[must_use]
+    pub fn suspended_in_kueue(self) -> Self {
+        let mut state = self.state.lock().expect("cluster");
+        state.job_suspended = true;
+        state.pod_on_admission = state.pod.take();
+        drop(state);
+        self
+    }
+
+    /// Kueue admits the Workload: `spec.suspend` flips to false and the Job
+    /// controller creates the Pod.
+    ///
+    /// A no-op for a fixture that was never suspended, so a test that calls it
+    /// on a healthy cluster still measures the healthy path.
+    pub fn kueue_admits(&self) {
+        let mut state = self.state.lock().expect("cluster");
+        state.job_suspended = false;
+        if let Some(pod) = state.pod_on_admission.take() {
+            state.pod = Some(pod);
+        }
+    }
+
+    /// Kueue admits the Workload but the Job controller creates no Pod.
+    ///
+    /// `spec.suspend` is false and there is still nothing to observe. The window
+    /// is real and normally milliseconds long; a run stuck in it is a genuine
+    /// stall, and it must keep the launcher's short leash rather than inherit
+    /// the queue's generous one.
+    pub fn kueue_admits_without_creating_the_pod(&self) {
+        self.state.lock().expect("cluster").job_suspended = false;
+    }
+
+    /// What an observer of the Job would read, exactly as
+    /// `TaskRunPodResizeSurface::observe_job_admission` reads it.
+    #[must_use]
+    pub fn job_admission(&self) -> JobAdmission {
+        if self.state.lock().expect("cluster").job_suspended {
+            JobAdmission::Suspended
+        } else {
+            JobAdmission::Admitted
+        }
     }
 
     /// Model a node that accepts the resize request and never actuates it.

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -2297,7 +2297,30 @@ pub async fn get_taskrun_pod_fresh(
     }
 }
 
-/// The three apiserver operations the resize bootstrap performs, bound to one
+/// Whether a task run's Job has left the Kueue admission queue.
+///
+/// A Job Kueue is still holding carries `spec.suspend: true`, and the Job
+/// controller creates **no Pod** for a suspended Job. That is not a slow start:
+/// while this reads [`Self::Suspended`] there is no launcher in existence, so
+/// there is nothing to resize and nothing that could confirm a birth limit. Any
+/// budget that measures the launcher must therefore not run.
+///
+/// The three variants are deliberately not two. Only a *proven* suspension may
+/// defer a deadline; a Job that could not be read at all must keep the launcher
+/// clock running, or an apiserver outage would buy an unbounded wait.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum JobAdmission {
+    /// The Job exists and `spec.suspend` is `true` — queued, not started.
+    Suspended,
+    /// The Job exists and is not suspended. A Pod is expected to materialize;
+    /// one that does not is a real stall.
+    Admitted,
+    /// No Job carries this task run's label, or the read failed. Folded with
+    /// [`Self::Admitted`] by every caller, on purpose: see the type docs.
+    Unknown(String),
+}
+
+/// The four apiserver operations the resize bootstrap performs, bound to one
 /// namespace and one field manager.
 ///
 /// It exists so `djinn-server` can drive the bootstrap without depending on
@@ -2397,6 +2420,39 @@ impl TaskRunPodResizeSurface {
                 crate::pod_resize::CpuLimit::from_millis(target_millicores),
             )
             .await
+    }
+
+    /// Whether this task run's Job has been admitted out of the Kueue queue.
+    ///
+    /// Reads `spec.suspend` off the Job itself rather than the Kueue Workload:
+    /// `suspend` is the field the Job controller actually consults before it
+    /// creates a Pod, so it is the fact that decides whether a Pod can exist.
+    /// A Workload condition is Kueue's *intent*; this is the effect.
+    ///
+    /// Never returns an error. An unreadable Job is [`JobAdmission::Unknown`],
+    /// which every caller folds with [`JobAdmission::Admitted`] — the fail-safe
+    /// direction, because only a proven suspension may defer a deadline.
+    pub async fn observe_job_admission(&self, task_run_id: &str) -> JobAdmission {
+        let jobs: Api<Job> = Api::namespaced(self.client.clone(), &self.namespace);
+        let selector = format!("{}={task_run_id}", crate::job::LABEL_TASK_RUN_ID);
+        let listed = match jobs.list(&ListParams::default().labels(&selector)).await {
+            Ok(list) => list.items,
+            Err(error) => return JobAdmission::Unknown(format!("list task-run Jobs: {error}")),
+        };
+        match listed.as_slice() {
+            [] => JobAdmission::Unknown(format!("no Job carries the label `{selector}`")),
+            [job] => {
+                if job.spec.as_ref().and_then(|spec| spec.suspend) == Some(true) {
+                    JobAdmission::Suspended
+                } else {
+                    JobAdmission::Admitted
+                }
+            }
+            many => JobAdmission::Unknown(format!(
+                "task-run {task_run_id} resolves to {} Jobs; refusing to pick one",
+                many.len()
+            )),
+        }
     }
 
     /// UID-fenced destruction of exactly the observed Pod, plus its Job.

--- a/server/src/task_run_resize_bootstrap.rs
+++ b/server/src/task_run_resize_bootstrap.rs
@@ -28,6 +28,24 @@
 //! happens after admission is that a mutating webhook may have changed what was
 //! rendered.
 //!
+//! # A queued Job is not a stalled one
+//!
+//! Under `9oga` a task-run Job is created **suspended** and Kueue unsuspends it
+//! when quota is available. A suspended Job has no Pod: the Job controller
+//! creates none. So for as long as it sits in the queue there is no launcher, no
+//! ceiling to capture, and nothing that could confirm a birth limit.
+//!
+//! The wait budget in [`TaskRunResizeAdmissionBridge`] therefore does not start
+//! at dispatch. It starts when a Pod exists. Queue time runs against a separate
+//! [`QUEUE_ADMISSION_BUDGET_DEFAULT`], and the two clocks are separate objects
+//! rather than one clock with a subtraction so that no amount of queueing can
+//! consume the launcher's budget by arithmetic accident.
+//!
+//! This is the only thing about the ordering below that is negotiable. The clamp
+//! is not: the Pod is created with the launcher at its full admitted ceiling, and
+//! between Pod start and the confirmed downsize the launcher is ungoverned, so no
+//! worker session may dispatch until the clamp is confirmed.
+//!
 //! # `birth_confirmed` is a capture state, not a confirmation state
 //!
 //! Migration 164's `capture_resize_identity` sets `state = 'birth_confirmed'`
@@ -101,7 +119,7 @@ use djinn_db::{
 use djinn_k8s::launcher::LAUNCHER_CPU_REQUEST_MILLICORES;
 use djinn_k8s::pod_resize::PodResizeError;
 use djinn_k8s::runtime::{
-    LauncherObservationError, ObservedLauncherSidecar, TaskRunPodResizeSurface,
+    JobAdmission, LauncherObservationError, ObservedLauncherSidecar, TaskRunPodResizeSurface,
 };
 use djinn_launcher_protocol::LauncherAuthorityProtocol;
 use tracing::{info, warn};
@@ -128,12 +146,17 @@ const UNIQUE_VIOLATION: &str = "23505";
 
 // ── The apiserver seam ─────────────────────────────────────────────────────
 
-/// The three Kubernetes operations bootstrap performs.
+/// The four Kubernetes operations bootstrap performs.
 ///
 /// Behind a trait so the whole sequence is drivable from fixtures with no
 /// cluster, and so this crate needs no `kube` / `k8s-openapi` dependency of its
 /// own. The production implementation is
 /// [`djinn_k8s::runtime::TaskRunPodResizeSurface`].
+///
+/// [`Self::observe_job_admission`] deliberately has **no default body**. A
+/// default returning "admitted" would be the pre-`9oga` assumption written down
+/// as a trait default, and every fixture that forgot to override it would
+/// silently re-acquire the defect this method exists to fix.
 #[async_trait]
 pub trait TaskRunPodSurface: Send + Sync {
     /// Fresh GET of the single Pod labelled for this task run, flattened to the
@@ -161,6 +184,12 @@ pub trait TaskRunPodSurface: Send + Sync {
         target_millicores: u64,
     ) -> Result<(), PodResizeError>;
 
+    /// Whether this task run's Job has left the Kueue admission queue.
+    ///
+    /// Never fails: an unreadable Job is [`JobAdmission::Unknown`], which the
+    /// caller folds with [`JobAdmission::Admitted`].
+    async fn observe_job_admission(&self, task_run_id: &str) -> JobAdmission;
+
     /// UID-fenced destruction of exactly the observed Pod.
     ///
     /// # Errors
@@ -184,6 +213,10 @@ impl TaskRunPodSurface for TaskRunPodResizeSurface {
         target_millicores: u64,
     ) -> Result<(), PodResizeError> {
         Self::resize_launcher_cpu(self, pod_name, target_millicores).await
+    }
+
+    async fn observe_job_admission(&self, task_run_id: &str) -> JobAdmission {
+        Self::observe_job_admission(self, task_run_id).await
     }
 
     async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
@@ -238,6 +271,29 @@ pub enum NotReady {
     /// must not be destroyed because Postgres blinked.
     #[error("durable storage unavailable: {0}")]
     StorageUnavailable(String),
+}
+
+impl NotReady {
+    /// Whether reaching this outcome required a Pod object to exist.
+    ///
+    /// This is the predicate the birth budget is armed by, so it is a statement
+    /// about *evidence*, not about likelihood. Three variants are only
+    /// reachable from a stored Pod the bootstrap actually read:
+    /// [`Self::PodIncomplete`] and [`Self::LauncherNotStarted`] are produced by
+    /// flattening one, and [`Self::BirthUnconfirmed`] by resizing one.
+    ///
+    /// The rest are not. [`Self::PodAbsent`] says so outright;
+    /// [`Self::JobNotBound`] is decided before any observation; and the two
+    /// unavailability variants mean the observation did not happen at all. For
+    /// those the caller must ask the Job whether it is queued — an apiserver
+    /// that did not answer is *not* proof of a Kueue queue.
+    #[must_use]
+    pub const fn observed_a_pod(&self) -> bool {
+        matches!(
+            self,
+            Self::PodIncomplete(_) | Self::LauncherNotStarted { .. } | Self::BirthUnconfirmed(_)
+        )
+    }
 }
 
 /// Why bootstrap refused, permanently, for this Pod.
@@ -926,13 +982,40 @@ impl TaskRunResizeBootstrap {
 /// Environment override for the birth-confirmation wait budget, in seconds.
 pub const BIRTH_ADMISSION_BUDGET_ENV: &str = "DJINN_BIRTH_CONFIRMATION_BUDGET_SECS";
 
-/// How long one dispatch waits for its launcher sidecar to be admitted and its
-/// birth downsize confirmed.
+/// How long one dispatch waits, **once its Pod exists**, for the launcher
+/// sidecar to be admitted and its birth downsize confirmed.
 ///
 /// Deliberately shorter than the supervisor's 480s pre-session deadline: an
 /// unconfirmable Pod must surface as a dispatch failure that names *why*, not as
 /// a pre-session timeout that names nothing.
+///
+/// # This clock does not start at dispatch
+///
+/// It starts when there is a launcher to measure. Between `9oga` (Kueue
+/// create-then-admit) and this gate there is a window in which the Job carries
+/// `spec.suspend: true`, the Job controller has created no Pod, and no launcher
+/// exists — 2026-08-01 saw 13 dispatches refused inside that window, against a
+/// `ClusterQueue` holding `admitted=3 pending=5` with a nominal quota of 3 Pods.
+/// The refusals were literally accurate and entirely wrong: the confirmation
+/// they timed out waiting for was not late, it was impossible.
+///
+/// Queue time is bounded by [`QUEUE_ADMISSION_BUDGET_DEFAULT`] instead, which is
+/// a separate clock precisely so no amount of queueing can consume this one.
 pub const BIRTH_ADMISSION_BUDGET_DEFAULT: Duration = Duration::from_secs(180);
+
+/// Environment override for the Kueue queue-wait budget, in seconds.
+pub const QUEUE_ADMISSION_BUDGET_ENV: &str = "DJINN_KUEUE_QUEUE_WAIT_BUDGET_SECS";
+
+/// How long one dispatch waits for Kueue to admit its Job at all.
+///
+/// A queue is not a stall, so this is generous — an hour of quota contention is
+/// a capacity fact, not a broken Pod. It is nevertheless finite: a slot held for
+/// a Workload that will never be admitted is a wedge, and trading a false
+/// refusal for a hang is not an improvement.
+///
+/// It is measured from dispatch and is **never** re-armed, so it also bounds the
+/// pathological case where a Workload is repeatedly admitted and preempted.
+pub const QUEUE_ADMISSION_BUDGET_DEFAULT: Duration = Duration::from_secs(3600);
 
 /// Interval between bootstrap passes while the launcher is still starting.
 const BIRTH_ADMISSION_POLL_INTERVAL: Duration = Duration::from_millis(500);
@@ -959,6 +1042,7 @@ pub struct TaskRunResizeAdmissionBridge {
     gate: Arc<DispatchGate>,
     surface: SurfaceSource,
     budget: Duration,
+    queue_budget: Duration,
     poll_interval: Duration,
 }
 
@@ -972,6 +1056,7 @@ impl TaskRunResizeAdmissionBridge {
             gate: Arc::new(DispatchGate::new()),
             surface: SurfaceSource::Ambient(tokio::sync::OnceCell::new()),
             budget: budget_from_env(),
+            queue_budget: queue_budget_from_env(),
             poll_interval: BIRTH_ADMISSION_POLL_INTERVAL,
         }
     }
@@ -984,15 +1069,27 @@ impl TaskRunResizeAdmissionBridge {
             gate: Arc::new(DispatchGate::new()),
             surface: SurfaceSource::Fixed(surface),
             budget: budget_from_env(),
+            queue_budget: queue_budget_from_env(),
             poll_interval: BIRTH_ADMISSION_POLL_INTERVAL,
         }
     }
 
-    /// Override the wait budget and poll interval.
+    /// Override the birth-confirmation wait budget and poll interval.
+    ///
+    /// Leaves the queue budget alone: a caller that shortens the launcher clock
+    /// to prove a refusal must not shorten the Kueue clock by accident, or the
+    /// refusal it observes may be the wrong one.
     #[must_use]
     pub const fn with_wait(mut self, budget: Duration, poll_interval: Duration) -> Self {
         self.budget = budget;
         self.poll_interval = poll_interval;
+        self
+    }
+
+    /// Override the Kueue queue-wait budget.
+    #[must_use]
+    pub const fn with_queue_wait(mut self, queue_budget: Duration) -> Self {
+        self.queue_budget = queue_budget;
         self
     }
 
@@ -1026,6 +1123,24 @@ fn budget_from_env() -> Duration {
         .map_or(BIRTH_ADMISSION_BUDGET_DEFAULT, Duration::from_secs)
 }
 
+fn queue_budget_from_env() -> Duration {
+    std::env::var(QUEUE_ADMISSION_BUDGET_ENV)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map_or(QUEUE_ADMISSION_BUDGET_DEFAULT, Duration::from_secs)
+}
+
+/// Which of the bridge's two wait clocks ran out, carrying the condition that
+/// was still unmet when it did.
+enum BudgetExpiry {
+    /// A Pod existed and its launcher never reached the birth limit. The real
+    /// failure mode, and the one this gate exists for.
+    Birth(String),
+    /// Kueue never admitted the Job, so no Pod ever existed to govern.
+    Queue(String),
+}
+
 fn refused(reason: impl Into<String>, disposition: &PodDisposition) -> ResizeAdmissionRefused {
     ResizeAdmissionRefused {
         reason: reason.into(),
@@ -1057,10 +1172,23 @@ impl TaskRunResizeAdmission for TaskRunResizeAdmissionBridge {
             self.gate.clone(),
         );
 
-        let deadline = tokio::time::Instant::now() + self.budget;
+        // Two clocks, and at most one of them is running at any moment.
+        //
+        // `queue_deadline` bounds the whole wait from dispatch and is never
+        // re-armed, so nothing here can hang. `birth_deadline` is the launcher's
+        // own budget: unarmed until a Pod is known to exist, and *disarmed*
+        // again whenever the Job is observed back in the Kueue queue. That is
+        // what makes queue time structurally unable to consume it — not an
+        // estimate subtracted after the fact, but a clock that is not running.
+        let queue_deadline = tokio::time::Instant::now() + self.queue_budget;
+        let mut birth_deadline: Option<tokio::time::Instant> = None;
         // Assigned on exactly the path that breaks out of the loop, so the
-        // refusal below always names the condition that was still unmet.
-        let stalled: String;
+        // refusal below always names the clock that ran out and the condition
+        // that was still unmet.
+        let expiry: BudgetExpiry;
+        // One line per dispatch, not one per poll: an operator needs to know a
+        // run is queued rather than stalled, and needs it once.
+        let mut queue_wait_logged = false;
         loop {
             match bootstrap
                 .bootstrap(&permit, request.effective_protocol)
@@ -1095,9 +1223,56 @@ impl TaskRunResizeAdmission for TaskRunResizeAdmissionBridge {
                     return Ok(ResizeAdmissionOutcome::LeafAuthority);
                 }
                 BootstrapOutcome::NotReady(reason) => {
-                    if tokio::time::Instant::now() >= deadline {
-                        stalled = reason.to_string();
-                        break;
+                    let now = tokio::time::Instant::now();
+                    if reason.observed_a_pod() {
+                        // There is a launcher to measure, so the launcher's
+                        // clock runs. From here a birth limit that never
+                        // confirms is a genuine stall and is refused as one.
+                        birth_deadline.get_or_insert(now + self.budget);
+                    } else {
+                        match bootstrap
+                            .surface
+                            .observe_job_admission(&permit.task_run_id)
+                            .await
+                        {
+                            // Proven suspended: no Pod exists, none can, and
+                            // the launcher clock is unarmed rather than merely
+                            // paused. A Workload that is admitted, preempted
+                            // and re-queued therefore gets a full budget on
+                            // each admission — which is the only correct
+                            // reading, since its Pod is destroyed and rebuilt
+                            // each time.
+                            JobAdmission::Suspended => {
+                                if !queue_wait_logged {
+                                    queue_wait_logged = true;
+                                    info!(
+                                        task_run_id = %permit.task_run_id,
+                                        queue_budget_secs = self.queue_budget.as_secs(),
+                                        "task_run_resize_bootstrap: Job is suspended in the \
+                                         Kueue admission queue; the launcher birth budget is \
+                                         not running"
+                                    );
+                                }
+                                birth_deadline = None;
+                            }
+                            // An unreadable Job is NOT evidence of a queue. It
+                            // folds with `Admitted` so that an apiserver
+                            // outage cannot buy an unbounded wait.
+                            JobAdmission::Admitted | JobAdmission::Unknown(_) => {
+                                birth_deadline.get_or_insert(now + self.budget);
+                            }
+                        }
+                    }
+                    match birth_deadline {
+                        Some(deadline) if now >= deadline => {
+                            expiry = BudgetExpiry::Birth(reason.to_string());
+                            break;
+                        }
+                        None if now >= queue_deadline => {
+                            expiry = BudgetExpiry::Queue(reason.to_string());
+                            break;
+                        }
+                        _ => {}
                     }
                     tokio::time::sleep(self.poll_interval).await;
                 }
@@ -1110,10 +1285,17 @@ impl TaskRunResizeAdmission for TaskRunResizeAdmissionBridge {
             }
         }
 
-        let message = format!(
-            "launcher birth limit was not confirmed within {}s: {stalled}",
-            self.budget.as_secs()
-        );
+        let message = match &expiry {
+            BudgetExpiry::Birth(stalled) => format!(
+                "launcher birth limit was not confirmed within {}s of the Pod existing: {stalled}",
+                self.budget.as_secs()
+            ),
+            BudgetExpiry::Queue(stalled) => format!(
+                "Kueue did not admit this task-run Job within {}s; the Job is still suspended \
+                 in the admission queue, so no Pod and no launcher have ever existed: {stalled}",
+                self.queue_budget.as_secs()
+            ),
+        };
         let disposition = bootstrap.abandon(&permit, &message).await;
         Err(refused(message, &disposition))
     }

--- a/server/src/task_run_resize_bootstrap_tests.rs
+++ b/server/src/task_run_resize_bootstrap_tests.rs
@@ -90,6 +90,16 @@ impl TaskRunPodSurface for FakeSurface {
         }
     }
 
+    /// Every test in this file drives `TaskRunResizeBootstrap::bootstrap`
+    /// directly, one pass at a time. Nothing here consults the Job: the Kueue
+    /// clock lives in the bridge's wait loop, which these tests do not enter.
+    /// The seam tests in `tests/task_run_resize_dispatch_seam.rs` are where a
+    /// suspended Job is driven, and they drive it through a real `Job` object
+    /// rather than a constant.
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        JobAdmission::Admitted
+    }
+
     async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
         self.state
             .lock()

--- a/server/src/task_run_resize_drop_tests.rs
+++ b/server/src/task_run_resize_drop_tests.rs
@@ -30,6 +30,7 @@ use djinn_db::{
     UserRepository,
 };
 use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
+use djinn_k8s::runtime::JobAdmission;
 use std::sync::Mutex as StdMutex;
 
 const CEILING: &str = "4";
@@ -85,6 +86,10 @@ impl TaskRunPodSurface for CountingSurface {
         self.cluster
             .resize_launcher_cpu(pod_name, target_millicores)
             .await
+    }
+
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        self.cluster.job_admission()
     }
 
     async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {

--- a/server/tests/task_run_resize_dispatch_seam.rs
+++ b/server/tests/task_run_resize_dispatch_seam.rs
@@ -49,7 +49,7 @@ use djinn_db::{
 };
 use djinn_k8s::pod_resize::{CpuLimit, PodResizeError};
 use djinn_k8s::pod_resize_fixture::StoredTaskRunPod;
-use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
+use djinn_k8s::runtime::{JobAdmission, LauncherObservationError, ObservedLauncherSidecar};
 use djinn_launcher_protocol::LauncherAuthorityProtocol;
 use djinn_runtime::{
     BiStream, ResolvedCredentials, RunHandle, RuntimeError, SessionRuntime, SupervisorFlow,
@@ -74,6 +74,22 @@ const CONFIRMING_BUDGET: Duration = Duration::from_secs(5);
 /// allowed by the env parser and would be a different code path anyway; one
 /// pass then a deadline is exactly the "never becomes admitted" shape.
 const GIVE_UP_BUDGET: Duration = Duration::from_millis(1);
+
+/// The bridge's poll interval in every test here. Named because the Kueue tests
+/// derive an elapsed-time lower bound from it.
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+/// The launcher's own budget in the Kueue tests. Short on purpose: the queue
+/// wait below outlives it several times over, which is the whole point.
+const BIRTH_BUDGET: Duration = Duration::from_millis(150);
+
+/// Long enough that no Kueue test can reach it by accident, so a refusal in one
+/// of them is always the *birth* clock and never this one.
+const PATIENT_QUEUE_BUDGET: Duration = Duration::from_secs(120);
+
+/// How many Job observations Kueue holds a Workload for in these tests.
+/// `60 * POLL_INTERVAL` = 300ms, twice [`BIRTH_BUDGET`].
+const QUEUED_OBSERVATIONS: u64 = 60;
 
 // ── The apiserver surface ─────────────────────────────────────────────────
 
@@ -104,8 +120,88 @@ impl TaskRunPodSurface for FixtureSurface {
             .await
     }
 
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        self.0.job_admission()
+    }
+
     async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
         self.0.uid_fenced_delete(task_run_id, pod_uid)
+    }
+}
+
+/// A cluster whose Job starts suspended in the Kueue admission queue.
+///
+/// It counts Job observations and models the admission edge on the Nth one, so
+/// "the gate waited out the queue" is a *call count* rather than a wall-clock
+/// guess. `admit_after` observations at the bridge's poll interval is also a
+/// lower bound on elapsed time, which is what makes the birth budget provably
+/// outlived.
+struct QueuedSurface {
+    cluster: StoredTaskRunPod,
+    admit_after: u64,
+    /// What the Job controller does when Kueue admits: create the Pod, or not.
+    creates_pod_on_admission: bool,
+    job_observations: Arc<AtomicUsize>,
+}
+
+impl QueuedSurface {
+    fn new(cluster: &StoredTaskRunPod, admit_after: u64, creates_pod_on_admission: bool) -> Self {
+        Self {
+            cluster: cluster.clone().suspended_in_kueue(),
+            admit_after,
+            creates_pod_on_admission,
+            job_observations: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// A cluster that is never suspended at all — the healthy fleet's shape.
+    fn never_queued(cluster: &StoredTaskRunPod) -> Self {
+        Self {
+            cluster: cluster.clone(),
+            admit_after: 0,
+            creates_pod_on_admission: true,
+            job_observations: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn job_observations(&self) -> usize {
+        self.job_observations.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TaskRunPodSurface for QueuedSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.cluster.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        self.cluster
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
+    }
+
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        let seen = self.job_observations.fetch_add(1, Ordering::SeqCst) + 1;
+        if seen as u64 >= self.admit_after {
+            if self.creates_pod_on_admission {
+                self.cluster.kueue_admits();
+            } else {
+                self.cluster.kueue_admits_without_creating_the_pod();
+            }
+        }
+        self.cluster.job_admission()
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        self.cluster.uid_fenced_delete(task_run_id, pod_uid)
     }
 }
 
@@ -412,6 +508,20 @@ fn bridge_for(
             Arc::new(FixtureSurface(cluster.clone())) as Arc<dyn TaskRunPodSurface>,
         )
         .with_wait(budget, Duration::from_millis(5)),
+    )
+}
+
+/// A bridge over a caller-supplied surface, with both wait clocks set.
+fn bridge_over(
+    db: &Database,
+    surface: Arc<dyn TaskRunPodSurface>,
+    birth_budget: Duration,
+    queue_budget: Duration,
+) -> Arc<TaskRunResizeAdmissionBridge> {
+    Arc::new(
+        TaskRunResizeAdmissionBridge::with_surface(db.clone(), surface)
+            .with_wait(birth_budget, POLL_INTERVAL)
+            .with_queue_wait(queue_budget),
     )
 }
 
@@ -922,6 +1032,312 @@ async fn a_resize_v2_render_still_refuses_when_no_permit_can_be_obtained() {
         status, "failed",
         "a refused dispatch must not leave its run row live forever"
     );
+}
+
+// ── Kueue queue time is not launcher latency ───────────────────────────────
+//
+// Production, 2026-08-01, server v0.7.35: 13 dispatches refused by this gate
+// with "launcher birth limit was not confirmed within 180s: no Pod exists for
+// this task run", while their Jobs sat `Suspended` for ~10 minutes against a
+// ClusterQueue holding admitted=3 pending=5 on a nominal quota of 3 Pods. A
+// suspended Job has no Pod, so the confirmation the gate waited for was not
+// late — it was impossible, and the 180s were spent entirely in the queue.
+
+/// **The defect.** A task run whose Job stays suspended past the birth budget is
+/// NOT refused. The gate keeps waiting, and when Kueue finally admits it the run
+/// dispatches normally with its launcher clamped.
+///
+/// The queue here outlives the birth budget by 2x, measured two independent
+/// ways: [`QUEUED_OBSERVATIONS`] polls of the Job, and the elapsed wall clock.
+///
+/// **Named mutation.** In `TaskRunResizeAdmissionBridge::admit_dispatch`, make
+/// queue time count: change the wait loop's
+/// `JobAdmission::Suspended => birth_deadline = None` arm to
+/// `JobAdmission::Suspended => { birth_deadline.get_or_insert(now + self.budget); }`.
+/// One clock, running while the Job is suspended — `main`'s behaviour and the
+/// production defect. This test then fails at `drive_seam`: the seam returns the
+/// refusal, `attaches()` is 0 and no identity is ever captured.
+#[tokio::test]
+async fn a_job_still_suspended_in_the_kueue_queue_is_waited_out_rather_than_refused() {
+    const POD_UID: &str = "pod-uid-kueue-wait";
+    const JOB_UID: &str = "job-uid-kueue-wait";
+
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed(&db, "kueuewait").await;
+    let cluster = StoredTaskRunPod::resize_v2(POD_UID, RENDERED_CEILING);
+    let surface = Arc::new(QueuedSurface::new(&cluster, QUEUED_OBSERVATIONS, true));
+    let bridge = bridge_over(
+        &db,
+        surface.clone() as Arc<dyn TaskRunPodSurface>,
+        BIRTH_BUDGET,
+        PATIENT_QUEUE_BUDGET,
+    );
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::new(Some(JOB_UID), Some(LauncherAuthorityProtocol::ResizeV2));
+
+    // The premise: while the Job is suspended the cluster serves no Pod at all.
+    assert_eq!(surface.cluster.job_admission(), JobAdmission::Suspended);
+    assert!(
+        surface
+            .cluster
+            .observe_launcher()
+            .expect("a suspended Job is not an observation error")
+            .is_none(),
+        "a suspended Job has no Pod; a fixture that serves one is not modelling the defect"
+    );
+
+    let started = SystemClock::new().now_instant();
+    drive_seam(runtime.clone(), &seeded, &context)
+        .await
+        .expect("a Job waiting on Kueue quota must not be refused as a stalled launcher");
+    let elapsed = started.elapsed();
+
+    // The wait genuinely spanned more queue time than the launcher's whole
+    // budget — twice over — so a budget that counted it would have expired.
+    assert!(
+        surface.job_observations() as u64 >= QUEUED_OBSERVATIONS,
+        "the gate must have polled the queued Job {QUEUED_OBSERVATIONS} times; saw {}",
+        surface.job_observations()
+    );
+    assert!(
+        elapsed > BIRTH_BUDGET * 2,
+        "the dispatch outlived twice the birth budget in the queue ({elapsed:?}) and was \
+         still admitted, which is only possible if queue time never ran the launcher clock"
+    );
+
+    // And the clamp is not weakened by any of it: the launcher is at 250m
+    // before the worker session starts.
+    assert_eq!(
+        CpuLimit::parse(
+            &cluster
+                .launcher_status_cpu()
+                .expect("the launcher reports a cpu limit")
+        )
+        .expect("the reported quantity parses")
+        .millis(),
+        BIRTH_MILLICORES,
+        "a run admitted after a queue wait is still clamped to the birth limit"
+    );
+    let row = BuildPodPermitRepository::new(db.clone())
+        .active(&seeded.spec.task_run_id)
+        .await
+        .expect("read permit")
+        .expect("the seam acquired a permit");
+    assert_eq!(row.state, BuildPodPermitState::BirthConfirmed);
+    assert_eq!(
+        row.resize_identity
+            .expect("a birth_confirmed row carries an identity")
+            .pod_uid,
+        POD_UID,
+        "the identity is fenced to the Pod Kueue eventually produced"
+    );
+    assert_eq!(runtime.attaches(), 1, "the worker session started");
+    assert_eq!(
+        cluster.deletes(),
+        Vec::new(),
+        "a queued Job's Pod is never destroyed for being queued"
+    );
+    assert_eq!(bridge.gate().dispatches_before_birth_confirmation(), 0);
+}
+
+/// **The failure mode survives.** Once the Pod exists, a launcher that never
+/// reaches its birth limit is still refused — inside the birth budget, and with
+/// the Pod destroyed.
+///
+/// This is the composed shape, not the pre-existing one: the Job is queued
+/// first, admitted, and only then does its launcher fail to actuate. So it
+/// proves the birth clock *arms* on Pod existence rather than never running.
+///
+/// **Named mutation.** Delete the birth-expiry arm from the wait loop — the
+/// `Some(deadline) if now >= deadline => { expiry = BudgetExpiry::Birth(..); break }`
+/// match arm — so an armed clock can no longer end the loop. The seam then waits
+/// out the 120s queue budget and this test fails on its 30s timeout.
+#[tokio::test]
+async fn a_launcher_that_never_confirms_after_admission_is_still_refused() {
+    const POD_UID: &str = "pod-uid-kueue-stall";
+
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed(&db, "kueuestall").await;
+    // Kueue admits it; the apiserver accepts the resize; the kubelet never
+    // actuates it. A launcher above its birth limit, forever.
+    let cluster = StoredTaskRunPod::resize_v2(POD_UID, RENDERED_CEILING).never_actuating();
+    let surface = Arc::new(QueuedSurface::new(&cluster, QUEUED_OBSERVATIONS, true));
+    let bridge = bridge_over(
+        &db,
+        surface.clone() as Arc<dyn TaskRunPodSurface>,
+        BIRTH_BUDGET,
+        PATIENT_QUEUE_BUDGET,
+    );
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::new(
+        Some("job-uid-kueue-stall"),
+        Some(LauncherAuthorityProtocol::ResizeV2),
+    );
+
+    let error = tokio::time::timeout(
+        Duration::from_secs(30),
+        drive_seam(runtime.clone(), &seeded, &context),
+    )
+    .await
+    .expect("the gate must remain bounded; an unbounded wait is a wedged slot, not a fix")
+    .expect_err("a launcher that never confirms must not dispatch");
+    let rendered = format!("{error:#}");
+
+    // The refusal is the LAUNCHER's, not the queue's: the run got past Kueue.
+    assert!(
+        rendered.contains("launcher birth limit was not confirmed"),
+        "the birth clock must be the one that expired: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Kueue did not admit"),
+        "this run was admitted; refusing it as still-queued would name the wrong cause: \
+         {rendered}"
+    );
+    assert!(
+        surface.job_observations() as u64 >= QUEUED_OBSERVATIONS,
+        "the refusal must come after the queue wait, not during it"
+    );
+
+    assert_eq!(
+        runtime.attaches(),
+        0,
+        "no worker session may start behind an unconfirmed birth limit: {rendered}"
+    );
+    assert_eq!(runtime.teardowns(), 1, "the refused run is torn down");
+    assert!(
+        cluster.resize_patches() >= 1,
+        "the PATCH was issued and accepted; only confirmation failed"
+    );
+    assert_eq!(
+        cluster.deletes(),
+        vec![(seeded.spec.task_run_id.clone(), POD_UID.to_owned())],
+        "an ungovernable Pod is destroyed, fenced to its own uid"
+    );
+    assert_eq!(bridge.gate().dispatches_before_birth_confirmation(), 0);
+}
+
+/// **An admitted Job keeps the short leash.** Kueue unsuspends the Job and the
+/// Pod never appears. That is a stall, not a queue, and it must be refused on the
+/// birth budget rather than inherit the queue's generous one.
+///
+/// **Named mutation.** Fold `JobAdmission::Admitted` in with `Suspended` in the
+/// wait loop — `JobAdmission::Suspended | JobAdmission::Admitted => birth_deadline = None`
+/// — and this run waits out the whole 120s queue budget, blowing the 30s
+/// timeout; shorten the queue budget and the refusal names Kueue instead, which
+/// the assertions below reject.
+#[tokio::test]
+async fn an_admitted_job_whose_pod_never_appears_is_refused_on_the_birth_budget() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed(&db, "kueuepodless").await;
+    let cluster = StoredTaskRunPod::resize_v2("pod-uid-kueue-podless", RENDERED_CEILING);
+    // Admitted after the usual queue wait, but the Job controller creates
+    // nothing: `spec.suspend` is false and there is still no Pod.
+    let surface = Arc::new(QueuedSurface::new(&cluster, QUEUED_OBSERVATIONS, false));
+    let bridge = bridge_over(
+        &db,
+        surface.clone() as Arc<dyn TaskRunPodSurface>,
+        BIRTH_BUDGET,
+        PATIENT_QUEUE_BUDGET,
+    );
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::new(
+        Some("job-uid-kueue-podless"),
+        Some(LauncherAuthorityProtocol::ResizeV2),
+    );
+
+    let started = SystemClock::new().now_instant();
+    let error = tokio::time::timeout(
+        Duration::from_secs(30),
+        drive_seam(runtime.clone(), &seeded, &context),
+    )
+    .await
+    .expect("an admitted-but-Podless run must not wait out the queue budget")
+    .expect_err("a Pod that never appears must not dispatch");
+    let rendered = format!("{error:#}");
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        surface.cluster.job_admission(),
+        JobAdmission::Admitted,
+        "the premise: the Job left the queue"
+    );
+    assert!(
+        rendered.contains("launcher birth limit was not confirmed"),
+        "an admitted Job's missing Pod is a launcher stall: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Kueue did not admit"),
+        "an unsuspended Job must not be refused as still-queued: {rendered}"
+    );
+    assert!(
+        elapsed < PATIENT_QUEUE_BUDGET / 2,
+        "the short leash is the point; this took {elapsed:?} of a {PATIENT_QUEUE_BUDGET:?} \
+         queue budget"
+    );
+    assert_eq!(runtime.attaches(), 0, "nothing dispatched: {rendered}");
+    assert_eq!(cluster.resize_patches(), 0, "there was nothing to resize");
+    assert_eq!(
+        cluster.deletes(),
+        Vec::new(),
+        "there is no Pod to fence a delete to, and guessing a uid destroys someone else's"
+    );
+}
+
+/// **The fast path is unchanged and pays nothing.** A dispatch whose Job was
+/// never suspended confirms on the first pass, and the Job is never read at all.
+///
+/// The zero is the assertion. The Kueue lookup lives strictly on the
+/// "no Pod, and no evidence one exists" branch, so a healthy dispatch adds no
+/// apiserver call — and a refactor that moves the lookup to the top of the wait
+/// loop, or arms the clock by asking the Job first, turns this red.
+#[tokio::test]
+async fn a_dispatch_that_was_never_queued_confirms_without_consulting_the_job() {
+    const POD_UID: &str = "pod-uid-fastpath";
+
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed(&db, "fastpath").await;
+    let cluster = StoredTaskRunPod::resize_v2(POD_UID, RENDERED_CEILING);
+    let surface = Arc::new(QueuedSurface::never_queued(&cluster));
+    let bridge = bridge_over(
+        &db,
+        surface.clone() as Arc<dyn TaskRunPodSurface>,
+        BIRTH_BUDGET,
+        PATIENT_QUEUE_BUDGET,
+    );
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::new(
+        Some("job-uid-fastpath"),
+        Some(LauncherAuthorityProtocol::ResizeV2),
+    );
+
+    drive_seam(runtime.clone(), &seeded, &context)
+        .await
+        .expect("a healthy resize-v2 dispatch is admitted");
+
+    assert_eq!(
+        surface.job_observations(),
+        0,
+        "a run whose Pod exists on the first pass must never consult its Job"
+    );
+    assert_eq!(runtime.attaches(), 1, "the worker session started");
+    assert_eq!(
+        CpuLimit::parse(
+            &cluster
+                .launcher_status_cpu()
+                .expect("the launcher reports a cpu limit")
+        )
+        .expect("the reported quantity parses")
+        .millis(),
+        BIRTH_MILLICORES,
+        "the clamp is unchanged on the fast path"
+    );
+    let row = BuildPodPermitRepository::new(db.clone())
+        .active(&seeded.spec.task_run_id)
+        .await
+        .expect("read permit")
+        .expect("the seam acquired a permit");
+    assert_eq!(row.state, BuildPodPermitState::BirthConfirmed);
+    assert_eq!(bridge.gate().dispatches_before_birth_confirmation(), 0);
 }
 
 /// The bootstrap type is still constructible and still composes — a compile-time

--- a/server/tests/task_run_resize_faults.rs
+++ b/server/tests/task_run_resize_faults.rs
@@ -32,7 +32,7 @@ use djinn_db::{
 };
 use djinn_k8s::pod_resize::PodResizeError;
 use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
-use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
+use djinn_k8s::runtime::{JobAdmission, LauncherObservationError, ObservedLauncherSidecar};
 use djinn_server::task_run_resize_bootstrap::TaskRunPodSurface;
 use djinn_server::task_run_resize_drop::{ResizeDropClock, TaskRunResizeDropBridge};
 use djinn_server::task_run_resize_reconcile::{
@@ -71,6 +71,10 @@ impl TaskRunPodSurface for FixtureSurface {
         self.0
             .resize_launcher_cpu(pod_name, target_millicores)
             .await
+    }
+
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        self.0.job_admission()
     }
 
     async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
@@ -604,6 +608,10 @@ impl TaskRunPodSurface for ReconcilerRacingSurface {
         self.cluster
             .resize_launcher_cpu(pod_name, target_millicores)
             .await
+    }
+
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        self.cluster.job_admission()
     }
 
     async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -93,7 +93,7 @@ use djinn_db::{
     TaskRunRepository, TransitionBuildPodResizeLifecycleResult,
 };
 use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
-use djinn_k8s::runtime::{LauncherObservationError, ObservedLauncherSidecar};
+use djinn_k8s::runtime::{JobAdmission, LauncherObservationError, ObservedLauncherSidecar};
 use djinn_server::task_run_resize_bootstrap::TaskRunPodSurface;
 use djinn_server::task_run_resize_drop::{ResizeDropClock, TaskRunResizeDropBridge};
 use djinn_server::task_run_resize_reconcile::{
@@ -164,6 +164,10 @@ impl TaskRunPodSurface for CountingSurface {
         self.cluster
             .resize_launcher_cpu(pod_name, target_millicores)
             .await
+    }
+
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        self.cluster.job_admission()
     }
 
     async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
@@ -665,6 +669,10 @@ impl TaskRunPodSurface for LedgerRacingSurface {
         self.cluster
             .resize_launcher_cpu(pod_name, target_millicores)
             .await
+    }
+
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        self.cluster.job_admission()
     }
 
     async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {


### PR DESCRIPTION
## The production evidence

Production, 2026-08-01, server `v0.7.35`. **13 dispatches** refused like this:

```
ERROR slot lifecycle returned error (dispatch/setup failure)
  error: supervisor dispatch: task-run 019fbf6e-338e-75f2-a69e-0bdf46ac1fb8
         refused by the resize birth gate (pod_deleted=false):
         launcher birth limit was not confirmed within 180s: no Pod exists for this task
```

Those task-runs had their Jobs suspended by Kueue, waiting for admission quota:

```
djinn-taskrun-019fbf6e-2f31-…  Suspended  10m
djinn-taskrun-019fbf6e-313d-…  Suspended  10m
djinn-taskrun-019fbf6e-338e-…  Suspended  10m   <- refused by the birth gate
djinn-taskrun-019fbf6e-b214-…  Suspended  9m52s <- refused by the birth gate
ClusterQueue djinn-kueue: admitted=3 pending=5, nominalQuota pods=3
```

The message was literally correct and the conclusion was wrong. **A suspended Job
has no Pod** — the Job controller creates none while `spec.suspend` is true. So
during that window no launcher existed, nothing could be resized, and the
confirmation the gate waited for was not merely late: it was impossible. The
180s budget was consumed entirely by queue time, and then the gate failed the
dispatch and burned the slot cycle.

This is a composition bug between `9oga` (Kueue create-then-admit, which can
suspend a Job indefinitely) and `3i92` (the birth gate, written when "Job posted"
implied "Pod shortly after"). Each is correct alone.

## What was wrong: only *when the clock starts*

`server/src/task_run_resize_bootstrap.rs:1060` (pre-fix):

```rust
let deadline = tokio::time::Instant::now() + self.budget;
```

One clock, armed at `admit_dispatch` entry, before any Pod could exist. Every
`NotReady` variant was charged against it, including `PodAbsent` — "no Pod exists
for this task run yet", which is exactly what a queued Job looks like. Nothing
downstream rescued it either: the supervisor's 480s pre-session deadline starts
*after* the gate (`attach_and_await_terminal_report`), so the gate's own budget
was the only bound.

## The fix

Two clocks, and at most one of them running at any moment.

* **`birth_deadline`** — the launcher's own budget (180s, unchanged). Unarmed
  until a Pod is known to exist, and *disarmed* again whenever the Job is
  observed back in the queue. Queue time is structurally unable to consume it:
  the clock is not running, rather than having an estimate subtracted from it.
* **`queue_deadline`** — a new `QUEUE_ADMISSION_BUDGET_DEFAULT` (1h,
  `DJINN_KUEUE_QUEUE_WAIT_BUDGET_SECS`), measured from dispatch and never
  re-armed. A queue is not a stall, but a slot held for a Workload that will
  never be admitted is a wedge, so the wait stays bounded.

Arming is evidence-based, not heuristic. `NotReady::observed_a_pod()` names the
three outcomes only reachable from a Pod the bootstrap actually read
(`PodIncomplete`, `LauncherNotStarted`, `BirthUnconfirmed`). For anything else the
bridge asks the Job:

* `JobAdmission::Suspended` (`spec.suspend == true`) → disarm; queue time.
* `JobAdmission::Admitted` → arm; an unsuspended Job whose Pod never appears is a
  real stall and keeps the short leash.
* `JobAdmission::Unknown` (no Job, unreadable, ambiguous) → arm. An apiserver
  that did not answer is **not** proof of a Kueue queue, and must not buy an
  unbounded wait.

`TaskRunPodSurface::observe_job_admission` has **no default body** on purpose: a
default returning "admitted" would be the pre-`9oga` assumption written down as a
trait default, and every fixture that forgot to override it would silently
re-acquire this defect.

### What is deliberately unchanged

The clamp ordering. The Pod is still created with the launcher at its full
admitted ceiling; the ceiling is still captured from the *stored* Pod; the
downsize to `BIRTH_CPU_MILLICORES` is still confirmed through
`status.initContainerStatuses`; and no worker session dispatches until that
confirmation. Clamp-by-default, lift-on-demand. Nothing here is lazy, skipped, or
best-effort. The refusal message now distinguishes the two clocks, so an
incident reads "still queued" differently from "launcher never confirmed".

## Mutation table

Four new tests in `server/tests/task_run_resize_dispatch_seam.rs`, all driven
through the production seam (`execute_runtime_report_phase`) against real
Postgres, the real permit relation, and the real `PodResizeClient`. Every test
asserts the dispatch outcome, the `build_pod_permits` row, the launcher's
init-container status and the attach counter — never a log line.

Each mutation was applied to `main`'s source, run, observed red, and reverted;
the file was `diff`-verified identical afterwards.

| # | Test | Mutation applied | Result |
|---|------|------------------|--------|
| 1 | `a_job_still_suspended_in_the_kueue_queue_is_waited_out_rather_than_refused` | `JobAdmission::Suspended => birth_deadline = None` → `get_or_insert(now + self.budget)` (one clock, running during the queue — `main`'s behaviour) | **RED** 3 failed / 11 passed |
| 2 | `a_launcher_that_never_confirms_after_admission_is_still_refused` | delete the birth-expiry arm (`Some(deadline) if now >= deadline => break`) | **RED** 2 failed + 2 timed out / 10 passed |
| 3 | `an_admitted_job_whose_pod_never_appears_is_refused_on_the_birth_budget` | fold `Admitted` in with `Suspended` so an unsuspended Job also disarms | **RED** 1 failed / 13 passed (exact target) |
| 4 | `a_dispatch_that_was_never_queued_confirms_without_consulting_the_job` | move `observe_job_admission` to the top of the wait loop | **RED** 2 failed / 12 passed |

Notes on what each red proves:

1. Test 1's queue outlives the birth budget twice over, asserted two independent
   ways — 60 polls of the Job, and elapsed wall clock > 2× the budget. Under the
   mutation the seam refuses at ~150ms with `attaches() == 0` and no identity.
2. Test 2 wraps the seam in a 30s timeout, so an unbounded wait is a hard
   failure rather than a hang. It also asserts the refusal names the *launcher*
   clock and not Kueue, and that the ungovernable Pod is UID-fenced deleted.
3. Test 3 is the "admitted but Podless" window: it must be refused on the 150ms
   birth budget, not inherit the 120s queue budget. The mutation makes it wait
   out the queue budget and blow the timeout.
4. Test 4 is the fast path: a run whose Pod exists on the first pass never
   consults its Job at all (`job_observations() == 0`), so the fix adds zero
   apiserver calls to a healthy dispatch.

## Verification

* `cargo fmt --check` — clean
* `cargo clippy -p djinn-server -p djinn-k8s --lib --tests --all-features` — clean
* `djinn-server::task_run_resize_dispatch_seam` — **14/14 passed** (10 pre-existing + 4 new)
* `djinn-server::task_run_resize_faults` + `task_run_resize_recovery` + seam — **37/37 passed**
* `djinn-server --lib -E 'test(resize)'` — **34/34 passed**
* `djinn-k8s` — 465/466; the single failure
  (`a_protocol_less_undigested_image_creates_zero_kubernetes_objects`) reproduces
  on the base commit with this branch stashed and is unrelated to this change.

No migration is needed. No cluster was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
