### PR TITLE
feat(kueue): guarantee task capacity while warm and SCIP borrow

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -473,6 +473,8 @@ spec:
               value: {{ .Values.resources.warm.limits.memory | quote }}
             - name: DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS
               value: {{ .Values.resources.warm.jobTimeoutSeconds | quote }}
+            - name: DJINN_K8S_WARM_JOB_TERMINATION_GRACE_PERIOD_SECONDS
+              value: {{ .Values.resources.warm.terminationGracePeriodSeconds | quote }}
             # SCIP indexer cache retention. Tuning only — djinn-graph carries
             # the same defaults, so a deployment that omits these still gets a
             # bounded cache. The server forwards both onto every warm and

--- a/deploy/helm/djinn/templates/kueue-topology.yaml
+++ b/deploy/helm/djinn/templates/kueue-topology.yaml
@@ -33,7 +33,10 @@ state `deploy/kueue/zero-capture-gate.sh` verifies. `armed` implies `enabled`;
 {{- fail "kueue.enabled is true but kueue.buildPods is not a number. It is the pods nominalQuota for the ClusterQueue; set a positive integer, or set kueue.enabled=false if the Kueue prerequisite (deploy/helm/djinn-prereqs) is not installed." -}}
 {{- end -}}
 {{- end -}}
-{{- $clusterQueueName := printf "%s-kueue" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- $cohortName := printf "%s-build" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- $taskQueueName := printf "%s-kueue" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- $warmQueueName := printf "%s-warm" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- $scipQueueName := printf "%s-scip" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" -}}
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor
 metadata:
@@ -45,10 +48,13 @@ spec: {}
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
-  name: {{ $clusterQueueName }}
+  name: {{ $taskQueueName }}
   labels:
     {{- include "djinn.labels" . | nindent 4 }}
 spec:
+  cohort: {{ $cohortName }}
+  preemption:
+    reclaimWithinCohort: Any
   # WHO MAY SUBMIT — and the reason this line is not optional.
   #
   # MEASURED on a live armed kind cluster (fbiy-B1, 2026-07-30): with this field
@@ -136,7 +142,30 @@ metadata:
   labels:
     {{- include "djinn.labels" . | nindent 4 }}
 spec:
-  clusterQueue: {{ $clusterQueueName }}
+  clusterQueue: {{ $taskQueueName }}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: {{ $warmQueueName }}
+  labels:
+    {{- include "djinn.labels" . | nindent 4 }}
+spec:
+  cohort: {{ $cohortName }}
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+    - coveredResources: ["pods", "cpu", "memory"]
+      flavors:
+        - name: {{ printf "%s-kueue" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" }}
+          resources:
+            - name: pods
+              nominalQuota: 0
+              borrowingLimit: 1
+            - name: cpu
+              nominalQuota: 10k
+            - name: memory
+              nominalQuota: 100Ti
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
@@ -146,7 +175,7 @@ metadata:
   labels:
     {{- include "djinn.labels" . | nindent 4 }}
 spec:
-  clusterQueue: {{ $clusterQueueName }}
+  clusterQueue: {{ $warmQueueName }}
 ---
 {{- /*
 SCIP joins Kueue. rust-analyzer indexing is genuinely CPU-heavy — the measured
@@ -159,6 +188,29 @@ task-run holds a slot waiting on its project image while that image build is
 queued behind it. Adding a `-build` queue here re-introduces that.
 */ -}}
 apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: {{ $scipQueueName }}
+  labels:
+    {{- include "djinn.labels" . | nindent 4 }}
+spec:
+  cohort: {{ $cohortName }}
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+    - coveredResources: ["pods", "cpu", "memory"]
+      flavors:
+        - name: {{ printf "%s-kueue" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" }}
+          resources:
+            - name: pods
+              nominalQuota: 0
+              borrowingLimit: 1
+            - name: cpu
+              nominalQuota: 10k
+            - name: memory
+              nominalQuota: 100Ti
+---
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
 metadata:
   name: {{ include "djinn.fullname" . }}-scip
@@ -166,5 +218,5 @@ metadata:
   labels:
     {{- include "djinn.labels" . | nindent 4 }}
 spec:
-  clusterQueue: {{ $clusterQueueName }}
+  clusterQueue: {{ $scipQueueName }}
 {{- end }}

--- a/deploy/helm/djinn/tests/kueue-topology-render.sh
+++ b/deploy/helm/djinn/tests/kueue-topology-render.sh
@@ -592,9 +592,20 @@ flavor = flavors[0]
 assert flavor.get("spec") == {}, "ResourceFlavor must be empty"
 
 queues = named("ClusterQueue")
-assert len(queues) == 1, f"expected one ClusterQueue, got {len(queues)}"
-queue = queues[0]
+assert len(queues) == 3, f"expected task-run, warm and scip ClusterQueues, got {len(queues)}"
+queue_by_name = {queue["metadata"]["name"]: queue for queue in queues}
+assert set(queue_by_name) == {
+    "kueue-topology-test-djinn-kueue",
+    "kueue-topology-test-djinn-warm",
+    "kueue-topology-test-djinn-scip",
+}, f"unexpected ClusterQueue set: {sorted(queue_by_name)}"
+queue = queue_by_name["kueue-topology-test-djinn-kueue"]
 spec = queue["spec"]
+cohort = spec.get("cohort")
+assert cohort and all(q["spec"].get("cohort") == cohort for q in queues), "all queues must share one cohort"
+assert spec.get("preemption") == {"reclaimWithinCohort": "Any"}, (
+    f"task-run must reclaim its nominal capacity with Any, got {spec.get('preemption')}"
+)
 # BestEffortFIFO, not StrictFIFO: three kinds share a 3-slot queue, so one
 # head-of-line Workload that cannot fit would block everything behind it.
 assert spec.get("queueingStrategy") == "BestEffortFIFO", (
@@ -655,6 +666,28 @@ assert resources["pods"] == int(expected_pods), "pods quota must render buildPod
 assert resources["cpu"] == "10k", f"cpu quota must stay non-binding, got {resources['cpu']}"
 assert resources["memory"] == "100Ti", f"memory quota must stay non-binding, got {resources['memory']}"
 
+for background_name in ["kueue-topology-test-djinn-warm", "kueue-topology-test-djinn-scip"]:
+    background = queue_by_name[background_name]
+    background_spec = background["spec"]
+    assert "preemption" not in background_spec, f"{background_name} must not preempt"
+    assert "stopPolicy" not in background_spec, f"{background_name} must not set stopPolicy"
+    assert background_spec.get("namespaceSelector") == {}, f"{background_name} selector drifted"
+    assert background_spec.get("queueingStrategy") == "BestEffortFIFO"
+    bg_groups = background_spec.get("resourceGroups")
+    assert isinstance(bg_groups, list) and len(bg_groups) == 1
+    assert bg_groups[0].get("coveredResources") == covered
+    bg_entries = bg_groups[0]["flavors"][0]["resources"]
+    bg_resources = {entry["name"]: entry for entry in bg_entries}
+    assert set(bg_resources) == set(covered)
+    assert bg_resources["pods"].get("nominalQuota") == 0
+    assert bg_resources["pods"].get("borrowingLimit") == 1
+    assert bg_resources["cpu"].get("nominalQuota") == "10k"
+    assert bg_resources["memory"].get("nominalQuota") == "100Ti"
+    assert all("borrowingLimit" not in bg_resources[name] for name in ["cpu", "memory"])
+
+assert "withinClusterQueue" not in spec.get("preemption", {})
+assert "stopPolicy" not in spec
+
 # Exactly three LocalQueues. SCIP joins Kueue because rust-analyzer indexing is
 # CPU-heavy and excluding it under-counts the load the quota exists to bound.
 # Image build stays out on purpose: it is an UPSTREAM DEPENDENCY of a task-run,
@@ -668,7 +701,15 @@ assert local_names == {
     "kueue-topology-test-djinn-warm",
     "kueue-topology-test-djinn-scip",
 }, f"unexpected LocalQueue set: {sorted(local_names)}"
-assert all(local.get("spec", {}).get("clusterQueue") == queue["metadata"]["name"] for local in local_queues)
+local_targets = {
+    local["metadata"]["name"]: local.get("spec", {}).get("clusterQueue")
+    for local in local_queues
+}
+assert local_targets == {
+    "kueue-topology-test-djinn-task-run": "kueue-topology-test-djinn-kueue",
+    "kueue-topology-test-djinn-warm": "kueue-topology-test-djinn-warm",
+    "kueue-topology-test-djinn-scip": "kueue-topology-test-djinn-scip",
+}, f"LocalQueue targets drifted: {local_targets}"
 
 namespaces = named("Namespace")
 assert len(namespaces) == 1, f"expected one Namespace, got {len(namespaces)}"

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -449,6 +449,9 @@ resources:
     # that outlives the deadline which would kill the Pod anyway; to give the
     # test-binary compile more room, raise this rather than a per-step override.
     jobTimeoutSeconds: 7200
+    # Shared graph-warm/SCIP SIGTERM window. Internal child stop/reap and
+    # inventory cleanup are bounded to 8s total and must finish before this.
+    terminationGracePeriodSeconds: 30
 
 # -----------------------------------------------------------------------------
 # Node-local durable pod-log collector (disabled until the host store exists)

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -2364,6 +2364,82 @@ struct WarmGraphShutdownConfig {
 }
 
 #[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct WarmOutputInventory {
+    root: PathBuf,
+    existing: HashSet<PathBuf>,
+}
+
+#[cfg(target_os = "linux")]
+impl WarmOutputInventory {
+    fn capture_from_env() -> Result<Option<Self>> {
+        let Ok(configured) = std::env::var(CARGO_TARGET_DIR_ENV) else {
+            return Ok(None);
+        };
+        std::fs::create_dir_all(&configured)
+            .with_context(|| format!("create warm output root {configured}"))?;
+        let root = std::fs::canonicalize(&configured)
+            .with_context(|| format!("canonicalize warm output root {configured}"))?;
+        let mut existing = HashSet::new();
+        collect_warm_output_paths(&root, &root, &mut existing)?;
+        Ok(Some(Self { root, existing }))
+    }
+
+    fn cleanup_new_paths(self) -> Result<()> {
+        let canonical_root = std::fs::canonicalize(&self.root)
+            .context("re-canonicalize warm output root before cleanup")?;
+        anyhow::ensure!(
+            canonical_root == self.root,
+            "warm output root changed during run"
+        );
+        let mut current = HashSet::new();
+        collect_warm_output_paths(&self.root, &self.root, &mut current)?;
+        let mut created = current
+            .difference(&self.existing)
+            .cloned()
+            .collect::<Vec<_>>();
+        created.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+        for path in created {
+            anyhow::ensure!(
+                path.starts_with(&self.root),
+                "cleanup candidate escaped warm root"
+            );
+            let metadata = std::fs::symlink_metadata(&path)?;
+            if metadata.is_dir() {
+                match std::fs::remove_dir(&path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => {}
+                    Err(error) => {
+                        return Err(error).with_context(|| format!("remove {}", path.display()));
+                    }
+                }
+            } else {
+                std::fs::remove_file(&path)
+                    .with_context(|| format!("remove {}", path.display()))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn collect_warm_output_paths(root: &Path, dir: &Path, paths: &mut HashSet<PathBuf>) -> Result<()> {
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        anyhow::ensure!(
+            path.starts_with(root),
+            "inventory candidate escaped warm root"
+        );
+        paths.insert(path.clone());
+        if entry.file_type()?.is_dir() {
+            collect_warm_output_paths(root, &path, paths)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
 const WARM_GRAPH_SHUTDOWN_CONFIG: WarmGraphShutdownConfig = WarmGraphShutdownConfig {
     bound: WARM_GRAPH_SHUTDOWN_BOUND,
     term_grace: WARM_GRAPH_TERM_GRACE,
@@ -2431,9 +2507,57 @@ where
     let admission = reaper
         .admit(format!("warm-graph:{project_id}"))
         .context("admit warm-graph lifecycle")?;
-    let body = body_fn().await;
+    // Warm and SCIP are reclaimable cohort borrowers. Unlike task-runs they
+    // have no checkpoint RPC, but SIGTERM must still make their body return so
+    // the shared lifecycle owner can stop and reap every process group before
+    // kubelet's grace expires.
+    let inventory = WarmOutputInventory::capture_from_env()?;
+    let cancel = CancellationToken::new();
+    let signal_cancel = cancel.clone();
+    let signal_listener = tokio::spawn(async move {
+        let mut terminate = signal(SignalKind::terminate()).expect("install warm SIGTERM listener");
+        let mut interrupt = signal(SignalKind::interrupt()).expect("install warm SIGINT listener");
+        tokio::select! {
+            _ = terminate.recv() => {}
+            _ = interrupt.recv() => {}
+        }
+        signal_cancel.cancel();
+    });
+    let (body, interrupted) = tokio::select! {
+        result = body_fn() => (result, false),
+        _ = cancel.cancelled() => (Err(anyhow::anyhow!(
+            "warm lifecycle cancelled by termination signal"
+        )), true),
+    };
+    signal_listener.abort();
     admission.release();
     let cleanup = shutdown_linux_warm_lifecycle(reaper).await;
+    let interrupted_cleanup = if interrupted {
+        match inventory {
+            Some(inventory) => match tokio::time::timeout(
+                Duration::from_secs(4),
+                tokio::task::spawn_blocking(move || inventory.cleanup_new_paths()),
+            )
+            .await
+            {
+                Ok(Ok(result)) => result,
+                Ok(Err(error)) => Err(anyhow::Error::new(error)),
+                Err(_) => Err(anyhow::anyhow!(
+                    "interrupted warm cleanup exceeded 4s budget"
+                )),
+            },
+            None => Ok(()),
+        }
+    } else {
+        Ok(())
+    };
+
+    let body = match interrupted_cleanup {
+        Ok(()) => body,
+        Err(cleanup_error) => {
+            Err(cleanup_error.context(body.err().map(|e| e.to_string()).unwrap_or_default()))
+        }
+    };
 
     match (body, cleanup) {
         (Ok(()), Ok(())) => Ok(()),
@@ -6599,6 +6723,53 @@ warning: something
         assert!(reaper.wait_for_adopted_idle(Duration::ZERO));
         reaper.reopen_after_idle_for_test();
         reaper
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn interrupted_warm_cleanup_preserves_inventory() {
+        let root = tempfile::tempdir().expect("temp root");
+        let old = root.path().join("debug/deps/old.rlib");
+        std::fs::create_dir_all(old.parent().unwrap()).unwrap();
+        std::fs::write(&old, b"known-good").unwrap();
+        let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+        let mut existing = HashSet::new();
+        collect_warm_output_paths(&canonical_root, &canonical_root, &mut existing).unwrap();
+        let inventory = WarmOutputInventory {
+            root: canonical_root,
+            existing,
+        };
+
+        let new = root.path().join("debug/deps/interrupted.rmeta");
+        std::fs::write(&new, b"partial").unwrap();
+        inventory.cleanup_new_paths().unwrap();
+
+        assert_eq!(std::fs::read(old).unwrap(), b"known-good");
+        assert!(!new.exists(), "post-inventory output must be removed");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn interrupted_warm_cleanup_safety() {
+        let root = tempfile::tempdir().expect("temp root");
+        let outside = tempfile::tempdir().expect("outside root");
+        let link = root.path().join("escape");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+        let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+        let inventory = WarmOutputInventory {
+            root: canonical_root,
+            existing: HashSet::new(),
+        };
+        let protected = outside.path().join("protected");
+        std::fs::write(&protected, b"outside").unwrap();
+
+        inventory.cleanup_new_paths().unwrap();
+
+        assert_eq!(std::fs::read(protected).unwrap(), b"outside");
+        assert!(
+            !link.exists(),
+            "the symlink itself is removable; its target is not traversed"
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -164,6 +164,9 @@ pub struct KubernetesConfig {
     /// (plus a small grace) so a long warm run is not declared failed while the
     /// Job is still legitimately running.
     pub warm_job_timeout_seconds: i64,
+    /// Grace shared by graph-warm and standalone SCIP Pods. The worker's
+    /// bounded TERM/KILL and interrupted-output cleanup budgets fit inside it.
+    pub warm_job_termination_grace_period_seconds: i64,
     /// MySQL DSN forwarded to the warm Pod so `djinn-agent-worker
     /// warm-graph` can reuse the server's backing MySQL instance.
     /// `None` leaves the warm binary to fall back to its built-in default
@@ -515,6 +518,7 @@ impl KubernetesConfig {
             server_addr: "djinn.djinn.svc.cluster.local:8443".into(),
             warm_job_ttl_seconds: 300,
             warm_job_timeout_seconds: 7200,
+            warm_job_termination_grace_period_seconds: 30,
             database_url: None,
             task_run_active_deadline_seconds: 10800,
             task_run_termination_grace_period_seconds: 60,
@@ -692,6 +696,17 @@ impl KubernetesConfig {
                     error = %e,
                     "DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS not a valid i64 — keeping default"
                 ),
+            }
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_WARM_JOB_TERMINATION_GRACE_PERIOD_SECONDS") {
+            match v.parse::<i64>() {
+                Ok(n) if n > 8 => cfg.warm_job_termination_grace_period_seconds = n,
+                Ok(_) => tracing::warn!(
+                    "warm termination grace must exceed the 8s internal shutdown budget"
+                ),
+                Err(e) => {
+                    tracing::warn!(value = %v, error = %e, "invalid warm termination grace — keeping default")
+                }
             }
         }
         cfg.database_url = std::env::var("DJINN_DATABASE_URL")

--- a/server/crates/djinn-k8s/src/scip_job.rs
+++ b/server/crates/djinn-k8s/src/scip_job.rs
@@ -410,6 +410,7 @@ exec {bin} scip-index "{project_id}"
         volumes: Some(volumes),
         node_selector,
         tolerations,
+        termination_grace_period_seconds: Some(config.warm_job_termination_grace_period_seconds),
         // Same uid rationale as the warm Pod: this Pod CREATES content in the
         // shared `/cache` tree (the SCIP artifact cache, and whatever the
         // indexers spill into the cargo target base), and chmod/chown/utimes
@@ -588,6 +589,14 @@ mod tests {
         assert_eq!(
             spec.active_deadline_seconds,
             Some(cfg.scip_job_timeout_seconds)
+        );
+        assert_eq!(
+            spec.template
+                .spec
+                .as_ref()
+                .unwrap()
+                .termination_grace_period_seconds,
+            Some(cfg.warm_job_termination_grace_period_seconds),
         );
 
         let cmd = &container_of(&job).command.as_ref().expect("command")[2];

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -369,6 +369,7 @@ exec {bin} warm-graph "{project_id}"
         volumes: Some(volumes),
         node_selector,
         tolerations,
+        termination_grace_period_seconds: Some(config.warm_job_termination_grace_period_seconds),
         // Why CHILD_UID (1001), not WORKER_UID (1000). The rule for this field
         // is not "match the task-run pod": it is that every actor which CREATES
         // CONTENT in the shared `/cache/cargo-target` tree must be the same uid.

--- a/server/crates/djinn-k8s/src/warm_job_tests.rs
+++ b/server/crates/djinn-k8s/src/warm_job_tests.rs
@@ -45,6 +45,14 @@ fn builds_warm_job_manifest_with_expected_shape() {
         spec.active_deadline_seconds,
         Some(cfg.warm_job_timeout_seconds)
     );
+    assert_eq!(
+        spec.template
+            .spec
+            .as_ref()
+            .unwrap()
+            .termination_grace_period_seconds,
+        Some(30),
+    );
 
     let pod = spec.template.spec.as_ref().expect("pod");
     assert_eq!(pod.restart_policy.as_deref(), Some("Never"));


### PR DESCRIPTION
## Summary

- split task-run, graph-warm, and SCIP into three ClusterQueues in one cohort
- keep all nominal binding capacity with task-runs while warm and SCIP may each borrow one idle slot
- reclaim task-run nominal capacity with `reclaimWithinCohort: Any`
- make SIGTERM cancel both background worker bodies, stop and reap child process groups, then clean only post-inventory output
- render an explicit configurable termination grace for graph-warm and SCIP

## Proposal

Implements proposal `9cbn`, expanded per operator request so standalone SCIP receives the same borrow/yield and safe-termination contract as graph-warm.

The repository implementation does not claim the proposal's live-cluster validation artifact. That remains an operator rollout verification after deployment.

## Verification

- `cargo check -p djinn-agent-worker -p djinn-k8s --all-targets`
- `cargo clippy -p djinn-agent-worker -p djinn-k8s --all-targets --all-features -- -D warnings`
- `cargo test -p djinn-k8s warm_job --lib`
- `cargo test -p djinn-k8s builds_scip_index_job_with_expected_shape --lib`
- `cargo test -p djinn-agent-worker warm_lifecycle --bin djinn-agent-worker`
- `cargo test -p djinn-agent-worker interrupted_warm_cleanup --bin djinn-agent-worker`
- `deploy/helm/djinn/tests/kueue-topology-render.sh` (through umbrella chart runner)
- `git diff --check`

The umbrella Helm runner's Kueue contract passed; two unrelated log-observability scripts could not run locally because the `vector` binary is absent.
