### PR TITLE
test(warm): close proposal 9cbn evidence gaps

### DIFF
--- a/deploy/helm/djinn/templates/kueue-topology.yaml
+++ b/deploy/helm/djinn/templates/kueue-topology.yaml
@@ -28,6 +28,7 @@ state `deploy/kueue/zero-capture-gate.sh` verifies. `armed` implies `enabled`;
 */ -}}
 {{- if .Values.kueue.enabled -}}
 {{- $kueue := .Values.kueue -}}
+{{- $bindingResource := $kueue.bindingResource | default "pods" -}}
 {{- if not (kindIs "float64" $kueue.buildPods) -}}
 {{- if not (kindIs "int64" $kueue.buildPods) -}}
 {{- fail "kueue.enabled is true but kueue.buildPods is not a number. It is the pods nominalQuota for the ClusterQueue; set a positive integer, or set kueue.enabled=false if the Kueue prerequisite (deploy/helm/djinn-prereqs) is not installed." -}}
@@ -128,9 +129,17 @@ spec:
         - name: {{ printf "%s-kueue" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" }}
           resources:
             - name: pods
+              {{- if eq $bindingResource "pods" }}
               nominalQuota: {{ $kueue.buildPods }}
+              {{- else }}
+              nominalQuota: 10000
+              {{- end }}
             - name: cpu
+              {{- if eq $bindingResource "cpu" }}
+              nominalQuota: {{ $kueue.buildPods }}
+              {{- else }}
               nominalQuota: 10k
+              {{- end }}
             - name: memory
               nominalQuota: 100Ti
 ---
@@ -160,10 +169,19 @@ spec:
         - name: {{ printf "%s-kueue" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" }}
           resources:
             - name: pods
+              {{- if eq $bindingResource "pods" }}
               nominalQuota: 0
               borrowingLimit: 1
+              {{- else }}
+              nominalQuota: 10000
+              {{- end }}
             - name: cpu
+              {{- if eq $bindingResource "cpu" }}
+              nominalQuota: 0
+              borrowingLimit: 1
+              {{- else }}
               nominalQuota: 10k
+              {{- end }}
             - name: memory
               nominalQuota: 100Ti
 ---
@@ -203,10 +221,19 @@ spec:
         - name: {{ printf "%s-kueue" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" }}
           resources:
             - name: pods
+              {{- if eq $bindingResource "pods" }}
               nominalQuota: 0
               borrowingLimit: 1
+              {{- else }}
+              nominalQuota: 10000
+              {{- end }}
             - name: cpu
+              {{- if eq $bindingResource "cpu" }}
+              nominalQuota: 0
+              borrowingLimit: 1
+              {{- else }}
               nominalQuota: 10k
+              {{- end }}
             - name: memory
               nominalQuota: 100Ti
 ---

--- a/deploy/helm/djinn/tests/kueue-topology-render.sh
+++ b/deploy/helm/djinn/tests/kueue-topology-render.sh
@@ -573,13 +573,13 @@ python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print("renderers:",
 # `keys_json` is the derived renderer request set; it defaults to the real one
 # and is overridden only by the non-vacuity section at the bottom.
 assert_topology() {
-    local manifest=$1 expected_pods=$2 expected_managed=$3 keys_json=${4:-$RENDERER_KEYS}
-    python3 - "$manifest" "$expected_pods" "$expected_managed" "$keys_json" <<'PY'
+    local manifest=$1 expected_quota=$2 expected_managed=$3 keys_json=${4:-$RENDERER_KEYS} expected_binding=${5:-pods}
+    python3 - "$manifest" "$expected_quota" "$expected_managed" "$keys_json" "$expected_binding" <<'PY'
 import json
 import sys
 import yaml
 
-manifest, expected_pods, expected_managed, keys_json = sys.argv[1:]
+manifest, expected_quota, expected_managed, keys_json, expected_binding = sys.argv[1:]
 derived = json.load(open(keys_json, encoding="utf-8"))
 docs = [doc for doc in yaml.safe_load_all(open(manifest, encoding="utf-8")) if doc]
 
@@ -659,11 +659,16 @@ assert set(resources) == set(covered), (
     f"every covered resource needs a quota and vice versa; covered={sorted(covered)} "
     f"quota={sorted(resources)}"
 )
-assert resources["pods"] == int(expected_pods), "pods quota must render buildPods verbatim"
+assert resources[expected_binding] == int(expected_quota), (
+    f"{expected_binding} quota must render buildPods verbatim"
+)
 # Non-binding by construction: 10k cores and 100Ti are ~1000x any cluster Djinn
 # runs on. If either ever became a real bound, `pods` would stop being the thing
 # that limits concurrency and the whole topology would mean something else.
-assert resources["cpu"] == "10k", f"cpu quota must stay non-binding, got {resources['cpu']}"
+if expected_binding == "pods":
+    assert resources["cpu"] == "10k", f"cpu quota must stay non-binding, got {resources['cpu']}"
+else:
+    assert resources["pods"] == 10000, f"pods quota must stay non-binding, got {resources['pods']}"
 assert resources["memory"] == "100Ti", f"memory quota must stay non-binding, got {resources['memory']}"
 
 for background_name in ["kueue-topology-test-djinn-warm", "kueue-topology-test-djinn-scip"]:
@@ -679,11 +684,14 @@ for background_name in ["kueue-topology-test-djinn-warm", "kueue-topology-test-d
     bg_entries = bg_groups[0]["flavors"][0]["resources"]
     bg_resources = {entry["name"]: entry for entry in bg_entries}
     assert set(bg_resources) == set(covered)
-    assert bg_resources["pods"].get("nominalQuota") == 0
-    assert bg_resources["pods"].get("borrowingLimit") == 1
-    assert bg_resources["cpu"].get("nominalQuota") == "10k"
+    assert bg_resources[expected_binding].get("nominalQuota") == 0
+    assert bg_resources[expected_binding].get("borrowingLimit") == 1
+    nonbinding = "cpu" if expected_binding == "pods" else "pods"
+    expected_nonbinding = "10k" if nonbinding == "cpu" else 10000
+    assert bg_resources[nonbinding].get("nominalQuota") == expected_nonbinding
     assert bg_resources["memory"].get("nominalQuota") == "100Ti"
-    assert all("borrowingLimit" not in bg_resources[name] for name in ["cpu", "memory"])
+    assert "borrowingLimit" not in bg_resources[nonbinding]
+    assert "borrowingLimit" not in bg_resources["memory"]
 
 assert "withinClusterQueue" not in spec.get("preemption", {})
 assert "stopPolicy" not in spec
@@ -781,6 +789,10 @@ assert_topology "$WORK/valid.yaml" 7 no
 echo "=== armed state: enabled=true, armed=true ==="
 render_enabled "$WORK/armed.yaml" --set kueue.buildPods=7 --set kueue.armed=true
 assert_topology "$WORK/armed.yaml" 7 yes
+
+echo "=== CPU-bound cohort render composes without a pods assumption ==="
+render_enabled "$WORK/cpu-bound.yaml" --set kueue.buildPods=7 --set kueue.bindingResource=cpu
+assert_topology "$WORK/cpu-bound.yaml" 7 no "$RENDERER_KEYS" cpu
 
 # ---------------------------------------------------------------------------
 # THE COVERAGE CHECK MUST FAIL IN BOTH DIRECTIONS, INDEPENDENTLY.

--- a/deploy/helm/djinn/values.schema.json
+++ b/deploy/helm/djinn/values.schema.json
@@ -48,10 +48,11 @@
     "kueue": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["enabled", "buildPods", "armed", "namespaceLabelledExternally"],
+      "required": ["enabled", "buildPods", "bindingResource", "armed", "namespaceLabelledExternally"],
       "properties": {
         "enabled": { "type": "boolean" },
         "buildPods": { "type": "integer", "minimum": 1 },
+        "bindingResource": { "type": "string", "enum": ["pods", "cpu"] },
         "armed": { "type": "boolean" },
         "namespaceLabelledExternally": { "type": "boolean" }
       }

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -132,6 +132,9 @@ kueue:
   # namespace is Kueue-managed. Arming is the separate `armed` flag below.
   enabled: false
   buildPods: 3
+  # Admission's binding resource. `cpu` is supported for the oru9-compatible
+  # topology; buildPods is then interpreted as the nominal CPU quantity.
+  bindingResource: pods
 
   # Arm Kueue admission for build Jobs (cutover epic 4c9q, slice S1).
   #

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -2355,6 +2355,8 @@ impl WarmStepResult {
 const WARM_GRAPH_SHUTDOWN_BOUND: Duration = Duration::from_secs(4);
 #[cfg(target_os = "linux")]
 const WARM_GRAPH_TERM_GRACE: Duration = Duration::from_secs(2);
+#[cfg(target_os = "linux")]
+const WARM_INTERRUPTED_CLEANUP_BOUND: Duration = Duration::from_secs(4);
 
 #[cfg(target_os = "linux")]
 #[derive(Clone, Copy)]
@@ -2385,7 +2387,8 @@ impl WarmOutputInventory {
         Ok(Some(Self { root, existing }))
     }
 
-    fn cleanup_new_paths(self) -> Result<()> {
+    #[allow(clippy::disallowed_methods)] // blocking filesystem deadline needs a wall Instant
+    fn cleanup_new_paths(self, deadline: std::time::Instant) -> Result<()> {
         let canonical_root = std::fs::canonicalize(&self.root)
             .context("re-canonicalize warm output root before cleanup")?;
         anyhow::ensure!(
@@ -2400,6 +2403,10 @@ impl WarmOutputInventory {
             .collect::<Vec<_>>();
         created.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
         for path in created {
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "interrupted warm cleanup exceeded its deadline; residue preserved"
+            );
             anyhow::ensure!(
                 path.starts_with(&self.root),
                 "cleanup candidate escaped warm root"
@@ -2511,7 +2518,6 @@ where
     // have no checkpoint RPC, but SIGTERM must still make their body return so
     // the shared lifecycle owner can stop and reap every process group before
     // kubelet's grace expires.
-    let inventory = WarmOutputInventory::capture_from_env()?;
     let cancel = CancellationToken::new();
     let signal_cancel = cancel.clone();
     let signal_listener = tokio::spawn(async move {
@@ -2523,29 +2529,58 @@ where
         }
         signal_cancel.cancel();
     });
+    let result = run_linux_warm_graph_with_initializer_and_cancel(
+        project_id, reaper, admission, body_fn, cancel,
+    )
+    .await;
+    signal_listener.abort();
+    result
+}
+
+#[cfg(target_os = "linux")]
+#[allow(clippy::disallowed_methods)] // establishes the blocking cleanup's wall deadline
+async fn run_linux_warm_graph_with_initializer_and_cancel<F, Fut>(
+    project_id: &str,
+    reaper: &'static djinn_graph::child_reaper::ChildReaper,
+    admission: djinn_graph::child_reaper::Admission,
+    body_fn: F,
+    cancel: CancellationToken,
+) -> Result<()>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let inventory = WarmOutputInventory::capture_from_env()?;
     let (body, interrupted) = tokio::select! {
         result = body_fn() => (result, false),
         _ = cancel.cancelled() => (Err(anyhow::anyhow!(
             "warm lifecycle cancelled by termination signal"
         )), true),
     };
-    signal_listener.abort();
     admission.release();
     let cleanup = shutdown_linux_warm_lifecycle(reaper).await;
+    if cleanup.is_ok() && interrupted {
+        #[cfg(test)]
+        warm_cargo_test_phase("child-reaped");
+        info!(
+            project_id,
+            event = "warm_children_reaped",
+            "warm child processes stopped and reaped"
+        );
+    }
     let interrupted_cleanup = if interrupted {
+        #[cfg(test)]
+        warm_cargo_test_phase("termination-cleanup");
         match inventory {
-            Some(inventory) => match tokio::time::timeout(
-                Duration::from_secs(4),
-                tokio::task::spawn_blocking(move || inventory.cleanup_new_paths()),
-            )
-            .await
-            {
-                Ok(Ok(result)) => result,
-                Ok(Err(error)) => Err(anyhow::Error::new(error)),
-                Err(_) => Err(anyhow::anyhow!(
-                    "interrupted warm cleanup exceeded 4s budget"
-                )),
-            },
+            Some(inventory) => {
+                let deadline = std::time::Instant::now() + WARM_INTERRUPTED_CLEANUP_BOUND;
+                match tokio::task::spawn_blocking(move || inventory.cleanup_new_paths(deadline))
+                    .await
+                {
+                    Ok(result) => result,
+                    Err(error) => Err(anyhow::Error::new(error)),
+                }
+            }
             None => Ok(()),
         }
     } else {
@@ -2553,7 +2588,16 @@ where
     };
 
     let body = match interrupted_cleanup {
-        Ok(()) => body,
+        Ok(()) => {
+            if interrupted {
+                info!(
+                    project_id,
+                    event = "warm_interrupted_cleanup_complete",
+                    "interrupted warm cleanup completed"
+                );
+            }
+            body
+        }
         Err(cleanup_error) => {
             Err(cleanup_error.context(body.err().map(|e| e.to_string()).unwrap_or_default()))
         }
@@ -6308,7 +6352,7 @@ warning: something
     /// Unix-only for the `chmod`ed stub `cargo` the stamp step invokes.
     #[cfg(unix)]
     #[test]
-    fn truncated_warm_step_records_timeout_and_suppresses_the_tail_sweep() {
+    fn interrupted_warm_preserves_sweep_guard() {
         use std::os::unix::fs::PermissionsExt;
         let _serial = WARM_LIFECYCLE_TEST_MUTEX.blocking_lock();
         let fixture = tempfile::tempdir().expect("workspace fixture");
@@ -6727,6 +6771,7 @@ warning: something
 
     #[cfg(target_os = "linux")]
     #[test]
+    #[allow(clippy::disallowed_methods)]
     fn interrupted_warm_cleanup_preserves_inventory() {
         let root = tempfile::tempdir().expect("temp root");
         let old = root.path().join("debug/deps/old.rlib");
@@ -6742,7 +6787,9 @@ warning: something
 
         let new = root.path().join("debug/deps/interrupted.rmeta");
         std::fs::write(&new, b"partial").unwrap();
-        inventory.cleanup_new_paths().unwrap();
+        inventory
+            .cleanup_new_paths(std::time::Instant::now() + Duration::from_secs(1))
+            .unwrap();
 
         assert_eq!(std::fs::read(old).unwrap(), b"known-good");
         assert!(!new.exists(), "post-inventory output must be removed");
@@ -6750,6 +6797,7 @@ warning: something
 
     #[cfg(target_os = "linux")]
     #[test]
+    #[allow(clippy::disallowed_methods)]
     fn interrupted_warm_cleanup_safety() {
         let root = tempfile::tempdir().expect("temp root");
         let outside = tempfile::tempdir().expect("outside root");
@@ -6763,13 +6811,28 @@ warning: something
         let protected = outside.path().join("protected");
         std::fs::write(&protected, b"outside").unwrap();
 
-        inventory.cleanup_new_paths().unwrap();
+        inventory
+            .cleanup_new_paths(std::time::Instant::now() + Duration::from_secs(1))
+            .unwrap();
 
         assert_eq!(std::fs::read(protected).unwrap(), b"outside");
         assert!(
             !link.exists(),
             "the symlink itself is removable; its target is not traversed"
         );
+
+        let bounded_root = tempfile::tempdir().expect("bounded root");
+        let residue = bounded_root.path().join("partial-output");
+        std::fs::write(&residue, b"leave on uncertainty").unwrap();
+        let inventory = WarmOutputInventory {
+            root: std::fs::canonicalize(bounded_root.path()).unwrap(),
+            existing: HashSet::new(),
+        };
+        let error = inventory
+            .cleanup_new_paths(std::time::Instant::now())
+            .expect_err("expired cleanup must stop without widening deletion");
+        assert!(error.to_string().contains("deadline"));
+        assert_eq!(std::fs::read(residue).unwrap(), b"leave on uncertainty");
     }
 
     #[cfg(target_os = "linux")]
@@ -6853,6 +6916,61 @@ warning: something
         assert!(reaper.wait_for_supervisors_idle(Duration::ZERO));
         assert!(reaper.wait_for_adopted_idle(Duration::ZERO));
         // Restore the process-global admission gate this case closed.
+        restore_warm_lifecycle_admission(reaper);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn warm_sigterm_cancels_child() {
+        let _serial = WARM_LIFECYCLE_TEST_MUTEX.lock().await;
+        let reaper = test_warm_reaper();
+        let admission = reaper.admit("warm-sigterm-test").unwrap();
+        let cancel = CancellationToken::new();
+        assert!(
+            WARM_GRAPH_SHUTDOWN_BOUND + WARM_INTERRUPTED_CLEANUP_BOUND < Duration::from_secs(30),
+            "internal stop plus cleanup budgets must fit the rendered default grace"
+        );
+        WARM_CARGO_PHASES.lock().expect("recorder").clear();
+
+        let run = run_linux_warm_graph_with_initializer_and_cancel(
+            "sigterm-test",
+            reaper,
+            admission,
+            || async {
+                warm_cargo_test_phase("compile");
+                let mut command = std::process::Command::new("sh");
+                command.args(["-c", "trap '' TERM; exec sleep 30"]);
+                djinn_graph::process::output_with_timeout(command, Duration::from_secs(30)).await?;
+                Ok(())
+            },
+            cancel.clone(),
+        );
+        tokio::pin!(run);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if !reaper.supervisors().is_empty() {
+                    break;
+                }
+                tokio::select! {
+                    result = &mut run => panic!("warm body ended before cancellation: {result:?}"),
+                    _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+                }
+            }
+        })
+        .await
+        .expect("long-lived warm child must start");
+        cancel.cancel();
+
+        let error = tokio::time::timeout(Duration::from_secs(8), &mut run)
+            .await
+            .expect("warm cancellation must stay bounded")
+            .expect_err("termination must return non-zero");
+        assert!(error.to_string().contains("cancelled"), "{error:#}");
+        assert!(reaper.supervisors().is_empty(), "child must be reaped");
+        assert_eq!(
+            *WARM_CARGO_PHASES.lock().expect("recorder"),
+            ["compile", "child-reaped", "termination-cleanup"],
+        );
         restore_warm_lifecycle_admission(reaper);
     }
 

--- a/server/crates/djinn-k8s/src/scip_job.rs
+++ b/server/crates/djinn-k8s/src/scip_job.rs
@@ -549,6 +549,7 @@ mod tests {
     fn builds_scip_index_job_with_expected_shape() {
         let mut cfg = KubernetesConfig::for_testing();
         cfg.database_url = Some("postgres://djinn@djinn-postgres:5432/djinn".into());
+        cfg.warm_job_termination_grace_period_seconds = 47;
         let job = job(&cfg);
 
         assert_eq!(

--- a/server/crates/djinn-k8s/src/warm_job_tests.rs
+++ b/server/crates/djinn-k8s/src/warm_job_tests.rs
@@ -11,6 +11,7 @@ use super::*;
 fn builds_warm_job_manifest_with_expected_shape() {
     let mut cfg = KubernetesConfig::for_testing();
     cfg.database_url = Some("postgres://djinn@djinn-postgres:5432/djinn".into());
+    cfg.warm_job_termination_grace_period_seconds = 47;
     let job = build_warm_job(
         &cfg,
         "proj-xyz",
@@ -51,7 +52,7 @@ fn builds_warm_job_manifest_with_expected_shape() {
             .as_ref()
             .unwrap()
             .termination_grace_period_seconds,
-        Some(30),
+        Some(47),
     );
 
     let pod = spec.template.spec.as_ref().expect("pod");


### PR DESCRIPTION
## Summary

- add the exact proposal-named SIGTERM and interrupted-sweep tests
- prove cancellation stops and reaps a live process group before cleanup and returns non-zero
- make interrupted cleanup cooperatively deadline-aware so expiry leaves residue instead of allowing a detached blocking deletion to continue
- emit structured child-reaped and cleanup-complete events for live validation
- prove non-default graph-warm and SCIP grace values render verbatim
- support and test both pods-bound and CPU-bound cohort topology without hard-coding the borrowing dimension

## Proposal

Follow-up to #2899 for proposal `9cbn`. Proposal revision 9 now reflects the operator-requested SCIP borrow/yield scope and the final three-queue topology.

The live deployment artifact remains an operator action after this code is deployed.

## Verification

- `cargo test -p djinn-agent-worker warm_sigterm_cancels_child --bin djinn-agent-worker`
- `cargo test -p djinn-agent-worker interrupted_warm_preserves_sweep_guard --bin djinn-agent-worker`
- `cargo test -p djinn-agent-worker interrupted_warm_cleanup_safety --bin djinn-agent-worker`
- `cargo test -p djinn-k8s warm_job --lib`
- `bash deploy/helm/djinn/tests/kueue-topology-render.sh`
- `cargo clippy -p djinn-agent-worker -p djinn-k8s --all-targets --all-features -- -D warnings`
- `git diff --check`
