### PR TITLE
feat(deploy): arm Kueue admission and the standalone SCIP index by default, and refuse a cluster that cannot run them

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -3,8 +3,8 @@
 Phase 2 installs Djinn on top of Kubernetes via three charts:
 
 - `djinn-prereqs/` — cluster-scoped **third-party** prerequisites, pinned to
-  upstream releases. Today: Kueue `0.19.0`. Optional; install as its own
-  release before `djinn`, exactly like cert-manager. See its
+  upstream releases. Today: Kueue `0.19.0`. Required at stock values; install
+  as its own release before `djinn`, exactly like cert-manager. See its
   [README](djinn-prereqs/README.md) and
   [deploy/kueue/README.md](../kueue/README.md).
 - `djinn-crds/` — reserved for **Djinn's own** future CustomResourceDefinitions.
@@ -17,14 +17,24 @@ Phase 2 installs Djinn on top of Kubernetes via three charts:
 
 - `kubectl` >= 1.29
 - `helm` >= 3.14
-- Only if you set `kueue.enabled: true` on the `djinn` chart: the
-  `djinn-prereqs` release, and a cluster at **Kubernetes >= 1.30** (a Kueue 0.19
-  requirement that the upstream chart does not declare, so Helm will not check
-  it; 1.29 rejects its CRDs, and the floor is 1.30 rather than 1.34 only
+- The `djinn-prereqs` release, and a cluster at **Kubernetes >= 1.30** (a Kueue
+  0.19 requirement that the upstream chart does not declare, so Helm will not
+  check it; 1.29 rejects its CRDs, and the floor is 1.30 rather than 1.34 only
   because Djinn's values disable the DRA feature gates — see
   [deploy/kueue/README.md](../kueue/README.md#minimum-kubernetes-is-130-and-only-because-dra-is-disabled)).
-  Without it the `djinn` chart still installs — the queue topology is off
-  by default.
+  This is a hard prerequisite, not an option: the `djinn` chart defaults to
+  `kueue.enabled: true` and `kueue.armed: true`, so it renders
+  `kueue.x-k8s.io/v1beta1` objects and Kueue's `buildPods` quota is what bounds
+  build concurrency. Without it the `djinn` install is refused by
+  `djinn/templates/prereq-guard.yaml`, which names this chart in the error.
+- Nodes that have passed
+  `deploy/node/k3s/djinn-cgroup-writable-conformance.sh`. Task-run writable
+  cgroups are on by default and assign `RuntimeClass/djinn-cgroup-writable`,
+  whose `scheduling.nodeSelector` requires `djinn.io/cgroup-writable=true`; on
+  a cluster with no such node every task-run Pod stays Pending forever. The
+  conformance script owns that marker and applies it itself once the node
+  passes — never apply it by hand. The prereq guard refuses the install when no
+  node carries it.
 - A Kubernetes cluster. For production deploys, ensure a StorageClass that
   satisfies `ReadWriteMany` is available (the `mirrors` and `cache` PVCs
   default to RWX so the mirror cache can be shared across task-run Pods on
@@ -35,15 +45,33 @@ Phase 2 installs Djinn on top of Kubernetes via three charts:
 ## Install order (production / manual)
 
 ```bash
-# Optional, and only if you want the Kueue queue topology:
+# Required: the djinn chart renders the Kueue topology at stock values.
+# --wait matters — ClusterQueue/LocalQueue carry a conversion webhook, so the
+# controller must be serving before djinn applies the topology.
 helm install djinn-prereqs deploy/helm/djinn-prereqs \
   --namespace kueue-system --create-namespace --wait
 
 helm install djinn-crds deploy/helm/djinn-crds
 helm install djinn       deploy/helm/djinn \
   --namespace djinn --create-namespace
-# ... add --set kueue.enabled=true if you installed djinn-prereqs.
 ```
+
+For a cluster that will never have these prerequisites (kind, a laptop, a
+direct-worker profile), opt out of the armed profile explicitly. The switches
+only make sense together — half of them is the incoherent pairing that
+`djinn/templates/deployment-server.yaml` refuses at render time:
+
+```bash
+helm install djinn deploy/helm/djinn --namespace djinn --create-namespace \
+  --set cgroupLauncher.mode=disabled \
+  --set cgroupWritable.runtimeClass.enabled=false \
+  --set cgroupWritable.taskRuns.enabled=false \
+  --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1 \
+  --set kueue.enabled=false \
+  --set kueue.armed=false
+```
+
+`djinn/values.local.yaml` is exactly that profile, and Tilt uses it.
 
 ## Local kind workflow
 

--- a/deploy/helm/djinn-prereqs/README.md
+++ b/deploy/helm/djinn-prereqs/README.md
@@ -34,10 +34,20 @@ controller. Do not remove those gates without moving this number to 1.34;
 
 ## What this release does and does not do
 
-It is **inert**. Djinn's values set a *positive*
-`managedJobsNamespaceSelector` requiring `djinn.io/kueue-managed: "true"`, and
-nothing in this repository applies that label. Kueue therefore selects no
-namespace and creates no Workload. Arming it belongs to cutover epic 4c9q.
+Djinn's values set a *positive* `managedJobsNamespaceSelector` requiring
+`djinn.io/kueue-managed: "true"`, so this release captures nothing on its own —
+a namespace must be labelled first. At stock values the `djinn` chart applies
+that label: `kueue.armed: true` renders it onto the Namespace
+(`djinn/templates/namespace.yaml`) and stamps `suspend: true` plus a queue name
+onto every task-run, warm and standalone-SCIP Job, so Workloads are created and
+Kueue's quota is what bounds build concurrency. This release is inert only
+against a `djinn` deployment that explicitly sets `kueue.armed: false`.
+
+That distinction matters when you reach for stock upstream Kueue instead of
+this chart: at upstream defaults the Pod/Deployment/StatefulSet webhooks are
+`failurePolicy: Fail` with a selector that covers `djinn`, so an unavailable
+Kueue controller stops `djinn-server`, Postgres, Qdrant and task-run Pods
+alike. This chart's values are what prevent that.
 
 `values.yaml` is the whole repository-owned policy; the subchart is untouched.
 It replaces `deploy/kueue/vendor/kueue-v0.10.0.yaml`, a 13,175-line
@@ -87,10 +97,20 @@ operator and belongs here.
 
 ## Then install Djinn
 
-The `djinn` chart's Kueue queue topology is off by default and must be
-requested explicitly once this prerequisite exists:
+The `djinn` chart renders its Kueue queue topology at stock values
+(`kueue.enabled: true`) and arms admission (`kueue.armed: true`), so this
+release is a prerequisite rather than an option — nothing extra to request:
 
 ```bash
 helm install djinn deploy/helm/djinn \
-  --namespace djinn --create-namespace --set kueue.enabled=true
+  --namespace djinn --create-namespace
 ```
+
+Install this release **first**. `djinn/templates/prereq-guard.yaml` consults
+live API discovery during a real install and refuses the release, naming this
+chart, when `kueue.x-k8s.io/v1beta1` is not served — otherwise the operator
+gets the API server's bare `no matches for kind "ResourceFlavor"`, which names
+no remedy. A cluster that will never run Kueue installs `djinn` with
+`--set kueue.enabled=false --set kueue.armed=false` (see
+`djinn/values.local.yaml` for the full local-dev opt-out, which also disables
+the cgroup launcher stack).

--- a/deploy/helm/djinn/README.md
+++ b/deploy/helm/djinn/README.md
@@ -210,16 +210,49 @@ by a Postgres advisory lock rather than by replica count.
 `buildAdmission.mode=enforce` and `server.replicas=3` and asserts the render
 succeeds with neither environment variable present.
 
-## Writable cgroup preparation rollout
+## Standalone SCIP index
+
+`scipIndex.enabled` defaults to **`true`**, so a stock install dispatches the
+standalone SCIP-index Job. The binary still defaults it off, which makes this
+chart the only thing that arms it. Budget for the extra Pod it schedules, sized
+by `resources.scip` (a 16Gi memory limit against a measured ~10 GB peak); what
+it buys back is the inline index every graph-warm otherwise pays — measured
+2026-07-27 at 3644s of a 5442s warm. The cadence gates
+(`intervalSeconds`, `quiescenceSeconds`, `claimWaitSeconds`) are unchanged;
+read `djinn_k8s::scip_schedule::decide` before disarming it.
+
+## Writable cgroup rollout
 
 `cgroupWritable.runtimeClass.enabled` and `cgroupWritable.taskRuns.enabled`
-both default to `false`. The preparation release may set only
-`cgroupWritable.runtimeClass.enabled=true` after the node conformance process
-has labeled eligible nodes. That installs `RuntimeClass/djinn-cgroup-writable`
-with its existing handler and node selector, but does not assign it to task-run
-Pods or change launcher privileges.
+both default to **`true`**, alongside `cgroupLauncher.mode: required` — the
+stock profile is the production VPS profile, fully armed. That installs
+`RuntimeClass/djinn-cgroup-writable` with its handler and node selector *and*
+assigns it to task-run Pods.
 
-The same value also installs `RuntimeClass/djinn-cgroup-writable-probe`: the
+Setting only `cgroupWritable.runtimeClass.enabled=true` (with
+`taskRuns.enabled=false`) remains a valid staging step for a cluster mid-rollout:
+the RuntimeClass exists and nothing is assigned to it yet.
+
+That arming has a prerequisite this chart cannot render: nodes must carry
+`djinn.io/cgroup-writable=true`, which
+`deploy/node/k3s/djinn-cgroup-writable-conformance.sh` applies itself once a
+node has proven it can delegate a writable cgroup. Never apply the label by
+hand. `templates/prereq-guard.yaml` refuses an install when no node carries it
+(and, symmetrically, when `kueue.x-k8s.io/v1beta1` is not served while
+`kueue.enabled` is true), because both failures used to be silent: `helm
+install` reported success and every task-run Pod then stayed Pending forever.
+The guard is deliberately inert under `helm template` and client-side
+`--dry-run`, where Helm's `lookup` sees no cluster, and it fails open when the
+credentials cannot list Nodes.
+
+Keep the layers straight: values coherence is a render-time check in
+`templates/deployment-server.yaml`; cluster facts are an install-time check in
+`templates/prereq-guard.yaml`; `deploy/preflight/render-gate.sh` is
+render-only and inspects values, not a cluster; node runtime capability is the
+conformance script's job.
+
+`cgroupWritable.runtimeClass.enabled` also installs
+`RuntimeClass/djinn-cgroup-writable-probe`: the
 same `runc-cgroupwritable` handler with no `scheduling` block. The two always
 appear and disappear together. Node conformance uses the probe class because it
 runs on a node that does not yet carry `djinn.io/cgroup-writable=true`; the
@@ -230,7 +263,7 @@ could never be admitted, and conformance could never pass. Task-run Pods use
 
 `cgroupWritable.taskRuns.enabled=true` requires
 `cgroupWritable.runtimeClass.enabled=true`; Helm rejects the unsafe inverse
-pair. Task-run assignment is reserved for the later activation release.
+pair, which would assign a RuntimeClass the release never created.
 
 ## Node prerequisites
 

--- a/deploy/helm/djinn/templates/kueue-topology.yaml
+++ b/deploy/helm/djinn/templates/kueue-topology.yaml
@@ -199,7 +199,16 @@ metadata:
 spec:
   clusterQueue: {{ $warmQueueName }}
 ---
-{{- /*
+{{/*
+The left-trim marker is deliberately absent here (`{{/*`, not `{{- /*`). With
+it, this comment swallowed the newline after the `---` above and the trailing
+`-}}` swallowed the one below it, rendering the literal `---apiVersion:` — not a
+document separator. `helm template` re-splits and re-emits documents so its
+output looked correct, but `helm lint` parses the rendered file directly and
+reported "invalid Yaml document separator". It was invisible while
+`kueue.enabled` shipped false, because the whole file rendered to nothing; it
+surfaced the moment the topology became a chart default.
+
 SCIP joins Kueue. rust-analyzer indexing is genuinely CPU-heavy — the measured
 SCIP phase of a production warm was 3644s — so leaving it outside the quota
 would make the ClusterQueue under-count the very load it exists to bound.

--- a/deploy/helm/djinn/templates/prereq-guard.yaml
+++ b/deploy/helm/djinn/templates/prereq-guard.yaml
@@ -1,0 +1,85 @@
+{{- /*
+CLUSTER PREREQUISITE GUARD — fail the INSTALL, not the thousandth dispatch.
+
+# Why this exists
+
+The stock values of this chart are fully armed: `cgroupLauncher.mode: required`
+with `cgroupWritable.{runtimeClass,taskRuns}.enabled: true`, and
+`kueue.{enabled,armed}: true`. Both stacks have prerequisites that live OUTSIDE
+this chart, and both fail SILENTLY when they are absent:
+
+  * `RuntimeClass/djinn-cgroup-writable` carries
+    `scheduling.nodeSelector: djinn.io/cgroup-writable=true`. The RuntimeClass
+    admission controller merges that selector into every task-run Pod. On a
+    cluster with no node carrying the label, every task-run Pod is unschedulable
+    forever. `helm install` reports success; the deployment creates Jobs whose
+    Pods never start.
+  * `kueue.armed` renders every task-run, warm and SCIP Job `suspend: true` and
+    hands admission to Kueue. Without the Kueue CRDs the install fails at the
+    API server with "no matches for kind ResourceFlavor" — diagnosable, but it
+    names neither the prerequisite nor how to install it.
+
+The related outage is on the record: `cgroupLauncher.mode: required` paired with
+`cgroupWritable.taskRuns.enabled: false` was refused at dispatch as
+`RenderValidationError::MissingDelegatedRuntimeClass`, produced ZERO Jobs, and
+took production down on 2026-07-29 while every test stayed green. That
+particular pairing is now refused at render time by
+templates/deployment-server.yaml. This guard covers the half a values check
+never could: the cluster.
+
+# What is checkable WHERE
+
+  render time, values only   the coherent-pairing rules
+                             (templates/deployment-server.yaml, values.schema.json)
+  render time, cluster       THIS FILE — node labels + live API discovery
+  render + dispatch validator deploy/preflight/render-gate.sh (values, not cluster)
+  node runtime               deploy/node/k3s/djinn-cgroup-writable-conformance.sh
+
+# Why `lookup` and not `.Capabilities` alone
+
+`lookup` returns nothing when there is no cluster connection: under
+`helm template` (what Tilt and every chart contract test uses) and under a
+client-side `--dry-run`. That is precisely the signal this guard needs, so the
+Node list doubles as the liveness probe: an EMPTY node list means "this render
+cannot see a cluster" and the guard stands down entirely. A non-empty node list
+means the answers below are real, and only then is `.Capabilities.APIVersions`
+consulted — during a real install it is live discovery, while under
+`helm template` it is a stub that would report every optional API missing.
+
+Failing OPEN when the cluster is invisible is deliberate: an operator whose
+credentials cannot list Nodes gets no guard rather than a false refusal.
+
+# The probe line
+
+The single line below marked `djinn-prereq-probe` is the ONLY place this
+template touches the cluster. deploy/helm/djinn/tests/prereq-guard-render.sh
+substitutes it with literal fixtures to drive every branch of the decision
+underneath, which is the only way a `lookup` guard can be tested without a
+cluster. Keep it on one line, keep the marker, and keep every decision below it
+a pure function of `$facts`.
+*/ -}}
+{{- $facts := dict "nodes" ((lookup "v1" "Node" "" "").items | default (list)) "kueueApi" (.Capabilities.APIVersions.Has "kueue.x-k8s.io/v1beta1") -}}{{/* djinn-prereq-probe */}}
+{{- if $facts.nodes -}}
+{{- $missing := list -}}
+
+{{- if .Values.cgroupWritable.taskRuns.enabled -}}
+{{- $writable := 0 -}}
+{{- range $node := $facts.nodes -}}
+{{- $labels := default (dict) (default (dict) $node.metadata).labels -}}
+{{- if eq (toString (get $labels "djinn.io/cgroup-writable")) "true" -}}
+{{- $writable = add1 $writable -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $writable 0 -}}
+{{- $missing = append $missing (printf "NO NODE CARRIES djinn.io/cgroup-writable=true (checked %d node(s)).\n    cgroupWritable.taskRuns.enabled=true assigns RuntimeClass/djinn-cgroup-writable to every\n    task-run Pod, and that class carries scheduling.nodeSelector djinn.io/cgroup-writable=true.\n    With no eligible node every task-run Pod stays Pending forever and the deployment runs zero\n    tasks while looking healthy.\n    Fix, on each node that should run task-runs:\n      sudo deploy/node/k3s/djinn-cgroup-writable-conformance.sh\n    That script is the single owner of this marker: it installs the containerd\n    runc-cgroupwritable handler the RuntimeClass names, proves the node can actually delegate a\n    writable cgroup, and applies the marker itself only once the node passes. Do not apply the\n    marker by hand — an unproven node that carries it is an unschedulable Pod's slower cousin, a\n    Pod that starts and then cannot get a cgroup leaf." (len $facts.nodes)) -}}
+{{- end -}}
+{{- end -}}
+
+{{- if and .Values.kueue.enabled (not $facts.kueueApi) -}}
+{{- $missing = append $missing "THE KUEUE API (kueue.x-k8s.io/v1beta1) IS NOT SERVED BY THIS CLUSTER.\n    kueue.enabled=true renders ResourceFlavor/ClusterQueue/LocalQueue objects the API server\n    would reject, and kueue.armed=true additionally renders every task-run, warm and SCIP Job\n    suspend: true with nothing able to unsuspend it.\n    Fix:\n      helm install djinn-prereqs deploy/helm/djinn-prereqs --namespace kueue-system --create-namespace --wait\n    --wait matters: ClusterQueue and LocalQueue carry a conversion webhook, so applying even a\n    v1beta1 object needs the webhook service already serving. Requires Kubernetes >= 1.30.\n    See deploy/kueue/README.md." -}}
+{{- end -}}
+
+{{- if $missing -}}
+{{- fail (printf "\n\ndjinn: REFUSING TO INSTALL. This cluster is missing prerequisites that the stock (fully armed)\nchart defaults require. Installing anyway would report success and then dispatch nothing.\n\n  * %s\n\nBOOTSTRAPPING A FRESH CLUSTER — read this before reaching for the opt-out.\nNode conformance needs RuntimeClass/djinn-cgroup-writable-probe, and THIS chart is the only\nthing that renders it, so a cluster cannot be conformed before djinn is installed at all.\nInstall the preparation profile first: it still renders both RuntimeClasses, it just does not\nassign one to task-run Pods yet, so this guard does not fire.\n\n  1. helm upgrade --install djinn ... \\\n       --set cgroupLauncher.mode=disabled \\\n       --set cgroupWritable.taskRuns.enabled=false \\\n       --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1\n     (leave cgroupWritable.runtimeClass.enabled at its default true — that is what\n      renders the probe class conformance needs)\n  2. run deploy/node/k3s/djinn-cgroup-writable-conformance.sh on each node\n  3. helm upgrade --install djinn ...   # stock values; this guard now passes\n\nOr, for a cluster that will NEVER have these prerequisites (kind, a laptop, a direct-worker\nprofile), opt out of the armed profile permanently:\n\n  --set cgroupLauncher.mode=disabled \\\n  --set cgroupWritable.runtimeClass.enabled=false \\\n  --set cgroupWritable.taskRuns.enabled=false \\\n  --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1 \\\n  --set kueue.enabled=false \\\n  --set kueue.armed=false\n\n(deploy/helm/djinn/values.local.yaml is exactly that profile, for kind and laptops.)\n" (join "\n\n  * " $missing)) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/djinn/tests/build-admission-topology.sh
+++ b/deploy/helm/djinn/tests/build-admission-topology.sh
@@ -158,7 +158,7 @@ echo "=== full-chart render carries neither removed env var ==="
 helm template build-admission-test "$CHART_DIR" --is-upgrade \
     --set buildAdmission.mode=enforce \
     --set server.replicas=3 \
-    --set kueue.enabled=false \
+    --set kueue.enabled=false --set kueue.armed=false \
     > "$TMPDIR_RENDER/full.yaml"
 assert_no_removed_env "$TMPDIR_RENDER/full.yaml" "full chart"
 

--- a/deploy/helm/djinn/tests/kueue-topology-render.sh
+++ b/deploy/helm/djinn/tests/kueue-topology-render.sh
@@ -53,13 +53,24 @@ render_capture() {
     helm template kueue-topology-test "$CHART_DIR" --is-upgrade "$@" >"$output" 2>&1
 }
 
-# The topology is `kueue.x-k8s.io/v1beta1`, so it only renders when the operator
-# has declared the Kueue prerequisite installed. Everything below that asserts
-# topology shape therefore has to opt in explicitly.
+# Topology ON, arming OFF — the "Kueue installed, nothing captured" state.
+#
+# Both flags now SHIP true, so this harness has to re-establish that state
+# explicitly. `kueue.enabled=true` is redundant against the current defaults and
+# is kept deliberately: it is what these cases are about, and a future default
+# flip must not silently turn them into assertions about something else. The
+# disarm goes FIRST so a caller that wants the armed state can simply pass
+# `--set kueue.armed=true` after it — Helm applies `--set` in order and the last
+# one wins.
+#
+# Without this, "topology rendered, nothing captured" — the state
+# deploy/kueue/zero-capture-gate.sh exists to verify — would be unreachable from
+# here, and every `assert_topology ... no` below would be asserting a state the
+# chart can no longer produce.
 render_enabled() {
     local output=$1
     shift
-    render "$output" --set kueue.enabled=true "$@"
+    render "$output" --set kueue.enabled=true --set kueue.armed=false "$@"
 }
 
 # ---------------------------------------------------------------------------
@@ -856,28 +867,35 @@ PY
 expect_topology_rejected coverage-dropped "$WORK/coverage-dropped.yaml" 7 no \
     "$RENDERER_KEYS" "$(cat "$WORK/dropped-resource.txt")"
 
-echo "=== chart default omits the topology entirely ==="
-# Regression guard for the defect this flag fixes: the topology used to render
-# unconditionally, so `helm install djinn` failed on every cluster without the
-# Kueue CRDs (observed on the production VPS). The default must be installable.
+echo "=== chart defaults render the topology AND arm it ==="
+# The stock profile is the production profile. Kueue's pods quota is the only
+# remaining build-concurrency bound (the in-process reservation authority was
+# deleted in #2822), so a default that rendered no topology would ship an
+# unbounded fleet. `buildPods` ships 3, and the whole armed contract — Namespace
+# label included — is asserted here rather than only under an explicit `--set`.
+#
+# The prerequisite this creates is enforced where it can actually be checked:
+# templates/prereq-guard.yaml refuses an install against a cluster that does not
+# serve kueue.x-k8s.io/v1beta1, naming deploy/helm/djinn-prereqs. See
+# tests/prereq-guard-render.sh.
 render "$WORK/default.yaml"
-python3 - "$WORK/default.yaml" <<'PY'
+assert_topology "$WORK/default.yaml" 3 yes
+
+echo "=== explicitly disabled omits the topology ==="
+render "$WORK/disabled.yaml" --set kueue.enabled=false --set kueue.armed=false --set kueue.buildPods=7
+grep -q 'kueue.x-k8s.io/v1beta1' "$WORK/disabled.yaml" && {
+    echo "FAIL: kueue.enabled=false still rendered the v1beta1 topology" >&2
+    exit 1
+}
+python3 - "$WORK/disabled.yaml" <<'PY'
 import sys
 import yaml
 
 docs = [doc for doc in yaml.safe_load_all(open(sys.argv[1], encoding="utf-8")) if doc]
-topology = [
-    doc for doc in docs
-    if str(doc.get("apiVersion", "")).startswith("kueue.x-k8s.io/")
-]
-assert not topology, (
-    "chart defaults must render no kueue.x-k8s.io objects, got "
-    f"{[(d['kind'], d['metadata']['name']) for d in topology]}"
-)
 # Non-vacuity: the render must still be a real chart render, not an empty file
-# that trivially satisfies the assertion above.
+# that trivially satisfies the grep above.
 assert any(doc.get("kind") == "Deployment" for doc in docs), (
-    "default render produced no Deployment; the assertion above proved nothing"
+    "the disabled render produced no Deployment; the assertion above proved nothing"
 )
 # The controller's observation-only Workload RBAC is deliberately NOT gated:
 # it is inert without the CRDs and must not churn with the flag.
@@ -888,13 +906,6 @@ rules = [
 ]
 assert len(rules) == 1, f"expected the Workload RBAC rule to survive, got {rules}"
 PY
-
-echo "=== explicitly disabled omits the topology ==="
-render "$WORK/disabled.yaml" --set kueue.enabled=false --set kueue.buildPods=7
-grep -q 'kueue.x-k8s.io/v1beta1' "$WORK/disabled.yaml" && {
-    echo "FAIL: kueue.enabled=false still rendered the v1beta1 topology" >&2
-    exit 1
-}
 
 # ---------------------------------------------------------------------------
 # The topology flag alone arms nothing.
@@ -961,14 +972,14 @@ PY
 }
 
 echo "=== kueue.enabled alone arms nothing, at BOTH of its values ==="
-assert_disarmed_server "$WORK/default.yaml" "kueue.enabled=false"
+assert_disarmed_server "$WORK/disabled.yaml" "kueue.enabled=false"
 assert_disarmed_server "$WORK/valid.yaml" "kueue.enabled=true"
 
 # ---------------------------------------------------------------------------
 # armed implies enabled
 # ---------------------------------------------------------------------------
 echo "=== armed=true with enabled=false is rejected by name ==="
-if render_capture "$WORK/armed-without-enabled.out" --set kueue.armed=true; then
+if render_capture "$WORK/armed-without-enabled.out" --set kueue.enabled=false --set kueue.armed=true; then
     echo "FAIL: kueue.armed=true with kueue.enabled=false rendered successfully" >&2
     exit 1
 fi
@@ -1055,7 +1066,7 @@ echo "=== namespace.create=false alone still renders; only ARMING is gated ==="
 # Non-vacuity: an externally-managed namespace is a supported configuration and
 # must keep rendering. Without this the rejection above could be an unrelated
 # namespace.create=false breakage.
-render "$WORK/external-ns-disarmed.yaml" --set kueue.enabled=true --set namespace.create=false
+render "$WORK/external-ns-disarmed.yaml" --set kueue.enabled=true --set kueue.armed=false --set namespace.create=false
 assert_disarmed_server_no_namespace "$WORK/external-ns-disarmed.yaml" "namespace.create=false, armed=false"
 
 echo "=== the acknowledgement reopens the escape hatch ==="
@@ -1101,7 +1112,7 @@ PY
 echo "=== the acknowledgement does NOT arm anything on its own ==="
 # It is an acknowledgement, not a second arming switch.
 render "$WORK/ack-without-armed.yaml" \
-    --set kueue.enabled=true --set kueue.namespaceLabelledExternally=true
+    --set kueue.enabled=true --set kueue.armed=false --set kueue.namespaceLabelledExternally=true
 assert_topology "$WORK/ack-without-armed.yaml" 3 no
 
 echo "=== the acknowledgement is inert when the chart owns the namespace ==="
@@ -1242,20 +1253,27 @@ if helm template kueue-topology-test "$WORK/chart-without-kueue" --is-upgrade >"
     exit 1
 fi
 
-echo "=== kueue.armed ships false ==="
+echo "=== kueue ships enabled AND armed, and buildPods unchanged ==="
 python3 - "$CHART_DIR/values.yaml" <<'PY'
 import sys
 import yaml
 
 values = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
-assert values["kueue"]["armed"] is False, (
-    f"kueue.armed must ship false, got {values['kueue']['armed']!r}"
+# The stock profile is the production profile: everything armed on the
+# production VPS is the chart default. Kueue's pods quota is the ONLY remaining
+# build-concurrency bound, so a chart that shipped the topology disarmed would
+# ship no bound at all.
+assert values["kueue"]["enabled"] is True, (
+    f"kueue.enabled must ship true, got {values['kueue']['enabled']!r}"
 )
-assert values["kueue"]["enabled"] is False, (
-    f"kueue.enabled must ship false, got {values['kueue']['enabled']!r}"
+assert values["kueue"]["armed"] is True, (
+    f"kueue.armed must ship true, got {values['kueue']['armed']!r}. `enabled` "
+    "alone renders queues nothing is admitted into; only `armed` makes the "
+    "renderers hand their Jobs to Kueue, so the quota binds nothing without it."
 )
-# The escape hatch is opt-in too. Shipping it true would pre-acknowledge a claim
-# no operator ever made, which is exactly the silence this gate replaced.
+# The escape hatch stays opt-in. Shipping it true would pre-acknowledge a claim
+# no operator ever made — that an externally-managed namespace already carries
+# djinn.io/kueue-managed — which is exactly the silence that gate replaced.
 assert values["kueue"]["namespaceLabelledExternally"] is False, (
     "kueue.namespaceLabelledExternally must ship false, got "
     f"{values['kueue']['namespaceLabelledExternally']!r}"
@@ -1333,8 +1351,13 @@ PY
     fi
 }
 
-echo "=== zero-capture gate passes against the default render ==="
-run_gate_against_render default pass
+echo "=== zero-capture gate passes against the inert render the gate itself installs ==="
+# The gate owns `kueue.*` and pins BOTH halves on its own install line (see
+# deploy/kueue/zero-capture-gate.sh): topology on, arming off. Since `kueue.armed`
+# now ships TRUE, that pin is what keeps the inert state representable at all —
+# so this case reproduces the gate's own arguments rather than the bare chart
+# defaults, which are armed.
+run_gate_against_render inert pass --set kueue.enabled=true --set kueue.armed=false
 
 echo "=== zero-capture gate FAILS against an armed render ==="
 run_gate_against_render armed fail --set kueue.enabled=true --set kueue.armed=true

--- a/deploy/helm/djinn/tests/prereq-guard-render.sh
+++ b/deploy/helm/djinn/tests/prereq-guard-render.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Acceptance contract for templates/prereq-guard.yaml — the install-time refusal
+# that stops a fully-armed stock release from landing on a cluster that cannot
+# run it.
+#
+# # Why this test is shaped like this
+#
+# The guard's only cluster contact is one `lookup`, and `lookup` returns nothing
+# under `helm template`. A test that only ran `helm template` would therefore
+# exercise the guard's INERT branch and nothing else — it would stay green if
+# every `fail` underneath were deleted. That is the exact class of vacuous test
+# that let `cgroupLauncher.mode: required` + `cgroupWritable.taskRuns.enabled:
+# false` ship as the default pairing and take production down on 2026-07-29.
+#
+# So this suite copies the chart and replaces the single probe line — the one
+# marked `djinn-prereq-probe` — with literal cluster facts, then drives every
+# branch of the decision that hangs off it. The marker's presence is asserted
+# first: an unfindable probe is treated as a broken contract, never as a
+# satisfied one, so deleting or renaming it fails here rather than silently
+# turning every case below into a no-op.
+#
+# Usage: bash deploy/helm/djinn/tests/prereq-guard-render.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+GUARD="$CHART_DIR/templates/prereq-guard.yaml"
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "FAIL: required test tool '$1' is not installed" >&2
+        exit 1
+    }
+}
+
+require_tool helm
+require_tool python3
+require_tool grep
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+[ -f "$GUARD" ] || {
+    echo "FAIL: the prerequisite guard is missing: $GUARD" >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 0. The substitution anchor must exist, exactly once.
+# ---------------------------------------------------------------------------
+echo "=== the guard exposes exactly one cluster probe ==="
+probe_lines=$(grep -c 'djinn-prereq-probe' "$GUARD" || true)
+# Two hits: the prose paragraph that explains the marker, and the marker itself.
+# What must be unique is the LINE THAT CALLS lookup.
+probe_calls=$(grep -c 'lookup "v1" "Node"' "$GUARD" || true)
+if [ "$probe_calls" -ne 1 ]; then
+    echo "FAIL: expected exactly one Node lookup in $GUARD, found $probe_calls." >&2
+    echo "      Every fixture below substitutes that one line; more than one (or none)" >&2
+    echo "      means this suite is no longer driving the guard's real decision." >&2
+    exit 1
+fi
+if [ "$probe_lines" -lt 1 ]; then
+    echo "FAIL: the djinn-prereq-probe marker is gone from $GUARD" >&2
+    exit 1
+fi
+
+# Builds a chart copy whose probe line reports the given literal facts.
+#   $1  destination directory name under $WORK
+#   $2  Go-template list expression for the observed Nodes
+#   $3  `true` / `false` — whether kueue.x-k8s.io/v1beta1 is served
+fixture_chart() {
+    local name=$1 nodes=$2 kueue_api=$3
+    local dest="$WORK/$name"
+    cp -R "$CHART_DIR" "$dest"
+    python3 - "$dest/templates/prereq-guard.yaml" "$nodes" "$kueue_api" <<'PY'
+import sys
+
+path, nodes, kueue_api = sys.argv[1:]
+lines = open(path, encoding="utf-8").read().splitlines(keepends=True)
+targets = [i for i, line in enumerate(lines) if 'lookup "v1" "Node"' in line]
+assert len(targets) == 1, f"expected one probe line, found {len(targets)}"
+lines[targets[0]] = (
+    '{{- $facts := dict "nodes" (%s) "kueueApi" %s -}}\n' % (nodes, kueue_api)
+)
+open(path, "w", encoding="utf-8").write("".join(lines))
+PY
+    printf '%s' "$dest"
+}
+
+NO_NODES='list'
+UNLABELLED_NODE='list (dict "metadata" (dict "name" "node-a" "labels" (dict "kubernetes.io/os" "linux")))'
+LABELLED_NODE='list (dict "metadata" (dict "name" "node-a" "labels" (dict "djinn.io/cgroup-writable" "true")))'
+# A node whose label is present but NOT "true" must not count as prepared.
+FALSE_LABELLED_NODE='list (dict "metadata" (dict "name" "node-a" "labels" (dict "djinn.io/cgroup-writable" "false")))'
+# metadata.labels absent entirely — a real shape, and the one most likely to
+# blow up a naive label read.
+NO_LABELS_NODE='list (dict "metadata" (dict "name" "node-a"))'
+
+expect_render() {
+    local label=$1 chart=$2
+    shift 2
+    if ! helm template prereq-guard-test "$chart" --is-upgrade "$@" >"$WORK/$label.out" 2>&1; then
+        echo "FAIL [$label]: the guard refused a cluster that satisfies the prerequisites:" >&2
+        cat "$WORK/$label.out" >&2
+        exit 1
+    fi
+    # Non-vacuity: a render that produced nothing would satisfy any "it rendered"
+    # assertion trivially.
+    grep -q '^kind: Deployment$' "$WORK/$label.out" || {
+        echo "FAIL [$label]: the render produced no Deployment, so it proved nothing" >&2
+        exit 1
+    }
+    echo "ok [$label]"
+}
+
+expect_refusal() {
+    local label=$1 chart=$2
+    shift 2
+    local -a needles=()
+    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+        needles+=("$1")
+        shift
+    done
+    [ "${1:-}" = "--" ] && shift
+    if helm template prereq-guard-test "$chart" --is-upgrade "$@" >"$WORK/$label.out" 2>&1; then
+        echo "FAIL [$label]: the guard accepted a cluster missing its prerequisites." >&2
+        echo "      Nothing would have stopped this install from reporting success and" >&2
+        echo "      then dispatching zero Jobs." >&2
+        exit 1
+    fi
+    local needle
+    for needle in "${needles[@]}"; do
+        grep -qF -- "$needle" "$WORK/$label.out" || {
+            echo "FAIL [$label]: the refusal never mentions '$needle', so it does not tell" >&2
+            echo "      an operator what is missing or how to install it:" >&2
+            cat "$WORK/$label.out" >&2
+            exit 1
+        }
+    done
+    echo "ok [$label]"
+}
+
+# ---------------------------------------------------------------------------
+# 1. No visible cluster: the guard stands down.
+#
+# This is `helm template`, `--dry-run`, and an operator whose credentials cannot
+# list Nodes. Failing OPEN there is deliberate — a false refusal on an invisible
+# cluster would break Tilt and every other chart contract script in this
+# directory.
+# ---------------------------------------------------------------------------
+echo "=== an invisible cluster leaves the guard inert ==="
+expect_render invisible-cluster "$(fixture_chart invisible "$NO_NODES" false)"
+# The real, unsubstituted chart takes the same path under `helm template`.
+expect_render unsubstituted-chart "$CHART_DIR"
+
+# ---------------------------------------------------------------------------
+# 2. Nodes visible, none prepared for the writable cgroup rollout.
+# ---------------------------------------------------------------------------
+echo "=== unprepared nodes are refused, by name ==="
+expect_refusal unlabelled-nodes "$(fixture_chart unlabelled "$UNLABELLED_NODE" true)" \
+    'djinn.io/cgroup-writable=true' \
+    'deploy/node/k3s/djinn-cgroup-writable-conformance.sh' \
+    'RuntimeClass/djinn-cgroup-writable'
+
+echo "=== a node labelled with something other than \"true\" does not count ==="
+expect_refusal false-labelled-nodes "$(fixture_chart falselabel "$FALSE_LABELLED_NODE" true)" \
+    'djinn.io/cgroup-writable=true'
+
+echo "=== a node with no labels at all is handled, not crashed on ==="
+expect_refusal unlabelled-metadata "$(fixture_chart nolabels "$NO_LABELS_NODE" true)" \
+    'djinn.io/cgroup-writable=true'
+
+# ---------------------------------------------------------------------------
+# 3. Nodes prepared, Kueue absent.
+# ---------------------------------------------------------------------------
+echo "=== a cluster without the Kueue API is refused, naming the prerequisite ==="
+expect_refusal kueue-absent "$(fixture_chart kueueabsent "$LABELLED_NODE" false)" \
+    'kueue.x-k8s.io/v1beta1' \
+    'deploy/helm/djinn-prereqs' \
+    '--wait'
+
+# ---------------------------------------------------------------------------
+# 4. Both missing: the operator learns BOTH in one run.
+#
+# A guard that reported only the first defect would cost a second failed install
+# to discover the second.
+# ---------------------------------------------------------------------------
+echo "=== both prerequisites missing are reported together ==="
+expect_refusal both-missing "$(fixture_chart bothmissing "$UNLABELLED_NODE" false)" \
+    'djinn.io/cgroup-writable=true' \
+    'deploy/helm/djinn-prereqs'
+
+# ---------------------------------------------------------------------------
+# 5. A prepared cluster installs. This is the non-vacuity floor for every
+#    refusal above: without it they could all be passing because the chart does
+#    not render at all under a substituted probe.
+# ---------------------------------------------------------------------------
+echo "=== a prepared cluster renders ==="
+expect_render prepared-cluster "$(fixture_chart prepared "$LABELLED_NODE" true)"
+
+# ---------------------------------------------------------------------------
+# 6. The documented escape hatch really escapes.
+#
+# The refusal message tells an operator to disable the armed profile. If those
+# flags did not actually silence the guard, the message would be a lie and an
+# unprepared cluster would have no supported install at all.
+# ---------------------------------------------------------------------------
+echo "=== the opt-out named in the refusal actually works ==="
+expect_render opted-out "$(fixture_chart optedout "$UNLABELLED_NODE" false)" \
+    --set cgroupLauncher.mode=disabled \
+    --set cgroupWritable.runtimeClass.enabled=false \
+    --set cgroupWritable.taskRuns.enabled=false \
+    --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1 \
+    --set kueue.enabled=false \
+    --set kueue.armed=false
+
+# The bootstrap path the refusal message prescribes MUST work, or a fresh
+# cluster has no way in at all: node conformance needs
+# RuntimeClass/djinn-cgroup-writable-probe, and this chart is the only thing
+# that renders it. The guard therefore keys on `taskRuns.enabled` (the
+# assignment) and NOT on `runtimeClass.enabled` (the class itself) — this case
+# is what pins that distinction.
+echo "=== the preparation profile installs on an unconformed cluster, and still renders the probe class ==="
+PREPARATION_CHART="$(fixture_chart preparation "$UNLABELLED_NODE" true)"
+expect_render preparation "$PREPARATION_CHART" \
+    --set cgroupLauncher.mode=disabled \
+    --set cgroupWritable.taskRuns.enabled=false \
+    --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1
+grep -q 'name: djinn-cgroup-writable-probe' "$WORK/preparation.out" || {
+    echo "FAIL: the preparation profile did not render the probe RuntimeClass, so node" >&2
+    echo "      conformance could never run and the bootstrap the refusal message" >&2
+    echo "      prescribes would be a dead end." >&2
+    exit 1
+}
+echo "ok [preparation renders the probe class]"
+
+echo "=== the local-dev values profile installs on an unprepared cluster ==="
+expect_render local-profile "$(fixture_chart localprofile "$UNLABELLED_NODE" false)" \
+    --values "$CHART_DIR/values.local.yaml" \
+    --set-string migration.designatedOperatorSecret=prereq-guard-test
+
+# ---------------------------------------------------------------------------
+# 7. Each half is independently gated: disabling one stack must not silence the
+#    other. A single collapsed condition would pass every case above.
+# ---------------------------------------------------------------------------
+echo "=== disabling Kueue alone does not excuse unprepared nodes ==="
+expect_refusal kueue-off-nodes-bad "$(fixture_chart kueueoff "$UNLABELLED_NODE" false)" \
+    'djinn.io/cgroup-writable=true' -- \
+    --set kueue.enabled=false --set kueue.armed=false
+
+echo "=== disabling the cgroup stack alone does not excuse a missing Kueue ==="
+expect_refusal cgroup-off-kueue-bad "$(fixture_chart cgroupoff "$UNLABELLED_NODE" false)" \
+    'deploy/helm/djinn-prereqs' -- \
+    --set cgroupLauncher.mode=disabled \
+    --set cgroupWritable.runtimeClass.enabled=false \
+    --set cgroupWritable.taskRuns.enabled=false \
+    --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1
+
+echo "=== All prerequisite-guard render tests passed ==="

--- a/deploy/helm/djinn/tests/scip-index-arming-render.sh
+++ b/deploy/helm/djinn/tests/scip-index-arming-render.sh
@@ -107,6 +107,31 @@ for name in switches:
     value = env_value(name)
     assert value != "", f"{name} renders an empty value, which the server cannot parse"
 
+# THE SECOND HALF OF THE CONTRACT: the surface must ship ARMED.
+#
+# Every switch on this list is fail-closed in the BINARY — `KubernetesConfig::
+# for_testing` defaults it off, and the Rust probe
+# `fail_closed_arming_switches_are_all_off_by_default` keeps that true. That
+# makes this chart the ONLY thing that can arm any of them, which is exactly why
+# a rendered "false" is not a conservative default here: it is the shipped-and-
+# never-ran defect this whole file exists to catch, one step further along. The
+# standalone SCIP-index Job had a surface for a while and still never created a
+# Job in production, because the surface rendered `false`.
+#
+# The set is derived from the Rust, never enumerated: a switch added to
+# FAIL_CLOSED_ARMING_SWITCHES that the chart ships disarmed fails HERE, forcing
+# an explicit decision instead of another silently inert feature.
+ARMED = {"1", "true", "yes", "on"}
+disarmed = [name for name in switches if env_value(name).strip().lower() not in ARMED]
+assert not disarmed, (
+    f"these fail-closed arming switches ship DISARMED from the chart: {disarmed}. "
+    "The binary defaults every one of them off, so the chart is their only "
+    "activation surface; rendering `false` ships a feature no deployment will "
+    "ever run. Arm it in deploy/helm/djinn/values.yaml, or — if it genuinely "
+    "must ship off — remove it from FAIL_CLOSED_ARMING_SWITCHES and say why "
+    "there."
+)
+
 print(f"checked {len(switches)} fail-closed arming switch(es): {', '.join(switches)}")
 PY
 }
@@ -165,24 +190,37 @@ echo "=== every fail-closed arming switch has a chart surface ==="
 render "$TMPDIR_RENDER/defaults.yaml"
 assert_every_arming_switch_is_rendered "$TMPDIR_RENDER/defaults.yaml"
 
-echo "=== shipped defaults render the SCIP Job disarmed, explicitly ==="
+echo "=== shipped defaults render the SCIP Job ARMED, with its measured cadence ==="
+# The stock profile is the production profile. The inline index was 3644s of a
+# measured 5442s warm — 67% of the warm's wall clock — and the split that
+# removes it only runs when this renders armed.
 assert_env_values "$TMPDIR_RENDER/defaults.yaml" \
-    DJINN_K8S_SCIP_INDEX_ENABLED=false \
+    DJINN_K8S_SCIP_INDEX_ENABLED=true \
     DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS=10800 \
     DJINN_K8S_SCIP_QUIESCENCE_SECONDS=3523 \
     DJINN_K8S_SCIP_CLAIM_WAIT_SECONDS=900
 
-echo "=== an operator can arm it and retune every gate ==="
-render "$TMPDIR_RENDER/armed.yaml" \
-    --set scipIndex.enabled=true \
+echo "=== the OTHER fail-closed switch also ships armed ==="
+# Named explicitly as well as derived: the derived check above proves the rule,
+# this proves the instance, and the two fail differently if the chart or the
+# Rust list drifts apart.
+assert_env_values "$TMPDIR_RENDER/defaults.yaml" DJINN_KUEUE_ARMED=true
+
+echo "=== an operator can disarm it and retune every gate ==="
+render "$TMPDIR_RENDER/retuned.yaml" \
+    --set scipIndex.enabled=false \
     --set scipIndex.intervalSeconds=3600 \
     --set scipIndex.quiescenceSeconds=0 \
     --set scipIndex.claimWaitSeconds=0
-assert_env_values "$TMPDIR_RENDER/armed.yaml" \
-    DJINN_K8S_SCIP_INDEX_ENABLED=true \
+assert_env_values "$TMPDIR_RENDER/retuned.yaml" \
+    DJINN_K8S_SCIP_INDEX_ENABLED=false \
     DJINN_K8S_SCIP_INDEX_INTERVAL_SECONDS=3600 \
     DJINN_K8S_SCIP_QUIESCENCE_SECONDS=0 \
     DJINN_K8S_SCIP_CLAIM_WAIT_SECONDS=0
+
+echo "=== an explicit re-arm is still a supported flip ==="
+render "$TMPDIR_RENDER/armed.yaml" --set scipIndex.enabled=true
+assert_env_values "$TMPDIR_RENDER/armed.yaml" DJINN_K8S_SCIP_INDEX_ENABLED=true
 
 expect_rejected negative-interval --set scipIndex.intervalSeconds=-1
 expect_rejected negative-quiescence --set scipIndex.quiescenceSeconds=-1

--- a/deploy/helm/djinn/values.local.yaml
+++ b/deploy/helm/djinn/values.local.yaml
@@ -40,6 +40,39 @@ graphRetention:
 migration:
   designatedOperatorSecret: djinn-local-migration-operator
 
+# ---------------------------------------------------------------------------
+# The local-dev opt-out from the fully-armed stock profile.
+# ---------------------------------------------------------------------------
+# The chart defaults are the production VPS profile: an armed cgroup launcher
+# with the writable-cgroup RuntimeClass, resize-v2 launcher authority, and Kueue
+# admission. All three have prerequisites a `scripts/kind/setup-kind.sh` cluster
+# does not have, and each fails a different way:
+#
+#   * RuntimeClass/djinn-cgroup-writable carries
+#     `scheduling.nodeSelector: djinn.io/cgroup-writable=true`, and the kind node
+#     carries neither that label nor the `runc-cgroupwritable` containerd
+#     handler (setup-kind.sh installs no containerd config; only
+#     scripts/kind/setup-resize-kind-cluster.sh does). Task-run Pods would be
+#     unschedulable.
+#   * resize-v2 launcher authority requires the armed launcher, so it moves with
+#     the pair above rather than independently.
+#   * kueue.x-k8s.io/v1beta1 is not served by a plain kind cluster at all, so
+#     the topology objects would be rejected outright.
+#
+# templates/prereq-guard.yaml refuses an install that hits any of these on a
+# cluster it can see, naming the missing piece. This block is the supported
+# answer for a cluster that will never have them.
+cgroupLauncher:
+  mode: disabled
+cgroupWritable:
+  runtimeClass:
+    enabled: false
+  taskRuns:
+    enabled: false
+kueue:
+  enabled: false
+  armed: false
+
 # Kind uses rancher.io/local-path as the default storage class, which
 # dynamically provisions hostPath-backed PVs under the kind node. Since
 # kind is single-node, ReadWriteOnce PVCs can be shared across the server
@@ -157,6 +190,11 @@ imagePipeline:
   # resource). ghcr.io/djinnos/djinn-image-builder:latest is org-private;
   # anonymous pulls 401 inside kind. Override to the in-cluster registry.
   builderImage: "localhost:5001/djinn-image-builder:dev"
+  controller:
+    # Moves with `cgroupLauncher.mode: disabled` above — resize-v2 declares that
+    # Kubernetes in-place Pod resize owns CPU quota, and the chart refuses that
+    # claim when no cgroup-launcher sidecar is rendered to enforce it.
+    launcherAuthorityProtocol: leaf-v1
   buildkitd:
     # The chart default (ghcr.io/djinnos/djinn-buildkitd:latest) only
     # publishes linux/amd64 — on Apple Silicon the kind node is arm64 and

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -83,17 +83,20 @@ scipCache:
 # `<fullname>-scip` LocalQueue (templates/kueue-topology.yaml) to admit Jobs
 # that nothing could create.
 #
-# Arming this creates an additional Pod sized by `resources.scip` — a 16Gi
-# memory limit against a measured ~10 GB peak. Read the cadence gates in
-# `djinn_k8s::scip_schedule::decide` before arming: the Job is additionally
-# skipped while a warm Job is in flight and while the head has not stood still
-# for `quiescenceSeconds`, so on a repository that merges more often than it
-# indexes, arming it costs a Pod and returns little.
+# Armed by default. The switch costs an additional Pod sized by
+# `resources.scip` — a 16Gi memory limit against a measured ~10 GB peak — and
+# buys back the 67% of every warm that the inline index costs. Read the cadence
+# gates in `djinn_k8s::scip_schedule::decide` before disarming it: the Job is
+# additionally skipped while a warm Job is in flight and while the head has not
+# stood still for `quiescenceSeconds`, so on a repository that merges more often
+# than it indexes it already declines to run.
 scipIndex:
-  # Master arming switch. False renders the switch explicitly OFF — which is
-  # the point: an env var rendered as "false" is a lever an operator can find
-  # and flip; an absent one is a feature nobody can reach.
-  enabled: false
+  # Master arming switch. The BINARY still defaults this off
+  # (`KubernetesConfig::for_testing`), so this chart is the only thing that
+  # arms it — see `djinn_k8s::config::FAIL_CLOSED_ARMING_SWITCHES`, whose
+  # chart-render obligation `tests/scip-index-arming-render.sh` enforces in
+  # both directions (a surface must exist, and it must ship armed).
+  enabled: true
   # Cadence floor between dispatches, in seconds. Default 3h.
   intervalSeconds: 10800
   # How long the repository head must have stood still before an index is worth
@@ -107,30 +110,45 @@ scipIndex:
   claimWaitSeconds: 900
 
 # -----------------------------------------------------------------------------
-# Kueue prerequisite topology
+# Kueue build admission
 # -----------------------------------------------------------------------------
-# The exact pods quota for Kueue's inert prerequisite queues; task-run and warm
-# Jobs are not selected for Kueue admission until the later cutover release.
+# The pods quota Kueue admits build Jobs against. This is the ONLY remaining
+# build-concurrency bound — the in-process pods-quota reservation authority was
+# deleted in #2822 — so both flags below ship armed and an install that turns
+# them off has no bound on concurrent build Pods at all.
 kueue:
   # Render the ResourceFlavor / ClusterQueue / LocalQueue topology.
   #
-  # OFF by default because the topology is `kueue.x-k8s.io/v1beta1`, and a
-  # cluster without Kueue rejects those objects — which used to make this whole
-  # chart un-installable anywhere Kueue was absent. Install the prerequisite
-  # release first (`deploy/helm/djinn-prereqs`, see deploy/kueue/README.md and
-  # docs/deploy/kubernetes.md), then set this true. Note that the Kueue
-  # controller must be READY, not merely installed: ClusterQueue and LocalQueue
-  # carry a conversion webhook, so applying even a v1beta1 object needs the
-  # webhook service serving. Install the prerequisite with `--wait`.
+  # ON by default: Kueue's pods quota is the only remaining build-concurrency
+  # bound (the in-process pods-quota reservation authority was deleted in
+  # #2822), so a stock install that omitted the topology would dispatch
+  # unbounded build Pods.
   #
-  # This is an explicit value rather than a `.Capabilities.APIVersions` probe on
-  # purpose: capability probing is empty under `helm template` (what Tilt uses),
-  # so it would silently omit the topology in local dev. With this flag, a true
-  # value on a Kueue-less cluster fails the install loudly instead.
+  # `djinn-prereqs` IS THEREFORE A PREREQUISITE, NOT AN OPTION. The topology is
+  # `kueue.x-k8s.io/v1beta1`, and a cluster without Kueue rejects those objects.
+  # Install the prerequisite release first (`deploy/helm/djinn-prereqs`, see
+  # deploy/kueue/README.md and docs/deploy/kubernetes.md). The Kueue controller
+  # must be READY, not merely installed: ClusterQueue and LocalQueue carry a
+  # conversion webhook, so applying even a v1beta1 object needs the webhook
+  # service serving. Install the prerequisite with `--wait`.
+  #
+  # A cluster without it fails at INSTALL, by name: templates/prereq-guard.yaml
+  # checks `kueue.x-k8s.io/v1beta1` against live API discovery and stops the
+  # release with the prerequisite's path in the message, rather than letting the
+  # API server answer "no matches for kind ResourceFlavor" with no remedy.
+  #
+  # This stays an explicit value rather than a `.Capabilities.APIVersions` probe
+  # that decides what to render: capability probing is empty under `helm
+  # template` (what Tilt uses), so a probe would silently omit the topology in
+  # local dev and silently include it in a live install — two manifests from one
+  # chart. The guard uses discovery only to REFUSE, never to render less.
   #
   # Enabling it does NOT arm anything: no Job carries a queue name and no
   # namespace is Kueue-managed. Arming is the separate `armed` flag below.
-  enabled: false
+  #
+  # Set both this and `armed` false for a cluster that will never run Kueue
+  # (see values.local.yaml, the kind/local-dev profile).
+  enabled: true
   buildPods: 3
   # Admission's binding resource. `cpu` is supported for the oru9-compatible
   # topology; buildPods is then interpreted as the nominal CPU quantity.
@@ -149,6 +167,10 @@ kueue:
     failSafeCompileSlots: 2
 
   # Arm Kueue admission for build Jobs (cutover epic 4c9q, slice S1).
+  #
+  # ON by default. `enabled` alone renders queues nothing is admitted into; the
+  # quota only binds once the renderers hand their Jobs to Kueue, which is what
+  # this flag does. A stock install therefore ships the bound, not the scaffold.
   #
   # This single value drives BOTH halves of the capture contract, and they can
   # never be split onto separate flags:
@@ -175,7 +197,7 @@ kueue:
   # Image builds stay deliberately unarmed at every value of this flag: an image
   # build is an upstream dependency of a task-run, so sharing one ClusterQueue
   # creates a priority-inversion deadlock.
-  armed: false
+  armed: true
 
   # Operator acknowledgement that an EXTERNALLY MANAGED namespace already
   # carries `djinn.io/kueue-managed=true`.
@@ -240,31 +262,42 @@ kueue:
 # before a Job is submitted, and a launcher that cannot establish its delegation
 # exits non-zero before binding its socket.
 #
-# WHY THE DEFAULT IS `disabled` — READ BEFORE CHANGING IT
-# -------------------------------------------------------
-# `required` is not a value this chart can default to on its own, because an
-# armed launcher is only half of a pair. `validate_enforcement_render` refuses
-# to dispatch when `cgroupLauncher.mode: required` is paired with
+# WHY THE DEFAULT IS `required`, AND WHAT IT DEMANDS OF YOUR NODES
+# ----------------------------------------------------------------
+# An armed launcher is only half of a pair. `validate_enforcement_render`
+# refuses to dispatch when `cgroupLauncher.mode: required` is paired with
 # `cgroupWritable.taskRuns.enabled: false`, and that pairing was this file's
 # default through v0.7.25: a fresh `helm install` with stock values could not
 # dispatch a single task on any node, and production went down for exactly that
-# reason on 2026-07-29. The two knobs must move together or not at all.
-#
-# Arming is therefore an explicit, three-line act with node prerequisites:
+# reason on 2026-07-29. The two knobs must move together or not at all, so the
+# stock profile arms BOTH:
 #
 #   cgroupLauncher:  { mode: required }
 #   cgroupWritable:  { runtimeClass: { enabled: true }, taskRuns: { enabled: true } }
 #
-# and only after the nodes pass
-# `deploy/node/k3s/djinn-cgroup-writable-conformance.sh` and carry
-# `djinn.io/cgroup-writable=true` — otherwise the RuntimeClass assignment
-# leaves task-run Pods unschedulable, which is a slower failure but a failure
-# all the same. Defaulting the OTHER way (arming everything out of the box)
-# would ship precisely that.
+# That pairing is checked at render time — `templates/deployment-server.yaml`
+# refuses the incoherent halves by name — but the NODE half cannot be. The
+# task-run RuntimeClass carries `scheduling.nodeSelector:
+# djinn.io/cgroup-writable=true`, so on a cluster whose nodes have not passed
+# `deploy/node/k3s/djinn-cgroup-writable-conformance.sh` and been labelled,
+# every task-run Pod is simply unschedulable — a slower failure than the 07-29
+# outage but a failure all the same, and a silent one.
+#
+# `templates/prereq-guard.yaml` is what makes it loud: on a real install or
+# upgrade it lists the cluster's Nodes and refuses the release, naming the
+# label, the conformance script and the RuntimeClass, instead of installing
+# "successfully" onto a cluster that can never run a task. It is inert under
+# `helm template` (Helm's `lookup` returns nothing there), which is why the
+# render-only gate below still answers the render-shaped question.
 #
 # `deploy/preflight/render-gate.sh` runs the real dispatch validator against a
 # real render; run it against the values you are about to deploy before you
-# deploy them.
+# deploy them. It is deliberately NOT a cluster check — the node prerequisites
+# are the prereq guard's and the conformance script's business, not its.
+#
+# For a cluster that will never have prepared nodes (kind, a laptop, a
+# direct-worker profile), disable the complete stack explicitly — see
+# values.local.yaml, which does exactly that.
 cgroupLauncher:
   # Armed by default: a production render must include the quota mechanism
   # required by resize-v2 rather than silently dispatching ungoverned work.

--- a/deploy/kueue/README.md
+++ b/deploy/kueue/README.md
@@ -5,10 +5,14 @@ the sense cert-manager already is: you install it as its own release, before
 the `djinn` chart, and Djinn does not own its lifecycle. It is installed from
 `deploy/helm/djinn-prereqs`.
 
-It is deliberately **install and scope only**: nothing here labels the `djinn`
-namespace, changes any Djinn workload, task-run, warm job, or control-plane
-object, or activates Kueue admission for build Jobs. Arming it is the Kueue
-cutover epic **4c9q**.
+This release is deliberately **install and scope only**: nothing *here* labels
+the `djinn` namespace, changes any Djinn workload, task-run, warm job, or
+control-plane object, or activates Kueue admission for build Jobs. Arming is
+the `djinn` chart's job, and at stock values it does arm: `kueue.enabled` and
+`kueue.armed` both default to `true`, so the `djinn` chart labels its own
+Namespace `djinn.io/kueue-managed=true` and renders build Jobs `suspend: true`.
+Read that as a division of labour, not as "nothing is captured" — the scoping
+below is what bounds *where* capture can happen, not whether it happens.
 
 ## Provenance
 
@@ -58,8 +62,10 @@ anything older the process exits at startup:
 That is fatal, not degraded. `helm --wait` never returns, the Deployment
 CrashLoopBackOffs, and the release is left with all 11 CRDs Established and
 **both** webhook configurations registered with CA bundles injected, backed by
-a dead controller. Harmless today only because `mjob`/`vjob` are fenced to a
-label nothing applies — a fragile place to be.
+a dead controller. With the `djinn` chart at stock values that is not harmless:
+`kueue.armed: true` labels the `djinn` namespace, so `mjob`/`vjob`
+(`failurePolicy: Fail`) select it and a dead controller blocks every `batch/v1`
+Job CREATE there.
 
 Djinn uses no dynamic resource allocation, so `values.yaml` turns the
 integration off (all three gates: the two child gates declare a hard dependency
@@ -119,8 +125,11 @@ managedJobsNamespaceSelector:
 ```
 
 A namespace must be explicitly labelled before any Kueue admission webhook can
-select an object in it. **No asset in this repository applies that label.** That
-is what makes the release inert.
+select an object in it. This prerequisite release applies that label nowhere;
+the `djinn` chart applies it to its own Namespace when `kueue.armed` is true,
+which is the stock default (`deploy/helm/djinn/templates/namespace.yaml`). The
+fence therefore bounds capture to `djinn` rather than eliminating it, and a
+deployment with `kueue.armed: false` captures nothing at all.
 
 > `managedJobsNamespaceSelector` is **not** merely controller config. The 0.19.0
 > chart templates each webhook's own `namespaceSelector` from it:
@@ -190,7 +199,7 @@ For comparison, at **stock upstream defaults** all six would be
 namespace fence and the `Ignore` policy are Djinn values doing work; the
 contract proves it by rejecting the stock render.
 
-### Residual risk (input to 4c9q)
+### Residual risk (live at stock values)
 
 `mjob`/`vjob` keep upstream's `failurePolicy: Fail` and are now fenced by
 **namespace only**. In a namespace labelled `djinn.io/kueue-managed=true`, every
@@ -198,21 +207,20 @@ contract proves it by rejecting the stock render.
 outage blocks all of them — not just Djinn build Jobs. The fork's per-object
 label used to bound that set.
 
-Today the blast radius is **zero**, because no namespace carries the label —
-and that is *asserted*, not assumed: `tests/webhook-selectors.sh` extracts the
-labels the `djinn` chart actually renders onto its Namespace and evaluates every
-relevant webhook's `namespaceSelector` against them the way the API server
-would. The same test also runs the inverse case, so the cost of labelling
-`djinn` is printed as a failure rather than discovered in production.
+This is no longer hypothetical. The `djinn` chart defaults to
+`kueue.armed: true`, which labels the **`djinn` namespace itself**, so every
+Job in the control-plane namespace now sits behind that `Fail`-policy webhook.
+Treat Kueue controller availability as a dispatch dependency: budget for it in
+upgrades of the prerequisite release, and reach for
+`deploy/kueue/preflight.sh` (below) rather than flipping the label by hand.
+`tests/webhook-selectors.sh` extracts the labels the `djinn` chart really
+renders onto its Namespace and evaluates every relevant webhook's
+`namespaceSelector` against them the way the API server would, so the cost of
+that labelling is computed from the shipped render rather than guessed.
 
-The cutover epic **4c9q** must choose where that label goes with this in mind:
-
-- A **dedicated build-Job namespace** keeps the fenced set to build Jobs. This
-  is the option the residual risk argues for. It is deliberately *not*
-  implemented here — it belongs to 4c9q.
-- Labelling **`djinn` itself** would put every Job in the control-plane
-  namespace behind a `Fail`-policy webhook. Do not do this without deciding the
-  outage story first.
+A **dedicated build-Job namespace** would keep the fenced set to build Jobs
+instead of the whole control plane. That option is still open and still the one
+the residual risk argues for; it is not what ships today.
 
 Do **not** "fix" this by post-processing chart output to re-add an
 `objectSelector`. That is a fork with extra steps.
@@ -260,8 +268,12 @@ prove that installing the prerequisite alongside the inert chart captures
 nothing. `zero-capture-gate.sh` proves that on a real disposable cluster, and
 `deploy/runbooks/kueue-inert-release-zero-capture.md` makes a passing invocation
 a mandatory prerequisite for 4c9q. It installs `deploy/helm/djinn-prereqs`
-followed by the `djinn` chart with `kueue.enabled=true`, then requires
-`kubectl get workloads -n djinn` to return zero items.
+followed by the `djinn` chart with `kueue.enabled=true` **and
+`kueue.armed=false`**, then requires `kubectl get workloads -n djinn` to return
+zero items. The gate owns both of those `--set`s and rejects a caller that
+overrides either: since the chart now ships `kueue.armed: true`, a gate that
+inherited the default would install the armed state and so could never observe
+the unarmed one it claims to verify.
 
 `deploy/kueue/tests/zero-capture-gate.sh` is its hermetic fake-`kubectl`
 contract; it needs no cluster credentials.

--- a/deploy/kueue/tests/webhook-selectors.sh
+++ b/deploy/kueue/tests/webhook-selectors.sh
@@ -71,9 +71,31 @@ render_prereqs() {
 # The availability assertion is only meaningful against the labels the `djinn`
 # chart REALLY puts on its Namespace. Extract them from a live render rather
 # than hard-coding a guess that could drift away from the chart.
+#
+# TWO renders, because the chart now has two materially different postures and
+# each answers a different question:
+#
+#   DISARMED (`kueue.armed=false`) — does the PREREQUISITE RELEASE, on its own,
+#     bring the djinn namespace into Kueue's webhook scope? It must not. This is
+#     the property `djinn-prereqs` is responsible for, and the only one it can
+#     be held to: it ships a positive `managedJobsNamespaceSelector` keyed on
+#     `djinn.io/kueue-managed`, so scope is decided by whoever applies that
+#     label, not by this chart.
+#
+#   ARMED (chart defaults) — what does arming COST? `kueue.armed: true` now
+#     ships as the default, so the djinn namespace carries the label and IS in
+#     scope. That is a deliberate, accepted coupling and it is asserted below,
+#     by name, rather than left to be discovered during an outage.
+#
+# Both are real renders. The armed set used to be synthesised here by editing
+# the disarmed one in python; reading it off the actual default render is
+# strictly stronger, because a chart that stopped applying the label would now
+# fail the armed case instead of quietly agreeing with a hand-built fixture.
 DJINN_CHART="$REPO_ROOT/deploy/helm/djinn"
+helm template djinn "$DJINN_CHART" --is-upgrade --set kueue.armed=false >"$WORK/djinn-disarmed.yaml"
 helm template djinn "$DJINN_CHART" --is-upgrade >"$WORK/djinn.yaml"
-DJINN_NS_LABELS=$(python3 - "$WORK/djinn.yaml" <<'PY'
+extract_ns_labels() {
+    python3 - "$1" <<'PY'
 import json
 import sys
 
@@ -90,17 +112,39 @@ labels = metadata.get("labels") or {}
 labels.setdefault("kubernetes.io/metadata.name", metadata["name"])
 print(json.dumps(labels, sort_keys=True))
 PY
-) || fail 'could not extract the djinn Namespace labels from a chart render'
-printf 'INFO: evaluating webhook namespaceSelectors against real djinn Namespace labels: %s\n' "$DJINN_NS_LABELS"
+}
+DJINN_NS_LABELS=$(extract_ns_labels "$WORK/djinn-disarmed.yaml") ||
+    fail 'could not extract the djinn Namespace labels from a disarmed chart render'
+DJINN_NS_LABELS_ARMED=$(extract_ns_labels "$WORK/djinn.yaml") ||
+    fail 'could not extract the djinn Namespace labels from the default chart render'
+printf 'INFO: evaluating webhook namespaceSelectors against real djinn Namespace labels\n'
+printf 'INFO:   disarmed (kueue.armed=false): %s\n' "$DJINN_NS_LABELS"
+printf 'INFO:   armed    (chart defaults):    %s\n' "$DJINN_NS_LABELS_ARMED"
 
 # Non-vacuity for the extraction itself: an empty label set would make the
 # selector evaluation trivially non-matching and quietly prove nothing.
 python3 -c 'import json,sys; d=json.loads(sys.argv[1]); sys.exit(0 if d.get("kubernetes.io/metadata.name") else 1)' "$DJINN_NS_LABELS" \
     || fail 'extracted djinn Namespace labels lack kubernetes.io/metadata.name; the selector evaluation would be vacuous'
 
+# The two renders must actually DIFFER on the fence label, or every case below
+# collapses into the same question asked twice.
+python3 - "$DJINN_NS_LABELS" "$DJINN_NS_LABELS_ARMED" <<'PY' || fail 'the armed and disarmed renders do not differ on djinn.io/kueue-managed; the cases below would be redundant'
+import json
+import sys
+
+disarmed, armed = (json.loads(arg) for arg in sys.argv[1:])
+assert "djinn.io/kueue-managed" not in disarmed, (
+    f"kueue.armed=false still labelled the namespace: {disarmed}"
+)
+assert armed.get("djinn.io/kueue-managed") == "true", (
+    "the chart's DEFAULT render must label the namespace djinn.io/kueue-managed=true "
+    f"(kueue.armed ships true); got {armed}"
+)
+PY
+
 check_render() {
     python3 "$SELECTOR_CHECKER" "$1" \
-        --namespace-name djinn --namespace-labels "$DJINN_NS_LABELS"
+        --namespace-name djinn --namespace-labels "${2:-$DJINN_NS_LABELS}"
 }
 
 expect_pass() {
@@ -134,7 +178,11 @@ expect_rejected() {
     printf 'PASS: checker rejected %s\n' "$label"
 }
 
-echo "=== shipped render: deploy/helm/djinn-prereqs ==="
+echo "=== shipped render: deploy/helm/djinn-prereqs brings nothing into scope on its own ==="
+# Evaluated against the DISARMED djinn namespace. This is the prerequisite
+# release's own contract: installing it must not put any djinn workload behind a
+# Kueue webhook. Scope is granted by the `djinn.io/kueue-managed` label, which
+# the `djinn` chart applies only when armed — see the armed case below.
 render_prereqs "$WORK/shipped.yaml"
 expect_pass 'shipped render' "$WORK/shipped.yaml"
 
@@ -152,25 +200,45 @@ expect_rejected 'upstream-default render' "$WORK/upstream-default.yaml" \
     "webhook mpod.kb.io: namespaceSelector SELECTS namespace 'djinn'" \
     "webhook vjob.kb.io: namespaceSelector SELECTS namespace 'djinn'"
 
-echo "=== negative: what labelling the djinn namespace would cost (4c9q input) ==="
-# The fence is correct; the namespace is not. This is the 4c9q decision made the
-# wrong way, and it must be visible as a failure here rather than discovered in
-# production. It also proves the selector evaluation is non-vacuous: the same
-# shipped render that passed above is rejected purely by changing the labels.
-LABELLED_NS=$(python3 -c 'import json,sys; d=json.loads(sys.argv[1]); d["djinn.io/kueue-managed"]="true"; print(json.dumps(d, sort_keys=True))' "$DJINN_NS_LABELS")
+echo "=== WHAT THE ARMED DEFAULT COSTS: the djinn namespace IS in Kueue's webhook scope ==="
+# THIS IS NOT A FAILURE. It is the accepted price of `kueue.armed: true`, pinned
+# here so it stays a named, deliberate coupling instead of an outage nobody
+# predicted. Kueue admission cannot exist without the webhooks that implement
+# it, so arming necessarily puts the djinn namespace behind them.
+#
+# What that buys: Kueue's pods quota, which is the ONLY remaining
+# build-concurrency bound (the in-process reservation authority was deleted in
+# #2822). An unarmed install has no bound at all.
+#
+# What it costs, precisely: `vjob.kb.io` carries `failurePolicy: Fail`, so while
+# the Kueue controller is UNAVAILABLE, Job CREATE in the djinn namespace is
+# rejected — i.e. task-run, warm and SCIP dispatch all stop until it recovers.
+# The Pod/Deployment/StatefulSet webhooks are `failurePolicy: Ignore` and
+# degrade instead of blocking, which is why djinn-server, Postgres and Qdrant
+# keep being schedulable through the same outage. Install the prerequisite with
+# `--wait`, and treat Kueue controller availability as a dispatch dependency.
+#
+# The assertion is on the checker's REPORT, not on a verdict: the same shipped
+# prereqs render that passed above is reported as in-scope purely by swapping in
+# the armed namespace labels, which is also what keeps the selector evaluation
+# non-vacuous in both directions.
 set +e
-LABELLED_OUT=$(python3 "$SELECTOR_CHECKER" "$WORK/shipped.yaml" --namespace-name djinn --namespace-labels "$LABELLED_NS" 2>&1)
+LABELLED_OUT=$(check_render "$WORK/shipped.yaml" "$DJINN_NS_LABELS_ARMED" 2>&1)
 LABELLED_STATUS=$?
 set -e
 [ "$LABELLED_STATUS" -eq 1 ] || {
     printf '%s\n' "$LABELLED_OUT" >&2
-    fail 'labelling the djinn namespace was not reported as bringing it into Kueue scope'
+    fail 'the armed default was not reported as bringing the djinn namespace into Kueue scope; either the chart stopped labelling the namespace or the checker stopped evaluating selectors'
 }
 grep -Fq -- "webhook vjob.kb.io: namespaceSelector SELECTS namespace 'djinn'" <<<"$LABELLED_OUT" || {
     printf '%s\n' "$LABELLED_OUT" >&2
-    fail 'expected the Job webhook to be reported as selecting a labelled djinn namespace'
+    fail 'expected the Job webhook to be reported as selecting the armed djinn namespace'
 }
-printf 'PASS: labelling djinn.io/kueue-managed on the djinn namespace is reported as bringing Job CREATE into a failurePolicy=Fail webhook\n'
+grep -Fq -- "failurePolicy 'Fail'" <<<"$LABELLED_OUT" || {
+    printf '%s\n' "$LABELLED_OUT" >&2
+    fail 'the report no longer names the failurePolicy that makes this a dispatch dependency'
+}
+printf 'PASS: the armed default is reported as bringing Job CREATE into a failurePolicy=Fail webhook — accepted, and named\n'
 
 echo "=== negative: 'pod' put back into integrations.frameworks ==="
 # Isolates the frameworks half: the namespace fence is left intact, so the only

--- a/deploy/kueue/tests/zero-capture-gate.sh
+++ b/deploy/kueue/tests/zero-capture-gate.sh
@@ -159,6 +159,12 @@ if grep -Eq -- '(^|[[:space:]])apply -f ' "$SUCCESS_LOG"; then
 fi
 grep -Fq -- "upgrade --install djinn-inert-kueue-gate $CHART_DIR" "$SUCCESS_LOG" || fail 'success did not install inert Djinn chart'
 grep -Fq -- 'kueue.enabled=true' "$SUCCESS_LOG" || fail 'success did not request the Kueue queue topology, so it proved nothing about it'
+# The chart ships `kueue.armed: true`. A gate that inherited that default would
+# install a fully ARMED release — Namespace labelled djinn.io/kueue-managed,
+# every build Job suspended — and then fail its own inert-state check having
+# proved nothing about capture. The disarm must be on the install line, not left
+# to a chart default that has already moved once.
+grep -Fq -- 'kueue.armed=false' "$SUCCESS_LOG" || fail 'gate did not pin kueue.armed=false, so the inert state it verifies is not the state it installs'
 grep -Fq -- 'migration.designatedOperatorSecret=fake-designated-operator' "$SUCCESS_LOG" || fail 'success did not provide the fresh-install designated operator Secret'
 grep -Fq -- "apply -n djinn -f $SCRIPT_DIR/fixtures/precutover-task-run.yaml" "$SUCCESS_LOG" || fail 'success did not apply pre-cutover fixture'
 grep -Fq -- 'get workloads -n djinn' "$SUCCESS_LOG" || fail 'success did not query namespace Workloads'

--- a/deploy/kueue/zero-capture-gate.sh
+++ b/deploy/kueue/zero-capture-gate.sh
@@ -232,13 +232,27 @@ if ! "$KUBECTL" --context "$CONTEXT" get secret "$DESIGNATED_OPERATOR_SECRET" -n
 fi
 
 printf 'INFO: installing inert Djinn chart release %s\n' "$RELEASE"
-# kueue.enabled=true is what makes this gate meaningful: the Djinn queue
-# topology only renders on request, and the gate exists to prove that rendering
-# it alongside the prerequisite still captures nothing. It is set LAST so that
-# it also wins against any caller --set that slipped past reject_gate_owned_key.
+# BOTH halves of the Kueue contract are pinned here, and both are load-bearing.
+#
+# kueue.enabled=true is what makes this gate meaningful: the gate exists to prove
+# that rendering the Djinn queue topology alongside the prerequisite still
+# captures nothing, and a run with no topology would report "zero Workloads
+# captured" for the trivial reason that no queue exists.
+#
+# kueue.armed=false is what makes the inert state REACHABLE. The chart's stock
+# values ship `armed: true` (the production profile), which labels the Namespace
+# djinn.io/kueue-managed and renders every build Job `suspend: true`. Installing
+# the defaults would therefore hand this gate a fully armed release, and it would
+# fail on its own namespace-label check having proved nothing about capture.
+# Pinning it false here is the difference between "nothing was captured" and
+# "nothing could have been captured for a reason this gate did not choose".
+#
+# Both are set LAST so they also win against any caller --set that slipped past
+# reject_gate_owned_key.
 run_helm upgrade --install "$RELEASE" "$CHART" --namespace "$NAMESPACE" --create-namespace --wait --timeout "${INSTALL_TIMEOUT_SECONDS}s" \
     ${CHART_VALUE_ARGS[@]+"${CHART_VALUE_ARGS[@]}"} \
-    --set kueue.enabled=true --set-string "migration.designatedOperatorSecret=$DESIGNATED_OPERATOR_SECRET"
+    --set kueue.enabled=true --set kueue.armed=false \
+    --set-string "migration.designatedOperatorSecret=$DESIGNATED_OPERATOR_SECRET"
 
 namespace_label=$(run_kubectl get namespace "$NAMESPACE" -o 'jsonpath={.metadata.labels.djinn\.io/kueue-managed}')
 if [ "$namespace_label" = 'true' ]; then

--- a/deploy/preflight/render-gate.sh
+++ b/deploy/preflight/render-gate.sh
@@ -22,10 +22,26 @@
 #
 # WHAT IT IS NOT
 # --------------
-# It is not a cluster check. It answers "would the server refuse this render at
-# dispatch", not "do the nodes satisfy the runtime prerequisites" — node
-# labels, the containerd handler, and cgroup delegation are the subject of
-# `deploy/node/k3s/djinn-cgroup-writable-conformance.sh`.
+# It is not a cluster check, and it structurally cannot become one: it drives
+# `helm template`, where Helm's `lookup` returns nothing and
+# `.Capabilities.APIVersions` is a stub. It answers "would the server refuse
+# this render at dispatch", not "do the nodes satisfy the runtime
+# prerequisites".
+#
+# The cluster half is covered where it can actually run:
+#
+#   deploy/helm/djinn/templates/prereq-guard.yaml
+#       On a real `helm install`/`helm upgrade` — the only place the cluster is
+#       visible — refuses the release when no node carries
+#       `djinn.io/cgroup-writable=true` or when `kueue.x-k8s.io/v1beta1` is not
+#       served, naming the prerequisite and how to install it. Inert here, by
+#       design; see tests/prereq-guard-render.sh.
+#   deploy/node/k3s/djinn-cgroup-writable-conformance.sh
+#       The node itself: containerd handler, cgroup delegation, and the
+#       `djinn.io/cgroup-writable` marker it applies only after the node passes.
+#
+# Now that the chart's stock values are fully armed, all three matter on a fresh
+# install and none substitutes for another.
 #
 # USAGE
 #   deploy/preflight/render-gate.sh <chart-dir> [helm template args...]

--- a/deploy/runbooks/cgroup-launcher-rearm.md
+++ b/deploy/runbooks/cgroup-launcher-rearm.md
@@ -71,8 +71,17 @@ helm upgrade djinn deploy/helm/djinn \
   --reuse-values \
   --set cgroupWritable.runtimeClass.enabled=true \
   --set cgroupWritable.taskRuns.enabled=false \
-  --set cgroupLauncher.mode=disabled
+  --set cgroupLauncher.mode=disabled \
+  --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1
 ```
+
+The fourth flag is not optional. `imagePipeline.controller.launcherAuthorityProtocol`
+now defaults to `resize-v2`, and `templates/deployment-server.yaml` refuses any
+render that claims resize-v2 authority while `cgroupLauncher.mode` is not
+`required` — resize-v2 declares that Kubernetes in-place Pod resize owns CPU
+quota, and disarming the launcher renders no quota mechanism to own it. Without
+this flag the preparation upgrade fails at render time and the whole runbook
+stalls at step 0. Step 4 restores it by dropping the override.
 
 After this preparation upgrade both classes exist in the cluster, but no
 task-run is scheduled onto either (`cgroupWritable.taskRuns.enabled: false`)

--- a/docs/deploy/kubernetes.md
+++ b/docs/deploy/kubernetes.md
@@ -34,9 +34,21 @@ bits. Nothing in the chart is AWS-specific.
   schedule `buildkitd` (see [the hub](README.md#node-prerequisites)); on
   managed node images, set them via node group launch-template user data or a
   privileged DaemonSet.
-- **Optional: Kueue**, if you want the Djinn queue topology
-  (`kueue.enabled: true`). Kubernetes **>= 1.30** required. See
-  [the prerequisite release](#cluster-prerequisite-releases) below.
+- **Kueue** — required, not optional. `kueue.enabled` and `kueue.armed` both
+  default to `true`, so a stock install renders `kueue.x-k8s.io/v1beta1`
+  objects and hands build-Job admission to Kueue. Kubernetes **>= 1.30**
+  required. See [the prerequisite release](#cluster-prerequisite-releases)
+  below.
+- **Nodes that pass the writable-cgroup conformance.** `cgroupWritable.taskRuns`
+  is on by default, which assigns `RuntimeClass/djinn-cgroup-writable` to every
+  task-run Pod; that class carries `scheduling.nodeSelector:
+  djinn.io/cgroup-writable=true`. Run
+  `deploy/node/k3s/djinn-cgroup-writable-conformance.sh` on each node that
+  should run task-runs — it installs the containerd `runc-cgroupwritable`
+  handler, proves the node can delegate a writable cgroup, and applies the
+  marker label itself once the node passes. Never apply that label by hand: an
+  unproven node that carries it schedules Pods that then cannot get a cgroup
+  leaf.
 
 ### Cluster prerequisite releases
 
@@ -51,7 +63,8 @@ helm upgrade --install cert-manager jetstack/cert-manager \
 ```
 
 Kueue follows the same pattern, from a chart in this repository that pins the
-upstream OCI chart and applies Djinn's scoping as values:
+upstream OCI chart and applies Djinn's scoping as values. Unlike cert-manager
+it is **mandatory at stock values** — install it before `djinn`:
 
 ```bash
 helm upgrade --install djinn-prereqs deploy/helm/djinn-prereqs \
@@ -68,19 +81,76 @@ gates. Kueue 0.19 ships `KueueDRAIntegration` on, which needs
 `resource.k8s.io/v1` (GA in Kubernetes 1.34) and CrashLoopBackOffs below it.
 See [deploy/kueue/README.md](../../deploy/kueue/README.md#minimum-kubernetes-is-130-and-only-because-dra-is-disabled).
 
-The release is **inert**: Djinn's values set a *positive*
-`managedJobsNamespaceSelector` matching only namespaces labelled
-`djinn.io/kueue-managed=true`, and nothing labels one. No Workload is ever
-created. Read [deploy/kueue/README.md](../../deploy/kueue/README.md) — in
-particular the residual-risk section — before applying that label anywhere.
+Djinn's values set a *positive* `managedJobsNamespaceSelector` matching only
+namespaces labelled `djinn.io/kueue-managed=true`, so Kueue captures nothing
+until a namespace carries that label. At stock `djinn` values it does:
+`kueue.armed: true` labels the `djinn` Namespace and renders every task-run,
+warm and SCIP Job `suspend: true`, so Workloads **are** created and Kueue's
+`buildPods` quota is what bounds build concurrency. The release is inert only
+for a deployment that explicitly sets `kueue.armed: false`. Read
+[deploy/kueue/README.md](../../deploy/kueue/README.md) — in particular the
+residual-risk section — before changing where that label goes: with the
+namespace labelled, every `batch/v1` Job CREATE in it routes through a
+`failurePolicy: Fail` webhook, so a Kueue control-plane outage blocks them all.
 
-Skip this if you don't want the queue topology: the `djinn` chart defaults to
-`kueue.enabled: false` and installs fine on a cluster with no Kueue CRDs. Set
-`kueue.enabled: true` **only** after installing `djinn-prereqs`; the topology is
-`kueue.x-k8s.io/v1beta1`, so without it the install fails with `no matches for
-kind "ResourceFlavor"`. `ClusterQueue` and `LocalQueue` also carry a conversion
-webhook, so the Kueue controller must be **Ready**, not merely installed — hence
-the `--wait` above.
+Do **not** substitute stock upstream Kueue for `djinn-prereqs`. At upstream
+defaults the Pod/Deployment/StatefulSet webhooks are `failurePolicy: Fail` with
+a selector that covers `djinn`, so an unavailable Kueue controller stops
+`djinn-server`, Postgres, Qdrant and task-run Pods alike.
+`deploy/kueue/tests/webhook-selectors.sh` asserts Djinn's scoping on the
+rendered output.
+
+You cannot skip this and still install at stock values: the topology is
+`kueue.x-k8s.io/v1beta1`, so a cluster without Kueue is refused — by
+`templates/prereq-guard.yaml`, which consults live API discovery during a real
+`helm install` and names the missing prerequisite, rather than by the API
+server's bare `no matches for kind "ResourceFlavor"`. `ClusterQueue` and
+`LocalQueue` also carry a conversion webhook, so the Kueue controller must be
+**Ready**, not merely installed — hence the `--wait` above.
+
+The guard also refuses when no node carries `djinn.io/cgroup-writable=true`
+while `cgroupWritable.taskRuns.enabled` is true. It exists because both
+failures used to be silent: `helm install` reported success and the deployment
+then dispatched zero usable Jobs. It is deliberately inert under `helm
+template` and client-side `--dry-run` (Helm's `lookup` sees no cluster there),
+and it fails **open** if the credentials cannot list Nodes — an operator with
+restricted RBAC gets no guard rather than a false refusal.
+
+Bootstrapping order matters here: the conformance probe Pod names
+`RuntimeClass/djinn-cgroup-writable-probe`, which only this chart renders, so a
+fresh cluster needs one preparation install before conformance can run:
+
+```bash
+helm install djinn deploy/helm/djinn --namespace djinn --create-namespace \
+  --set cgroupWritable.taskRuns.enabled=false \
+  --set cgroupLauncher.mode=disabled \
+  --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1
+```
+
+All three move together — the armed launcher requires the task-run
+RuntimeClass, and `resize-v2` requires the armed launcher, so
+`deployment-server.yaml` refuses any subset. That state renders both
+RuntimeClasses, assigns neither to task-runs, and leaves the guard's node check
+inapplicable. Run the conformance script on each node, then `helm upgrade` back
+to stock values. `deploy/runbooks/cgroup-launcher-rearm.md` is the full staged
+order.
+
+For a cluster that will never have these prerequisites (kind, a laptop, a
+direct-worker profile), opt out of the whole armed profile explicitly — the
+switches only work together:
+
+```bash
+helm install djinn deploy/helm/djinn --namespace djinn --create-namespace \
+  --set cgroupLauncher.mode=disabled \
+  --set cgroupWritable.runtimeClass.enabled=false \
+  --set cgroupWritable.taskRuns.enabled=false \
+  --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1 \
+  --set kueue.enabled=false \
+  --set kueue.armed=false
+```
+
+`deploy/helm/djinn/values.local.yaml` ships exactly that profile, and Tilt uses
+it.
 
 For GitOps, `djinn-prereqs` is a separate Application/HelmRelease with a sync
 wave ahead of `djinn` — again, exactly like cert-manager.

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -219,12 +219,16 @@ git clone https://github.com/djinnos/djinn
 cd djinn
 ```
 
-### Optional: install the Kueue prerequisite
+### Install the Kueue prerequisite (required)
 
 Same shape as cert-manager above — a cluster-scoped third-party release Djinn
-does not own. Only needed if you want the Kueue queue topology
-(`kueue.enabled: true` in your values below); the chart installs fine without
-it, and the topology is inert either way.
+does not own. It is **not optional**: the `djinn` chart defaults to
+`kueue.enabled: true` and `kueue.armed: true`, so a stock install renders
+`kueue.x-k8s.io/v1beta1` objects and hands build-Job admission to Kueue.
+Kueue's `buildPods` quota is also the only remaining bound on build
+concurrency, so turning the topology off instead would dispatch unbounded build
+Pods. Install this release first: `templates/prereq-guard.yaml` refuses the
+`djinn` release, naming this chart, if the Kueue API is not served.
 
 Requires **Kubernetes >= 1.30** — `k3s --version`. The upstream chart declares
 no `kubeVersion`, so Helm will not check this for you. The production VPS runs
@@ -241,9 +245,13 @@ helm install djinn-prereqs deploy/helm/djinn-prereqs \
 This pins Kueue `0.19.0` from `oci://registry.k8s.io/kueue/charts/kueue`, with
 Djinn's scoping applied as values: a *positive*
 `managedJobsNamespaceSelector` that only selects namespaces labelled
-`djinn.io/kueue-managed=true`. No namespace carries that label, so nothing is
-captured. Read [deploy/kueue/README.md](../../deploy/kueue/README.md) before
-labelling anything.
+`djinn.io/kueue-managed=true`. That fence is what keeps capture confined to
+Djinn's own namespace — and at stock `djinn` values the namespace **is**
+labelled (`kueue.armed: true` renders both the label and `suspend: true` Jobs),
+so Workloads are created and every `batch/v1` Job CREATE in `djinn` traverses a
+`failurePolicy: Fail` webhook. Read
+[deploy/kueue/README.md](../../deploy/kueue/README.md), especially the
+residual-risk section, before moving that label anywhere else.
 
 > **Do not install stock upstream Kueue on this box instead.** At its defaults
 > the Pod webhook is registered with `failurePolicy: Fail` and a selector that
@@ -255,6 +263,45 @@ labelling anything.
 
 Keep `--wait`: `ClusterQueue`/`LocalQueue` carry a conversion webhook, so the
 Kueue controller must be Ready before the `djinn` chart applies the topology.
+
+### Prepare the node for writable cgroups (required)
+
+The stock chart also arms the cgroup launcher (`cgroupLauncher.mode: required`,
+`cgroupWritable.{runtimeClass,taskRuns}.enabled: true`), which assigns
+`RuntimeClass/djinn-cgroup-writable` to every task-run Pod. That class carries
+`scheduling.nodeSelector: djinn.io/cgroup-writable=true`, so an unprepared node
+leaves every task-run Pod Pending forever while the release looks healthy:
+
+```bash
+sudo deploy/node/k3s/djinn-cgroup-writable-conformance.sh
+```
+
+That script is the single owner of the marker label: it installs the containerd
+`runc-cgroupwritable` handler the RuntimeClass names, proves the node can
+actually delegate a writable cgroup, and applies
+`djinn.io/cgroup-writable=true` itself only once the node passes. Do not apply
+the label by hand — a node that carries it unproven trades an unschedulable Pod
+for a Pod that starts and then cannot get a cgroup leaf.
+`templates/prereq-guard.yaml` refuses the `djinn` install if no node carries
+the marker.
+
+Chicken-and-egg on a brand-new box: the probe Pod names
+`RuntimeClass/djinn-cgroup-writable-probe`, which only the `djinn` chart
+renders. So run [step 4](#4-install) once as a *preparation* install with these
+three flags appended, run the conformance script, then re-run step 4 without
+them:
+
+```bash
+  --set cgroupWritable.taskRuns.enabled=false \
+  --set cgroupLauncher.mode=disabled \
+  --set imagePipeline.controller.launcherAuthorityProtocol=leaf-v1
+```
+
+The three move together: the armed launcher requires the task-run RuntimeClass
+and `resize-v2` requires the armed launcher, so the chart refuses any subset at
+render time. That state renders both RuntimeClasses, assigns neither to
+task-runs, and leaves the guard's node check inapplicable.
+`deploy/runbooks/cgroup-launcher-rearm.md` is the full staged order.
 
 Create `my-values.yaml` (a complete, working single-node profile — see
 [Configuration](configuration.md) for every knob):

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -19,13 +19,21 @@ use crate::launcher::CgroupLauncherMode;
 /// followed by the whole warm.
 pub const MEASURED_FULL_WARM_SECONDS: i64 = 5_442;
 
-/// One operator lever whose default is OFF, so an unset environment variable
-/// leaves the feature permanently inert.
+/// One operator lever whose BINARY default is OFF, so an unset environment
+/// variable leaves the feature permanently inert.
+///
+/// "Default" here means the binary's own default — [`KubernetesConfig::for_testing`],
+/// which is what [`KubernetesConfig::from_env`] falls back to for anything unset.
+/// It deliberately does NOT mean the Helm chart's default: the chart ships every
+/// switch on this list ARMED, and that is precisely what makes membership
+/// meaningful rather than redundant. A switch is on this list because the only
+/// thing standing between it and permanent inertness is a chart rendering it,
+/// so the chart owes it a surface.
 ///
 /// The `armed` probe is what makes membership checkable rather than declared:
 /// [`fail_closed_arming_switches_are_all_off_by_default`] reads it against
-/// [`KubernetesConfig::for_testing`], so a switch listed here that is actually
-/// on by default fails the build instead of quietly overstating the contract.
+/// [`KubernetesConfig::for_testing`], so a switch listed here whose BINARY
+/// default is on fails the build instead of quietly overstating the contract.
 #[derive(Clone, Copy, Debug)]
 pub struct ArmingSwitch {
     /// Environment variable the server reads to arm the feature.
@@ -55,6 +63,31 @@ pub struct ArmingSwitch {
 /// a member. Adding a switch here without a chart surface fails that test;
 /// deleting the chart surface of an existing one fails it too. The list is the
 /// contract, the chart is the obligation.
+///
+/// # Why a chart that ships these ARMED does not retire the list
+///
+/// The chart's stock values now arm every switch below — `scipIndex.enabled`
+/// and `kueue.armed` both ship `true`, matching the production VPS. That could
+/// look like it dissolves the contract ("a switch that is on by default needs
+/// no chart surface to be reachable"), and it does not, because the two
+/// defaults are different defaults. The BINARY still fails closed: delete the
+/// env block from `deployment-server.yaml` and `from_env` falls back to
+/// `for_testing`, which is `false`, and the feature is unreachable again with
+/// nothing anywhere reporting a problem. The chart is not one activation path
+/// among several — it is the only one. That makes the render obligation
+/// stronger than it was when the chart shipped these disarmed, not weaker.
+///
+/// The obligation therefore has two halves, and the shell test checks both:
+///
+///   1. every member is RENDERED onto the server Deployment with a value the
+///      server can parse (a missing surface is an unreachable feature);
+///   2. every member is rendered ARMED (a surface that ships `false` is the
+///      same shipped-and-never-ran defect, one step further along — the SCIP
+///      Job had a surface for a release and still created zero Jobs).
+///
+/// Half 2 is why a switch that genuinely must ship off does not belong here:
+/// it would have to leave this list, with the reason written down, rather than
+/// quietly weaken what the list promises.
 pub const FAIL_CLOSED_ARMING_SWITCHES: &[ArmingSwitch] = &[
     ArmingSwitch {
         env: "DJINN_K8S_SCIP_INDEX_ENABLED",
@@ -1017,6 +1050,14 @@ pub(crate) mod tests {
     /// so listing it here would inflate the contract with an entry whose
     /// absence from the chart costs nothing — and the next reader would trust
     /// the list less. Probing the config is what keeps the list honest.
+    ///
+    /// "By default" is [`KubernetesConfig::for_testing`], the fallback
+    /// [`KubernetesConfig::from_env`] uses for anything unset — i.e. the
+    /// BINARY's default, not the chart's. The Helm chart ships every one of
+    /// these armed; that is the obligation being discharged, not a reason to
+    /// retire it. If this probe ever starts failing because a binary default
+    /// flipped on, the honest fix is to remove that switch from the list (it no
+    /// longer needs a chart to be reachable), never to relax the probe.
     #[test]
     fn fail_closed_arming_switches_are_all_off_by_default() {
         let cfg = KubernetesConfig::for_testing();


### PR DESCRIPTION
Production runs Kueue admission and the standalone SCIP-index Job; the chart shipped both off. Everything enabled on the production VPS is now the chart default.

| value | was | now |
|---|---|---|
| `kueue.enabled` | `false` | `true` |
| `kueue.armed` | `false` | `true` |
| `scipIndex.enabled` | `false` | `true` |

Verified against `/opt/djinn/values.vps.yaml` on the box (read-only; no cluster was mutated): all three are `true` there.

**Not touched, because `main` already ships them armed:** `cgroupLauncher.mode: required`, `cgroupWritable.runtimeClass/taskRuns: true`, `imagePipeline.controller.launcherAuthorityProtocol: resize-v2`. This PR does **not** arm the launcher.

Also deliberately left alone:
- `kueue.buildPods: 3` — matches production.
- `kueue.capacity.*` — new in #2901, landed today; production does not set it, so it stays at its shipped default. That knob belongs to its own PR.
- `kueue.namespaceLabelledExternally: false` — production sets it `true` only because Ansible creates the namespace *outside* the release. The chart's `namespace.create` default applies the label itself, so `false` is the correct chart default and `kueue-topology-render.sh` asserts it.

## Caveat: `scipIndex.enabled` matches production, it is not an endorsement

Proposal `q4jg` found that in production both observed standalone SCIP dispatches delivered **zero value** — one indexed a revision the warm Job had already fully indexed 87 seconds earlier (all workspaces cache-hit), the other spent 59 minutes indexing a superseded tree — and that SCIP's timing writes inflate the warm Job's own cargo budget by ~12%.

The directive is that production settings become chart defaults, and SCIP is enabled in production, so it is flipped here. **This default is set to match production, not because standalone SCIP is currently earning its keep.** If `q4jg` concludes it should be off, that is a one-line change to this same value — and the derived contract described below will then require it to leave `FAIL_CLOSED_ARMING_SWITCHES` with a reason, rather than quietly reverting to a shipped-but-inert feature.

## What a stock install now does that it didn't before

- **Build concurrency is bounded.** Kueue's pods quota is the only remaining build-concurrency bound — the in-process reservation authority was deleted in #2822 — so before this, a stock install had no bound at all on concurrent build Pods.
- **Build Jobs are captured.** Task-run, warm and SCIP Jobs render `suspend: true` with a queue-name label, and the `djinn` Namespace carries `djinn.io/kueue-managed=true`.
- **The standalone SCIP-index Job dispatches** (one extra Pod sized by `resources.scip`), subject to its unchanged cadence gates — see the caveat above.

## What a cluster missing the prerequisites now sees

`templates/prereq-guard.yaml` (new) refuses the install, naming what is missing and how to install it (`deploy/helm/djinn-prereqs`, the node label, `deploy/node/k3s/djinn-cgroup-writable-conformance.sh`), plus the bootstrap ordering and the opt-out.

Its only cluster contact is one `lookup`, which returns nothing under `helm template` and client-side `--dry-run` — so the **Node list doubles as the liveness probe** and the guard stands down entirely when it cannot see a cluster. It **fails open** when credentials cannot list Nodes.

### Scope note — please tell me if you'd rather split this

The guard covers two prerequisites and they have different provenance:

- **The Kueue-API check is introduced by this PR.** `kueue.enabled: true` is my flip; without the guard a Kueue-less cluster gets `no matches for kind ResourceFlavor`, which is diagnosable but names neither the prerequisite nor the fix.
- **The node-label check closes a pre-existing gap.** `main` already arms the launcher, so that risk is not introduced here.

I kept them together because they are the same `lookup`, the same `$missing` list and the same refusal message — splitting would ship half a guard and then add three lines in a follow-up. Happy to extract the node half into its own PR if you'd prefer the diff scoped strictly to what this change introduces.

Both prerequisite failures were previously **silent**: an armed install without Kueue suspends every build Job with nothing able to unsuspend it; a task-run Pod naming `RuntimeClass/djinn-cgroup-writable` on a cluster with no labelled node stays Pending forever. `helm install` reported success either way.

### Where each check can actually run

| layer | mechanism | sees |
|---|---|---|
| value coherence | `templates/deployment-server.yaml` `fail` | values only |
| cluster facts | **`templates/prereq-guard.yaml`** (new) | live install/upgrade only |
| dispatch validity | `deploy/preflight/render-gate.sh` | a render; **not** a cluster check, and structurally cannot become one |
| node runtime | `deploy/node/k3s/djinn-cgroup-writable-conformance.sh` | the node |

### Bootstrap chicken-and-egg, handled

Node conformance needs `RuntimeClass/djinn-cgroup-writable-probe`, and this chart is the only thing that renders it — so a fresh cluster cannot be conformed before djinn is installed. The guard keys on `cgroupWritable.taskRuns.enabled` (the *assignment*) rather than `runtimeClass.enabled` (the *class*), so the preparation install still renders the probe class. `tests/prereq-guard-render.sh` pins that with a case that fails if the preparation profile stops rendering it.

## `FAIL_CLOSED_ARMING_SWITCHES` keeps both entries

`DJINN_K8S_SCIP_INDEX_ENABLED` and `DJINN_KUEUE_ARMED` stay listed. The contract reads "off by default", and the probe operationalises that as the **binary** default (`KubernetesConfig::for_testing`), which is still `false` for both — only the *chart* default moved. Delete the env block from `deployment-server.yaml` and `from_env` falls back to `false` and the feature is unreachable again. The chart is not one activation path among several; it is the only one, which makes the render obligation **stronger** than when the chart shipped these disarmed.

The obligation gained its missing half. `scip-index-arming-render.sh` already derived from the list that every member must be **rendered**; it now also derives that every member must render **armed**. A surface that ships `false` is the same shipped-and-never-ran defect one step further along — the SCIP Job had a surface for a release and still created zero Jobs in production.

## What arming Kueue costs, on the record

`deploy/kueue/tests/webhook-selectors.sh` carried a case titled *"what labelling the djinn namespace would cost"*, built from a synthesised label set. That is now the default, so the case reads the **real armed render** instead of a fixture and states the trade explicitly:

- **Buys:** the pods quota, the only build-concurrency bound there is.
- **Costs:** `vjob.kb.io` carries `failurePolicy: Fail`, so while the Kueue controller is unavailable, Job CREATE in the `djinn` namespace is rejected — task-run, warm and SCIP dispatch all stop until it recovers. The Pod/Deployment/StatefulSet webhooks are `failurePolicy: Ignore` and degrade instead of blocking, which is why djinn-server, Postgres and Qdrant stay schedulable through the same outage.

This is the same trade production accepted on 2026-07-31, in its own words in `values.vps.yaml`: *"a Kueue controller outage stops ALL task-run Job creation... a deliberate dependency choice — Kueue is a component we deploy and own, like Postgres — and it is reversible in seconds."*

The prerequisite chart's own contract is unchanged and still asserted, now against a **disarmed** render: installing `djinn-prereqs` brings nothing into scope by itself.

## Also fixed (all surfaced by making these the defaults)

- **`templates/kueue-topology.yaml` rendered `---apiVersion:` instead of a document separator.** A `{{- /*` comment ate the newline after `---` and the trailing `-}}` ate the one below. `helm template` re-splits documents so its output looked right, but `helm lint deploy/helm/djinn` (which CI runs) parses the rendered file and failed. Invisible while `kueue.enabled` shipped false, because the file rendered to nothing.
- **`values.local.yaml`** (Tilt/kind) opts out of the armed profile explicitly. A `scripts/kind/setup-kind.sh` cluster has neither the containerd handler, the node label, nor Kueue.
- **`deploy/runbooks/cgroup-launcher-rearm.md` step 0 was unrunnable.** With `launcherAuthorityProtocol` defaulting to `resize-v2`, the preparation upgrade is refused at render time unless it also passes `leaf-v1`. The rearm runbook would have stalled at its first step. Pre-existing on `main`.
- **`deploy/kueue/zero-capture-gate.sh` pins `kueue.armed=false`** on its own install line. It verifies an *inert* release; inheriting the armed default would have had it fail its own namespace-label check having proved nothing about capture.

## Verification

`bash scripts/test-helm-chart-contracts.sh` — 19 of 21 pass. The two failures (`incident-observability-contract.sh`, `log-collector-contract.sh`) are `FAIL: vector is required to execute VRL fixtures` and fail identically on `origin/main` in this environment; unrelated to this change.

`cargo test -p djinn-k8s --lib` — 384 passed, 0 failed.
`bash deploy/preflight/render-gate.sh deploy/helm/djinn` — `DISPATCHABLE` on stock defaults.
`bash deploy/preflight/tests/render-gate.sh` — 16 cases pass, including *stock chart defaults dispatch*.
`bash deploy/kueue/tests/webhook-selectors.sh`, `zero-capture-gate.sh`, `preflight.sh`, `deploy/preflight/tests/cutover-preflight.sh`, `task-run-resize-rollout.sh` — all pass.
`helm lint deploy/helm/djinn` and `--values values.local.yaml` — both clean.

All re-run after rebasing onto #2901, including its new `capacity-controller-render.sh`.

### Mutation evidence (each recorded by running it)

| mutation | fails |
|---|---|
| guard's Kueue branch disabled | `prereq-guard-render.sh` — *the guard accepted a cluster missing its prerequisites* |
| guard's node-label branch disabled | `prereq-guard-render.sh` — same, on `unlabelled-nodes` |
| `scipIndex.enabled` back to `false` | `scip-index-arming-render.sh` — the **derived** check fires first: *these fail-closed arming switches ship DISARMED from the chart: ['DJINN_K8S_SCIP_INDEX_ENABLED']* |
| `kueue.armed` back to `false` | `kueue-topology-render.sh` — *must label the Namespace djinn.io/kueue-managed=true, got None*; and `webhook-selectors.sh` — *the armed and disarmed renders do not differ* |
| probe line deleted/renamed | `prereq-guard-render.sh` fails on the anchor check rather than silently no-op'ing every case |

## Not verified

The guard's cluster-visible branches are driven by substituting the one `lookup` line with literal fixtures — the only way to test a `lookup` guard without a cluster. **It has not been run against a live `helm install`.** No cluster was mutated in preparing this change; the VPS was read with `cat`/`grep`/`sed` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
