### PR TITLE
fix(resize): a late kubelet is a wait, not a permanent refusal

### DIFF
--- a/server/crates/djinn-coordinator/src/resize_lift.rs
+++ b/server/crates/djinn-coordinator/src/resize_lift.rs
@@ -982,6 +982,15 @@ fn observation_failure(error: &LauncherObservationError) -> ResizeApplyFailure {
         // An incomplete `metadata` is the same answer as no Pod: there is
         // nothing to fence a resize against.
         LauncherObservationError::Incomplete { .. } => DegradedUnleasedReason::LiftPodAbsent,
+        // The kubelet has not (re)published the launcher's init-container
+        // status. Reaching this during a LIFT means the status went away after
+        // the birth capture read it — a Pod being replaced underneath us — so it
+        // is classified with the other "no Pod to fence against" answers rather
+        // than as an identity fault. It is not `LiftStatusStale`: nothing stale
+        // was read, there was nothing to read.
+        LauncherObservationError::StatusNotPopulated { .. } => {
+            DegradedUnleasedReason::LiftPodAbsent
+        }
         LauncherObservationError::Ambiguous(inner) => return apply_failure(inner),
         LauncherObservationError::Api(_) => DegradedUnleasedReason::ResizeSurfaceUnavailable,
     };

--- a/server/crates/djinn-db/src/repositories/build_pod_permit.rs
+++ b/server/crates/djinn-db/src/repositories/build_pod_permit.rs
@@ -109,6 +109,17 @@ pub(crate) const NONTERMINAL_RESIZE_STATES: [BuildPodPermitState; 6] = [
     BuildPodPermitState::Quarantined,
 ];
 
+/// The two states a permit occupies *before* the resize birth capture.
+///
+/// Deliberately the complement of [`NONTERMINAL_RESIZE_STATES`] within the
+/// unreleased set: together the two lists cover every state a live permit can be
+/// in, so a row cannot fall between the reconciler's two scans and be reaped by
+/// neither.
+pub(crate) const PRE_BIRTH_STATES: [BuildPodPermitState; 2] = [
+    BuildPodPermitState::Acquired,
+    BuildPodPermitState::JobCreated,
+];
+
 /// Render states as a SQL literal list body, e.g. `'lifted', 'quarantined'`.
 ///
 /// The spellings come from [`BuildPodPermitState::as_str`], which migration
@@ -679,6 +690,45 @@ impl BuildPodPermitRepository {
              WHERE state IN ({nonterminal}) \
              ORDER BY acquired_at, task_run_id"
         ))
+        .fetch_all(self.db.pool())
+        .await?
+        .into_iter()
+        .map(TryInto::try_into)
+        .collect()
+    }
+
+    /// List permits that never reached the resize lifecycle and have not moved
+    /// for `older_than`.
+    ///
+    /// # The gap this closes
+    ///
+    /// [`Self::list_nonterminal_resize`] scans the six states from migration 164
+    /// — every one of which is *past* the birth capture. A permit that is
+    /// refused, or whose dispatch dies, before `capture_resize_identity` ever
+    /// succeeds never enters that set: it rests at `acquired` or `job_created`
+    /// with `pod_uid IS NULL` and is invisible to the reconciler forever. On
+    /// 2026-08-02 production held 70 such rows, the oldest ~10 hours, against
+    /// three live task-run Jobs, and nothing in the system could see them.
+    ///
+    /// `pod_uid IS NULL` is part of the predicate rather than an assumption: it
+    /// is what makes a returned row *provably* pre-capture, so a caller can
+    /// retire it without racing the resize lifecycle for a Pod it never owned.
+    ///
+    /// Ordered oldest-first so a bounded pass drains the worst backlog first.
+    pub async fn list_pre_birth_stranded(
+        &self,
+        older_than: Duration,
+    ) -> DbResult<Vec<BuildPodPermitRow>> {
+        self.db.ensure_initialized().await?;
+        let pre_birth = sql_state_list(&PRE_BIRTH_STATES);
+        sqlx::query_as::<_, DbRow>(&format!(
+            "SELECT {ROW_COLUMNS} FROM build_pod_permits \
+             WHERE state IN ({pre_birth}) \
+               AND pod_uid IS NULL \
+               AND state_changed_at <= now() - make_interval(secs => $1) \
+             ORDER BY state_changed_at, task_run_id"
+        ))
+        .bind(older_than.as_secs_f64())
         .fetch_all(self.db.pool())
         .await?
         .into_iter()

--- a/server/crates/djinn-k8s/src/pod_resize_fixture.rs
+++ b/server/crates/djinn-k8s/src/pod_resize_fixture.rs
@@ -195,6 +195,58 @@ impl StoredTaskRunPod {
         ))
     }
 
+    /// The production race of 2026-08-02: the Pod object exists and its spec
+    /// names the launcher, but the kubelet has not written
+    /// `status.initContainerStatuses` yet — the array is **empty**.
+    ///
+    /// This is not a broken Pod. It is a healthy Pod observed a second or two
+    /// early, and [`Self::kubelet_publishes_status`] turns it into the same
+    /// object [`Self::resize_v2`] serves. A gate that treats this shape as a
+    /// permanent verdict leaves the launcher at `ceiling` forever.
+    #[must_use]
+    pub fn resize_v2_status_not_populated(pod_uid: &str, ceiling: &str) -> Self {
+        Self::new(build_pod(
+            pod_uid,
+            json!([
+                init_container("preflight", None, None),
+                init_container("cgroup-launcher", Some(ceiling), Some("resize-v2")),
+            ]),
+            json!([]),
+        ))
+    }
+
+    /// The kubelet catches up and publishes the init-container statuses.
+    ///
+    /// After this the cluster serves exactly what [`Self::resize_v2`] serves, so
+    /// a test can assert that the *same* Pod becomes governable rather than
+    /// asserting against a differently-shaped fixture.
+    pub fn kubelet_publishes_status(&self, ceiling: &str) {
+        let mut state = self.state.lock().expect("cluster");
+        let statuses: Vec<k8s_openapi::api::core::v1::ContainerStatus> =
+            serde_json::from_value(json!([
+                init_status("preflight", None, Some("containerd://preflight")),
+                init_status(
+                    "cgroup-launcher",
+                    Some(ceiling),
+                    Some("containerd://launcher")
+                ),
+            ]))
+            .expect("init container statuses");
+        let ClusterState {
+            pod,
+            pod_on_admission,
+            ..
+        } = &mut *state;
+        for pod in [pod.as_mut(), pod_on_admission.as_mut()]
+            .into_iter()
+            .flatten()
+        {
+            pod.status
+                .get_or_insert_with(Default::default)
+                .init_container_statuses = Some(statuses.clone());
+        }
+    }
+
     /// A `leaf-v1` Pod. It carries **no** launcher CPU limit, because
     /// `resolve_launcher_cpu_ceiling` returns `Ok(None)` for `leaf-v1` — a limit
     /// there is an ancestor clamp over every invocation leaf.

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -2190,10 +2190,16 @@ pub struct ObservedLauncherSidecar {
 
 /// Why a stored Pod could not be flattened into an [`ObservedLauncherSidecar`].
 ///
-/// Both variants are failures, but they are not the same failure: `Incomplete`
-/// describes a Pod that has not finished being admitted and may complete on the
-/// next read, while `Ambiguous` describes a Pod whose launcher cannot be *named*
-/// and never will be by waiting.
+/// These are failures, but they are not the *same* failure, and the difference
+/// decides whether a caller waits or gives up:
+///
+/// * `Incomplete` — the Pod has not finished being admitted; may complete on the
+///   next read.
+/// * `StatusNotPopulated` — the Pod exists and its spec names the launcher, but
+///   the kubelet has not written `status.initContainerStatuses` yet. **A wait,
+///   not a verdict.** See the variant's own docs.
+/// * `Ambiguous` — the launcher cannot be *named*, and no amount of waiting will
+///   change that.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum LauncherObservationError {
     /// A `metadata` field the fence depends on is not populated yet.
@@ -2202,12 +2208,65 @@ pub enum LauncherObservationError {
         /// The absent metadata field.
         field: &'static str,
     },
+    /// `status.initContainerStatuses` carries **zero** launcher entries, while
+    /// `spec.initContainers` names exactly one.
+    ///
+    /// # Why this is not `Ambiguous`
+    ///
+    /// A Pod's `spec` is written by the Job controller at creation; its
+    /// `status.initContainerStatuses` array is written by the kubelet, later,
+    /// after the Pod is bound to a node. Between those two events the launcher
+    /// is named in the spec and absent from the status — for seconds, routinely.
+    ///
+    /// Folding that window into `Ambiguous` is what production charged for on
+    /// 2026-08-02: the resize birth gate read a Pod three seconds after Kueue
+    /// unsuspended its Job, saw `found: 0` at the status site, refused
+    /// *permanently*, and left the Pod running at its full rendered `4` CPU with
+    /// no permit governing it and nothing that would ever retry. The launcher
+    /// was perfectly nameable one second later.
+    ///
+    /// Two or more entries is a different animal and stays [`Self::Ambiguous`]:
+    /// that one really cannot be resolved by waiting, and resolving it by
+    /// positional index would address the wrong container.
+    ///
+    /// The Pod identity is carried because the caller needs it precisely when it
+    /// gives up: a Pod that never became governable must be *destroyed*, and an
+    /// unfenced delete could destroy a replacement Pod some other actor owns.
+    #[error(
+        "launcher `{launcher_container_name}` is named in spec.initContainers but \
+         status.initContainerStatuses is not populated yet"
+    )]
+    StatusNotPopulated {
+        /// `metadata.uid` of the Pod that was read. Fences a delete.
+        pod_uid: String,
+        /// `metadata.name` of the Pod that was read.
+        pod_name: String,
+        /// The launcher container name located in `spec.initContainers`.
+        launcher_container_name: String,
+    },
     /// The launcher is not uniquely identifiable in the stored Pod.
     #[error("{0}")]
     Ambiguous(#[from] crate::pod_resize::PodResizeError),
     /// The apiserver read itself failed, or resolved to more than one Pod.
     #[error("{0}")]
     Api(String),
+}
+
+impl LauncherObservationError {
+    /// The Pod this failed observation read, when it read one and knows its UID.
+    ///
+    /// Only [`Self::StatusNotPopulated`] can answer: every other variant either
+    /// never reached a Pod object or could not establish which container it was
+    /// talking about.
+    #[must_use]
+    pub fn fenceable_pod(&self) -> Option<(&str, &str)> {
+        match self {
+            Self::StatusNotPopulated {
+                pod_uid, pod_name, ..
+            } => Some((pod_uid.as_str(), pod_name.as_str())),
+            _ => None,
+        }
+    }
 }
 
 /// Flatten a stored Pod into the launcher facts the resize bootstrap needs.
@@ -2232,7 +2291,23 @@ pub fn observe_launcher_sidecar(
         .ok_or(LauncherObservationError::Incomplete { field: "uid" })?;
 
     let spec = crate::pod_resize::locate_launcher_spec(pod)?;
-    let status = crate::pod_resize::locate_launcher_status(pod)?;
+    // Zero status entries is the kubelet being late, not the launcher being
+    // unnameable — the spec above just named it. Only that exact shape is a
+    // wait; two or more entries falls through to `Ambiguous` unchanged.
+    let status = match crate::pod_resize::locate_launcher_status(pod) {
+        Ok(status) => status,
+        Err(crate::pod_resize::PodResizeError::LauncherIdentityAmbiguous {
+            site: crate::pod_resize::LauncherIdentitySite::StatusInitContainerStatuses,
+            found: 0,
+        }) => {
+            return Err(LauncherObservationError::StatusNotPopulated {
+                pod_uid,
+                pod_name,
+                launcher_container_name: spec.name.clone(),
+            });
+        }
+        Err(error) => return Err(LauncherObservationError::Ambiguous(error)),
+    };
 
     // The declared limit is read through `declared_launcher_cpu_limit`, which is
     // documented as a spec read and explicitly NOT confirmation of anything. It
@@ -4469,6 +4544,82 @@ mod tests {
                     crate::pod_resize::PodResizeError::LauncherIdentityAmbiguous { found: 2, .. }
                 ))
             ));
+        }
+
+        /// The 2026-08-02 defect, at the layer that produced it.
+        ///
+        /// A Pod whose `spec.initContainers` names the launcher but whose
+        /// `status.initContainerStatuses` the kubelet has not written yet is a
+        /// **wait**, and must be reported as one. Folding it into `Ambiguous`
+        /// made the resize birth gate refuse permanently and leave the Pod
+        /// running at its full rendered ceiling.
+        ///
+        /// Non-vacuity: restore `let status = locate_launcher_status(pod)?;` in
+        /// `observe_launcher_sidecar` and this test fails — the error comes back
+        /// as `Ambiguous(LauncherIdentityAmbiguous { found: 0 })`, which is
+        /// precisely the production shape.
+        #[test]
+        fn an_unpopulated_status_array_is_a_wait_carrying_the_pod_identity() {
+            let observed = observe_launcher_sidecar(&pod(
+                vec![container(
+                    LAUNCHER_CONTAINER_NAME,
+                    Some("4000m"),
+                    Some("resize-v2"),
+                )],
+                vec![container("worker", Some("4"), None)],
+                // The kubelet has published nothing at all yet.
+                vec![],
+            ));
+            let Err(LauncherObservationError::StatusNotPopulated {
+                pod_uid,
+                pod_name,
+                launcher_container_name,
+            }) = observed
+            else {
+                panic!("expected StatusNotPopulated, got {observed:?}");
+            };
+            assert_eq!(launcher_container_name, LAUNCHER_CONTAINER_NAME);
+            // The identity must survive the failure: it is what lets a caller
+            // that gives up UID-fence a delete instead of leaving the Pod
+            // running ungoverned.
+            assert_eq!(pod_uid, "pod-uid-1");
+            assert_eq!(pod_name, "taskrun-pod");
+        }
+
+        /// The other half of the distinction, and the half that must NOT become
+        /// a wait: two entries carrying the launcher name cannot be resolved by
+        /// waiting, and resolving them by index would address the wrong
+        /// container.
+        ///
+        /// Non-vacuity: widen the new arm's guard from `found: 0` to any count
+        /// and this test fails.
+        #[test]
+        fn two_status_entries_stay_a_permanent_ambiguity() {
+            let observed = observe_launcher_sidecar(&pod(
+                vec![container(LAUNCHER_CONTAINER_NAME, Some("4000m"), None)],
+                vec![],
+                vec![
+                    status(LAUNCHER_CONTAINER_NAME, Some("c1"), Some("i")),
+                    status(LAUNCHER_CONTAINER_NAME, Some("c2"), Some("i")),
+                ],
+            ));
+            assert!(
+                matches!(
+                    observed,
+                    Err(LauncherObservationError::Ambiguous(
+                        crate::pod_resize::PodResizeError::LauncherIdentityAmbiguous {
+                            found: 2,
+                            ..
+                        }
+                    ))
+                ),
+                "two entries must remain a permanent refusal, got {observed:?}"
+            );
+            assert_eq!(
+                observed.expect_err("ambiguous").fenceable_pod(),
+                None,
+                "a genuinely unnameable launcher offers nothing to fence a delete against"
+            );
         }
 
         #[test]

--- a/server/src/task_run_resize_bootstrap.rs
+++ b/server/src/task_run_resize_bootstrap.rs
@@ -259,6 +259,23 @@ pub enum NotReady {
         /// Which status field is still absent.
         field: &'static str,
     },
+    /// The Pod's `spec.initContainers` names the launcher but the kubelet has
+    /// not written `status.initContainerStatuses` yet.
+    ///
+    /// Distinct from [`Self::LauncherNotStarted`] — there the status *entry*
+    /// exists and its fields are blank; here the array has no entry at all — and
+    /// emphatically distinct from
+    /// [`RefusalReason::LauncherNotNameable`], which is the permanent verdict
+    /// this variant exists to stop being conflated with. Two or more entries is
+    /// still that refusal.
+    #[error("launcher status is not populated yet: {detail}")]
+    LauncherStatusNotPopulated {
+        /// The Pod whose status is still empty. Carried so an expired budget can
+        /// UID-fence a delete instead of leaving it running ungoverned.
+        pod_uid: String,
+        /// Rendered observation error.
+        detail: String,
+    },
     /// The PATCH was accepted but the fresh init-container status does not
     /// agree yet. Backoff and the 30s confirmation deadline belong to `0ppk`.
     #[error("birth downsize not confirmed yet: {0}")]
@@ -287,12 +304,33 @@ impl NotReady {
     /// unavailability variants mean the observation did not happen at all. For
     /// those the caller must ask the Job whether it is queued — an apiserver
     /// that did not answer is *not* proof of a Kueue queue.
+    ///
+    /// [`Self::LauncherStatusNotPopulated`] belongs to the first group and its
+    /// membership is load-bearing: that is the variant a Pod sits in for the
+    /// seconds before the kubelet writes its init-container statuses, and it is
+    /// the birth budget — not an unbounded retry — that must bound the wait.
     #[must_use]
     pub const fn observed_a_pod(&self) -> bool {
         matches!(
             self,
-            Self::PodIncomplete(_) | Self::LauncherNotStarted { .. } | Self::BirthUnconfirmed(_)
+            Self::PodIncomplete(_)
+                | Self::LauncherNotStarted { .. }
+                | Self::LauncherStatusNotPopulated { .. }
+                | Self::BirthUnconfirmed(_)
         )
+    }
+
+    /// The Pod this outcome is waiting on, when it knows which one.
+    ///
+    /// Feeds [`TaskRunResizeBootstrap::abandon`]: a Pod whose launcher never
+    /// became observable still has to be destroyed when the budget runs out, and
+    /// the observation that failed is the only thing that ever knew its UID.
+    #[must_use]
+    pub fn fenceable_pod_uid(&self) -> Option<&str> {
+        match self {
+            Self::LauncherStatusNotPopulated { pod_uid, .. } => Some(pod_uid.as_str()),
+            _ => None,
+        }
     }
 }
 
@@ -650,6 +688,17 @@ impl TaskRunResizeBootstrap {
             Err(LauncherObservationError::Api(error)) => {
                 return BootstrapOutcome::NotReady(NotReady::KubernetesUnavailable(error));
             }
+            // The kubelet has not written `status.initContainerStatuses` yet.
+            // This is a WAIT, and it is bounded by the birth budget rather than
+            // by this arm — see `NotReady::observed_a_pod`. Refusing here is the
+            // 2026-08-02 defect: it left Pods running at their full rendered
+            // ceiling with no permit governing them and nothing that retried.
+            Err(ref error @ LauncherObservationError::StatusNotPopulated { ref pod_uid, .. }) => {
+                return BootstrapOutcome::NotReady(NotReady::LauncherStatusNotPopulated {
+                    pod_uid: pod_uid.clone(),
+                    detail: error.to_string(),
+                });
+            }
             Err(error @ LauncherObservationError::Ambiguous(_)) => {
                 // No Pod UID is available here by construction — the launcher
                 // could not be named, so there is nothing to fence a delete to.
@@ -917,8 +966,19 @@ impl TaskRunResizeBootstrap {
     /// option, because an unfenced delete can destroy a *replacement* Pod that
     /// some other actor legitimately owns.
     pub async fn abandon(&self, permit: &PermitBinding, reason: &str) -> PodDisposition {
-        let observed = match self.surface.observe_launcher(&permit.task_run_id).await {
-            Ok(Some(observed)) => observed,
+        // A failed observation is not automatically an unfenceable one. The
+        // budget most often expires on a Pod whose launcher was never observable
+        // — that is the whole failure mode this path exists for — and such a Pod
+        // is exactly the one that must not survive: nothing downstream will ever
+        // clamp it, so leaving it alive leaves a task-run Pod holding its full
+        // rendered ceiling forever. `fenceable_pod` recovers the UID the failed
+        // observation read but could not use.
+        let pod_uid = match self.surface.observe_launcher(&permit.task_run_id).await {
+            Ok(Some(observed)) => observed.pod_uid,
+            Err(ref error) if error.fenceable_pod().is_some() => {
+                let (pod_uid, _) = error.fenceable_pod().expect("checked by the guard");
+                pod_uid.to_owned()
+            }
             Ok(None) | Err(_) => {
                 warn!(
                     task_run_id = %permit.task_run_id,
@@ -930,11 +990,11 @@ impl TaskRunResizeBootstrap {
         };
         let deleted = self
             .surface
-            .uid_fenced_delete(&permit.task_run_id, &observed.pod_uid)
+            .uid_fenced_delete(&permit.task_run_id, &pod_uid)
             .await;
         warn!(
             task_run_id = %permit.task_run_id,
-            pod_uid = %observed.pod_uid,
+            pod_uid = %pod_uid,
             reason,
             delete_failed = deleted.is_err(),
             "task_run_resize_bootstrap: abandoning dispatch and UID-fenced deleting the Pod"

--- a/server/src/task_run_resize_drop.rs
+++ b/server/src/task_run_resize_drop.rs
@@ -562,6 +562,20 @@ impl TaskRunResizeDrop {
                 );
                 return FenceOutcome::Retry(DegradedUnleasedReason::LiftPodAbsent);
             }
+            // The kubelet has not published the launcher's init-container status
+            // yet. A drop CONFIRMS through that array, so there is nothing to
+            // read — but nothing is wrong with the Pod either, and quarantining
+            // it for a status the kubelet simply has not written yet would
+            // condemn a healthy launcher for being observed early. Retry inside
+            // the confirmation budget; the budget's own expiry still quarantines.
+            Err(LauncherObservationError::StatusNotPopulated { .. }) => {
+                warn!(
+                    task_run_id = %subject.task_run_id,
+                    "task_run_resize_drop: launcher init-container status is not populated yet; \
+                     retrying"
+                );
+                return FenceOutcome::Retry(DegradedUnleasedReason::LiftPodAbsent);
+            }
             Err(LauncherObservationError::Ambiguous(_)) => {
                 return FenceOutcome::Quarantine(DegradedUnleasedReason::LiftIdentityAmbiguous);
             }

--- a/server/src/task_run_resize_reconcile.rs
+++ b/server/src/task_run_resize_reconcile.rs
@@ -174,6 +174,27 @@ pub const DEFAULT_ROW_BUDGET: Duration = Duration::from_secs(45);
 /// handler that owns it is still inside its own wait.
 pub const DROP_TRANSIT_GRACE: Duration = Duration::from_secs(DROP_GATE_BUDGET.as_secs() * 2);
 
+/// How long a permit may rest at `acquired` or `job_created` before this module
+/// is allowed to conclude that no dispatch will ever advance it.
+///
+/// Must exceed the dispatch path's own birth window, or the reaper would retire
+/// a permit out from under a bootstrap that is still legitimately waiting for
+/// the kubelet. That window is
+/// [`crate::task_run_resize_bootstrap::QUEUE_ADMISSION_BUDGET_DEFAULT`] (Kueue
+/// queue time) plus
+/// [`crate::task_run_resize_bootstrap::BIRTH_ADMISSION_BUDGET_DEFAULT`] (the
+/// launcher's own clock), so the grace is derived from both rather than written
+/// as a number — a longer queue budget must widen this automatically.
+///
+/// The margin on top is deliberate: being late to reap a dead row costs one
+/// row's worth of capacity accounting, while being early costs a live task run
+/// its permit.
+pub const PRE_BIRTH_STRAND_GRACE: Duration = Duration::from_secs(
+    crate::task_run_resize_bootstrap::QUEUE_ADMISSION_BUDGET_DEFAULT.as_secs()
+        + crate::task_run_resize_bootstrap::BIRTH_ADMISSION_BUDGET_DEFAULT.as_secs()
+        + 300,
+);
+
 /// Environment variable naming the reconciler's per-tick mode.
 pub const MODE_ENV: &str = "DJINN_RESIZE_RECONCILE";
 
@@ -331,6 +352,13 @@ pub struct ResizeReconcilePass {
     pub unsettled: usize,
     /// `true` when the durable scan itself failed.
     pub scan_failed: bool,
+    /// Rows `list_pre_birth_stranded` returned.
+    pub pre_birth_scanned: usize,
+    /// Pre-birth permits this pass released, because no dispatch will ever
+    /// advance them and nothing else scans that state.
+    pub pre_birth_reaped: usize,
+    /// `true` when the pre-birth scan itself failed.
+    pub pre_birth_scan_failed: bool,
 }
 
 // ── The reconciler ─────────────────────────────────────────────────────────
@@ -496,7 +524,113 @@ impl TaskRunResizeReconciler {
                 pass.leases_released += 1;
             }
         }
+        self.reap_pre_birth(&mut pass, mode).await;
         pass
+    }
+
+    /// Release permits that never reached the birth capture and never will.
+    ///
+    /// # Why this is a second scan and not a widened first one
+    ///
+    /// The rows above are resumed: they own a Pod, a captured ceiling and an
+    /// unreleased `build_leases` row, so acting on one means driving a drop. A
+    /// pre-birth row owns none of that — `pod_uid IS NULL` is in the durable
+    /// predicate — so there is nothing to drop and the only correct action is to
+    /// let the permit go. Running them through `resume` would ask the drop
+    /// bridge to PATCH a Pod the row cannot name.
+    ///
+    /// # What bounds it
+    ///
+    /// Two independent facts, both worker-independent, and both required:
+    ///
+    /// 1. The row has not moved for [`PRE_BIRTH_STRAND_GRACE`], which is wider
+    ///    than the whole dispatch birth window. A bootstrap still inside its
+    ///    budget is not visible to this scan at all.
+    /// 2. The owning task run has ended. A run that is still live may be between
+    ///    dispatch attempts, and its permit is the dispatch path's to hold.
+    ///
+    /// Requiring both is what stops this from becoming the "reaper that killed
+    /// live builds": neither an old row with a live owner nor a young row with a
+    /// dead one is touched.
+    async fn reap_pre_birth(&self, pass: &mut ResizeReconcilePass, mode: ResizeReconcileMode) {
+        let rows = match self
+            .permits
+            .list_pre_birth_stranded(PRE_BIRTH_STRAND_GRACE)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(error) => {
+                warn!(
+                    %error,
+                    "task_run_resize_reconcile: the pre-birth permit scan failed; \
+                     stranded permits keep their capacity until the next tick"
+                );
+                pass.pre_birth_scan_failed = true;
+                return;
+            }
+        };
+        pass.pre_birth_scanned = rows.len();
+
+        for row in rows {
+            match self.owner_is_gone(&row.task_run_id).await {
+                Ok(true) => {}
+                // A live owner keeps its permit, however old the row is.
+                Ok(false) => {
+                    pass.skipped
+                        .push((row.task_run_id.clone(), SkipReason::OwnerLive));
+                    continue;
+                }
+                Err(()) => {
+                    pass.skipped
+                        .push((row.task_run_id.clone(), SkipReason::Unreadable));
+                    continue;
+                }
+            }
+            if !mode.acts() {
+                pass.would_resume += 1;
+                info!(
+                    task_run_id = %row.task_run_id,
+                    state = ?row.state,
+                    mode = mode.as_str(),
+                    state_age_secs = row.state_age().as_secs(),
+                    "task_run_resize_reconcile: would release this stranded pre-birth permit"
+                );
+                continue;
+            }
+            match self
+                .permits
+                .release(
+                    &row.task_run_id,
+                    &row.permit_id,
+                    row.fencing_token,
+                    "pre_birth_stranded",
+                )
+                .await
+            {
+                Ok(ReleaseBuildPodPermitResult::Released(_)) => {
+                    pass.pre_birth_reaped += 1;
+                    warn!(
+                        task_run_id = %row.task_run_id,
+                        state = ?row.state,
+                        state_age_secs = row.state_age().as_secs(),
+                        "task_run_resize_reconcile: released a permit that never reached the \
+                         resize birth capture; its dispatch is gone and no Pod was ever bound"
+                    );
+                }
+                Ok(ReleaseBuildPodPermitResult::AlreadyReleased(_)) => {}
+                Ok(ReleaseBuildPodPermitResult::Rejected) => {
+                    pass.skipped
+                        .push((row.task_run_id.clone(), SkipReason::ClaimLost));
+                }
+                Err(error) => {
+                    warn!(
+                        task_run_id = %row.task_run_id,
+                        %error,
+                        "task_run_resize_reconcile: the pre-birth permit could not be released"
+                    );
+                }
+            }
+        }
     }
 
     /// Retire the `build_pod_permits` row when nothing else ever will.

--- a/server/tests/task_run_resize_dispatch_seam.rs
+++ b/server/tests/task_run_resize_dispatch_seam.rs
@@ -1340,6 +1340,253 @@ async fn a_dispatch_that_was_never_queued_confirms_without_consulting_the_job() 
     assert_eq!(bridge.gate().dispatches_before_birth_confirmation(), 0);
 }
 
+// ── The 2026-08-02 defect: a late kubelet is a wait, not a verdict ────────
+//
+// Production ran 0.7.36 with 70 unreleased `build_pod_permits` rows, every one
+// of them `pod_uid IS NULL`, against three live task-run Jobs. The server logged
+//
+//   refused by the resize birth gate (pod_deleted=false): launcher identity is
+//   unusable: launcher identity ambiguous: expected exactly one `cgroup-launcher`
+//   entry in status.initContainerStatuses, found 0
+//
+// three seconds after Kueue unsuspended the Job. The Pod that refusal condemned
+// was read again minutes later and carried exactly one `cgroup-launcher` status
+// entry, `restartCount: 0`, `limits.cpu: 4` — never clamped, never governed, and
+// nothing anywhere retried it.
+
+/// A cluster whose kubelet publishes `status.initContainerStatuses` late.
+///
+/// It counts launcher observations and publishes on the Nth, so "the gate waited
+/// for the kubelet" is a call count rather than a wall-clock guess. Serving the
+/// *same* Pod before and after — see
+/// [`StoredTaskRunPod::kubelet_publishes_status`] — is what makes this a test
+/// about timing rather than about two differently-shaped fixtures.
+struct LateKubeletSurface {
+    cluster: StoredTaskRunPod,
+    publish_after: usize,
+    ceiling: &'static str,
+    launcher_observations: Arc<AtomicUsize>,
+}
+
+impl LateKubeletSurface {
+    fn new(cluster: &StoredTaskRunPod, publish_after: usize, ceiling: &'static str) -> Self {
+        Self {
+            cluster: cluster.clone(),
+            publish_after,
+            ceiling,
+            launcher_observations: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// A kubelet that never publishes at all.
+    fn never_publishes(cluster: &StoredTaskRunPod) -> Self {
+        Self {
+            cluster: cluster.clone(),
+            publish_after: usize::MAX,
+            ceiling: RENDERED_CEILING,
+            launcher_observations: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn launcher_observations(&self) -> usize {
+        self.launcher_observations.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl TaskRunPodSurface for LateKubeletSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        let seen = self.launcher_observations.fetch_add(1, Ordering::SeqCst) + 1;
+        if seen >= self.publish_after {
+            self.cluster.kubelet_publishes_status(self.ceiling);
+        }
+        self.cluster.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        self.cluster
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
+    }
+
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        self.cluster.job_admission()
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        self.cluster.uid_fenced_delete(task_run_id, pod_uid)
+    }
+}
+
+/// **The defect.** A Pod observed before its kubelet published
+/// `status.initContainerStatuses` is waited for, not refused — and when the
+/// statuses appear the launcher is clamped and the run dispatches.
+///
+/// Every assertion here is about state the mechanism *produced*: the launcher's
+/// actual CPU limit read back off the Pod, and the durable permit row's state
+/// and captured identity. No log line and no config value is asserted anywhere.
+///
+/// **Named mutation.** In `TaskRunResizeBootstrap::bootstrap`, replace the
+/// `Err(LauncherObservationError::StatusNotPopulated { .. })` arm's body with
+/// `BootstrapOutcome::Refused { reason:
+/// RefusalReason::LauncherNotNameable(error.to_string()), disposition:
+/// PodDisposition::Retained }` — `main`'s behaviour, one shared refusal for both
+/// counts. This test then fails at `drive_seam`, which returns the refusal
+/// instead of dispatching: `attaches()` is 0, the launcher is still at `4`, and
+/// the permit row is stuck at `job_created` with no identity — the exact
+/// production shape. Verified: under that mutation this test and
+/// `a_pod_that_never_becomes_governable_is_destroyed_rather_than_left_at_full_cpu`
+/// fail while all fourteen pre-existing tests in this file stay green, which is
+/// why the defect shipped.
+///
+/// *Deleting* the arm outright does not compile — the match on
+/// `observe_launcher` is exhaustive, so the enum split is additionally enforced
+/// by the type system.
+#[tokio::test]
+async fn a_pod_whose_kubelet_has_not_published_statuses_is_waited_for_and_then_clamped() {
+    const POD_UID: &str = "pod-uid-late-kubelet";
+    const JOB_UID: &str = "job-uid-late-kubelet";
+    /// Enough passes that a gate which refused on the first observation could
+    /// not possibly reach the clamp by accident.
+    const PUBLISH_AFTER: usize = 12;
+
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed(&db, "latekubelet").await;
+    let cluster = StoredTaskRunPod::resize_v2_status_not_populated(POD_UID, RENDERED_CEILING);
+
+    // The premise, established against the REAL observation function: this Pod
+    // exists, and reading it right now cannot name the launcher's status.
+    let premise = cluster.observe_launcher();
+    assert!(
+        matches!(
+            premise,
+            Err(LauncherObservationError::StatusNotPopulated { .. })
+        ),
+        "the fixture must actually model an unpopulated status array, got {premise:?}"
+    );
+
+    let surface = Arc::new(LateKubeletSurface::new(
+        &cluster,
+        PUBLISH_AFTER,
+        RENDERED_CEILING,
+    ));
+    let bridge = bridge_over(
+        &db,
+        surface.clone() as Arc<dyn TaskRunPodSurface>,
+        CONFIRMING_BUDGET,
+        PATIENT_QUEUE_BUDGET,
+    );
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::new(Some(JOB_UID), Some(LauncherAuthorityProtocol::ResizeV2));
+
+    drive_seam(runtime.clone(), &seeded, &context)
+        .await
+        .expect("a Pod whose kubelet is late must not be refused as unnameable");
+
+    // The gate genuinely waited across the window rather than winning a race.
+    assert!(
+        surface.launcher_observations() >= PUBLISH_AFTER,
+        "the gate must have re-observed the Pod at least {PUBLISH_AFTER} times; saw {}",
+        surface.launcher_observations()
+    );
+
+    // THE CLAMP. Read off the Pod, not off a constant: 250m, not the rendered 4.
+    assert_eq!(
+        CpuLimit::parse(
+            &cluster
+                .launcher_status_cpu()
+                .expect("the launcher reports a cpu limit")
+        )
+        .expect("the reported quantity parses")
+        .millis(),
+        BIRTH_MILLICORES,
+        "the launcher must end at the birth limit, not at the rendered ceiling"
+    );
+
+    // THE LEDGER. `job_created` with a NULL pod_uid is the production symptom;
+    // this row must be past it.
+    let row = BuildPodPermitRepository::new(db.clone())
+        .active(&seeded.spec.task_run_id)
+        .await
+        .expect("read permit")
+        .expect("the seam acquired a permit");
+    assert_eq!(row.state, BuildPodPermitState::BirthConfirmed);
+    let identity = row
+        .resize_identity
+        .expect("a birth-confirmed permit carries the captured identity");
+    assert_eq!(identity.pod_uid, POD_UID);
+    assert_eq!(
+        identity.admitted_cpu_millicores,
+        i64::try_from(
+            CpuLimit::parse(RENDERED_CEILING)
+                .expect("rendered ceiling parses")
+                .millis()
+        )
+        .expect("ceiling fits"),
+        "the captured ceiling is the admitted value the Pod declared"
+    );
+    assert_eq!(runtime.attaches(), 1, "the worker session started");
+    assert_eq!(bridge.gate().dispatches_before_birth_confirmation(), 0);
+}
+
+/// **Do not silently un-clamp.** A kubelet that never publishes leaves a Pod
+/// nothing can govern. The run is refused *and the Pod is destroyed*, rather
+/// than left alive holding its full rendered ceiling.
+///
+/// This is the half of the production defect that the retry alone does not fix:
+/// every refused run on 2026-08-02 logged `pod_deleted=false`, and those Pods
+/// were still running at `4` CPU hours later.
+///
+/// **Named mutation.** In `TaskRunResizeBootstrap::abandon`, delete the
+/// `Err(ref error) if error.fenceable_pod().is_some()` arm so an unreadable
+/// observation falls through to `PodDisposition::Retained`. The dispatch still
+/// fails, so a test asserting only the refusal stays green — this one fails on
+/// `deletes()`, which is empty, and on the surviving `4` CPU limit.
+#[tokio::test]
+async fn a_pod_that_never_becomes_governable_is_destroyed_rather_than_left_at_full_cpu() {
+    const POD_UID: &str = "pod-uid-mute-kubelet";
+    const JOB_UID: &str = "job-uid-mute-kubelet";
+
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let seeded = seed(&db, "mutekubelet").await;
+    let cluster = StoredTaskRunPod::resize_v2_status_not_populated(POD_UID, RENDERED_CEILING);
+    let surface = Arc::new(LateKubeletSurface::never_publishes(&cluster));
+    let bridge = bridge_over(
+        &db,
+        surface.clone() as Arc<dyn TaskRunPodSurface>,
+        GIVE_UP_BUDGET,
+        PATIENT_QUEUE_BUDGET,
+    );
+    let context = context_with(&db, &bridge);
+    let runtime = RecordingRuntime::new(Some(JOB_UID), Some(LauncherAuthorityProtocol::ResizeV2));
+
+    let refused = drive_seam(runtime.clone(), &seeded, &context)
+        .await
+        .expect_err("a launcher that never becomes observable must not dispatch");
+    let rendered = format!("{refused:#}");
+    assert!(
+        rendered.contains("not populated"),
+        "the refusal must name the unpopulated status, not a generic ambiguity: {rendered}"
+    );
+
+    // THE POINT. The ungovernable Pod is gone, UID-fenced to exactly the Pod
+    // that was observed.
+    assert_eq!(
+        cluster.deletes(),
+        vec![(seeded.spec.task_run_id.clone(), POD_UID.to_owned())],
+        "an unclampable Pod must be UID-fenced deleted, not left running ungoverned"
+    );
+    assert_eq!(runtime.attaches(), 0, "no worker session may have started");
+    assert_eq!(bridge.gate().dispatches_before_birth_confirmation(), 0);
+}
+
 /// The bootstrap type is still constructible and still composes — a compile-time
 /// statement only, kept so a refactor that changes its shape is caught here
 /// rather than in the bridge's private guts.

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -97,8 +97,8 @@ use djinn_k8s::runtime::{JobAdmission, LauncherObservationError, ObservedLaunche
 use djinn_server::task_run_resize_bootstrap::TaskRunPodSurface;
 use djinn_server::task_run_resize_drop::{ResizeDropClock, TaskRunResizeDropBridge};
 use djinn_server::task_run_resize_reconcile::{
-    DROP_TRANSIT_GRACE, ResizeReconcileGate, ResizeReconcileMode, SkipReason,
-    TaskRunResizeReconciler, run_loop,
+    DROP_TRANSIT_GRACE, PRE_BIRTH_STRAND_GRACE, ResizeReconcileGate, ResizeReconcileMode,
+    SkipReason, TaskRunResizeReconciler, run_loop,
 };
 use djinn_supervisor::services::{
     LeaseDeadlines, LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest,
@@ -2092,6 +2092,228 @@ async fn only_the_leader_reconciles_across_a_real_advisory_lock_race() {
 // ═══════════════════════════════════════════════════════════════════════════
 // Helpers
 // ═══════════════════════════════════════════════════════════════════════════
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The pre-birth strand: permits that never reached the resize lifecycle
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `list_nonterminal_resize` scans the six migration-164 states, every one of
+// them PAST the birth capture. A permit refused before `capture_resize_identity`
+// ever succeeded rests at `acquired` or `job_created` with `pod_uid IS NULL` and
+// is invisible to that scan forever. Production on 2026-08-02 held 70 such rows
+// — 58 `job_created`, 12 `acquired`, the oldest ~10 hours — against three live
+// task-run Jobs, and nothing in the system could see any of them.
+
+/// A reconciler for the pre-birth tests.
+///
+/// The drop bridge it carries is deliberately never exercised: a pre-birth row
+/// has no `pod_uid`, so there is no Pod to PATCH and the reaper must reach its
+/// decision without one. A test in which the bridge did work would be measuring
+/// the lifecycle path instead of the gap.
+fn pre_birth_reconciler(db: &Database) -> Arc<TaskRunResizeReconciler> {
+    let surface = Arc::new(CountingSurface::new(StoredTaskRunPod::resize_v2(
+        "pod-uid-never-observed",
+        "4",
+    )));
+    let bridge = Arc::new(TaskRunResizeDropBridge::with_surface(
+        db.clone(),
+        surface as Arc<dyn TaskRunPodSurface>,
+        Arc::new(RecordingClock::new()) as Arc<dyn ResizeDropClock>,
+    ));
+    Arc::new(TaskRunResizeReconciler::new(
+        db.clone(),
+        bridge,
+        None,
+        Arc::new(ArmedGate),
+    ))
+}
+
+/// Seed a permit that reached `job_created` and never captured an identity —
+/// the exact production shape, `pod_uid IS NULL` included.
+async fn pre_birth_permit(
+    permits: &BuildPodPermitRepository,
+    task_run_id: &str,
+) -> BuildPodPermitRow {
+    let row = match permits.acquire(task_run_id, 16).await {
+        AcquireBuildPodPermitResult::Acquired { row, .. } => row,
+        other => panic!("unexpected acquire outcome: {other:?}"),
+    };
+    let bound = match permits
+        .bind_or_refresh_job_uid(
+            task_run_id,
+            &row.permit_id,
+            row.fencing_token,
+            "job-uid-pre-birth",
+        )
+        .await
+        .expect("bind job uid")
+    {
+        BindBuildPodPermitResult::Bound(row) => row,
+        other => panic!("unexpected bind outcome: {other:?}"),
+    };
+    assert_eq!(bound.state, BuildPodPermitState::JobCreated);
+    assert!(
+        bound.resize_identity.is_none(),
+        "the fixture must model a permit that never captured an identity"
+    );
+    bound
+}
+
+/// A permit stranded before the birth capture, whose task run has ended, is
+/// released — and the capacity it was holding comes back.
+///
+/// **Named mutation.** Delete the `self.reap_pre_birth(&mut pass, mode).await;`
+/// call from `TaskRunResizeReconciler::run_pass` (or the `permits.release(..)`
+/// call inside `reap_pre_birth`). This test then fails on the row state, which
+/// stays `job_created` forever — which is precisely what production did for ten
+/// hours. Note the assertion is on the ROW, not on `pass.pre_birth_reaped`: a
+/// counter can be incremented by a body that does nothing.
+#[tokio::test]
+async fn a_permit_stranded_before_the_birth_capture_is_released_once_its_owner_is_gone() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let (_task_id, task_run_id) = seed_task_run(&db, "prebirth-reap").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    let seeded = pre_birth_permit(&permits, &task_run_id).await;
+
+    // The two facts the reaper requires, both worker-independent.
+    kill_the_worker(&db, &task_run_id).await;
+    permits
+        .backdate_state_change_for_test(
+            &task_run_id,
+            PRE_BIRTH_STRAND_GRACE + Duration::from_secs(60),
+        )
+        .await
+        .expect("backdate the strand");
+
+    // The premise: this row is invisible to the lifecycle scan the reconciler
+    // has always had. If this ever stops holding, the reaper is redundant and
+    // this whole path should be reconsidered rather than kept.
+    assert!(
+        permits
+            .list_nonterminal_resize()
+            .await
+            .expect("nonterminal scan")
+            .iter()
+            .all(|row| row.task_run_id != task_run_id),
+        "a pre-birth permit must NOT be reachable through list_nonterminal_resize; \
+         if it is, this test is no longer measuring the gap it was written for"
+    );
+
+    let pass = pre_birth_reconciler(&db).run_pass().await;
+
+    assert_eq!(pass.pre_birth_reaped, 1, "one row was reaped");
+    assert!(!pass.pre_birth_scan_failed);
+
+    // THE STATE THE MECHANISM PRODUCED, read back from Postgres.
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Released,
+        "the stranded permit must be released, not left at job_created"
+    );
+
+    // And the consequence that actually matters: the capacity it was holding is
+    // back. This is the number production had wrong — 70 permits occupying the
+    // pool against three live Jobs.
+    assert_eq!(
+        permits.active_count().await.expect("active count"),
+        0,
+        "a released permit must stop occupying build-pod capacity"
+    );
+
+    // The row is not resurrectable under the same task run, so the reap is
+    // final rather than a state a later actor can undo.
+    assert!(
+        matches!(
+            permits.acquire(&task_run_id, 16).await,
+            AcquireBuildPodPermitResult::AlreadyReleased { .. }
+        ),
+        "a reaped permit must stay released; the seeded token was {}",
+        seeded.fencing_token
+    );
+}
+
+/// The reaper is a WINDOW, not a blanket. A permit that is equally old but whose
+/// task run is still live belongs to the dispatch path, and is left alone.
+///
+/// Without this, "reap old pre-birth permits" would retire the permit of every
+/// run sitting in a long Kueue queue — the failure mode that turns a leak fix
+/// into an outage.
+///
+/// **Named mutation.** In `reap_pre_birth`, drop the `owner_is_gone` guard (make
+/// the `Ok(false)` arm fall through instead of `continue`). This test then fails:
+/// the live run's permit comes back `released`.
+#[tokio::test]
+async fn a_pre_birth_permit_whose_task_run_is_still_live_is_never_reaped() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let (_task_id, task_run_id) = seed_task_run(&db, "prebirth-live").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    pre_birth_permit(&permits, &task_run_id).await;
+
+    // Old enough to be scanned — and deliberately NOT terminalised.
+    permits
+        .backdate_state_change_for_test(
+            &task_run_id,
+            PRE_BIRTH_STRAND_GRACE + Duration::from_secs(60),
+        )
+        .await
+        .expect("backdate the strand");
+
+    let pass = pre_birth_reconciler(&db).run_pass().await;
+
+    assert_eq!(
+        pass.pre_birth_scanned, 1,
+        "the row must actually have been scanned, or this test proves nothing about the guard"
+    );
+    assert_eq!(pass.pre_birth_reaped, 0);
+    assert_eq!(
+        permits
+            .active(&task_run_id)
+            .await
+            .expect("read permit")
+            .expect("permit row")
+            .state,
+        BuildPodPermitState::JobCreated,
+        "a live task run keeps its permit however old the row is"
+    );
+}
+
+/// A pre-birth permit younger than the grace is not even returned by the scan,
+/// whatever its owner's status.
+///
+/// The grace is wider than the whole dispatch birth window
+/// (`QUEUE_ADMISSION_BUDGET_DEFAULT + BIRTH_ADMISSION_BUDGET_DEFAULT`), so a
+/// bootstrap still legitimately waiting for a late kubelet cannot have its
+/// permit retired out from under it.
+///
+/// **Named mutation.** Remove the `state_changed_at <= now() - ...` predicate
+/// from `list_pre_birth_stranded`. This test then fails on `pre_birth_scanned`.
+#[tokio::test]
+async fn a_recent_pre_birth_permit_is_below_the_grace_and_is_not_scanned() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let (_task_id, task_run_id) = seed_task_run(&db, "prebirth-young").await;
+    let permits = BuildPodPermitRepository::new(db.clone());
+    pre_birth_permit(&permits, &task_run_id).await;
+    // Terminal owner, so the ONLY thing standing between this row and the
+    // reaper is its age.
+    kill_the_worker(&db, &task_run_id).await;
+
+    let pass = pre_birth_reconciler(&db).run_pass().await;
+
+    assert_eq!(
+        pass.pre_birth_scanned, 0,
+        "a permit inside the dispatch birth window must not be scanned at all"
+    );
+    assert_eq!(pass.pre_birth_reaped, 0);
+    assert_eq!(
+        permits
+            .active(&task_run_id)
+            .await
+            .expect("read permit")
+            .expect("permit row")
+            .state,
+        BuildPodPermitState::JobCreated
+    );
+}
 
 /// Poll `condition` until it holds, or fail the test after 30 seconds.
 async fn wait_until<F, Fut>(mut condition: F)


### PR DESCRIPTION
## The symptom

Task-run Pods running at their full rendered `4` CPU with **no permit governing them**. Production `0.7.36` held **70 unreleased `build_pod_permits` rows** — 58 `job_created`, 12 `acquired`, every one with `pod_uid IS NULL`, the oldest ~10 hours — against **three** live task-run Jobs.

## Proven root cause

`observe_launcher_sidecar` requires the launcher to be uniquely nameable in **both** `spec.initContainers` and `status.initContainerStatuses`. `locate_launcher_status` returns the same `LauncherIdentityAmbiguous` error for **zero** entries as for **two**.

A Pod's `spec` is written by the Job controller at creation. Its `status.initContainerStatuses` is written by the **kubelet**, later, after the Pod is bound to a node. Between those two events the launcher is named in the spec and absent from the status — routinely, for seconds.

The birth gate folded that window into a permanent `Refused`, and the bridge's wait loop returns from `Refused` immediately. From the live server log:

```
02:36:19.151  Job is suspended in the Kueue admission queue; the launcher birth budget is not running
02:36:22.357  refused by the resize birth gate (pod_deleted=false): launcher identity is unusable:
              launcher identity ambiguous: expected exactly one `cgroup-launcher` entry in
              status.initContainerStatuses, found 0
```

**Three seconds.** The permit stayed at `job_created` with a NULL `pod_uid`, no clamp was ever applied, `pod_deleted=false` left the Pod alive, and nothing anywhere retried.

### The evidence that closes it

The Pod that refusal condemned, read minutes later:

```
specLimit=4   statusNames=cgroup-launcher svc-postgres   statusLimit=4   restarts=0
```

Exactly **one** `cgroup-launcher` status entry — so the launcher was perfectly nameable a second later — and `limits.cpu` still `4` in both spec and status with `restartCount: 0`, i.e. never clamped.

The permit differential rules out the "lifted Pods also read 4" trap; only the ledger distinguishes them:

| task run | state | captured | ceiling |
|---|---|---|---|
| `019fc059` | `job_created` | **false** | — |
| `019fc061` | `birth_confirmed` | true | 4000 |
| `019fc062` | `birth_confirmed` | true | 4000 |

### Not a regression from today's PRs

The refusal arm dates to #2844, not #2886/#2893/#2894/#2897. But **#2897 made it reachable**: before it, queue time consumed the birth budget and dispatches were refused *during the Kueue queue*, which masked this. Removing that failure exposed the one behind it.

## The fix

1. **`LauncherObservationError::StatusNotPopulated`** — zero status entries where the spec names the launcher. Carries the Pod identity, because the caller needs it precisely when it gives up. **Two or more entries stays `Ambiguous` and still fails closed.** Separate variant, separate code path, separate log line. The match on `observe_launcher` is exhaustive, so the split is additionally enforced by the type system.
2. **The birth gate maps it to a retryable `NotReady`** whose `observed_a_pod()` is true, so the birth budget arms and the wait is *bounded* rather than either unbounded or instant.
3. **`abandon` recovers the UID from the failed observation**, so a Pod that never becomes governable is UID-fenced deleted rather than left running at its full ceiling. This is the half a retry alone does not fix — every refused run logged `pod_deleted=false`.
4. **The drop path retries** an unpopulated status instead of quarantining a healthy launcher for being observed early.
5. **A pre-birth reaper.** `list_nonterminal_resize` scans only the six post-capture states, so `acquired`/`job_created` rows were invisible to the reconciler *forever*. `list_pre_birth_stranded` finds them; they are released only when the row has outlived the whole dispatch birth window (`QUEUE_ADMISSION_BUDGET + BIRTH_ADMISSION_BUDGET + 300s`, derived not hardcoded) **and** the task run has ended. **No migration. No row is deleted.**

### Why retry rather than reconcile, for the primary path

The clamp must land *before* dispatch, and only the dispatch path can gate on it. Retrying is therefore the correct primary answer. The reaper is the backstop for rows whose dispatch is already gone, where clamping serves nobody.

## Tests

Every assertion is on **state the mechanism produced** — the launcher's CPU limit read back off the Pod, the permit row's state and captured identity, reclaimed capacity — never a log line or a config value. Each test names the mutation that breaks it, and each was **verified by actually applying it**:

| Mutation | Result |
|---|---|
| Fold `StatusNotPopulated` back into the refusal | Both new seam tests fail; **all 14 pre-existing tests stay green** — which is why this shipped |
| Delete `abandon`'s `fenceable_pod` arm | Only `a_pod_that_never_becomes_governable_is_destroyed_...` fails |
| Remove the `reap_pre_birth` call | Only the reaper tests fail (19 others green) |
| Restore `locate_launcher_status(pod)?` | Only `an_unpopulated_status_array_is_a_wait_...` fails (6 others green) |

The end-to-end tests enter through `execute_runtime_report_phase` — the production dispatch seam — against real Postgres and the real `observe_launcher_sidecar` / `PodResizeClient`, with only the apiserver transport substituted.

```
task_run_resize_dispatch_seam   16 passed
task_run_resize_recovery        21 passed
task_run_resize_faults           5 passed
task_run_resize_cycles          16 passed
task_run_resize_mixed_version   22 passed
task_run_resize_rollout         21 passed
djinn-k8s --lib                371 passed
djinn-coordinator resize        26 passed
djinn-server --lib resize       32 passed
djinn-db permit repo            10 passed
```

`cargo clippy --workspace --all-targets` clean; `cargo fmt --all` applied.

## The already-stuck rows

Left to the reaper — code with tests, not a migration. The 12 `acquired` rows share an identical `state_changed_at` because **migration 170 backfilled the column at deploy**, not because they froze simultaneously; the 58 `job_created` rows have 48 distinct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)