### PR TITLE
docs(helm): correct cgroup launcher default marker

### DIFF
--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -237,14 +237,14 @@ kueue:
 # is lifted to the pod's full CPU limit only once it demonstrates it is actually
 # CPU-hungry.
 #
-#   required            — render the cgroup-launcher sidecar. The launcher
+#   required  (default) — render the cgroup-launcher sidecar. The launcher
 #                         establishes its own delegated cgroup v2 root at
 #                         startup, which needs `SYS_ADMIN` plus an AppArmor
 #                         opt-out for the duration of that bootstrap; it drops
 #                         the capability irreversibly out of its bounding set
 #                         before the broker accepts any work, which is the only
 #                         layer under it and is verified at runtime.
-#   disabled  (default) — explicit local/development compatibility: no sidecar,
+#   disabled            — explicit local/development compatibility: no sidecar,
 #                         cgroup leaf, or lease; shell commands run in-process
 #                         at the pod's own quota.
 #


### PR DESCRIPTION
## Summary

- move the inline `(default)` marker from `cgroupLauncher.mode: disabled` to `required`
- retain the post-#2903 safety documentation covering the 2026-07-29 outage, fail-closed dispatch validation, node conformance/label requirements, AppArmor and user-namespace constraints, and the install-time prerequisite guard
- change documentation only; no Helm value or template changes

## Verification

Verified against `origin/main` after #2903 landed as `861b2d15f`.

```text
$ bash scripts/test-helm-chart-contracts.sh
19 of 21 Helm chart contract scripts passed.
FAIL deploy/helm/djinn/tests/incident-observability-contract.sh: vector is required to execute VRL fixtures
FAIL deploy/helm/djinn/tests/log-collector-contract.sh: vector is required to execute VRL fixtures
FAIL: 2 of 21 Helm chart contract scripts failed
```

The two failures are environment prerequisites unrelated to this comment-only change. The cgroup writable, prerequisite guard, and all other Helm rendering contracts passed.

```text
$ git diff --check
# no output
```
