### PR TITLE
fix(kueue): let borrowed background work finish

### DIFF
--- a/deploy/helm/djinn/templates/kueue-topology.yaml
+++ b/deploy/helm/djinn/templates/kueue-topology.yaml
@@ -58,7 +58,7 @@ metadata:
 spec:
   cohort: {{ $cohortName }}
   preemption:
-    reclaimWithinCohort: Any
+    reclaimWithinCohort: Never
   # WHO MAY SUBMIT — and the reason this line is not optional.
   #
   # MEASURED on a live armed kind cluster (fbiy-B1, 2026-07-30): with this field

--- a/deploy/helm/djinn/tests/kueue-topology-render.sh
+++ b/deploy/helm/djinn/tests/kueue-topology-render.sh
@@ -614,8 +614,9 @@ queue = queue_by_name["kueue-topology-test-djinn-kueue"]
 spec = queue["spec"]
 cohort = spec.get("cohort")
 assert cohort and all(q["spec"].get("cohort") == cohort for q in queues), "all queues must share one cohort"
-assert spec.get("preemption") == {"reclaimWithinCohort": "Any"}, (
-    f"task-run must reclaim its nominal capacity with Any, got {spec.get('preemption')}"
+assert spec.get("preemption") == {"reclaimWithinCohort": "Never"}, (
+    "kueue-topology-test-djinn-kueue must let admitted background work run to completion "
+    f"with reclaimWithinCohort Never, got {spec.get('preemption')}"
 )
 # BestEffortFIFO, not StrictFIFO: three kinds share a 3-slot queue, so one
 # head-of-line Workload that cannot fit would block everything behind it.


### PR DESCRIPTION
## Summary

Change only the task ClusterQueue (`<fullname>-kueue`) from `reclaimWithinCohort: Any` to `Never`.

Warm and SCIP still reserve no binding quota (`nominalQuota: 0`), can borrow at most one unit (`borrowingLimit: 1`), and cannot reclaim task capacity. Once either background workload is admitted into genuinely idle cohort capacity, the task queue can no longer evict it through `InCohortReclamation`, so it can run to completion.

## Production evidence

On 2026-08-02 a warm Workload waited behind tasks, borrowed a pod after a task completed, then was evicted about five minutes later when a new task arrived:

- `Preempted=True`, reason `InCohortReclamation`
- `Requeued=True`
- `QuotaReserved=False`

Because the background queues have zero nominal quota, every admitted warm or SCIP pod is borrowed and therefore structurally eligible for task-queue reclamation while the task queue uses `Any`. A warm takes about 5,442 seconds, so this can discard up to roughly 90 minutes of partial compile work and repeat indefinitely under steady task arrivals.

## Tradeoff

The cohort contributes 3 binding units total (`kueue.buildPods: 3`); warm and SCIP contribute zero. With task reclamation disabled, warm(1) plus SCIP(1) can hold two of those three units, leaving one concurrent task-run, and nothing can claw those two units back.

This overlap is reachable, though uncommon:

- SCIP defers to warm. `observe_including_warm` folds `warm_in_flight` into its observation, and a warm-lister error fails closed: the observation becomes unavailable and scheduling resolves to `SkipInventoryUnavailable`.
- Warm does not defer to SCIP. `graph_warmer.rs` checks warm-versus-warm only, and its warm lister error fails open.

Therefore this PR does not claim warm+SCIP concurrency is impossible; it accepts the bounded 2-of-3 case in exchange for admitted background work completing.

## Tests

- `bash deploy/helm/djinn/tests/kueue-topology-render.sh` — PASS
- Mutation proof: temporarily changing the chart source back from `Never` to `Any` makes the topology test exit 1 with `kueue-topology-test-djinn-kueue ... expected ... Never, got ... Any`.
- `bash scripts/test-helm-chart-contracts.sh` — 19/21 PASS, including `kueue-topology-render.sh`. The two unrelated VRL suites fail because `vector` is not installed in the local environment:
  - `incident-observability-contract.sh`: `FAIL: vector is required to execute VRL fixtures`
  - `log-collector-contract.sh`: `FAIL: vector is required to execute VRL fixtures`

A targeted Rust test attempt for the SCIP/warm asymmetry could not compile locally because SQLx query macros could not reach the development database (`Connection refused`); the existing tests and production paths were inspected directly.

## Acceptance / mutation map

- Task queue cannot reclaim admitted background work: mutate `deploy/helm/djinn/templates/kueue-topology.yaml` from `Never` back to `Any`; `kueue-topology-render.sh` fails and names `kueue-topology-test-djinn-kueue`.
- The assertion is non-vacuous for deletion too: delete the task queue `preemption` body; the same exact-object assertion fails with the queue name and the missing/changed value.
- Cohort membership: remove or change any queue cohort in the template; the existing shared-cohort assertion fails.
- Zero background binding quota: change warm or SCIP binding `nominalQuota: 0`; the queue-specific background quota assertion fails.
- Bounded borrowing: change warm or SCIP `borrowingLimit: 1`; the queue-specific background borrowing assertion fails.
- Background non-preemption: add a `preemption` body to warm or SCIP; the queue-named background assertion fails.

No quota dimension, binding-resource, LocalQueue, warm, or SCIP manifest field changes in this PR.