### PR TITLE
ci: harden infrastructure failure handling

### DIFF
--- a/.github/workflows/memory-qa-nightly.yml
+++ b/.github/workflows/memory-qa-nightly.yml
@@ -57,7 +57,7 @@ jobs:
       DJINN_MEMORY_QA_SKIP_JUDGE: ${{ github.event.inputs.qa_run_only == 'true' && '1' || '' }}
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: djinn
@@ -178,8 +178,9 @@ jobs:
 
       - name: Write Phase 2 job summary
         if: always()
+        working-directory: ${{ github.workspace }}
         run: |
-          SUMMARY="target/memory-eval/phase2-qa-summary.md"
+          SUMMARY="server/target/memory-eval/phase2-qa-summary.md"
           if [[ -f "$SUMMARY" ]]; then
             cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
           else

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -437,9 +437,11 @@ jobs:
       # server-sqlx-freshness.
       - name: Report warm footprint
         if: always()
+        working-directory: ${{ github.workspace }}
         run: |-
-          echo "::notice::warm-footprint target=$(du -sh target 2>/dev/null | cut -f1) free=$(df -h --output=avail . | tail -1 | tr -d ' ')"
+          echo "::notice::warm-footprint target=$(du -sh server/target 2>/dev/null | cut -f1) free=$(df -h --output=avail . | tail -1 | tr -d ' ')"
       - name: Log cache family and restore status
+        working-directory: ${{ github.workspace }}
         run: |-
           echo "cache-family=server-test"
           echo "shared-key=server-test"
@@ -933,9 +935,10 @@ jobs:
         run: cargo clippy --workspace --all-targets --features qdrant --keep-going -- -D warnings
       - name: Fingerprint census (after clippy)
         if: always()
+        working-directory: ${{ github.workspace }}
         run: |-
           before='${{ steps.fingerprints-restored.outputs.count }}'
-          after=$(ls target/debug/.fingerprint 2>/dev/null | wc -l)
+          after=$(ls server/target/debug/.fingerprint 2>/dev/null | wc -l)
           echo "::notice::clippy-fingerprints restored=${before:-0} after=${after} built=$((after - ${before:-0}))"
   # deploy/preflight/tests/ is a DEPLOY contract, not a Rust one, but it must
   # `cargo build -p djinn-k8s --bin render-gate` and shell out to `helm`, so it
@@ -1050,7 +1053,7 @@ jobs:
       DJINN_TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/postgres
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: djinn
@@ -1707,7 +1710,7 @@ jobs:
         working-directory: server
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: djinn
@@ -2048,6 +2051,7 @@ jobs:
         # nextest log is simply absent there, and the annotation then reports
         # that observation — it does NOT name a layer it cannot see.
         if: failure()
+        working-directory: ${{ github.workspace }}
         run: |
           set -uo pipefail
           # The parsing lives in a checked-in script, NOT in an inline
@@ -2215,7 +2219,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/djinn
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: djinn
@@ -2309,7 +2313,7 @@ jobs:
       SQLX_OFFLINE: "true"
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: djinn
@@ -2425,8 +2429,9 @@ jobs:
           retention-days: 30
       - name: Write job summary
         if: always()
+        working-directory: ${{ github.workspace }}
         run: |
-          SUMMARY="target/memory-eval/phase1-summary.md"
+          SUMMARY="server/target/memory-eval/phase1-summary.md"
           if [[ -f "$SUMMARY" ]]; then
             cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -2446,7 +2451,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/djinn_test_template
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/.github/workflows/resize-matrix.yml
+++ b/.github/workflows/resize-matrix.yml
@@ -73,7 +73,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: djinn

--- a/scripts/ci-qa-smoke-workflow.test.mjs
+++ b/scripts/ci-qa-smoke-workflow.test.mjs
@@ -236,7 +236,7 @@ test('qa-smoke owns only a restore-only test cache and a disposable database', (
   assert.match(source, /^ {10}save-if:\s*false\s*$/m, 'qa-smoke must remain a restore-only cache consumer');
   const postgres = jobService(qa, 'postgres');
   assert.ok(postgres, 'qa-smoke must own a local postgres service');
-  assert.match(postgres, /^ {8}image:\s*postgres:16\s*$/m,
+  assert.match(postgres, /^ {8}image:\s*public\.ecr\.aws\/docker\/library\/postgres:16\s*$/m,
     'qa-smoke postgres service must use the intended Postgres image');
   assert.match(postgres, /^ {10}-\s*5433:5432\s*$/m,
     'qa-smoke postgres service must expose the isolated 5433 host port');

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/ci_directive_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/ci_directive_tests.rs
@@ -509,6 +509,12 @@ fn failing_directive_names_the_ranked_lane_and_shows_its_annotation() {
             "No space left on device",
             "_diag/Worker_20260724-105745-utc.log",
             // And the worker is told what to do with an infra failure.
+            "context deadline exceeded",
+            "docker pull failed",
+            "toomanyrequests",
+            "registry 5xx",
+            "TLS/handshake timeout",
+            "Initialize containers",
             "retrigger CI and report the infrastructure failure",
         ],
     );

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context/ci_directive.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context/ci_directive.rs
@@ -112,8 +112,10 @@ fn build_ci_head_blocking_directive(task: &Task) -> Option<String> {
          > Blocking checks are listed in causal order. Later entries may be \
          cancelled siblings or aggregator jobs swept up by a run-level cancel; \
          fixing the first lane usually clears the rest. If the annotations \
-         above describe a runner-host problem rather than a code problem \
-         (for example `No space left on device`), the correct action is to \
+         above describe an infrastructure problem rather than a code problem \
+         (for example `No space left on device`, `context deadline exceeded`, \
+         `docker pull failed`, `toomanyrequests`, a registry 5xx or TLS/handshake \
+         timeout, or `Initialize containers` failing), the correct action is to \
          retrigger CI and report the infrastructure failure — NOT to change code."
     ))
 }


### PR DESCRIPTION
## Summary

- run failure-surfacing and other conditional shell diagnostics from the guaranteed workspace root so pre-checkout failures remain visible
- teach the CI remediation prompt to recognize container-registry and network infrastructure signatures
- move all seven PostgreSQL 16 service pulls from Docker Hub to the anonymous AWS Public ECR official-image mirror

## Registry choice

Selected `public.ecr.aws/docker/library/postgres:16`. GitHub Actions service containers accept registry-qualified image names, and an anonymous manifest request returned a valid 16-platform OCI index for this tag. I did not select `mirror.gcr.io`: Google documents it as a daemon-configured cache and does not guarantee a tag remains cached. I did not pin a digest because this repository has no automated digest updater; retaining the `:16` major tag preserves PostgreSQL 16 patch/security updates.

This reduces exposure to Docker Hub outages by moving these pulls to a separate public registry. It cannot prove behavior during a future registry outage.

## Verification

- `actionlint .github/workflows/*.yml` — passed
- `git diff --check` — passed
- registry sweep — exactly 7 Public ECR references across 3 workflows; no unqualified `image: postgres:16` remains
- `SQLX_OFFLINE=true cargo test -p djinn-agent failing_directive_names_the_ranked_lane_and_shows_its_annotation --lib` — passed (1 passed)
- `SQLX_OFFLINE=true cargo test -p djinn-agent ci_directive --lib` — 12 passed; 1 database-backed test could not create its test project because no local PostgreSQL was running
- initial command without `SQLX_OFFLINE=true` failed at SQLx macro expansion because no local PostgreSQL was running

Expected but not locally provable: GitHub-hosted service-container startup and resilience during a future Docker Hub or registry outage.