### PR TITLE
ci: use runner-provided PostgreSQL 16

### DIFF
--- a/.github/workflows/memory-qa-nightly.yml
+++ b/.github/workflows/memory-qa-nightly.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   memory-qa-phase2:
     name: Phase 2 Memory QA Judge
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:
       run:
@@ -55,19 +55,11 @@ jobs:
       # publish a credential-error artifact, never fall back anonymously.
       DJINN_MEMORY_QA_JUDGE_MODEL: ${{ github.event.inputs.judge_model || vars.DJINN_MEMORY_QA_JUDGE_MODEL || '' }}
       DJINN_MEMORY_QA_SKIP_JUDGE: ${{ github.event.inputs.qa_run_only == 'true' && '1' || '' }}
-    services:
-      postgres:
-        image: public.ecr.aws/docker/library/postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: djinn
-        ports:
-          - 5433:5432
-        options: >-
-          --health-cmd="pg_isready -U postgres"
-          --health-interval=5s --health-timeout=3s --health-retries=20
     steps:
       - uses: actions/checkout@v4
+      - name: Start PostgreSQL 16
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/ci-start-postgres.sh
 
       - run: rustup toolchain install
         working-directory: server

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -215,6 +215,8 @@ jobs:
         run: node --test scripts/ci-cache-policy.test.mjs
       - name: Verify qa-smoke workflow contract
         run: node --test scripts/ci-qa-smoke-workflow.test.mjs
+      - name: Verify host PostgreSQL workflow contract
+        run: node --test scripts/ci-host-postgres-workflow.test.mjs
       - name: Verify release image validation contract
         run: node --test scripts/ci-release-image-validation.test.mjs
       - name: Verify shard failure summary contract
@@ -1027,7 +1029,7 @@ jobs:
     # and the djinn-k8s crate, and every path that can change either lands in
     # the router's `rustCore` lane or fails closed into `unknown`.
     if: needs.preflight.outputs.clippy == 'true' && github.event_name != 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # The deploy contract builds one binary and shells out to helm; the Rust
     # proofs need a migrated Postgres template. 30 leaves margin for a cold
     # djinn-k8s chain without hiding a hang.
@@ -1051,17 +1053,11 @@ jobs:
       DJINN_CUTOVER_EXPECTED_PROOFS: "18"
       # The drain-fence proofs open template-cloned per-test databases here.
       DJINN_TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/postgres
-    services:
-      postgres:
-        image: public.ecr.aws/docker/library/postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: djinn
-        ports:
-          - 5433:5432
-        options: --health-cmd="pg_isready -U postgres" --health-interval=5s --health-timeout=3s --health-retries=20
     steps:
       - uses: actions/checkout@v4
+      - name: Start PostgreSQL 16
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/ci-start-postgres.sh
       # Pinned to the same v3.12.3 deploy-render-gate installs — two lanes
       # rendering the same chart on different helm majors is a contract that
       # means nothing.
@@ -1664,7 +1660,7 @@ jobs:
     needs:
       - preflight
     if: needs.preflight.outputs.serverTest == 'true' && github.event_name != 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -1708,17 +1704,11 @@ jobs:
     defaults:
       run:
         working-directory: server
-    services:
-      postgres:
-        image: public.ecr.aws/docker/library/postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: djinn
-        ports:
-          - 5433:5432
-        options: --health-cmd="pg_isready -U postgres" --health-interval=5s --health-timeout=3s --health-retries=20
     steps:
       - uses: actions/checkout@v4
+      - name: Start PostgreSQL 16
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/ci-start-postgres.sh
       - name: Reclaim runner disk for server test artifacts (background)
         run: |
           # The all-targets test build can exhaust the hosted runner after the
@@ -1731,15 +1721,6 @@ jobs:
             touch "$RUNNER_TEMP/disk-reclaim.done"
           ' > "$RUNNER_TEMP/disk-reclaim.log" 2>&1 &
           echo "disk reclaim started"
-      - name: Install PostgreSQL client tools
-        run: |
-          # The x64 hosted runner images preinstall postgresql-client; the
-          # arm64 images do not, and without it pg_isready/psql are missing
-          # and the template-database wait loop below spins forever. Guarded
-          # so it is a no-op wherever the client already exists.
-          if ! command -v pg_isready >/dev/null 2>&1; then
-            sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends postgresql-client
-          fi
       - name: Start fail-fast watcher (background)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -2070,10 +2051,17 @@ jobs:
           # djinn-provider::stream_event_consumer_audit. The script is
           # exercised by scripts/ci-shard-failure-summary.test.mjs against
           # captured nextest output from that very run.
-          node "$GITHUB_WORKSPACE/scripts/ci-shard-failure-summary.mjs" \
-            --shard "${{ matrix.shard }}" \
-            --log "$RUNNER_TEMP/nextest-run.log" \
-            --summary "$GITHUB_STEP_SUMMARY"
+          summary_script="$GITHUB_WORKSPACE/scripts/ci-shard-failure-summary.mjs"
+          if [[ -f "$summary_script" ]]; then
+            node "$summary_script" \
+              --shard "${{ matrix.shard }}" \
+              --log "$RUNNER_TEMP/nextest-run.log" \
+              --summary "$GITHUB_STEP_SUMMARY"
+          else
+            message="Server Test (${{ matrix.shard }}) failed before checkout; inspect the earliest failing setup step in this job"
+            echo "::error title=Server shard failed before checkout::$message"
+            printf '### Server shard failure\n\n%s\n' "$message" >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Upload retained shard timing data
         if: always() && steps.shard.outputs.active == 'true'
         uses: actions/upload-artifact@v4
@@ -2210,24 +2198,18 @@ jobs:
     name: Server sqlx Freshness
     needs: preflight
     if: needs.preflight.outputs.sqlxFreshness == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     defaults:
       run:
         working-directory: server
     env:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/djinn
-    services:
-      postgres:
-        image: public.ecr.aws/docker/library/postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: djinn
-        ports:
-          - 5433:5432
-        options: --health-cmd="pg_isready -U postgres" --health-interval=5s --health-timeout=3s --health-retries=20
     steps:
       - uses: actions/checkout@v4
+      - name: Start PostgreSQL 16
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/ci-start-postgres.sh
       - run: rustup toolchain install
         working-directory: server
       - uses: Swatinem/rust-cache@v2
@@ -2304,24 +2286,18 @@ jobs:
     name: Memory Eval Phase 1
     needs: preflight
     if: needs.preflight.outputs.memoryEval == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     defaults:
       run:
         working-directory: server
     env:
       SQLX_OFFLINE: "true"
-    services:
-      postgres:
-        image: public.ecr.aws/docker/library/postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: djinn
-        ports:
-          - 5433:5432
-        options: --health-cmd="pg_isready -U postgres" --health-interval=5s --health-timeout=3s --health-retries=20
     steps:
       - uses: actions/checkout@v4
+      - name: Start PostgreSQL 16
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/ci-start-postgres.sh
       - run: rustup toolchain install
         working-directory: server
       - uses: Swatinem/rust-cache@v2
@@ -2439,7 +2415,7 @@ jobs:
     name: qa-smoke
     needs: preflight
     if: needs.preflight.outputs.qaSmoke == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     defaults:
       run:
@@ -2449,25 +2425,11 @@ jobs:
     env:
       DJINN_TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/postgres
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/djinn_test_template
-    services:
-      postgres:
-        image: public.ecr.aws/docker/library/postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5433:5432
-        options: --health-cmd="pg_isready -U postgres" --health-interval=5s --health-timeout=3s --health-retries=20
     steps:
       - uses: actions/checkout@v4
-      - name: Install PostgreSQL client tools
-        run: |
-          # The x64 hosted runner images preinstall postgresql-client; the
-          # arm64 images do not, and without it pg_isready/psql are missing
-          # and the template-database wait loop below spins forever. Guarded
-          # so it is a no-op wherever the client already exists.
-          if ! command -v pg_isready >/dev/null 2>&1; then
-            sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends postgresql-client
-          fi
+      - name: Start PostgreSQL 16
+        working-directory: ${{ github.workspace }}
+        run: ./scripts/ci-start-postgres.sh
       - run: rustup toolchain install
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/resize-matrix.yml
+++ b/.github/workflows/resize-matrix.yml
@@ -64,26 +64,12 @@ env:
 jobs:
   resize-matrix:
     name: Three real image classes against four server modes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     # Belt and braces: the only trigger is workflow_dispatch, and this makes a
     # future edit that adds `pull_request` fail to turn this into a PR check by
     # accident.
     if: github.event_name == 'workflow_dispatch'
-
-    services:
-      postgres:
-        image: public.ecr.aws/docker/library/postgres:16
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: djinn
-        ports:
-          - "5433:5432"
-        options: >-
-          --health-cmd="pg_isready -U postgres"
-          --health-interval=5s
-          --health-timeout=3s
-          --health-retries=20
 
     steps:
       # `fetch-depth: 0`: the legacy image is compiled from a pinned commit in a
@@ -92,6 +78,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Start PostgreSQL 16
+        run: ./scripts/ci-start-postgres.sh
 
       - name: Install kind, kubectl and helm
         run: |

--- a/scripts/ci-host-postgres-workflow.test.mjs
+++ b/scripts/ci-host-postgres-workflow.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflowPaths = [
+  '.github/workflows/quality-gate.yml',
+  '.github/workflows/resize-matrix.yml',
+  '.github/workflows/memory-qa-nightly.yml',
+];
+const workflows = workflowPaths.map((path) => readFileSync(path, 'utf8')).join('\n');
+const setupScript = readFileSync('scripts/ci-start-postgres.sh', 'utf8');
+
+test('database jobs use runner PostgreSQL instead of registry service containers', () => {
+  assert.doesNotMatch(workflows, /image:\s*(?:public\.ecr\.aws\/docker\/library\/)?postgres:16/,
+    'PostgreSQL CI jobs must not pull a registry image before checkout');
+  assert.equal(workflows.match(/name: Start PostgreSQL 16/g)?.length, 7,
+    'all seven PostgreSQL jobs must start the runner installation');
+  assert.equal(workflows.match(/runs-on: ubuntu-24\.04/g)?.length, 7,
+    'the seven jobs must pin the runner image that provides PostgreSQL 16');
+});
+
+test('host setup preserves the existing PostgreSQL contract and fails on runner drift', () => {
+  assert.match(setupScript, /readonly expected_major=16/);
+  assert.match(setupScript, /readonly port=5433/);
+  assert.match(setupScript, /readonly database=djinn/);
+  assert.match(setupScript, /Unexpected PostgreSQL version/);
+  assert.match(setupScript, /PostgreSQL cluster missing/);
+  assert.match(setupScript, /ALTER USER postgres WITH PASSWORD 'postgres'/);
+  assert.match(setupScript, /ALTER SYSTEM SET port = '5433'/);
+});

--- a/scripts/ci-qa-smoke-workflow.test.mjs
+++ b/scripts/ci-qa-smoke-workflow.test.mjs
@@ -226,7 +226,7 @@ test('qa-smoke consumes the routed output and is event-safe', () => {
   assert.doesNotMatch(condition, /github\.event_name\s*==\s*['"]push['"]/, 'qa-smoke must not run on push');
 });
 
-test('qa-smoke owns only a restore-only test cache and a disposable database', () => {
+test('qa-smoke owns only a restore-only test cache and a disposable host database', () => {
   const qa = parseJobs(readFileSync(WORKFLOW, 'utf8')).jobs.get('qa-smoke');
   assert.ok(qa, 'qa-smoke job must exist');
   const source = blockCode(qa);
@@ -234,12 +234,12 @@ test('qa-smoke owns only a restore-only test cache and a disposable database', (
   assert.match(source, /Swatinem\/rust-cache@v2/, 'qa-smoke must restore Rust build inputs');
   assert.match(source, /^ {10}shared-key:\s*server-test\s*$/m, 'qa-smoke must use the server-test cache family');
   assert.match(source, /^ {10}save-if:\s*false\s*$/m, 'qa-smoke must remain a restore-only cache consumer');
-  const postgres = jobService(qa, 'postgres');
-  assert.ok(postgres, 'qa-smoke must own a local postgres service');
-  assert.match(postgres, /^ {8}image:\s*public\.ecr\.aws\/docker\/library\/postgres:16\s*$/m,
-    'qa-smoke postgres service must use the intended Postgres image');
-  assert.match(postgres, /^ {10}-\s*5433:5432\s*$/m,
-    'qa-smoke postgres service must expose the isolated 5433 host port');
+  assert.equal(jobService(qa, 'postgres'), undefined,
+    'qa-smoke must not pull a registry-backed Postgres service before checkout');
+  assert.match(source, /^ {4}runs-on:\s*ubuntu-24\.04\s*$/m,
+    'qa-smoke must pin the runner image that provides PostgreSQL 16');
+  assert.match(source, /run:\s*\.\/scripts\/ci-start-postgres\.sh/,
+    'qa-smoke must start the runner-provided PostgreSQL 16 installation');
   assert.match(source, /^ {6}DJINN_TEST_DATABASE_URL:\s*postgres:\/\/postgres:postgres@127\.0\.0\.1:5433\/postgres\s*$/m,
     'clone ownership must use the disposable maintenance database');
   assert.match(source, /^ {6}DATABASE_URL:\s*postgres:\/\/postgres:postgres@127\.0\.0\.1:5433\/djinn_test_template\s*$/m,

--- a/scripts/ci-start-postgres.sh
+++ b/scripts/ci-start-postgres.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub's ubuntu-24.04 runner image includes PostgreSQL 16 but leaves the
+# service disabled. Use that installation instead of pulling the same image in
+# every matrix job before checkout, where neither retries nor Actions caches
+# are available.
+readonly expected_major=16
+readonly port=5433
+readonly database=djinn
+
+installed_major="$(psql --version | sed -E 's/^psql \(PostgreSQL\) ([0-9]+).*/\1/')"
+if [[ "$installed_major" != "$expected_major" ]]; then
+  echo "::error title=Unexpected PostgreSQL version::ubuntu-24.04 must provide PostgreSQL ${expected_major}; found '${installed_major:-unknown}'"
+  exit 1
+fi
+if ! pg_lsclusters --no-header | awk '{ print $1, $2 }' | grep -qx "${expected_major} main"; then
+  echo "::error title=PostgreSQL cluster missing::Expected the ubuntu-24.04 runner to provide cluster '${expected_major} main'"
+  pg_lsclusters || true
+  exit 1
+fi
+
+sudo pg_ctlcluster "$expected_major" main start
+sudo -u postgres psql --set=ON_ERROR_STOP=1 <<'SQL'
+ALTER USER postgres WITH PASSWORD 'postgres';
+ALTER SYSTEM SET port = '5433';
+SQL
+sudo pg_ctlcluster "$expected_major" main restart
+
+for attempt in {1..20}; do
+  if pg_isready --host 127.0.0.1 --port "$port" --username postgres >/dev/null 2>&1; then
+    break
+  fi
+  if [[ "$attempt" == 20 ]]; then
+    echo "::error title=PostgreSQL startup timed out::PostgreSQL ${expected_major} did not become ready on port ${port}"
+    sudo journalctl --unit "postgresql@${expected_major}-main.service" --no-pager --lines 100 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+if ! sudo -u postgres psql --port "$port" --tuples-only --no-align \
+  --command "SELECT 1 FROM pg_database WHERE datname = '${database}'" | grep -qx 1; then
+  sudo -u postgres createdb --port "$port" "$database"
+fi
+
+PGPASSWORD=postgres psql \
+  --host 127.0.0.1 --port "$port" --username postgres --dbname "$database" \
+  --set=ON_ERROR_STOP=1 --command 'SELECT version();'

--- a/server/crates/djinn-k8s/tests/cutover_preflight.rs
+++ b/server/crates/djinn-k8s/tests/cutover_preflight.rs
@@ -1454,7 +1454,8 @@ fn the_cutover_preflight_lane_is_wired_and_cannot_silently_skip() {
         "--run-ignored all",
         "DJINN_CUTOVER_EXPECTED_PROOFS",
         "azure/setup-helm@v4",
-        "postgres:16",
+        "runs-on: ubuntu-24.04",
+        "./scripts/ci-start-postgres.sh",
         // Without a database URL the driver reports the drain fence
         // UNOBSERVABLE, and the suite's clean case is never a genuine exit 0.
         "DJINN_DATABASE_URL:",


### PR DESCRIPTION
## Summary

- remove all seven registry-backed PostgreSQL service containers from CI
- pin the affected jobs to `ubuntu-24.04` and start its preinstalled PostgreSQL 16 after checkout
- preserve the existing PostgreSQL password, `djinn` database, and port 5433 connection contract
- add a CI contract preventing registry services or runner-version drift from returning
- make shard failure surfacing self-contained when checkout never created the checked-in summary script

## Why

Merge-queue run 30752357184 failed before checkout when anonymous Public ECR returned `toomanyrequests: Rate exceeded` three times. The fallback diagnostic then found the workspace root but masked that error with `MODULE_NOT_FOUND` because checkout had not installed its script.

GitHub publishes PostgreSQL 16 as part of the Ubuntu 24.04 runner image. Starting that installation as a normal post-checkout step removes the external registry from job initialization, where Actions cache restoration and custom retry/fallback logic cannot run.

## Verification

- `node --test scripts/ci-host-postgres-workflow.test.mjs scripts/ci-qa-smoke-workflow.test.mjs scripts/ci-shard-failure-summary.test.mjs` — 19 passed
- `bash -n scripts/ci-start-postgres.sh` — passed
- `shellcheck scripts/ci-start-postgres.sh` — passed
- `actionlint .github/workflows/*.yml` — passed
- `git diff --check` — passed
- sweep confirms 7 setup steps, 7 pinned runner declarations, and no remaining PostgreSQL service image references

The live startup path must be proven by the GitHub-hosted PR run because the preinstalled runner image is not available locally.