### PR TITLE
fix(coordinator): make adopted-PR handoff transition regardless of dedupe row

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
@@ -445,12 +445,30 @@ const HANDOFF_ACTOR_ROLE: &str = "respawn_guard";
 /// transitioned to `pr_review`.
 ///
 /// Every successful handoff records a `pr_terminal_handoff` activity keyed by
-/// reason and head SHA. Re-entry for the same head is a durable no-op, while a
-/// new head records a new handoff marker.
+/// reason and head SHA. Re-entry for the same head does not duplicate that
+/// marker row, while a new head records a new one.
 ///
-/// Returns `true` when the handoff is established, including when the durable
-/// marker proves it was already established for this head, and an `Err` when
-/// persistence fails.
+/// # Ownership is decided by STATUS, never by a marker row
+///
+/// The two concerns below are deliberately separated and must stay that way:
+///
+/// 1. **Ownership** — whether the task must be moved into `pr_review`. This is
+///    decided *solely* from `current_status`. `pr_review` is the only no-op.
+/// 2. **Audit** — whether a duplicate `pr_terminal_handoff` marker row would be
+///    written. This may only ever suppress the row, never the transition.
+///
+/// Conflating them is the livelock this function was rewritten to kill: the
+/// dedupe used to run *before* the transition and early-return `Ok(true)`, so
+/// once any marker row existed the task was never moved again. A durable marker
+/// proves a handoff *was once written*; it does NOT prove the task is
+/// poller-owned *now* — the startup reaper, an escalation, or any reopen can put
+/// it back in `open` long after the marker landed. Tasks z8i8 (PR #2972) and
+/// zkas (PR #2970) then sat in `open` for 9.5h/11.7h with green CI and an
+/// approved PR: the pollers scan `pr_draft` / `pr_review` / `needs_task_review`,
+/// so an `open` task carrying a mergeable PR is owned by nobody.
+///
+/// Returns `true` when the handoff is established (ownership asserted, marker
+/// present) and an `Err` when the transition or the marker write fails.
 pub async fn handoff_pr_to_poller(
     task_repo: &TaskRepository,
     task_id: &str,
@@ -459,22 +477,7 @@ pub async fn handoff_pr_to_poller(
     reason: &str,
     head_sha: Option<&str>,
 ) -> std::result::Result<bool, String> {
-    let already_handed_off = task_repo
-        .list_activity(task_id)
-        .await
-        .map_err(|e| e.to_string())?
-        .iter()
-        .filter(|entry| entry.event_type == "pr_terminal_handoff")
-        .filter_map(|entry| serde_json::from_str::<serde_json::Value>(&entry.payload).ok())
-        .any(|payload| {
-            payload.get("head_sha").and_then(|value| value.as_str()) == head_sha
-                && payload.get("reason").and_then(|value| value.as_str()) == Some(reason)
-        });
-    if already_handed_off {
-        tracing::debug!(task_id = %task_id, ?head_sha, "respawn_guard: terminal PR handoff already recorded for head");
-        return Ok(true);
-    }
-
+    // ── 1. Ownership: state-gated, never row-gated. ──────────────────────
     if current_status == TaskStatus::PrReview.as_str() {
         tracing::debug!(task_id = %task_id, current_status = %current_status, "respawn_guard: task already in pr_review — handoff is an idempotent no-op");
     } else if let Err(e) = task_repo
@@ -490,6 +493,20 @@ pub async fn handoff_pr_to_poller(
     {
         tracing::warn!(task_id = %task_id, pr_url = %pr_url, error = %e, "respawn_guard: failed to hand PR off to poller");
         return Err(e.to_string());
+    }
+
+    // ── 2. Audit: dedupe the marker ROW only. Ownership is already
+    // established above, so returning early here cannot skip a state change.
+    //
+    // A `None` head is not an identity and must never match a stored `null`:
+    // the old predicate compared `Option<&str>` to `Option<&str>`, so
+    // `None == None` held for every adoption (which always passed `None`),
+    // collapsing the key to the per-PR-deterministic `reason` alone.
+    if let Some(head_sha) = head_sha
+        && marker_recorded_for_head(task_repo, task_id, reason, head_sha).await?
+    {
+        tracing::debug!(task_id = %task_id, head_sha, "respawn_guard: terminal PR handoff marker already recorded for head");
+        return Ok(true);
     }
 
     let payload = serde_json::json!({
@@ -514,13 +531,45 @@ pub async fn handoff_pr_to_poller(
     Ok(true)
 }
 
+/// True when a `pr_terminal_handoff` marker already exists for this exact
+/// (`reason`, `head_sha`) pair.
+///
+/// Audit-only: callers must have settled ownership before consulting this. The
+/// head is a `&str`, not an `Option<&str>`, so an absent head cannot be
+/// compared at all — a stored `null` head has no identity to match against.
+async fn marker_recorded_for_head(
+    task_repo: &TaskRepository,
+    task_id: &str,
+    reason: &str,
+    head_sha: &str,
+) -> std::result::Result<bool, String> {
+    Ok(task_repo
+        .list_activity(task_id)
+        .await
+        .map_err(|e| e.to_string())?
+        .iter()
+        .filter(|entry| entry.event_type == "pr_terminal_handoff")
+        .filter_map(|entry| serde_json::from_str::<serde_json::Value>(&entry.payload).ok())
+        .any(|payload| {
+            payload.get("head_sha").and_then(|value| value.as_str()) == Some(head_sha)
+                && payload.get("reason").and_then(|value| value.as_str()) == Some(reason)
+        }))
+}
+
 /// Compatibility wrapper for the respawn-guard adoption path. The terminal
 /// gate uses [`handoff_pr_to_poller`] directly so it can fail safe on errors.
+///
+/// `head_sha` is the task's current head (`ci_github_head_sha` falling back to
+/// `ci_head_sha`). It must be forwarded, not hardcoded to `None`: the marker
+/// dedupe key is (`reason`, `head_sha`), and the adoption `reason` is
+/// deterministic per PR, so a `None` head leaves the key with no varying
+/// component at all.
 pub async fn handoff_adopted_pr_to_poller(
     task_repo: &TaskRepository,
     task_id: &str,
     current_status: &str,
     pr_url: &str,
+    head_sha: Option<&str>,
 ) -> bool {
     let reason =
         format!("respawn_guard: adopted open PR {pr_url} — handing off to PR poller (pr_review)");
@@ -544,9 +593,16 @@ pub async fn handoff_adopted_pr_to_poller(
             .await
             .is_ok();
     }
-    handoff_pr_to_poller(task_repo, task_id, current_status, pr_url, &reason, None)
-        .await
-        .unwrap_or(false)
+    handoff_pr_to_poller(
+        task_repo,
+        task_id,
+        current_status,
+        pr_url,
+        &reason,
+        head_sha,
+    )
+    .await
+    .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard_mergequeue_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard_mergequeue_tests.rs
@@ -148,7 +148,7 @@ async fn adopt_then_handoff_then_mergequeue_loop_bypasses_adoption() {
         "a healthy open PR is still adopted"
     );
     record_adopted_pr_attempt(&db, &task.id, "worker", PR, Some("adopted")).await;
-    assert!(handoff_adopted_pr_to_poller(&task_repo, &task.id, &task.status, PR).await);
+    assert!(handoff_adopted_pr_to_poller(&task_repo, &task.id, &task.status, PR, None).await);
 
     // Poller enqueues, merge_group fails, reopens (cycle 1) → back to open.
     merge_queue_reopen(&db, &task.id, 1).await;

--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard_tests.rs
@@ -1194,7 +1194,7 @@ async fn handoff_moves_open_task_to_pr_review_with_audit_and_activity() {
     .await
     .expect("adopted_pr audit row inserts");
     let moved =
-        handoff_adopted_pr_to_poller(&test_task_repo(&db), &task.id, &task.status, pr).await;
+        handoff_adopted_pr_to_poller(&test_task_repo(&db), &task.id, &task.status, pr, None).await;
     assert!(
         moved,
         "an open adopted task must be handed off to the poller"
@@ -1243,7 +1243,7 @@ async fn handoff_is_one_shot_and_idempotent() {
     let repo = test_task_repo(&db);
 
     // First handoff moves open → pr_review.
-    assert!(handoff_adopted_pr_to_poller(&repo, &task.id, "open", pr).await);
+    assert!(handoff_adopted_pr_to_poller(&repo, &task.id, "open", pr, None).await);
     let s1 = repo.get(&task.id).await.unwrap().unwrap().status;
     assert_eq!(s1, "pr_review");
 
@@ -1251,7 +1251,7 @@ async fn handoff_is_one_shot_and_idempotent() {
     // the task stays in pr_review, no transition runs, but an activity entry is
     // still recorded so the handoff reason is durable.
     assert!(
-        handoff_adopted_pr_to_poller(&repo, &task.id, &s1, pr).await,
+        handoff_adopted_pr_to_poller(&repo, &task.id, &s1, pr, None).await,
         "handoff is idempotent for already-pr_review: returns true, no transition"
     );
     assert_eq!(
@@ -1298,7 +1298,9 @@ async fn reopened_task_with_retained_pr_url_is_handed_to_poller_not_wedged() {
     record_adopted_pr_attempt(&db, &task.id, "worker", pr, Some("adopted"))
         .await
         .expect("audit row inserts");
-    assert!(handoff_adopted_pr_to_poller(&test_task_repo(&db), &task.id, &task.status, pr).await);
+    assert!(
+        handoff_adopted_pr_to_poller(&test_task_repo(&db), &task.id, &task.status, pr, None).await
+    );
 
     let updated = test_task_repo(&db).get(&task.id).await.unwrap().unwrap();
     assert_eq!(
@@ -1310,7 +1312,8 @@ async fn reopened_task_with_retained_pr_url_is_handed_to_poller_not_wedged() {
     // now-pr_review task is an idempotent no-op that returns true (no
     // transition, but activity is still recorded).
     assert!(
-        handoff_adopted_pr_to_poller(&test_task_repo(&db), &updated.id, &updated.status, pr).await
+        handoff_adopted_pr_to_poller(&test_task_repo(&db), &updated.id, &updated.status, pr, None)
+            .await
     );
 }
 
@@ -1329,7 +1332,7 @@ async fn handoff_advances_pr_draft_and_idempotent_for_pr_review() {
         .await
         .expect("set_status moves the task to pr_draft");
     assert!(
-        handoff_adopted_pr_to_poller(&repo, &task.id, "pr_draft", "https://x/pull/1").await,
+        handoff_adopted_pr_to_poller(&repo, &task.id, "pr_draft", "https://x/pull/1", None).await,
         "pr_draft must be advanced to pr_review, not treated as a no-op"
     );
     assert_eq!(
@@ -1340,7 +1343,7 @@ async fn handoff_advances_pr_draft_and_idempotent_for_pr_review() {
 
     // pr_review → pr_review (idempotent no-op, returns true).
     assert!(
-        handoff_adopted_pr_to_poller(&repo, &task.id, "pr_review", "https://x/pull/1").await,
+        handoff_adopted_pr_to_poller(&repo, &task.id, "pr_review", "https://x/pull/1", None).await,
         "pr_review handoff must be an idempotent no-op returning true"
     );
     assert_eq!(
@@ -1363,12 +1366,238 @@ async fn handoff_transitions_non_open_status_to_pr_review() {
         .expect("set_status moves the task to in_progress");
 
     assert!(
-        handoff_adopted_pr_to_poller(&repo, &task.id, "in_progress", "https://x/pull/1").await,
+        handoff_adopted_pr_to_poller(&repo, &task.id, "in_progress", "https://x/pull/1", None)
+            .await,
         "in_progress task must be advanced to pr_review"
     );
     assert_eq!(
         repo.get(&task.id).await.unwrap().unwrap().status,
         "pr_review",
         "in_progress task must land in pr_review"
+    );
+}
+
+// ─── Handoff dedupe must never gate the TRANSITION (livelock regression) ──
+//
+// Production, 6h on one deployment, one coordinator:
+//
+//   "respawn guard adopting existing open PR" ......... 568
+//   "terminal PR handoff already recorded for head" ... 568   <- short-circuit
+//   "PR handed off to poller (pr_review)" .............   0   <- never happened
+//
+// The dedupe predicate compared `Option<&str>` to `Option<&str>`, and the
+// adoption path always passed `head_sha: None` while the stored payload held
+// `"head_sha": null` — so `None == None` held forever and the key collapsed to
+// the per-PR-deterministic `reason`. Worse, the dedupe ran BEFORE the
+// transition and returned `Ok(true)`, so it suppressed the state change rather
+// than just the duplicate row. Tasks z8i8 (PR #2972) and zkas (PR #2970) sat in
+// `open` for 9.5h/11.7h with green CI and an approved PR while `pr_watcher`
+// scans only `pr_draft` — owned by nobody.
+//
+// These tests assert the SIDE EFFECT (the task's status read back from the
+// repository). Asserting the `true` return value is exactly what the bug did.
+
+/// The literal adoption reason the wrapper builds — the dedupe key's only
+/// varying component once the head is `None`.
+fn adoption_reason(pr_url: &str) -> String {
+    format!("respawn_guard: adopted open PR {pr_url} — handing off to PR poller (pr_review)")
+}
+
+/// Seed the durable marker the production loop tripped over.
+async fn seed_handoff_marker(
+    repo: &TaskRepository,
+    task_id: &str,
+    reason: &str,
+    head_sha: Option<&str>,
+) {
+    let payload = serde_json::json!({
+        "from_status": "open",
+        "to_status": "pr_review",
+        "reason": reason,
+        "pr_url": "https://github.example/owner/repo/pull/2972",
+        "head_sha": head_sha,
+    })
+    .to_string();
+    repo.log_activity(
+        Some(task_id),
+        "system",
+        "respawn_guard",
+        "pr_terminal_handoff",
+        &payload,
+    )
+    .await
+    .expect("seed marker inserts");
+}
+
+fn marker_count(activity: &[djinn_core::models::ActivityEntry]) -> usize {
+    activity
+        .iter()
+        .filter(|e| e.event_type == "pr_terminal_handoff")
+        .count()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn open_task_with_prior_null_head_marker_is_still_transitioned() {
+    // THE production state (z8i8 / zkas): the task was handed off once, then
+    // reopened to `open` (startup reaper after a deploy) while the marker row
+    // — carrying `"head_sha": null` and this exact reason — stayed durable.
+    // Every later adoption pass must STILL move it into `pr_review`.
+    let db = test_db();
+    let task = create_task(&db).await; // open
+    let repo = test_task_repo(&db);
+    let pr = "https://github.example/owner/repo/pull/2972";
+    let reason = adoption_reason(pr);
+
+    seed_handoff_marker(&repo, &task.id, &reason, None).await;
+
+    // The exact production call shape: adoption passed `head_sha: None`, so
+    // `None == null` matched and the transition was skipped.
+    handoff_adopted_pr_to_poller(&repo, &task.id, "open", pr, None).await;
+
+    assert_eq!(
+        repo.get(&task.id).await.unwrap().unwrap().status,
+        "pr_review",
+        "a prior handoff MARKER must never suppress the handoff TRANSITION — \
+         the task was left wedged in `open`, polled by nobody, for 9.5h"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn open_task_with_prior_null_head_marker_is_transitioned_with_real_head() {
+    // Same durable `null`-head marker, but the call site now forwards a real
+    // head. A `None`-vs-`null` shape must not be reachable as a match at all,
+    // and a real head cannot match a stored `null` either.
+    let db = test_db();
+    let task = create_task(&db).await;
+    let repo = test_task_repo(&db);
+    let pr = "https://github.example/owner/repo/pull/2970";
+    let reason = adoption_reason(pr);
+
+    seed_handoff_marker(&repo, &task.id, &reason, None).await;
+
+    assert!(handoff_adopted_pr_to_poller(&repo, &task.id, "open", pr, Some("deadbeef")).await);
+
+    assert_eq!(
+        repo.get(&task.id).await.unwrap().unwrap().status,
+        "pr_review",
+        "a real head must not match a stored null head"
+    );
+    let activity = repo.list_activity(&task.id).await.unwrap();
+    assert_eq!(
+        marker_count(&activity),
+        2,
+        "a head that matches no stored marker records its own marker"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repeated_adoption_at_same_head_transitions_without_duplicate_markers() {
+    // The reopen loop that produced 568 adoptions: each pass must re-establish
+    // ownership (transition) while the marker row stays deduped at one per
+    // (reason, head).
+    let db = test_db();
+    let task = create_task(&db).await;
+    let repo = test_task_repo(&db);
+    let pr = "https://github.example/owner/repo/pull/2972";
+    let head = "1111111111111111111111111111111111111111";
+
+    for pass in 0..3 {
+        // Reaper/escalation puts the task back in the dispatchable column.
+        repo.set_status(&task.id, "open")
+            .await
+            .expect("set_status reopens the task");
+        assert!(
+            handoff_adopted_pr_to_poller(&repo, &task.id, "open", pr, Some(head)).await,
+            "pass {pass}: adoption handoff must succeed"
+        );
+        assert_eq!(
+            repo.get(&task.id).await.unwrap().unwrap().status,
+            "pr_review",
+            "pass {pass}: every adoption pass must leave the task poller-owned"
+        );
+    }
+
+    let activity = repo.list_activity(&task.id).await.unwrap();
+    assert_eq!(
+        marker_count(&activity),
+        1,
+        "the dedupe still collapses duplicate marker ROWS for the same head"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn adoption_at_new_head_transitions_and_records_new_marker() {
+    // A push moves the head: the new head is a distinct dedupe key, so the
+    // handoff both transitions and records its own marker.
+    let db = test_db();
+    let task = create_task(&db).await;
+    let repo = test_task_repo(&db);
+    let pr = "https://github.example/owner/repo/pull/2972";
+
+    assert!(handoff_adopted_pr_to_poller(&repo, &task.id, "open", pr, Some("aaaa1111")).await);
+    assert_eq!(
+        repo.get(&task.id).await.unwrap().unwrap().status,
+        "pr_review"
+    );
+
+    repo.set_status(&task.id, "open")
+        .await
+        .expect("set_status reopens the task");
+    assert!(handoff_adopted_pr_to_poller(&repo, &task.id, "open", pr, Some("bbbb2222")).await);
+
+    assert_eq!(
+        repo.get(&task.id).await.unwrap().unwrap().status,
+        "pr_review",
+        "a new head must transition too"
+    );
+    let activity = repo.list_activity(&task.id).await.unwrap();
+    assert_eq!(
+        marker_count(&activity),
+        2,
+        "each distinct head records its own handoff marker"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pr_review_task_is_a_noop_with_no_transition_and_no_duplicate_marker() {
+    // Already poller-owned: the status gate — not the marker — makes this a
+    // no-op. No AdoptionHandoff transition, no second marker row.
+    let db = test_db();
+    let task = create_task(&db).await;
+    let repo = test_task_repo(&db);
+    let pr = "https://github.example/owner/repo/pull/2972";
+    let reason = adoption_reason(pr);
+    let head = "cccc3333";
+
+    repo.set_status(&task.id, "pr_review")
+        .await
+        .expect("set_status moves the task to pr_review");
+    seed_handoff_marker(&repo, &task.id, &reason, Some(head)).await;
+
+    assert!(
+        handoff_pr_to_poller(&repo, &task.id, "pr_review", pr, &reason, Some(head))
+            .await
+            .expect("pr_review handoff is an idempotent success"),
+        "an already-poller-owned task is an idempotent no-op"
+    );
+
+    assert_eq!(
+        repo.get(&task.id).await.unwrap().unwrap().status,
+        "pr_review",
+        "no spurious status change"
+    );
+    let activity = repo.list_activity(&task.id).await.unwrap();
+    assert_eq!(
+        marker_count(&activity),
+        1,
+        "the same (reason, head) must not duplicate the marker row"
+    );
+    assert_eq!(
+        activity
+            .iter()
+            .filter(|e| e.event_type == "adoption_handoff")
+            .count(),
+        0,
+        "no AdoptionHandoff transition may run for an already-pr_review task"
     );
 }

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -2247,11 +2247,19 @@ impl CoordinatorActor {
                     // `pr_review` column so the PR poller advances it (incident
                     // gton — an adopted `open` task was polled by nobody and
                     // wedged 9h). Idempotent: a no-op if already poller-owned.
+                    //
+                    // The head SHA keys the handoff's audit marker. It must be
+                    // the real head: a `None` head made the marker's dedupe key
+                    // collapse to the per-PR-deterministic reason, which
+                    // permanently suppressed the handoff itself.
                     super::respawn_guard::handoff_adopted_pr_to_poller(
                         &self.task_repo(),
                         &task.id,
                         &task.status,
                         &pr_url,
+                        task.ci_github_head_sha
+                            .as_deref()
+                            .or(task.ci_head_sha.as_deref()),
                     )
                     .await;
                     continue;


### PR DESCRIPTION
## The livelock

`respawn_guard::handoff_pr_to_poller` ran its `pr_terminal_handoff` dedupe **before** the state transition and returned `Ok(true)` on a hit. Two defects compounded into a permanent wedge.

### 1. `None == None` collapsed the dedupe key

`handoff_adopted_pr_to_poller` always called it with `head_sha: None`, and the row it writes stores `"head_sha": null`. So `payload.get("head_sha").and_then(|v| v.as_str())` yields `None`, and the predicate compared `Option<&str>` to `Option<&str>`:

```rust
payload.get("head_sha").and_then(|value| value.as_str()) == head_sha   // None == None
    && payload.get("reason").and_then(|value| value.as_str()) == Some(reason)
```

`None == None` is permanently true, so the key collapsed to `reason` alone — which is

```rust
format!("respawn_guard: adopted open PR {pr_url} — handing off to PR poller (pr_review)")
```

deterministic per PR and byte-identical on every coordinator tick forever.

### 2. The dedupe short-circuited the state transition, not the duplicate row

Because it ran first and returned `Ok(true)`, a hit skipped `TaskRepository::transition` entirely. It asserted a **label** (a row exists) instead of the **side effect** (the task is poller-owned). A durable marker proves a handoff *was once written*; it does not prove the task is poller-owned *now* — the startup reaper, an escalation, or any reopen can put it back in `open` long after the marker landed. Once the first row existed, the task was never moved again.

## Production evidence

Measured on the live VPS over 6h on one deployment:

```
"respawn guard adopting existing open PR" ......... 568
"terminal PR handoff already recorded for head" ... 568   <- short-circuit
"PR handed off to poller (pr_review)" .............   0   <- never happened
```

Tasks `z8i8` (PR #2972) and `zkas` (PR #2970) sat in `open` for **9.5h** and **11.7h** with green CI, an approved PR, and a released tripwire hold. The pollers scan `pr_draft` / `pr_review` / `needs_task_review` (`pr_watcher.rs:22`, `pr_watcher.rs:684`, `pr_review_watcher.rs:13`), so an `open` task carrying a mergeable PR is owned by nobody. The incident-`gton` fix that `task_dispatch.rs` cites at the call site was present but rendered inert by this dedupe.

## The fix

**Ownership is gated on status; the dedupe may only ever suppress a row.** The two concerns are now separated in `handoff_pr_to_poller` and cannot be conflated again:

1. **Ownership** — decided solely from `current_status`. `pr_review` is the only no-op; every other non-closed status is transitioned (`transition` is idempotent).
2. **Audit** — the marker dedupe runs *after* ownership is settled, so an early return there cannot skip a state change.

**A `None` head is not an identity.** The dedupe helper takes a `&str` head, not an `Option<&str>`, so an absent head cannot be compared at all — a `None`-vs-`null` match is unrepresentable rather than merely avoided.

**A real head is forwarded.** `handoff_adopted_pr_to_poller` now accepts `head_sha` and the call site in `dispatch/task_dispatch.rs` passes `ci_github_head_sha` falling back to `ci_head_sha`, matching what the terminal gate in `session_recovery.rs` already does.

No migration. The tripwire, the poller's status scan set, the escalation ladder, and `pr_watcher`'s queries are untouched.

## Tests

The existing tests all passed while this was live in production, so they did not constrain the broken behavior. Every new test asserts the **side effect** — the task's status read back from the repository — because returning `Ok(true)` is precisely what the bug did.

| Test | Fails without the fix |
| --- | --- |
| `open_task_with_prior_null_head_marker_is_still_transitioned` — the exact production state: `open` task, pre-existing marker with `head_sha: null` and the same `reason` | **yes** (`left: "open"`, `right: "pr_review"`) |
| `repeated_adoption_at_same_head_transitions_without_duplicate_markers` — 3 reopen/adopt passes must each re-establish ownership; marker row stays at 1 | **yes** (`pass 1: left: "open"`) |
| `open_task_with_prior_null_head_marker_is_transitioned_with_real_head` — a real head must not match a stored `null` | no (guards the new key semantics) |
| `adoption_at_new_head_transitions_and_records_new_marker` | no (guards the new-head path) |
| `pr_review_task_is_a_noop_with_no_transition_and_no_duplicate_marker` | no (guards idempotence) |

Verified by re-inserting the original pre-transition dedupe block and re-running: exactly those two fail, the other 47 pass.

```
cargo test -p djinn-coordinator respawn_guard   ->  49 passed; 0 failed
cargo test -p djinn-coordinator --lib           ->  2063 passed; 0 failed
cargo clippy -p djinn-coordinator --all-targets ->  clean
cargo fmt --check -p djinn-coordinator          ->  clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
