### PR TITLE
Keep the platform DSN out of every process the agent spawns

### DIFF
--- a/deploy/roles/djinn_task_run.sql
+++ b/deploy/roles/djinn_task_run.sql
@@ -1,0 +1,350 @@
+-- Least-privilege platform-database role for task-run Pods.
+--
+-- ============================================================================
+-- WHY THIS EXISTS
+-- ============================================================================
+--
+-- On 2026-08-04 the production platform database was found with migration
+-- 182's DDL applied and no `_sqlx_migrations` ledger row for it, which
+-- crash-looped the migrate init container on the v0.7.41 deploy. sqlx 0.8.6
+-- cannot produce that state: `execute_migration` runs the migration SQL and
+-- the ledger INSERT in one transaction. So the DDL was applied out-of-band, by
+-- something holding a DDL-capable connection to the platform database.
+--
+-- Who is unprovable — production runs with `log_statement = none`. This role
+-- makes the question moot rather than answering it: a task-run Pod that cannot
+-- issue DDL and does not own any relation cannot reach that state at all,
+-- whatever runs inside it.
+--
+-- The companion change (djinn-agent-worker `platform_dsn`, and the deny-set in
+-- `djinn_cgroup_launcher::env`) removes the DSN from the environment of every
+-- process the agent spawns. This role is the second, independent control: it
+-- bounds what the DSN can do even when something legitimately holds it.
+--
+-- ============================================================================
+-- WHAT THE POD ACTUALLY NEEDS (enumerated from the code, not assumed)
+-- ============================================================================
+--
+-- `bootstrap_warm_database()` (djinn-agent-worker/src/main.rs) opens this DSN
+-- and calls `verify_and_mark_initialized()`. Traced from there:
+--
+--   * The worker NEVER migrates. `verify_and_mark_initialized` reads
+--     `information_schema.tables` and `SELECT version, success FROM
+--     _sqlx_migrations`, then marks the handle initialized so no later
+--     repository call can trigger a lazy migrator. `sqlx::migrate!(...)` is
+--     expanded only to enumerate compiled-in versions in memory; `.run()` is
+--     never called on this path. => the role needs SELECT on
+--     `_sqlx_migrations` and nothing else on it. It must NOT be able to write
+--     that table: an INSERT there is how a partially-applied migration would
+--     be papered over.
+--
+--   * Session GUCs on every pooled connection: `statement_timeout`,
+--     `lock_timeout`, `idle_in_transaction_session_timeout`. Plain session
+--     SETs; no privilege needed.
+--
+--   * The durable invocation-lease authority reads
+--     `SELECT ... FROM admission_handoff WHERE name = $1`. Read only — every
+--     write path on that table (seed/set_mode/upsert/delete, and the
+--     `SELECT ... FOR UPDATE` arms) belongs to the coordinator, not the pod.
+--
+--   * The rest is ordinary board DML: `activity_log`, `task_runs`, `tasks`,
+--     `task_attempts`, `task_arbitrations`, `blockers`, `sessions`,
+--     `session_messages`, `session_compaction_boundaries`, `notes` and the
+--     `note_*` tables, `retrieval_traces`, `extension_load_diagnostics`,
+--     `projects`, `agents`, `epics`, `proposals`, the `evidence_*` and
+--     `typed_evidence_*` families -- plus everything else the agent's own MCP
+--     tool surface can reach, because `AgentContext.db` is the unnarrowed
+--     platform handle and it is wired into `DjinnMcpServer`.
+--
+--   * `pg_advisory_xact_lock` on the note-write path. Advisory locks need no
+--     GRANT.
+--
+--   * NO sequence privileges. Verified against the migrated schema: the only
+--     serial/identity columns in `public` are `model_turn_pools.id`,
+--     `build_pod_permits.fencing_token`, `repo_graph_generation.publish_seq`
+--     and `build_leases.enqueue_sequence`, none of which a task-run Pod
+--     inserts into. `nextval('build_lease_fencing_token_seq')` and
+--     `nextval('board_health_mismatch_scan_leader_epoch_seq')` are
+--     coordinator-side. So the role gets no USAGE on any sequence, and an
+--     attempt to insert into a host-owned ledger fails on the sequence as well
+--     as on the table.
+--
+--   * NO row-level security is defined anywhere in the schema, so a non-owner
+--     role is not silently subject to policies the owner bypassed.
+--
+-- ============================================================================
+-- SCOPE OF STAGE 1 (this file) vs STAGE 2 (deferred)
+-- ============================================================================
+--
+-- STAGE 1, applied by this script, removes the two capabilities that produced
+-- the incident and the two categories that have no business in a Pod:
+--
+--   * no DDL of any kind, and no ownership of any relation;
+--   * no write access to `_sqlx_migrations`;
+--   * no access at all to the credential and auth tables;
+--   * DML on the remaining board tables, which is what the agent's tool
+--     surface uses today.
+--
+-- STAGE 2 -- narrowing table-by-table to the deterministic set enumerated
+-- above -- is NOT in this file, and deliberately so. `AgentContext.db` hands
+-- the whole platform `Database` to the MCP tool dispatcher
+-- (`djinn-agent/src/context.rs`, `fn db()` / `to_mcp_state()`), which
+-- reconstructs `DjinnMcpServer` inside the Pod. A per-table grant derived from
+-- the deterministic path would break `memory_*`, `task_*`, `epic_*`,
+-- `proposal_*` and the evidence tools the moment an agent used one. The
+-- prerequisite is routing those helpers through `SupervisorServices` RPC so
+-- the Pod needs no board `Database` at all; see the PR body.
+--
+-- ============================================================================
+-- HOW TO APPLY  (idempotent; safe against an existing database)
+-- ============================================================================
+--
+--   1. Create the login role and its password OUT OF BAND -- never in this
+--      repository:
+--
+--        CREATE ROLE djinn_task_run_pod LOGIN PASSWORD '<generated>'
+--          NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+--
+--   2. Run this script as the database owner (the role that owns the tables,
+--      i.e. the one the migrate Job connects as):
+--
+--        psql "$DJINN_DATABASE_URL" -v ON_ERROR_STOP=1 \
+--          -f deploy/roles/djinn_task_run.sql
+--
+--   3. GRANT djinn_task_run TO djinn_task_run_pod;
+--
+--   4. Point ONLY the task-run Pod's `DJINN_DATABASE_URL` at
+--      `djinn_task_run_pod`. djinn-server, the coordinator and the migrate Job
+--      keep the owner DSN -- the migrate Job in particular MUST stay the owner
+--      or migrations stop working.
+--
+--   5. Re-run this script after any migration that adds a table, so the new
+--      table is covered and any new secret table is revoked. Step 6's
+--      verification will tell you if you forgot.
+--
+--   6. Verify (expects zero rows from each):
+--
+--        SELECT has_schema_privilege('djinn_task_run','public','CREATE')
+--          WHERE has_schema_privilege('djinn_task_run','public','CREATE');
+--
+--        SELECT c.relname FROM pg_class c JOIN pg_namespace n
+--          ON n.oid = c.relnamespace
+--         WHERE n.nspname = 'public'
+--           AND pg_get_userbyid(c.relowner) = 'djinn_task_run';
+--
+--        SELECT table_name, privilege_type
+--          FROM information_schema.role_table_grants
+--         WHERE grantee = 'djinn_task_run'
+--           AND (table_name = '_sqlx_migrations' AND privilege_type <> 'SELECT'
+--                OR table_name IN ('credentials','custom_providers',
+--                                  'mcp_access_tokens','oauth_clients',
+--                                  'oauth_authorization_codes',
+--                                  'user_auth_sessions'));
+--
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- The role itself. NOLOGIN: it is a privilege bundle, not an identity. The
+-- identity is a separate login role the operator creates with a password that
+-- never enters this repository, and which is granted this one.
+--
+-- Every attribute here is a capability this role must not have. NOCREATEDB and
+-- NOCREATEROLE are not decoration: they are the difference between "cannot
+-- issue DDL against these tables" and "cannot build somewhere else to issue it
+-- from".
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'djinn_task_run') THEN
+        CREATE ROLE djinn_task_run NOLOGIN;
+    END IF;
+END
+$$;
+
+ALTER ROLE djinn_task_run
+    NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+
+-- ---------------------------------------------------------------------------
+-- Schema access: USAGE, never CREATE.
+--
+-- `REVOKE CREATE ON SCHEMA public FROM PUBLIC` is the load-bearing line for
+-- databases initialised before PostgreSQL 15, where `public` was writable by
+-- every role by default. Without it the role could `CREATE TABLE` in `public`
+-- no matter what is or is not granted below, and the whole point of this file
+-- would be decorative.
+-- ---------------------------------------------------------------------------
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM djinn_task_run;
+GRANT USAGE ON SCHEMA public TO djinn_task_run;
+
+-- No database-level CREATE either (that is CREATE SCHEMA).
+DO $$
+BEGIN
+    EXECUTE format('REVOKE CREATE ON DATABASE %I FROM PUBLIC', current_database());
+    EXECUTE format('REVOKE CREATE ON DATABASE %I FROM djinn_task_run', current_database());
+    EXECUTE format('GRANT CONNECT ON DATABASE %I TO djinn_task_run', current_database());
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Start from nothing, every run. This is what makes the script idempotent
+-- against a database whose grants have drifted, and what makes step 5
+-- (re-running after a migration) converge rather than accumulate.
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM djinn_task_run;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM djinn_task_run;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA public FROM djinn_task_run;
+
+-- ---------------------------------------------------------------------------
+-- Board DML on everything except the tables named below.
+--
+-- TRUNCATE and REFERENCES are excluded on purpose. TRUNCATE is a destructive
+-- verb no application path uses, and REFERENCES lets a role create a foreign
+-- key -- which is DDL, and would also pin the referenced rows.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    target text;
+    -- Tables the Pod must never read or write.
+    --
+    -- The credential and auth surface. `AgentContext.db` reaches
+    -- `CredentialRepository` and the OAuth/token repositories through the same
+    -- handle, even though the deterministic worker path never calls them
+    -- (`provider_override.is_some()` short-circuits credential resolution).
+    -- The Pod already receives the one credential it needs as a mounted
+    -- Secret, so nothing legitimate is lost.
+    secret_tables constant text[] := ARRAY[
+        'credentials',
+        'custom_providers',
+        'mcp_access_tokens',
+        'oauth_authorization_codes',
+        'oauth_clients',
+        'user_auth_sessions'
+    ];
+    -- Tables the Pod may read but must never write.
+    --
+    -- `_sqlx_migrations` is the object the incident corrupted: the boot-time
+    -- schema verification reads it, and nothing in a Pod has any business
+    -- writing it. `admission_handoff` is the durable invocation-lease
+    -- authority -- the Pod projects it into a lift decision; only the
+    -- coordinator arms it.
+    read_only_tables constant text[] := ARRAY[
+        '_sqlx_migrations',
+        'admission_handoff'
+    ];
+BEGIN
+    FOR target IN
+        SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+    LOOP
+        IF target = ANY (secret_tables) THEN
+            CONTINUE;
+        ELSIF target = ANY (read_only_tables) THEN
+            EXECUTE format('GRANT SELECT ON public.%I TO djinn_task_run', target);
+        ELSE
+            EXECUTE format(
+                'GRANT SELECT, INSERT, UPDATE, DELETE ON public.%I TO djinn_task_run',
+                target
+            );
+        END IF;
+    END LOOP;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Future tables.
+--
+-- Without this, the next migration that adds a table takes the Pod down: the
+-- table exists, the code writes it, and the role has no privilege on it. The
+-- default is deliberately the permissive arm -- a new SECRET table is the case
+-- the operator must handle, and step 5 plus step 6's verification is how.
+--
+-- `FOR ROLE` is derived from whoever owns the tables today rather than
+-- hard-coded, because default privileges attach to the CREATING role and the
+-- migrate Job's identity is a deployment detail, not a constant.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    owner_role text;
+BEGIN
+    SELECT pg_get_userbyid(c.relowner)
+      INTO owner_role
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public'
+       AND c.relkind = 'r'
+     GROUP BY pg_get_userbyid(c.relowner)
+     ORDER BY count(*) DESC
+     LIMIT 1;
+
+    IF owner_role IS NULL THEN
+        RAISE EXCEPTION
+            'no tables in schema public: run this after the migrations, not before';
+    END IF;
+
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA public '
+        'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO djinn_task_run',
+        owner_role
+    );
+    -- No default sequence or function privileges: see the header note on why
+    -- the Pod needs neither.
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA public '
+        'REVOKE ALL ON SEQUENCES FROM djinn_task_run',
+        owner_role
+    );
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Assert the properties this file claims, inside the same transaction that
+-- established them. A grant script that cannot fail is a grant script nobody
+-- can trust; these three checks are the reason the incident is now
+-- structurally impossible for this role rather than merely unlikely.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    offender text;
+BEGIN
+    IF has_schema_privilege('djinn_task_run', 'public', 'CREATE') THEN
+        RAISE EXCEPTION 'djinn_task_run has CREATE on schema public; it must not';
+    END IF;
+
+    SELECT string_agg(c.relname, ', ')
+      INTO offender
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public'
+       AND pg_get_userbyid(c.relowner) = 'djinn_task_run';
+    IF offender IS NOT NULL THEN
+        RAISE EXCEPTION 'djinn_task_run owns relations (%); it must own none', offender;
+    END IF;
+
+    SELECT string_agg(format('%s:%s', table_name, privilege_type), ', ')
+      INTO offender
+      FROM information_schema.role_table_grants
+     WHERE grantee = 'djinn_task_run'
+       AND table_schema = 'public'
+       AND ((table_name = '_sqlx_migrations' AND privilege_type <> 'SELECT')
+            OR table_name IN ('credentials', 'custom_providers', 'mcp_access_tokens',
+                              'oauth_authorization_codes', 'oauth_clients',
+                              'user_auth_sessions'));
+    IF offender IS NOT NULL THEN
+        RAISE EXCEPTION 'djinn_task_run holds forbidden grants (%)', offender;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_roles
+         WHERE rolname = 'djinn_task_run'
+           AND (rolsuper OR rolcreatedb OR rolcreaterole OR rolbypassrls)
+    ) THEN
+        RAISE EXCEPTION 'djinn_task_run carries a role attribute it must not';
+    END IF;
+END
+$$;
+
+COMMIT;

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -75,6 +75,7 @@ mod checkpoint;
 mod checkpoint_safety;
 mod launcher_handshake;
 mod lifecycle;
+mod platform_dsn;
 pub mod warm_base_census;
 pub mod warm_build_lease;
 pub mod warm_step_budget;
@@ -414,6 +415,17 @@ impl djinn_graph::WarmContext for WorkerWarmContext {
 }
 
 fn main() {
+    // FIRST, before Tokio, before telemetry, before any thread exists: move the
+    // platform DSN out of this process's environment. Every command the agent
+    // runs is a descendant of this process, so this is the only place a scrub
+    // covers spawn paths that have not been written yet — including the ones
+    // that execute repository-controlled code (`build.rs`, `postinstall`, a
+    // language server). The value is kept, not dropped;
+    // `bootstrap_warm_database()` reads it from `platform_dsn` and the
+    // invocation-lease authority is composed over the handle exactly as before.
+    // See `platform_dsn` for the measurement and for why `remove_var` is sound
+    // at this point.
+    platform_dsn::take_from_environment();
     // Install before constructing Tokio or dispatching work.
     djinn_telemetry::panic_capture::install();
     let exit = tokio::runtime::Builder::new_multi_thread()
@@ -4457,9 +4469,15 @@ async fn load_cached_graph_artifact(
 /// only manage one configuration surface:
 ///
 /// * `DJINN_DATABASE_URL` — full DSN (required).
+///
+/// Read from [`platform_dsn`], not from the environment: `main` moves the
+/// variable out of this process at startup so nothing the agent spawns can
+/// inherit a DDL-capable platform connection string. The value is unchanged —
+/// this function still opens the same database, and the durable
+/// invocation-lease authority is still built over the handle it returns.
 async fn bootstrap_warm_database() -> Result<Database> {
-    let url = std::env::var("DJINN_DATABASE_URL")
-        .map_err(|_| anyhow::anyhow!("DJINN_DATABASE_URL must be set for the warm worker pod"))?;
+    let url = platform_dsn::platform_dsn()
+        .ok_or_else(|| anyhow::anyhow!("DJINN_DATABASE_URL must be set for the warm worker pod"))?;
 
     let connect = DatabaseConnectConfig::Postgres(PostgresDatabaseConfig { url });
     let db = Database::open_with_config(connect).context("open warm worker database")?;
@@ -4530,6 +4548,111 @@ mod tests {
     const WARM_TEST_PROJECT: &str = "warm-worker-project";
     const WARM_TEST_REVISION: &str = "warm-worker-revision";
     const WARM_TEST_DEADLINE: &str = "2099-01-01T00:00:00.000Z";
+
+    /// Serialises the two tests that render `DJINN_DATABASE_URL` into this
+    /// process and then take it away again. A `tokio::sync::Mutex` because both
+    /// hold it across `.await`.
+    static PLATFORM_DSN_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// The goxi-13 guard: scrubbing the platform DSN out of the process
+    /// environment must not disarm the invocation-lease authority.
+    ///
+    /// Blocker 13 was a composition change that left the runner holding an
+    /// authority which answered `Unleased` for every invocation while the
+    /// durable authority was armed — no error, no log, four rollouts. This
+    /// change moves where `bootstrap_warm_database()` gets its DSN from, which
+    /// is exactly the kind of rewiring that produced it. So the assertion here
+    /// is on the DECISION the authority reaches over the database that
+    /// `bootstrap_warm_database()` actually opened, not on the fact that a
+    /// `Database` was constructed: an authority armed to `Enforce` must project
+    /// to `Lift`.
+    #[tokio::test]
+    async fn the_scrubbed_worker_still_resolves_the_platform_invocation_lease_authority() {
+        use djinn_db::InvocationLeaseMode;
+        use djinn_supervisor::services::{
+            DurableInvocationLiftAuthority, InvocationLiftAuthority, InvocationLiftDecision,
+        };
+
+        // A real platform database: the migrated template clone, with the
+        // durable authority row seeded and armed the way production arms it.
+        let platform = Database::open_in_memory().expect("platform test database");
+        let authority_rows = djinn_db::InvocationLeaseAuthorityRepository::new(platform.clone());
+        let row = authority_rows
+            .seed_baseline()
+            .await
+            .expect("seed the disarmed baseline");
+        authority_rows
+            .set_mode_and_cap(row.epoch, InvocationLeaseMode::Enforce, None)
+            .await
+            .expect("arm the invocation lease authority");
+        let dsn = platform
+            .test_dsn()
+            .expect("the test harness exposes the per-test DSN");
+
+        // Render it the way `djinn_k8s::job` renders a task-run Pod, then run
+        // the worker's startup scrub over it.
+        let _guard = PLATFORM_DSN_TEST_MUTEX.lock().await;
+        platform_dsn::clear_for_test();
+        // SAFETY: serialised by `_guard`; this test binary mutates no other
+        // process-global environment concurrently.
+        unsafe { std::env::set_var(platform_dsn::PLATFORM_DSN_ENV, &dsn) };
+        platform_dsn::take_from_environment();
+        assert!(
+            std::env::var_os(platform_dsn::PLATFORM_DSN_ENV).is_none(),
+            "the scrub must have taken the variable out of the environment, or this test \
+             would prove nothing about the state the worker actually runs in"
+        );
+
+        // The worker binary's own bootstrap, unchanged in every other respect.
+        let opened = bootstrap_warm_database()
+            .await
+            .expect("the worker must still open the platform database after the scrub");
+
+        // The authority the in-pod composition builds over that handle
+        // (`djinn_agent::context::ShellLaunchContext::broker_backed`), asked the
+        // same question the runner asks per invocation.
+        let decision = DurableInvocationLiftAuthority::new(opened, "in-pod worker")
+            .invocation_lift_decision()
+            .await;
+        assert!(
+            matches!(decision, InvocationLiftDecision::Lift),
+            "an armed durable authority must still project to Lift after the scrub; \
+             {decision:?} is the blocker-13 shape"
+        );
+
+        drop(platform);
+    }
+
+    /// Deleting the scrub from `main` must break loudly, not silently.
+    ///
+    /// The scrub is on the ONLY path to the DSN: `bootstrap_warm_database()`
+    /// reads `platform_dsn`, never the environment. So a future edit that drops
+    /// `platform_dsn::take_from_environment()` from `main` does not quietly
+    /// restore the leak — the worker fails at startup with the same hard error
+    /// it has always raised for a missing DSN, before a session exists. This
+    /// asserts that coupling directly, because the alternative (a scrub that
+    /// some other code path can bypass) is exactly how the exposure lasted.
+    #[tokio::test]
+    async fn the_platform_dsn_is_unreachable_without_the_startup_scrub() {
+        let _guard = PLATFORM_DSN_TEST_MUTEX.lock().await;
+        platform_dsn::clear_for_test();
+        // SAFETY: serialised by `_guard`.
+        unsafe {
+            std::env::set_var(
+                platform_dsn::PLATFORM_DSN_ENV,
+                "postgres://u:p@127.0.0.1:5432/djinn",
+            );
+        }
+        // Deliberately do NOT call `take_from_environment()`.
+        let error = bootstrap_warm_database()
+            .await
+            .expect_err("a rendered variable that was never taken must not open a database");
+        assert!(
+            error.to_string().contains("DJINN_DATABASE_URL must be set"),
+            "the failure must be the existing hard startup error, got: {error}"
+        );
+        platform_dsn::clear_for_test();
+    }
 
     #[test]
     fn only_an_indexed_scip_outcome_completes_successfully() {

--- a/server/crates/djinn-agent-worker/src/platform_dsn.rs
+++ b/server/crates/djinn-agent-worker/src/platform_dsn.rs
@@ -1,0 +1,223 @@
+//! The platform database DSN, taken out of the process environment at startup.
+//!
+//! # The exposure this closes (measured 2026-08-04)
+//!
+//! A task-run Pod's **worker container** is rendered with two Postgres DSNs:
+//!
+//! * `DATABASE_URL` / `TEST_POSTGRES_URL` — the pod-local `svc-postgres`
+//!   sidecar on `127.0.0.1:5432`. Project-scoped, disposable, correct.
+//! * `DJINN_DATABASE_URL` — the **platform** control-plane database. It holds
+//!   `tasks`, `sessions`, `credentials` and `_sqlx_migrations`, and the role it
+//!   authenticates as is DDL-capable.
+//!
+//! Every command the model runs — `bash -lc`, a `build.rs`, a test binary, an
+//! npm `postinstall`, a language server — is a descendant of this process, so
+//! every one of them inherited the second one. Nothing downstream of the worker
+//! binary needs it: repository-controlled code that wants a database wants the
+//! sidecar.
+//!
+//! # Why this is done here rather than at the spawn sites
+//!
+//! `unsetenv` in the parent is the only control that holds for spawn paths that
+//! do not exist yet. The agent reaches a child process through the launcher
+//! broker, through the launcher-free `bash -lc` fallback, through the
+//! setup-hook runner, through git, through the LSP manager and through
+//! project-configured MCP servers; each of those is a separate `Command`, and a
+//! scrub attached to any subset of them is one new call site away from being
+//! wrong again. A variable that is not in this process's environment cannot be
+//! inherited by anything, and the `#[cfg(test)]` proof below asserts exactly
+//! that against a child that applies no filtering at all.
+//!
+//! `djinn_cgroup_launcher::env`'s deny-set is the second, independent control:
+//! it refuses the key at the broker boundary even if some other process in the
+//! Pod holds the value.
+//!
+//! # Why the value survives (goxi launcher blocker 13)
+//!
+//! The worker *binary* legitimately needs the platform database:
+//! `bootstrap_warm_database()` opens it, and `djinn_agent::context` builds the
+//! durable invocation-lease authority — the thing that decides whether a build
+//! may be lifted off the 250m unleased quota — over that handle and nothing
+//! else. Blocker 13 was a wiring change that left that authority answering
+//! `Unleased` for every invocation while it was armed, silently and with no
+//! error. So the value is not dropped, it is *moved*: read once, before any
+//! thread exists, into this module, and handed to `bootstrap_warm_database()`
+//! from here.
+
+use std::sync::RwLock;
+
+/// The environment variable the Pod renders the platform DSN into.
+pub const PLATFORM_DSN_ENV: &str = "DJINN_DATABASE_URL";
+
+/// The DSN this process took out of its own environment, if it had one.
+///
+/// A `RwLock` rather than a `OnceLock` because tests take it repeatedly; the
+/// production path writes it exactly once, from `main`, before the Tokio
+/// runtime exists.
+static PLATFORM_DSN: RwLock<Option<String>> = RwLock::new(None);
+
+/// Move [`PLATFORM_DSN_ENV`] out of this process's environment and into
+/// [`PLATFORM_DSN`].
+///
+/// # Safety
+///
+/// `std::env::remove_var` mutates a process-global that other threads may be
+/// reading, so it is only sound while this process is single-threaded. The one
+/// production caller is the first statement of `main`, before the Tokio runtime
+/// is built and before any subcommand is dispatched — so every later
+/// `bootstrap_warm_database()` call, in every subcommand, sees the stashed
+/// value.
+///
+/// Idempotent: a second call with the variable already gone keeps the value
+/// taken by the first.
+pub fn take_from_environment() {
+    let Some(value) = std::env::var_os(PLATFORM_DSN_ENV) else {
+        return;
+    };
+    // SAFETY: called before the Tokio runtime is built and before any thread is
+    // spawned; see the note above.
+    unsafe { std::env::remove_var(PLATFORM_DSN_ENV) };
+    let value = value.to_string_lossy().into_owned();
+    *PLATFORM_DSN
+        .write()
+        .expect("platform DSN lock is never held across a panic") = Some(value);
+}
+
+/// The platform DSN taken by [`take_from_environment`], if any.
+pub fn platform_dsn() -> Option<String> {
+    PLATFORM_DSN
+        .read()
+        .expect("platform DSN lock is never held across a panic")
+        .clone()
+}
+
+/// Return this process to the state `main` starts in: no rendered variable and
+/// nothing taken. Test-only — production takes exactly once, from `main`.
+///
+/// # Safety
+///
+/// Mutates the process environment; callers must hold the serialising lock of
+/// whichever test module they belong to.
+#[cfg(test)]
+pub(crate) fn clear_for_test() {
+    // SAFETY: the caller holds its module's environment lock.
+    unsafe { std::env::remove_var(PLATFORM_DSN_ENV) };
+    *PLATFORM_DSN.write().unwrap() = None;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    /// Serialises the tests in this module: they mutate the process
+    /// environment, which every thread in the test binary shares.
+    static ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn reset() {
+        super::clear_for_test();
+    }
+
+    /// The regression, asserted on a child's ACTUAL environment.
+    ///
+    /// The child here is deliberately unfiltered — a bare
+    /// `std::process::Command` with no allow-list, no `env_clear`, nothing.
+    /// That is the point: it stands in for every spawn path in the worker,
+    /// including the ones nobody has written yet. If this passes, none of them
+    /// can see the platform DSN.
+    #[test]
+    fn no_child_of_this_process_can_observe_the_platform_dsn() {
+        let _guard = ENV.lock().unwrap_or_else(|error| error.into_inner());
+        reset();
+        // SAFETY: serialised by `_guard`.
+        unsafe {
+            std::env::set_var(
+                PLATFORM_DSN_ENV,
+                "postgres://djinn:hunter2@djinn-postgres.djinn.svc.cluster.local:5432/djinn",
+            );
+        }
+
+        // Before: an ordinary child sees it. This half proves the test is
+        // wired to something real rather than to an always-empty variable.
+        let leaked = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("printf %s \"${DJINN_DATABASE_URL-}\"")
+            .output()
+            .expect("spawn the probe child");
+        assert_eq!(
+            String::from_utf8_lossy(&leaked.stdout),
+            "postgres://djinn:hunter2@djinn-postgres.djinn.svc.cluster.local:5432/djinn",
+            "the probe must observe the variable before the scrub, or it proves nothing"
+        );
+
+        take_from_environment();
+
+        let scrubbed = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("printf %s \"${DJINN_DATABASE_URL-}\"")
+            .output()
+            .expect("spawn the probe child");
+        assert_eq!(
+            String::from_utf8_lossy(&scrubbed.stdout),
+            "",
+            "no child of the worker may observe the platform DSN"
+        );
+        // And nothing else in the environment leaks it either — a value scrub
+        // that merely renamed the key would be the same defect.
+        let dumped = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("env")
+            .output()
+            .expect("spawn the probe child");
+        assert!(
+            !String::from_utf8_lossy(&dumped.stdout).contains("hunter2"),
+            "the platform DSN must not survive under any key in the child environment"
+        );
+
+        reset();
+    }
+
+    /// The value is MOVED, not dropped: the worker binary must still be able to
+    /// open the platform database. This is the half that keeps the
+    /// invocation-lease authority alive (goxi launcher blocker 13); the
+    /// end-to-end proof over a real database lives in `main.rs`'s test module.
+    #[test]
+    fn the_worker_keeps_the_value_it_took() {
+        let _guard = ENV.lock().unwrap_or_else(|error| error.into_inner());
+        reset();
+        // SAFETY: serialised by `_guard`.
+        unsafe { std::env::set_var(PLATFORM_DSN_ENV, "postgres://u:p@host:5432/djinn") };
+
+        take_from_environment();
+
+        assert_eq!(
+            platform_dsn().as_deref(),
+            Some("postgres://u:p@host:5432/djinn"),
+            "the DSN must survive the scrub for bootstrap_warm_database()"
+        );
+        assert!(
+            std::env::var_os(PLATFORM_DSN_ENV).is_none(),
+            "and must no longer be in this process's environment"
+        );
+
+        // Idempotent: a second take does not lose it.
+        take_from_environment();
+        assert_eq!(
+            platform_dsn().as_deref(),
+            Some("postgres://u:p@host:5432/djinn")
+        );
+
+        reset();
+    }
+
+    /// An absent variable stays absent — the local/non-pod run, where
+    /// `bootstrap_warm_database()` must keep producing its own hard error
+    /// rather than a confusing empty DSN.
+    #[test]
+    fn an_absent_variable_yields_no_dsn() {
+        let _guard = ENV.lock().unwrap_or_else(|error| error.into_inner());
+        reset();
+        take_from_environment();
+        assert!(platform_dsn().is_none());
+    }
+}

--- a/server/crates/djinn-agent/src/environment.rs
+++ b/server/crates/djinn-agent/src/environment.rs
@@ -475,6 +475,96 @@ mod tests {
         assert!(!project_has_indexable_code(&db, "p1").await);
     }
 
+    /// Serialises the tests below: they mutate the process environment, which
+    /// every thread in this test binary shares.
+    static CHILD_ENVIRONMENT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// The platform DSN must not reach a process the agent's shell path spawns.
+    ///
+    /// Asserted on the child's ACTUAL environment — the bytes a `bash -lc`
+    /// prints — rather than on the fact that a filter was called. `bash -lc`
+    /// with `printenv` is the exact shape
+    /// `extension::handlers::workspace::run_shell` builds, and
+    /// `clear_and_admit_child_environment` is the exact call it makes on the
+    /// launcher-free path.
+    ///
+    /// Measured on a live task-run Job spec, 2026-08-04: the worker container
+    /// carries `DJINN_DATABASE_URL` pointing at the production platform
+    /// database, and it reached this child because the launcher allow-list
+    /// admits the whole `DJINN_` prefix.
+    #[test]
+    #[cfg(unix)]
+    fn the_agent_shell_child_cannot_observe_the_platform_dsn() {
+        const DSN: &str =
+            "postgres://djinn:hunter2@djinn-postgres.djinn.svc.cluster.local:5432/djinn";
+        let _guard = CHILD_ENVIRONMENT_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        // SAFETY: serialised by `_guard`.
+        unsafe {
+            std::env::set_var("DJINN_DATABASE_URL", DSN);
+            // A sibling on the same open `DJINN_` prefix that is NOT a secret:
+            // it must still reach the child, or this would be a scrub of the
+            // whole namespace wearing a narrower name.
+            std::env::set_var("DJINN_TASK_RUN_ID", "task-run-fixture");
+            std::env::set_var("PATH", "/usr/local/bin:/usr/bin:/bin");
+        }
+
+        let probe = "printf %s \"${DJINN_DATABASE_URL-}|${DJINN_TASK_RUN_ID-}\"";
+
+        // The launcher-free production path.
+        let mut command = Command::new("bash");
+        command
+            .arg("-lc")
+            .arg(probe)
+            .current_dir("/")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null());
+        clear_and_admit_child_environment(&mut command).expect("admit the child environment");
+        let output = command.output().expect("spawn the probe child");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "|task-run-fixture",
+            "the platform DSN must be absent from the child's environment, and the \
+             non-secret DJINN_ sibling must still be present"
+        );
+
+        // The brokered production path builds a `CommandSpec` instead of
+        // spawning directly, and the privileged broker re-checks the same
+        // predicate before `execve`. Drive the REAL conversion.
+        let mut brokered = Command::new("bash");
+        // `CommandSpec::validate` restricts the cwd to the mounts a task-run Pod
+        // actually has; `/workspace` is the one `run_shell` uses.
+        brokered.arg("-lc").arg(probe).current_dir("/workspace");
+        let spec = crate::process::command_spec(brokered).expect("build the brokered spec");
+        assert!(
+            !spec
+                .environment
+                .iter()
+                .any(|(key, _)| key == "DJINN_DATABASE_URL"),
+            "the brokered child's environment must not carry the platform DSN"
+        );
+        assert!(
+            !spec
+                .environment
+                .iter()
+                .any(|(_, value)| value.contains(DSN)),
+            "and it must not carry the DSN under any other key either"
+        );
+        assert!(
+            spec.environment
+                .iter()
+                .any(|(key, value)| key == "DJINN_TASK_RUN_ID" && value == "task-run-fixture"),
+            "the non-secret DJINN_ namespace must still reach a brokered child"
+        );
+
+        // SAFETY: serialised by `_guard`.
+        unsafe {
+            std::env::remove_var("DJINN_DATABASE_URL");
+            std::env::remove_var("DJINN_TASK_RUN_ID");
+        }
+    }
+
     #[test]
     fn hook_commands_to_specs_handles_shell_form() {
         let hooks = vec![

--- a/server/crates/djinn-cgroup-launcher/src/env.rs
+++ b/server/crates/djinn-cgroup-launcher/src/env.rs
@@ -148,13 +148,108 @@ const ALLOWED_PREFIXES: &[&str] = &[
     "POETRY_",
 ];
 
+/// Keys the `DJINN_` prefix would otherwise admit, and must not.
+///
+/// # Why a deny-set inside an allow-list is not a contradiction
+///
+/// `DJINN_` is a *prefix* entry on [`ALLOWED_PREFIXES`], so it is open by
+/// default: every variable the pod renders into that namespace reaches the
+/// child. That is right for the rendered build/runtime configuration it was
+/// added for, and wrong for the handful of entries in the same namespace that
+/// are platform secrets rather than configuration. Naming them here keeps the
+/// open prefix (a new `DJINN_CAPACITY_*` knob still reaches the child without a
+/// code change) while closing the entries that must never cross.
+///
+/// # `DJINN_DATABASE_URL` (measured, 2026-08-04)
+///
+/// This is the **platform** Postgres DSN — the control-plane database holding
+/// `tasks`, `sessions`, `credentials` and `_sqlx_migrations` — and it is
+/// DDL-capable. It is rendered onto the task-run Pod's worker container because
+/// the worker *binary* needs it (`bootstrap_warm_database()` opens it, and the
+/// durable invocation-lease authority is read from it). Nothing the agent
+/// spawns needs it: the project's own database is the pod-local `svc-postgres`
+/// sidecar on `DATABASE_URL`/`TEST_POSTGRES_URL`, which is a different server
+/// and is not on this allow-list at all. Forwarding it put a DDL-capable
+/// connection string in the environment of every `bash -lc` the model runs.
+///
+/// The worker also strips this key from its **own** process environment at
+/// startup so no child of any spawn path inherits it; this entry is the
+/// second, independent control at the boundary the broker exists to establish.
+///
+/// # The credential paths
+///
+/// `DJINN_CREDENTIALS_PATH`, `DJINN_LAUNCHER_CREDENTIAL_PATH` and
+/// `DJINN_TOKEN_PATH` name files under the `/var/run/djinn` and
+/// `/var/run/secrets` mounts that
+/// [`djinn_sandbox::confidential`](../../djinn-sandbox/src/confidential.rs)
+/// already withholds from repository-controlled code. Withholding the *names*
+/// too costs nothing — no child reads them; they are consumed by the worker's
+/// own argv (`Cli`) and by the launcher process — and means the read denial is
+/// not the only thing standing between a spawned command and the secret's
+/// location.
+const DENIED_KEYS: &[&str] = &[
+    "DJINN_DATABASE_URL",
+    "DJINN_MYSQL_URL",
+    "DJINN_CREDENTIALS_PATH",
+    "DJINN_LAUNCHER_CREDENTIAL_PATH",
+    "DJINN_TOKEN_PATH",
+];
+
+/// URI schemes whose values carry a database credential when they embed
+/// userinfo. Used by [`is_allowed_environment_entry`]'s shape rule.
+///
+/// Deliberately database-only. A registry variable on an allowed prefix
+/// (`NPM_CONFIG_REGISTRY`, `PIP_INDEX_URL`, `UV_INDEX_URL`) may legitimately
+/// carry `https://user:token@host`, and a private-registry build must keep
+/// working.
+const CREDENTIALED_URI_SCHEMES: &[&str] = &[
+    "postgres://",
+    "postgresql://",
+    "mysql://",
+    "mariadb://",
+    "mongodb://",
+    "mongodb+srv://",
+    "redis://",
+    "rediss://",
+];
+
+/// Does `value` look like a database URI that embeds a username and password?
+///
+/// The point is to catch the *class* rather than the names in [`DENIED_KEYS`]:
+/// a variable added later that carries a platform DSN is refused by shape even
+/// if nobody remembers to name it above. Matching requires userinfo containing
+/// a `:` — a bare `postgres://host/db` names no credential and is not what this
+/// is protecting.
+fn is_credentialed_database_uri(value: &str) -> bool {
+    let Some(rest) = CREDENTIALED_URI_SCHEMES
+        .iter()
+        .find_map(|scheme| value.strip_prefix(scheme))
+    else {
+        return false;
+    };
+    // Userinfo is everything before the first `@`, and must not run past the
+    // authority (a `/`, `?` or `#` ends it).
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    match authority.split_once('@') {
+        Some((userinfo, _)) => userinfo.contains(':'),
+        None => false,
+    }
+}
+
 /// Is `key` forwardable to a launched child?
 ///
 /// This is the single predicate behind both ends of the hop: the worker filters
 /// its own environment with it before building a [`CommandSpec`](crate::CommandSpec),
 /// and `CommandSpec::validate` re-checks it inside the privileged broker. The
 /// worker-side filter is a convenience; the broker-side check is the control.
+///
+/// [`DENIED_KEYS`] is consulted FIRST so a denied name cannot be re-admitted by
+/// [`ALLOWED_PREFIXES`].
 pub fn is_allowed_environment_key(key: &str) -> bool {
+    if DENIED_KEYS.contains(&key) {
+        return false;
+    }
     ALLOWED_KEYS.contains(&key)
         || ALLOWED_PREFIXES
             .iter()
@@ -177,10 +272,18 @@ pub fn is_allowed_environment_key(key: &str) -> bool {
 /// process wrote. A caller cannot name it usefully (the launcher overwrites the
 /// value on every spawn regardless) and cannot name anything else at all.
 ///
+/// A value that is a credentialed database URI is refused whatever its key, for
+/// the same reason [`DENIED_KEYS`] exists: the leak that motivated both was a
+/// DDL-capable platform DSN reaching `bash -lc`, and the next one will arrive
+/// under a name nobody thought to deny. See [`is_credentialed_database_uri`].
+///
 /// Every other key is judged by name, as before.
 pub fn is_allowed_environment_entry(key: &str, value: &str) -> bool {
     if key == GIT_TRUST_ANCHOR_KEY {
         return crate::git_trust::is_anchor_value(value);
+    }
+    if is_credentialed_database_uri(value) {
+        return false;
     }
     is_allowed_environment_key(key)
 }
@@ -305,6 +408,90 @@ mod tests {
                 "{denied} must not be forwardable"
             );
         }
+    }
+
+    /// The platform DSN and the credential paths sit inside the OPEN `DJINN_`
+    /// prefix, so they were forwarded to every child until they were named.
+    /// Measured on a live task-run Job spec on 2026-08-04: the worker container
+    /// carried `DJINN_DATABASE_URL` pointing at the production platform
+    /// database, and the agent's `bash -lc` inherited it.
+    #[test]
+    fn the_platform_secrets_inside_the_open_djinn_prefix_are_denied() {
+        for denied in [
+            "DJINN_DATABASE_URL",
+            "DJINN_MYSQL_URL",
+            "DJINN_CREDENTIALS_PATH",
+            "DJINN_LAUNCHER_CREDENTIAL_PATH",
+            "DJINN_TOKEN_PATH",
+        ] {
+            assert!(
+                !is_allowed_environment_key(denied),
+                "{denied} must not be forwardable by name"
+            );
+            assert!(
+                !is_allowed_environment_entry(denied, "postgres://u:p@host:5432/djinn"),
+                "{denied} must not be forwardable as an entry"
+            );
+            assert!(
+                denied.starts_with("DJINN_"),
+                "{denied} only needs denying because the DJINN_ prefix would admit it"
+            );
+        }
+    }
+
+    /// The deny-set closes the names we measured; this closes the class. A DSN
+    /// added later under a name nobody thought to deny is refused by shape.
+    #[test]
+    fn a_credentialed_database_uri_is_refused_whatever_its_key_is() {
+        for value in [
+            "postgres://djinn:hunter2@djinn-postgres.djinn.svc.cluster.local:5432/djinn",
+            "postgresql://djinn:hunter2@127.0.0.1:5432/djinn?sslmode=require",
+            "mysql://root:root@db:3306/app",
+            "redis://default:secret@cache:6379",
+            "mongodb+srv://user:pw@cluster0.example.net/db",
+        ] {
+            assert!(
+                !is_allowed_environment_entry("DJINN_SOME_FUTURE_URL", value),
+                "a credentialed database URI must not be forwardable: {value}"
+            );
+            assert!(
+                !is_allowed_environment_entry("RUST_LOG", value),
+                "the shape rule is key-independent: {value}"
+            );
+        }
+    }
+
+    /// The shape rule must not become a private-registry outage. A token in an
+    /// `https://` index URL on an allowed prefix keeps working, and a
+    /// credential-free database URI is judged by its key like anything else.
+    #[test]
+    fn the_shape_rule_does_not_reach_registry_urls_or_credential_free_dsns() {
+        assert!(
+            is_allowed_environment_entry(
+                "PIP_INDEX_URL",
+                "https://user:token@pypi.example.com/simple"
+            ),
+            "a private package index must keep working"
+        );
+        assert!(
+            is_allowed_environment_entry(
+                "NPM_CONFIG_REGISTRY",
+                "https://build:token@npm.example.com/"
+            ),
+            "a private npm registry must keep working"
+        );
+        assert!(
+            !is_credentialed_database_uri("postgres://localhost:5432/app_test"),
+            "a DSN with no userinfo names no credential"
+        );
+        assert!(
+            !is_credentialed_database_uri("postgres://user@localhost:5432/app_test"),
+            "userinfo with no password is not a credential"
+        );
+        assert!(
+            !is_credentialed_database_uri("postgres://localhost:5432/db?opts=a:b@c"),
+            "a `:`+`@` in the path or query is not userinfo"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The exposure

Measured 2026-08-04 by reading a live task-run Job spec on the VPS. Every task-run Pod's **worker container** carries three Postgres DSNs:

| Variable | Points at | |
|---|---|---|
| `DJINN_DATABASE_URL` | `djinn-postgres.djinn.svc.cluster.local:5432/djinn` | **production platform DB, DDL-capable** |
| `DATABASE_URL` | `127.0.0.1:5432/app_test` | pod-local sidecar (correct) |
| `TEST_POSTGRES_URL` | `127.0.0.1:5432/app_test` | pod-local sidecar (correct) |

The agent's shell commands run inside that same container, so every `bash -lc`, every `build.rs`, every test binary, every npm `postinstall` and every language server inherited a DDL-capable connection string to the control-plane database.

Confirmed against the current code, not assumed: `djinn_cgroup_launcher::env::ALLOWED_PREFIXES` carries `"DJINN_"` as an **open prefix**, so the platform DSN was admitted to both child-spawn paths that filter (`extension::handlers::workspace::run_shell`'s launcher-free fallback, and `process_broker::command_spec`'s brokered path), and inherited outright by the ones that do not (`commands::run_commands` setup hooks, git, LSP, MCP servers).

Today production ended up with migration 182's DDL applied and no `_sqlx_migrations` ledger row, which crash-looped the migrate init container on the v0.7.41 deploy. **The actor is unproven and `log_statement=none` means it is probably unknowable. Nothing here asserts a culprit.** The point is to make the question moot.

## Part A — the agent's shell cannot see the platform DSN (done)

Two independent controls. Neither is a per-call-site `env_remove`.

### 1. The worker takes the variable out of its own environment (`platform_dsn.rs`, new)

`fn main()` calls `platform_dsn::take_from_environment()` as its first statement — before `djinn_telemetry::panic_capture::install()`, before the Tokio runtime is built, before any subcommand dispatches, and therefore while the process is still single-threaded (which is what makes `remove_var` sound). The value is stashed in a process-global; `bootstrap_warm_database()` reads it from there instead of from `std::env`.

This is the chokepoint the task asked for, and it is a genuine one: I enumerated the agent's spawn paths (`process_broker.rs`, `extension/handlers/workspace.rs`, `commands.rs`, `process.rs`, git, `lsp.rs`, `mcp_client`) and they are *several* separate `Command`s, so a scrub attached to any subset is one new call site away from being wrong again. `unsetenv` in the parent is the only control that covers spawn paths that do not exist yet.

**The value is moved, not dropped.** `bootstrap_warm_database()` still opens the same database, and `djinn_agent::context::ShellLaunchContext::broker_backed` still builds `DurableInvocationLiftAuthority` over that handle.

**Deleting the scrub is not silent.** `bootstrap_warm_database()` no longer reads the environment at all, so removing the `main` call makes the worker fail at startup with the pre-existing hard `DJINN_DATABASE_URL must be set` error, before a session exists — asserted by `the_platform_dsn_is_unreachable_without_the_startup_scrub`.

### 2. The launcher env contract names the secrets in the open `DJINN_` prefix (`djinn-cgroup-launcher/src/env.rs`)

`DENIED_KEYS` is consulted *before* the prefix rules, so a denied name cannot be re-admitted:

```
DJINN_DATABASE_URL, DJINN_MYSQL_URL, DJINN_CREDENTIALS_PATH,
DJINN_LAUNCHER_CREDENTIAL_PATH, DJINN_TOKEN_PATH
```

Plus a **value-shape rule**: any value that is a credentialed database URI (`postgres|postgresql|mysql|mariadb|mongodb|mongodb+srv|redis|rediss` with a `user:pass@` authority) is refused whatever its key. This closes the class rather than the five names — a DSN added later under a name nobody thought to deny is still refused. It is deliberately database-only so `PIP_INDEX_URL` / `NPM_CONFIG_REGISTRY` with an `https://user:token@` private registry keep working (asserted).

This predicate is the one `CommandSpec::validate` re-applies **inside the privileged broker**, so it holds even if some other process in the Pod holds the value. The `DJINN_` prefix stays open otherwise — a new `DJINN_CAPACITY_*` knob still reaches the child with no code change.

### The goxi-13 guard

`context.rs` records blocker 13: a composition defect where the runner got a `SupervisorServices` whose defaulted `invocation_lift_decision` returned `Unleased` for every invocation while the authority was armed — silent, no error, four rollouts. This change rewires where `bootstrap_warm_database()` gets its DSN, which is exactly that shape of edit.

`the_scrubbed_worker_still_resolves_the_platform_invocation_lease_authority` seeds and arms a real durable authority row in a migrated database, renders the DSN, runs the scrub, calls the real `bootstrap_warm_database()`, and asserts the **decision** — `InvocationLiftDecision::Lift` — not that a `Database` was constructed.

### Other secrets in the same position (reported, not widened)

- `DJINN_CREDENTIALS_PATH`, `DJINN_LAUNCHER_CREDENTIAL_PATH`, `DJINN_TOKEN_PATH` were leaked by the same open prefix. They are now denied — same one-line change, no scope creep. Note they leak only the *location*: `djinn_sandbox::confidential::CONFIDENTIAL_ROOTS` already withholds `/var/run/djinn` and `/var/run/secrets` contents from repository-controlled code via Landlock, and `commands.rs` arms that for setup hooks. So this hardens an already-covered surface rather than closing a second hole.
- `DJINN_MYSQL_URL` is rendered by `djinn-k8s` and is a second DSN in the same namespace. Denied.

### Follow-ups NOT taken here

1. **`commands::run_commands` (setup hooks) does not scrub at all.** It runs repository-controlled build tooling (`build.rs`, npm `postinstall`, Makefile targets) with the worker's full inherited environment. The platform DSN no longer reaches it (control 1 covers every child), so this is no longer a DSN leak — but it is still an unfiltered inheritance path and does not share the launcher's entry policy the way the two shell paths do. Routing it through `clear_and_admit_child_environment` would drop `DATABASE_URL`/`TEST_POSTGRES_URL` from setup hooks, which may be load-bearing for project setup, so it needs its own change and its own test.
2. `DATABASE_URL` / `TEST_POSTGRES_URL` are *not* on the launcher allow-list, so the agent's shell already cannot see the pod-local sidecar either. That is pre-existing and unchanged here, but it is worth a deliberate decision rather than an accident.

## Part B — least privilege for the platform DSN (partially delivered; narrowing deferred)

Delivered: **`deploy/roles/djinn_task_run.sql`**. Nothing has been applied to production, no VPS connection was made, and `djinn-vps-deploy` is untouched.

### What the pod actually needs (enumerated from code, not guessed)

Traced from `bootstrap_warm_database()` (`djinn-agent-worker/src/main.rs:4460`) through every place the returned `Database` flows:

| Path | Statements |
|---|---|
| `verify_and_mark_initialized` (boot, once) | `SELECT count(*) FROM information_schema.tables …`; `SELECT version, success FROM _sqlx_migrations` |
| `after_connect` (every pooled conn) | `SET statement_timeout/lock_timeout/idle_in_transaction_session_timeout` — session GUCs, no privilege |
| Invocation-lease authority | `SELECT … FROM admission_handoff WHERE name = $1` — **read only** |
| Activity sink / teardown | `BEGIN` / `INSERT INTO activity_log …` / `SELECT … FROM activity_log WHERE id=$1` / `COMMIT` |
| Stage setup | `UPDATE task_runs SET workspace_path = COALESCE(…)` |
| Role overrides | `SELECT … FROM agents WHERE project_id=$1 AND base_role=$2 …` |
| Environment/read-sources | `SELECT` on `projects` |
| Arbiter directive | `SELECT` + `UPDATE` on `task_arbitrations` |
| Extension diagnostics | `INSERT … ON CONFLICT DO UPDATE` + `SELECT` on `extension_load_diagnostics` |
| Prompt assembly | `SELECT` on `notes`, `note_associations`, `note_embeddings`, `note_embedding_meta`, `memory_entity_associations`, `epics`, `epic_*`, `proposals`, `proposal_*`, `tasks`; `INSERT INTO retrieval_traces` |
| Per-turn persistence | `INSERT`/`SELECT`/`UPDATE` on `session_messages`, `sessions`, `session_compaction_boundaries` |
| Teardown transitions | `tasks`, `blockers`, `task_attempts`, `task_pr_ci_snapshots` |
| Memory write | `pg_advisory_xact_lock(hashtextextended($1,0))` — advisory locks need no GRANT |

Facts that matter and were verified against the migrated schema rather than assumed:

- **The worker never migrates and issues no DDL.** `sqlx::migrate!` is expanded only to enumerate compiled-in versions in memory; `.run()` is never called on this path. That is deliberate and documented at `main.rs:4466-4471` (the migrator's `pg_advisory_lock` contends with the migrate Job and the 10s `lock_timeout` wedges the worker).
- **No sequence privileges are needed.** The only serial/identity columns in `public` are `model_turn_pools.id`, `build_pod_permits.fencing_token`, `repo_graph_generation.publish_seq`, `build_leases.enqueue_sequence` — all host/coordinator-side. `nextval('build_lease_fencing_token_seq')` and `nextval('board_health_mismatch_scan_leader_epoch_seq')` are coordinator-side too.
- **No row-level security exists anywhere in the schema**, so a non-owner role is not silently subject to policies the owner bypassed.
- **No `LISTEN`/`NOTIFY`, no temp tables.**

### What the artifact does (Stage 1)

- `djinn_task_run`, `NOLOGIN` (a privilege bundle, not an identity), `NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`.
- `REVOKE CREATE ON SCHEMA public FROM PUBLIC` (load-bearing on databases initialised before PG 15), `GRANT USAGE` only. `REVOKE CREATE ON DATABASE`.
- Owns nothing → **no `ALTER`/`DROP` on any relation**.
- `_sqlx_migrations`: **`SELECT` only.** This is the exact object the incident corrupted; nothing in a Pod may write it.
- `admission_handoff`: `SELECT` only (the coordinator arms it).
- `credentials`, `custom_providers`, `mcp_access_tokens`, `oauth_clients`, `oauth_authorization_codes`, `user_auth_sessions`: **no privilege at all.**
- `SELECT, INSERT, UPDATE, DELETE` (no `TRUNCATE`, no `REFERENCES` — `REFERENCES` is DDL) on the remaining board tables.
- **No sequence and no function grants.**
- `ALTER DEFAULT PRIVILEGES` derived from the actual table owner, so the next migration that adds a table does not take the Pod down.
- A `DO` block at the end that **raises** if the role has `CREATE` on `public`, owns any relation, holds a forbidden grant, or carries a forbidden role attribute. Idempotent and re-runnable.

Validated against a real database with all 184 migrations applied (143 tables). Behavioural probe as the granted login role:

```
CREATE TABLE evil_ddl(x int);                  -> ERROR: permission denied for schema public
ALTER TABLE tasks ADD COLUMN evil text;        -> ERROR: must be owner of table tasks
INSERT INTO _sqlx_migrations (...);            -> ERROR: permission denied for table _sqlx_migrations
SELECT count(*) FROM credentials;              -> ERROR: permission denied for table credentials
UPDATE admission_handoff SET name=name ...;    -> ERROR: permission denied for table admission_handoff
SELECT count(*) FROM _sqlx_migrations;         -> 184        (boot verification still works)
SELECT count(*) FROM admission_handoff;        -> 1          (lease authority still readable)
UPDATE tasks / DELETE activity_log / INSERT notes  -> OK      (board DML intact)
SELECT pg_advisory_xact_lock(...)              -> OK          (memory write path intact)
INSERT into a table created after the script   -> OK          (default privileges work)
```

The script re-runs cleanly (idempotent), and the three documented verification queries all return zero rows.

### What is deferred, and why (Stage 2)

Narrowing table-by-table to the deterministic set above is **not** in this file, deliberately — a half-done role would be worse than a documented one.

`AgentContext.db` is the *unnarrowed* platform handle: `context.rs` implements `ExtensionContext::db()` and `to_mcp_state()` over it, and handlers reconstruct a full `DjinnMcpServer` **inside the Pod** (`extension/handlers/memory_agent.rs`, `task_epic.rs`, `djinn-mcp-extension/src/handlers/`). So a grant derived from the deterministic path would break `memory_*`, `task_*`, `epic_*`, `proposal_*`, `pr_review_context` and the evidence tools the moment an agent used one.

The prerequisite is the "Phase 7 follow-up" the code already names (`main.rs:3219-3221`, `worker_services.rs:26-35`): route those helpers through `SupervisorServices` RPC so the Pod needs no board `Database` at all beyond `admission_handoff`. Stage 1 is worth landing before that work, because it removes DDL and ownership — the capabilities the incident actually required — without depending on it.

### Operator steps (nothing performed)

1. Out of band, never in this repo: `CREATE ROLE djinn_task_run_pod LOGIN PASSWORD '<generated>' NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;`
2. As the table owner (the identity the migrate Job connects as): `psql "$DJINN_DATABASE_URL" -v ON_ERROR_STOP=1 -f deploy/roles/djinn_task_run.sql`
3. `GRANT djinn_task_run TO djinn_task_run_pod;`
4. **`djinn-vps-deploy` change, described but not performed:** the `DJINN_DATABASE_URL` that `djinn_k8s::job::build_task_run_job` renders onto the task-run worker container comes from `KubernetesConfig::database_url`, which `config.rs:745` reads from **djinn-server's own environment** — the same value the server and coordinator use. Adopting this role therefore requires splitting that one value in two: a task-run-specific DSN (`djinn_task_run_pod`) used only for the rendered task-run/warm/scip Job env, and the existing owner DSN kept for djinn-server, the coordinator and — critically — the **migrate Job, which must stay the owner or migrations stop working**. That is a new config key plus a new Secret key in the chart; it is not a value substitution in place.
5. Re-run the script after any migration that adds a table (step 6's verification will say if you forgot).
6. Verify with the three queries in the file header.

## Tests

New:

| Test | Crate | Asserts |
|---|---|---|
| `no_child_of_this_process_can_observe_the_platform_dsn` | `djinn-agent-worker` | Spawns a **deliberately unfiltered** `std::process::Command` and reads its actual stdout. Asserts the child *does* see the DSN before the scrub (so the probe is wired to something real) and does not after — and that `env` in the child contains the password under no key at all. |
| `the_agent_shell_child_cannot_observe_the_platform_dsn` | `djinn-agent` | Spawns a real `bash -lc` through the **launcher-free production path** (`clear_and_admit_child_environment`) and asserts on the child's printed environment; then drives the real `command_spec()` for the **brokered path** and asserts the DSN is absent by key and by value. Also asserts a non-secret `DJINN_` sibling still reaches both, so this is not a scrub of the whole namespace wearing a narrower name. |
| `the_scrubbed_worker_still_resolves_the_platform_invocation_lease_authority` | `djinn-agent-worker` | The goxi-13 guard. Armed authority row in a real migrated DB → real `bootstrap_warm_database()` after the scrub → asserts `InvocationLiftDecision::Lift`. |
| `the_platform_dsn_is_unreachable_without_the_startup_scrub` | `djinn-agent-worker` | Deleting the `main` call fails loudly, not silently. |
| `the_platform_secrets_inside_the_open_djinn_prefix_are_denied` | `djinn-cgroup-launcher` | The five denied keys, by name and as entries. |
| `a_credentialed_database_uri_is_refused_whatever_its_key_is` | `djinn-cgroup-launcher` | The shape rule closes the class. |
| `the_shape_rule_does_not_reach_registry_urls_or_credential_free_dsns` | `djinn-cgroup-launcher` | Private registries keep working; no-userinfo DSNs are judged by key as before. |

### The regressions were confirmed to fail without the fix

Each of the three production changes was reverted independently and the suites re-run:

1. **Deny-set + shape rule reverted** → `the_platform_secrets_inside_the_open_djinn_prefix_are_denied` and `a_credentialed_database_uri_is_refused_whatever_its_key_is` FAIL, and `the_agent_shell_child_cannot_observe_the_platform_dsn` FAILS with the real child's stdout: `left: "postgres://djinn:hunter2@djinn-postgres.djinn.svc.cluster.local:5432/djinn|task-run-fixture"` vs `right: "|task-run-fixture"`.
2. **`remove_var` reverted** → `no_child_of_this_process_can_observe_the_platform_dsn` FAILS (`left: "postgres://…hunter2@…"`, `right: ""`) and `the_worker_keeps_the_value_it_took` FAILS.
3. **`bootstrap_warm_database` reverted to `std::env::var`** → `the_platform_dsn_is_unreachable_without_the_startup_scrub` and `the_scrubbed_worker_still_resolves_the_platform_invocation_lease_authority` both FAIL.

All three were restored and the suites re-run green.

### Commands and results

```
cargo clippy -p djinn-cgroup-launcher -p djinn-agent -p djinn-agent-worker --all-targets   -> clean
cargo fmt --check -p djinn-cgroup-launcher -p djinn-agent -p djinn-agent-worker            -> clean
cargo test  -p djinn-cgroup-launcher                72 + 4 + 9 + 3 + 9 + 4 + 1 + 3 passed, 0 failed
cargo test  -p djinn-agent --tests                  1477 + 35 passed, 0 failed
cargo test  -p djinn-agent-worker --tests           48 + 356 + 25 passed, 0 failed
cargo test  -p djinn-k8s --lib                      406 passed, 0 failed
```

Against Postgres 17 with all 184 migrations applied.

## Not done

- No migration added (the role is an operator-applied artifact, not schema, and the password must not enter the repo).
- Nothing applied to production, no VPS connection, `djinn-vps-deploy` untouched.
- No claim about who applied migration 182's DDL.
