### PR TITLE
fix(warm): render the attempt env under the names warm-graph actually reads

### DIFF
--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -183,6 +183,18 @@ const CARGO_TARGET_DIR_ENV: &str = "CARGO_TARGET_DIR";
 const ENV_WARM_GRAPH_ATTEMPT_ID: &str = "DJINN_WARM_GRAPH_ATTEMPT_ID";
 const ENV_WARM_GRAPH_ATTEMPT_DEADLINE: &str = "DJINN_WARM_GRAPH_ATTEMPT_DEADLINE";
 
+/// Every environment key `warm-graph` cannot start without.
+///
+/// These sit behind `std::env::var` rather than clap, so the argv-only warm
+/// contract in [`crate::rendered_job_env_contract`] cannot derive them from the
+/// parser the way it derives `task-run`'s. This list is that derivation: adding
+/// a required warm environment key here fails the renderer contract until
+/// `djinn-k8s` projects it, which is the check that was missing when the
+/// producer (#2941) and the consumer (#2942) landed under different names and
+/// every warm Pod exited before warming anything.
+const REQUIRED_WARM_GRAPH_ENVIRONMENT: &[&str] =
+    &[ENV_WARM_GRAPH_ATTEMPT_ID, ENV_WARM_GRAPH_ATTEMPT_DEADLINE];
+
 use worker_services::WorkerSupervisorServices;
 
 /// Top-level arg parser for the worker binary.
@@ -4319,6 +4331,16 @@ async fn finish_failed_warm_attempt(
 }
 
 fn required_warm_environment(key: &str) -> Result<String> {
+    // Every key read here must also be declared in
+    // `REQUIRED_WARM_GRAPH_ENVIRONMENT`, because that list — not this call site
+    // — is what `rendered_job_env_contract` checks the renderer against. A key
+    // required here but absent from the list is a requirement no test can see,
+    // which is precisely how the warm Pod came to fail closed in production.
+    debug_assert!(
+        REQUIRED_WARM_GRAPH_ENVIRONMENT.contains(&key),
+        "`{key}` is required for warm graph but is not declared in \
+         REQUIRED_WARM_GRAPH_ENVIRONMENT, so no test proves any renderer supplies it"
+    );
     let value = std::env::var(key).with_context(|| format!("{key} must be set for warm graph"))?;
     if value.trim().is_empty() {
         anyhow::bail!("{key} must not be blank for warm graph");

--- a/server/crates/djinn-agent-worker/src/rendered_job_env_contract.rs
+++ b/server/crates/djinn-agent-worker/src/rendered_job_env_contract.rs
@@ -38,9 +38,9 @@ use uuid::Uuid;
 
 use djinn_k8s::config::KubernetesConfig;
 use djinn_k8s::job::build_task_run_job;
-use djinn_k8s::warm_job::{WARM_COMMAND_BIN, build_warm_job};
+use djinn_k8s::warm_job::{WARM_COMMAND_BIN, build_warm_job, stamp_warm_attempt};
 
-use crate::Cli;
+use crate::{Cli, REQUIRED_WARM_GRAPH_ENVIRONMENT};
 
 /// An argument the process cannot start without: clap marked it required and no
 /// default value can stand in for a missing one.
@@ -399,5 +399,67 @@ fn the_unleased_warm_job_renders_no_build_lease_identity() {
             assert_ne!(entry.name, ENV_WARM_LEASE_CONSUMER_ID);
             assert_ne!(entry.name, ENV_WARM_LEASE_FENCING_TOKEN);
         }
+    }
+}
+
+/// **The contract, warm environment path.** Every environment key the
+/// `warm-graph` subcommand cannot start without is present, and non-empty, in
+/// the warm Job the production dispatcher actually posts.
+///
+/// The argv test above is deliberately blind to this: it proves the command
+/// line parses, and asserts only that no *clap* requirement hides behind the
+/// environment. `warm-graph`'s durable attempt projection is read straight from
+/// `std::env::var`, so it never appeared in `Cli::command()` and no assertion
+/// on either side of the boundary compared the two spellings.
+///
+/// That is exactly how this broke. #2941 taught the renderer to project the
+/// attempt as `DJINN_WARM_ATTEMPT_ID`; #2942, merged eleven minutes earlier,
+/// taught the worker to require `DJINN_WARM_GRAPH_ATTEMPT_ID`. Both suites
+/// passed — each asserted its own constant — and every warm Pod for the next
+/// day and a half exited before touching cargo or an indexer, with the graph
+/// frozen at the deploy that shipped them.
+///
+/// The manifest here is stamped the way `K8sGraphWarmer` stamps it, so the
+/// assertion runs against the bytes the apiserver receives.
+#[test]
+fn every_required_warm_graph_environment_key_is_rendered_into_the_job() {
+    let mut job = build_warm_job(
+        &KubernetesConfig::for_testing(),
+        "proj-opsu",
+        "deadbeef",
+        "registry.example/djinn-project:opsu",
+        None,
+    );
+    stamp_warm_attempt(
+        &mut job,
+        "019fc384-c2d5-7460-aeed-5a168b112b03",
+        "2026-08-02T17:30:00Z",
+    );
+
+    let pod = job
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .expect("rendered warm Job has a pod spec");
+    let rendered: BTreeMap<&str, &str> = pod
+        .containers
+        .iter()
+        .flat_map(|container| container.env.iter().flatten())
+        .filter_map(|entry| Some((entry.name.as_str(), entry.value.as_deref()?)))
+        .collect();
+
+    for key in REQUIRED_WARM_GRAPH_ENVIRONMENT {
+        let value = rendered.get(key).copied().unwrap_or_else(|| {
+            panic!(
+                "warm-graph cannot start without `{key}`, and the rendered warm Job does not \
+                 project it. Rendered keys: {:?}\nEvery warm Pod dispatched with this manifest \
+                 fails closed before warming anything, and the graph stops advancing.",
+                rendered.keys().collect::<Vec<_>>()
+            )
+        });
+        assert!(
+            !value.trim().is_empty(),
+            "warm-graph rejects a blank `{key}`, but the rendered warm Job projects one"
+        );
     }
 }

--- a/server/crates/djinn-k8s/src/graph_warmer_tests.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_tests.rs
@@ -99,8 +99,8 @@ impl WarmJobDispatcher for AttemptInspectingDispatcher {
                 .and_then(|entry| entry.value.clone())
                 .unwrap_or_else(|| panic!("warm Job missing {key}"))
         };
-        let attempt_id = env_value(crate::warm_job::ENV_WARM_ATTEMPT_ID);
-        let deadline_at = env_value(crate::warm_job::ENV_WARM_ATTEMPT_DEADLINE_AT);
+        let attempt_id = env_value(crate::warm_job::ENV_WARM_GRAPH_ATTEMPT_ID);
+        let deadline_at = env_value(crate::warm_job::ENV_WARM_GRAPH_ATTEMPT_DEADLINE);
         let row = WarmGraphAttemptRepository::new(self.db.clone())
             .get_attempt(&attempt_id)
             .await

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -94,7 +94,7 @@ pub use scip_schedule::{
     observe_from_jobs,
 };
 pub use token_review::TokenReviewer;
-pub use warm_job::{build_leased_warm_job, build_warm_job, warm_job_name};
+pub use warm_job::{build_leased_warm_job, build_warm_job, stamp_warm_attempt, warm_job_name};
 pub use workload_inventory::{
     JOB_CONDITION_COMPLETE, JOB_CONDITION_FAILED, KubeWorkloadInventory, LABEL_ADMISSION_DOMAIN,
     LABEL_ADMISSION_GENERATION, LABEL_ADMISSION_WORK_ID, ObjectPresence, UidGetResult,

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -78,9 +78,15 @@ pub const ENV_WARM_LEASE_CONSUMER_ID: &str = "DJINN_WARM_LEASE_CONSUMER_ID";
 pub const ENV_WARM_LEASE_FENCING_TOKEN: &str = "DJINN_WARM_LEASE_FENCING_TOKEN";
 /// Durable attempt identity read by `warm-graph` to finish exactly the row
 /// created by the producer before this Job was posted.
-pub const ENV_WARM_ATTEMPT_ID: &str = "DJINN_WARM_ATTEMPT_ID";
+///
+/// The name is the worker's, not this crate's: `djinn-agent-worker` reads it
+/// with `std::env::var` and fails closed when it is absent, so a renderer that
+/// spells it differently produces a Pod that dies before warming anything.
+/// `rendered_job_env_contract` binds the two sides so they cannot drift again.
+pub const ENV_WARM_GRAPH_ATTEMPT_ID: &str = "DJINN_WARM_GRAPH_ATTEMPT_ID";
 /// Immutable RFC3339 deadline shared by the attempt ledger and warm worker.
-pub const ENV_WARM_ATTEMPT_DEADLINE_AT: &str = "DJINN_WARM_ATTEMPT_DEADLINE_AT";
+/// Same naming contract as [`ENV_WARM_GRAPH_ATTEMPT_ID`].
+pub const ENV_WARM_GRAPH_ATTEMPT_DEADLINE: &str = "DJINN_WARM_GRAPH_ATTEMPT_DEADLINE";
 
 /// Mount path for the read-only mirror PVC (mirrors the task-run Job).
 pub const MIRROR_MOUNT_DIR: &str = "/mirror";
@@ -592,7 +598,11 @@ fn env_var(name: &str, value: &str) -> EnvVar {
 /// Stamp durable attempt data after either warm manifest variant has been
 /// constructed. This keeps public builders and deterministic Job identity
 /// unchanged while giving leased and unleased Pods the same worker contract.
-pub(crate) fn stamp_warm_attempt(job: &mut Job, attempt_id: &str, deadline_at: &str) {
+///
+/// Public so the binary crate that owns the reader (`djinn-agent-worker`) can
+/// render the production-equivalent manifest and assert it satisfies the
+/// worker's environment contract; nothing else outside this crate calls it.
+pub fn stamp_warm_attempt(job: &mut Job, attempt_id: &str, deadline_at: &str) {
     let container = job
         .spec
         .as_mut()
@@ -600,8 +610,8 @@ pub(crate) fn stamp_warm_attempt(job: &mut Job, attempt_id: &str, deadline_at: &
         .and_then(|spec| spec.containers.first_mut())
         .expect("warm Job builder always renders a warmer container");
     let env = container.env.get_or_insert_with(Vec::new);
-    env.push(env_var(ENV_WARM_ATTEMPT_ID, attempt_id));
-    env.push(env_var(ENV_WARM_ATTEMPT_DEADLINE_AT, deadline_at));
+    env.push(env_var(ENV_WARM_GRAPH_ATTEMPT_ID, attempt_id));
+    env.push(env_var(ENV_WARM_GRAPH_ATTEMPT_DEADLINE, deadline_at));
 }
 
 /// Sanitise a project id to a DNS-label-safe form for Job names and label

--- a/server/crates/djinn-k8s/src/warm_job_tests.rs
+++ b/server/crates/djinn-k8s/src/warm_job_tests.rs
@@ -410,11 +410,14 @@ fn durable_attempt_stamp_reaches_leased_and_unleased_pods_without_renaming_them(
             .and_then(|spec| spec.containers.first())
             .and_then(|container| container.env.as_ref())
             .expect("warmer env");
-        assert!(env.iter().any(|entry| entry.name == ENV_WARM_ATTEMPT_ID
-            && entry.value.as_deref() == Some("019fc384-c2d5-7460-aeed-5a168b112b03")));
         assert!(
             env.iter()
-                .any(|entry| entry.name == ENV_WARM_ATTEMPT_DEADLINE_AT
+                .any(|entry| entry.name == ENV_WARM_GRAPH_ATTEMPT_ID
+                    && entry.value.as_deref() == Some("019fc384-c2d5-7460-aeed-5a168b112b03"))
+        );
+        assert!(
+            env.iter()
+                .any(|entry| entry.name == ENV_WARM_GRAPH_ATTEMPT_DEADLINE
                     && entry.value.as_deref() == Some("2026-08-02T17:30:00Z"))
         );
     }


### PR DESCRIPTION
## The failure

Every graph-warm Pod has failed closed since the 2026-08-03 ~14:00Z deploy. Captured live from a warm Pod before its 300s TTL reaped it:

```
INFO  djinn_agent_worker::volume_contract: volume permission contract satisfied context="warm-graph" mode="enforce"
ERROR djinn_agent_worker: djinn-agent-worker failed
      error=DJINN_WARM_GRAPH_ATTEMPT_ID must be set for warm graph: environment variable not found
```

The volume contract passes; it dies on the next line, in `projected_warm_attempt`.

| side | file | value |
|---|---|---|
| renderer emitted | `djinn-k8s/src/warm_job.rs` | `DJINN_WARM_ATTEMPT_ID`, `DJINN_WARM_ATTEMPT_DEADLINE_AT` |
| worker requires | `djinn-agent-worker/src/main.rs` | `DJINN_WARM_GRAPH_ATTEMPT_ID`, `DJINN_WARM_GRAPH_ATTEMPT_DEADLINE` |

Producer #2941 and consumer #2942 merged eleven minutes apart on Aug 2, each internally consistent, each test asserting only its own constant. Nothing compared the two spellings.

## Blast radius

`warm_graph_attempt` on prod holds **110 rows: 108 `failed`, 2 `timed_out`, zero successes ever** — the table was created with this feature, so it has never seen a green attempt. Confirmed 17 warm Pods launched on 2026-08-04 alone, every one dead inside a minute, across 6 distinct pinned revisions (recovered by reversing the deterministic `gw.<project>.<revision>` job-name hash). `code_graph status` last published `2026-08-03T14:00:29Z` — the last warm on the pre-mismatch image.

It stayed silent because the Pod dies before it can claim its ledger row, `ttlSecondsAfterFinished: 300` deletes the Pod and its logs, and the watcher writes only a generic `"warm Job watcher observed terminal failure"` detail.

## The fix

Align the renderer on the reader's names. The reader is the side that fails closed, and it ships inside the per-project image, which rebuilds on a slower cadence than djinn-server — so fixing the renderer goes green on the next server deploy with no image rebuild.

## The guard

`rendered_job_env_contract` exists for exactly this class of bug and still missed it: it derives `task-run`'s required set from clap, and its own comment states the precondition for the warm path — *"The argv path only proves the warm subcommand is satisfiable because none of its required arguments hide behind the environment. If that changes, the warm Job's env needs the same treatment."* #2942 changed it; the attempt projection is read through `std::env::var` and never appeared in `Cli::command()`.

So this adds:
- `REQUIRED_WARM_GRAPH_ENVIRONMENT` — the declaration of what `warm-graph` cannot start without;
- `every_required_warm_graph_environment_key_is_rendered_into_the_job` — renders the production-equivalent manifest (stamped the way `K8sGraphWarmer` stamps it) and asserts every declared key is present and non-blank;
- a `debug_assert!` in `required_warm_environment` so a key read but not declared fails loudly rather than becoming a requirement no test can see.

## Verification

- New test **fails on the pre-fix renderer** with the production symptom, listing the rendered keys, and passes after. (Checked by temporarily restoring the old names.)
- `cargo test -p djinn-agent-worker --bin djinn-agent-worker rendered_job_env_contract` — 6/6 pass.
- `cargo test -p djinn-k8s --lib warm_job` — 15 pass; 1 unrelated failure needing a live Postgres.
- `cargo fmt --all -- --check` clean; `cargo clippy -p djinn-k8s -p djinn-agent-worker --all-targets` clean.

Deploying this does not by itself fix the cargo warm base, which has not advanced since Jul 27 and predates this regression — that is a separate issue.