### PR TITLE
fix(platform): restore in-pod verification and unwedge exact-pod teardown

### DIFF
--- a/server/crates/djinn-cgroup-launcher/src/env.rs
+++ b/server/crates/djinn-cgroup-launcher/src/env.rs
@@ -126,6 +126,20 @@ const ALLOWED_KEYS: &[&str] = &[
     "MAKEFLAGS",
     "NEXTEST_TEST_THREADS",
     "RAYON_NUM_THREADS",
+    // ── Pod-local backing services ──────────────────────────────────────────
+    // The task-run Pod injects each declared service sidecar under the names in
+    // its preset's `conn_env_var` (`preset-postgres-18` exports both of these).
+    // These name the **project's own** database — the in-Pod `svc-postgres`
+    // sidecar on loopback — not the platform control plane, which is
+    // `DJINN_DATABASE_URL` and is denied by name in [`DENIED_KEYS`].
+    //
+    // Admitting them by name is necessary but not sufficient: the sidecar DSN
+    // embeds `postgres:postgres` userinfo, so the shape rule in
+    // [`is_allowed_environment_entry`] would refuse it. That rule exempts
+    // loopback authorities — see [`is_pod_local_database_uri`] — which is what
+    // makes these usable while keeping every off-Pod DSN refused.
+    "DATABASE_URL",
+    "TEST_POSTGRES_URL",
 ];
 
 /// Key prefixes the broker forwards wholesale.
@@ -237,6 +251,60 @@ fn is_credentialed_database_uri(value: &str) -> bool {
     }
 }
 
+/// Loopback authorities a pod-local backing service can legitimately name.
+///
+/// Deliberately exact literals rather than a range. A task-run Pod's injected
+/// sidecar is always reached on loopback in the Pod's own network namespace, so
+/// nothing legitimate needs `127.0.0.2` or a hostname that merely resolves to
+/// loopback — and refusing those keeps the exemption from widening by accident.
+const POD_LOCAL_HOSTS: &[&str] = &["127.0.0.1", "localhost", "::1", "[::1]"];
+
+/// Does `value` name a database on this Pod's own loopback interface?
+///
+/// This is the exemption that lets [`is_allowed_environment_entry`]'s shape rule
+/// refuse credentialed DSNs in general while still admitting the backing
+/// services the task-run Pod injects for the project under test.
+///
+/// The distinction is not cosmetic. The leak the shape rule was written for was
+/// a **platform** DSN — `djinn-postgres.djinn.svc.cluster.local`, a different
+/// server holding `tasks`, `sessions` and `credentials`. A loopback authority
+/// cannot name that host, or any host outside this Pod's network namespace, so
+/// admitting it forfeits nothing the rule was protecting. What it buys is the
+/// project's own database: without it, `sqlx` compile-time macro expansion and
+/// every database-backed test in a task-run Pod fail with `Connection refused`,
+/// because cargo's `[env]` default fills the gap with an address nothing serves.
+fn is_pod_local_database_uri(value: &str) -> bool {
+    let Some(rest) = CREDENTIALED_URI_SCHEMES
+        .iter()
+        .find_map(|scheme| value.strip_prefix(scheme))
+    else {
+        return false;
+    };
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    // Drop userinfo; what remains is `host` or `host:port`.
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    // A `:` is only a port separator when it cannot belong to an IPv6 literal.
+    let host = if let Some(after_bracket) = host_port.strip_prefix('[') {
+        // Bracketed literal: the host runs through the closing bracket.
+        match after_bracket.find(']') {
+            Some(end) => &host_port[..end + 2],
+            None => host_port,
+        }
+    } else if host_port.matches(':').count() == 1 {
+        host_port
+            .split_once(':')
+            .map_or(host_port, |(head, _)| head)
+    } else {
+        // No colon (bare host) or several (an unbracketed IPv6 literal, which
+        // cannot carry a port at all).
+        host_port
+    };
+    POD_LOCAL_HOSTS.contains(&host)
+}
+
 /// Is `key` forwardable to a launched child?
 ///
 /// This is the single predicate behind both ends of the hop: the worker filters
@@ -277,12 +345,23 @@ pub fn is_allowed_environment_key(key: &str) -> bool {
 /// DDL-capable platform DSN reaching `bash -lc`, and the next one will arrive
 /// under a name nobody thought to deny. See [`is_credentialed_database_uri`].
 ///
+/// The one exception is a DSN whose authority is loopback — the task-run Pod's
+/// own injected service sidecars. Those name a server that exists only inside
+/// this Pod, so they are outside what the rule protects, and refusing them broke
+/// every database-backed test and every `sqlx` macro expansion in a task-run
+/// Pod. See [`is_pod_local_database_uri`].
+///
+/// Order matters: the loopback exemption is a carve-out of the *shape* rule
+/// only. [`DENIED_KEYS`] is still consulted inside
+/// [`is_allowed_environment_key`], so a denied name stays denied even if some
+/// future value happens to be loopback.
+///
 /// Every other key is judged by name, as before.
 pub fn is_allowed_environment_entry(key: &str, value: &str) -> bool {
     if key == GIT_TRUST_ANCHOR_KEY {
         return crate::git_trust::is_anchor_value(value);
     }
-    if is_credentialed_database_uri(value) {
+    if is_credentialed_database_uri(value) && !is_pod_local_database_uri(value) {
         return false;
     }
     is_allowed_environment_key(key)
@@ -443,9 +522,12 @@ mod tests {
     /// added later under a name nobody thought to deny is refused by shape.
     #[test]
     fn a_credentialed_database_uri_is_refused_whatever_its_key_is() {
+        // Every case here is deliberately **off-Pod**. A loopback authority is
+        // exempt by design — see
+        // `a_pod_local_sidecar_dsn_is_admitted_but_an_off_pod_one_is_not`.
         for value in [
             "postgres://djinn:hunter2@djinn-postgres.djinn.svc.cluster.local:5432/djinn",
-            "postgresql://djinn:hunter2@127.0.0.1:5432/djinn?sslmode=require",
+            "postgresql://djinn:hunter2@db.internal:5432/djinn?sslmode=require",
             "mysql://root:root@db:3306/app",
             "redis://default:secret@cache:6379",
             "mongodb+srv://user:pw@cluster0.example.net/db",
@@ -457,6 +539,62 @@ mod tests {
             assert!(
                 !is_allowed_environment_entry("RUST_LOG", value),
                 "the shape rule is key-independent: {value}"
+            );
+        }
+    }
+
+    /// The task-run Pod injects its declared service sidecars on loopback under
+    /// `DATABASE_URL`/`TEST_POSTGRES_URL`. Refusing those is what broke `sqlx`
+    /// compile-time macro expansion and every database-backed test inside a
+    /// task-run Pod: with the key absent, cargo's `[env]` default filled the gap
+    /// with an address nothing serves, so the whole workspace failed to compile.
+    ///
+    /// The exemption is scoped to the authority, not to the key, and the
+    /// platform DSN must stay refused by both name and shape.
+    #[test]
+    fn a_pod_local_sidecar_dsn_is_admitted_but_an_off_pod_one_is_not() {
+        for value in [
+            "postgres://postgres:postgres@127.0.0.1:5432/app_test?sslmode=disable",
+            "postgres://postgres:postgres@localhost:5432/app_test",
+            "postgres://postgres:postgres@[::1]:5432/app_test",
+            "redis://default:secret@127.0.0.1:6379",
+        ] {
+            assert!(
+                is_pod_local_database_uri(value),
+                "a loopback authority is Pod-local: {value}"
+            );
+            assert!(
+                is_allowed_environment_entry("DATABASE_URL", value),
+                "the injected sidecar DSN must reach the child: {value}"
+            );
+            assert!(
+                is_allowed_environment_entry("TEST_POSTGRES_URL", value),
+                "both names in the preset's conn_env_var must reach the child: {value}"
+            );
+        }
+
+        // A loopback value does not re-open a denied name, and a hostname that
+        // merely looks local is still off-Pod.
+        assert!(
+            !is_allowed_environment_entry(
+                "DJINN_DATABASE_URL",
+                "postgres://postgres:postgres@127.0.0.1:5432/app_test"
+            ),
+            "DENIED_KEYS outranks the loopback exemption"
+        );
+        for value in [
+            "postgres://djinn:hunter2@djinn-postgres.djinn.svc.cluster.local:5432/djinn",
+            "postgres://djinn:hunter2@127.0.0.1.example.com:5432/djinn",
+            "postgres://djinn:hunter2@localhost.evil.net:5432/djinn",
+            "postgres://djinn:hunter2@127.0.0.2:5432/djinn",
+        ] {
+            assert!(
+                !is_pod_local_database_uri(value),
+                "only exact loopback literals are Pod-local: {value}"
+            );
+            assert!(
+                !is_allowed_environment_entry("DATABASE_URL", value),
+                "an off-Pod DSN stays refused even under an admitted key: {value}"
             );
         }
     }

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -1878,7 +1878,7 @@ pub async fn terminate_taskrun_pod_exact(
         // teardown: the hold below keeps the deleted Pod observable, so a
         // release that failed after the Job DELETE is finished here instead of
         // erroring forever. Every other absent Job stays unconfirmed.
-        return release_confirmed_exact_pod(&pods, &selector, task_run_id, pod_uid).await;
+        return release_confirmed_exact_pod(&pods, &selector, pod_uid).await;
     };
     if job.metadata.deletion_timestamp.is_some() {
         return Err("exact-pod watchdog termination task-run Job is not confirmable".into());
@@ -2035,14 +2035,35 @@ async fn release_exact_pod_hold(
 }
 
 /// Finish a teardown whose Job is already gone. This is a terminal resolution
-/// only when the held, terminating Pod carrying this protocol's own finalizer
-/// is still visible with the recorded UID under the canonical Job owner — the
-/// exact state left behind when the Job DELETE succeeded and the release did
-/// not. Anything else keeps the original unavailable-Job error.
+/// only when the held, terminating Pod carrying this protocol's own finalizer is
+/// still visible with the recorded UID — the exact state left behind when the
+/// Job DELETE succeeded and the release did not. Anything else keeps the
+/// original unavailable-Job error.
+///
+/// # Why the owning Job is not part of the proof
+///
+/// It used to be, and that made this function's success condition unsatisfiable.
+/// The preceding step, [`delete_taskrun_job_orphaned`], deletes with
+/// [`PropagationPolicy::Orphan`], whose defined effect is that the garbage
+/// collector strips the `ownerReferences` entry naming that Job from every
+/// dependent. So by the time this recovery runs, the owner reference it was
+/// looking for has been removed *by design* — it can never be found, the hold is
+/// never released, and the Pod stays in `Terminating` forever while
+/// `confirm_absence` re-issues its UID-fenced delete on a ~2s backoff for the
+/// life of the process. Measured 2026-08-05: 181 Pods pinned this way, the
+/// oldest for ten days, every one of them `ownerReferences: null` with its Job
+/// already 404 — and the resize reconciler's sweep degraded from its 30s design
+/// cadence to ~20 minutes because each wedged row costs it a 45s budget.
+///
+/// The remaining three facts are already a complete proof of the state this
+/// resolves. The UID match pins the exact Pod incarnation; the deletion
+/// timestamp proves the delete this protocol issued was accepted; and the
+/// finalizer is added in exactly one place — [`hold_exact_pod`], immediately
+/// before this protocol's own UID-fenced DELETE — so its presence proves this
+/// protocol, and no other actor, is what the Pod is waiting on.
 async fn release_confirmed_exact_pod(
     pods: &Api<Pod>,
     selector: &str,
-    task_run_id: &str,
     pod_uid: &str,
 ) -> Result<(), String> {
     let listed_pods = pods
@@ -2050,30 +2071,22 @@ async fn release_confirmed_exact_pod(
         .await
         .map_err(|e| format!("list task-run Pods: {e}"))?
         .items;
-    let job_name = taskrun_job_name(task_run_id);
     let confirmed = listed_pods.into_iter().find(|pod| {
         pod.metadata.uid.as_deref() == Some(pod_uid)
             && pod.metadata.deletion_timestamp.is_some()
             && pod_holds_termination_finalizer(pod)
-            && pod
-                .metadata
-                .owner_references
-                .as_ref()
-                .is_some_and(|owners| {
-                    owners
-                        .iter()
-                        .any(|owner| owner.kind == "Job" && owner.name == job_name)
-                })
     });
     let Some(pod) = confirmed else {
-        return Err("exact-pod watchdog termination task-run Job is unavailable".into());
+        return Err(
+            "exact-pod watchdog termination: no held terminating Pod with the recorded UID".into(),
+        );
     };
     let pod_name = pod
         .metadata
         .name
         .clone()
         .filter(|name| !name.trim().is_empty())
-        .ok_or_else(|| "exact-pod watchdog termination task-run Job is unavailable".to_string())?;
+        .ok_or_else(|| "exact-pod watchdog termination: held Pod has no name".to_string())?;
     release_exact_pod_hold(pods, &pod_name, pod_uid, &pod).await
 }
 

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -9698,8 +9698,14 @@ mod tests {
         let captured = logs.take();
         // Must contain the junk-only message with structured fields.
         assert!(
-            captured.contains("no legitimate changes after stage; junk-only files excluded"),
+            captured.contains("NO commit created"),
             "expected junk-only log message, got:\n{captured}"
+        );
+        // Reported at WARN, not INFO: a stage whose every path was filtered out
+        // leaves the branch unchanged while the author believes work landed.
+        assert!(
+            captured.contains("WARN"),
+            "junk-only exclusion must be visible at WARN, got:\n{captured}"
         );
         assert!(
             captured.contains("excluded_count="),
@@ -9773,8 +9779,15 @@ mod tests {
         let captured = logs.take();
         // Must contain the committed message WITH scratch exclusion details.
         assert!(
-            captured.contains("committed worker/architect changes (some scratch files excluded)"),
+            captured.contains("OMITTED excluded paths"),
             "expected committed-with-exclusions log message, got:\n{captured}"
+        );
+        // Reported at WARN, not INFO: the commit exists but does not contain
+        // everything the author edited, and a reviewer diffing the branch would
+        // otherwise see no trace of those edits.
+        assert!(
+            captured.contains("WARN"),
+            "a commit omitting edited paths must be visible at WARN, got:\n{captured}"
         );
         assert!(
             captured.contains("excluded_count="),
@@ -9786,7 +9799,7 @@ mod tests {
         );
         // Must NOT contain the junk-only message (legitimate changes exist).
         assert!(
-            !captured.contains("no legitimate changes after stage"),
+            !captured.contains("NO commit created"),
             "mixed commit must NOT log as junk-only, got:\n{captured}"
         );
     }

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -2276,13 +2276,19 @@ impl TaskRunSupervisor {
                                         "supervisor: committed worker/architect changes"
                                     );
                                 } else {
-                                    tracing::info!(
+                                    // WARN, not INFO: the commit exists but does
+                                    // not contain everything the author edited.
+                                    // A reviewer diffing this branch sees no
+                                    // trace of those edits and reasonably
+                                    // concludes the author never made them.
+                                    tracing::warn!(
                                         task_id = %task.short_id,
                                         task_run_id = %run_id,
                                         role = %role_kind.as_str(),
                                         excluded_count = excluded.len(),
                                         excluded_paths = ?excluded,
-                                        "supervisor: committed worker/architect changes (some scratch files excluded)"
+                                        "supervisor: committed changes but OMITTED excluded paths; \
+                                         edits to these files are absent from the branch diff"
                                     );
                                 }
                                 // The push that makes this commit durable in the
@@ -2296,13 +2302,20 @@ impl TaskRunSupervisor {
                             Ok(djinn_workspace::CommitOutcome::NoLegitimateChanges {
                                 ref excluded,
                             }) => {
-                                tracing::info!(
+                                // WARN, not INFO: every file this stage touched
+                                // was filtered out, so the branch gains nothing
+                                // while the author believes the work landed.
+                                // If these paths are not obviously generated
+                                // artifacts, the filter is over-broad — that is
+                                // the shape the `.cargo` component produced.
+                                tracing::warn!(
                                     task_id = %task.short_id,
                                     task_run_id = %run_id,
                                     role = %role_kind.as_str(),
                                     excluded_count = excluded.len(),
                                     excluded_paths = ?excluded,
-                                    "supervisor: no legitimate changes after stage; junk-only files excluded"
+                                    "supervisor: NO commit created; every changed path was excluded \
+                                     by the commit-safety filter"
                                 );
                             }
                             Ok(djinn_workspace::CommitOutcome::NoChanges) => {

--- a/server/crates/djinn-workspace/src/commit_safety.rs
+++ b/server/crates/djinn-workspace/src/commit_safety.rs
@@ -132,7 +132,14 @@ pub const DEFAULT_EXCLUDED_DIR_COMPONENTS: &[&str] = &[
     ".nuxt",
     ".svelte-kit",
     "vendor",
-    ".cargo",
+    // NOTE: `.cargo` is deliberately NOT a component here. The artifact this
+    // list is after is the downloaded crate cache, and that is already excluded
+    // by the `.cargo/registry/` path pattern above. Excluding the bare
+    // component swept up `<workspace>/.cargo/config.toml` — a tracked source
+    // file that configures every cargo invocation in the workspace — so a
+    // worker could edit it, verify the fix, and have the change silently
+    // dropped from its own commit. Three sessions were then spent concluding
+    // the worker had fabricated the change.
     ".pnpm-store",
     ".yarn",
     "logs",
@@ -451,6 +458,37 @@ mod tests {
         let config = default_config();
         assert!(is_generated_path("target/debug/foo", &config));
         assert!(is_generated_path("target/foo", &config));
+    }
+
+    /// `<workspace>/.cargo/config.toml` is tracked source: it configures every
+    /// cargo invocation in the workspace, and a worker fixing the build has to
+    /// be able to commit it. The downloaded crate cache under `.cargo/registry/`
+    /// is the thing that must stay excluded, and it is covered by a path
+    /// pattern rather than by a bare `.cargo` component.
+    #[test]
+    fn cargo_config_is_committable_while_the_registry_cache_is_not() {
+        let config = default_config();
+        for committable in [
+            ".cargo/config.toml",
+            "server/.cargo/config.toml",
+            "server/.cargo/audit.toml",
+        ] {
+            assert_eq!(
+                classify_path(committable, &config),
+                PathClassification::Allowed,
+                "cargo configuration is tracked source: {committable}"
+            );
+        }
+        for excluded in [
+            ".cargo/registry/index/foo",
+            "server/.cargo/registry/cache/bar.crate",
+        ] {
+            assert_eq!(
+                classify_path(excluded, &config),
+                PathClassification::Excluded(PathExclusionReason::GeneratedPath),
+                "the downloaded crate cache stays excluded: {excluded}"
+            );
+        }
     }
 
     #[test]

--- a/server/crates/djinn-workspace/src/workspace.rs
+++ b/server/crates/djinn-workspace/src/workspace.rs
@@ -331,6 +331,22 @@ impl Workspace {
         )
         .await?;
         self.assert_merge_tree_integrity().await?;
+        // A commit that silently omits a path the author edited is the worst
+        // shape this filter can take: the work looks committed, the reviewer
+        // sees no diff, and the author gets read as having fabricated the
+        // change. (That is exactly what happened when `.cargo` was a excluded
+        // directory component — see `commit_safety::DEFAULT_EXCLUDED_DIR_COMPONENTS`.)
+        // The exclusion is still correct and still not fatal; it just must not
+        // be invisible, so it is reported at WARN and carried out on the
+        // outcome for the caller to surface to the author.
+        if !excluded.is_empty() {
+            tracing::warn!(
+                excluded_paths = ?excluded,
+                excluded_count = excluded.len(),
+                "commit: created a commit that omits excluded paths; \
+                 the author's edits to these files are NOT in the commit"
+            );
+        }
         Ok(CommitOutcome::Committed { excluded })
     }
 


### PR DESCRIPTION
Overnight 2026-08-05 the fleet ran at ~0.45 merges/h against a 1.5/h daytime baseline, with **~72% of dispatched runs producing nothing durable** (~34 of 48 slot-hours spent redoing work). Individual tasks burned 19–24 sessions without merging. Three defects, each independently confirmed against production.

## 1. Workers could not run any Rust test (since 2026-08-02)

The launcher's closed-by-default allow-list never carried `DATABASE_URL` / `TEST_POSTGRES_URL` — the names the injected `svc-postgres` sidecar is exported under (`preset-postgres-18`'s `conn_env_var`). With those absent from the child environment, cargo's `[env]` block in `server/.cargo/config.toml` supplied its `127.0.0.1:5433` default, where nothing listens.

Every `sqlx::query!` expansion then failed with `Connection refused`, which breaks compilation of `djinn-db`, `djinn-coordinator` and `djinn-control-plane` — not merely the DB-backed tests. Consequence: workers submitted unverified, reviewers approved by reading code, and **CI became the first place tests ever ran**, reopening the task each cycle. Any acceptance criterion of the form "command X passes" became unsatisfiable by construction.

Admitting the keys is necessary but not sufficient — the sidecar DSN embeds `postgres:postgres` userinfo, so the value-shape rule refused it. The rule now exempts **loopback authorities only**. The leak it was written for was a *platform* DSN on a different host; a loopback authority cannot name anything outside the Pod's own network namespace, so the carve-out forfeits nothing it protected. `DENIED_KEYS` is still consulted first, so `DJINN_DATABASE_URL` stays denied by name whatever its value.

## 2. `server/.cargo/config.toml` was silently uncommittable

`.cargo` was a bare excluded *directory component*, and the matcher tests every component — so the workspace's tracked cargo configuration was dropped from every auto-commit. The artifact that entry was after is the downloaded crate cache, already covered by the `.cargo/registry/` path pattern.

A worker fixing the build could apply the correct change, run the required command, get exit 0 — and have the file vanish from its own commit. The reviewer saw no branch diff and three sessions were spent concluding the worker had fabricated it.

Exclusions stay **non-fatal** — hard-failing `submit_work` would create a new class of unsubmittable task — but they no longer stay invisible: a commit that omits paths, and a stage whose every path was filtered out, are both now reported at WARN naming the consequence.

## 3. Exact-pod teardown could never release its own hold

`release_confirmed_exact_pod` required the Pod to still carry an `ownerReferences` entry naming its Job. The preceding step deletes that Job with `PropagationPolicy::Orphan`, whose defined effect is to strip exactly that reference. The success condition was **unsatisfiable by construction**: the finalizer was never removed, the Pod stayed `Terminating` forever, and `confirm_absence` re-issued its UID-fenced delete on a ~2s backoff for the life of the process.

Measured in production:
- **181 Pods** pinned in `Terminating`, oldest for **ten days**, every one `ownerReferences: null` with its Job already 404
- the retry accounted for **26% of all server log volume**
- the resize reconciler's sweep degraded from its 30s design cadence to **~20 minutes** (each wedged row costs a 45s budget), so a genuinely stranded live Pod holding a 4000m ceiling waits that long to return CPU — against a 7050m cluster budget

UID match + deletion timestamp + this protocol's own finalizer (added in exactly one place, immediately before its own UID-fenced DELETE) are already a complete proof, so the owner-reference clause is dropped. The error string named the wrong fact and is corrected.

## Verification

- `djinn-cgroup-launcher` — 73/73 lib tests pass, including a new test covering the loopback exemption, the IPv6/bracketed-authority parse, and that `DJINN_DATABASE_URL` and near-miss hosts (`127.0.0.1.example.com`, `localhost.evil.net`, `127.0.0.2`) all stay refused.
- `djinn-workspace` — `commit_safety` 33/33 pass, including a new regression that `server/.cargo/config.toml` is committable while `.cargo/registry/**` stays excluded.
- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --no-deps` clean on all touched crates.
- **Not verified locally:** DB-backed tests in `djinn-k8s` and `djinn-workspace` fail on this machine with `Connection refused` (no local Postgres). They fail **identically on the base commit** — verified by stashing — so they are environmental, not regressions. CI must confirm them.

## Follow-ups deliberately not in this PR

- The 181 already-wedged Pods will not drain on their own; they need one finalizer-clearing pass after this deploys.
- The drop path has no arm for an already-terminated launcher, so it burns a 30s confirmation budget and quarantines healthy runs whose launcher merely exited.
- `stage.rs` passes the same token as both `cancel` and `global_cancel`, making SIGTERM indistinguishable from RPC disconnect in the terminal report — the reason "reply loop error: session cancelled" is currently undiagnosable.
- The reconciler bounds each row but not the pass, so N wedged rows multiply the sweep cadence by N.