### PR TITLE
fix(agent): attribute cancellations so "session cancelled" names its cause

### DIFF
--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -100,6 +100,7 @@ use djinn_agent::context::{AgentContext, ReconciliationSweepConfig, ShellLaunchC
 use djinn_agent::file_time::FileTime;
 use djinn_agent::lsp::LspManager;
 use djinn_agent::roles::RoleRegistry;
+use djinn_core::cancel_origin::{CancelOrigin, CancelOriginTag};
 use djinn_core::events::EventBus;
 use djinn_core::models::KnowledgeInjectionConfig;
 use djinn_db::{Database, DatabaseConnectConfig, PostgresDatabaseConfig};
@@ -2977,6 +2978,15 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     //    loop.  Any post-handshake `SupervisorServices` call round-trips over
     //    that same TCP connection.
     let cancel = CancellationToken::new();
+    // Side channel for WHICH trigger fires `cancel`. A `CancellationToken`
+    // carries no payload, and this one Pod-wide token is fired from SIGTERM,
+    // the soft deadline, a host control frame, RPC transport death, and
+    // orderly teardown — so without this every one of those settled as an
+    // indistinguishable "session cancelled". Each trigger stamps the tag
+    // immediately before `.cancel()`; the stage boundary reads it when the
+    // reply loop reports a cancellation. Unstamped reads back as `unknown`
+    // and never gates anything.
+    let cancel_origin = CancelOriginTag::new();
 
     // The live ephemeral stage clone's path, populated by
     // `WorkerSupervisorServices::execute_stage` on its first call and read
@@ -3016,6 +3026,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     // we have to checkpoint + drain the RPC before SIGKILL hits.
     install_termination_handlers(
         cancel.clone(),
+        cancel_origin.clone(),
         args.task_run_id.clone(),
         captured_workspace_path.clone(),
         spec.task_branch.clone(),
@@ -3038,6 +3049,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     // absent/unparseable → no soft deadline (the kubelet backstop still applies).
     install_soft_deadline(
         cancel.clone(),
+        cancel_origin.clone(),
         args.task_run_id.clone(),
         captured_workspace_path.clone(),
         spec.task_branch.clone(),
@@ -3065,6 +3077,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
         args.task_run_id.clone(),
         token,
         cancel.clone(),
+        cancel_origin.clone(),
     )
     .await
     .with_context(|| format!("dial djinn-server at {server_addr}"))?;
@@ -3219,6 +3232,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
             // Shut down RPC cleanly before exiting.
             drop(rpc);
             let _ = background.writer.await;
+            cancel_origin.record(CancelOrigin::WorkerTeardown);
             cancel.cancel();
             let _ = background.reader.await;
             drop(workspace);
@@ -3256,6 +3270,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
         rpc.clone(),
         credentials,
         cancel.clone(),
+        cancel_origin.clone(),
         agent_context,
         captured_workspace_path,
     ));
@@ -3337,6 +3352,9 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     let _ = background.writer.await;
     // Reader still needs an explicit cancel — it's parked on a read that
     // won't wake up on its own now that we've closed our side of the write.
+    // The run is already over here, so this attribution only ever wins when
+    // nothing else cancelled first.
+    cancel_origin.record(CancelOrigin::WorkerTeardown);
     cancel.cancel();
     let _ = background.reader.await;
 
@@ -3512,14 +3530,15 @@ async fn checkpoint_workspace(
 /// the supervisor records once stages begin.
 fn install_termination_handlers(
     cancel: CancellationToken,
+    cancel_origin: CancelOriginTag,
     task_run_id: String,
     captured_workspace_path: Arc<std::sync::Mutex<Option<PathBuf>>>,
     task_branch: String,
     identity: CheckpointIdentity,
 ) {
-    for (kind, label) in [
-        (SignalKind::terminate(), "SIGTERM"),
-        (SignalKind::interrupt(), "SIGINT"),
+    for (kind, label, origin) in [
+        (SignalKind::terminate(), "SIGTERM", CancelOrigin::Sigterm),
+        (SignalKind::interrupt(), "SIGINT", CancelOrigin::Sigint),
     ] {
         let mut stream = match signal(kind) {
             Ok(s) => s,
@@ -3533,6 +3552,7 @@ fn install_termination_handlers(
             }
         };
         let cancel = cancel.clone();
+        let cancel_origin = cancel_origin.clone();
         let task_run_id = task_run_id.clone();
         let captured_workspace_path = captured_workspace_path.clone();
         let task_branch = task_branch.clone();
@@ -3541,9 +3561,14 @@ fn install_termination_handlers(
             if stream.recv().await.is_some() {
                 info!(
                     signal = label,
+                    cancel_origin = origin.as_str(),
                     task_run_id = %task_run_id,
                     "received termination signal; cancelling supervisor + checkpointing work"
                 );
+                // Attribute the cancellation BEFORE firing the token: the
+                // reply loop and the stage boundary read the origin the
+                // instant they wake, and a token carries no cause of its own.
+                cancel_origin.record(origin);
                 // Cancel first so the supervisor stops streaming and starts its
                 // own graceful exit; then checkpoint to save in-flight work.
                 cancel.cancel();
@@ -3584,6 +3609,7 @@ fn soft_deadline_interval(deadline_secs: u64) -> Duration {
 /// configured deadlines (tests) don't fire immediately at startup.
 fn install_soft_deadline(
     cancel: CancellationToken,
+    cancel_origin: CancelOriginTag,
     task_run_id: String,
     captured_workspace_path: Arc<std::sync::Mutex<Option<PathBuf>>>,
     task_branch: String,
@@ -3625,8 +3651,10 @@ fn install_soft_deadline(
                 warn!(
                     task_run_id = %task_run_id,
                     soft_deadline_secs = fire_after.as_secs(),
+                    cancel_origin = CancelOrigin::SoftDeadline.as_str(),
                     "soft deadline reached; winding down (cancel + checkpoint) before the kubelet hard-kills the Pod"
                 );
+                cancel_origin.record(CancelOrigin::SoftDeadline);
                 cancel.cancel();
                 checkpoint_workspace(
                     &captured_workspace_path,
@@ -4983,7 +5011,8 @@ mod tests {
             let (stream, _peer) = tokio::io::duplex(64);
             let (read, write) = tokio::io::split(stream);
             let cancel = CancellationToken::new();
-            let (rpc, _tasks) = RpcServices::from_split(read, write, cancel.clone());
+            let (rpc, _tasks) =
+                RpcServices::from_split(read, write, cancel.clone(), CancelOriginTag::new());
             let spec = TaskRunSpec {
                 task_run_id: "worker-config-propagation".into(),
                 task_attempt_id: None,
@@ -5065,7 +5094,8 @@ mod tests {
         let (stream, _peer) = tokio::io::duplex(64);
         let (read, write) = tokio::io::split(stream);
         let cancel = CancellationToken::new();
-        let (rpc, _tasks) = RpcServices::from_split(read, write, cancel.clone());
+        let (rpc, _tasks) =
+            RpcServices::from_split(read, write, cancel.clone(), CancelOriginTag::new());
         let context = build_worker_agent_context(
             Database::open_in_memory().expect("in-memory worker database"),
             rpc,

--- a/server/crates/djinn-agent-worker/src/worker_services.rs
+++ b/server/crates/djinn-agent-worker/src/worker_services.rs
@@ -44,6 +44,7 @@ use async_trait::async_trait;
 use djinn_agent::actors::slot::helpers::OAuthConfigWire;
 use djinn_agent::context::AgentContext;
 use djinn_agent::supervisor::worker_execute_stage;
+use djinn_core::cancel_origin::CancelOriginTag;
 use djinn_core::models::{SessionFailureCause, SessionRecord, SessionStatus, Task, TaskRunStatus};
 use djinn_provider::message::Conversation;
 use djinn_provider::provider::{
@@ -74,6 +75,11 @@ pub struct WorkerSupervisorServices {
     rpc: Arc<RpcServices>,
     credentials: ResolvedCredentials,
     cancel: CancellationToken,
+    /// Origin side channel for `cancel`, stamped by whichever trigger fires
+    /// the Pod-wide token. Handed to the per-stage executor so a cancelled
+    /// stage can name its cause instead of settling as a bare
+    /// "session cancelled". See [`djinn_core::cancel_origin`].
+    cancel_origin: CancelOriginTag,
     agent_context: AgentContext,
     /// Path of the supervisor-created ephemeral [`Workspace`], captured the
     /// first time `execute_stage` is invoked.  Used by `open_pr` to
@@ -106,6 +112,7 @@ impl WorkerSupervisorServices {
         rpc: Arc<RpcServices>,
         credentials: ResolvedCredentials,
         cancel: CancellationToken,
+        cancel_origin: CancelOriginTag,
         agent_context: AgentContext,
         captured_workspace_path: Arc<Mutex<Option<PathBuf>>>,
     ) -> Self {
@@ -113,6 +120,7 @@ impl WorkerSupervisorServices {
             rpc,
             credentials,
             cancel,
+            cancel_origin,
             agent_context,
             captured_workspace_path,
         }
@@ -454,6 +462,7 @@ impl SupervisorServices for WorkerSupervisorServices {
             spec,
             self.agent_context.clone(),
             self.cancel.clone(),
+            self.cancel_origin.clone(),
             provider,
             billing_signal,
             self,
@@ -967,6 +976,7 @@ mod tests {
 mod lease_adapter_conformance_tests {
     use super::WorkerSupervisorServices;
     use djinn_agent::direct_services::DirectServices;
+    use djinn_core::cancel_origin::CancelOriginTag;
     use djinn_db::BuildLeaseRepository;
     use djinn_runtime::ResolvedCredentials;
     use djinn_supervisor::services::{
@@ -1190,13 +1200,15 @@ mod lease_adapter_conformance_tests {
             .await
             .expect("serve");
         let cancel = CancellationToken::new();
-        let (rpc, background) = RpcServices::connect_unix(&path, cancel.clone())
-            .await
-            .expect("rpc");
+        let (rpc, background) =
+            RpcServices::connect_unix(&path, cancel.clone(), CancelOriginTag::new())
+                .await
+                .expect("rpc");
         let worker = WorkerSupervisorServices::new(
             rpc.clone(),
             ResolvedCredentials::default(),
             CancellationToken::new(),
+            CancelOriginTag::new(),
             djinn_agent::test_helpers::agent_context_from_db(
                 djinn_agent::test_helpers::create_test_db(),
                 CancellationToken::new(),
@@ -1210,14 +1222,18 @@ mod lease_adapter_conformance_tests {
             .await
             .expect("serve timeout");
         let timeout_cancel = CancellationToken::new();
-        let (timeout_rpc, timeout_background) =
-            RpcServices::connect_unix(&timeout_path, timeout_cancel.clone())
-                .await
-                .expect("connect timeout rpc");
+        let (timeout_rpc, timeout_background) = RpcServices::connect_unix(
+            &timeout_path,
+            timeout_cancel.clone(),
+            CancelOriginTag::new(),
+        )
+        .await
+        .expect("connect timeout rpc");
         let timeout_worker = WorkerSupervisorServices::new(
             timeout_rpc.clone(),
             ResolvedCredentials::default(),
             CancellationToken::new(),
+            CancelOriginTag::new(),
             djinn_agent::test_helpers::agent_context_from_db(
                 djinn_agent::test_helpers::create_test_db(),
                 CancellationToken::new(),

--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -326,6 +326,12 @@ impl DirectServices {
             callbacks: SupervisorCallbackContext {
                 agent_context,
                 cancel,
+                // The in-process host surface owns no cancellation trigger of
+                // its own — the Pod-side triggers (SIGTERM, soft deadline, RPC
+                // teardown) all live in `djinn-agent-worker`. Nothing stamps
+                // this tag on the direct path, so a direct-path cancellation
+                // reports `origin=unknown`, which is exactly what it is.
+                cancel_origin: djinn_core::cancel_origin::CancelOriginTag::new(),
                 provider_override,
                 // Host path derives the billing signal from the resolved
                 // credential inside `execute_stage`; nothing to pre-supply.
@@ -3865,9 +3871,13 @@ mod dispatch_identity_rpc_persistence_tests {
         let socket = dir.path().join("supervisor.sock");
         let server = serve_on_unix_socket(&socket, host).await.unwrap();
         let cancel = CancellationToken::new();
-        let (rpc, background) = RpcServices::connect_unix(&socket, cancel.clone())
-            .await
-            .unwrap();
+        let (rpc, background) = RpcServices::connect_unix(
+            &socket,
+            cancel.clone(),
+            djinn_core::cancel_origin::CancelOriginTag::new(),
+        )
+        .await
+        .unwrap();
         let attempts = TaskAttemptRepository::new(db.clone());
 
         let owner = uuid::Uuid::now_v7().to_string();
@@ -4074,9 +4084,13 @@ mod stale_pod_session_rpc_persistence_tests {
             .await
             .expect("serve host");
         let cancel = CancellationToken::new();
-        let (worker_rpc, background) = RpcServices::connect_unix(&socket, cancel.clone())
-            .await
-            .expect("connect worker rpc");
+        let (worker_rpc, background) = RpcServices::connect_unix(
+            &socket,
+            cancel.clone(),
+            djinn_core::cancel_origin::CancelOriginTag::new(),
+        )
+        .await
+        .expect("connect worker rpc");
 
         let error = worker_rpc
             .create_session(SerializableCreateSessionParams {

--- a/server/crates/djinn-agent/src/supervisor.rs
+++ b/server/crates/djinn-agent/src/supervisor.rs
@@ -121,6 +121,12 @@ pub async fn worker_execute_stage(
     spec: &djinn_supervisor::TaskRunSpec,
     agent_context: AgentContext,
     cancel: CancellationToken,
+    // Origin side channel for `cancel` (see `djinn_core::cancel_origin`). The
+    // worker stamps it at every trigger site — SIGTERM, the in-pod soft
+    // deadline, host control frames, RPC transport death, teardown — so a
+    // cancelled stage settles naming its cause instead of a bare
+    // "session cancelled". Unstamped reads back as `unknown`.
+    cancel_origin: djinn_core::cancel_origin::CancelOriginTag,
     provider: Arc<dyn LlmProvider>,
     billing_signal: Option<(
         djinn_supervisor::services::CostBasisHint,
@@ -131,6 +137,7 @@ pub async fn worker_execute_stage(
     let callbacks = SupervisorCallbackContext {
         agent_context,
         cancel,
+        cancel_origin,
         provider_override: Some(provider),
         billing_signal,
     };

--- a/server/crates/djinn-agent/src/supervisor_impl/mod.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/mod.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;
 
+use djinn_core::cancel_origin::CancelOriginTag;
+
 use crate::context::AgentContext;
 use djinn_provider::provider::LlmProvider;
 
@@ -56,6 +58,18 @@ pub(crate) use stage::execute_stage;
 pub(crate) struct SupervisorCallbackContext {
     pub agent_context: AgentContext,
     pub cancel: CancellationToken,
+    /// Which trigger fired [`Self::cancel`], recorded at the trigger site.
+    ///
+    /// A `CancellationToken` carries no payload, so the stage boundary could
+    /// only ever report "cancelled" and never *why*. The worker Pod fires one
+    /// token from SIGTERM, the in-pod soft deadline, host control frames, RPC
+    /// transport death, and orderly teardown; this side channel is what lets
+    /// [`stage::execute_stage`] name the cause in the durable terminal reason.
+    ///
+    /// Purely diagnostic: an unattributed cancellation reads back as
+    /// [`djinn_core::cancel_origin::CancelOrigin::Unknown`] and nothing gates
+    /// on it.
+    pub cancel_origin: CancelOriginTag,
     /// Injected `LlmProvider`. This is THE production in-Pod worker path
     /// (`djinn-agent-worker` builds the provider from a Secret-mounted
     /// credential and passes it here) as well as the integration-test stub

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -101,6 +101,7 @@ use crate::actors::slot::reply_loop::loop_guard::{
 use crate::actors::slot::reply_loop::{ReplyLoopContext, run_reply_loop};
 use crate::context::AgentContext;
 use crate::roles::{AgentRole, role_impl_for};
+use djinn_core::cancel_origin::CancelOrigin;
 use djinn_provider::message::{Conversation, Message};
 use djinn_provider::provider::LlmProvider;
 use djinn_provider::provider::error::ProviderError;
@@ -249,6 +250,33 @@ fn classify_reply_loop_failure(err: &anyhow::Error) -> ReplyLoopFailureClass {
     } else {
         ReplyLoopFailureClass::Other
     }
+}
+
+/// Append the cancellation trigger to a diagnostic, so a cancelled session
+/// names its cause instead of only its observation.
+///
+/// Production sessions died at ~4.3/hour with the bare reason
+/// `session cancelled`, which said *that* the token fired and never *who* fired
+/// it: one Pod-wide `CancellationToken` is triggered by SIGTERM, the in-pod
+/// soft deadline, a host control frame, RPC transport death, and orderly
+/// teardown, and a token carries no payload to tell them apart.
+///
+/// The `origin=` suffix is always emitted, including for
+/// [`CancelOrigin::Unknown`]. An unattributed cancellation is a normal outcome
+/// (some trigger simply did not stamp the tag), and emitting it explicitly is
+/// what distinguishes "we looked and nobody claimed it" from "this row predates
+/// origin tagging". It is never an error and never gates anything.
+fn with_cancel_origin(diagnostic: &str, origin: CancelOrigin) -> String {
+    format!("{diagnostic} (origin={})", origin.as_str())
+}
+
+/// [`with_cancel_origin`] under the established `reply loop error:` prefix,
+/// for the [`StageOutcome::Failed`] reason that reaches `task_runs`.
+fn cancelled_stage_reason(error_display: &str, origin: CancelOrigin) -> String {
+    format!(
+        "reply loop error: {}",
+        with_cancel_origin(error_display, origin)
+    )
 }
 
 /// Classify a reply-loop terminal error into the breaker-relevant
@@ -1607,7 +1635,16 @@ pub(crate) async fn execute_stage(
             context_window,
             model_id: &model_id,
             cancel: &callbacks.cancel,
-            global_cancel: &callbacks.cancel,
+            // NOT `&callbacks.cancel` again. Passing the same token to both
+            // fields made the reply loop's supervisor-shutdown select arm
+            // unreachable, because the biased select always resolved the
+            // session arm first. `services.cancel()` is the supervisor-wide
+            // token by definition (see `SupervisorServices::cancel`), so it is
+            // the correct source for this field. Every current wiring happens
+            // to hand the stage the same object, so this is behaviour-neutral
+            // today; the actual cause disambiguation comes from
+            // `callbacks.cancel_origin`, read at settlement below.
+            global_cancel: services.cancel(),
             app_state: agent_context,
             services,
             mcp_registry: mcp_registry.as_ref(),
@@ -1644,7 +1681,18 @@ pub(crate) async fn execute_stage(
     // Capture type-based settlement data before formatting the error for the
     // outward diagnostic. No error text participates in cause classification.
     let reply_failure_cause = reply_result.as_ref().err().map(reply_loop_failure_cause);
-    let final_error = reply_result.as_ref().err().map(|e| e.to_string());
+    // The same origin attribution the `Failed` reason carries, so the
+    // `session_error` activity row logged by `spawn_post_session_work` names
+    // the trigger too — otherwise the durable reason and the activity log
+    // disagree about the same cancellation.
+    let final_error = reply_result.as_ref().err().map(|e| {
+        let diagnostic = e.to_string();
+        if classify_reply_loop_failure(e) == ReplyLoopFailureClass::Cancelled {
+            with_cancel_origin(&diagnostic, callbacks.cancel_origin.get())
+        } else {
+            diagnostic
+        }
+    });
     let stage_outcome = match reply_result {
         Err(e) => {
             if e.downcast_ref::<BudgetWindDownIgnored>().is_some() {
@@ -1663,8 +1711,17 @@ pub(crate) async fn execute_stage(
             } else if classify_reply_loop_failure(&e) == ReplyLoopFailureClass::Cancelled {
                 // Preserve the established diagnostic and wire shape while making
                 // the typed cancellation seam explicit for durable settlement.
+                // The origin suffix is what turns an undiagnosable
+                // "session cancelled" into a row that names its trigger.
+                let origin = callbacks.cancel_origin.get();
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    session_id = %session_id,
+                    cancel_origin = origin.as_str(),
+                    "reply loop cancelled"
+                );
                 StageOutcome::Failed {
-                    reason: format!("reply loop error: {e}"),
+                    reason: cancelled_stage_reason(&e.to_string(), origin),
                     provider_failure: None,
                 }
             } else {
@@ -2655,6 +2712,115 @@ mod tests {
         ];
         for error in errors {
             assert_eq!(classify_provider_failure(&error), None);
+        }
+    }
+
+    /// The defect this addresses: every cancellation settled as the same
+    /// undiagnosable `reply loop error: session cancelled`, so production could
+    /// not tell a kubelet SIGTERM from a soft-deadline wind-down from a dead
+    /// RPC socket. The durable reason must now name the trigger.
+    #[test]
+    fn a_cancelled_stage_reason_names_the_trigger_that_fired_the_token() {
+        let cancelled = anyhow::Error::new(ReplyLoopCancelled::session()).to_string();
+
+        for (origin, expected) in [
+            (CancelOrigin::Sigterm, "origin=sigterm"),
+            (CancelOrigin::Sigint, "origin=sigint"),
+            (CancelOrigin::SoftDeadline, "origin=soft_deadline"),
+            (
+                CancelOrigin::HostCancelControl,
+                "origin=host_cancel_control",
+            ),
+            (
+                CancelOrigin::HostShutdownControl,
+                "origin=host_shutdown_control",
+            ),
+            (
+                CancelOrigin::RpcTransportClosed,
+                "origin=rpc_transport_closed",
+            ),
+            (CancelOrigin::WorkerTeardown, "origin=worker_teardown"),
+            (
+                CancelOrigin::SupervisorShutdown,
+                "origin=supervisor_shutdown",
+            ),
+            (CancelOrigin::Session, "origin=session"),
+        ] {
+            let reason = cancelled_stage_reason(&cancelled, origin);
+            assert!(
+                reason.contains(expected),
+                "reason must name the trigger: {reason}"
+            );
+        }
+
+        // Distinct triggers must produce distinct rows — that is the whole
+        // point. Two origins that render identically would put us back where
+        // we started.
+        assert_ne!(
+            cancelled_stage_reason(&cancelled, CancelOrigin::Sigterm),
+            cancelled_stage_reason(&cancelled, CancelOrigin::SoftDeadline),
+        );
+    }
+
+    /// Hard constraint: an unattributed cancellation degrades to `unknown`. It
+    /// must never become an error, an empty reason, or a missing field — the
+    /// platform has repeatedly been wedged by fail-closed diagnostics.
+    #[test]
+    fn an_unattributed_cancellation_degrades_to_unknown_and_keeps_the_diagnostic() {
+        let cancelled = anyhow::Error::new(ReplyLoopCancelled::session()).to_string();
+        let reason = cancelled_stage_reason(&cancelled, CancelOrigin::Unknown);
+
+        assert!(reason.contains("origin=unknown"), "{reason}");
+        // The established diagnostic is preserved, not replaced: existing
+        // consumers of the reply-loop prefix and the cancellation text keep
+        // matching.
+        assert!(reason.starts_with("reply loop error: "), "{reason}");
+        assert!(reason.contains("session cancelled"), "{reason}");
+    }
+
+    /// The `task_runs` reason and the `session_error` activity row are two
+    /// different strings built from the same error. Both must carry the
+    /// attribution, or an operator reading one of them is still blind.
+    #[test]
+    fn the_activity_log_diagnostic_carries_the_same_origin_as_the_stage_reason() {
+        let cancelled = anyhow::Error::new(ReplyLoopCancelled::session()).to_string();
+        let activity = with_cancel_origin(&cancelled, CancelOrigin::SoftDeadline);
+        let stage_reason = cancelled_stage_reason(&cancelled, CancelOrigin::SoftDeadline);
+
+        assert!(activity.contains("origin=soft_deadline"), "{activity}");
+        assert!(
+            stage_reason.contains("origin=soft_deadline"),
+            "{stage_reason}"
+        );
+        assert!(
+            stage_reason.ends_with(&activity),
+            "the stage reason must be the activity diagnostic under the \
+             established prefix: {stage_reason} / {activity}"
+        );
+    }
+
+    /// The origin rides along with, and never replaces, the durable settlement
+    /// cause. A tagged cancellation is still a cancellation.
+    #[test]
+    fn origin_tagging_does_not_change_how_a_cancellation_settles() {
+        for cancellation in [
+            ReplyLoopCancelled::session(),
+            ReplyLoopCancelled::supervisor_shutdown(),
+        ] {
+            let error = anyhow::Error::new(cancellation);
+            assert_eq!(
+                classify_reply_loop_failure(&error),
+                ReplyLoopFailureClass::Cancelled,
+            );
+            assert_eq!(
+                reply_loop_failure_cause(&error),
+                SessionFailureCause::Cancelled
+            );
+            assert_eq!(
+                classify_provider_failure(&error),
+                None,
+                "a cancellation must stay breaker-neutral however it is tagged",
+            );
         }
     }
 

--- a/server/crates/djinn-core/src/cancel_origin.rs
+++ b/server/crates/djinn-core/src/cancel_origin.rs
@@ -1,0 +1,288 @@
+//! Origin tagging for run cancellation.
+//!
+//! A [`tokio_util::sync::CancellationToken`] carries no payload: once it is
+//! cancelled, every observer learns *that* the run was cancelled and nothing
+//! about *who* cancelled it. A worker Pod fires exactly one token from many
+//! distinct places (SIGTERM, the in-pod soft deadline, a host `Cancel` control
+//! frame, RPC transport death, orderly teardown), so every one of those causes
+//! collapsed into the same terminal reason and production could not tell them
+//! apart.
+//!
+//! [`CancelOriginTag`] is the missing side channel: a cheap, cloneable,
+//! lock-free slot written immediately *before* `.cancel()` at each trigger site
+//! and read wherever the cancellation is observed.
+//!
+//! # This is observability, never a gate
+//!
+//! An unrecorded cancellation reads back as [`CancelOrigin::Unknown`]. That is
+//! a legitimate, expected value — it means "nobody tagged this trigger", not
+//! "something is wrong". Nothing here returns an error, fails closed, or
+//! changes control flow, and no caller may treat `Unknown` as a fault.
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Who fired a run's cancellation token.
+///
+/// The discriminants are part of the on-wire-ish contract only in the sense
+/// that [`CancelOriginTag`] packs them into an `AtomicU8`; they are never
+/// persisted numerically. [`CancelOrigin::as_str`] is the stable, greppable
+/// spelling that reaches durable terminal reasons and log fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub enum CancelOrigin {
+    /// No trigger site recorded an origin before cancelling. Always a valid
+    /// outcome — read it as "not attributed", never as an error.
+    #[default]
+    Unknown,
+    /// A session-scoped cancel: this session was stopped on its own, without
+    /// the surrounding supervisor or Pod winding down.
+    Session,
+    /// The supervisor tore the run down (server shutdown, operator kill).
+    SupervisorShutdown,
+    /// The worker Pod received `SIGTERM` (kubelet eviction, graceful drain,
+    /// `activeDeadlineSeconds` grace, `helm upgrade` roll).
+    Sigterm,
+    /// The worker Pod received `SIGINT`.
+    Sigint,
+    /// The in-pod soft deadline fired ahead of the kubelet's hard
+    /// `activeDeadlineSeconds` backstop.
+    SoftDeadline,
+    /// The host sent an explicit `Control(Cancel)` frame over RPC.
+    HostCancelControl,
+    /// The host sent a `Control(Shutdown)` frame over RPC.
+    HostShutdownControl,
+    /// The RPC transport died (socket closed, frame write failed). There is no
+    /// reconnect, so the worker winds down through the same graceful path.
+    RpcTransportClosed,
+    /// Orderly end-of-run teardown after the supervisor already returned.
+    WorkerTeardown,
+}
+
+impl CancelOrigin {
+    /// Stable, lowercase, snake_case spelling used in terminal reasons, log
+    /// fields, and metric labels. Never change an existing spelling — dashboards
+    /// and incident greps key off these tokens.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Session => "session",
+            Self::SupervisorShutdown => "supervisor_shutdown",
+            Self::Sigterm => "sigterm",
+            Self::Sigint => "sigint",
+            Self::SoftDeadline => "soft_deadline",
+            Self::HostCancelControl => "host_cancel_control",
+            Self::HostShutdownControl => "host_shutdown_control",
+            Self::RpcTransportClosed => "rpc_transport_closed",
+            Self::WorkerTeardown => "worker_teardown",
+        }
+    }
+
+    /// Whether an origin was actually attributed.
+    pub const fn is_known(self) -> bool {
+        !matches!(self, Self::Unknown)
+    }
+
+    const fn as_u8(self) -> u8 {
+        match self {
+            Self::Unknown => 0,
+            Self::Session => 1,
+            Self::SupervisorShutdown => 2,
+            Self::Sigterm => 3,
+            Self::Sigint => 4,
+            Self::SoftDeadline => 5,
+            Self::HostCancelControl => 6,
+            Self::HostShutdownControl => 7,
+            Self::RpcTransportClosed => 8,
+            Self::WorkerTeardown => 9,
+        }
+    }
+
+    /// Total: any unrecognised byte degrades to [`CancelOrigin::Unknown`]
+    /// rather than panicking. A torn or future-versioned value must never be
+    /// able to take a process down over a diagnostic.
+    const fn from_u8(raw: u8) -> Self {
+        match raw {
+            1 => Self::Session,
+            2 => Self::SupervisorShutdown,
+            3 => Self::Sigterm,
+            4 => Self::Sigint,
+            5 => Self::SoftDeadline,
+            6 => Self::HostCancelControl,
+            7 => Self::HostShutdownControl,
+            8 => Self::RpcTransportClosed,
+            9 => Self::WorkerTeardown,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl fmt::Display for CancelOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Shared, cloneable slot recording which trigger fired a cancellation token.
+///
+/// Clone it wherever the matching `CancellationToken` is cloned; every clone
+/// reads and writes the same slot.
+///
+/// # First writer wins
+///
+/// Cancellation is racy by nature: SIGTERM and the RPC reader can observe the
+/// same Pod teardown microseconds apart. The *first* recorded origin is the one
+/// that caused the cancellation; later ones are consequences of it, so
+/// [`Self::record`] never overwrites an already-attributed origin.
+#[derive(Clone, Debug, Default)]
+pub struct CancelOriginTag {
+    slot: Arc<AtomicU8>,
+}
+
+impl CancelOriginTag {
+    /// A fresh, unattributed tag.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attribute this cancellation, if it is not already attributed.
+    ///
+    /// Call this immediately *before* `token.cancel()` so any observer that
+    /// wakes on the token can already read the origin. Recording
+    /// [`CancelOrigin::Unknown`] is a no-op, and recording a second origin
+    /// leaves the first in place (see the type docs).
+    ///
+    /// Infallible by construction — a diagnostic must never be able to fail a
+    /// teardown path.
+    pub fn record(&self, origin: CancelOrigin) {
+        if !origin.is_known() {
+            return;
+        }
+        // Only claim the slot when it is still unattributed. `Relaxed` on
+        // failure is sufficient: we discard the observed value either way.
+        let _ = self.slot.compare_exchange(
+            CancelOrigin::Unknown.as_u8(),
+            origin.as_u8(),
+            Ordering::AcqRel,
+            Ordering::Relaxed,
+        );
+    }
+
+    /// Read the recorded origin, or [`CancelOrigin::Unknown`] when no trigger
+    /// site attributed one.
+    pub fn get(&self) -> CancelOrigin {
+        CancelOrigin::from_u8(self.slot.load(Ordering::Acquire))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unrecorded_tag_reads_unknown_and_never_errors() {
+        let tag = CancelOriginTag::new();
+        assert_eq!(tag.get(), CancelOrigin::Unknown);
+        assert!(!tag.get().is_known());
+        // Recording `Unknown` is a no-op, not a state change.
+        tag.record(CancelOrigin::Unknown);
+        assert_eq!(tag.get(), CancelOrigin::Unknown);
+    }
+
+    #[test]
+    fn record_attributes_the_origin_to_every_clone() {
+        let tag = CancelOriginTag::new();
+        let observer = tag.clone();
+        tag.record(CancelOrigin::Sigterm);
+        assert_eq!(observer.get(), CancelOrigin::Sigterm);
+        assert!(observer.get().is_known());
+    }
+
+    #[test]
+    fn first_writer_wins_so_a_consequence_cannot_overwrite_the_cause() {
+        let tag = CancelOriginTag::new();
+        // SIGTERM is the cause; the RPC transport dying afterwards is a
+        // consequence of the same teardown and must not relabel the row.
+        tag.record(CancelOrigin::Sigterm);
+        tag.record(CancelOrigin::RpcTransportClosed);
+        tag.record(CancelOrigin::WorkerTeardown);
+        assert_eq!(tag.get(), CancelOrigin::Sigterm);
+    }
+
+    #[test]
+    fn every_origin_round_trips_through_the_packed_byte() {
+        for origin in [
+            CancelOrigin::Unknown,
+            CancelOrigin::Session,
+            CancelOrigin::SupervisorShutdown,
+            CancelOrigin::Sigterm,
+            CancelOrigin::Sigint,
+            CancelOrigin::SoftDeadline,
+            CancelOrigin::HostCancelControl,
+            CancelOrigin::HostShutdownControl,
+            CancelOrigin::RpcTransportClosed,
+            CancelOrigin::WorkerTeardown,
+        ] {
+            assert_eq!(CancelOrigin::from_u8(origin.as_u8()), origin);
+            let tag = CancelOriginTag::new();
+            tag.record(origin);
+            assert_eq!(tag.get(), origin);
+        }
+    }
+
+    #[test]
+    fn an_unrecognised_byte_degrades_to_unknown_instead_of_panicking() {
+        assert_eq!(CancelOrigin::from_u8(200), CancelOrigin::Unknown);
+        assert_eq!(CancelOrigin::from_u8(u8::MAX), CancelOrigin::Unknown);
+    }
+
+    #[test]
+    fn origin_spellings_are_distinct_and_stable() {
+        let all = [
+            CancelOrigin::Unknown,
+            CancelOrigin::Session,
+            CancelOrigin::SupervisorShutdown,
+            CancelOrigin::Sigterm,
+            CancelOrigin::Sigint,
+            CancelOrigin::SoftDeadline,
+            CancelOrigin::HostCancelControl,
+            CancelOrigin::HostShutdownControl,
+            CancelOrigin::RpcTransportClosed,
+            CancelOrigin::WorkerTeardown,
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for origin in all {
+            assert!(
+                seen.insert(origin.as_str()),
+                "duplicate origin spelling: {origin}"
+            );
+            assert_eq!(origin.to_string(), origin.as_str());
+        }
+        assert_eq!(CancelOrigin::Sigterm.as_str(), "sigterm");
+        assert_eq!(CancelOrigin::Unknown.as_str(), "unknown");
+    }
+
+    #[test]
+    fn concurrent_recorders_settle_on_exactly_one_known_origin() {
+        let tag = CancelOriginTag::new();
+        let origins = [
+            CancelOrigin::Sigterm,
+            CancelOrigin::SoftDeadline,
+            CancelOrigin::RpcTransportClosed,
+            CancelOrigin::WorkerTeardown,
+        ];
+        std::thread::scope(|scope| {
+            for origin in origins {
+                let tag = tag.clone();
+                scope.spawn(move || tag.record(origin));
+            }
+        });
+        let settled = tag.get();
+        assert!(settled.is_known(), "a raced record must still attribute");
+        assert!(origins.contains(&settled));
+        // Stable afterwards: reads never mutate, later writes never win.
+        assert_eq!(tag.get(), settled);
+        tag.record(CancelOrigin::Session);
+        assert_eq!(tag.get(), settled);
+    }
+}

--- a/server/crates/djinn-core/src/lib.rs
+++ b/server/crates/djinn-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth_context;
+pub mod cancel_origin;
 pub mod cargo_target_runs;
 pub mod child_ownership;
 pub mod clock;

--- a/server/crates/djinn-supervisor/src/services/rpc.rs
+++ b/server/crates/djinn-supervisor/src/services/rpc.rs
@@ -39,6 +39,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
+use djinn_core::cancel_origin::{CancelOrigin, CancelOriginTag};
 use djinn_core::models::{Task, TaskRunStatus};
 use djinn_runtime::wire::{ControlMsg, WorkspaceRef, read_frame, write_frame};
 use djinn_workspace::Workspace;
@@ -145,10 +146,19 @@ impl RpcServices {
     /// round-trip on TCP) MUST be consumed by the caller before handing
     /// the halves in — this function assumes the stream is positioned at
     /// the start of the post-handshake RPC byte stream.
+    /// `cancel_origin` is the side channel that records WHICH trigger fired
+    /// `cancel` (see [`djinn_core::cancel_origin`]). The reader and writer
+    /// loops are themselves cancellation triggers — transport death winds the
+    /// worker down — so they must stamp the tag before firing the token, or
+    /// the resulting terminal reason cannot name the RPC as the cause. Pass a
+    /// clone of the tag that travels with `cancel`; a fresh
+    /// [`CancelOriginTag::new`] simply leaves those cancellations
+    /// unattributed.
     pub fn from_split<R, W>(
         read_half: R,
         write_half: W,
         cancel: CancellationToken,
+        cancel_origin: CancelOriginTag,
     ) -> (Arc<Self>, RpcBackgroundTasks)
     where
         R: AsyncRead + Unpin + Send + 'static,
@@ -164,8 +174,13 @@ impl RpcServices {
             next_id: AtomicU64::new(1),
         });
 
-        let reader = tokio::spawn(reader_loop(read_half, pending.clone(), cancel.clone()));
-        let writer = tokio::spawn(writer_loop(write_half, rx, cancel.clone()));
+        let reader = tokio::spawn(reader_loop(
+            read_half,
+            pending.clone(),
+            cancel.clone(),
+            cancel_origin.clone(),
+        ));
+        let writer = tokio::spawn(writer_loop(write_half, rx, cancel.clone(), cancel_origin));
 
         (services, RpcBackgroundTasks { reader, writer })
     }
@@ -174,18 +189,20 @@ impl RpcServices {
     pub fn from_unix_stream(
         stream: UnixStream,
         cancel: CancellationToken,
+        cancel_origin: CancelOriginTag,
     ) -> (Arc<Self>, RpcBackgroundTasks) {
         let (read_half, write_half) = stream.into_split();
-        Self::from_split(read_half, write_half, cancel)
+        Self::from_split(read_half, write_half, cancel, cancel_origin)
     }
 
     /// Split a [`TcpStream`] and delegate to [`RpcServices::from_split`].
     pub fn from_stream(
         stream: TcpStream,
         cancel: CancellationToken,
+        cancel_origin: CancelOriginTag,
     ) -> (Arc<Self>, RpcBackgroundTasks) {
         let (read_half, write_half) = stream.into_split();
-        Self::from_split(read_half, write_half, cancel)
+        Self::from_split(read_half, write_half, cancel, cancel_origin)
     }
 
     /// Convenience wrapper: dial `path` via `UnixStream`, then delegate to
@@ -193,9 +210,10 @@ impl RpcServices {
     pub async fn connect_unix(
         path: impl AsRef<Path>,
         cancel: CancellationToken,
+        cancel_origin: CancelOriginTag,
     ) -> std::io::Result<(Arc<Self>, RpcBackgroundTasks)> {
         let stream = UnixStream::connect(path.as_ref()).await?;
-        Ok(Self::from_unix_stream(stream, cancel))
+        Ok(Self::from_unix_stream(stream, cancel, cancel_origin))
     }
 
     /// Dial `addr`, perform the [`FramePayload::AuthHello`] handshake, and —
@@ -219,6 +237,7 @@ impl RpcServices {
         task_run_id: String,
         token: String,
         cancel: CancellationToken,
+        cancel_origin: CancelOriginTag,
     ) -> Result<(Arc<Self>, RpcBackgroundTasks), ConnectTcpError> {
         // Retry the TCP dial with exponential backoff so the worker tolerates
         // launcher races AND a server rolling restart: the dispatch path can
@@ -312,7 +331,12 @@ impl RpcServices {
 
         // 3. Split the stream and enter the shared dispatch loop.
         let (read_half, write_half) = stream.into_split();
-        Ok(Self::from_split(read_half, write_half, cancel))
+        Ok(Self::from_split(
+            read_half,
+            write_half,
+            cancel,
+            cancel_origin,
+        ))
     }
 
     /// Push an out-of-band [`WorkerEvent`] onto the outbound mpsc channel so
@@ -1125,8 +1149,12 @@ impl SupervisorServices for RpcServices {
 
 // ── Reader / writer loops ────────────────────────────────────────────────────
 
-async fn reader_loop<R>(mut read_half: R, pending: PendingMap, cancel: CancellationToken)
-where
+async fn reader_loop<R>(
+    mut read_half: R,
+    pending: PendingMap,
+    cancel: CancellationToken,
+    cancel_origin: CancelOriginTag,
+) where
     R: AsyncRead + Unpin + Send + 'static,
 {
     // Loop until cancellation or socket close, then drain `pending` on the
@@ -1159,10 +1187,14 @@ where
                         }
                         FramePayload::Control(ControlMsg::Cancel) => {
                             debug!("rpc reader: received Cancel control frame");
+                            // Stamp the origin BEFORE firing so anything that
+                            // wakes on the token already reads the cause.
+                            cancel_origin.record(CancelOrigin::HostCancelControl);
                             cancel.cancel();
                         }
                         FramePayload::Control(ControlMsg::Shutdown) => {
                             debug!("rpc reader: received Shutdown control frame");
+                            cancel_origin.record(CancelOrigin::HostShutdownControl);
                             cancel.cancel();
                             break Ok(());
                         }
@@ -1182,6 +1214,7 @@ where
                         // their pods kept running for 50+ min, wedging
                         // scheduling on the single-node VPS.)
                         warn!(error = %e, "rpc reader: stream closed; cancelling worker");
+                        cancel_origin.record(CancelOrigin::RpcTransportClosed);
                         cancel.cancel();
                         break Ok(());
                     }
@@ -1209,8 +1242,12 @@ where
     }
 }
 
-async fn writer_loop<W>(mut write_half: W, mut rx: mpsc::Receiver<Frame>, cancel: CancellationToken)
-where
+async fn writer_loop<W>(
+    mut write_half: W,
+    mut rx: mpsc::Receiver<Frame>,
+    cancel: CancellationToken,
+    cancel_origin: CancelOriginTag,
+) where
     W: AsyncWrite + Unpin + Send + 'static,
 {
     // Unlike the reader, the writer does NOT exit eagerly on cancel.  On a
@@ -1242,6 +1279,7 @@ where
             // write means the host is gone and there is no reconnect, so the
             // worker must wind down rather than orphan itself.
             error!(error = %e, "rpc writer: failed to write frame; cancelling worker");
+            cancel_origin.record(CancelOrigin::RpcTransportClosed);
             cancel.cancel();
             return;
         }
@@ -1593,7 +1631,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let result = services.load_task("hello-task".into()).await;
         let task = result.expect("load_task ok");
         assert_eq!(task.id, "hello-task");
@@ -1644,7 +1683,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let params = SerializableCreateTaskRunParams {
             id: "run-create-rt".into(),
             task_attempt_id: None,
@@ -1699,7 +1739,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         services
             .update_task_run_status("run-update-rt".into(), TaskRunStatus::Completed)
             .await
@@ -1737,7 +1778,8 @@ mod tests {
         });
 
         let cancel2 = CancellationToken::new();
-        let (services2, bg2) = RpcServices::from_unix_stream(client2, cancel2.clone());
+        let (services2, bg2) =
+            RpcServices::from_unix_stream(client2, cancel2.clone(), CancelOriginTag::new());
         let err = services2
             .update_task_run_status("run-update-err".into(), TaskRunStatus::Failed)
             .await
@@ -1776,7 +1818,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let got = services
             .get_model_context_window("anthropic/claude-opus-4-7".into())
             .await
@@ -1813,7 +1856,8 @@ mod tests {
         });
 
         let cancel2 = CancellationToken::new();
-        let (services2, bg2) = RpcServices::from_unix_stream(client2, cancel2.clone());
+        let (services2, bg2) =
+            RpcServices::from_unix_stream(client2, cancel2.clone(), CancelOriginTag::new());
         let err = services2
             .get_model_context_window("missing/model".into())
             .await
@@ -1853,7 +1897,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let got = services
             .get_provider_base_url("anthropic".into())
             .await
@@ -1890,7 +1935,8 @@ mod tests {
         });
 
         let cancel2 = CancellationToken::new();
-        let (services2, bg2) = RpcServices::from_unix_stream(client2, cancel2.clone());
+        let (services2, bg2) =
+            RpcServices::from_unix_stream(client2, cancel2.clone(), CancelOriginTag::new());
         let err = services2
             .get_provider_base_url("no-such-provider".into())
             .await
@@ -1927,7 +1973,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let got = services
             .pick_any_default_model()
             .await
@@ -1964,7 +2011,8 @@ mod tests {
         });
 
         let cancel2 = CancellationToken::new();
-        let (services2, bg2) = RpcServices::from_unix_stream(client2, cancel2.clone());
+        let (services2, bg2) =
+            RpcServices::from_unix_stream(client2, cancel2.clone(), CancelOriginTag::new());
         let got = services2
             .pick_any_default_model()
             .await
@@ -2026,7 +2074,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let params = SerializableCreateSessionParams {
             project_id: "p1".into(),
             task_id: Some("t1".into()),
@@ -2082,7 +2131,8 @@ mod tests {
             }
         });
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let error = services
             .create_session(SerializableCreateSessionParams {
                 project_id: "p1".into(),
@@ -2140,7 +2190,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         services
             .publish_session_message(
                 "s1".into(),
@@ -2213,7 +2264,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let mut conv = Conversation::new();
         conv.push(Message::user("ping"));
         let got = services
@@ -2265,7 +2317,8 @@ mod tests {
         });
 
         let cancel = CancellationToken::new();
-        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone());
+        let (services, bg) =
+            RpcServices::from_unix_stream(client, cancel.clone(), CancelOriginTag::new());
         let cfg = services
             .get_environment_config("p1".into())
             .await
@@ -2284,6 +2337,92 @@ mod tests {
         let _ = bg.reader.await;
         let _ = bg.writer.await;
         let _ = server_task.await;
+    }
+
+    /// A dead transport already cancelled the worker; before this change the
+    /// cause was indistinguishable from every other cancellation. Assert the
+    /// *attribution*, and assert the cancellation still fires — the tag is an
+    /// addition to the teardown, never a replacement for it.
+    #[tokio::test]
+    async fn transport_death_attributes_the_cancellation_to_the_rpc_reader() {
+        let (client, server) = UnixStream::pair().expect("pair");
+        let cancel = CancellationToken::new();
+        let origin = CancelOriginTag::new();
+        assert_eq!(
+            origin.get(),
+            CancelOrigin::Unknown,
+            "unattributed before any trigger fires"
+        );
+
+        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone(), origin.clone());
+
+        // Kill the transport under the reader.
+        drop(server);
+        cancel.cancelled().await;
+
+        assert!(cancel.is_cancelled(), "transport death must still cancel");
+        assert_eq!(origin.get(), CancelOrigin::RpcTransportClosed);
+
+        drop(services);
+        let _ = bg.reader.await;
+        let _ = bg.writer.await;
+    }
+
+    /// A host `Control(Shutdown)` frame and a host `Control(Cancel)` frame are
+    /// different operator actions that used to settle identically.
+    #[tokio::test]
+    async fn a_host_shutdown_control_frame_is_attributed_to_the_host() {
+        let (client, server) = UnixStream::pair().expect("pair");
+        let cancel = CancellationToken::new();
+        let origin = CancelOriginTag::new();
+
+        let server_task = tokio::spawn(async move {
+            let (_read, mut write) = server.into_split();
+            let frame = Frame {
+                correlation_id: 0,
+                payload: FramePayload::Control(ControlMsg::Shutdown),
+            };
+            write_frame(&mut write, &frame)
+                .await
+                .expect("write control");
+            // Hold the socket open so the reader observes the control frame
+            // rather than an EOF.
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        });
+
+        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone(), origin.clone());
+        cancel.cancelled().await;
+
+        assert_eq!(origin.get(), CancelOrigin::HostShutdownControl);
+
+        drop(services);
+        let _ = bg.reader.await;
+        let _ = bg.writer.await;
+        let _ = server_task.await;
+    }
+
+    /// The cause outranks its consequences: the transport dying *after* the
+    /// pod already began winding down must not relabel the row.
+    #[tokio::test]
+    async fn an_already_attributed_cancellation_survives_transport_death() {
+        let (client, server) = UnixStream::pair().expect("pair");
+        let cancel = CancellationToken::new();
+        let origin = CancelOriginTag::new();
+        origin.record(CancelOrigin::Sigterm);
+
+        let (services, bg) = RpcServices::from_unix_stream(client, cancel.clone(), origin.clone());
+        drop(server);
+        cancel.cancelled().await;
+
+        assert_eq!(
+            origin.get(),
+            CancelOrigin::Sigterm,
+            "SIGTERM caused the teardown; the RPC close is downstream of it"
+        );
+
+        drop(services);
+        let _ = bg.reader.await;
+        let _ = bg.writer.await;
     }
 
     fn fixture_task() -> Task {

--- a/server/crates/djinn-supervisor/src/services/server.rs
+++ b/server/crates/djinn-supervisor/src/services/server.rs
@@ -1696,9 +1696,13 @@ mod tests {
 
         // Drive the worker side via RpcServices.
         let client_cancel = CancellationToken::new();
-        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(&sock, client_cancel.clone())
-            .await
-            .expect("connect rpc");
+        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(
+            &sock,
+            client_cancel.clone(),
+            djinn_core::cancel_origin::CancelOriginTag::new(),
+        )
+        .await
+        .expect("connect rpc");
         let task = rpc
             .load_task("wire-task-1".into())
             .await
@@ -1848,7 +1852,11 @@ mod tests {
         // Now the stream is in the shared dispatch loop.  Hand it to
         // `RpcServices::from_stream` and round-trip a load_task.
         let cancel = CancellationToken::new();
-        let (rpc, bg) = super::super::rpc::RpcServices::from_stream(stream, cancel.clone());
+        let (rpc, bg) = super::super::rpc::RpcServices::from_stream(
+            stream,
+            cancel.clone(),
+            djinn_core::cancel_origin::CancelOriginTag::new(),
+        );
         let task = rpc
             .load_task("tcp-task-1".into())
             .await
@@ -2114,9 +2122,13 @@ mod tests {
             .await
             .expect("bind server");
         let client_cancel = CancellationToken::new();
-        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(&sock, client_cancel.clone())
-            .await
-            .expect("connect rpc");
+        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(
+            &sock,
+            client_cancel.clone(),
+            djinn_core::cancel_origin::CancelOriginTag::new(),
+        )
+        .await
+        .expect("connect rpc");
         let result = rpc
             .plan_memory_intents(super::super::wire::AttributedPlannerRequest {
                 project_id: "project-1".into(),
@@ -2432,9 +2444,13 @@ mod tests {
             .await
             .expect("bind server");
         let client_cancel = CancellationToken::new();
-        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(&sock, client_cancel.clone())
-            .await
-            .expect("connect rpc");
+        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(
+            &sock,
+            client_cancel.clone(),
+            djinn_core::cancel_origin::CancelOriginTag::new(),
+        )
+        .await
+        .expect("connect rpc");
         (rpc, bg, handle, client_cancel, dir)
     }
 
@@ -2561,9 +2577,13 @@ mod tests {
             .await
             .expect("bind server");
         let client_cancel = CancellationToken::new();
-        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(&sock, client_cancel.clone())
-            .await
-            .expect("connect rpc");
+        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(
+            &sock,
+            client_cancel.clone(),
+            djinn_core::cancel_origin::CancelOriginTag::new(),
+        )
+        .await
+        .expect("connect rpc");
 
         // Tear down the server side, breaking the transport.
         handle.cancel();
@@ -2604,9 +2624,13 @@ mod tests {
             .await
             .expect("bind server");
         let client_cancel = CancellationToken::new();
-        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(&sock, client_cancel.clone())
-            .await
-            .expect("connect rpc");
+        let (rpc, bg) = super::super::rpc::RpcServices::connect_unix(
+            &sock,
+            client_cancel.clone(),
+            djinn_core::cancel_origin::CancelOriginTag::new(),
+        )
+        .await
+        .expect("connect rpc");
         let valid = WatchdogTerminationRequest {
             task_id: "task-1".into(),
             task_run_id: "run-1".into(),

--- a/server/tests/task_run_resize_kind.rs
+++ b/server/tests/task_run_resize_kind.rs
@@ -1160,9 +1160,13 @@ async fn live_a_real_brokered_shell_is_governed_by_the_resized_sidecar() {
         .await
         .expect("the supervisor RPC server binds");
     let cancel = CancellationToken::new();
-    let (rpc, background) = RpcServices::connect_unix(&socket, cancel.clone())
-        .await
-        .expect("the supervisor RPC client connects");
+    let (rpc, background) = RpcServices::connect_unix(
+        &socket,
+        cancel.clone(),
+        djinn_core::cancel_origin::CancelOriginTag::new(),
+    )
+    .await
+    .expect("the supervisor RPC client connects");
 
     // Render first: the lease identity must carry the SAME task-run id the
     // renderer stamped onto the Job, or the lease and the Pod are two unrelated
@@ -1469,9 +1473,13 @@ async fn live_the_absent_init_status_is_not_confirmed() {
         .await
         .expect("the supervisor RPC server binds");
     let cancel = CancellationToken::new();
-    let (rpc, background) = RpcServices::connect_unix(&socket, cancel.clone())
-        .await
-        .expect("the client connects");
+    let (rpc, background) = RpcServices::connect_unix(
+        &socket,
+        cancel.clone(),
+        djinn_core::cancel_origin::CancelOriginTag::new(),
+    )
+    .await
+    .expect("the client connects");
     let granted = confirm_launcher_cpu(&pod, CpuLimit::from_millis(2_000)).is_ok();
     assert!(
         !granted,


### PR DESCRIPTION
## The defect

Production sessions terminate with the reason `session cancelled` at ~4.3/hour and the row says nothing about why. Already ruled out with evidence: the invocation-journal watchdog (0 exact-pod terminations), OOM (no kernel kills, 6GiB of 22GiB), RPC disconnect (0 transport errors), DB pool exhaustion (26 idle of 200), supervisor kill (`slot.kill_requested` = 0).

The reason is undiagnosable **by construction**, and there are two layers to it.

**1. The aliased token pair.** `supervisor_impl/stage.rs` passed the same `CancellationToken` to both fields of the reply-loop context:

```rust
cancel: &callbacks.cancel,
global_cancel: &callbacks.cancel,   // same object
```

The reply loop's `select!` in `djinn-slot/src/reply_loop/streaming.rs` is `biased`, so with both fields aliased the session arm always wins and the supervisor-shutdown arm is unreachable. Every cancellation became `ReplyLoopCancelled::session()` → `"session cancelled"`.

**2. The deeper one: a token carries no payload.** Even de-aliased, the two arms could only ever distinguish *which token* fired, never *who fired it*. In a worker Pod there is exactly one cancellation authority, and it is triggered from six places:

| trigger | site |
| --- | --- |
| SIGTERM / SIGINT | `djinn-agent-worker/src/main.rs` `install_termination_handlers` |
| in-pod soft deadline | `djinn-agent-worker/src/main.rs` `install_soft_deadline` |
| host `Control(Cancel)` | `djinn-supervisor/src/services/rpc.rs` reader loop |
| host `Control(Shutdown)` | same reader loop |
| RPC transport death | reader stream-closed + writer write-failure |
| orderly teardown | `main.rs` end-of-run |

No arrangement of select arms separates those. **The origin has to be carried out-of-band.**

## What this adds

`djinn_core::cancel_origin` — a cheap, cloneable, lock-free `AtomicU8` slot travelling alongside the token:

- `CancelOrigin` — `Unknown | Session | SupervisorShutdown | Sigterm | Sigint | SoftDeadline | HostCancelControl | HostShutdownControl | RpcTransportClosed | WorkerTeardown`, each with a stable snake_case `as_str()` spelling for greps and dashboards.
- `CancelOriginTag` — `record(origin)` immediately **before** `.cancel()`, `get()` where the cancellation is observed.

**First writer wins.** Cancellation is racy — SIGTERM and the RPC reader observe the same Pod teardown microseconds apart — so the first recorded origin is the cause and later ones are consequences of it. A SIGTERM is not relabelled `rpc_transport_closed` by the socket dying a moment later.

Both durable surfaces now carry it, because they are two different strings built from the same error and an operator reading either one has to see the cause:

- `StageOutcome::Failed { reason }` → `task_runs`: `reply loop error: session cancelled (origin=sigterm)`
- `final_error` → the `session_error` activity row: `session cancelled (origin=sigterm)`

Plus a structured `cancel_origin` field on the warn-level log at the stage boundary and at each trigger site.

**And the aliasing is fixed:** `global_cancel` now reads `services.cancel()` — the supervisor-wide token *by definition* (`SupervisorServices::cancel`'s own doc: "Flagged when the task-run is torn down") — instead of re-passing the stage's token.

### One thing that contradicts the framing, stated plainly

The task asked me to thread a distinct supervisor token through if none existed at the call site. **I did not, and I believe threading one would be wrong here.** Every wiring — `WorkerSupervisorServices`, `DirectServices`, `RpcServices` — hands the stage the *same* `CancellationToken` object, and in the worker Pod that is correct: there is no session-scoped cancel distinct from Pod shutdown. Every trigger in the table above is Pod-wide. Splitting the token would not create a real distinction; it would either make the *session* arm unreachable instead (no gain) or risk a path that cancels one token and not the other — exactly the hang-instead-of-cancel regression the brief calls far worse than the current blindness.

So `global_cancel: services.cancel()` is a semantic correction (the field now names the supervisor authority rather than aliasing its neighbour) that is behaviour-neutral today and becomes load-bearing for free if a future wiring ever does give the supervisor its own token. The actual disambiguation comes from the origin tag.

## Behaviour is unchanged

Cancellation still cancels, through the identical path, with identical timing and control flow. The tag is a store before an existing `.cancel()` and a load at an existing settlement branch. No new gate, no fail-closed path: an unattributed cancellation renders `origin=unknown`, which is a normal, expected value meaning "no trigger claimed it" — never an error. `record()` and `get()` are infallible by construction. Cancellation still settles as `SessionFailureCause::Cancelled` and stays breaker-neutral however it is tagged (asserted).

The established diagnostic is preserved rather than replaced — the `reply loop error: ` prefix and the `session cancelled` text still match for existing consumers; the origin is appended.

## Verified locally

Run from `server/` with `SQLX_OFFLINE=true`:

- `cargo check --workspace --all-targets` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p djinn-core -p djinn-supervisor -p djinn-agent -p djinn-agent-worker --all-targets --no-deps` — clean, zero warnings
- New tests, all passing: 7 in `djinn-core` (tag semantics, first-writer-wins, unrecognised-byte degradation, a threaded race), 3 in `djinn-supervisor` (real Unix-socket transport death is attributed; a host `Control(Shutdown)` frame is attributed; an already-attributed SIGTERM survives the transport dying afterwards), 4 in `djinn-agent` (the reason names each trigger and distinct triggers render distinctly; unknown degrades without losing the diagnostic; the activity row and the stage reason agree; settlement is unchanged).

Tests assert structured values and behaviour — origin tokens, cancellation state, settlement class — not log prose.

### What I could NOT verify locally

**DB-backed tests fail with `Connection refused` — no local Postgres.** Confirmed pre-existing by re-running the same suites on the base commit (`26f11b232`); the failure counts are identical and my new tests are the entire delta:

| crate | base | this branch |
| --- | --- | --- |
| `djinn-core` (lib) | 330 pass / 1 fail | 337 pass / 1 fail (+7 new) |
| `djinn-supervisor` (lib) | 191 pass / 4 fail | 194 pass / 4 fail (+3 new) |
| `djinn-agent` (lib) | 1297 pass / 184 fail | 1301 pass / 184 fail (+4 new) |
| `djinn-agent-worker` (lib+bins) | 345 pass / 12 fail | 345 pass / 12 fail |

Every failure on both sides is `Sqlx(Io(ConnectionRefused))`. The one non-DB pre-existing failure, `djinn-core cargo_target_runs::tests::joint_trim_reports_over_budget_error_when_removal_fails`, also fails identically on the base commit.

**Not verifiable without a cluster:** that a real kubelet SIGTERM in a live Pod produces `origin=sigterm` in `task_runs`. The signal handler is covered by inspection only — the tagging is one `record()` call immediately before the pre-existing `cancel.cancel()`, and the transport equivalents are covered end-to-end against a real Unix socket pair. The first production cancellation after deploy will show which trigger actually accounts for the 4.3/hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
