### PR TITLE
feat(ui): render the ledger at /task/:taskId from live session data

### DIFF
--- a/ui/src/components/session/SessionLedger.tsx
+++ b/ui/src/components/session/SessionLedger.tsx
@@ -121,7 +121,9 @@ function ActivityRun({ strand }: { strand: ActivityStrand }) {
         className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-zinc-400 transition-colors hover:bg-white/[0.03] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/25"
       >
         <span className="text-zinc-600">⋯</span>
-        <span className="font-medium text-zinc-300 tabular-nums">{strand.steps.length} steps</span>
+        <span className="font-medium text-zinc-300 tabular-nums">
+          {strand.steps.length} {strand.steps.length === 1 ? "step" : "steps"}
+        </span>
         {strand.durationLabel && (
           <span className="text-zinc-500 tabular-nums">· {strand.durationLabel}</span>
         )}
@@ -416,12 +418,22 @@ function PhaseBand({ phase }: { phase: LedgerPhase }) {
             <span className="shrink-0 tabular-nums">· {phase.durationLabel}</span>
           )}
         </span>
-        {phase.running && (
-          <span className="ml-auto flex shrink-0 items-center gap-1.5 text-[11px] text-zinc-300">
-            <LiveDot className="bg-emerald-400" />
-            running
-          </span>
-        )}
+        <span className="ml-auto flex shrink-0 items-center gap-2">
+          {phase.attempts && phase.attempts.failed > 0 && (
+            <span
+              className="rounded border border-red-400/25 bg-red-400/10 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-red-300"
+              title={`${phase.attempts.failed} of ${phase.attempts.total} sessions failed and respawned`}
+            >
+              attempt {phase.attempts.total} · {phase.attempts.failed} failed
+            </span>
+          )}
+          {phase.running && (
+            <span className="flex items-center gap-1.5 text-[11px] text-zinc-300">
+              <LiveDot className="bg-emerald-400" />
+              running
+            </span>
+          )}
+        </span>
       </header>
 
       <div className="flex flex-col">
@@ -554,6 +566,8 @@ export function SessionLedger({
   blockers = [],
   entries,
   live = null,
+  showHeader = true,
+  emptyMessage = "No session activity yet.",
 }: SessionLedgerProps) {
   const metCount = criteria.filter((c) => c.met).length;
   const liveIdentity = live ? getAgentIdentity(live.agentType) : null;
@@ -561,6 +575,7 @@ export function SessionLedger({
 
   return (
     <div className="flex h-full flex-col bg-background text-foreground">
+      {showHeader && (
       <header className="flex shrink-0 items-center gap-3 border-b border-white/[0.06] px-4 py-2.5">
         <span className="shrink-0 font-mono text-xs text-zinc-500">{taskShortId}</span>
         <h1 className="min-w-0 flex-1 truncate text-sm font-semibold text-zinc-100">{taskTitle}</h1>
@@ -578,12 +593,16 @@ export function SessionLedger({
           {statusLabel}
         </span>
       </header>
+      )}
 
       <div className="flex min-h-0 flex-1">
         <Rail criteria={criteria} agents={agents} blockers={blockers} />
 
         <main className="min-w-0 flex-1 overflow-y-auto">
           <div className="mx-auto flex max-w-3xl flex-col gap-4 px-5 py-5">
+            {entries.length === 0 && (
+              <p className="py-8 text-center text-sm text-zinc-500">{emptyMessage}</p>
+            )}
             {entries.map((entry) =>
               entry.kind === "handoff" ? (
                 <HandoffBand key={entry.id} handoff={entry} />

--- a/ui/src/components/session/buildLedger.test.ts
+++ b/ui/src/components/session/buildLedger.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { buildLedger, toolDetail } from "./buildLedger";
+import type { SessionInfo, TimelineEntry } from "@/hooks/useSessionMessages";
+
+const session = (over: Partial<SessionInfo> & { id: string; agentType: string }): SessionInfo => ({
+  modelId: "openai/gpt-5.6-sol",
+  startedAt: "2026-08-04T18:30:00.000Z",
+  status: "completed",
+  tokensIn: 0,
+  tokensOut: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+  ...over,
+});
+
+const msg = (
+  sessionId: string,
+  agentType: string,
+  content: Record<string, unknown>[],
+): TimelineEntry => ({
+  kind: "message",
+  role: "assistant",
+  content: content as TimelineEntry extends { content: infer C } ? C : never,
+  sessionId,
+  agentType,
+  modelId: "openai/gpt-5.6-sol",
+  timestamp: "2026-08-04T18:31:00.000Z",
+});
+
+describe("buildLedger", () => {
+  it("keeps every non-final tool call as an activity step", () => {
+    const { entries } = buildLedger({
+      timeline: [
+        msg("s1", "worker", [
+          { type: "thinking", thinking: "**Inspecting branch commit diffs**" },
+          { type: "tool_use", name: "shell", input: { command: "git diff --stat" } },
+          { type: "tool_use", name: "Read", input: { file_path: "src/lib.rs" } },
+          { type: "tool_use", name: "Grep", input: { pattern: "sse_frame_parser_v1" } },
+        ]),
+      ],
+      sessions: [session({ id: "s1", agentType: "worker" })],
+    });
+
+    const phase = entries.find((e) => e.kind === "phase" && e.agentType === "worker");
+    const strand = phase?.kind === "phase" ? phase.turns[0].blocks[0] : undefined;
+    expect(strand?.kind).toBe("activity");
+    if (strand?.kind !== "activity") throw new Error("expected activity strand");
+
+    // The regression this whole view exists for: SessionThread dropped these.
+    expect(strand.steps.filter((s) => s.kind === "tool")).toHaveLength(3);
+    expect(strand.steps.map((s) => s.label)).toEqual(["Inspecting branch commit diffs", "shell", "Read", "Grep"]);
+    expect(strand.steps[1].detail).toBe("git diff --stat");
+  });
+
+  it("reads provider reasoning that is not typed `thinking`", () => {
+    const { entries } = buildLedger({
+      timeline: [
+        msg("s1", "reviewer", [
+          {
+            type: "open_a_i_reasoning",
+            summary: [{ type: "summary_text", text: "**Inspecting provider test files**" }],
+          },
+        ]),
+      ],
+      sessions: [session({ id: "s1", agentType: "reviewer" })],
+    });
+
+    const phase = entries.find((e) => e.kind === "phase");
+    const strand = phase?.kind === "phase" ? phase.turns[0].blocks[0] : undefined;
+    if (strand?.kind !== "activity") throw new Error("expected activity strand");
+    expect(strand.steps[0]).toMatchObject({
+      kind: "thinking",
+      label: "Inspecting provider test files",
+    });
+  });
+
+  it("renders a submission as an artifact, not a strand step", () => {
+    const { entries } = buildLedger({
+      timeline: [
+        msg("s1", "worker", [
+          { type: "tool_use", name: "shell", input: { command: "cargo fmt" } },
+          {
+            type: "tool_use",
+            name: "submit_work",
+            input: {
+              summary: "Recovered the covered B1 reply-loop launch path.",
+              files_changed: ["a.rs", "b.rs"],
+              remaining_concerns: ["scoped provider test command not run"],
+            },
+          },
+        ]),
+      ],
+      sessions: [session({ id: "s1", agentType: "worker" })],
+    });
+
+    const phase = entries.find((e) => e.kind === "phase");
+    if (phase?.kind !== "phase") throw new Error("expected phase");
+    const [strand, artifact] = phase.turns[0].blocks;
+    expect(strand.kind).toBe("activity");
+    expect(artifact).toMatchObject({
+      kind: "artifact",
+      variant: "work_submitted",
+      files: ["a.rs", "b.rs"],
+      concerns: ["scoped provider test command not run"],
+    });
+  });
+
+  it("splits phases on agent change and inserts a handoff", () => {
+    const { entries } = buildLedger({
+      timeline: [
+        msg("s1", "worker", [{ type: "text", text: "done" }]),
+        msg("s2", "reviewer", [{ type: "text", text: "reviewing" }]),
+      ],
+      sessions: [
+        session({ id: "s1", agentType: "worker" }),
+        session({ id: "s2", agentType: "reviewer" }),
+      ],
+    });
+
+    expect(entries.map((e) => (e.kind === "handoff" ? `>${e.to}` : e.agentType))).toEqual([
+      ">worker",
+      "worker",
+      ">reviewer",
+      "reviewer",
+    ]);
+  });
+
+  it("folds a respawned agent into one phase and counts the failures", () => {
+    // The real shape of task 3j5q: one review phase, six reviewer sessions,
+    // five of them dead. Previously all five rendered as nothing.
+    const reviewerSessions = [
+      session({ id: "r1", agentType: "reviewer", status: "failed" }),
+      session({ id: "r2", agentType: "reviewer", status: "failed" }),
+      session({ id: "r3", agentType: "reviewer", status: "failed" }),
+      session({ id: "r4", agentType: "reviewer", status: "failed" }),
+      session({ id: "r5", agentType: "reviewer", status: "failed" }),
+      session({ id: "r6", agentType: "reviewer", status: "running" }),
+    ];
+
+    const { entries, agents } = buildLedger({
+      timeline: [
+        msg("r1", "reviewer", [{ type: "tool_use", name: "shell", input: { command: "git diff" } }]),
+        msg("r6", "reviewer", [{ type: "tool_use", name: "shell", input: { command: "cargo test" } }]),
+      ],
+      sessions: reviewerSessions,
+    });
+
+    const phases = entries.filter((e) => e.kind === "phase" && e.agentType === "reviewer");
+    expect(phases).toHaveLength(1);
+    const phase = phases[0];
+    if (phase.kind !== "phase") throw new Error("expected phase");
+    expect(phase.attempts).toEqual({ total: 6, failed: 5 });
+    expect(phase.running).toBe(true);
+    expect(agents.find((a) => a.agentType === "reviewer")?.running).toBe(true);
+  });
+
+  it("maps criteria and the brief without inventing a phase", () => {
+    const { entries, criteria } = buildLedger({
+      timeline: [],
+      sessions: [],
+      description: "Recover the covered launch cut.",
+      criteria: [
+        { criterion: "fixtures land", met: true },
+        { criterion: "cargo test passes", met: false },
+      ],
+      filedBy: "fernando",
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind === "phase" && entries[0].brief?.body).toBe(
+      "Recover the covered launch cut.",
+    );
+    expect(criteria).toEqual([
+      { text: "fixtures land", met: true },
+      { text: "cargo test passes", met: false },
+    ]);
+  });
+
+  it("drops user messages", () => {
+    const { entries } = buildLedger({
+      timeline: [
+        { ...msg("s1", "worker", [{ type: "text", text: "prompt" }]), role: "user" } as TimelineEntry,
+      ],
+      sessions: [session({ id: "s1", agentType: "worker" })],
+    });
+    expect(entries.filter((e) => e.kind === "phase")).toHaveLength(0);
+  });
+});
+
+describe("toolDetail", () => {
+  it("prefers the conventional subject key", () => {
+    expect(toolDetail({ command: "git diff", cwd: "/x" })).toBe("git diff");
+    expect(toolDetail({ file_path: "src/lib.rs" })).toBe("src/lib.rs");
+    expect(toolDetail({ pattern: "foo" })).toBe("foo");
+  });
+
+  it("falls back to truncated json", () => {
+    const detail = toolDetail({ weird: "x".repeat(400) });
+    expect(detail.length).toBeLessThanOrEqual(120);
+    expect(detail.endsWith("…")).toBe(true);
+  });
+});

--- a/ui/src/components/session/buildLedger.ts
+++ b/ui/src/components/session/buildLedger.ts
@@ -1,0 +1,419 @@
+/**
+ * Derives the ledger view model from a live session timeline.
+ *
+ * The timeline is flat and message-shaped; the ledger is structural. Two rules
+ * carry most of the work:
+ *
+ *   - A PHASE is a contiguous run of sessions with the same agent type. When
+ *     the agent changes, that is a HANDOFF. When it does not change but the
+ *     session id does, the phase gained another ATTEMPT — this is how a
+ *     reviewer that died five times and respawned reads as one review phase
+ *     with six attempts rather than as nothing at all.
+ *   - Reasoning and tool calls collapse into one chronological ACTIVITY strand
+ *     per phase, flushed whenever prose or a submission interrupts them, so
+ *     order is preserved without a chip per thought.
+ */
+
+import type {
+  ChatMessage,
+  CommandBlock,
+  CommentBlock,
+  ContentBlock,
+  SessionInfo,
+  TimelineEntry,
+} from "@/hooks/useSessionMessages";
+import type {
+  AcceptanceCriterion as LedgerCriterion,
+  ActivityStep,
+  ArtifactVariant,
+  LedgerAgentStatus,
+  LedgerEntry,
+  LedgerLiveState,
+  LedgerPhase,
+  LedgerTurn,
+  TurnBlock,
+} from "./ledger";
+
+// ── Tool classification ─────────────────────────────────────────────────────
+
+/** Submissions get their own card; everything else belongs in the strand. */
+const FINAL_TOOLS: Record<string, ArtifactVariant> = {
+  submit_work: "work_submitted",
+  submit_review: "review_submitted",
+  submit_decision: "lead_decision",
+  submit_grooming: "grooming",
+  request_lead: "escalated",
+  request_architect: "escalated",
+};
+
+const RUNNING_STATUSES = new Set(["running", "active", "starting"]);
+const FAILED_STATUSES = new Set(["failed", "errored", "crashed", "timeout"]);
+
+const PHASE_TITLES: Record<string, string> = {
+  worker: "Implementation",
+  reviewer: "Review",
+  epic_reviewer: "Epic review",
+  lead: "Lead",
+  pm: "Lead",
+  planner: "Planning",
+  architect: "Architecture",
+  advocate: "Advocacy",
+  adversary: "Challenge",
+  judge: "Judgement",
+};
+
+function phaseTitle(agentType: string): string {
+  return PHASE_TITLES[agentType] ?? agentType.replace(/_/g, " ");
+}
+
+// ── Formatting ──────────────────────────────────────────────────────────────
+
+export function formatClock(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function formatDuration(fromIso?: string, toIso?: string): string | undefined {
+  if (!fromIso) return undefined;
+  const from = new Date(fromIso).getTime();
+  const to = toIso ? new Date(toIso).getTime() : Date.now();
+  if (Number.isNaN(from) || Number.isNaN(to) || to < from) return undefined;
+  const mins = Math.floor((to - from) / 60_000);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+/**
+ * A one-line preview of what a tool call actually did. Tools name their
+ * subject differently, so probe the conventional keys before falling back to
+ * a compact JSON rendering.
+ */
+export function toolDetail(input?: Record<string, unknown>): string {
+  if (!input) return "";
+  const keys = ["command", "file_path", "path", "pattern", "query", "url", "id", "task_id"];
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  const json = JSON.stringify(input);
+  return json.length > 120 ? `${json.slice(0, 117)}…` : json;
+}
+
+/** Reasoning text arrives as `thinking`, or as a provider-specific summary array. */
+function reasoningText(block: ContentBlock): string | undefined {
+  if (typeof block.thinking === "string" && block.thinking.trim()) {
+    return block.thinking.trim();
+  }
+  const summary = block.summary;
+  if (Array.isArray(summary)) {
+    for (const item of summary) {
+      const text = (item as { text?: unknown })?.text;
+      if (typeof text === "string" && text.trim()) return text.trim();
+    }
+  }
+  return undefined;
+}
+
+/** Strip the leading `**Bold headline**` providers wrap reasoning summaries in. */
+function reasoningHeadline(text: string): string {
+  const firstLine = text.split("\n").find((l) => l.trim()) ?? text;
+  return firstLine.replace(/\*\*/g, "").trim();
+}
+
+function isReasoning(block: ContentBlock): boolean {
+  return block.type === "thinking" || block.type.includes("reasoning");
+}
+
+// ── Phase accumulator ───────────────────────────────────────────────────────
+
+class PhaseBuilder {
+  readonly agentType: string;
+  readonly sessionIds = new Set<string>();
+  private readonly blocks: TurnBlock[] = [];
+  private steps: ActivityStep[] = [];
+
+  constructor(agentType: string, sessionId?: string) {
+    this.agentType = agentType;
+    if (sessionId) this.sessionIds.add(sessionId);
+  }
+
+  pushStep(step: ActivityStep) {
+    this.steps.push(step);
+  }
+
+  /** Activity only stays contiguous while nothing else interrupts it. */
+  private flush() {
+    if (this.steps.length === 0) return;
+    this.blocks.push({ kind: "activity", steps: this.steps });
+    this.steps = [];
+  }
+
+  pushBlock(block: TurnBlock) {
+    this.flush();
+    this.blocks.push(block);
+  }
+
+  hasContent(): boolean {
+    return this.blocks.length > 0 || this.steps.length > 0;
+  }
+
+  build(id: string, sessions: SessionInfo[]): LedgerPhase {
+    this.flush();
+
+    const own = sessions.filter((s) => this.sessionIds.has(s.id));
+    const running = own.some((s) => RUNNING_STATUSES.has(s.status));
+    const failed = own.filter((s) => FAILED_STATUSES.has(s.status)).length;
+    const first = own[0];
+    const last = own[own.length - 1];
+
+    const turns: LedgerTurn[] =
+      this.blocks.length > 0
+        ? [{ id: `${id}-turn`, agentType: this.agentType, blocks: this.blocks }]
+        : [];
+
+    return {
+      kind: "phase",
+      id,
+      title: phaseTitle(this.agentType),
+      agentType: this.agentType,
+      modelId: first?.modelId,
+      durationLabel: formatDuration(first?.startedAt, running ? undefined : last?.endedAt),
+      running,
+      attempts: own.length > 1 ? { total: own.length, failed } : undefined,
+      turns,
+    };
+  }
+}
+
+// ── Timeline entry handling ─────────────────────────────────────────────────
+
+function applyMessage(phase: PhaseBuilder, entry: ChatMessage) {
+  for (const block of entry.content) {
+    if (isReasoning(block)) {
+      const text = reasoningText(block);
+      if (text) phase.pushStep({ kind: "thinking", label: reasoningHeadline(text) });
+      continue;
+    }
+
+    if (block.type === "tool_use") {
+      const name = block.name ?? "tool";
+      const variant = FINAL_TOOLS[name];
+      if (variant) {
+        phase.pushBlock(buildArtifact(variant, block, entry.timestamp));
+      } else {
+        phase.pushStep({ kind: "tool", label: name, detail: toolDetail(block.input) });
+      }
+      continue;
+    }
+
+    if (block.type === "text" && typeof block.text === "string" && block.text.trim()) {
+      phase.pushBlock({ kind: "say", markdown: block.text });
+    }
+  }
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (typeof value === "string") return value.trim() ? [value.trim()] : undefined;
+  if (!Array.isArray(value)) return undefined;
+  const out = value.filter((v): v is string => typeof v === "string" && v.trim().length > 0);
+  return out.length > 0 ? out : undefined;
+}
+
+function buildArtifact(
+  variant: ArtifactVariant,
+  block: ContentBlock,
+  timestamp?: string,
+): TurnBlock {
+  const input = block.input ?? {};
+  const summary =
+    (typeof input.summary === "string" && input.summary) ||
+    (typeof input.reason === "string" && input.reason) ||
+    (typeof input.feedback === "string" && input.feedback) ||
+    "";
+  const outcome =
+    (typeof input.verdict === "string" && input.verdict) ||
+    (typeof input.decision === "string" && input.decision) ||
+    undefined;
+
+  return {
+    kind: "artifact",
+    variant,
+    summary,
+    files: asStringArray(input.files_changed ?? input.files),
+    concerns: asStringArray(input.remaining_concerns ?? input.concerns),
+    outcome,
+    timestamp: formatClock(timestamp),
+  };
+}
+
+function applyCommand(phase: PhaseBuilder, entry: CommandBlock) {
+  phase.pushStep({
+    kind: "tool",
+    label: entry.name,
+    detail: entry.command ?? entry.body.split("\n")[0] ?? "",
+    meta: entry.passed ? "pass" : `exit ${entry.exitCode ?? 1}`,
+  });
+}
+
+function applyComment(phase: PhaseBuilder, entry: CommentBlock) {
+  phase.pushBlock({ kind: "say", markdown: entry.body });
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+
+export interface BuildLedgerArgs {
+  timeline: TimelineEntry[];
+  sessions: SessionInfo[];
+  description?: string;
+  criteria?: { criterion: string; met: boolean }[];
+  filedBy?: string;
+  filedAt?: string;
+}
+
+export interface BuiltLedger {
+  entries: LedgerEntry[];
+  agents: LedgerAgentStatus[];
+  criteria: LedgerCriterion[];
+  live: LedgerLiveState | null;
+}
+
+export function buildLedger({
+  timeline,
+  sessions,
+  description,
+  criteria = [],
+  filedBy,
+  filedAt,
+}: BuildLedgerArgs): BuiltLedger {
+  const sessionsById = new Map(sessions.map((s) => [s.id, s]));
+  const entries: LedgerEntry[] = [];
+
+  if (description?.trim()) {
+    entries.push({
+      kind: "phase",
+      id: "brief",
+      title: "Brief",
+      turns: [],
+      brief: {
+        body: description.trim(),
+        filedBy: filedBy ?? "unknown",
+        timestamp: formatClock(filedAt),
+      },
+    });
+  }
+
+  let current: PhaseBuilder | null = null;
+  let phaseIndex = 0;
+  let previousAgent: string | undefined;
+
+  const closeCurrent = () => {
+    if (!current) return;
+    if (current.hasContent()) {
+      entries.push(current.build(`phase-${phaseIndex++}`, sessions));
+    }
+    current = null;
+  };
+
+  for (const entry of timeline) {
+    // Only messages carry the session identity that defines a phase; other
+    // entries attach to whichever phase is open around them.
+    if (entry.kind === "message") {
+      if (entry.role === "user") continue;
+
+      const agentType = entry.agentType || "worker";
+      if (!current || current.agentType !== agentType) {
+        closeCurrent();
+        entries.push({
+          kind: "handoff",
+          id: `handoff-${entries.length}`,
+          from: previousAgent,
+          to: agentType,
+          label: previousAgent ? "Handoff" : "Dispatched",
+          timestamp: formatClock(
+            sessionsById.get(entry.sessionId)?.startedAt ?? entry.timestamp,
+          ),
+        });
+        previousAgent = agentType;
+        current = new PhaseBuilder(agentType, entry.sessionId);
+      } else if (entry.sessionId) {
+        // Same agent, new session id — a retry of this phase, not a new phase.
+        current.sessionIds.add(entry.sessionId);
+      }
+
+      applyMessage(current, entry);
+      continue;
+    }
+
+    if (!current) continue;
+    if (entry.kind === "command") applyCommand(current, entry);
+    else if (entry.kind === "comment") applyComment(current, entry);
+  }
+
+  closeCurrent();
+
+  // Sessions that produced no renderable messages still happened. Fold their
+  // attempt counts into the matching phase so a crash-looping agent is visible.
+  for (const session of sessions) {
+    const known = entries.some(
+      (e) => e.kind === "phase" && e.agentType === session.agentType,
+    );
+    if (known) continue;
+    if (!RUNNING_STATUSES.has(session.status) && !FAILED_STATUSES.has(session.status)) continue;
+    entries.push({
+      kind: "phase",
+      id: `phase-${phaseIndex++}`,
+      title: phaseTitle(session.agentType),
+      agentType: session.agentType,
+      modelId: session.modelId,
+      durationLabel: formatDuration(session.startedAt, session.endedAt),
+      running: RUNNING_STATUSES.has(session.status),
+      turns: [],
+    });
+  }
+
+  // Attempt counts per agent across the whole task, not just per phase run.
+  const byAgent = new Map<string, SessionInfo[]>();
+  for (const s of sessions) {
+    const list = byAgent.get(s.agentType) ?? [];
+    list.push(s);
+    byAgent.set(s.agentType, list);
+  }
+  for (const entry of entries) {
+    if (entry.kind !== "phase" || !entry.agentType) continue;
+    const own = byAgent.get(entry.agentType) ?? [];
+    const failed = own.filter((s) => FAILED_STATUSES.has(s.status)).length;
+    if (own.length > 1) entry.attempts = { total: own.length, failed };
+  }
+
+  const agents: LedgerAgentStatus[] = Array.from(byAgent.entries()).map(([agentType, own]) => {
+    const running = own.some((s) => RUNNING_STATUSES.has(s.status));
+    const failed = own.filter((s) => FAILED_STATUSES.has(s.status)).length;
+    const first = own[0];
+    const last = own[own.length - 1];
+    return {
+      agentType,
+      durationLabel: formatDuration(first?.startedAt, running ? undefined : last?.endedAt) ?? "",
+      status: running ? "running" : failed === own.length ? "failed" : "done",
+      running,
+    };
+  });
+
+  const activeSession = sessions.find((s) => RUNNING_STATUSES.has(s.status));
+  const live: LedgerLiveState | null = activeSession
+    ? {
+        agentType: activeSession.agentType,
+        durationLabel: formatDuration(activeSession.startedAt) ?? "",
+        stepLabel: "",
+        nowLabel: "",
+      }
+    : null;
+
+  return {
+    entries,
+    agents,
+    criteria: criteria.map((c) => ({ text: c.criterion, met: c.met })),
+    live,
+  };
+}

--- a/ui/src/components/session/ledger.ts
+++ b/ui/src/components/session/ledger.ts
@@ -87,6 +87,12 @@ export interface LedgerPhase {
   modelId?: string;
   durationLabel?: string;
   running?: boolean;
+  /**
+   * Set when a phase spanned more than one session. A phase whose agent died
+   * and respawned renders as one phase with N attempts; without this the dead
+   * sessions render as nothing at all.
+   */
+  attempts?: { total: number; failed: number };
   turns: LedgerTurn[];
   /** Present only on the origin band. */
   brief?: LedgerBrief;
@@ -139,4 +145,8 @@ export interface SessionLedgerProps {
   blockers?: string[];
   entries: LedgerEntry[];
   live?: LedgerLiveState | null;
+  /** Off when the host page already renders its own title bar. */
+  showHeader?: boolean;
+  /** Rendered in place of the thread when there is nothing to show. */
+  emptyMessage?: string;
 }

--- a/ui/src/pages/TaskSessionPage.tsx
+++ b/ui/src/pages/TaskSessionPage.tsx
@@ -5,16 +5,15 @@
  * Right panel: unified chat thread (ADR-007)
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useSelectedProject } from "@/stores/useProjectStore";
 import { useTaskStore } from "@/stores/useTaskStore";
 import { useSessionMessages } from "@/hooks/useSessionMessages";
-import { SessionThread } from "@/components/SessionThread";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { SessionLedger } from "@/components/session/SessionLedger";
+import { buildLedger } from "@/components/session/buildLedger";
 import { cn } from "@/lib/utils";
-import type { AcceptanceCriterion, Task } from "@/api/types";
+import type { AcceptanceCriterion } from "@/api/types";
 import {
   AlertDiamondIcon,
   ArrowLeft02Icon,
@@ -86,13 +85,6 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
-function SectionHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-      {children}
-    </h3>
-  );
-}
 
 // ── Token totals derived from sessions ──────────────────────────────────────
 
@@ -129,51 +121,6 @@ function TaskSidebarSkeleton() {
           <TextSkeleton lines={4} />
         </div>
       </div>
-    </div>
-  );
-}
-
-// ── Left panel ───────────────────────────────────────────────────────────────
-
-function TaskSidebar({ task }: { task: Task }) {
-  const criteria = (task.acceptance_criteria ?? []).map(parseCriterion);
-  return (
-    <div className="flex w-80 shrink-0 flex-col gap-4 overflow-y-auto border-r border-border p-4">
-      {/* Acceptance Criteria */}
-      {criteria.length > 0 && (
-        <div className="rounded-lg bg-card p-4 ring-1 ring-foreground/10">
-          <SectionHeader>Acceptance Criteria</SectionHeader>
-          <ul className="mt-3 space-y-2">
-            {criteria.map((item: { criterion: string; met: boolean }, idx: number) => (
-              <li key={idx} className="flex items-start gap-2 text-xs">
-                <span
-                  className={cn(
-                    "mt-0.5 flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm border text-[9px]",
-                    item.met
-                      ? "border-emerald-500/50 bg-emerald-500/20 text-emerald-400"
-                      : "border-border"
-                  )}
-                >
-                  {item.met ? "✓" : ""}
-                </span>
-                <span className={item.met ? "text-muted-foreground line-through" : ""}>
-                  {item.criterion}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {/* Description */}
-      {task.description && (
-        <div className="rounded-lg bg-card p-4 ring-1 ring-foreground/10">
-          <SectionHeader>Description</SectionHeader>
-          <div className="prose prose-sm max-w-none pt-3 text-xs dark:prose-invert">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{task.description}</ReactMarkdown>
-          </div>
-        </div>
-      )}
     </div>
   );
 }
@@ -220,6 +167,39 @@ export function TaskSessionPage() {
   // Determine active agent type for streaming display
   const activeSession = sessions.find(
     (s) => s.status === "running" || s.status === "active"
+  );
+
+  const ledger = useMemo(
+    () =>
+      buildLedger({
+        timeline,
+        sessions,
+        description: task?.description ?? undefined,
+        criteria: (task?.acceptance_criteria ?? []).map(parseCriterion),
+        filedBy: task?.created_by_user_id ?? undefined,
+        filedAt: task?.created_at,
+      }),
+    [timeline, sessions, task]
+  );
+
+  // The strand's live tail comes from the stream, not from persisted messages.
+  const live = useMemo(() => {
+    if (!ledger.live) return null;
+    const thinking = activeSession ? streamingThinking.get(activeSession.id) : undefined;
+    const text = activeSession ? streamingText.get(activeSession.id) : undefined;
+    const tail = (thinking ?? text ?? "").split("\n").find((l) => l.trim());
+    return {
+      ...ledger.live,
+      nowLabel: tail ? tail.replace(/\*\*/g, "").slice(0, 120) : "working",
+    };
+  }, [ledger.live, activeSession, streamingThinking, streamingText]);
+
+  const blockers = useMemo(
+    () =>
+      (task?.unresolved_blocker_count ?? 0) > 0
+        ? [`${task?.unresolved_blocker_count} unresolved`]
+        : [],
+    [task?.unresolved_blocker_count]
   );
 
   // Loading / skeleton state
@@ -295,19 +275,20 @@ export function TaskSessionPage() {
         className="shrink-0 border-b border-border px-4 py-2 mb-0"
       />
 
-      {/* Content: sidebar + thread */}
+      {/* Content: the ledger owns the rail and the thread */}
       <div className="flex min-h-0 flex-1">
-        <TaskSidebar task={task} />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <SessionThread
-            timeline={timeline}
-            streamingText={streamingText}
-            streamingThinking={streamingThinking}
-            loading={loading}
-            error={error}
-            activeAgentType={activeSession?.agentType}
-          />
-        </div>
+        <SessionLedger
+          showHeader={false}
+          taskShortId={task.short_id}
+          taskTitle={task.title}
+          statusLabel={STATUS_LABELS[task.status] ?? task.status}
+          criteria={ledger.criteria}
+          agents={ledger.agents}
+          blockers={blockers}
+          entries={ledger.entries}
+          live={live}
+          emptyMessage={error ?? "No session activity yet."}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Follow-up to #3024, which added `SessionLedger` as a fixture-only component. Nothing rendered it. This wires it to real data, so clicking a task shows the phase/turn view instead of the flat thread.

## The adapter

`buildLedger` derives structure the timeline only implies:

**Phases and attempts.** A phase is a contiguous run of sessions sharing an agent type. When the agent changes, that is a handoff. When it does *not* change but the session id does, the phase gained an **attempt**.

That rule is what makes a crash-looping agent visible. Task `3j5q` has six reviewer sessions — five `failed` after ~40 minutes each, with the sixth running. Every one of those five previously rendered as nothing at all, which is why a wedged reviewer was indistinguishable from a slow one. Phases now carry `{total, failed}` and show it on the band.

**Activity strand.** Reasoning and tool calls collapse into one chronological run, flushed whenever prose or a submission interrupts them. Non-final tool calls reach the screen for the first time — `SessionThread` discarded every `tool_use` outside its six-name allowlist.

**Provider reasoning.** Read from `thinking` *and* from provider-specific blocks carrying `summary[].text`, so OpenAI sessions are no longer near-blank.

## Page changes

`TaskSidebar` is removed; the ledger rail replaces it and splits the old panel by mutability — the immutable brief moves to the head of the thread where it reads as the first turn, while acceptance criteria stay pinned in the rail where they can be checked against what you are reading.

`SessionLedger` gains `showHeader` (the page supplies its own `PageHeader`) and `emptyMessage`. `SessionThread` is left in place and untouched, so this is revertible by swapping the two components back.

## Verification

- `buildLedger` unit tests, 9 cases, including the six-attempt retry fold and the dropped-tool-call regression.
- `tsc -b` and `eslint` clean; session + `App` tests pass (29).
- Rendered end-to-end via the `Session/TaskSessionPage` stories, which drive the real page through the Storybook `useSessionMessages` mock.

## Known gaps

- The live footer's `stepLabel` is empty and `nowLabel` falls back to the streaming tail; wiring real step counts needs a per-turn index the hook does not expose yet.
- Loop-guard and budget-park timeline entries are carried through but not given dedicated cards.
- Activity strands render collapsed with no persistence, so expanding is per-visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)