### PR TITLE
fix(launcher): a killed invocation must not leave the control surface rejecting

### DIFF
--- a/scripts/fixtures/resize-cutover-retention/accept-local-variable-rename/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/accept-local-variable-rename/fixture.json
@@ -6,8 +6,8 @@
     {
       "op": "replace",
       "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
-      "find": "        let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n        if populated_zero(&events)? {\n",
-      "with": "        let drained = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n        if populated_zero(&drained)? {\n"
+      "find": "            let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n            if populated_zero(&events)? {\n",
+      "with": "            let drained = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n            if populated_zero(&drained)? {\n"
     }
   ]
 }

--- a/scripts/fixtures/resize-cutover-retention/delete-wait-empty/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/delete-wait-empty/fixture.json
@@ -6,7 +6,7 @@
     {
       "op": "replace",
       "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
-      "find": "    pub fn wait_empty(&mut self, leaf: &Leaf) -> Result<(), Error> {\n        let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n        if populated_zero(&events)? {\n            Ok(())\n        } else {\n            Err(Error::StillPopulated)\n        }\n    }\n",
+      "find": "    pub fn wait_empty(&mut self, leaf: &Leaf) -> Result<(), Error> {\n        let settle = self.config.kill_settle;\n        let mut remaining = settle.attempts.max(1);\n        loop {\n            let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n            if populated_zero(&events)? {\n                return Ok(());\n            }\n            remaining -= 1;\n            if remaining == 0 {\n                return Err(Error::StillPopulated);\n            }\n            if !settle.poll.is_zero() {\n                std::thread::sleep(settle.poll);\n            }\n        }\n    }\n",
       "with": ""
     }
   ]

--- a/scripts/fixtures/resize-cutover-retention/disable-wait-empty-call-site/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-wait-empty-call-site/fixture.json
@@ -1,13 +1,13 @@
 {
   "asset": "wait-empty",
   "expect": "reject",
-  "why": "Retirement by unreachability. `wait_empty` survives untouched in the launcher, the broker, the transport and the handle trait — and the one production caller that turns the asynchronous `cgroup.kill` into an OBSERVED drain is gone. Presence checks all pass. This is the failure mode the resize reachability guard was written for, applied to containment.",
+  "why": "Retirement by unreachability. `wait_empty` survives untouched in the launcher, the broker, the transport and the handle trait — and the one production caller that turns the asynchronous `cgroup.kill` into an OBSERVED drain is gone. Presence checks all pass. This is the failure mode the resize reachability guard was written for, applied to containment. The anchor is the drain call inside `release_invocation_leaf`, the runner's terminal teardown; substituting a constant `Ok` for it is exactly \"the teardown stopped waiting\" while every other reference survives.",
   "operations": [
     {
       "op": "replace",
       "path": "server/crates/djinn-agent/src/process.rs",
-      "find": "        child.wait_empty().map_err(LeaseInvocationError::Launcher)?;\n",
-      "with": ""
+      "find": "    match child.wait_empty() {\n",
+      "with": "    match Ok::<(), io::Error>(()) {\n"
     }
   ]
 }

--- a/scripts/fixtures/resize-cutover-retention/disable-wait-empty-immediate-ok/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-wait-empty-immediate-ok/fixture.json
@@ -1,12 +1,12 @@
 {
   "asset": "wait-empty",
   "expect": "reject",
-  "why": "AC9, mutation one. `wait_empty` replaced with an immediate `Ok(())`. The symbol is still there, the call sites still compile, every existence check still passes — and the leaf is never observed to drain. A gate that only checks the file still exists stays green under this.",
+  "why": "AC9, mutation one. `wait_empty` replaced with an immediate `Ok(())`. The symbol is still there, the call sites still compile, every existence check still passes — and the leaf is never observed to drain. A gate that only checks the file still exists stays green under this. The body is now a bounded poll rather than a single read, so the anchor is the whole loop: replacing it with `Ok(())` retires the read, the `populated_zero` interpretation and the `StillPopulated` failure arm together, exactly as before.",
   "operations": [
     {
       "op": "replace",
       "path": "server/crates/djinn-cgroup-launcher/src/lib.rs",
-      "find": "        let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n        if populated_zero(&events)? {\n            Ok(())\n        } else {\n            Err(Error::StillPopulated)\n        }\n",
+      "find": "        let settle = self.config.kill_settle;\n        let mut remaining = settle.attempts.max(1);\n        loop {\n            let events = self.fs.read_leaf(leaf.fd, \"cgroup.events\")?;\n            if populated_zero(&events)? {\n                return Ok(());\n            }\n            remaining -= 1;\n            if remaining == 0 {\n                return Err(Error::StillPopulated);\n            }\n            if !settle.poll.is_zero() {\n                std::thread::sleep(settle.poll);\n            }\n        }\n",
       "with": "        Ok(())\n"
     }
   ]

--- a/scripts/fixtures/resize-cutover-retention/disable-wait-empty-test-only-caller/fixture.json
+++ b/scripts/fixtures/resize-cutover-retention/disable-wait-empty-test-only-caller/fixture.json
@@ -6,8 +6,8 @@
     {
       "op": "replace",
       "path": "server/crates/djinn-agent/src/process.rs",
-      "find": "        child.wait_empty().map_err(LeaseInvocationError::Launcher)?;\n",
-      "with": ""
+      "find": "    match child.wait_empty() {\n",
+      "with": "    match Ok::<(), io::Error>(()) {\n"
     },
     {
       "op": "append",

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -1076,10 +1076,50 @@ impl LeaseInvocationRunner {
                 .record_at(&identity, fence.clone(), true, self.clock.now())
                 .map_err(LeaseInvocationError::Launcher)?;
         }
-        child.kill().map_err(LeaseInvocationError::Launcher)?;
-        child.wait_empty().map_err(LeaseInvocationError::Launcher)?;
-        drain_remote(&mut *child, &mut stdout, &mut stderr)?;
-        let status = observed.unwrap_or(child.wait().map_err(started_lease_error)?);
+        // TEARDOWN MUST NOT FAIL A COMMAND THAT HAS ALREADY RUN.
+        //
+        // Everything from here on is the disposal of a leaf whose command is
+        // over: the output is collected, the status is decided, the durable
+        // lease is reconciled below. A `?` on any of it discards all of that —
+        // and it did, for 30-48 minutes of work at a time.
+        //
+        // `cgroup.kill` is asynchronous, so `wait_empty` on a leaf whose tree was
+        // still alive (i.e. every timeout and every cancellation) had to observe
+        // `populated 1`. That is `Error::StillPopulated`, which the broker
+        // categorises as `ControlRejection::State`, and this line propagated it:
+        //
+        //   ReplyLoop: tool call returned error tool=shell error=failed to run
+        //   shell command: lease invocation failed: Launcher(Custom { kind:
+        //   Other, error: ControlRejected(State) })
+        //
+        // measured immediately after a `cargo test` hit its 1800s budget. The
+        // `?` also skipped `cleanup()` below, so the leaf, its descriptors and
+        // the broker's invocation binding were never released.
+        //
+        // `Launcher::wait_empty` now waits the settling kill out (see
+        // `KillSettle`), which fixes the cause. This is the second half of the
+        // same rule the lift already follows one arm up — a lease-subsystem
+        // failure makes a command SLOW or LOSSY, never dead — so that a leaf
+        // that still refuses to drain costs a warning and a synthesized status
+        // instead of the whole invocation.
+        let drained = release_invocation_leaf(&mut *child, &identity);
+        if let Err(error) = drain_remote(&mut *child, &mut stdout, &mut stderr) {
+            tracing::warn!(
+                invocation_id = %identity.invocation_id,
+                task_run_id = %identity.task_run_id,
+                error = ?error,
+                "post-terminal output drain failed; reporting the bytes already collected"
+            );
+        }
+        let status = match observed {
+            Some(status) => status,
+            None => settled_status(&mut *child, drained, &identity).ok_or_else(|| {
+                started_lease_error(io::Error::other(
+                    "the invocation leaf never reported populated 0 and no terminal child status \
+                     could be observed",
+                ))
+            })?,
+        };
         let process = ProcessOutput {
             output: Output {
                 status,
@@ -1088,7 +1128,15 @@ impl LeaseInvocationRunner {
             },
             termination,
         };
-        child.cleanup().map_err(LeaseInvocationError::Launcher)?;
+        if let Err(error) = child.cleanup() {
+            tracing::warn!(
+                invocation_id = %identity.invocation_id,
+                task_run_id = %identity.task_run_id,
+                error = %error,
+                "invocation leaf cleanup failed; the leaf and its broker binding are leaked for \
+                 this invocation, but the command's result is preserved"
+            );
+        }
         if queued
             && reconcile_terminal_lease(self.services.as_ref(), lease, fence).await
             && let Some(journal) = &self.journal
@@ -1180,6 +1228,80 @@ fn terminal_now(
         .try_wait()
         .map_err(started_lease_error)?
         .map(|status| (Some(status), ProcessTermination::Exited)))
+}
+
+/// Kill the invocation's cgroup leaf and wait for it to report `populated 0`.
+///
+/// Returns whether emptiness was actually observed. Neither step can fail the
+/// invocation: by the time this runs the command is over, so a teardown refusal
+/// is a leak to report, never a result to discard.
+fn release_invocation_leaf(
+    child: &mut dyn ProcessHandle,
+    identity: &TaskInvocationLeaseIdentity,
+) -> bool {
+    if let Err(error) = child.kill() {
+        tracing::warn!(
+            invocation_id = %identity.invocation_id,
+            task_run_id = %identity.task_run_id,
+            error = %error,
+            "cgroup.kill for the invocation leaf failed; still waiting for the leaf to drain"
+        );
+    }
+    match child.wait_empty() {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(
+                invocation_id = %identity.invocation_id,
+                task_run_id = %identity.task_run_id,
+                error = %error,
+                "the invocation leaf did not reach populated 0 within the launcher's settle \
+                 budget; the command's result is preserved and the leaf is abandoned"
+            );
+            false
+        }
+    }
+}
+
+/// The terminal status for a child the runner never observed exiting.
+///
+/// A drained leaf holds no live process, so waiting on it returns at once. A
+/// leaf that never drained must NOT be waited on: [`ProcessHandle::wait`] polls
+/// until a terminal status appears, so blocking there would trade a lost command
+/// for a hung session — the same trade `cleanup_and_reap` refuses with its
+/// bounded post-kill reap.
+fn settled_status(
+    child: &mut dyn ProcessHandle,
+    drained: bool,
+    identity: &TaskInvocationLeaseIdentity,
+) -> Option<std::process::ExitStatus> {
+    if drained && let Ok(status) = child.wait() {
+        return Some(status);
+    }
+    if let Ok(Some(status)) = child.try_wait() {
+        return Some(status);
+    }
+    let status = abandoned_child_status()?;
+    tracing::warn!(
+        invocation_id = %identity.invocation_id,
+        task_run_id = %identity.task_run_id,
+        "no terminal status could be read for the killed child; reporting it as SIGKILLed so the \
+         session keeps running"
+    );
+    Some(status)
+}
+
+/// A killed-but-unreapable child reports as SIGKILLed, exactly as the direct
+/// (non-brokered) runner's `cleanup_and_reap` already does.
+#[cfg(unix)]
+fn abandoned_child_status() -> Option<std::process::ExitStatus> {
+    Some(std::process::ExitStatus::from_raw(libc::SIGKILL))
+}
+
+/// No portable constructor exists off Unix, and neither does the cgroup leaf
+/// this whole path governs.
+#[cfg(not(unix))]
+fn abandoned_child_status() -> Option<std::process::ExitStatus> {
+    None
 }
 
 fn drain_remote(

--- a/server/crates/djinn-agent/src/process/tests/process_lease_broker_lift_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_broker_lift_tests.rs
@@ -64,14 +64,33 @@ struct RecordingFs {
     next_fd: RawFd,
     /// Latest value per (fd, file), so `read_leaf` answers what was written.
     files: std::collections::HashMap<(RawFd, String), String>,
+    /// Reads of `cgroup.events` that still report descendants — the fake's
+    /// stand-in for an asynchronous `cgroup.kill` that has not settled.
+    settling_reads: Arc<Mutex<usize>>,
+    /// Leaf names actually unlinked, so a leaked leaf is observable.
+    removed: Arc<Mutex<Vec<String>>>,
 }
 
 impl RecordingFs {
     fn new(writes: Writes) -> Self {
+        Self::settling(
+            writes,
+            Arc::new(Mutex::new(0)),
+            Arc::new(Mutex::new(Vec::new())),
+        )
+    }
+
+    fn settling(
+        writes: Writes,
+        settling_reads: Arc<Mutex<usize>>,
+        removed: Arc<Mutex<Vec<String>>>,
+    ) -> Self {
         Self {
             writes,
             next_fd: 100,
             files: std::collections::HashMap::new(),
+            settling_reads,
+            removed,
         }
     }
 }
@@ -99,6 +118,11 @@ impl CgroupFs for RecordingFs {
     }
     fn read_leaf(&mut self, fd: RawFd, file: &str) -> Result<String, LauncherError> {
         if file == "cgroup.events" {
+            let mut settling = self.settling_reads.lock().unwrap();
+            if *settling > 0 {
+                *settling -= 1;
+                return Ok("populated 1".to_owned());
+            }
             return Ok("populated 0".to_owned());
         }
         Ok(self
@@ -107,7 +131,8 @@ impl CgroupFs for RecordingFs {
             .cloned()
             .unwrap_or_else(|| "usage_usec 0".to_owned()))
     }
-    fn remove_leaf(&mut self, _: RawFd, _: &str) -> Result<(), LauncherError> {
+    fn remove_leaf(&mut self, _: RawFd, name: &str) -> Result<(), LauncherError> {
+        self.removed.lock().unwrap().push(name.to_owned());
         Ok(())
     }
 }
@@ -153,8 +178,15 @@ fn broker(
     writes: Writes,
     born: Arc<Mutex<Vec<Invocation>>>,
 ) -> Broker<RecordingFs, RecordingSpawn> {
+    broker_with_fs(RecordingFs::new(writes), born)
+}
+
+fn broker_with_fs(
+    fs: RecordingFs,
+    born: Arc<Mutex<Vec<Invocation>>>,
+) -> Broker<RecordingFs, RecordingSpawn> {
     let launcher = Launcher::new(
-        RecordingFs::new(writes),
+        fs,
         RecordingSpawn { born },
         LauncherConfig::new(None, None, unsafe { libc::geteuid() }).expect("launcher config"),
     )
@@ -363,4 +395,93 @@ fn distinct_invocations_get_distinct_fences() {
         crate::process::broker_invocation_fence("a"),
         crate::process::broker_invocation_fence("b")
     );
+}
+
+/// THE regression test for the teardown wedge.
+///
+/// A killed invocation must tear its leaf down and leave the launcher able to
+/// serve the next one.
+///
+/// `cgroup.kill` is asynchronous: the leaf keeps reporting `populated 1` for as
+/// long as its members take to run their exit paths, which for a 30-minute
+/// `cargo test` killed at its budget is not instant. `Launcher::wait_empty` read
+/// `cgroup.events` exactly ONCE, so the teardown of every killed invocation was
+/// refused with `StillPopulated` -> `ControlRejection::State`:
+///
+/// ```text
+/// ReplyLoop: tool call returned error tool=shell error=failed to run shell
+/// command: lease invocation failed: Launcher(Custom { kind: Other, error:
+/// ControlRejected(State) })
+/// ```
+///
+/// and the `CLEAN` that follows never ran, so the leaf, its descriptors and the
+/// broker's invocation binding were leaked. Nothing here is a double of the
+/// launcher: the broker, its nonce rotation, `Launcher::wait_empty` and
+/// `Launcher::remove` are all real, and only cgroupfs is recorded.
+#[test]
+fn a_killed_invocation_drains_its_leaf_and_the_next_lease_invocation_succeeds() {
+    let writes: Writes = Arc::new(Mutex::new(Vec::new()));
+    let born = Arc::new(Mutex::new(Vec::new()));
+    // Three reads after the kill still see descendants; the fourth sees the
+    // leaf drained. One read - what production did - sees only the first.
+    let settling = Arc::new(Mutex::new(3_usize));
+    let removed = Arc::new(Mutex::new(Vec::new()));
+    let (client_stream, server_stream) = UnixStream::pair().expect("socketpair");
+
+    std::thread::scope(|scope| {
+        let mut server = UnixBrokerServer::new(broker_with_fs(
+            RecordingFs::settling(writes.clone(), settling.clone(), removed.clone()),
+            born.clone(),
+        ));
+        let served = scope.spawn(move || server.serve_connection(server_stream));
+
+        let launcher = UnixBrokerLauncher::new(connected_client(client_stream));
+
+        // The invocation that gets killed mid-flight.
+        let killed = identity();
+        let mut handle = launcher
+            .launch(shell_command(), &killed, LeaseAuthority::Armed)
+            .expect("the brokered launch must succeed");
+        handle.kill().expect("cgroup.kill");
+        handle.wait_empty().expect(
+            "a settling cgroup.kill must be waited out, not refused; this is the \
+             ControlRejected(State) that failed the shell tool after 30 minutes of work",
+        );
+        handle
+            .cleanup()
+            .expect("the drained leaf must be removable");
+        assert_eq!(
+            *settling.lock().unwrap(),
+            0,
+            "wait_empty must have re-read cgroup.events until it flipped"
+        );
+        assert_eq!(
+            removed.lock().unwrap().clone(),
+            vec![killed.invocation_id.clone()],
+            "the killed invocation's leaf must be unlinked; a skipped CLEAN leaks the leaf, its \
+             descriptors and the broker's invocation binding"
+        );
+        drop(handle);
+
+        // The next lease invocation on the same launcher and broker.
+        let next = identity();
+        let mut handle = launcher
+            .launch(shell_command(), &next, LeaseAuthority::Armed)
+            .expect("the launcher must still admit a lease invocation after a killed one");
+        handle
+            .fenced_lift()
+            .expect("and it must still be a fully usable invocation");
+        handle.kill().expect("cgroup.kill");
+        handle.wait_empty().expect("populated 0");
+        handle.cleanup().expect("cleanup");
+        assert_eq!(
+            removed.lock().unwrap().clone(),
+            vec![killed.invocation_id, next.invocation_id],
+            "both leaves must have been released"
+        );
+
+        drop(handle);
+        drop(launcher);
+        served.join().expect("server thread").expect("served");
+    });
 }

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -138,6 +138,9 @@ struct BrokerBackedState {
     empties: usize,
     cleanups: usize,
     samples: usize,
+    /// When set, `wait_empty` answers with the refusal a leaf whose
+    /// `cgroup.kill` has not settled produces on the wire.
+    wait_empty_refuses: bool,
 }
 
 impl BrokerBackedLauncher {
@@ -154,6 +157,7 @@ impl BrokerBackedLauncher {
                 empties: 0,
                 cleanups: 0,
                 samples: 0,
+                wait_empty_refuses: false,
             })),
             cpu_usage_usec: 0,
         }
@@ -171,9 +175,17 @@ impl BrokerBackedLauncher {
                 empties: 0,
                 cleanups: 0,
                 samples: 0,
+                wait_empty_refuses: false,
             })),
             cpu_usage_usec,
         }
+    }
+
+    /// Make the leaf refuse to report `populated 0`, exactly as the broker does
+    /// for a subtree whose asynchronous `cgroup.kill` has not finished.
+    fn refusing_teardown(self) -> Self {
+        self.state.lock().unwrap().wait_empty_refuses = true;
+        self
     }
 }
 
@@ -238,7 +250,17 @@ impl ProcessHandle for BrokerBackedHandle {
         Ok(())
     }
     fn wait_empty(&mut self) -> io::Result<()> {
-        self.state.lock().unwrap().empties += 1;
+        let mut state = self.state.lock().unwrap();
+        state.empties += 1;
+        if state.wait_empty_refuses {
+            // The production wire form: `StillPopulated` is categorised as
+            // `ControlRejection::State` before it reaches the worker.
+            return Err(io::Error::other(
+                djinn_cgroup_launcher::Error::ControlRejected(
+                    djinn_cgroup_launcher::ControlRejection::State,
+                ),
+            ));
+        }
         Ok(())
     }
     fn cleanup(&mut self) -> io::Result<()> {
@@ -862,6 +884,79 @@ async fn broker_backed_shell_cancellation_kills_waits_empty_and_cleans_up() {
 
     assert_eq!(output.process.termination, ProcessTermination::Cancelled);
     assert_eq!(services.queue_calls.load(Ordering::SeqCst), 0);
+    let state = launcher.state.lock().unwrap();
+    assert_eq!((state.kills, state.empties, state.cleanups), (1, 1, 1));
+}
+
+/// A leaf that will not report `populated 0` must cost a warning, not the
+/// command.
+///
+/// `cgroup.kill` is asynchronous, so the teardown `wait_empty` on any killed
+/// invocation could observe `populated 1` -> `StillPopulated` ->
+/// `ControlRejection::State`. Production propagated that with a `?`, which
+/// (a) failed the agent's shell tool for a command that had ALREADY produced
+/// its output and exit status, and (b) skipped `cleanup`, leaking the leaf and
+/// the broker's invocation binding. Both halves are asserted here.
+#[tokio::test]
+async fn a_refused_leaf_teardown_preserves_the_result_and_still_cleans_up() {
+    let services = Arc::new(ScriptedServices::new(vec![], vec![], vec![]));
+    let launcher = Arc::new(
+        BrokerBackedLauncher::exited(b"cargo output\n", b"cargo warnings\n", 101)
+            .refusing_teardown(),
+    );
+    let runner = LeaseInvocationRunner::new(
+        services.clone(),
+        services.clone(),
+        launcher.clone(),
+        clock(),
+    );
+
+    let output = runner
+        .output(command(), config(), CancellationToken::new())
+        .await
+        .expect(
+            "a teardown refusal must not discard a command that already ran; this is the \
+             ControlRejected(State) that ended 59% of production task-runs as Interrupted",
+        );
+
+    assert_eq!(output.process.output.stdout, b"cargo output\n");
+    assert_eq!(output.process.output.stderr, b"cargo warnings\n");
+    assert_eq!(output.process.output.status.code(), Some(101));
+    let state = launcher.state.lock().unwrap();
+    assert_eq!(
+        (state.kills, state.empties, state.cleanups),
+        (1, 1, 1),
+        "CLEAN must still be sent: the `?` that failed the command also leaked the leaf, its \
+         descriptors and the broker's invocation binding"
+    );
+}
+
+/// The same refusal on the CANCELLED path, where the runner has no observed
+/// exit status of its own and used to block or fail deciding one.
+#[tokio::test]
+async fn a_refused_leaf_teardown_still_reports_a_terminal_status_for_a_killed_child() {
+    let services = Arc::new(ScriptedServices::new(vec![], vec![], vec![]));
+    let launcher = Arc::new(BrokerBackedLauncher::running(0).refusing_teardown());
+    let runner = LeaseInvocationRunner::new(
+        services.clone(),
+        services.clone(),
+        launcher.clone(),
+        clock(),
+    );
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let output = runner
+        .output(command(), config(), cancel)
+        .await
+        .expect("a cancelled invocation whose leaf will not drain must still report");
+
+    assert_eq!(output.process.termination, ProcessTermination::Cancelled);
+    assert_eq!(
+        output.process.output.status.signal(),
+        Some(libc::SIGKILL),
+        "a child the launcher killed reports as signalled, never as a missing status"
+    );
     let state = launcher.state.lock().unwrap();
     assert_eq!((state.kills, state.empties, state.cleanups), (1, 1, 1));
 }

--- a/server/crates/djinn-cgroup-launcher/src/broker.rs
+++ b/server/crates/djinn-cgroup-launcher/src/broker.rs
@@ -559,13 +559,19 @@ mod tests {
     fn broker() -> Broker<Fs, Clone, Nonces> {
         broker_running(crate::LauncherAuthorityProtocol::LeafV1)
     }
+    /// `IMMEDIATE`, so the cases below that assert a still-populated refusal
+    /// answer from the first `cgroup.events` read instead of sleeping out the
+    /// production settle budget.
+    fn test_config() -> crate::LauncherConfig {
+        crate::LauncherConfig::new(None, None, 0)
+            .unwrap()
+            .with_kill_settle(crate::KillSettle::IMMEDIATE)
+    }
     fn broker_running(protocol: crate::LauncherAuthorityProtocol) -> Broker<Fs, Clone, Nonces> {
         let launcher = Launcher::new(
             Fs::ready(),
             Clone,
-            crate::LauncherConfig::new(None, None, 0)
-                .unwrap()
-                .with_authority_protocol(protocol),
+            test_config().with_authority_protocol(protocol),
         )
         .unwrap();
         Broker::new(
@@ -890,12 +896,7 @@ mod tests {
     fn duplicate_create_does_not_clone_or_replace_the_active_leaf() {
         let fs = Fs::ready();
         let creates = Rc::clone(&fs.creates);
-        let launcher = Launcher::new(
-            fs,
-            Clone,
-            crate::LauncherConfig::new(None, None, 0).unwrap(),
-        )
-        .unwrap();
+        let launcher = Launcher::new(fs, Clone, test_config()).unwrap();
         let mut broker = Broker::new(
             launcher,
             BrokerConfig::worker(42, b"private".to_vec()).unwrap(),
@@ -952,12 +953,7 @@ mod tests {
         let fs = Fs::ready();
         let events = Rc::clone(&fs.events);
         *events.borrow_mut() = "populated 1".into();
-        let launcher = Launcher::new(
-            fs,
-            Clone,
-            crate::LauncherConfig::new(None, None, 0).unwrap(),
-        )
-        .unwrap();
+        let launcher = Launcher::new(fs, Clone, test_config()).unwrap();
         let mut broker = Broker::new(
             launcher,
             BrokerConfig::worker(42, b"private".to_vec()).unwrap(),

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -5,7 +5,7 @@
 //! this boundary only creates and controls one direct child of a validated
 //! delegated cgroup root.
 
-use std::{collections::BTreeSet, io, os::fd::RawFd};
+use std::{collections::BTreeSet, io, os::fd::RawFd, time::Duration};
 
 use thiserror::Error;
 
@@ -125,12 +125,60 @@ fn cpu_max_for(millicores: u32) -> String {
     )
 }
 
+/// How long [`Launcher::wait_empty`] keeps re-reading `cgroup.events` before it
+/// gives up and reports [`Error::StillPopulated`].
+///
+/// # Why waiting is not optional
+///
+/// `cgroup.kill` is **asynchronous**: writing `1` marks the subtree for
+/// SIGKILL, but every member still has to be scheduled and run its exit path
+/// before `cgroup.events` flips to `populated 0`. A single read taken straight
+/// after the write therefore observes `populated 1` for any leaf whose child
+/// tree was alive at teardown — which is exactly the timeout and cancellation
+/// paths, and exactly the two paths a cargo build dies on.
+///
+/// The launcher's own kernel tests have always known this: every one of them
+/// wraps `wait_empty` in a 200x25ms retry loop after `cgroup.kill`. Production
+/// called it once, so a 30-minute `cargo test` that hit its budget produced
+/// `StillPopulated` -> `ControlRejection::State`, the worker's shell tool failed
+/// on the *teardown* of a command that had already produced its output, and the
+/// invocation's `CLEAN` never ran — leaking the leaf, its descriptors and the
+/// broker's invocation binding. The wait belongs here, next to the write that
+/// makes it necessary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct KillSettle {
+    /// Reads of `cgroup.events` allowed, including the first (unslept) one.
+    pub attempts: u32,
+    /// Pause between reads.
+    pub poll: Duration,
+}
+
+impl KillSettle {
+    /// 500 x 20ms = a 10s ceiling. Bounded on purpose: the privileged broker
+    /// serves controls one at a time, so an unbounded wait here would be a
+    /// stall with no upper limit. A caller that still observes
+    /// [`Error::StillPopulated`] after this must degrade, not fail — see the
+    /// runner's terminal teardown.
+    pub const DEFAULT: Self = Self {
+        attempts: 500,
+        poll: Duration::from_millis(20),
+    };
+
+    /// Answer from the first read only. Used by tests that assert the
+    /// still-populated refusal itself and must not sleep out the budget.
+    pub const IMMEDIATE: Self = Self {
+        attempts: 1,
+        poll: Duration::ZERO,
+    };
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LauncherConfig {
     pub unleased_quota: UnleasedQuota,
     pub leased_quota: LeasedQuota,
     pub expected_uid: u32,
     authority_protocol: LauncherAuthorityProtocol,
+    kill_settle: KillSettle,
 }
 
 impl LauncherConfig {
@@ -154,6 +202,7 @@ impl LauncherConfig {
             leased_quota: leased,
             expected_uid,
             authority_protocol: LauncherAuthorityProtocol::LeafV1,
+            kill_settle: KillSettle::DEFAULT,
         })
     }
 
@@ -164,8 +213,19 @@ impl LauncherConfig {
         self
     }
 
+    /// How long [`Launcher::wait_empty`] waits out an asynchronous
+    /// `cgroup.kill`. See [`KillSettle`].
+    pub fn with_kill_settle(mut self, settle: KillSettle) -> Self {
+        self.kill_settle = settle;
+        self
+    }
+
     pub fn authority_protocol(&self) -> LauncherAuthorityProtocol {
         self.authority_protocol
+    }
+
+    pub fn kill_settle(&self) -> KillSettle {
+        self.kill_settle
     }
 }
 
@@ -494,12 +554,33 @@ impl<F: CgroupFs, S: SpawnIntoCgroup> Launcher<F, S> {
         self.fs.write_leaf(leaf.fd, "cgroup.kill", "1")
     }
 
+    /// Return once the leaf reports `populated 0`, or after the configured
+    /// [`KillSettle`] budget is spent.
+    ///
+    /// This POLLS. `cgroup.kill` only marks the subtree for SIGKILL; the flip to
+    /// `populated 0` happens later, once every member has actually run its exit
+    /// path. A single read is a coin toss on any leaf that was alive when it was
+    /// killed, and losing that toss used to be reported to the worker as
+    /// `ControlRejection::State` — see [`KillSettle`].
+    ///
+    /// An unreadable or malformed `cgroup.events` still fails immediately: that
+    /// is a broken delegation, not a settling kill, and no amount of waiting
+    /// changes it.
     pub fn wait_empty(&mut self, leaf: &Leaf) -> Result<(), Error> {
-        let events = self.fs.read_leaf(leaf.fd, "cgroup.events")?;
-        if populated_zero(&events)? {
-            Ok(())
-        } else {
-            Err(Error::StillPopulated)
+        let settle = self.config.kill_settle;
+        let mut remaining = settle.attempts.max(1);
+        loop {
+            let events = self.fs.read_leaf(leaf.fd, "cgroup.events")?;
+            if populated_zero(&events)? {
+                return Ok(());
+            }
+            remaining -= 1;
+            if remaining == 0 {
+                return Err(Error::StillPopulated);
+            }
+            if !settle.poll.is_zero() {
+                std::thread::sleep(settle.poll);
+            }
         }
     }
 
@@ -703,6 +784,10 @@ mod tests {
         created: Vec<String>,
         removed: Vec<String>,
         next: i32,
+        /// Reads of `cgroup.events` that still report descendants before the
+        /// recorded value takes over — the fake's stand-in for an asynchronous
+        /// `cgroup.kill` that has not finished tearing the subtree down.
+        settling_reads: usize,
     }
     impl FakeFs {
         fn ready() -> Self {
@@ -743,6 +828,10 @@ mod tests {
         }
         fn read_leaf(&mut self, fd: RawFd, file: &str) -> Result<String, Error> {
             self.reads.push(file.into());
+            if file == "cgroup.events" && self.settling_reads > 0 {
+                self.settling_reads -= 1;
+                return Ok("populated 1\n".into());
+            }
             Ok(self
                 .files
                 .get(&(fd, file.into()))
@@ -781,8 +870,14 @@ mod tests {
             })
         }
     }
+    /// `IMMEDIATE` so the cases that assert the still-populated refusal answer
+    /// from the first read instead of sleeping out the production budget. The
+    /// budget itself is proven in
+    /// [`wait_empty_polls_a_settling_kill_and_stays_bounded`].
     fn config() -> LauncherConfig {
-        LauncherConfig::new(None, None, 7).unwrap()
+        LauncherConfig::new(None, None, 7)
+            .unwrap()
+            .with_kill_settle(KillSettle::IMMEDIATE)
     }
     fn launcher() -> Launcher<FakeFs, FakeSpawn> {
         Launcher::new(FakeFs::ready(), FakeSpawn::default(), config()).unwrap()
@@ -1095,6 +1190,82 @@ mod tests {
             launcher.fs.reads,
             vec!["cgroup.events"],
             "spawn failure waits for cgroup.events to report emptiness before removal"
+        );
+    }
+
+    /// A leaf killed while its tree was alive does NOT report `populated 0` on
+    /// the read that follows the `cgroup.kill` write. `wait_empty` must sit
+    /// through the settling window rather than refusing — a single read is what
+    /// turned every timed-out build's teardown into `StillPopulated`, i.e. a
+    /// `ControlRejection::State` that failed the shell tool after the command
+    /// had already produced its output.
+    #[test]
+    fn wait_empty_polls_a_settling_kill_and_stays_bounded() {
+        let mut fs = FakeFs::ready();
+        // Three reads still see descendants; the fourth sees the leaf drained.
+        fs.settling_reads = 3;
+        let mut l = Launcher::new(
+            fs,
+            FakeSpawn::default(),
+            LauncherConfig::new(None, None, 7)
+                .unwrap()
+                .with_kill_settle(KillSettle {
+                    attempts: 8,
+                    poll: Duration::from_millis(1),
+                }),
+        )
+        .unwrap();
+        let mut leaf = create(&mut l, "settling");
+        l.fs.files
+            .insert((leaf.fd, "cgroup.events".into()), "populated 0\n".into());
+        l.kill(&mut leaf).unwrap();
+        l.remove(&leaf)
+            .expect("a kill that settles inside the budget must not refuse the teardown");
+        assert_eq!(
+            l.fs.reads
+                .iter()
+                .filter(|file| file.as_str() == "cgroup.events")
+                .count(),
+            4,
+            "wait_empty must re-read cgroup.events until it flips, not once"
+        );
+        assert_eq!(
+            l.fs.removed,
+            vec!["settling"],
+            "the drained leaf must actually be unlinked"
+        );
+
+        // The wait is bounded: a leaf that never drains still refuses, after
+        // exactly the configured number of reads and no more.
+        let mut fs = FakeFs::ready();
+        fs.settling_reads = usize::MAX;
+        let mut stuck = Launcher::new(
+            fs,
+            FakeSpawn::default(),
+            LauncherConfig::new(None, None, 7)
+                .unwrap()
+                .with_kill_settle(KillSettle {
+                    attempts: 3,
+                    poll: Duration::ZERO,
+                }),
+        )
+        .unwrap();
+        let mut leaf = create(&mut stuck, "stuck");
+        stuck.kill(&mut leaf).unwrap();
+        assert!(matches!(stuck.remove(&leaf), Err(Error::StillPopulated)));
+        assert_eq!(
+            stuck
+                .fs
+                .reads
+                .iter()
+                .filter(|file| file.as_str() == "cgroup.events")
+                .count(),
+            3,
+            "the budget must cap the wait; an unbounded one would stall the broker"
+        );
+        assert!(
+            stuck.fs.removed.is_empty(),
+            "no cgroup is unlinked while still populated"
         );
     }
 

--- a/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use djinn_cgroup_launcher::{
-    CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher,
+    CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, KillSettle, Launcher,
     LauncherAuthorityProtocol, LauncherConfig, LeaseAuthority, Readiness, SpawnIntoCgroup,
     broker::{
         Broker, BrokerConfig, OsNonceSource, PeerCredentials, UnixPeer, WORKER_GID, WORKER_UID,
@@ -390,7 +390,12 @@ fn ac2_daemon_and_double_fork_stay_in_one_cgroup_and_release_gates_on_populated_
     let mut launcher = Launcher::new(
         fs.clone(),
         clone.clone(),
-        LauncherConfig::new(None, None, 7).expect("config"),
+        // IMMEDIATE: this case asserts the still-populated refusal itself, so
+        // it must answer from the first `cgroup.events` read rather than
+        // sitting through the production settle budget.
+        LauncherConfig::new(None, None, 7)
+            .expect("config")
+            .with_kill_settle(KillSettle::IMMEDIATE),
     )
     .expect("launcher");
 
@@ -462,7 +467,11 @@ fn ac2_cleanup_after_kill_still_requires_empty_before_unlink() {
     let mut launcher = Launcher::new(
         fs.clone(),
         FakeClone::allow(),
-        LauncherConfig::new(None, None, 3).expect("config"),
+        // IMMEDIATE for the same reason as above: the assertion below is that a
+        // still-populated leaf is never unlinked, not how long the wait is.
+        LauncherConfig::new(None, None, 3)
+            .expect("config")
+            .with_kill_settle(KillSettle::IMMEDIATE),
     )
     .expect("launcher");
     let (mut leaf, _) = launcher


### PR DESCRIPTION
## The mechanism

Captured from inside a live task-run Pod: a `cargo test` hits its 1800s budget, and the very next log line is the agent's shell tool failing with `ControlRejected(State)` — after which the session can run nothing and the stage loop early-exits `Interrupted`, discarding 30–48 minutes of work.

The rejection is not a stale lease or a leaf name collision. It is the **teardown of the killed invocation itself**, and it fires deterministically for every killed invocation:

1. `cgroup.kill` is **asynchronous**. Writing `1` marks the subtree for SIGKILL; `cgroup.events` only flips to `populated 0` once every member has been scheduled and run its exit path. For a killed cargo tree that is not instant.
2. `Launcher::wait_empty` (`server/crates/djinn-cgroup-launcher/src/lib.rs`) read `cgroup.events` **exactly once** and returned `Error::StillPopulated` if it was not already `populated 0`.
3. `ControlRejection::of` maps `StillPopulated` to `ControlRejection::State` (`control_rejection.rs:102`) — the same wire category as `InvalidControl`, which is why the capture reads `ControlRejected(State)`.
4. The runner propagated it: `child.wait_empty().map_err(LeaseInvocationError::Launcher)?` at `djinn-agent/src/process.rs:1080`. That `?` failed a command that had **already produced its output and exit status**, and it skipped the `child.cleanup()` eight lines below — so the leaf, its stdout/stderr descriptors and the broker's `active` invocation binding were never released.

A command that exits on its own leaves an already-empty leaf, so the race never fires there. It fires on exactly the two paths where the tree is alive at teardown: **timeout and cancellation**. That is why it correlates 1:1 with the 1800s cargo budget, and why cancelled follow-up invocations failed within 1–18 ms of launching.

Corroboration inside the repo: every kernel test in this crate already wraps `wait_empty` in a `(0..200)` × 25 ms retry loop after `cgroup.kill` (`tests/delegated_cpu_lease_lifecycle.rs:462`, `tests/brokered_lease_lift_boundary.rs:329`). The test authors knew the kill was asynchronous; production called it once.

### Correction to the stated hypothesis

The hypothesis was "a killed invocation leaves a stale leaf / unreleased lease, so the launcher still believes the prior invocation is live and refuses a *new* one."

Half right, and the half that is right is a *consequence*, not the cause:

- **Confirmed:** the killed invocation does leave a stale leaf and an unreleased broker binding — because `cleanup()` is skipped by the `?`.
- **Refuted:** the stale leaf is not what rejects the next invocation. Each invocation mints a fresh `uuid::Uuid::now_v7()` that is both its broker id and its leaf name (`process.rs:601`, `process_broker.rs:165`), so a leaked binding cannot collide with a new one. `begin_invocation` on a fresh id succeeds, and so does `create`.
- **What actually happens:** the rejection is *per-invocation and repeats*. Every subsequent invocation reaches its own teardown and is refused for the same reason — immediately, once the session's cancellation token is set, because a cancelled invocation is killed the instant it launches. From outside it is indistinguishable from a globally wedged launcher.

## The fix

**1. `Launcher::wait_empty` waits.** It now polls `cgroup.events` until it reports emptiness, bounded by a new `KillSettle` on `LauncherConfig` (default `500 × 20ms` = 10s ceiling; the first read is unslept, so the common already-empty path costs nothing). A malformed or unreadable `cgroup.events` still fails immediately — that is a broken delegation, not a settling kill.

Nothing about the fencing or UID guarantees moves. The still-populated check is *not* deleted: `remove()` still refuses to unlink a populated leaf, the leaf name, birth fence, nonce rotation, peer authentication and one-way lift are untouched. The check is made reliable, not weaker.

**2. Teardown never fails a command that already ran.** `release_invocation_leaf` / `settled_status` in `process.rs` make kill, wait and clean best-effort with structured warnings. `cleanup()` is now always reached, so the leaf and the broker binding are released. A leaf that still will not drain after the budget yields a synthesized `SIGKILL` status rather than a blocking `wait()` — the same trade the non-brokered runner's `cleanup_and_reap` already makes and documents ("abandoning to unblock the worker"). This is the recover-never-brick half: the platform prefers a session that keeps running to a "safe" one that can do nothing.

The 1800s budget is **unchanged** — the timeout firing is legitimate. (Separately: 484s and 456s invocations were also captured ending this way, so the budget is not the discriminator; the aftermath was.)

## Tests

All assert behaviour and structured values; no log-sentence assertions.

- `djinn-cgroup-launcher` `wait_empty_polls_a_settling_kill_and_stays_bounded` — a fake cgroupfs that reports `populated 1` for the first three reads and `populated 0` on the fourth. Asserts the leaf is unlinked, the exact read count, and that the budget still caps the wait (3 reads, no unlink) when a leaf never drains.
- `djinn-agent` `a_killed_invocation_drains_its_leaf_and_the_next_lease_invocation_succeeds` — **the requested regression test**, over the real production composition (`UnixBrokerLauncher` → `UnixBrokerClient` → real Unix socket → `UnixBrokerServer` → `Broker` → `Launcher`; only cgroupfs is recorded). Invocation killed mid-flight with a settling kill → `wait_empty` must succeed, `CLEAN` must unlink the leaf, and a second lease invocation on the same launcher and broker must launch, lift and tear down.
- `djinn-agent` `a_refused_leaf_teardown_preserves_the_result_and_still_cleans_up` and `..._still_reports_a_terminal_status_for_a_killed_child` — a handle whose `wait_empty` answers with the production `ControlRejected(State)`. Assert stdout/stderr/exit code survive, that `CLEAN` is still sent, and that a cancelled invocation reports `signal() == SIGKILL`.

**Mutation-checked.** Reverting `Launcher::wait_empty` to a single read fails the broker-composition test with `Custom { kind: Other, error: ControlRejected(State) }`; restoring the `?` in the runner fails both runner tests with `Launcher(Custom { kind: Other, error: ControlRejected(State) })` — byte-for-byte the production message.

## Verified locally

From `server/`, `SQLX_OFFLINE=true`:

- `cargo check --workspace --all-targets` — clean.
- `cargo clippy -p djinn-cgroup-launcher -p djinn-agent --all-targets --no-deps` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo test -p djinn-cgroup-launcher` — **74 + 4 + 9 + 3 + 9 + 4 + 1 + 3 pass, 0 fail, 7 ignored**.
- `cargo test -p djinn-agent --lib` — **1300 passed, 184 failed**.

### What I could not verify locally

- **The 184 `djinn-agent` failures are pre-existing and DB-only.** All 184 are `Sqlx(Io(Os { code: 111, ConnectionRefused }))` — no local Postgres. Confirmed against the base commit (`26f11b232`) by stashing this branch and re-running: base is **1297 passed / 184 failed**, the identical 184, also all `Connection refused`. This branch adds 3 passing tests and no failures.
- **The 7 ignored `djinn-cgroup-launcher` tests are the privileged kernel lane** and cannot run here (they need uid 0, real UID separation, a writable delegated cgroup-v2 hierarchy and installable seccomp): `delegated_cpu_lease_lifecycle::…` (1), `kernel_boundary_under_rendered_context::…` (3), `brokered_git_trust::…` (2), `brokered_lease_lift_boundary::…` (1). This PR adds and removes no `#[ignore]`, so the per-file declared-count guards those suites enforce are unaffected. **The one thing only that lane can prove is the real-kernel settling window** — that a real `cgroup.kill` on a real leaf drains inside the 10s budget. The polling logic itself is proven against the recorded filesystem seam here.
- `djinn-image-controller --test protocol_catalog_and_preservation`: 4 pass (including the source-preservation checks that require `fn wait_empty` to still exist), 2 fail on `Connection refused` — same pre-existing DB cause.
