### PR TITLE
fix(ui): scope the task page to its own project and fix the ledger layout

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -87,12 +87,11 @@ describe("MainLayout — project selector chrome", () => {
     expect(selector).toBeInTheDocument();
   });
 
-  it("renders the shared project selector on /task/:taskId (global-project-context)", () => {
+  it("hides the shared project selector on /task/:taskId (task is bound to one project)", () => {
     render(<MainLayout />, {
       wrapperOptions: { routerProps: { initialEntries: ["/task/abc-123"] } },
     });
-    const selector = screen.getByLabelText("Select project");
-    expect(selector).toBeInTheDocument();
+    expect(screen.queryByLabelText("Select project")).not.toBeInTheDocument();
   });
 
   it("renders the shared project selector on /memory (global-project-context)", () => {

--- a/ui/src/components/session/SessionLedger.tsx
+++ b/ui/src/components/session/SessionLedger.tsx
@@ -360,7 +360,7 @@ function BriefBand({ phase }: { phase: LedgerPhase }) {
         </button>
       </header>
       <div className="px-3.5 py-3">
-        <p className="max-w-[68ch] text-sm leading-relaxed text-zinc-300">{brief.body}</p>
+        <p className="text-sm leading-relaxed text-zinc-300">{brief.body}</p>
         {brief.facets && brief.facets.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-1.5">
             {brief.facets.map((f) => (
@@ -480,7 +480,7 @@ function Rail({
   blockers: string[];
 }) {
   return (
-    <aside className="flex w-52 shrink-0 flex-col gap-5 overflow-y-auto border-r border-white/[0.06] px-3 py-4">
+    <aside className="flex w-72 shrink-0 flex-col gap-5 overflow-y-auto border-r border-white/[0.06] px-4 py-4">
       <section className="flex flex-col gap-2.5">
         <Eyebrow className="text-zinc-500">Criteria</Eyebrow>
         <CriteriaMeter criteria={criteria} />
@@ -498,7 +498,7 @@ function Rail({
               <div className="min-w-0">
                 <p
                   className={cn(
-                    "line-clamp-3 text-[11px] leading-snug",
+                    "line-clamp-4 text-[11px] leading-relaxed",
                     c.met ? "text-zinc-500" : "text-zinc-300",
                   )}
                   title={c.text}
@@ -574,7 +574,7 @@ export function SessionLedger({
   const liveAccent = accentFor(live?.agentType);
 
   return (
-    <div className="flex h-full flex-col bg-background text-foreground">
+    <div className="flex h-full min-w-0 flex-1 flex-col bg-background text-foreground">
       {showHeader && (
       <header className="flex shrink-0 items-center gap-3 border-b border-white/[0.06] px-4 py-2.5">
         <span className="shrink-0 font-mono text-xs text-zinc-500">{taskShortId}</span>
@@ -599,7 +599,10 @@ export function SessionLedger({
         <Rail criteria={criteria} agents={agents} blockers={blockers} />
 
         <main className="min-w-0 flex-1 overflow-y-auto">
-          <div className="mx-auto flex max-w-3xl flex-col gap-4 px-5 py-5">
+          {/* The scroll container fills the pane so the scrollbar sits at the
+              screen edge, while the column itself stays a centred, bounded
+              measure — full-bleed text is unreadable on a wide display. */}
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-6 py-5">
             {entries.length === 0 && (
               <p className="py-8 text-center text-sm text-zinc-500">{emptyMessage}</p>
             )}

--- a/ui/src/lib/routeScopes.test.ts
+++ b/ui/src/lib/routeScopes.test.ts
@@ -12,9 +12,9 @@ describe("routeScopes", () => {
       expect(isGlobalProjectContextRoute("/agents")).toBe(true);
     });
 
-    it("returns true for /task/:taskId (any task id)", () => {
-      expect(isGlobalProjectContextRoute("/task/abc-123")).toBe(true);
-      expect(isGlobalProjectContextRoute("/task/xyz")).toBe(true);
+    it("returns false for /task/:taskId (the task carries its own project)", () => {
+      expect(isGlobalProjectContextRoute("/task/abc-123")).toBe(false);
+      expect(isGlobalProjectContextRoute("/task/xyz")).toBe(false);
     });
 
     it("returns true for /memory (local picker removed)", () => {
@@ -71,7 +71,6 @@ describe("routeScopes", () => {
   describe("needsChromeProjectSelector", () => {
     it("returns true for global-project-context routes without an in-page selector", () => {
       expect(needsChromeProjectSelector("/agents")).toBe(true);
-      expect(needsChromeProjectSelector("/task/abc-123")).toBe(true);
       expect(needsChromeProjectSelector("/memory")).toBe(true);
     });
 
@@ -106,6 +105,12 @@ describe("routeScopes", () => {
 
     it("returns path-scoped for /projects/:id/environment", () => {
       const entry = getRouteScopeEntry("/projects/proj-1/environment");
+      expect(entry).toBeDefined();
+      expect(entry!.scope).toBe("path-scoped");
+    });
+
+    it("returns path-scoped for /task/:taskId — the task resolves its own project", () => {
+      const entry = getRouteScopeEntry("/task/abc-123");
       expect(entry).toBeDefined();
       expect(entry!.scope).toBe("path-scoped");
     });

--- a/ui/src/lib/routeScopes.ts
+++ b/ui/src/lib/routeScopes.ts
@@ -75,11 +75,6 @@ export const ROUTE_SCOPES: readonly RouteScopeEntry[] = [
     note: "AgentsPage reads useSelectedProject() for metrics/MCP context",
   },
   {
-    pattern: "/task/:taskId",
-    scope: "global-project-context",
-    note: "TaskSessionPage reads useSelectedProject() for session context/back-nav",
-  },
-  {
     pattern: "/code-graph",
     scope: "global-project-context",
     inPageSelector: true,
@@ -116,6 +111,15 @@ export const ROUTE_SCOPES: readonly RouteScopeEntry[] = [
   },
 
   // ── path-scoped ─────────────────────────────────────────────────────────
+  {
+    pattern: "/task/:taskId",
+    scope: "path-scoped",
+    note:
+      "A task is always bound to one project, so TaskSessionPage resolves its " +
+      "project from the task's own project_id rather than the global store. " +
+      "Showing a selector implied the page could be re-scoped, which it cannot; " +
+      "deriving it also makes cross-project deep links resolve correctly.",
+  },
   {
     pattern: "/projects/:id/environment",
     scope: "path-scoped",

--- a/ui/src/pages/TaskSessionPage.tsx
+++ b/ui/src/pages/TaskSessionPage.tsx
@@ -7,7 +7,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useSelectedProject } from "@/stores/useProjectStore";
+import { useProjects, useSelectedProject } from "@/stores/useProjectStore";
 import { useTaskStore } from "@/stores/useTaskStore";
 import { useSessionMessages } from "@/hooks/useSessionMessages";
 import { SessionLedger } from "@/components/session/SessionLedger";
@@ -130,16 +130,23 @@ function TaskSidebarSkeleton() {
 export function TaskSessionPage() {
   const { taskId } = useParams<{ taskId: string }>();
   const navigate = useNavigate();
+  const projects = useProjects();
   const selectedProject = useSelectedProject();
-  const projectSlug = selectedProject
-    ? `${selectedProject.github_owner}/${selectedProject.github_repo}`
-    : null;
   const tasks = useTaskStore((s) => s.tasks);
 
   // Derive the task straight from the store. `taskStore` replaces the tasks Map
   // on every mutation, so the selector above re-renders on any change — no
   // effect-based syncing or manual subscription is needed.
   const task = taskId ? tasks.get(taskId) ?? null : null;
+
+  // A task belongs to exactly one project, so the task is the authority — not
+  // the global selector. Deriving it here is what lets a deep link into a task
+  // outside the currently selected project load its sessions at all.
+  const project = useMemo(
+    () => projects.find((p) => p.id === task?.project_id) ?? selectedProject,
+    [projects, task?.project_id, selectedProject]
+  );
+  const projectSlug = project ? `${project.github_owner}/${project.github_repo}` : null;
 
   // Give the store a brief moment to populate before showing "not found". The
   // grace window resets whenever the task id changes (render-phase pattern) and


### PR DESCRIPTION
Four fixes from looking at the ledger in production.

## Project selector on `/task/:taskId`

A task belongs to exactly one project, so offering a selector implied the page could be re-scoped, which it cannot. `/task/:taskId` moves from `global-project-context` to `path-scoped`, and `TaskSessionPage` resolves its project from the task's own `project_id`, falling back to the global store only while the task is still loading.

This also fixes a real bug rather than just removing a control: the session slug came from the *selector*, so a deep link into a task outside the currently selected project could not load its sessions at all.

## The ledger did not fill its pane

`SessionLedger`'s root is a flex column inside a flex row, and without `flex-1` it sized to content — which is why there was dead space to the right and the scrollbar sat mid-screen rather than at the edge. `min-w-0 flex-1` puts the scrollbar and the live footer where they belong.

## The rail was squeezed

`w-52` wrapped each acceptance criterion into three cramped, clipped lines. Widened to `w-72` with looser leading, so criteria read on one or two lines.

## Content measure

The scroll container now fills the pane, but the column inside stays centred and bounded at `max-w-5xl`. Full-bleed text is unreadable on a wide display — the pane fills the screen, the measure does not.

## Verification

- `tsc -b` and `eslint` clean.
- 396 pass / 1 expected-fail across `src/lib`, `App`, and the session components.
- Route-scope tests updated for the new scope, plus one asserting `/task/:taskId` is `path-scoped`.
- Checked at 1900px and 2560px against the `Session/TaskSessionPage` stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)