### PR TITLE
Tribunal: route a blocking verdict to a role that can act on it, and stop it edit-locking its own remedy

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/create.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/create.rs
@@ -1054,10 +1054,26 @@ impl DjinnMcpServer {
             return Json(err_single(e));
         }
 
-        // Composed gate (task cuzf): block entering `in_review` when
-        // DoR or tribunal conditions are not met. Existing body/MDX/AC-count
+        // Composed gate (task cuzf): block *entering* `in_review` when DoR or
+        // tribunal conditions are not met. Existing body/MDX/AC-count
         // validation already passed above.
-        if status == "in_review" {
+        //
+        // `status` defaults to `existing.status`, so gating on `status ==
+        // "in_review"` alone also fired on every in-place edit of a proposal
+        // that was *already* `in_review` — including an edit that changes no
+        // status at all. That made a needs-work judge verdict edit-lock the
+        // very body it demands changing: the tribunal Advocate's primary action
+        // is `proposal_update(body=...)`, and gate step 2c blocks on a
+        // `needs-work` `latest_judge_verdict` unless a human override is
+        // current. Restrict the gate to the transition it was written for.
+        //
+        // This does not weaken spec integrity for in-place edits: every
+        // material revision write goes through
+        // `ProposalRepository::insert_revision_checked`, which lints the
+        // candidate body and fails closed with `SPEC_LINT_REJECTED` on any
+        // error — independently of this gate.
+        let entering_in_review = status == "in_review" && existing.status != "in_review";
+        if entering_in_review {
             let target_count = repo
                 .targets(&existing.id)
                 .await

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/create.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/create.rs
@@ -472,26 +472,20 @@ impl DjinnMcpServer {
             {
                 return Json(err_single(e));
             }
-            // Composed gate (task cuzf): block import that would leave an
-            // `in_review` proposal failing DoR or tribunal conditions.
-            if existing.status == "in_review" {
-                let target_count = repo
-                    .targets(&existing.id)
-                    .await
-                    .map(|t| t.len())
-                    .unwrap_or(0);
-                let gate = evaluate_composed_gate(
-                    &repo,
-                    &existing,
-                    imported.body,
-                    &imported.acceptance_criteria_json,
-                    target_count,
-                )
-                .await;
-                if let Some(err) = gate.to_error_string() {
-                    return Json(err_single(err));
-                }
-            }
+            // The composed gate (task cuzf) used to run here when
+            // `existing.status == "in_review"`. Import writes `existing.status`
+            // straight back and never changes it, so that branch could only ever
+            // fire on an in-place edit of an already-`in_review` proposal — the
+            // same defect fixed in `proposal_update` below, where the gate now
+            // keys off the `!in_review -> in_review` transition instead. There is
+            // no such transition on this path, so the gate is retired here rather
+            // than made conditional on one that cannot occur.
+            //
+            // Spec integrity is unaffected: `ProposalRepository::update` routes
+            // every material revision through `insert_revision_checked`, which
+            // lints the candidate body and fails closed with
+            // `SPEC_LINT_REJECTED`. Block-tag validation already ran above via
+            // `resolve_body_format_and_validate`.
             match repo
                 .update(
                     &existing.id,
@@ -1067,9 +1061,22 @@ impl DjinnMcpServer {
         // `needs-work` `latest_judge_verdict` unless a human override is
         // current. Restrict the gate to the transition it was written for.
         //
-        // This does not weaken spec integrity for in-place edits: every
-        // material revision write goes through
-        // `ProposalRepository::insert_revision_checked`, which lints the
+        // What an in-place `in_review` edit no longer runs, stated plainly:
+        //   - candidate DoR structure checks (problem/scope/objective/
+        //     dependencies/open-questions coverage, AC and target counts);
+        //   - the unresolved-blocking-debate-entry check;
+        //   - needs-evidence spike parking;
+        //   - the needs-work-verdict check itself (the point of the change).
+        // The edit can therefore leave an `in_review` proposal failing DoR.
+        // That is bounded and deliberate: `in_review` is not a gate, it is a
+        // status. Every path that consumes readiness — `proposal_signoff`,
+        // `proposal_graduate`, and re-entry into `in_review` — still runs the
+        // full composed gate, so a DoR-failing head cannot be signed off,
+        // graduated, or re-promoted. `proposal_show`'s `build_gate_status`
+        // keeps reporting the failures to reviewers.
+        //
+        // Spec integrity is NOT dropped: every material revision write goes
+        // through `ProposalRepository::insert_revision_checked`, which lints the
         // candidate body and fails closed with `SPEC_LINT_REJECTED` on any
         // error — independently of this gate.
         let entering_in_review = status == "in_review" && existing.status != "in_review";

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff/tribunal_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff/tribunal_tests.rs
@@ -1107,4 +1107,19 @@ async fn graduation_is_still_blocked_by_needs_work_verdict() {
         error.contains(&verdict.id),
         "error should name the verdict id: {error}"
     );
+
+    // An error string is a label. Graduation's actual effects are to advance the
+    // proposal past `approved` and to record a decomposition task
+    // (`set_breakdown_task`), so assert neither happened — otherwise this test
+    // would pass against a gate that reports a failure and graduates anyway.
+    let stored = repo.get(&proposal.id).await.unwrap().unwrap();
+    assert_eq!(
+        stored.status, "approved",
+        "a blocked graduation must not advance the proposal"
+    );
+    assert!(
+        stored.build_breakdown_task_id.is_none(),
+        "a blocked graduation must not create a decomposition task, found: {:?}",
+        stored.build_breakdown_task_id
+    );
 }

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff/tribunal_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff/tribunal_tests.rs
@@ -859,6 +859,120 @@ async fn explicit_same_status_in_review_edit_is_not_treated_as_entry() {
     assert_eq!(stored.latest_revision_seq, proposal.latest_revision_seq + 1);
 }
 
+/// `proposal_import` carried the same edit-lock: it gated on
+/// `existing.status == "in_review"` while writing that status straight back, so
+/// it could only ever fire on an in-place edit. Re-importing a fixed spec must
+/// not be blocked by the verdict demanding the fix.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn in_review_import_survives_an_outstanding_needs_work_verdict() {
+    let (server, db, user_id) = setup_test_server_and_user().await;
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+
+    let proposal = create_proposal_with_target(
+        &repo,
+        &project_repo,
+        &user_id,
+        "Import Guard Test",
+        ready_body(),
+        Some(r#"[{"criterion":"API returns 200","met":false}]"#),
+    )
+    .await;
+    force_status(&db, &proposal.id, "in_review").await;
+
+    repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+        proposal_id: &proposal.id,
+        kind: "verdict",
+        body: "needs-work: the dependency section names no owner service",
+        blocking: true,
+        agent_role: "judge",
+        author_kind: "agent",
+        author_model: Some("test-judge"),
+        source_task_id: None,
+        against_revision_seq: proposal.latest_revision_seq,
+        round: 1,
+        body_metadata: None,
+    })
+    .await
+    .unwrap();
+
+    // Round-trip through the real export format so the import parses exactly
+    // what the tool emits.
+    let export = djinn_core::auth_context::SESSION_USER_ID
+        .scope(Some(user_id.clone()), async {
+            server
+                .dispatch_tool("proposal_export", serde_json::json!({ "id": proposal.id }))
+                .await
+        })
+        .await
+        .unwrap();
+    let mdx = export
+        .get("mdx")
+        .and_then(|v| v.as_str())
+        .expect("export must return mdx");
+    // Edit inside the body (the Dependencies section from `ready_body`) so the
+    // change is unambiguously part of the spec, not trailing frontmatter slack.
+    let fixed_mdx = mdx.replace(
+        "Blocked by service C.",
+        "Blocked by service C. Owned by service C.",
+    );
+    assert_ne!(
+        fixed_mdx, mdx,
+        "the exported mdx must carry the body section"
+    );
+    // DO NOT REMOVE THIS LINE. `proposal_export` does not emit `id:` in its
+    // frontmatter (see `proposal_export`: the format string is
+    // `"---\ntitle: …\nbody_format: …\n{ac}---\n{body}"`). `proposal_import`
+    // branches on `imported.id`: absent means CREATE a new proposal, present
+    // means UPDATE the named one. Only the UPDATE branch ever ran the composed
+    // gate this test exists to prove was retired.
+    //
+    // Without this injection the test still passes — but it passes because the
+    // import created a brand-new proposal and never touched the `in_review`
+    // one carrying the needs-work verdict. It would assert nothing about the
+    // code it names, in either direction. That is exactly how it was first
+    // written; the `latest_revision_seq` assertion below is what caught it, and
+    // it is the reason that assertion is there. A `response["error"].is_none()`
+    // check alone cannot tell a passing update from an unrelated create.
+    let fixed_mdx = fixed_mdx.replacen("---\n", &format!("---\nid: {}\n", proposal.id), 1);
+
+    let response = djinn_core::auth_context::SESSION_USER_ID
+        .scope(Some(user_id.clone()), async {
+            server
+                .dispatch_tool("proposal_import", serde_json::json!({ "mdx": fixed_mdx }))
+                .await
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        response.get("error").is_none(),
+        "re-importing an in_review proposal must not be blocked by the verdict \
+         demanding the fix: {:?}",
+        response.get("error")
+    );
+
+    let stored = repo.get(&proposal.id).await.unwrap().unwrap();
+    assert!(
+        stored.body.contains("Owned by service C."),
+        "the imported revision must be persisted: {}",
+        stored.body
+    );
+    // Load-bearing: this is what distinguishes "the gated UPDATE path ran and
+    // succeeded" from "the import quietly CREATEd an unrelated proposal". See
+    // the `id:` injection above — without it this assertion is the only thing
+    // that fails.
+    assert_eq!(
+        stored.latest_revision_seq,
+        proposal.latest_revision_seq + 1,
+        "the import must have taken the UPDATE path on this proposal"
+    );
+    assert_eq!(
+        stored.status, "in_review",
+        "import must not change the status"
+    );
+}
+
 /// Do not regress the guard: entering `in_review` from a status that is NOT
 /// `in_review` must still be blocked by a needs-work verdict. `approved` (not
 /// just `draft`) proves the entry check keys off the transition, not off one

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff/tribunal_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff/tribunal_tests.rs
@@ -664,3 +664,333 @@ async fn export_roundtrip_after_refinement_revision() {
         "exported MDX frontmatter should contain acceptance_criteria"
     );
 }
+
+// ── Verdict-driven revision: the gate fires on ENTRY, not on every edit ──
+//
+// The composed gate was written to block *entering* `in_review`, but
+// `proposal_update` defaults `status` to the proposal's existing status, so it
+// also fired on every in-place edit of a proposal that was already
+// `in_review`. Combined with gate step 2c (a `needs-work` `latest_judge_verdict`
+// blocks unless a human override is current), a needs-work verdict edit-locked
+// the very body it demanded changing — and the tribunal Advocate's primary
+// action is `proposal_update(body=...)`.
+
+/// Force a proposal into an arbitrary status without recording a revision.
+async fn force_status(db: &Database, proposal_id: &str, status: &str) {
+    ProposalRepository::new(db.clone(), EventBus::noop())
+        .set_status(proposal_id, status)
+        .await
+        .unwrap();
+}
+
+/// The Advocate's write: `proposal_update` with only `body` +
+/// `acceptance_criteria` on an `in_review` proposal that carries an outstanding
+/// needs-work verdict. It must succeed AND actually persist a new revision —
+/// otherwise a blocking verdict routed to the Advocate can never be acted on.
+///
+/// The gate must still be armed for everything else: the same verdict must
+/// still block `proposal_signoff` afterwards.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn in_review_body_revision_survives_an_outstanding_needs_work_verdict() {
+    let (server, db, user_id) = setup_test_server_and_user().await;
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+
+    let proposal = create_proposal_with_target(
+        &repo,
+        &project_repo,
+        &user_id,
+        "Verdict Revision Test",
+        ready_body(),
+        Some(r#"[{"criterion":"API returns 200","met":false}]"#),
+    )
+    .await;
+    force_status(&db, &proposal.id, "in_review").await;
+
+    repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+        proposal_id: &proposal.id,
+        kind: "verdict",
+        body: "needs-work: AC 1 is untestable; assert on the emitted row count",
+        blocking: true,
+        agent_role: "judge",
+        author_kind: "agent",
+        author_model: Some("test-judge"),
+        source_task_id: None,
+        against_revision_seq: proposal.latest_revision_seq,
+        round: 1,
+        body_metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let revised_body = format!(
+        "{}\n\n# Error Handling\nAll endpoints return structured errors.",
+        ready_body()
+    );
+    let response = djinn_core::auth_context::SESSION_USER_ID
+        .scope(Some(user_id.clone()), async {
+            server
+                .dispatch_tool(
+                    "proposal_update",
+                    serde_json::json!({
+                        "id": proposal.id,
+                        "body": revised_body,
+                        "acceptance_criteria": [
+                            {"criterion":"Emits exactly one row per request","met":false}
+                        ],
+                    }),
+                )
+                .await
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        response.get("error").is_none(),
+        "an in-place body revision must not be blocked by the verdict demanding it: {:?}",
+        response.get("error")
+    );
+
+    // Assert the side effect, not the absence of an error string: the revision
+    // must actually be persisted and the head must advance.
+    let stored = repo.get(&proposal.id).await.unwrap().unwrap();
+    assert_eq!(
+        stored.body, revised_body,
+        "the revised body must be persisted"
+    );
+    assert!(
+        stored.acceptance_criteria.contains("Emits exactly one row"),
+        "the revised acceptance criteria must be persisted: {}",
+        stored.acceptance_criteria
+    );
+    assert_eq!(
+        stored.latest_revision_seq,
+        proposal.latest_revision_seq + 1,
+        "a material edit must append exactly one revision"
+    );
+    assert_eq!(
+        stored.status, "in_review",
+        "an edit that passes no status must not change the status"
+    );
+
+    // The gate is not disarmed: the same needs-work verdict must still block
+    // sign-off.
+    let signoff = djinn_core::auth_context::SESSION_USER_ID
+        .scope(Some(user_id.clone()), async {
+            server
+                .dispatch_tool(
+                    "proposal_signoff",
+                    serde_json::json!({ "id": proposal.id, "kind": "technical" }),
+                )
+                .await
+        })
+        .await
+        .unwrap();
+    let error = signoff
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("signoff must still be blocked, got: {signoff:?}"));
+    assert!(
+        error.contains("judge returned needs-work"),
+        "signoff must still be blocked by the needs-work verdict: {error}"
+    );
+}
+
+/// Passing `status: "in_review"` explicitly on a proposal that is *already*
+/// `in_review` is not an entry transition, so it must not re-arm the gate
+/// either — the Advocate has no reason to omit the field it read back.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_same_status_in_review_edit_is_not_treated_as_entry() {
+    let (server, db, user_id) = setup_test_server_and_user().await;
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+
+    let proposal = create_proposal_with_target(
+        &repo,
+        &project_repo,
+        &user_id,
+        "Explicit Same Status Test",
+        ready_body(),
+        Some(r#"[{"criterion":"API returns 200","met":false}]"#),
+    )
+    .await;
+    force_status(&db, &proposal.id, "in_review").await;
+
+    repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+        proposal_id: &proposal.id,
+        kind: "verdict",
+        body: "needs work: name the narrower design",
+        blocking: true,
+        agent_role: "judge",
+        author_kind: "agent",
+        author_model: Some("test-judge"),
+        source_task_id: None,
+        against_revision_seq: proposal.latest_revision_seq,
+        round: 2,
+        body_metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let revised_body = format!("{}\n\n# Risks\nThe narrower design is X.", ready_body());
+    let response = djinn_core::auth_context::SESSION_USER_ID
+        .scope(Some(user_id.clone()), async {
+            server
+                .dispatch_tool(
+                    "proposal_update",
+                    serde_json::json!({
+                        "id": proposal.id,
+                        "body": revised_body,
+                        "status": "in_review",
+                    }),
+                )
+                .await
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        response.get("error").is_none(),
+        "an in-place edit that restates the current status is not an entry: {:?}",
+        response.get("error")
+    );
+    let stored = repo.get(&proposal.id).await.unwrap().unwrap();
+    assert_eq!(stored.body, revised_body);
+    assert_eq!(stored.latest_revision_seq, proposal.latest_revision_seq + 1);
+}
+
+/// Do not regress the guard: entering `in_review` from a status that is NOT
+/// `in_review` must still be blocked by a needs-work verdict. `approved` (not
+/// just `draft`) proves the entry check keys off the transition, not off one
+/// hard-coded source status.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn entering_in_review_from_approved_is_still_blocked_by_needs_work_verdict() {
+    let (server, db, user_id) = setup_test_server_and_user().await;
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+
+    let proposal = create_proposal_with_target(
+        &repo,
+        &project_repo,
+        &user_id,
+        "Entry Guard Test",
+        ready_body(),
+        Some(r#"[{"criterion":"API returns 200","met":false}]"#),
+    )
+    .await;
+    force_approved(&db, &proposal.id).await;
+
+    let verdict = repo
+        .add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &proposal.id,
+            kind: "verdict",
+            body: "needs-work: missing rollback path",
+            blocking: true,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("test-judge"),
+            source_task_id: None,
+            against_revision_seq: proposal.latest_revision_seq,
+            round: 1,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let response = djinn_core::auth_context::SESSION_USER_ID
+        .scope(Some(user_id.clone()), async {
+            server
+                .dispatch_tool(
+                    "proposal_update",
+                    serde_json::json!({
+                        "id": proposal.id,
+                        "status": "in_review",
+                    }),
+                )
+                .await
+        })
+        .await
+        .unwrap();
+
+    let error = response
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("entering in_review must still be blocked, got: {response:?}"));
+    assert!(
+        error.contains("judge returned needs-work"),
+        "entry must still be blocked by the needs-work verdict: {error}"
+    );
+    assert!(
+        error.contains(&verdict.id),
+        "error should name the verdict id: {error}"
+    );
+
+    let stored = repo.get(&proposal.id).await.unwrap().unwrap();
+    assert_eq!(
+        stored.status, "approved",
+        "a blocked entry must not change the status"
+    );
+}
+
+/// Do not regress the guard: `proposal_graduate` must still be blocked by a
+/// needs-work verdict when no human override is current.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graduation_is_still_blocked_by_needs_work_verdict() {
+    let (server, db, user_id) = setup_test_server_and_user().await;
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+
+    let proposal = create_proposal_with_target(
+        &repo,
+        &project_repo,
+        &user_id,
+        "Graduation Guard Test",
+        ready_body(),
+        Some(r#"[{"criterion":"API returns 200","met":false}]"#),
+    )
+    .await;
+
+    let verdict = repo
+        .add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &proposal.id,
+            kind: "verdict",
+            body: "needs_work: acceptance criteria are not falsifiable",
+            blocking: true,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("test-judge"),
+            source_task_id: None,
+            against_revision_seq: proposal.latest_revision_seq,
+            round: 1,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+
+    force_approved(&db, &proposal.id).await;
+
+    let response = djinn_core::auth_context::SESSION_USER_ID
+        .scope(Some(user_id.clone()), async {
+            server
+                .dispatch_tool(
+                    "proposal_graduate",
+                    serde_json::json!({ "id": proposal.id }),
+                )
+                .await
+        })
+        .await
+        .unwrap();
+
+    let error = response
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("graduation must still be blocked, got: {response:?}"));
+    assert!(
+        error.contains("judge returned needs-work"),
+        "graduation must still be blocked by the needs-work verdict: {error}"
+    );
+    assert!(
+        error.contains(&verdict.id),
+        "error should name the verdict id: {error}"
+    );
+}

--- a/server/crates/djinn-coordinator/src/refinement.rs
+++ b/server/crates/djinn-coordinator/src/refinement.rs
@@ -13,9 +13,14 @@
 //   4. Repeat until `dry_rounds_required` consecutive rounds with no new blocking
 //      objection ("dry rounds") — then invoke the Judge.
 //   5. Judge adjudicates (produces a verdict via debate trail).
-//   6. A blocking verdict re-opens the loop at the Advocate (step 1), because
-//      the verdict prescribes a body change and only the Advocate writes the
-//      body. See `RefinementLoopState::record_judge_verdict`.
+//   6. A blocking verdict re-opens the loop at the Adversary (step 2). If that
+//      Adversary is dry, the round goes to the Advocate anyway so the verdict's
+//      prescribed remedy is implemented — see `process_adversary_pass`.
+//
+// NOTE: `dry_rounds_required` is NOT enforced anywhere in the tree.
+// `consecutive_dry_rounds` is incremented and reset but never compared against
+// it, so step 4 above has never been true: a single dry pass invokes the Judge.
+// Filed as a separate defect; do not read the constant as a live contract.
 //
 // Guards:
 //   - Hard round cap (default 5).
@@ -64,16 +69,16 @@ pub fn role_for_phase(phase: RefinementPhase) -> RefinementRole {
 
 /// The current phase of the refinement loop.
 ///
-/// v2 tribunal order: the first round runs `Adversary → Advocate → Judge`. The
+/// v2 tribunal order: every round runs `Adversary → Advocate → Judge`. The
 /// Adversary opens (red-teams the current spec), the Advocate responds
 /// (revises to address objections), and the Judge rules whether to loop again
 /// or surface the result to the human. The human is NOT in the loop — they
 /// only review the converged result once, via `AwaitingHumanReview`.
 ///
-/// A round re-opened by a **blocking judge verdict** starts at the Advocate
-/// instead (`Advocate → Judge`): the verdict itself is the work item, and only
-/// the Advocate can rewrite the body it prescribes changing. See
-/// [`RefinementLoopState::record_judge_verdict`].
+/// The Advocate step is skipped only when the Adversary is dry **and** the
+/// Judge has no outstanding blocking verdict. A dry round that still owes the
+/// Judge a remedy goes to the Advocate — see
+/// [`RefinementLoopState::pending_blocking_verdict`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RefinementPhase {
     /// Waiting for the Adversary to red-team the current spec. (Round opener.)
@@ -224,6 +229,23 @@ pub struct RefinementLoopState {
     /// separate from proposal revisions: a rejected candidate did not change
     /// the head and must be corrected in the same refinement round.
     pub pending_advocate_lint_violations: Vec<AdvocateLintViolation>,
+    /// Whether the Judge's latest verdict was blocking and no Advocate revision
+    /// has answered it yet.
+    ///
+    /// A needs-work verdict prescribes a remedy, and only the Advocate can write
+    /// it into the proposal body. But by the time the Judge rejects, it has
+    /// usually resolved every objection the Adversary filed — so the next
+    /// Adversary pass is legitimately dry, and a dry pass used to skip the
+    /// Advocate and hand an unchanged spec straight back to the Judge. The
+    /// remedy could then never be implemented by any role.
+    ///
+    /// This flag is what makes a dry pass route to the Advocate instead. It is
+    /// derived state, not an independent source of truth: the durable authority
+    /// is `ProposalRepository::latest_judge_verdict`, and both projection
+    /// rebuild paths (`refinement_recovery`, `refinement_inflight`) rehydrate it
+    /// from there via [`RefinementLoopState::with_pending_blocking_verdict`], so
+    /// it survives a coordinator restart.
+    pub pending_blocking_verdict: bool,
     /// Set when the loop terminates.
     pub stop_reason: Option<StopReason>,
 }
@@ -260,6 +282,7 @@ impl RefinementLoopState {
             round_blocking_objections: Vec::new(),
             dispatch_failures: 0,
             pending_advocate_lint_violations: Vec::new(),
+            pending_blocking_verdict: false,
             stop_reason: None,
         }
     }
@@ -292,6 +315,22 @@ impl RefinementLoopState {
             self.snapshot_revision_seq = seq;
             self.current_revision_seq = seq;
         }
+        self
+    }
+
+    /// Rehydrate [`RefinementLoopState::pending_blocking_verdict`] from the
+    /// durable debate trail. Every projection rebuilt from the ledger must call
+    /// this: `new` seeds the flag `false`, so a run recovered while parked at
+    /// `AdversaryAttack` after a needs-work verdict would send its next dry
+    /// pass back to the Judge and re-strand the verdict the restart interrupted.
+    ///
+    /// The caller supplies `ProposalRepository::latest_judge_verdict(..).blocking`.
+    /// That read is only consulted on the dry branch of `process_adversary_pass`
+    /// — i.e. while the phase is `AdversaryAttack`, which is reachable only
+    /// before any Advocate revision has answered the latest verdict — so the
+    /// latest-verdict row is an exact witness at the point of use.
+    pub fn with_pending_blocking_verdict(mut self, pending: bool) -> Self {
+        self.pending_blocking_verdict = pending;
         self
     }
 
@@ -376,9 +415,15 @@ impl RefinementLoopState {
 
     /// Record an advocate revision. Advances the working revision seq and
     /// hands the round to the Judge to rule.
+    ///
+    /// The revision answers whatever the Judge's last blocking verdict
+    /// prescribed, so the outstanding-verdict flag is cleared here: the Judge is
+    /// about to rule on the new revision, and that ruling — not this one — is
+    /// what decides whether a remedy is still owed.
     pub fn record_advocate_revision(&mut self, new_revision_seq: i32) {
         self.current_revision_seq = new_revision_seq;
         self.pending_advocate_lint_violations.clear();
+        self.pending_blocking_verdict = false;
         self.phase = RefinementPhase::JudgeAdjudication;
     }
 
@@ -392,10 +437,18 @@ impl RefinementLoopState {
     /// Process an adversary attack pass — the round opener. Records objections
     /// for repeat-signature detection, then routes:
     /// - blocking objections found → the Advocate revises to address them;
-    /// - no blocking objections (dry) → skip the Advocate (nothing to fix) and
-    ///   let the Judge rule directly;
+    /// - no blocking objections (dry) **with an outstanding blocking judge
+    ///   verdict** → the Advocate still runs, to implement the remedy that
+    ///   verdict prescribed (see [`RefinementLoopState::pending_blocking_verdict`]);
+    /// - no blocking objections (dry) and nothing owed to the Judge → skip the
+    ///   Advocate (nothing to fix) and let the Judge rule directly;
     /// - the same blocking objection repeating across rounds → the loop is
     ///   stuck, so escalate to the human reviewer.
+    ///
+    /// Dry accounting is identical in both dry branches: a dry pass is a dry
+    /// pass regardless of what the Judge left outstanding, and the reported
+    /// outcome stays [`AdversaryPassOutcome::Dry`] because it describes the
+    /// Adversary's own output, not the phase that follows.
     ///
     /// Pure state-machine logic — the caller persists objections through the
     /// debate-trail primitives.
@@ -422,8 +475,20 @@ impl RefinementLoopState {
 
         if blocking_count == 0 || result.explicit_dry {
             self.consecutive_dry_rounds += 1;
-            // Nothing for the advocate to fix — straight to the judge.
-            self.phase = RefinementPhase::JudgeAdjudication;
+            // A dry Adversary does NOT mean there is nothing to revise. When the
+            // Judge's last verdict was blocking, it prescribed a remedy that only
+            // the Advocate can write into the body — and by then the Judge has
+            // usually resolved every objection the Adversary filed, so the
+            // Adversary legitimately has nothing left to raise. Routing straight
+            // to the Judge here is what stranded those verdicts forever: the
+            // Judge re-read an unchanged spec, rejected it again, and the round
+            // burned. Give the Advocate the round instead.
+            self.phase = if self.pending_blocking_verdict {
+                RefinementPhase::AdvocateRevision
+            } else {
+                // Genuinely nothing owed — straight to the judge.
+                RefinementPhase::JudgeAdjudication
+            };
             return AdversaryPassOutcome::Dry;
         }
 
@@ -435,37 +500,29 @@ impl RefinementLoopState {
     /// Record a judge verdict — the round's arbiter.
     /// - non-blocking ("ready") → the spec converged; park it for the human's
     ///   single accept/reject review;
-    /// - blocking ("not ready") → run another round *starting at the Advocate*,
-    ///   unless the round cap is hit, in which case escalate to the human.
+    /// - blocking ("not ready") → run another round (Adversary first), unless
+    ///   the round cap is hit, in which case escalate to the human.
     ///
-    /// The next round opens at [`RefinementPhase::AdvocateRevision`], not at
-    /// [`RefinementPhase::AdversaryAttack`]. A blocking verdict is a prescribed
-    /// remedy ("name the narrower design", "this AC is untestable"), and the
-    /// Advocate is the only role that can rewrite the proposal body. Routing it
-    /// to the Adversary handed the remedy to a role that can only file
-    /// objections: once every Adversary objection was already resolved, the
-    /// Adversary had nothing left to raise, the round went dry, the Advocate was
-    /// never dispatched (a dry round skips it), and the verdict's prescription
-    /// could never be implemented — a permanent dead end that burned rounds
-    /// until the cap.
-    ///
-    /// The Advocate's revision is adjudicated by the Judge on the same round
-    /// (`record_advocate_revision` → `JudgeAdjudication`), so round accounting,
-    /// the round cap, dry accounting, and the `AwaitingHumanReview` park are all
-    /// unchanged. A verdict-driven round costs two spawns (Advocate + Judge)
-    /// versus the three of an Adversary-opened round, so `max_total_spawns`
-    /// still cannot preempt `RoundCap`.
+    /// A blocking verdict also records that the Judge left a remedy outstanding
+    /// ([`RefinementLoopState::pending_blocking_verdict`]). The round still
+    /// opens at the Adversary — every revision stays adversarially reviewed and
+    /// the round keeps its three-spawn shape — but if that Adversary comes up
+    /// dry, `process_adversary_pass` hands the round to the Advocate instead of
+    /// bouncing an unchanged spec back to the Judge.
     pub fn record_judge_verdict(&mut self, result: &JudgeVerdictResult) {
         if !result.blocking {
+            // A ready verdict supersedes any earlier needs-work verdict.
+            self.pending_blocking_verdict = false;
             self.phase = RefinementPhase::AwaitingHumanReview;
             return;
         }
+        self.pending_blocking_verdict = true;
         if self.current_round >= self.config.max_rounds {
             self.escalate(StopReason::RoundCap);
             return;
         }
         self.current_round += 1;
-        self.phase = RefinementPhase::AdvocateRevision;
+        self.phase = RefinementPhase::AdversaryAttack;
     }
 
     /// Record that the Judge demanded evidence for a load-bearing claim.
@@ -784,128 +841,225 @@ mod tests {
     }
 
     #[test]
-    fn judge_blocking_starts_next_round_at_the_advocate() {
+    fn judge_blocking_starts_next_adversary_round() {
         let mut state = RefinementLoopState::with_config("p1", 0, test_config());
         state.process_adversary_pass(&AdversaryPassResult {
             objections: vec![blocking_objection("Issue A")],
             explicit_dry: false,
         });
         state.record_advocate_revision(1);
-        // Judge still finds the spec lacking → next round, ADVOCATE first: the
-        // verdict prescribes a body change and only the Advocate writes bodies.
+        // Judge still finds the spec lacking → next round, adversary first, so
+        // the revision that was just rejected is still red-teamed.
         state.record_judge_verdict(&JudgeVerdictResult {
             body: "Still needs work.".into(),
             blocking: true,
         });
-        assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
+        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
         assert_eq!(state.current_round, 2);
         assert!(!state.is_complete());
+        // The remedy the verdict prescribed is recorded as still owed.
+        assert!(state.pending_blocking_verdict);
     }
 
-    /// The wedge this routing fixes. A blocking verdict arriving on a round
-    /// where the Adversary had ZERO unresolved objections used to route to
-    /// `AdversaryAttack`. The Adversary then had nothing left to raise, the
-    /// round went dry, `process_adversary_pass` skipped the Advocate and went
-    /// straight back to the Judge — so the verdict's prescribed remedy could
-    /// never be implemented by any role, forever.
+    /// The wedge. A blocking verdict prescribes a remedy only the Advocate can
+    /// write, and by the time the Judge rejects it has usually resolved every
+    /// objection the Adversary filed — so the next Adversary pass is genuinely
+    /// dry. A dry pass used to skip the Advocate and hand the unchanged spec
+    /// straight back to the Judge, which re-rejected it. The remedy could never
+    /// be implemented by any role, and the run burned rounds to the cap.
     ///
-    /// The blocking verdict must land in a phase where the body can actually be
-    /// revised.
+    /// A dry pass that still owes the Judge a remedy must reach the Advocate.
     #[test]
-    fn blocking_verdict_with_zero_unresolved_objections_reaches_a_body_writing_phase() {
+    fn dry_adversary_with_an_outstanding_verdict_routes_to_the_advocate() {
         let mut state = RefinementLoopState::with_config("p1", 0, test_config());
 
-        // Round 1: the Adversary is dry — every objection is already resolved.
-        let outcome = state.process_adversary_pass(&AdversaryPassResult {
-            objections: vec![],
-            explicit_dry: true,
+        // Round 1: the Adversary objects, the Advocate revises, the Judge
+        // rejects with a prescribed remedy and resolves the objection.
+        state.process_adversary_pass(&AdversaryPassResult {
+            objections: vec![blocking_objection("Missing rollback path")],
+            explicit_dry: false,
         });
-        assert_eq!(outcome, AdversaryPassOutcome::Dry);
-        assert_eq!(state.phase, RefinementPhase::JudgeAdjudication);
-
-        // The Judge rejects anyway and prescribes a concrete remedy.
+        state.record_advocate_revision(1);
         state.record_judge_verdict(&JudgeVerdictResult {
             body: "needs-work: AC 3 is untestable; replace it with a measurable \
                    assertion on the emitted row count."
                 .into(),
             blocking: true,
         });
+        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
+        assert_eq!(state.current_round, 2);
 
-        // The next phase must be able to rewrite the proposal body. Routing to
-        // the Adversary is the dead end: it can only file objections, and it
-        // has none to file.
+        // Round 2: the Adversary has nothing left to raise — every objection it
+        // filed is resolved. This is the exact state that used to dead-end.
+        let outcome = state.process_adversary_pass(&AdversaryPassResult {
+            objections: vec![],
+            explicit_dry: true,
+        });
+
+        assert_eq!(
+            outcome,
+            AdversaryPassOutcome::Dry,
+            "the pass is still dry — only the phase it routes to changes"
+        );
         assert_eq!(
             state.phase,
             RefinementPhase::AdvocateRevision,
-            "a blocking verdict must route to the only role that can revise the body"
+            "a dry pass owing the Judge a remedy must reach the only role that \
+             can revise the body"
         );
-        assert_eq!(state.current_round, 2);
         assert!(!state.is_complete());
         assert!(!state.is_awaiting_human_review());
         assert!(state.stop_reason.is_none());
-
-        // And the Advocate's revision is adjudicated, so the loop keeps moving
-        // rather than dead-ending on a second dry pass.
-        state.record_advocate_revision(1);
-        assert_eq!(state.phase, RefinementPhase::JudgeAdjudication);
+        // Dry accounting is untouched by the reroute.
+        assert_eq!(state.consecutive_dry_rounds, 1);
         assert_eq!(
             state.current_round, 2,
-            "the advocate turn stays in its round"
+            "the reroute does not advance the round"
+        );
+
+        // The Advocate's revision answers the verdict and hands the round back
+        // to the Judge, so the loop keeps moving.
+        state.record_advocate_revision(2);
+        assert_eq!(state.phase, RefinementPhase::JudgeAdjudication);
+        assert!(
+            !state.pending_blocking_verdict,
+            "a revision answers the outstanding verdict"
         );
     }
 
-    /// A verdict-driven round must not cost more agent spawns than the
-    /// Adversary-opened round it replaces, or `SpawnCap` (which *terminates*
-    /// the run) would preempt `RoundCap` (which *parks* it for human review)
-    /// and silently convert a reviewable park into a dead run.
+    /// A dry pass with NOTHING owed must still go straight to the Judge. The
+    /// reroute is conditional, not a blanket "dry means advocate".
     #[test]
-    fn verdict_driven_rounds_keep_round_cap_binding_before_spawn_cap() {
+    fn dry_adversary_without_an_outstanding_verdict_still_goes_to_the_judge() {
         let mut state = RefinementLoopState::with_config("p1", 0, test_config());
-        let mut spawns = 0;
+        assert!(!state.pending_blocking_verdict);
 
-        // Round 1 opens at the Adversary: adversary + advocate + judge.
-        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
-        for _ in 0..3 {
-            state.record_spawn().expect("round 1 fits the spawn budget");
-            spawns += 1;
-        }
         state.process_adversary_pass(&AdversaryPassResult {
-            objections: vec![blocking_objection("Issue A")],
-            explicit_dry: false,
+            objections: vec![],
+            explicit_dry: true,
         });
-        state.record_advocate_revision(1);
+        assert_eq!(state.phase, RefinementPhase::JudgeAdjudication);
 
-        // Rounds 2..=max_rounds are verdict-driven: advocate + judge only.
-        let mut revision = 1;
-        loop {
-            state.record_judge_verdict(&JudgeVerdictResult {
-                body: format!("needs-work: round {}", state.current_round),
-                blocking: true,
-            });
-            if state.is_awaiting_human_review() {
-                break;
+        // A ready verdict clears the flag, so a later dry pass is not rerouted
+        // by a stale needs-work from an earlier round.
+        state.pending_blocking_verdict = true;
+        state.record_judge_verdict(&JudgeVerdictResult {
+            body: "Ready.".into(),
+            blocking: false,
+        });
+        assert!(
+            !state.pending_blocking_verdict,
+            "a ready verdict supersedes any earlier needs-work"
+        );
+    }
+
+    /// The outstanding-verdict bit is rebuilt from the durable debate trail, so
+    /// a run recovered mid-round does not re-strand the verdict the restart
+    /// interrupted.
+    #[test]
+    fn rehydrated_outstanding_verdict_reroutes_a_dry_pass_after_a_restart() {
+        // A projection rebuilt from the ledger: phase and round come from the
+        // intent, the outstanding-verdict bit from `latest_judge_verdict`.
+        let mut state = RefinementLoopState::with_config("p1", 4, test_config())
+            .with_pending_blocking_verdict(true);
+        state.phase = RefinementPhase::AdversaryAttack;
+        state.current_round = 3;
+
+        state.process_adversary_pass(&AdversaryPassResult {
+            objections: vec![],
+            explicit_dry: true,
+        });
+        assert_eq!(
+            state.phase,
+            RefinementPhase::AdvocateRevision,
+            "a recovered run must honor the verdict the trail still shows outstanding"
+        );
+
+        // The same projection without the rehydration falls back to the
+        // pre-existing routing — this is what the recovery read prevents.
+        let mut unrehydrated = RefinementLoopState::with_config("p1", 4, test_config());
+        unrehydrated.phase = RefinementPhase::AdversaryAttack;
+        unrehydrated.current_round = 3;
+        unrehydrated.process_adversary_pass(&AdversaryPassResult {
+            objections: vec![],
+            explicit_dry: true,
+        });
+        assert_eq!(unrehydrated.phase, RefinementPhase::JudgeAdjudication);
+    }
+
+    /// The reroute must not cost extra agent spawns. `SpawnCap` *terminates* a
+    /// run; `RoundCap` *parks* it for human review. If a dry-with-verdict round
+    /// ever costs more than the round it replaces, `SpawnCap` preempts
+    /// `RoundCap` and a reviewable park silently becomes a dead run.
+    ///
+    /// The spawn count here is DERIVED from the phases the state machine
+    /// actually asks for — one agent per dispatchable phase — rather than a
+    /// schedule this test hard-codes. A change that visits an extra phase per
+    /// round therefore blows the budget and trips `record_spawn`, instead of
+    /// passing because the test's own model was updated to match.
+    #[test]
+    fn worst_case_dry_verdict_run_parks_on_the_round_cap_not_the_spawn_cap() {
+        let config = test_config();
+        let mut state = RefinementLoopState::with_config("p1", 0, config.clone());
+        let mut visited: Vec<RefinementPhase> = Vec::new();
+        let mut revision = 0;
+
+        // Worst case for this fix: the Judge rejects every round, and the
+        // Adversary is dry every round because the Judge resolved its
+        // objections. Bounded by the round cap; the guard below is the budget.
+        while !state.is_awaiting_human_review() && !state.is_complete() {
+            assert!(
+                visited.len() < 64,
+                "the loop must terminate through a cap, not run forever"
+            );
+            state
+                .record_spawn()
+                .unwrap_or_else(|reason| panic!("spawn budget exhausted at {reason:?}"));
+            visited.push(state.phase);
+            match state.phase {
+                RefinementPhase::AdversaryAttack => {
+                    state.process_adversary_pass(&AdversaryPassResult {
+                        objections: vec![],
+                        explicit_dry: true,
+                    });
+                }
+                RefinementPhase::AdvocateRevision => {
+                    revision += 1;
+                    state.record_advocate_revision(revision);
+                }
+                RefinementPhase::JudgeAdjudication => {
+                    state.record_judge_verdict(&JudgeVerdictResult {
+                        body: format!("needs-work: round {}", state.current_round),
+                        blocking: true,
+                    });
+                }
+                other => panic!("non-dispatchable phase reached the dispatch loop: {other:?}"),
             }
-            assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
-            for _ in 0..2 {
-                state
-                    .record_spawn()
-                    .expect("verdict-driven rounds stay inside the spawn budget");
-                spawns += 1;
-            }
-            revision += 1;
-            state.record_advocate_revision(revision);
         }
 
-        // The run parked on the ROUND cap, not the spawn cap, and never
-        // terminated.
+        // Parked for a human on the ROUND cap — not terminated on the spawn cap.
         assert_eq!(state.stop_reason, Some(StopReason::RoundCap));
         assert!(state.is_awaiting_human_review());
         assert!(!state.is_complete());
-        assert_eq!(state.current_round, test_config().max_rounds);
+        assert_eq!(state.current_round, config.max_rounds);
         assert!(
-            spawns <= test_config().max_total_spawns,
-            "worst-case verdict-driven run used {spawns} spawns, budget is {}",
-            test_config().max_total_spawns
+            visited.len() as i32 <= config.max_total_spawns,
+            "worst-case run asked for {} spawns, budget is {}: {visited:?}",
+            visited.len(),
+            config.max_total_spawns
+        );
+
+        // And the reroute actually happened: the Advocate ran on the dry rounds
+        // that owed the Judge a remedy (every round after the first).
+        let advocate_turns = visited
+            .iter()
+            .filter(|phase| **phase == RefinementPhase::AdvocateRevision)
+            .count();
+        assert_eq!(
+            advocate_turns,
+            (config.max_rounds - 1) as usize,
+            "every dry round after the first owes a verdict and must run the \
+             Advocate: {visited:?}"
         );
     }
 
@@ -928,10 +1082,14 @@ mod tests {
             blocking: true,
         });
         assert_eq!(state.current_round, 2);
-        assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
+        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
 
-        // Round 2 (== cap): advocate implements the verdict → judge blocking →
+        // Round 2 (== cap): adversary blocking → advocate → judge blocking →
         // escalate to human review (round cap reached).
+        state.process_adversary_pass(&AdversaryPassResult {
+            objections: vec![blocking_objection("Issue B")],
+            explicit_dry: false,
+        });
         state.record_advocate_revision(2);
         state.record_judge_verdict(&JudgeVerdictResult {
             body: "Still needs work.".into(),
@@ -948,8 +1106,7 @@ mod tests {
     fn repeated_blocking_objection_escalates_to_human_review() {
         let mut state = RefinementLoopState::with_config("p1", 0, test_config());
 
-        // Round 1: blocking objection → advocate revision → judge approves →
-        // parked for the human's single review.
+        // Round 1: blocking objection → advocate revision.
         let outcome = state.process_adversary_pass(&AdversaryPassResult {
             objections: vec![blocking_objection("Missing Problem Statement")],
             explicit_dry: false,
@@ -957,19 +1114,15 @@ mod tests {
         assert_eq!(outcome, AdversaryPassOutcome::Continue);
         state.record_advocate_revision(1);
         state.record_judge_verdict(&JudgeVerdictResult {
-            body: "Ready.".into(),
-            blocking: false,
+            body: "Not ready.".into(),
+            blocking: true,
         });
-        assert!(state.is_awaiting_human_review());
-
-        // The human rejects WITH feedback, which re-opens the tribunal at the
-        // Adversary — the path on which a second Adversary pass is reachable.
-        state.resolve_human_review(false, true);
-        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
         assert_eq!(state.current_round, 2);
+        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
 
         // Round 2: the same objection (different casing/whitespace) repeats →
-        // the tribunal is stuck, escalate to the human.
+        // the tribunal is stuck, escalate to the human. Reachable on every
+        // judge-rejected round because those rounds still open at the Adversary.
         let outcome = state.process_adversary_pass(&AdversaryPassResult {
             objections: vec![blocking_objection("missing  problem  statement")],
             explicit_dry: false,
@@ -1379,8 +1532,11 @@ mod tests {
         });
         assert_eq!(state.current_round, 2);
 
-        // Round 2 is verdict-driven: advocate → judge demands evidence.
-        assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
+        // Round 2: adversary → advocate → judge demands evidence.
+        state.process_adversary_pass(&AdversaryPassResult {
+            objections: vec![blocking_objection("Issue B")],
+            explicit_dry: false,
+        });
         state.record_advocate_revision(2);
         state.record_needs_evidence();
         assert_eq!(

--- a/server/crates/djinn-coordinator/src/refinement.rs
+++ b/server/crates/djinn-coordinator/src/refinement.rs
@@ -13,6 +13,9 @@
 //   4. Repeat until `dry_rounds_required` consecutive rounds with no new blocking
 //      objection ("dry rounds") — then invoke the Judge.
 //   5. Judge adjudicates (produces a verdict via debate trail).
+//   6. A blocking verdict re-opens the loop at the Advocate (step 1), because
+//      the verdict prescribes a body change and only the Advocate writes the
+//      body. See `RefinementLoopState::record_judge_verdict`.
 //
 // Guards:
 //   - Hard round cap (default 5).
@@ -61,11 +64,16 @@ pub fn role_for_phase(phase: RefinementPhase) -> RefinementRole {
 
 /// The current phase of the refinement loop.
 ///
-/// v2 tribunal order: each round runs `Adversary → Advocate → Judge`. The
+/// v2 tribunal order: the first round runs `Adversary → Advocate → Judge`. The
 /// Adversary opens (red-teams the current spec), the Advocate responds
 /// (revises to address objections), and the Judge rules whether to loop again
 /// or surface the result to the human. The human is NOT in the loop — they
 /// only review the converged result once, via `AwaitingHumanReview`.
+///
+/// A round re-opened by a **blocking judge verdict** starts at the Advocate
+/// instead (`Advocate → Judge`): the verdict itself is the work item, and only
+/// the Advocate can rewrite the body it prescribes changing. See
+/// [`RefinementLoopState::record_judge_verdict`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RefinementPhase {
     /// Waiting for the Adversary to red-team the current spec. (Round opener.)
@@ -427,8 +435,26 @@ impl RefinementLoopState {
     /// Record a judge verdict — the round's arbiter.
     /// - non-blocking ("ready") → the spec converged; park it for the human's
     ///   single accept/reject review;
-    /// - blocking ("not ready") → run another round (Adversary first), unless
-    ///   the round cap is hit, in which case escalate to the human.
+    /// - blocking ("not ready") → run another round *starting at the Advocate*,
+    ///   unless the round cap is hit, in which case escalate to the human.
+    ///
+    /// The next round opens at [`RefinementPhase::AdvocateRevision`], not at
+    /// [`RefinementPhase::AdversaryAttack`]. A blocking verdict is a prescribed
+    /// remedy ("name the narrower design", "this AC is untestable"), and the
+    /// Advocate is the only role that can rewrite the proposal body. Routing it
+    /// to the Adversary handed the remedy to a role that can only file
+    /// objections: once every Adversary objection was already resolved, the
+    /// Adversary had nothing left to raise, the round went dry, the Advocate was
+    /// never dispatched (a dry round skips it), and the verdict's prescription
+    /// could never be implemented — a permanent dead end that burned rounds
+    /// until the cap.
+    ///
+    /// The Advocate's revision is adjudicated by the Judge on the same round
+    /// (`record_advocate_revision` → `JudgeAdjudication`), so round accounting,
+    /// the round cap, dry accounting, and the `AwaitingHumanReview` park are all
+    /// unchanged. A verdict-driven round costs two spawns (Advocate + Judge)
+    /// versus the three of an Adversary-opened round, so `max_total_spawns`
+    /// still cannot preempt `RoundCap`.
     pub fn record_judge_verdict(&mut self, result: &JudgeVerdictResult) {
         if !result.blocking {
             self.phase = RefinementPhase::AwaitingHumanReview;
@@ -439,7 +465,7 @@ impl RefinementLoopState {
             return;
         }
         self.current_round += 1;
-        self.phase = RefinementPhase::AdversaryAttack;
+        self.phase = RefinementPhase::AdvocateRevision;
     }
 
     /// Record that the Judge demanded evidence for a load-bearing claim.
@@ -758,21 +784,129 @@ mod tests {
     }
 
     #[test]
-    fn judge_blocking_starts_next_adversary_round() {
+    fn judge_blocking_starts_next_round_at_the_advocate() {
         let mut state = RefinementLoopState::with_config("p1", 0, test_config());
         state.process_adversary_pass(&AdversaryPassResult {
             objections: vec![blocking_objection("Issue A")],
             explicit_dry: false,
         });
         state.record_advocate_revision(1);
-        // Judge still finds the spec lacking → next round, adversary first.
+        // Judge still finds the spec lacking → next round, ADVOCATE first: the
+        // verdict prescribes a body change and only the Advocate writes bodies.
         state.record_judge_verdict(&JudgeVerdictResult {
             body: "Still needs work.".into(),
             blocking: true,
         });
-        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
+        assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
         assert_eq!(state.current_round, 2);
         assert!(!state.is_complete());
+    }
+
+    /// The wedge this routing fixes. A blocking verdict arriving on a round
+    /// where the Adversary had ZERO unresolved objections used to route to
+    /// `AdversaryAttack`. The Adversary then had nothing left to raise, the
+    /// round went dry, `process_adversary_pass` skipped the Advocate and went
+    /// straight back to the Judge — so the verdict's prescribed remedy could
+    /// never be implemented by any role, forever.
+    ///
+    /// The blocking verdict must land in a phase where the body can actually be
+    /// revised.
+    #[test]
+    fn blocking_verdict_with_zero_unresolved_objections_reaches_a_body_writing_phase() {
+        let mut state = RefinementLoopState::with_config("p1", 0, test_config());
+
+        // Round 1: the Adversary is dry — every objection is already resolved.
+        let outcome = state.process_adversary_pass(&AdversaryPassResult {
+            objections: vec![],
+            explicit_dry: true,
+        });
+        assert_eq!(outcome, AdversaryPassOutcome::Dry);
+        assert_eq!(state.phase, RefinementPhase::JudgeAdjudication);
+
+        // The Judge rejects anyway and prescribes a concrete remedy.
+        state.record_judge_verdict(&JudgeVerdictResult {
+            body: "needs-work: AC 3 is untestable; replace it with a measurable \
+                   assertion on the emitted row count."
+                .into(),
+            blocking: true,
+        });
+
+        // The next phase must be able to rewrite the proposal body. Routing to
+        // the Adversary is the dead end: it can only file objections, and it
+        // has none to file.
+        assert_eq!(
+            state.phase,
+            RefinementPhase::AdvocateRevision,
+            "a blocking verdict must route to the only role that can revise the body"
+        );
+        assert_eq!(state.current_round, 2);
+        assert!(!state.is_complete());
+        assert!(!state.is_awaiting_human_review());
+        assert!(state.stop_reason.is_none());
+
+        // And the Advocate's revision is adjudicated, so the loop keeps moving
+        // rather than dead-ending on a second dry pass.
+        state.record_advocate_revision(1);
+        assert_eq!(state.phase, RefinementPhase::JudgeAdjudication);
+        assert_eq!(
+            state.current_round, 2,
+            "the advocate turn stays in its round"
+        );
+    }
+
+    /// A verdict-driven round must not cost more agent spawns than the
+    /// Adversary-opened round it replaces, or `SpawnCap` (which *terminates*
+    /// the run) would preempt `RoundCap` (which *parks* it for human review)
+    /// and silently convert a reviewable park into a dead run.
+    #[test]
+    fn verdict_driven_rounds_keep_round_cap_binding_before_spawn_cap() {
+        let mut state = RefinementLoopState::with_config("p1", 0, test_config());
+        let mut spawns = 0;
+
+        // Round 1 opens at the Adversary: adversary + advocate + judge.
+        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
+        for _ in 0..3 {
+            state.record_spawn().expect("round 1 fits the spawn budget");
+            spawns += 1;
+        }
+        state.process_adversary_pass(&AdversaryPassResult {
+            objections: vec![blocking_objection("Issue A")],
+            explicit_dry: false,
+        });
+        state.record_advocate_revision(1);
+
+        // Rounds 2..=max_rounds are verdict-driven: advocate + judge only.
+        let mut revision = 1;
+        loop {
+            state.record_judge_verdict(&JudgeVerdictResult {
+                body: format!("needs-work: round {}", state.current_round),
+                blocking: true,
+            });
+            if state.is_awaiting_human_review() {
+                break;
+            }
+            assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
+            for _ in 0..2 {
+                state
+                    .record_spawn()
+                    .expect("verdict-driven rounds stay inside the spawn budget");
+                spawns += 1;
+            }
+            revision += 1;
+            state.record_advocate_revision(revision);
+        }
+
+        // The run parked on the ROUND cap, not the spawn cap, and never
+        // terminated.
+        assert_eq!(state.stop_reason, Some(StopReason::RoundCap));
+        assert!(state.is_awaiting_human_review());
+        assert!(!state.is_complete());
+        assert_eq!(state.current_round, test_config().max_rounds);
+        assert!(
+            spawns <= test_config().max_total_spawns,
+            "worst-case verdict-driven run used {spawns} spawns, budget is {}",
+            test_config().max_total_spawns
+        );
     }
 
     #[test]
@@ -794,14 +928,10 @@ mod tests {
             blocking: true,
         });
         assert_eq!(state.current_round, 2);
-        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
+        assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
 
-        // Round 2 (== cap): adversary blocking → advocate → judge blocking →
+        // Round 2 (== cap): advocate implements the verdict → judge blocking →
         // escalate to human review (round cap reached).
-        state.process_adversary_pass(&AdversaryPassResult {
-            objections: vec![blocking_objection("Issue B")],
-            explicit_dry: false,
-        });
         state.record_advocate_revision(2);
         state.record_judge_verdict(&JudgeVerdictResult {
             body: "Still needs work.".into(),
@@ -818,7 +948,8 @@ mod tests {
     fn repeated_blocking_objection_escalates_to_human_review() {
         let mut state = RefinementLoopState::with_config("p1", 0, test_config());
 
-        // Round 1: blocking objection → advocate revision.
+        // Round 1: blocking objection → advocate revision → judge approves →
+        // parked for the human's single review.
         let outcome = state.process_adversary_pass(&AdversaryPassResult {
             objections: vec![blocking_objection("Missing Problem Statement")],
             explicit_dry: false,
@@ -826,9 +957,15 @@ mod tests {
         assert_eq!(outcome, AdversaryPassOutcome::Continue);
         state.record_advocate_revision(1);
         state.record_judge_verdict(&JudgeVerdictResult {
-            body: "Not ready.".into(),
-            blocking: true,
+            body: "Ready.".into(),
+            blocking: false,
         });
+        assert!(state.is_awaiting_human_review());
+
+        // The human rejects WITH feedback, which re-opens the tribunal at the
+        // Adversary — the path on which a second Adversary pass is reachable.
+        state.resolve_human_review(false, true);
+        assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
         assert_eq!(state.current_round, 2);
 
         // Round 2: the same objection (different casing/whitespace) repeats →
@@ -1242,11 +1379,8 @@ mod tests {
         });
         assert_eq!(state.current_round, 2);
 
-        // Round 2: adversary → advocate → judge demands evidence.
-        state.process_adversary_pass(&AdversaryPassResult {
-            objections: vec![blocking_objection("Issue B")],
-            explicit_dry: false,
-        });
+        // Round 2 is verdict-driven: advocate → judge demands evidence.
+        assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
         state.record_advocate_revision(2);
         state.record_needs_evidence();
         assert_eq!(

--- a/server/crates/djinn-coordinator/src/refinement.rs
+++ b/server/crates/djinn-coordinator/src/refinement.rs
@@ -726,12 +726,17 @@ pub fn build_verdict_debate_params<'a>(
 mod tests {
     use super::*;
 
+    /// Derived from the shipped defaults, not hardcoded: the spawn-budget test
+    /// below asserts a relationship between the round cap and the spawn cap, and
+    /// that assertion is only meaningful if it runs against the values
+    /// production actually uses. Hardcoding them would let a default change
+    /// silently break the `RoundCap`-before-`SpawnCap` guarantee.
     fn test_config() -> RefinementConfig {
         RefinementConfig {
-            max_rounds: 5,
-            dry_rounds_required: 2,
-            max_total_spawns: 16,
-            repeat_objection_threshold: 2,
+            max_rounds: DEFAULT_MAX_ROUNDS,
+            dry_rounds_required: DEFAULT_DRY_ROUNDS_REQUIRED,
+            max_total_spawns: DEFAULT_MAX_TOTAL_SPAWNS,
+            repeat_objection_threshold: DEFAULT_REPEAT_OBJECTION_THRESHOLD,
         }
     }
 
@@ -992,75 +997,112 @@ mod tests {
     /// ever costs more than the round it replaces, `SpawnCap` preempts
     /// `RoundCap` and a reviewable park silently becomes a dead run.
     ///
-    /// The spawn count here is DERIVED from the phases the state machine
-    /// actually asks for — one agent per dispatchable phase — rather than a
-    /// schedule this test hard-codes. A change that visits an extra phase per
-    /// round therefore blows the budget and trips `record_spawn`, instead of
-    /// passing because the test's own model was updated to match.
+    /// Both adversary behaviors are exercised, because they are NOT the same
+    /// cost and the binding one is the non-dry path:
+    ///
+    /// - always dry: round 1 is Adversary+Judge (nothing owed yet), rounds 2..N
+    ///   are Adversary+Advocate+Judge — `3N-1` spawns.
+    /// - always blocking: every round is Adversary+Advocate+Judge, the GLOBAL
+    ///   maximum at `3N`. Unchanged from `main`, since the reroute only ever
+    ///   fires on a dry pass.
+    ///
+    /// The spawn count is DERIVED from the phases the state machine actually
+    /// asks for — one agent per dispatchable phase — rather than a schedule this
+    /// test hard-codes. A change that visits an extra phase per round therefore
+    /// blows the budget and trips `record_spawn`, instead of passing because the
+    /// test's own model was updated to match.
     #[test]
-    fn worst_case_dry_verdict_run_parks_on_the_round_cap_not_the_spawn_cap() {
+    fn worst_case_verdict_runs_park_on_the_round_cap_not_the_spawn_cap() {
         let config = test_config();
-        let mut state = RefinementLoopState::with_config("p1", 0, config.clone());
-        let mut visited: Vec<RefinementPhase> = Vec::new();
-        let mut revision = 0;
 
-        // Worst case for this fix: the Judge rejects every round, and the
-        // Adversary is dry every round because the Judge resolved its
-        // objections. Bounded by the round cap; the guard below is the budget.
-        while !state.is_awaiting_human_review() && !state.is_complete() {
-            assert!(
-                visited.len() < 64,
-                "the loop must terminate through a cap, not run forever"
+        for adversary_is_dry in [true, false] {
+            let mut state = RefinementLoopState::with_config("p1", 0, config.clone());
+            let mut visited: Vec<RefinementPhase> = Vec::new();
+            let mut revision = 0;
+            let mut objection = 0;
+
+            // The Judge rejects every round, so the loop runs to the round cap.
+            while !state.is_awaiting_human_review() && !state.is_complete() {
+                assert!(
+                    visited.len() < 64,
+                    "the loop must terminate through a cap, not run forever"
+                );
+                state
+                    .record_spawn()
+                    .unwrap_or_else(|reason| panic!("spawn budget exhausted at {reason:?}"));
+                visited.push(state.phase);
+                match state.phase {
+                    RefinementPhase::AdversaryAttack => {
+                        // Distinct bodies: identical ones would trip
+                        // repeat-objection escalation and end the run early.
+                        objection += 1;
+                        state.process_adversary_pass(&AdversaryPassResult {
+                            objections: if adversary_is_dry {
+                                vec![]
+                            } else {
+                                vec![blocking_objection(&format!("distinct issue {objection}"))]
+                            },
+                            explicit_dry: adversary_is_dry,
+                        });
+                    }
+                    RefinementPhase::AdvocateRevision => {
+                        revision += 1;
+                        state.record_advocate_revision(revision);
+                    }
+                    RefinementPhase::JudgeAdjudication => {
+                        state.record_judge_verdict(&JudgeVerdictResult {
+                            body: format!("needs-work: round {}", state.current_round),
+                            blocking: true,
+                        });
+                    }
+                    other => panic!("non-dispatchable phase reached the dispatch loop: {other:?}"),
+                }
+            }
+
+            // Parked for a human on the ROUND cap — not terminated on the spawn
+            // cap.
+            assert_eq!(
+                state.stop_reason,
+                Some(StopReason::RoundCap),
+                "dry={adversary_is_dry}"
             );
-            state
-                .record_spawn()
-                .unwrap_or_else(|reason| panic!("spawn budget exhausted at {reason:?}"));
-            visited.push(state.phase);
-            match state.phase {
-                RefinementPhase::AdversaryAttack => {
-                    state.process_adversary_pass(&AdversaryPassResult {
-                        objections: vec![],
-                        explicit_dry: true,
-                    });
-                }
-                RefinementPhase::AdvocateRevision => {
-                    revision += 1;
-                    state.record_advocate_revision(revision);
-                }
-                RefinementPhase::JudgeAdjudication => {
-                    state.record_judge_verdict(&JudgeVerdictResult {
-                        body: format!("needs-work: round {}", state.current_round),
-                        blocking: true,
-                    });
-                }
-                other => panic!("non-dispatchable phase reached the dispatch loop: {other:?}"),
+            assert!(state.is_awaiting_human_review(), "dry={adversary_is_dry}");
+            assert!(!state.is_complete(), "dry={adversary_is_dry}");
+            assert_eq!(state.current_round, config.max_rounds);
+            assert!(
+                visited.len() as i32 <= config.max_total_spawns,
+                "dry={adversary_is_dry}: run asked for {} spawns, budget is {}: {visited:?}",
+                visited.len(),
+                config.max_total_spawns
+            );
+
+            let advocate_turns = visited
+                .iter()
+                .filter(|phase| **phase == RefinementPhase::AdvocateRevision)
+                .count();
+            if adversary_is_dry {
+                // The reroute actually happened: every dry round after the first
+                // owed the Judge a remedy and ran the Advocate.
+                assert_eq!(
+                    advocate_turns,
+                    (config.max_rounds - 1) as usize,
+                    "every dry round after the first must run the Advocate: {visited:?}"
+                );
+                assert_eq!(visited.len() as i32, 3 * config.max_rounds - 1);
+            } else {
+                // Unchanged from `main`: the Adversary's objections drive the
+                // Advocate, and the reroute never fires.
+                assert_eq!(
+                    advocate_turns, config.max_rounds as usize,
+                    "every blocking round runs the Advocate: {visited:?}"
+                );
+                assert_eq!(
+                    visited.len() as i32,
+                    3 * config.max_rounds,
+                    "the non-dry path is the global spawn maximum"
+                );
             }
         }
-
-        // Parked for a human on the ROUND cap — not terminated on the spawn cap.
-        assert_eq!(state.stop_reason, Some(StopReason::RoundCap));
-        assert!(state.is_awaiting_human_review());
-        assert!(!state.is_complete());
-        assert_eq!(state.current_round, config.max_rounds);
-        assert!(
-            visited.len() as i32 <= config.max_total_spawns,
-            "worst-case run asked for {} spawns, budget is {}: {visited:?}",
-            visited.len(),
-            config.max_total_spawns
-        );
-
-        // And the reroute actually happened: the Advocate ran on the dry rounds
-        // that owed the Judge a remedy (every round after the first).
-        let advocate_turns = visited
-            .iter()
-            .filter(|phase| **phase == RefinementPhase::AdvocateRevision)
-            .count();
-        assert_eq!(
-            advocate_turns,
-            (config.max_rounds - 1) as usize,
-            "every dry round after the first owes a verdict and must run the \
-             Advocate: {visited:?}"
-        );
     }
 
     #[test]

--- a/server/crates/djinn-coordinator/src/refinement_inflight.rs
+++ b/server/crates/djinn-coordinator/src/refinement_inflight.rs
@@ -43,6 +43,31 @@ fn local_phase(phase: DurablePhase) -> RefinementPhase {
 }
 
 impl CoordinatorActor {
+    /// Whether the proposal's latest judge verdict is blocking — the durable
+    /// witness behind `RefinementLoopState::pending_blocking_verdict`.
+    ///
+    /// Both projection-rebuild paths call this. Fails safe toward `false` (the
+    /// pre-existing routing) so a transient DB error cannot invent an Advocate
+    /// round that the debate trail does not justify.
+    pub(super) async fn outstanding_blocking_verdict(
+        proposal_repo: &djinn_db::ProposalRepository,
+        proposal_id: &str,
+    ) -> bool {
+        match proposal_repo.latest_judge_verdict(proposal_id).await {
+            Ok(Some(verdict)) => verdict.blocking,
+            Ok(None) => false,
+            Err(error) => {
+                tracing::warn!(
+                    proposal_id,
+                    %error,
+                    "Failed to read latest judge verdict while rebuilding a refinement \
+                     projection; treating the verdict as answered"
+                );
+                false
+            }
+        }
+    }
+
     /// Ensure the disposable projections name this materialized intent as the
     /// run's in-flight work, and report whether its role agent already started.
     ///
@@ -113,16 +138,23 @@ impl CoordinatorActor {
         // projection rebuilt alongside a fresh in-flight session must agree with
         // it, or the outcome correlation fence rejects every observation and the
         // run stalls exactly as it did before.
-        let captured_snapshot_seq = djinn_db::ProposalRepository::new(
+        let proposal_repo = djinn_db::ProposalRepository::new(
             self.db.clone(),
             crate::events::event_bus_for(&self.events_tx),
-        )
-        .refinement_run_captured_snapshot_seq(run_id)
-        .await
-        .unwrap_or_default();
+        );
+        let captured_snapshot_seq = proposal_repo
+            .refinement_run_captured_snapshot_seq(run_id)
+            .await
+            .unwrap_or_default();
+        // Same rehydration the startup recovery path performs: a projection
+        // rebuilt here (session not tracked) otherwise loses the outstanding
+        // needs-work verdict and re-strands it on the next dry Adversary pass.
+        let pending_blocking_verdict =
+            Self::outstanding_blocking_verdict(&proposal_repo, &proposal.id).await;
         let mut state = RefinementLoopState::new(&proposal.id, proposal.latest_revision_seq)
             .with_run_identity(run_id.to_owned(), generation)
             .with_recovered_snapshot_seq(captured_snapshot_seq)
+            .with_pending_blocking_verdict(pending_blocking_verdict)
             .with_attributed_user(proposal.refinement_owner_user_id.clone());
         state.phase = phase;
         state.current_round = round;

--- a/server/crates/djinn-coordinator/src/refinement_inflight.rs
+++ b/server/crates/djinn-coordinator/src/refinement_inflight.rs
@@ -43,29 +43,57 @@ fn local_phase(phase: DurablePhase) -> RefinementPhase {
 }
 
 impl CoordinatorActor {
-    /// Whether the proposal's latest judge verdict is blocking — the durable
+    /// Whether **this run's** latest judge verdict is blocking — the durable
     /// witness behind `RefinementLoopState::pending_blocking_verdict`.
     ///
-    /// Both projection-rebuild paths call this. Fails safe toward `false` (the
-    /// pre-existing routing) so a transient DB error cannot invent an Advocate
-    /// round that the debate trail does not justify.
+    /// Both projection-rebuild paths call this.
+    ///
+    /// Scoped to the current run via `entry_in_current_run`, the same boundary
+    /// `select_current_run_verdict` uses. `ProposalRepository::latest_judge_verdict`
+    /// is deliberately NOT used here: it is `WHERE proposal_id = $1 ORDER BY
+    /// created_at DESC LIMIT 1`, i.e. proposal-scoped, so a *previous* run's
+    /// needs-work verdict would win. A fresh run whose projection happened to be
+    /// rebuilt would then route its first dry Adversary pass to the Advocate and
+    /// implement a superseded run's remedy — and routing would depend on whether
+    /// a rebuild occurred, since `new()` seeds this `false`. That is incident
+    /// 019f0c29's failure mode (stale prior-run verdict authority), which is the
+    /// very class of defect this loop change exists to remove.
+    ///
+    /// Unlike `select_current_run_verdict` this is NOT round-scoped. At the only
+    /// point the flag is read — a dry pass while the phase is `AdversaryAttack`
+    /// at round N — the verdict that matters was written by the Judge closing
+    /// round N-1, so scoping to N would find nothing.
+    ///
+    /// Fails safe toward `false` (the pre-existing routing) on a read error, so
+    /// a transient DB fault cannot invent an Advocate round. When no
+    /// `refinement_start` boundary exists, `entry_in_current_run` admits every
+    /// entry — the same documented fallback the outcome path takes.
     pub(super) async fn outstanding_blocking_verdict(
+        &self,
         proposal_repo: &djinn_db::ProposalRepository,
         proposal_id: &str,
     ) -> bool {
-        match proposal_repo.latest_judge_verdict(proposal_id).await {
-            Ok(Some(verdict)) => verdict.blocking,
-            Ok(None) => false,
+        let run_start = self.latest_refinement_run_start(proposal_id).await;
+        let entries = match proposal_repo.debate_trail(proposal_id).await {
+            Ok(entries) => entries,
             Err(error) => {
                 tracing::warn!(
                     proposal_id,
                     %error,
-                    "Failed to read latest judge verdict while rebuilding a refinement \
+                    "Failed to read the debate trail while rebuilding a refinement \
                      projection; treating the verdict as answered"
                 );
-                false
+                return false;
             }
-        }
+        };
+        entries
+            .iter()
+            .filter(|entry| entry.kind == "verdict" && entry.agent_role == "judge")
+            .filter(|entry| {
+                super::refinement_outcome::entry_in_current_run(entry, run_start.as_deref())
+            })
+            .max_by(|a, b| a.created_at.cmp(&b.created_at))
+            .is_some_and(|verdict| verdict.blocking)
     }
 
     /// Ensure the disposable projections name this materialized intent as the
@@ -149,8 +177,9 @@ impl CoordinatorActor {
         // Same rehydration the startup recovery path performs: a projection
         // rebuilt here (session not tracked) otherwise loses the outstanding
         // needs-work verdict and re-strands it on the next dry Adversary pass.
-        let pending_blocking_verdict =
-            Self::outstanding_blocking_verdict(&proposal_repo, &proposal.id).await;
+        let pending_blocking_verdict = self
+            .outstanding_blocking_verdict(&proposal_repo, &proposal.id)
+            .await;
         let mut state = RefinementLoopState::new(&proposal.id, proposal.latest_revision_seq)
             .with_run_identity(run_id.to_owned(), generation)
             .with_recovered_snapshot_seq(captured_snapshot_seq)

--- a/server/crates/djinn-coordinator/src/refinement_outcome_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome_tests.rs
@@ -200,12 +200,14 @@ fn verdict_scoping_ignores_stale_prior_run_approve() {
     assert_eq!(selected.against_revision_seq, 3);
 
     // The state machine must run another round, not park for human review.
+    // A blocking verdict re-opens at the Advocate — the only role that can
+    // implement the remedy the verdict prescribes.
     let mut state = RefinementLoopState::with_config("p1", 3, test_config());
     state.record_judge_verdict(&JudgeVerdictResult {
         body: selected.body.clone(),
         blocking: selected.blocking,
     });
-    assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
+    assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
     assert!(!state.is_awaiting_human_review());
 }
 

--- a/server/crates/djinn-coordinator/src/refinement_outcome_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome_tests.rs
@@ -200,15 +200,16 @@ fn verdict_scoping_ignores_stale_prior_run_approve() {
     assert_eq!(selected.against_revision_seq, 3);
 
     // The state machine must run another round, not park for human review.
-    // A blocking verdict re-opens at the Advocate — the only role that can
-    // implement the remedy the verdict prescribes.
     let mut state = RefinementLoopState::with_config("p1", 3, test_config());
     state.record_judge_verdict(&JudgeVerdictResult {
         body: selected.body.clone(),
         blocking: selected.blocking,
     });
-    assert_eq!(state.phase, RefinementPhase::AdvocateRevision);
+    assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
     assert!(!state.is_awaiting_human_review());
+    // …and the round it re-opens carries the outstanding remedy, so a dry
+    // Adversary hands the round to the Advocate rather than stranding it.
+    assert!(state.pending_blocking_verdict);
 }
 
 /// Belt-and-braces: even with no `refinement_start` boundary recorded

--- a/server/crates/djinn-coordinator/src/refinement_recovery.rs
+++ b/server/crates/djinn-coordinator/src/refinement_recovery.rs
@@ -85,10 +85,10 @@ impl CoordinatorActor {
             // recovered while parked at `AdversaryAttack` after a needs-work
             // verdict would then send its next dry pass back to the Judge and
             // re-strand exactly the verdict the restart interrupted. The durable
-            // authority is the debate trail.
-            let pending_blocking_verdict =
-                CoordinatorActor::outstanding_blocking_verdict(&proposal_repo, &exact.proposal_id)
-                    .await;
+            // authority is the debate trail, scoped to THIS run.
+            let pending_blocking_verdict = self
+                .outstanding_blocking_verdict(&proposal_repo, &exact.proposal_id)
+                .await;
             let mut state =
                 RefinementLoopState::new(&exact.proposal_id, proposal.latest_revision_seq)
                     .with_run_identity(run.run_id.clone(), exact.generation)

--- a/server/crates/djinn-coordinator/src/refinement_recovery.rs
+++ b/server/crates/djinn-coordinator/src/refinement_recovery.rs
@@ -81,10 +81,19 @@ impl CoordinatorActor {
                 .refinement_run_captured_snapshot_seq(&run.run_id)
                 .await
                 .unwrap_or_default();
+            // Rebuilt projections seed `pending_blocking_verdict` false. A run
+            // recovered while parked at `AdversaryAttack` after a needs-work
+            // verdict would then send its next dry pass back to the Judge and
+            // re-strand exactly the verdict the restart interrupted. The durable
+            // authority is the debate trail.
+            let pending_blocking_verdict =
+                CoordinatorActor::outstanding_blocking_verdict(&proposal_repo, &exact.proposal_id)
+                    .await;
             let mut state =
                 RefinementLoopState::new(&exact.proposal_id, proposal.latest_revision_seq)
                     .with_run_identity(run.run_id.clone(), exact.generation)
                     .with_recovered_snapshot_seq(captured_snapshot_seq)
+                    .with_pending_blocking_verdict(pending_blocking_verdict)
                     .with_attributed_user(proposal.refinement_owner_user_id.clone());
 
             if let Some(park) = exact.snapshot.park.as_ref() {

--- a/server/crates/djinn-coordinator/src/refinement_recovery_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_recovery_tests.rs
@@ -776,3 +776,186 @@ async fn recovery_hydrates_both_parks_and_omits_terminal_exact_runs() {
         assert!(!actor.active_refinements.contains_key(&run_id));
     }
 }
+
+// ── Outstanding-verdict rehydration (end-to-end through recovery) ───────────
+//
+// `RefinementLoopState::new` seeds `pending_blocking_verdict` false, so a
+// projection rebuilt from the ledger loses the fact that the Judge left a
+// remedy owed. The next dry Adversary pass would then bounce an unchanged spec
+// back to the Judge — re-stranding exactly the verdict the restart interrupted.
+// These tests exercise the real `recover_interrupted_refinements` wiring, not
+// the `with_pending_blocking_verdict` setter.
+
+/// Write a judge verdict onto the proposal's debate trail.
+async fn append_judge_verdict(
+    repo: &ProposalRepository,
+    proposal_id: &str,
+    blocking: bool,
+    round: i32,
+    body: &str,
+) {
+    repo.add_debate_trail_entry(djinn_db::ProposalDebateTrailCreateInput {
+        proposal_id,
+        kind: "verdict",
+        body,
+        blocking,
+        agent_role: "judge",
+        author_kind: "agent",
+        author_model: Some("test-judge"),
+        source_task_id: None,
+        against_revision_seq: 1,
+        round,
+        body_metadata: None,
+    })
+    .await
+    .expect("append judge verdict");
+}
+
+/// `created_at` is millisecond-precision and the run boundary comparison is a
+/// strict `>`, so two writes in the same millisecond are not ordered. Separate
+/// them.
+async fn advance_wall_clock() {
+    tokio::time::sleep(std::time::Duration::from_millis(15)).await;
+}
+
+/// A run recovered after a needs-work verdict must rehydrate the outstanding
+/// remedy, so its next dry Adversary pass reaches the Advocate.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_rehydrates_an_outstanding_verdict_and_reroutes_the_next_dry_pass() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(16);
+    let mut actor = build_refinement_actor(&db, &events_tx, spawn_test_pool(&db, 1));
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+
+    // The run starts, then the Judge rejects — both inside this run.
+    repo.record_refinement_lifecycle(&fixture.proposal_id, "refinement_start", None)
+        .await
+        .expect("record refinement start boundary");
+    advance_wall_clock().await;
+    let (run_id, _generation, _) = admit(&repo, &fixture.proposal_id, "verdict-rehydrate").await;
+    append_judge_verdict(
+        &repo,
+        &fixture.proposal_id,
+        true,
+        1,
+        "needs-work: AC 2 is untestable; assert on the emitted row count",
+    )
+    .await;
+
+    // The coordinator restarts and rebuilds the projection from the ledger.
+    actor.recover_interrupted_refinements().await;
+    let state = actor
+        .active_refinements
+        .get(&run_id)
+        .expect("exact run projection");
+    assert_eq!(state.phase, RefinementPhase::AdversaryAttack);
+    assert!(
+        state.pending_blocking_verdict,
+        "recovery must rehydrate the outstanding needs-work verdict from the trail"
+    );
+
+    // The behavior that flag exists for: a dry pass reaches the Advocate.
+    let mut resumed = state.clone();
+    resumed.process_adversary_pass(&crate::refinement::AdversaryPassResult {
+        objections: vec![],
+        explicit_dry: true,
+    });
+    assert_eq!(
+        resumed.phase,
+        RefinementPhase::AdvocateRevision,
+        "a recovered run must still implement the verdict the restart interrupted"
+    );
+}
+
+/// A verdict written before this run's `refinement_start` belongs to a PREVIOUS
+/// run and must not reroute anything.
+///
+/// `ProposalRepository::latest_judge_verdict` is proposal-scoped
+/// (`WHERE proposal_id = $1 ORDER BY created_at DESC LIMIT 1`), so using it here
+/// would let a superseded run's remedy drive a fresh run's routing — incident
+/// 019f0c29's failure mode, and the same class of stale-verdict-authority defect
+/// this loop change exists to remove.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_ignores_a_prior_runs_blocking_verdict() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(16);
+    let mut actor = build_refinement_actor(&db, &events_tx, spawn_test_pool(&db, 1));
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+
+    // Previous run: rejected, then abandoned.
+    repo.record_refinement_lifecycle(&fixture.proposal_id, "refinement_start", None)
+        .await
+        .expect("record prior run start");
+    advance_wall_clock().await;
+    append_judge_verdict(
+        &repo,
+        &fixture.proposal_id,
+        true,
+        3,
+        "needs-work: stale remedy from the abandoned run",
+    )
+    .await;
+    advance_wall_clock().await;
+
+    // A FRESH run starts after that verdict.
+    repo.record_refinement_lifecycle(&fixture.proposal_id, "refinement_start", None)
+        .await
+        .expect("record fresh run start");
+    advance_wall_clock().await;
+    let (run_id, _generation, _) = admit(&repo, &fixture.proposal_id, "fresh-after-stale").await;
+
+    actor.recover_interrupted_refinements().await;
+    let state = actor
+        .active_refinements
+        .get(&run_id)
+        .expect("exact run projection");
+    assert!(
+        !state.pending_blocking_verdict,
+        "a prior run's verdict must not carry into a fresh run"
+    );
+
+    // And the routing consequence: the dry pass goes to the Judge, exactly as it
+    // would without any rebuild. Rebuilding must not change routing.
+    let mut resumed = state.clone();
+    resumed.process_adversary_pass(&crate::refinement::AdversaryPassResult {
+        objections: vec![],
+        explicit_dry: true,
+    });
+    assert_eq!(
+        resumed.phase,
+        RefinementPhase::JudgeAdjudication,
+        "a fresh run must not implement a superseded run's remedy"
+    );
+}
+
+/// A ready verdict inside the current run leaves nothing owed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_does_not_rehydrate_an_answered_verdict() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(16);
+    let mut actor = build_refinement_actor(&db, &events_tx, spawn_test_pool(&db, 1));
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+
+    repo.record_refinement_lifecycle(&fixture.proposal_id, "refinement_start", None)
+        .await
+        .expect("record refinement start boundary");
+    advance_wall_clock().await;
+    let (run_id, _generation, _) = admit(&repo, &fixture.proposal_id, "answered-verdict").await;
+    append_judge_verdict(&repo, &fixture.proposal_id, true, 1, "needs-work: round 1").await;
+    advance_wall_clock().await;
+    // The Judge later rules ready — the LATEST verdict wins, not the first.
+    append_judge_verdict(&repo, &fixture.proposal_id, false, 2, "ready").await;
+
+    actor.recover_interrupted_refinements().await;
+    let state = actor
+        .active_refinements
+        .get(&run_id)
+        .expect("exact run projection");
+    assert!(
+        !state.pending_blocking_verdict,
+        "a later ready verdict supersedes the earlier needs-work"
+    );
+}

--- a/server/crates/djinn-roles/src/prompts/adversary.md
+++ b/server/crates/djinn-roles/src/prompts/adversary.md
@@ -8,7 +8,7 @@ You are dispatched after the Advocate delivers a revision. Your responsibilities
 2. **Demand visual, reviewable specs** — proposals are reviewed by humans, so visual clarity is a core requirement, not a nicety. File a **blocking** objection when the spec is shallow prose that should be structured MDX: no mockups, diagrams, file-structure / file-map blocks, or real MDX code blocks where they would materially aid review (e.g. an architecture, a data model, a file layout, a flow, an API shape). Plain triple-backtick fences or a wall of prose where a structured block belongs is a gap. The resolution criterion is concrete: name which section needs which kind of MDX block. Do not block a spec that is already appropriately visual.
 3. **Attack over-engineering, not just gaps** — a spec can fail by doing too much as well as too little. File a **blocking** objection when the design's scope is disproportionate to the problem it solves: mechanism added for threats no current caller/provider/input can produce, blast radius (crates touched, APIs widened, atomic-landing surface) out of scale with the defect's severity, or permanent maintenance artifacts (audit fixtures, migration scaffolding) policing hazards the design itself introduces. The resolution criterion must name the narrower design that would still resolve the standing objections — "make it smaller" without a concrete alternative is not falsifiable. Compare the current revision against revision 1: locally-justified additions that compound into an unjustified whole are exactly what each single round cannot see, and catching that ratchet is your job.
 4. **Produce non-blocking objections** — flag improvements, nice-to-haves, or minor clarity issues that do not block graduation but would improve spec quality.
-5. **Avoid repeat objections** — if a prior objection was addressed by the Advocate's revision, do not re-raise it unless the fix is incomplete or introduces a new issue. Unresolved objections left by an earlier interrupted run are carried into round 1 automatically by the loop, so do not re-file them either. If a prior objection was **rebutted** by the Advocate and the Judge dismissed it, do not re-raise it without new evidence that defeats the rebuttal.
+5. **Avoid repeat objections** — if a prior **objection** was addressed by the Advocate's revision, do not re-raise it unless the fix is incomplete or introduces a new issue. Unresolved objections left by an earlier interrupted run are carried into round 1 automatically by the loop, so do not re-file them either. If a prior objection was **rebutted** by the Advocate and the Judge dismissed it, do not re-raise it without new evidence that defeats the rebuttal. This rule is about **your own prior objections** — it does not apply to requirements the Judge introduced (see *Judge verdicts are not your dedup list*).
 6. **Signal dry status** — when you have no new blocking objections, explicitly state that the Adversary is dry for this round.
 
 You do NOT revise the proposal yourself. You do NOT adjudicate whether objections stand — that is the Judge's role. You only produce challenges.
@@ -28,6 +28,15 @@ Before you file any objection via `proposal_debate_append`, it must pass every c
 Djinn writes code and opens pull requests. That is the whole of its model. Whether a pull request is approved, by whom, and when it merges is **enforced by the forge and its configured owners**, and is outside the agent's world entirely. Do not file an objection that a proposal lacks authorization, sign-off, separation of duties, approver or reviewer identity, delegated or signed authority, CODEOWNERS mapping, a named organizational role, or an escalation owner/deadline. A spec that omits those is complete, not incomplete — demanding them is a category error, not a blocking objection.
 
 A proposal may note in a **runbook** that a human must approve something before it lands. That note is not an acceptance criterion, and no worker may be asked to build, validate, or simulate the approval workflow behind it. If a real technical risk is what prompted the impulse — an irreversible deletion, a missing rollback path, an unmeasured loss — object to *that*, and name the repository-checkable evidence that would resolve it.
+
+### Judge verdicts are not your dedup list
+
+The dedup rule above is scoped to **objections** — entries you (or a prior Adversary) filed. A `kind="verdict"` entry is a different thing: it is a requirement the **Judge** introduced, and it is never marked resolved (no role sets `resolved_at` on a verdict row). Two consequences:
+
+1. **An unresolved needs-work verdict is not a "resolved objection" and not an "already filed" objection.** Never suppress a real, falsifiable finding on the grounds that the Judge already said something similar. The Judge's channel is the verdict; yours is the objection; they are read by different roles at different points in the loop.
+2. **If the latest verdict is `blocking=true` and the current revision still does not satisfy what it prescribed, that gap is yours to file** — as a normal objection, through the Pre-Report Gate like any other, citing the exact spec text and naming the resolution criterion. A verdict the Advocate did not implement is exactly the kind of concrete, falsifiable defect you exist to catch.
+
+What you must still not do is manufacture an objection that merely paraphrases the verdict when the Advocate *did* implement it. Evaluate the revision in front of you.
 
 ### Fight your generosity in both directions
 
@@ -62,7 +71,7 @@ Each objection's `body` must include:
 
 You CAN:
 - Read the proposal specification via `proposal_show` and related read tools.
-- Read the full debate trail via `proposal_debate_list` — **do this first.** It shows every objection, rebuttal, and verdict from all prior rounds so you do NOT re-raise an objection already filed or already resolved by the Advocate.
+- Read the full debate trail via `proposal_debate_list` — **do this first.** It shows every objection, rebuttal, and verdict from all prior rounds. Use the **`kind="objection"`** entries as your dedup filter: do NOT re-raise an objection already filed or already resolved. The **`kind="verdict"`** entries are not a dedup filter — see *Judge verdicts are not your dedup list* below.
 - Read memory notes for context on prior decisions and patterns.
 - File objections via `proposal_debate_append` (one call per objection).
 - Add task comments for narration (optional; not read by the loop).

--- a/server/crates/djinn-roles/src/prompts/adversary.md
+++ b/server/crates/djinn-roles/src/prompts/adversary.md
@@ -89,7 +89,7 @@ You MUST NOT:
 - You evaluate the Advocate's latest revision against the current proposal state.
 - If you find blocking issues, file each as a `proposal_debate_append` objection with `blocking=true`.
 - If you have **no new blocking objections**, you are **dry**: file zero objections this round (this signals the Judge that the proposal may be ready). Optionally file `blocking=false` non-blocking objections.
-- The loop terminates when you produce no new blocking objections for N=2 consecutive rounds.
+- A dry round does NOT end the tribunal. The Judge closes every round and decides: approve (done) or needs-work (another round runs). Your dry signal means "I have nothing to add to this revision", not "ship it".
 - You may produce objections across multiple rounds; each round's objections are tracked separately by the `round` you pass.
 
 ## Session Completion

--- a/server/crates/djinn-roles/src/prompts/adversary.md
+++ b/server/crates/djinn-roles/src/prompts/adversary.md
@@ -44,7 +44,7 @@ Do not talk yourself out of a real blocker because the proposal has potential. D
 
 ## How to file objections — READ THIS CAREFULLY
 
-You file objections by calling **`proposal_debate_append`**, once per objection. **This is the only channel the refinement loop reads.** Objections you write in `submit_review` (or in task comments, or in prose) are **ignored** by the loop — if you put them only there, the round looks "dry", the Advocate is never run, and your work is thrown away. So: **every objection is a `proposal_debate_append` call.**
+You file objections by calling **`proposal_debate_append`**, once per objection. **This is the only channel the refinement loop reads.** Objections you write in `submit_review` (or in task comments, or in prose) are **ignored** by the loop — if you put them only there, the round is scored as "dry" and your work is thrown away: the Advocate never sees the objection, and the Judge is told you had nothing to raise. So: **every objection is a `proposal_debate_append` call.**
 
 For each objection, call:
 

--- a/server/crates/djinn-roles/src/prompts/advocate.md
+++ b/server/crates/djinn-roles/src/prompts/advocate.md
@@ -20,7 +20,7 @@ You do NOT adjudicate disputes between objections — you may argue one side via
 - **`blocking=false` ("ready")** — the Judge approved. Nothing is owed.
 - **`blocking=true` ("needs-work")** — the Judge rejected the current revision and its body names what is wrong and, per the Judge's own contract, **the concrete remedy** (the narrower design to evaluate, the acceptance criterion that fails, the missing coverage, why a rebuttal you filed was not accepted). That remedy is a **first-class work item for you, ranked alongside every open blocking objection.** You are the only role that can rewrite the proposal body, so if you do not implement it, nobody will.
 
-**A round can be verdict-only.** When the Judge rejects, the loop dispatches you next — and by that point the Judge has usually already resolved every objection the Adversary filed. So `proposal_debate_list` may show **zero unresolved objections and still an outstanding needs-work verdict**. That is not a dry round and it is not an error: the verdict *is* the round's work. Never end such a session with "nothing to do" — implement the verdict's remedy and revise.
+**A round can be verdict-only.** When the Judge rejects, the next round re-runs the Adversary against the current revision — and by that point the Judge has usually already resolved every objection the Adversary filed, so the Adversary often has nothing left to raise. You are dispatched anyway, precisely so the verdict gets implemented. So `proposal_debate_list` may show **zero unresolved objections and still an outstanding needs-work verdict**. That is not an error and it is not a no-op round: the verdict *is* the round's work. Never end such a session with "nothing to do" — implement the verdict's remedy and revise.
 
 Verdict entries are **never marked resolved** — no role sets `resolved_at` on a `kind="verdict"` row, and you must not try. A needs-work verdict is superseded by the Judge's *next* verdict on your new revision, not by resolution. So do not treat an unresolved verdict as evidence that it is still open from some earlier round: **only the latest verdict counts.** Ignore superseded ones.
 
@@ -84,7 +84,7 @@ Each round, in order:
 5. `proposal_debate_append(kind="rebuttal", ...)` — rebut the items you contest, with evidence.
 6. `submit_work` to end the session, stating which objections and which verdict points you fixed, and which you rebutted.
 
-After your revision the Judge adjudicates again — it weighs rebuttals against their objections, resolves what your revision satisfies or your rebuttal defeats, and rules ready when none remain. A needs-work verdict sends the round back to you; a ready verdict parks the proposal for the human's single review. The Adversary opens the tribunal and re-opens it whenever a human rejects with feedback.
+After your revision the Judge adjudicates — it weighs rebuttals against their objections, resolves what your revision satisfies or your rebuttal defeats, and rules ready when none remain. A ready verdict parks the proposal for the human's single review. A needs-work verdict starts another round: the Adversary re-attacks your revision, then you run again — to answer whatever new objections it raised, and to implement the remedy the verdict named.
 
 ## Visual Enrichment
 

--- a/server/crates/djinn-roles/src/prompts/advocate.md
+++ b/server/crates/djinn-roles/src/prompts/advocate.md
@@ -6,15 +6,29 @@ You are dispatched as part of the proposal refinement loop. Your responsibilitie
 
 1. **Draft and revise proposal specs** — produce clear, complete, and testable acceptance criteria that downstream epics and tasks can consume without ambiguity.
 2. **Address adversary objections** — when the Adversary produces blocking or non-blocking objections, you either revise the proposal to resolve them, or **rebut them with evidence** (see *Rebut, don't appease* below). Acknowledge non-blocking ones with rationale.
-3. **Defend the minimal design** — you are the tribunal's counterweight against scope ratchet. Every objection has two legitimate resolutions: change the spec, or prove the objection wrong/disproportionate. Before you grow the design to satisfy an objection, check whether the narrower path resolves it: a protocol invariant, existing code behavior, a bounded failure mode, or a cheaper fix inside the current design. A revision that resolves objections by accumulating mechanism the problem does not need is a *worse* spec, and the Judge is instructed to reject it as needs-work.
-4. **Author a visually rich spec** — proposals are reviewed by humans, so the spec must be easy to scan: use the `visual-spec` native skill and enrich the body with structured MDX (mockups, diagrams, file-structure/file-map blocks, real MDX code blocks) so reviewers see the design, not a wall of prose. A shallow, non-visual spec is a quality gap the Adversary will object to. This is **default behavior, not a deterministic DoR gate** — prose grounding remains sufficient for the deterministic readiness floor, but the tribunal expects MDX richness.
-5. **Keep the body pure spec** — the proposal body is the design a reader needs, not a changelog. Authorship (role, round, human author) is recorded automatically in the revision metadata, so you never write it into the body.
+3. **Implement the Judge's needs-work verdict** — a blocking (`needs-work`) verdict is a work item you own, exactly like a blocking objection. See *The judge's verdict is your work item* below. You may be dispatched for a round where the verdict is the ONLY thing to act on and every objection is already resolved; that round is not a no-op.
+4. **Defend the minimal design** — you are the tribunal's counterweight against scope ratchet. Every objection has two legitimate resolutions: change the spec, or prove the objection wrong/disproportionate. Before you grow the design to satisfy an objection, check whether the narrower path resolves it: a protocol invariant, existing code behavior, a bounded failure mode, or a cheaper fix inside the current design. A revision that resolves objections by accumulating mechanism the problem does not need is a *worse* spec, and the Judge is instructed to reject it as needs-work.
+5. **Author a visually rich spec** — proposals are reviewed by humans, so the spec must be easy to scan: use the `visual-spec` native skill and enrich the body with structured MDX (mockups, diagrams, file-structure/file-map blocks, real MDX code blocks) so reviewers see the design, not a wall of prose. A shallow, non-visual spec is a quality gap the Adversary will object to. This is **default behavior, not a deterministic DoR gate** — prose grounding remains sufficient for the deterministic readiness floor, but the tribunal expects MDX richness.
+6. **Keep the body pure spec** — the proposal body is the design a reader needs, not a changelog. Authorship (role, round, human author) is recorded automatically in the revision metadata, so you never write it into the body.
 
 You do NOT adjudicate disputes between objections — you may argue one side via a rebuttal, but the Judge decides. You do NOT produce objections yourself — that is the Adversary's role.
 
+## The judge's verdict is your work item
+
+`proposal_debate_list` returns three kinds of entry: `objection` (from the Adversary), `rebuttal` (from you), and **`verdict` (from the Judge)**. Do not read it as an objection list. Read the whole trail, and find the **latest `kind="verdict"` entry**.
+
+- **`blocking=false` ("ready")** — the Judge approved. Nothing is owed.
+- **`blocking=true` ("needs-work")** — the Judge rejected the current revision and its body names what is wrong and, per the Judge's own contract, **the concrete remedy** (the narrower design to evaluate, the acceptance criterion that fails, the missing coverage, why a rebuttal you filed was not accepted). That remedy is a **first-class work item for you, ranked alongside every open blocking objection.** You are the only role that can rewrite the proposal body, so if you do not implement it, nobody will.
+
+**A round can be verdict-only.** When the Judge rejects, the loop dispatches you next — and by that point the Judge has usually already resolved every objection the Adversary filed. So `proposal_debate_list` may show **zero unresolved objections and still an outstanding needs-work verdict**. That is not a dry round and it is not an error: the verdict *is* the round's work. Never end such a session with "nothing to do" — implement the verdict's remedy and revise.
+
+Verdict entries are **never marked resolved** — no role sets `resolved_at` on a `kind="verdict"` row, and you must not try. A needs-work verdict is superseded by the Judge's *next* verdict on your new revision, not by resolution. So do not treat an unresolved verdict as evidence that it is still open from some earlier round: **only the latest verdict counts.** Ignore superseded ones.
+
+If you believe the verdict is wrong or disproportionate, you have exactly one channel: file a `kind="rebuttal"` entry with evidence, same as for an objection (see *Rebut, don't appease*), and say so in `submit_work`. You may **not** file a verdict of your own, and you may **not** resolve one.
+
 ## Rebut, don't appease
 
-When you believe a blocking objection is **wrong, already answered, or disproportionate to the defect**, do not silently absorb it into the design. File a rebuttal on the debate trail:
+When you believe a blocking objection **or a needs-work verdict** is **wrong, already answered, or disproportionate to the defect**, do not silently absorb it into the design. File a rebuttal on the debate trail:
 
 ```
 proposal_debate_append(
@@ -29,7 +43,7 @@ proposal_debate_append(
 ```
 
 Each rebuttal's `body` must include:
-- **Rebuts**: the `id` of the objection being rebutted (from `proposal_debate_list`).
+- **Rebuts**: the `id` of the objection **or verdict** being rebutted (from `proposal_debate_list`).
 - **Claim**: what the objection gets wrong — a factual error, a violated-in-theory-only invariant, or a cost/benefit disproportion (the mitigation's blast radius exceeds the defect's severity).
 - **Evidence**: concrete grounding — protocol/spec contracts, existing code behavior (file paths, function names), observed data, or a bounded worst-case analysis. An unevidenced rebuttal is appeasement with extra steps; the Judge will side with the objection.
 - **Proposed disposition**: what should happen instead — dismiss the objection, downgrade it to non-blocking, or resolve it with a named narrower change.
@@ -44,8 +58,8 @@ Rules:
 ## Your Authority
 
 You CAN:
-- Read the adversary's objections via `proposal_debate_list` — **do this first.** Each objection has an `id`, a `body`, and `blocking`/`resolved` flags. The objections are NOT in your task description — read them with this tool.
-- **Rebut an objection** via `proposal_debate_append(kind="rebuttal", ...)` when you have evidence it is wrong or disproportionate — see *Rebut, don't appease* above.
+- Read the **full debate trail** via `proposal_debate_list` — **do this first.** It returns the Adversary's `objection` entries, your own `rebuttal` entries, AND the Judge's `verdict` entries, each with an `id`, a `body`, and `blocking`/`resolved` flags. None of it is in your task description — read it with this tool. Extract two things: every **open blocking objection**, and the **latest `kind="verdict"` entry** (see *The judge's verdict is your work item* above).
+- **Rebut an objection or a needs-work verdict** via `proposal_debate_append(kind="rebuttal", ...)` when you have evidence it is wrong or disproportionate — see *Rebut, don't appease* above.
 - **Revise the proposal BODY** via `proposal_update` — this is your primary action. Most objections ask for content in the spec *body* (e.g. explicit Problem / Scope / Objectives / Dependencies / Risks sections, a file-map/code-path grounding block). `proposal_update(body=...)` is the only way to add them; setting acceptance criteria alone does NOT satisfy a body-coverage objection.
 - Set structured acceptance criteria via `proposal_ac_set`.
 - **Keep the title in sync** via `proposal_update(title=...)` — if your body revisions move the spec away from its title (common when a proposal was seeded by merging or stub-captured ideas, so it still wears a placeholder like "Merged: A + B + C"), rewrite the title to a crisp, accurate name. The title is yours to own; nothing else in the tribunal sets it.
@@ -63,13 +77,14 @@ You MUST NOT:
 ## Workflow Contract
 
 Each round, in order:
-1. `proposal_show` + `proposal_debate_list` — read the current spec and every open objection.
-2. For each **blocking** objection, decide: fix or rebut. When an objection offers alternative resolution paths (many do — "specify X, **or** provide evidence that Y"), take the cheapest path that genuinely resolves it; growing the design is the last resort, not the default.
-3. `proposal_update` (and `proposal_ac_set`) — revise the spec to genuinely fix the objections you accept. Address the body content the objection asks for; AC alone does not satisfy a body-coverage objection.
-4. `proposal_debate_append(kind="rebuttal", ...)` — rebut the objections you contest, with evidence.
-5. `submit_work` to end the session, stating which objections you fixed and which you rebutted.
+1. `proposal_show` + `proposal_debate_list` — read the current spec, every open objection, **and the latest judge verdict**.
+2. Build one work list from both sources: every **open blocking objection**, plus the remedy prescribed by the **latest verdict if it is `blocking=true`**. If that list is empty, the round is genuinely a no-op; if it contains only the verdict, the round is still real work.
+3. For each item, decide: fix or rebut. When an objection or verdict offers alternative resolution paths (many do — "specify X, **or** provide evidence that Y"), take the cheapest path that genuinely resolves it; growing the design is the last resort, not the default.
+4. `proposal_update` (and `proposal_ac_set`) — revise the spec to genuinely fix the items you accept. Address the body content the item asks for; AC alone does not satisfy a body-coverage objection.
+5. `proposal_debate_append(kind="rebuttal", ...)` — rebut the items you contest, with evidence.
+6. `submit_work` to end the session, stating which objections and which verdict points you fixed, and which you rebutted.
 
-After your revision, the Adversary re-evaluates and the Judge adjudicates — the Judge weighs rebuttals against their objections, resolves what your revision satisfies or your rebuttal defeats, and rules ready when none remain. The loop continues until the Adversary produces no new blocking objections for N=2 consecutive rounds.
+After your revision the Judge adjudicates again — it weighs rebuttals against their objections, resolves what your revision satisfies or your rebuttal defeats, and rules ready when none remain. A needs-work verdict sends the round back to you; a ready verdict parks the proposal for the human's single review. The Adversary opens the tribunal and re-opens it whenever a human rejects with feedback.
 
 ## Visual Enrichment
 

--- a/server/crates/djinn-roles/src/prompts/judge.md
+++ b/server/crates/djinn-roles/src/prompts/judge.md
@@ -1,8 +1,14 @@
 ## Mission: Proposal Judge (Independent Adjudicator)
 
-You are the **Judge** — the independent adjudicator within the tribunal refinement workflow. Your job is to **evaluate the proposal specification after the Adversary is dry** and render a final readiness verdict.
+You are the **Judge** — the independent adjudicator within the tribunal refinement workflow. Your job is to **evaluate the current proposal specification** and render a readiness verdict.
 
-You are dispatched ONLY after the Adversary produces no new blocking objections for N=2 consecutive rounds. You do NOT participate in the revision loop — you adjudicate after it converges.
+You close **every** round. The loop runs `Adversary → Advocate → Judge`, and you rule at the end of each one — on the Advocate's newest revision when it revised, or on the unchanged spec when the Adversary was dry and owed nothing. You are not a one-shot reviewer that runs after the loop converges: **you are the thing that decides whether it converges.** Expect to see the same proposal several times, each time with your own previous verdict in the trail.
+
+Your verdict is the loop's steering signal:
+- **Approve** → the tribunal is done; the spec parks for the human's single review.
+- **Reject (needs-work)** → another round runs. The Adversary re-attacks the current revision; if it has nothing left to raise, the round goes to the **Advocate**, which reads your verdict and implements the remedy you named.
+
+That second path is why a needs-work verdict body **must name a concrete, implementable remedy**. It is not commentary for the audit log — it is the work order the Advocate executes, and on a dry round it is the *only* instruction that round has. A verdict that says "still not ready" without naming what to change gives the Advocate nothing to do and burns a round.
 
 ## Your Responsibilities
 
@@ -38,7 +44,7 @@ Use when:
 - Every acceptance criterion passes the **Definition of Done** below.
 - The design passes the **Minimality** check in the Definition of Done — scope proportionate to the problem, no mechanism for unreal threats, no self-created hazards.
 - No new blocking issues are apparent from your independent review.
-- The Adversary has been dry for the required consecutive rounds.
+- The Adversary was dry this round (it raised no new blocking objection against the current revision).
 - Any injected `Current DoR status` is the clean/pass message: `Proposal currently meets all DoR checks.`
 
 ### 2. Reject / needs-work (not ready)
@@ -203,12 +209,12 @@ You MUST NOT:
 
 ## Workflow Contract
 
-- You receive the current proposal state, the full debate trail (all objections and revisions), and the Adversary's dry signal.
+- You close every round. You receive the current proposal state, the full debate trail (all objections, rebuttals, revisions, and your own prior verdicts), and whether the Adversary was dry.
 - Your decision is one of three outcomes:
   - **Approve** (`proposal_debate_append(kind="verdict", blocking=false)`) → advances to human review.
   - **Reject** (`proposal_debate_append(kind="verdict", blocking=true)`) → sends it back for another round (bounded by the round cap).
   - **Demand evidence** (`proposal_refinement_demand_evidence(...)`) → parks refinement until the evidence spike produces findings.
-- If you reject, the refinement loop runs another round (bounded by the round cap).
+- If you reject, the refinement loop runs another round (bounded by the round cap): the Adversary attacks the current revision, and the Advocate revises — either to answer new objections, or, on a dry round, to implement the remedy your verdict named. Your verdict is the only work order that round has, so name the remedy concretely.
 - If you demand evidence and the demand is accepted, the loop parks in `AwaitingEvidence` — no further rounds until findings arrive.
 
 ## Session Completion

--- a/server/crates/djinn-roles/src/prompts/tests.rs
+++ b/server/crates/djinn-roles/src/prompts/tests.rs
@@ -1026,6 +1026,100 @@ fn adversary_prompt_contains_objection_contract() {
     );
 }
 
+/// A blocking judge verdict now routes to the Advocate (it is the only role
+/// that rewrites the proposal body). The Advocate's prompt must therefore tell
+/// it to read judge verdicts and treat a needs-work verdict's prescribed remedy
+/// as a work item — the prompt previously framed `proposal_debate_list` purely
+/// as an objection list and mentioned "verdict" only to forbid writing one, so
+/// a verdict-only round read as "nothing to do".
+#[test]
+fn advocate_prompt_treats_a_needs_work_verdict_as_a_work_item() {
+    let task = make_task();
+    let ctx = make_ctx();
+    let prompt = render_prompt(AgentType::Advocate, &task, &ctx);
+
+    assert!(
+        prompt.contains("kind=\"verdict\"") || prompt.contains("`verdict`"),
+        "advocate prompt must name the verdict entry kind it has to read"
+    );
+    assert!(
+        prompt.contains("needs-work"),
+        "advocate prompt must name the needs-work verdict it has to act on"
+    );
+    assert!(
+        prompt.contains("latest"),
+        "advocate prompt must tell the Advocate to take the LATEST verdict \
+         (verdicts are never marked resolved, so an unresolved old one is not a signal)"
+    );
+    // A verdict-only round — zero unresolved objections, one outstanding
+    // needs-work verdict — is exactly the state that used to dead-end.
+    assert!(
+        prompt.contains("zero unresolved objections"),
+        "advocate prompt must state that a round can carry only a verdict"
+    );
+    // The write path the Advocate must use must still be named.
+    assert!(
+        prompt.contains("proposal_update"),
+        "advocate prompt must name the body-revision tool"
+    );
+    // The existing authority boundary must survive: rebuttal-only appends, and
+    // no verdicts or resolutions from the Advocate.
+    assert!(
+        prompt.contains("kind=\"rebuttal\"") && prompt.contains("ONLY kind you may append"),
+        "advocate prompt must keep the rebuttal-only append rule"
+    );
+    assert!(
+        prompt.contains("Never file objections or verdicts"),
+        "advocate prompt must keep the never-file-verdicts rule"
+    );
+    assert!(
+        !prompt.contains("{{"),
+        "advocate prompt should have no unresolved placeholders"
+    );
+}
+
+/// The Adversary's dedup guidance must stay scoped to its *own* prior
+/// objections. Framing judge verdicts as part of the dedup filter ("so you do
+/// NOT re-raise an objection already filed or already resolved") suppressed
+/// judge-originated requirements: the Adversary read the verdict as something
+/// already handled and filed nothing, the round went dry, and the Advocate was
+/// never dispatched.
+#[test]
+fn adversary_prompt_scopes_dedup_to_objections_not_judge_verdicts() {
+    let task = make_task();
+    let ctx = make_ctx();
+    let prompt = render_prompt(AgentType::Adversary, &task, &ctx);
+
+    // Dedup survives.
+    assert!(
+        prompt.contains("re-raise an objection already filed"),
+        "adversary prompt must keep the objection dedup rule"
+    );
+    // But it is explicitly scoped away from verdicts.
+    assert!(
+        prompt.contains("Judge verdicts are not your dedup list"),
+        "adversary prompt must carry the verdict-dedup carve-out"
+    );
+    assert!(
+        prompt.contains("never marked resolved"),
+        "adversary prompt must explain why an unresolved verdict is not a dedup signal"
+    );
+    assert!(
+        prompt.contains("verdict the Advocate did not implement"),
+        "adversary prompt must license filing an objection for an unimplemented verdict"
+    );
+    // The anti-filler rule must survive so the carve-out is not read as a
+    // license to paraphrase the verdict into a manufactured objection.
+    assert!(
+        prompt.contains("manufactured blockers are worse than a dry round"),
+        "adversary prompt must keep the anti-filler rule"
+    );
+    assert!(
+        !prompt.contains("{{"),
+        "adversary prompt should have no unresolved placeholders"
+    );
+}
+
 /// Human approval, authorization and organizational structure are categorically
 /// outside the agent's model: djinn writes code and opens PRs, and approval and
 /// merge are enforced by the forge and its configured owners. Without this rule

--- a/server/crates/djinn-roles/src/prompts/tests.rs
+++ b/server/crates/djinn-roles/src/prompts/tests.rs
@@ -1120,6 +1120,54 @@ fn adversary_prompt_scopes_dedup_to_objections_not_judge_verdicts() {
     );
 }
 
+/// The Judge closes every round — `record_advocate_revision` has always routed
+/// straight to `JudgeAdjudication` — but `judge.md` claimed it was dispatched
+/// "ONLY after the Adversary produces no new blocking objections for N=2
+/// consecutive rounds" and did "NOT participate in the revision loop". Both were
+/// false, and `dry_rounds_required` is not enforced anywhere in the tree, so no
+/// prompt may restate that as a live contract. The Judge must also know its
+/// needs-work verdict is the Advocate's work order on a dry round.
+#[test]
+fn tribunal_prompts_do_not_restate_the_unenforced_dry_round_contract() {
+    let ctx = make_ctx();
+    let task = make_task();
+
+    for agent in [AgentType::Judge, AgentType::Adversary, AgentType::Advocate] {
+        let prompt = render_prompt(agent, &task, &ctx);
+        assert!(
+            !prompt.contains("N=2"),
+            "{} prompt must not restate the unenforced dry-round contract",
+            agent.as_str()
+        );
+        assert!(
+            !prompt.contains("consecutive rounds"),
+            "{} prompt must not restate the unenforced dry-round contract",
+            agent.as_str()
+        );
+    }
+
+    let judge = render_prompt(AgentType::Judge, &task, &ctx);
+    assert!(
+        !judge.contains("do NOT participate in the revision loop")
+            && !judge.contains("dispatched ONLY after"),
+        "judge prompt must not claim it sits outside the revision loop"
+    );
+    assert!(
+        judge.contains("close **every** round") || judge.contains("You close every round"),
+        "judge prompt must state that it rules at the end of every round"
+    );
+    // The needs-work verdict is the Advocate's only instruction on a dry round,
+    // so the Judge has to be told to make it concrete.
+    assert!(
+        judge.contains("work order"),
+        "judge prompt must frame a needs-work verdict as the Advocate's work order"
+    );
+    assert!(
+        !judge.contains("{{"),
+        "judge prompt should have no unresolved placeholders"
+    );
+}
+
 /// Human approval, authorization and organizational structure are categorically
 /// outside the agent's model: djinn writes code and opens PRs, and approval and
 /// merge are enforced by the forge and its configured owners. Without this rule


### PR DESCRIPTION
Fixes three coupled defects that left a judge's needs-work verdict with no path to ever being acted on. Proposal `nafu` sat wedged from 2026-08-04 15:25 until it was hand-patched today: 15/15 objections resolved, 8 verdicts, none actionable.

## The defects

**1. A blocking verdict routed to the role that cannot act on it.** `record_judge_verdict` set `phase = AdversaryAttack`; the Advocate is the only role that rewrites the body. Combined with `process_adversary_pass` routing a dry pass straight to `JudgeAdjudication`, a judge-prescribed remedy with no matching objection could never be implemented — the round went dry and the Advocate never ran.

**2. Neither role was told to act on verdicts.** `advocate.md` framed `proposal_debate_list` purely as objections and mentioned verdicts only to say *don't write one*. `adversary.md` framed them as a dedup filter, actively discouraging carrying a judge-originated requirement forward.

**3. The verdict edit-locked the body it demanded changing.** `proposal_update` resolved status via `p.status.unwrap_or(&existing.status)`, so an already-`in_review` proposal ran the composed gate on **every** edit — and gate step 2c blocks on a needs-work verdict. Defects 1 and 3 compound: fixing routing alone dispatches the Advocate into a wedge.

## The fix — Option A

`record_judge_verdict` keeps routing to `AdversaryAttack`. The change is in the **dry branch** of `process_adversary_pass`: when `pending_blocking_verdict` is set, a dry pass goes to `AdvocateRevision` instead of bouncing an unchanged spec to the Judge.

Round order stays `Adversary → Advocate → Judge` every round, so every round's revision is red-teamed and `detect_repeated_signature` stays reachable. **Spawn cost is unchanged from `main`:** all-dry `3N-1` = 14, all-blocking `3N` = 15, against a budget of 16 — `RoundCap` still binds before `SpawnCap`. No cap bump, no durable enum variant, no migration.

A first attempt routed the verdict directly to `AdvocateRevision`, which removed the Adversary from every post-verdict round; an independent audit rejected it. That mattered because the spawn-budget argument for it was false — the 19-spawn figure was an artifact of one implementation, not a property of keeping the Adversary.

`pending_blocking_verdict` is set on a blocking verdict, cleared on a ready verdict and on `record_advocate_revision`, and rehydrated in both projection-rebuild paths (`refinement_recovery.rs`, `refinement_inflight.rs`), failing safe to `false`.

## Two defects found by audit and fixed here

**The rehydration wiring was completely untested.** Hardcoding both call sites to `false` left the suite byte-identical to baseline — both production call sites were free to delete. The only test named for it hand-built state with `.with_pending_blocking_verdict(true)`, testing the setter, not the recovery. Three tests now drive the real `recover_interrupted_refinements` path; the same mutation now yields 1 failure.

**The read was not run-scoped.** `latest_judge_verdict(proposal_id)` is proposal-wide, so a prior run's blocking verdict could reroute a fresh run's round 1 into implementing a superseded remedy — and made routing non-deterministic, since `new()` seeds `false` and only a rebuild consulted the DB. Now scoped via `entry_in_current_run` with `run_start` from `latest_refinement_run_start`. Note `select_current_run_verdict` could not be reused: it is *round*-scoped, and the verdict that matters on round N was written closing round N-1.

**Known caveat:** when no `refinement_start` lifecycle row exists, `entry_in_current_run` admits everything. This matches the documented fallback the outcome path already takes rather than inventing a stricter rule, but run-scoping does depend on that row. `admit_refinement_run` does not write it; `proposal_refinement_start` does.

## Gate change

`entering_in_review = status == "in_review" && existing.status != "in_review"`. `evaluate_composed_gate` is a pure read, so this drops checks, not side effects. On an in-place `in_review` edit it no longer runs: candidate DoR structure checks, the unresolved-blocking-debate-entry check, needs-evidence spike parking, and the verdict check. **Signoff, graduation, creation, and re-entry all still run the full gate**, and spec integrity is independently enforced by `insert_revision_checked` → `SPEC_LINT_REJECTED`. `proposal_import`'s equivalent branch is retired — its UPDATE path writes `status: &existing.status`, so no transition existed to gate.

## Prompts

`advocate.md` gains a *The judge's verdict is your work item* section and the verdict-only round. `adversary.md` scopes dedup to `kind="objection"`. `judge.md` rewritten around closing every round. The false `N=2 consecutive dry rounds` claim is removed from both, guarded by a test — because `dry_rounds_required` is **dead config**: `consecutive_dry_rounds` is incremented and reset but never compared to it, so that contract has never been enforced. One dry pass invokes the Judge.

## Not fixed here

Two pre-existing bugs, recorded as a memory note rather than repaired in this PR:
- `dry_rounds_required` dead config (above).
- `resolve_human_review` never resets `total_spawns`, so a run that spent its budget and is then rejected-with-feedback trips `SpawnCap` → `terminate()` → a dead run where the human asked for another pass. Note `SpawnCap` terminates while `RoundCap` parks for review — that asymmetry turns a budget overrun into a silent death.

Also recorded: the Advocate's dispatched task description carries no signal derived from `pending_blocking_verdict`. The state machine knows a remedy is owed; it never tells the agent. Left as a design question.

## Verification

3285 passed / 0 failed across `djinn-coordinator`, `djinn-control-plane`, `djinn-roles`. fmt, clippy `--all-targets`, and `scripts/check_boundaries.py` clean.

Independently audited on a separate checkout. Every fix verified by mutation: reverting the dry reroute fails 3 tests; reverting the gate condition fails 2 with the exact production error; re-inserting the `N=2` claim fails the prompt test; hardcoding rehydration to `false` fails 1; reverting run-scoping fails 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
