### PR TITLE
nafu W1: durable CI route attempts, subject-scoped keys, and pre-call recovery

### DIFF
--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -7829,6 +7829,24 @@ async fn evidence_reap_is_live_lookup_error_counts_as_crashed_unproven() {
     let sj: serde_json::Value = serde_json::from_str(row.summary_json.as_deref().unwrap()).unwrap();
     assert_eq!(sj["failure_class"], "orphaned_pending_attempt_unproven");
     assert_eq!(sj["owner_classification"], "lookup_error");
+
+    // `lookup_error` alone does NOT identify which of the two reads failed:
+    // `classify_orphan_owner` emits it for a failed `get()` and for a failed
+    // `is_live()`. The two are distinguishable only by their evidence — the
+    // `get()` branch builds `OwnerLeaseEvidence { ..Default::default() }` and
+    // therefore carries no lease timestamps, while the `is_live()` branch
+    // copies them off the resolved row.
+    //
+    // Asserting the timestamps is what makes this test discriminate. Without
+    // it, anything that breaks the FIRST read — a column added to
+    // `coordinator_incarnations` and forgotten in the fixture view, say — keeps
+    // this assertion green while the branch under test goes unexecuted.
+    assert_eq!(
+        sj["owner_lease_registered_at"], inc.registered_at,
+        "the get() read must have SUCCEEDED; a lookup_error without lease \
+         timestamps means the first read failed and this test proved nothing"
+    );
+    assert_eq!(sj["owner_lease_last_renewed_at"], inc.last_renewed_at);
 }
 
 /// A non-NULL dispatch group is terminalized through the exact-group repository

--- a/server/crates/djinn-db/migrations_postgres/191_ci_route_attempts.sql
+++ b/server/crates/djinn-db/migrations_postgres/191_ci_route_attempts.sql
@@ -1,0 +1,310 @@
+-- Migration 191: durable CI evidence-route attempts, monotonic retry budgets,
+-- calling-recovery audit, and coordinator provider-action drain proof.
+--
+-- Proposal `nafu` wave 1 ("Route CI failures through bounded retries and
+-- evidence-led remedies"). This migration is deliberately ADDITIVE ONLY: it
+-- creates three new relations and adds two nullable columns to
+-- `coordinator_incarnations`. No existing row is rewritten and no existing
+-- column changes shape, so a binary that predates the feature keeps running
+-- against this schema with the tables simply empty (the "migration only, old
+-- binary" row of the proposal's mixed-version matrix).
+--
+-- The three invariants this schema exists to enforce, in the database rather
+-- than in a coordinator that can crash between statements:
+--
+--  1. AT MOST ONE PROVIDER-CALL EPISODE PER EVIDENCE IDENTITY.
+--     `ci_route_attempts.provider_action_key` is UNIQUE and is the primary
+--     key. It is a caller-computed hash of the immutable evidence identity
+--     (lane + PR number + PR-head SHA + run id + run head SHA + dequeue
+--     identity) plus the action. Duplicate polls and restarts collide on it.
+--
+--  2. MONOTONIC RETRY BUDGETS. `ci_route_budget_counters.charged_count` has a
+--     CHECK that keeps it non-negative and the repository never issues a
+--     decrement: once an attempt reaches `calling` its signature and head
+--     slots are spent regardless of what the provider answered or whether the
+--     process survived to hear it. There is deliberately no refund path and no
+--     reversible accounting column.
+--
+--  3. AT MOST ONE TIER-2 (Lead) ADJUDICATION PER CURRENT EVIDENCE.
+--     A PARTIAL UNIQUE INDEX on `tier2_lease_key` restricted to `open` leases
+--     makes concurrent openers mutually exclusive; a resolved lease releases
+--     the key so a genuinely newer evidence identity can adjudicate later.
+--
+-- The `reserved` -> `calling` -> terminal phase column carries the fourth
+-- invariant, the one the whole pre-call recovery contract rests on: a
+-- `reserved` row is repository-local proof that NO process ever acquired call
+-- ownership, therefore no provider mutation happened. Recovery of such a row
+-- resumes it, supersedes it, or exhausts it -- there is no abandonment state,
+-- which is why no `abandoned` value appears in the terminal vocabulary below.
+
+CREATE TABLE ci_route_attempts (
+    -- ---- identity ---------------------------------------------------------
+    -- Caller-computed hash over the immutable evidence identity plus action.
+    -- Primary key: the unique constraint IS the idempotency mechanism.
+    provider_action_key     VARCHAR(128) NOT NULL,
+
+    -- Immutable evidence identity, stored in expanded form so a recovery
+    -- sweep can compare it against a freshly observed identity without having
+    -- to recompute the caller's hash function.
+    lane                    VARCHAR(16)  NOT NULL,
+    pr_number               BIGINT       NOT NULL,
+    pr_head_sha             VARCHAR(64)  NOT NULL,
+    run_id                  BIGINT       NOT NULL,
+    run_head_sha            VARCHAR(64)  NOT NULL,
+    dequeue_id              VARCHAR(128) NULL,
+
+    -- Board linkage. `task_id` is what makes "sessions per merged PR by lane"
+    -- reportable; `origin_state` is the board state the route was opened from
+    -- and the state a Lead-driven `PrCiFailed` must transition out of.
+    task_id                 VARCHAR(36)  NOT NULL,
+    origin_state            VARCHAR(32)  NOT NULL,
+
+    -- ---- classification ---------------------------------------------------
+    class                   VARCHAR(32)  NOT NULL,
+    action                  VARCHAR(32)  NOT NULL,
+    transient_fingerprint   VARCHAR(128) NOT NULL,
+
+    -- Aggregate budget identity. Deliberately a SEPARATE column from
+    -- `provider_action_key`: the budget key excludes run and dequeue ids so
+    -- equivalent later evidence shares one budget, while the action key
+    -- includes them so a distinct later run gets its own call episode.
+    retry_budget_key        VARCHAR(128) NOT NULL,
+    head_budget_key         VARCHAR(128) NOT NULL,
+
+    -- ---- action phase -----------------------------------------------------
+    -- 'reserved'  : row committed, provider mutation FORBIDDEN.
+    -- 'calling'   : exactly one winner owns the provider-call episode.
+    -- 'terminal'  : `terminal_outcome` is set and is never rewritten.
+    action_phase            VARCHAR(16)  NOT NULL DEFAULT 'reserved',
+    terminal_outcome        VARCHAR(32)  NULL,
+
+    reserved_at             TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    calling_at              TIMESTAMPTZ  NULL,
+    terminalized_at         TIMESTAMPTZ  NULL,
+
+    -- The coordinator incarnation that won the `reserved` -> `calling`
+    -- compare-and-set. Only two writers may ever touch it: that CAS (from
+    -- NULL) and the owner-handoff CAS in `recover_calling_owner`, which
+    -- requires the exact former owner and writes an audit row.
+    owner_incarnation_id    VARCHAR(36)  NULL,
+
+    -- How many pre-call recoveries ran against this row. Purely diagnostic:
+    -- the charge is governed by the phase CAS, not by this counter, so N
+    -- recoveries still produce exactly one charge.
+    pre_call_resumptions    BIGINT       NOT NULL DEFAULT 0,
+
+    -- Charged slot counts observed at the moment of the charge. Written once,
+    -- with the phase CAS.
+    charged_signature_count BIGINT       NULL,
+    charged_head_count      BIGINT       NULL,
+    -- Set when a still-current `reserved` row could no longer be charged.
+    retry_exhausted_at      TIMESTAMPTZ  NULL,
+
+    -- ---- Tier 2 ----------------------------------------------------------
+    -- `tier2_lease_key` is the current-evidence scope (lane + PR + PR-head
+    -- SHA): at most one Lead adjudication may be open for a PR head at a
+    -- time, which is the "head-level hold" the proposal's retry-storm
+    -- safeguard names.
+    tier2_lease_id          VARCHAR(36)  NULL,
+    tier2_lease_key         VARCHAR(128) NULL,
+    tier2_lease_state       VARCHAR(16)  NULL,
+    tier2_lease_reason      VARCHAR(32)  NULL,
+    tier2_leased_at         TIMESTAMPTZ  NULL,
+    tier2_resolved_at       TIMESTAMPTZ  NULL,
+    tier2_resolution        VARCHAR(32)  NULL,
+    lead_session_id         VARCHAR(36)  NULL,
+
+    -- ---- Lead result detail ----------------------------------------------
+    reopen_mode             VARCHAR(16)  NULL,
+    diagnostic_reason       VARCHAR(32)  NULL,
+    park_justification      TEXT         NULL,
+
+    -- ---- provider outcome / supersession evidence ------------------------
+    provider_error          JSONB        NULL,
+    -- The observed current identity (or newer passing/merged snapshot) that
+    -- DEFEATED a compare-and-set. Recorded so a supersession is auditable
+    -- without ever making the obsolete evidence authoritative.
+    superseded_by_evidence  JSONB        NULL,
+
+    created_at              TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT ci_route_attempts_pkey PRIMARY KEY (provider_action_key),
+    CONSTRAINT ci_route_attempts_task_fkey
+        FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+
+    CONSTRAINT ci_route_attempts_lane_check
+        CHECK (lane IN ('pr_head', 'merge_group')),
+    CONSTRAINT ci_route_attempts_origin_state_check
+        CHECK (origin_state IN ('pr_draft', 'pr_review')),
+    CONSTRAINT ci_route_attempts_class_check
+        CHECK (class IN ('inconclusive', 'causal_failure', 'unknown')),
+    CONSTRAINT ci_route_attempts_action_check
+        CHECK (action IN ('rerun_run', 'reenqueue', 'ask_lead', 'hold', 'discard')),
+    CONSTRAINT ci_route_attempts_phase_check
+        CHECK (action_phase IN ('reserved', 'calling', 'terminal')),
+
+    -- The closed terminal vocabulary. Note what is NOT here: there is no
+    -- `abandoned` outcome, because a row proven not to have called the
+    -- provider is resumed, superseded, or exhausted -- never dropped.
+    CONSTRAINT ci_route_attempts_terminal_outcome_check
+        CHECK (terminal_outcome IS NULL OR terminal_outcome IN (
+            'superseded_pre_call',
+            'retriggered',
+            'reenqueued',
+            'superseded_after_call',
+            'outcome_unknown',
+            'action_failed',
+            'held',
+            'superseded_before_lead',
+            'superseded_before_apply',
+            'repair_reopened',
+            'diagnostic_reopened',
+            'parked',
+            'superseded',
+            'passed',
+            'merged'
+        )),
+    -- A terminal phase and a terminal outcome are the same fact stated twice;
+    -- they may never disagree.
+    CONSTRAINT ci_route_attempts_terminal_agreement_check
+        CHECK ((action_phase = 'terminal') = (terminal_outcome IS NOT NULL)),
+    -- `calling` and every phase after it must name the owner that got there.
+    CONSTRAINT ci_route_attempts_calling_owner_check
+        CHECK (action_phase <> 'calling' OR (owner_incarnation_id IS NOT NULL AND calling_at IS NOT NULL)),
+    CONSTRAINT ci_route_attempts_charged_pairing_check
+        CHECK ((charged_signature_count IS NULL) = (charged_head_count IS NULL)),
+    CONSTRAINT ci_route_attempts_charged_nonneg_check
+        CHECK (charged_signature_count IS NULL OR charged_signature_count > 0),
+    CONSTRAINT ci_route_attempts_head_charge_nonneg_check
+        CHECK (charged_head_count IS NULL OR charged_head_count > 0),
+    CONSTRAINT ci_route_attempts_resumptions_check
+        CHECK (pre_call_resumptions >= 0),
+    CONSTRAINT ci_route_attempts_tier2_state_check
+        CHECK (tier2_lease_state IS NULL OR tier2_lease_state IN ('open', 'resolved')),
+    CONSTRAINT ci_route_attempts_tier2_pairing_check
+        CHECK ((tier2_lease_state IS NULL)
+               = (tier2_lease_id IS NULL AND tier2_lease_key IS NULL AND tier2_leased_at IS NULL)),
+    CONSTRAINT ci_route_attempts_tier2_reason_check
+        CHECK (tier2_lease_reason IS NULL OR tier2_lease_reason IN (
+            'causal_failure',
+            'evidence_unknown',
+            'provider_action_failed',
+            'outcome_unknown',
+            'retry_exhausted'
+        )),
+    CONSTRAINT ci_route_attempts_reopen_mode_check
+        CHECK (reopen_mode IS NULL OR reopen_mode IN ('repair', 'diagnose')),
+    CONSTRAINT ci_route_attempts_diagnostic_reason_check
+        CHECK (diagnostic_reason IS NULL OR diagnostic_reason IN (
+            'evidence_incomplete',
+            'provider_action_failed',
+            'no_grounded_remedy',
+            'no_repository_command'
+        )),
+    -- A diagnostic reason belongs only to a diagnose-mode reopen.
+    CONSTRAINT ci_route_attempts_diagnostic_pairing_check
+        CHECK (diagnostic_reason IS NULL OR reopen_mode = 'diagnose')
+);
+
+-- The current-evidence Tier-2 hold. PARTIAL so that only OPEN leases are
+-- mutually exclusive: once Lead's result has been applied the key is free for
+-- a genuinely newer evidence identity.
+CREATE UNIQUE INDEX ci_route_attempts_open_tier2_lease_uniq
+    ON ci_route_attempts(tier2_lease_key)
+    WHERE tier2_lease_state = 'open';
+
+-- Recovery sweeps scan by phase; reporting scans by lane/PR identity.
+CREATE INDEX ci_route_attempts_phase_idx
+    ON ci_route_attempts(action_phase)
+    WHERE action_phase <> 'terminal';
+CREATE INDEX ci_route_attempts_lane_identity_idx
+    ON ci_route_attempts(lane, pr_number, pr_head_sha);
+CREATE INDEX ci_route_attempts_task_idx
+    ON ci_route_attempts(task_id);
+CREATE INDEX ci_route_attempts_owner_idx
+    ON ci_route_attempts(owner_incarnation_id)
+    WHERE owner_incarnation_id IS NOT NULL;
+
+-- Monotonic charge ledger. Two scopes share one relation because they share
+-- one rule: increment only.
+--
+--   scope='signature' -> key = lane + PR + PR-head SHA + transient fingerprint
+--   scope='head'      -> key = PR + PR-head SHA, shared ACROSS both lanes
+--
+-- The ceilings (2 and 4) live in the repository, not in a CHECK, because
+-- "budget exhausted" is a routing decision that sends the evidence to Lead --
+-- it is not a corrupt row. A CHECK here would turn a normal, expected
+-- exhaustion into a transaction abort.
+CREATE TABLE ci_route_budget_counters (
+    scope            VARCHAR(16)  NOT NULL,
+    counter_key      VARCHAR(128) NOT NULL,
+    charged_count    BIGINT       NOT NULL DEFAULT 0,
+    first_charged_at TIMESTAMPTZ  NULL,
+    last_charged_at  TIMESTAMPTZ  NULL,
+
+    CONSTRAINT ci_route_budget_counters_pkey PRIMARY KEY (scope, counter_key),
+    CONSTRAINT ci_route_budget_counters_scope_check
+        CHECK (scope IN ('signature', 'head')),
+    CONSTRAINT ci_route_budget_counters_nonneg_check
+        CHECK (charged_count >= 0)
+);
+
+-- Append-only audit of every `calling`-row owner handoff ATTEMPT, including
+-- the ones that legally did nothing. The deferrals are the point: a periodic
+-- sweep that correctly left a live owner alone has to be observable, or
+-- "we never steal a live owner's row" is an unfalsifiable claim.
+CREATE TABLE ci_route_calling_recoveries (
+    id                        VARCHAR(36)  NOT NULL,
+    provider_action_key       VARCHAR(128) NOT NULL,
+    former_owner_incarnation  VARCHAR(36)  NULL,
+    recovering_incarnation    VARCHAR(36)  NOT NULL,
+    -- Attested by the caller: it holds the exclusive coordinator advisory
+    -- lock for this exact incarnation.
+    holds_exclusive_lock      BOOLEAN      NOT NULL,
+    -- How the former owner's provider futures were proven gone. Elapsed time
+    -- is NOT one of the options, by design.
+    quiescence_proof          VARCHAR(32)  NOT NULL,
+    recovery_reason           VARCHAR(32)  NOT NULL,
+    calling_recovery_timeout_secs BIGINT   NOT NULL,
+    observed_calling_at       TIMESTAMPTZ  NULL,
+    -- Whether the compare-and-set actually took the row.
+    cas_won                   BOOLEAN      NOT NULL,
+    resulting_outcome         VARCHAR(32)  NULL,
+    recorded_at               TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    CONSTRAINT ci_route_calling_recoveries_pkey PRIMARY KEY (id),
+    CONSTRAINT ci_route_calling_recoveries_attempt_fkey
+        FOREIGN KEY (provider_action_key)
+        REFERENCES ci_route_attempts(provider_action_key) ON DELETE CASCADE,
+    CONSTRAINT ci_route_calling_recoveries_quiescence_check
+        CHECK (quiescence_proof IN ('graceful_drain', 'process_terminated', 'none')),
+    CONSTRAINT ci_route_calling_recoveries_reason_check
+        CHECK (recovery_reason IN (
+            'startup_owner_handoff',
+            'live_owner_deferred',
+            'not_calling',
+            'owner_mismatch',
+            'timeout_not_elapsed',
+            'lock_not_held',
+            'cas_lost'
+        )),
+    CONSTRAINT ci_route_calling_recoveries_timeout_check
+        CHECK (calling_recovery_timeout_secs > 0)
+);
+
+CREATE INDEX ci_route_calling_recoveries_attempt_idx
+    ON ci_route_calling_recoveries(provider_action_key);
+
+-- Provider-action drain proof on the coordinator incarnation lease.
+--
+-- These are what turn the advisory lock from "someone holds it" into an
+-- EXCLUSION PROOF for provider-action futures. `draining_at` is stamped when
+-- leadership cancellation closes action admission; `provider_actions_drained_at`
+-- is stamped ONLY after the registered provider-action scope is empty, and
+-- only then may the lock session be released. Both are nullable and additive:
+-- an incarnation registered by an old binary simply has neither, and the
+-- calling-recovery predicate treats a missing drain proof as "not proven",
+-- never as "drained".
+ALTER TABLE coordinator_incarnations ADD COLUMN draining_at VARCHAR(64) NULL;
+ALTER TABLE coordinator_incarnations ADD COLUMN provider_actions_drained_at VARCHAR(64) NULL;

--- a/server/crates/djinn-db/migrations_postgres/191_ci_route_attempts.sql
+++ b/server/crates/djinn-db/migrations_postgres/191_ci_route_attempts.sql
@@ -26,13 +26,15 @@
 --     process survived to hear it. There is deliberately no refund path and no
 --     reversible accounting column.
 --
---  3. AT MOST ONE TIER-2 (Lead) ADJUDICATION PER CURRENT EVIDENCE.
---     A PARTIAL UNIQUE INDEX on the subject-scoped lease key, restricted to
---     `open` leases, makes concurrent openers mutually exclusive; resolving a
---     lease releases the key for genuinely newer evidence. A given ROW may
---     still only ever route to Tier 2 once — that is enforced in the
---     repository, which refuses to re-lease a row whose lease already
---     resolved.
+--  3. AT MOST ONE TIER-2 (Lead) ADJUDICATION PER CURRENT EVIDENCE,
+--     PER SUBJECT. A PARTIAL UNIQUE INDEX on the subject-scoped lease key,
+--     restricted to `open` leases, makes concurrent openers mutually
+--     exclusive within a subject; resolving a lease releases the key for
+--     genuinely newer evidence. It is NOT globally exclusive — see the
+--     `tier2_lease_key` column note for what that means and when it starts to
+--     matter. A given ROW may still only ever route to Tier 2 once, which is
+--     enforced in the repository: it refuses to re-lease a row whose lease
+--     already resolved.
 --
 -- The `reserved` -> `calling` -> terminal phase column carries the fourth
 -- invariant, the one the whole pre-call recovery contract rests on: a
@@ -150,11 +152,51 @@ CREATE TABLE ci_route_attempts (
 
     -- ---- Tier 2 ----------------------------------------------------------
     -- `tier2_lease_key` is the current-evidence scope. It carries the PR
-    -- number and PR-head SHA and NOT the lane, the run id, or the dequeue id:
-    -- at most one Lead adjudication may be open per PR head ACROSS BOTH LANES,
-    -- which is the "head-level hold" the proposal's retry-storm safeguard
-    -- names. A lane-scoped key would permit two concurrent adjudications for
-    -- one head and defeat it.
+    -- number and PR-head SHA and NOT the lane, the run id, or the dequeue id,
+    -- so one PR head cannot hold two concurrent Lead adjudications by having
+    -- failed in both lanes. A lane-scoped key would defeat that outright.
+    --
+    -- THIS SCOPE IS A CHOICE, NOT A DERIVATION. Proposal `nafu` describes the
+    -- lease three different and mutually incompatible ways:
+    --
+    --   * "a unique evidence-scoped route lease"  (lane transitions table)
+    --       -> would include the run id, so two runs on one head each get an
+    --          adjudication;
+    --   * "at most one Lead adjudication for current evidence"
+    --                                             (Idempotency section)
+    --       -> ambiguous between the two others;
+    --   * "a head-level hold while current provider failure or unknown
+    --      outcome is adjudicated"                (Risks section)
+    --       -> head only.
+    --
+    -- Head scope is the most conservative of the three: it admits the fewest
+    -- Lead sessions and is the only reading under which the retry-storm
+    -- safeguard the Risks section names actually exists. That is why it was
+    -- chosen. It is NOT implied by the other two statements, and a later wave
+    -- that reads the lane-transitions wording literally would widen the hold
+    -- and reintroduce concurrent adjudications for one head. Resolve the spec
+    -- before changing this.
+    --
+    -- Be precise about the extent of the hold, because it is NOT global. The
+    -- unique index below is `(subject_kind, subject_id, tier2_lease_key)`, so
+    -- the hold is **per subject, per PR head across both lanes** — two
+    -- different subjects CAN hold the identical lease key open at the same
+    -- time. The same is true of the head budget counter and of the
+    -- pass/merge close, which are also subject-scoped.
+    --
+    -- That is the deliberate flip side of the subject scoping: scoping is what
+    -- makes a key collision unable to swallow a foreign route, and that
+    -- property was judged more important than a globally exclusive hold.
+    --
+    -- It is harmless today ONLY because every subject is a task and one PR
+    -- maps to one task, so no two subjects share a PR head. **The first wave
+    -- that writes a non-task subject must re-derive this**: if a `proposal`
+    -- subject and a `task` subject ever share a PR head, the head budget for
+    -- that head doubles (4 per subject rather than 4 in total) and two Lead
+    -- adjudications can be open for it at once. Neither is a schema bug; both
+    -- are consequences of the scope, and whichever wave introduces the overlap
+    -- owns deciding whether to widen the hold or to keep the subjects
+    -- genuinely disjoint.
     tier2_lease_id          VARCHAR(36)  NULL,
     tier2_lease_key         VARCHAR(128) NULL,
     tier2_lease_state       VARCHAR(16)  NULL,

--- a/server/crates/djinn-db/migrations_postgres/191_ci_route_attempts.sql
+++ b/server/crates/djinn-db/migrations_postgres/191_ci_route_attempts.sql
@@ -6,17 +6,18 @@
 -- creates three new relations and adds two nullable columns to
 -- `coordinator_incarnations`. No existing row is rewritten and no existing
 -- column changes shape, so a binary that predates the feature keeps running
--- against this schema with the tables simply empty (the "migration only, old
+-- against this schema with the tables empty (the "migration only, old
 -- binary" row of the proposal's mixed-version matrix).
 --
 -- The three invariants this schema exists to enforce, in the database rather
 -- than in a coordinator that can crash between statements:
 --
 --  1. AT MOST ONE PROVIDER-CALL EPISODE PER EVIDENCE IDENTITY.
---     `ci_route_attempts.provider_action_key` is UNIQUE and is the primary
---     key. It is a caller-computed hash of the immutable evidence identity
---     (lane + PR number + PR-head SHA + run id + run head SHA + dequeue
---     identity) plus the action. Duplicate polls and restarts collide on it.
+--     `provider_action_key` is a caller-computed hash of the immutable
+--     evidence identity (lane + PR number + PR-head SHA + run id + run head
+--     SHA + dequeue identity) plus the action. Duplicate polls and restarts
+--     collide on it. It is scoped by the route SUBJECT rather than global —
+--     see below, that scoping is load bearing.
 --
 --  2. MONOTONIC RETRY BUDGETS. `ci_route_budget_counters.charged_count` has a
 --     CHECK that keeps it non-negative and the repository never issues a
@@ -26,9 +27,12 @@
 --     reversible accounting column.
 --
 --  3. AT MOST ONE TIER-2 (Lead) ADJUDICATION PER CURRENT EVIDENCE.
---     A PARTIAL UNIQUE INDEX on `tier2_lease_key` restricted to `open` leases
---     makes concurrent openers mutually exclusive; a resolved lease releases
---     the key so a genuinely newer evidence identity can adjudicate later.
+--     A PARTIAL UNIQUE INDEX on the subject-scoped lease key, restricted to
+--     `open` leases, makes concurrent openers mutually exclusive; resolving a
+--     lease releases the key for genuinely newer evidence. A given ROW may
+--     still only ever route to Tier 2 once — that is enforced in the
+--     repository, which refuses to re-lease a row whose lease already
+--     resolved.
 --
 -- The `reserved` -> `calling` -> terminal phase column carries the fourth
 -- invariant, the one the whole pre-call recovery contract rests on: a
@@ -36,11 +40,51 @@
 -- ownership, therefore no provider mutation happened. Recovery of such a row
 -- resumes it, supersedes it, or exhausts it -- there is no abandonment state,
 -- which is why no `abandoned` value appears in the terminal vocabulary below.
+--
+-- ---------------------------------------------------------------------------
+-- Why the route subject is polymorphic
+-- ---------------------------------------------------------------------------
+--
+-- Every key on this table is caller-computed, so two routes could in principle
+-- collide. The consequence of a collision is NOT a merely-shared budget: with
+-- a globally unique `provider_action_key` a colliding reservation returns
+-- "already present" for FOREIGN evidence and that route then silently never
+-- exists. The same shape applies to the Tier-2 lease: a colliding lease key
+-- reports "already leased" and the Lead adjudication never opens. Scoping both
+-- by the owning subject makes that class structurally impossible rather than
+-- merely unlikely.
+--
+-- The subject is `(subject_kind, subject_id)` rather than a bare `task_id`
+-- because a CI evidence identity has no task in it. A PR opened from a
+-- proposal branch has no owning task at all, and its remedy is new work rather
+-- than one reopen; Tier 1 applies to it unchanged and only the Tier-2 subject
+-- differs. Modelling that now costs two columns. Retrofitting it later means
+-- dropping NOT NULL, dropping a foreign key, backfilling, and rebuilding both
+-- the primary key and the lease index on a table carrying live routing state.
+--
+-- Referential integrity is kept for the task case WITHOUT denormalization:
+-- `task_id` is `GENERATED ALWAYS ... STORED` from the subject and carries the
+-- real foreign key. PostgreSQL enforces the key on the generated value and
+-- cascades a task delete through it, and because the column is GENERATED
+-- ALWAYS the repository physically cannot write a value that disagrees with
+-- `subject_id` (verified on PostgreSQL 16). The honest limit: a non-task
+-- subject generates NULL, so it has NO database-enforced referential
+-- integrity. Whichever wave first writes a non-task subject owns proving that
+-- its subject exists.
 
 CREATE TABLE ci_route_attempts (
+    -- ---- subject ----------------------------------------------------------
+    -- The thing this route is remediating. `task` today; the vocabulary
+    -- reserves `proposal` so a proposal-branch PR route needs no DDL, but
+    -- wave 1 has NO writer for it and nothing branches on it.
+    subject_kind            VARCHAR(32)  NOT NULL,
+    subject_id              VARCHAR(36)  NOT NULL,
+
     -- ---- identity ---------------------------------------------------------
     -- Caller-computed hash over the immutable evidence identity plus action.
-    -- Primary key: the unique constraint IS the idempotency mechanism.
+    -- Unique WITHIN a subject: the unique constraint is the idempotency
+    -- mechanism, and scoping it is what stops one subject's route from
+    -- swallowing another's.
     provider_action_key     VARCHAR(128) NOT NULL,
 
     -- Immutable evidence identity, stored in expanded form so a recovery
@@ -53,10 +97,14 @@ CREATE TABLE ci_route_attempts (
     run_head_sha            VARCHAR(64)  NOT NULL,
     dequeue_id              VARCHAR(128) NULL,
 
-    -- Board linkage. `task_id` is what makes "sessions per merged PR by lane"
-    -- reportable; `origin_state` is the board state the route was opened from
-    -- and the state a Lead-driven `PrCiFailed` must transition out of.
-    task_id                 VARCHAR(36)  NOT NULL,
+    -- Real referential integrity for the task subject, derived rather than
+    -- duplicated. See the header note.
+    task_id                 VARCHAR(36)
+        GENERATED ALWAYS AS (CASE WHEN subject_kind = 'task' THEN subject_id END) STORED
+        REFERENCES tasks(id) ON DELETE CASCADE,
+
+    -- The board state the route was opened from, and the state a Lead-driven
+    -- `PrCiFailed` must transition out of.
     origin_state            VARCHAR(32)  NOT NULL,
 
     -- ---- classification ---------------------------------------------------
@@ -101,10 +149,12 @@ CREATE TABLE ci_route_attempts (
     retry_exhausted_at      TIMESTAMPTZ  NULL,
 
     -- ---- Tier 2 ----------------------------------------------------------
-    -- `tier2_lease_key` is the current-evidence scope (lane + PR + PR-head
-    -- SHA): at most one Lead adjudication may be open for a PR head at a
-    -- time, which is the "head-level hold" the proposal's retry-storm
-    -- safeguard names.
+    -- `tier2_lease_key` is the current-evidence scope. It carries the PR
+    -- number and PR-head SHA and NOT the lane, the run id, or the dequeue id:
+    -- at most one Lead adjudication may be open per PR head ACROSS BOTH LANES,
+    -- which is the "head-level hold" the proposal's retry-storm safeguard
+    -- names. A lane-scoped key would permit two concurrent adjudications for
+    -- one head and defeat it.
     tier2_lease_id          VARCHAR(36)  NULL,
     tier2_lease_key         VARCHAR(128) NULL,
     tier2_lease_state       VARCHAR(16)  NULL,
@@ -129,10 +179,11 @@ CREATE TABLE ci_route_attempts (
     created_at              TIMESTAMPTZ  NOT NULL DEFAULT now(),
     updated_at              TIMESTAMPTZ  NOT NULL DEFAULT now(),
 
-    CONSTRAINT ci_route_attempts_pkey PRIMARY KEY (provider_action_key),
-    CONSTRAINT ci_route_attempts_task_fkey
-        FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT ci_route_attempts_pkey
+        PRIMARY KEY (subject_kind, subject_id, provider_action_key),
 
+    CONSTRAINT ci_route_attempts_subject_kind_check
+        CHECK (subject_kind IN ('task', 'proposal')),
     CONSTRAINT ci_route_attempts_lane_check
         CHECK (lane IN ('pr_head', 'merge_group')),
     CONSTRAINT ci_route_attempts_origin_state_check
@@ -207,21 +258,23 @@ CREATE TABLE ci_route_attempts (
         CHECK (diagnostic_reason IS NULL OR reopen_mode = 'diagnose')
 );
 
--- The current-evidence Tier-2 hold. PARTIAL so that only OPEN leases are
--- mutually exclusive: once Lead's result has been applied the key is free for
--- a genuinely newer evidence identity.
+-- The current-evidence Tier-2 hold, scoped to the subject for the same reason
+-- the primary key is. PARTIAL so that only OPEN leases are mutually exclusive:
+-- once Lead's result has been applied the key is free for a genuinely newer
+-- evidence identity on a different row.
 CREATE UNIQUE INDEX ci_route_attempts_open_tier2_lease_uniq
-    ON ci_route_attempts(tier2_lease_key)
+    ON ci_route_attempts(subject_kind, subject_id, tier2_lease_key)
     WHERE tier2_lease_state = 'open';
 
--- Recovery sweeps scan by phase; reporting scans by lane/PR identity.
+-- Recovery sweeps scan by phase; reporting scans by subject and lane identity.
 CREATE INDEX ci_route_attempts_phase_idx
     ON ci_route_attempts(action_phase)
     WHERE action_phase <> 'terminal';
 CREATE INDEX ci_route_attempts_lane_identity_idx
-    ON ci_route_attempts(lane, pr_number, pr_head_sha);
+    ON ci_route_attempts(subject_kind, subject_id, lane, pr_number, pr_head_sha);
 CREATE INDEX ci_route_attempts_task_idx
-    ON ci_route_attempts(task_id);
+    ON ci_route_attempts(task_id)
+    WHERE task_id IS NOT NULL;
 CREATE INDEX ci_route_attempts_owner_idx
     ON ci_route_attempts(owner_incarnation_id)
     WHERE owner_incarnation_id IS NOT NULL;
@@ -237,13 +290,18 @@ CREATE INDEX ci_route_attempts_owner_idx
 -- it is not a corrupt row. A CHECK here would turn a normal, expected
 -- exhaustion into a transaction abort.
 CREATE TABLE ci_route_budget_counters (
+    subject_kind     VARCHAR(32)  NOT NULL,
+    subject_id       VARCHAR(36)  NOT NULL,
     scope            VARCHAR(16)  NOT NULL,
     counter_key      VARCHAR(128) NOT NULL,
     charged_count    BIGINT       NOT NULL DEFAULT 0,
     first_charged_at TIMESTAMPTZ  NULL,
     last_charged_at  TIMESTAMPTZ  NULL,
 
-    CONSTRAINT ci_route_budget_counters_pkey PRIMARY KEY (scope, counter_key),
+    CONSTRAINT ci_route_budget_counters_pkey
+        PRIMARY KEY (subject_kind, subject_id, scope, counter_key),
+    CONSTRAINT ci_route_budget_counters_subject_kind_check
+        CHECK (subject_kind IN ('task', 'proposal')),
     CONSTRAINT ci_route_budget_counters_scope_check
         CHECK (scope IN ('signature', 'head')),
     CONSTRAINT ci_route_budget_counters_nonneg_check
@@ -256,6 +314,8 @@ CREATE TABLE ci_route_budget_counters (
 -- "we never steal a live owner's row" is an unfalsifiable claim.
 CREATE TABLE ci_route_calling_recoveries (
     id                        VARCHAR(36)  NOT NULL,
+    subject_kind              VARCHAR(32)  NOT NULL,
+    subject_id                VARCHAR(36)  NOT NULL,
     provider_action_key       VARCHAR(128) NOT NULL,
     former_owner_incarnation  VARCHAR(36)  NULL,
     recovering_incarnation    VARCHAR(36)  NOT NULL,
@@ -275,8 +335,9 @@ CREATE TABLE ci_route_calling_recoveries (
 
     CONSTRAINT ci_route_calling_recoveries_pkey PRIMARY KEY (id),
     CONSTRAINT ci_route_calling_recoveries_attempt_fkey
-        FOREIGN KEY (provider_action_key)
-        REFERENCES ci_route_attempts(provider_action_key) ON DELETE CASCADE,
+        FOREIGN KEY (subject_kind, subject_id, provider_action_key)
+        REFERENCES ci_route_attempts(subject_kind, subject_id, provider_action_key)
+        ON DELETE CASCADE,
     CONSTRAINT ci_route_calling_recoveries_quiescence_check
         CHECK (quiescence_proof IN ('graceful_drain', 'process_terminated', 'none')),
     CONSTRAINT ci_route_calling_recoveries_reason_check
@@ -294,7 +355,7 @@ CREATE TABLE ci_route_calling_recoveries (
 );
 
 CREATE INDEX ci_route_calling_recoveries_attempt_idx
-    ON ci_route_calling_recoveries(provider_action_key);
+    ON ci_route_calling_recoveries(subject_kind, subject_id, provider_action_key);
 
 -- Provider-action drain proof on the coordinator incarnation lease.
 --
@@ -306,5 +367,9 @@ CREATE INDEX ci_route_calling_recoveries_attempt_idx
 -- an incarnation registered by an old binary simply has neither, and the
 -- calling-recovery predicate treats a missing drain proof as "not proven",
 -- never as "drained".
+--
+-- Anything that reads `coordinator_incarnations` through
+-- `CoordinatorIncarnationRepository::get` must project these two columns --
+-- including the test-support fixtures that replace the table with a view.
 ALTER TABLE coordinator_incarnations ADD COLUMN draining_at VARCHAR(64) NULL;
 ALTER TABLE coordinator_incarnations ADD COLUMN provider_actions_drained_at VARCHAR(64) NULL;

--- a/server/crates/djinn-db/migrations_postgres/193_ci_route_attempts.sql
+++ b/server/crates/djinn-db/migrations_postgres/193_ci_route_attempts.sql
@@ -1,4 +1,4 @@
--- Migration 191: durable CI evidence-route attempts, monotonic retry budgets,
+-- Migration 193: durable CI evidence-route attempts, monotonic retry budgets,
 -- calling-recovery audit, and coordinator provider-action drain proof.
 --
 -- Proposal `nafu` wave 1 ("Route CI failures through bounded retries and

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -118,8 +118,8 @@ pub use repositories::{
         CiCallingRecoveryRecord, CiChargeOutcome, CiClass, CiDiagnosticReason, CiEvidenceIdentity,
         CiLane, CiOriginState, CiQuiescenceProof, CiReopenMode, CiReserveOutcome,
         CiReservedRecovery, CiRouteAttempt, CiRouteAttemptRepository, CiRouteOutcome,
-        CiRouteQuiescence, CiRouteReservation, CiTier2LeaseOutcome, CiTier2LeaseState,
-        CiTier2Reason, CiTier2Resolution,
+        CiRouteQuiescence, CiRouteReservation, CiRouteSubject, CiSubjectKind, CiTier2LeaseOutcome,
+        CiTier2LeaseState, CiTier2Reason, CiTier2Resolution,
     },
     code_chunk::{
         ChunkAndEmbedReport, CodeChunk, CodeChunkEmbeddingProvider, CodeChunkRepairEmbeddingRow,

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -111,6 +111,16 @@ pub use repositories::{
     chat_interruption_notice::{
         ChatInterruptionNotice, ChatInterruptionNoticeRepository, CreateChatInterruptionNotice,
     },
+    ci_route_attempt::{
+        CI_CALLING_RECOVERY_TIMEOUT_SECS, CI_HEAD_BUDGET_LIMIT,
+        CI_RESERVATION_RECOVERY_TIMEOUT_SECS, CI_SIGNATURE_BUDGET_LIMIT, CiAction, CiActionPhase,
+        CiBudgetCounts, CiCallingRecovery, CiCallingRecoveryAuthority, CiCallingRecoveryReason,
+        CiCallingRecoveryRecord, CiChargeOutcome, CiClass, CiDiagnosticReason, CiEvidenceIdentity,
+        CiLane, CiOriginState, CiQuiescenceProof, CiReopenMode, CiReserveOutcome,
+        CiReservedRecovery, CiRouteAttempt, CiRouteAttemptRepository, CiRouteOutcome,
+        CiRouteQuiescence, CiRouteReservation, CiTier2LeaseOutcome, CiTier2LeaseState,
+        CiTier2Reason, CiTier2Resolution,
+    },
     code_chunk::{
         ChunkAndEmbedReport, CodeChunk, CodeChunkEmbeddingProvider, CodeChunkRepairEmbeddingRow,
         CodeChunkRepository, CodeChunkSearchHit, CodeChunkVectorBackend, CodeChunkVectorMatch,

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
@@ -31,11 +31,20 @@
 //! | Identity current, budget exhausted | route through retry exhaustion | no charge, at most one Tier-2 lease |
 //!
 //! The middle row is the one worth stating twice: N concurrent recoveries and
-//! N restarts converge on **one** winner and **one** charge, because the
-//! charge is welded to the `reserved` -> `calling` compare-and-set inside a
-//! single transaction that holds the row with `SELECT ... FOR UPDATE`. The
-//! `pre_call_resumptions` counter records how many recoveries ran; it has no
-//! influence on the charge, which is the point of recording it.
+//! N restarts converge on **one** winner and **one** charge. Two mechanisms
+//! do that, and it is worth being precise about which does what, because they
+//! are easy to confuse:
+//!
+//! * the **row lock** (`SELECT ... FOR UPDATE` in [`fetch_locked`]) serializes
+//!   the recoveries so the losers observe a non-`reserved` phase and return
+//!   without charging; and
+//! * the **counter lock plus the phase CAS** is what makes a double charge
+//!   impossible even if the row lock were absent — a loser that got as far as
+//!   incrementing would find `action_phase = 'reserved'` no longer true, fail
+//!   the CAS, and roll its increment back with the transaction.
+//!
+//! `pre_call_resumptions` records how many recoveries ran; it has no influence
+//! on the charge, which is the point of recording it.
 //!
 //! # Why `calling` recovery is so much more restricted
 //!
@@ -55,6 +64,20 @@
 //! including the ones that correctly did nothing. A sweep that left a live
 //! owner alone has to be observable, or the claim "we never steal a live
 //! owner's row" cannot be falsified by a test.
+//!
+//! # Two write-once outcome fields, not one
+//!
+//! [`CiRouteAttempt::terminal_outcome`] is the route's own single terminal
+//! fact and is never rewritten. A row that terminalized on its provider
+//! result (`action_failed`, `outcome_unknown`) may still legally route to Tier
+//! 2 **once**; that adjudication lands in
+//! [`CiRouteAttempt::tier2_resolution`] instead, because terminalization
+//! already happened and is write-once.
+//!
+//! **Downstream obligation (W2/W4/W5):** any query that counts reopens, parks,
+//! or supersessions must union *both* columns. Reading only `terminal_outcome`
+//! silently drops every reopen that followed a provider failure — which is
+//! precisely the population the evidence-led route exists to serve.
 
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Row, Transaction};
@@ -84,7 +107,7 @@ pub const CI_RESERVATION_RECOVERY_TIMEOUT_SECS: i64 = 60;
 /// considered. Fixed by the proposal.
 pub const CI_CALLING_RECOVERY_TIMEOUT_SECS: i64 = 300;
 
-const ROW_COLUMNS: &str = "provider_action_key, lane, pr_number, pr_head_sha, run_id, run_head_sha, dequeue_id, \
+const ROW_COLUMNS: &str = "subject_kind, subject_id, provider_action_key, lane, pr_number, pr_head_sha, run_id, run_head_sha, dequeue_id, \
     task_id, origin_state, class, action, transient_fingerprint, retry_budget_key, head_budget_key, \
     action_phase, terminal_outcome, \
     to_char(reserved_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS reserved_at, \
@@ -96,6 +119,9 @@ const ROW_COLUMNS: &str = "provider_action_key, lane, pr_number, pr_head_sha, ru
     to_char(tier2_leased_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS tier2_leased_at, \
     tier2_resolution, lead_session_id, reopen_mode, diagnostic_reason, park_justification, \
     provider_error::text AS provider_error, superseded_by_evidence::text AS superseded_by_evidence";
+
+/// `WHERE` fragment naming one row by its full subject-scoped primary key.
+const BY_PK: &str = "subject_kind = $1 AND subject_id = $2 AND provider_action_key = $3";
 
 // ---------------------------------------------------------------------------
 // Vocabularies
@@ -141,6 +167,24 @@ macro_rules! durable_enum {
             }
         }
     };
+}
+
+durable_enum! {
+    /// What a route is remediating.
+    ///
+    /// A CI evidence identity contains no subject of its own, so the subject
+    /// is carried alongside it. Every key on the table is scoped by it.
+    CiSubjectKind {
+        /// A board task. The only kind wave 1 writes, and the only kind with
+        /// database-enforced referential integrity (migration 191 derives
+        /// `task_id` from the subject and puts the foreign key on it).
+        Task => "task",
+        /// Reserved for a proposal-branch PR, which has no owning task and
+        /// whose remedy is new work rather than one reopen. Wave 1 has **no
+        /// writer** for this and nothing branches on it; the value exists so
+        /// that route needs no DDL on a table carrying live routing state.
+        Proposal => "proposal",
+    }
 }
 
 durable_enum! {
@@ -215,6 +259,21 @@ durable_enum! {
     }
 }
 
+impl CiRouteOutcome {
+    /// The three outcomes that assert something about a provider call.
+    ///
+    /// They are reachable only through
+    /// [`CiRouteAttemptRepository::finalize_calling`], which is fenced to the
+    /// exact `calling` owner. Nothing else may claim the provider was called.
+    #[must_use]
+    pub fn is_provider_finalization(self) -> bool {
+        matches!(
+            self,
+            Self::Retriggered | Self::Reenqueued | Self::ActionFailed
+        )
+    }
+}
+
 durable_enum! {
     /// Why a Tier-2 lease was opened.
     CiTier2Reason {
@@ -285,13 +344,38 @@ durable_enum! {
 }
 
 // ---------------------------------------------------------------------------
-// Identity
+// Subject and identity
 // ---------------------------------------------------------------------------
+
+/// The thing a route is remediating, and the scope of every key on the table.
+///
+/// Scoping matters more than it looks. `provider_action_key` and
+/// `tier2_lease_key` are caller-computed hashes; if they were globally unique
+/// a collision would not merely share a budget, it would make
+/// [`CiRouteAttemptRepository::reserve`] answer "already present" for *foreign*
+/// evidence, so the colliding route would silently never exist. Scoping by
+/// subject makes that class impossible rather than unlikely.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CiRouteSubject {
+    pub kind: CiSubjectKind,
+    pub id: String,
+}
+
+impl CiRouteSubject {
+    /// The task subject — the only kind wave 1 writes.
+    #[must_use]
+    pub fn task(task_id: impl Into<String>) -> Self {
+        Self {
+            kind: CiSubjectKind::Task,
+            id: task_id.into(),
+        }
+    }
+}
 
 /// The immutable evidence identity a route attempt is bound to.
 ///
 /// Stored expanded on the row (not only as the caller's hash) so a recovery
-/// sweep can compare a freshly observed identity against it without
+/// sweep can compare it against a freshly observed identity without
 /// recomputing the caller's hash function — and so a supersession is
 /// explainable by reading the row.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -325,9 +409,12 @@ impl CiEvidenceIdentity {
 /// One durable route attempt.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CiRouteAttempt {
+    pub subject: CiRouteSubject,
     pub provider_action_key: String,
     pub identity: CiEvidenceIdentity,
-    pub task_id: String,
+    /// The generated, foreign-key-backed task id. `Some` exactly when the
+    /// subject is a task; the database derives it and refuses a direct write.
+    pub task_id: Option<String>,
     pub origin_state: CiOriginState,
     pub class: CiClass,
     pub action: CiAction,
@@ -372,6 +459,10 @@ impl CiRouteAttempt {
             }
         }
         Ok(Self {
+            subject: CiRouteSubject {
+                kind: CiSubjectKind::parse(row.try_get::<String, _>("subject_kind")?.as_str())?,
+                id: row.try_get("subject_id")?,
+            },
             provider_action_key: row.try_get("provider_action_key")?,
             identity: CiEvidenceIdentity {
                 lane: CiLane::parse(row.try_get::<String, _>("lane")?.as_str())?,
@@ -430,6 +521,27 @@ impl CiRouteAttempt {
     pub fn holds_open_tier2_lease(&self) -> bool {
         self.tier2_lease_state == Some(CiTier2LeaseState::Open)
     }
+
+    /// Whether this row has already used its one trip to Tier 2.
+    ///
+    /// True from the moment a lease is opened, and it stays true after that
+    /// lease resolves. "Route **once** to Tier 2" is a once-ever property, not
+    /// a concurrency property.
+    #[must_use]
+    pub fn has_routed_to_tier2(&self) -> bool {
+        self.tier2_lease_state.is_some()
+    }
+
+    /// The Lead adjudication that closed this route, wherever it landed.
+    ///
+    /// See the module note on the two write-once outcome fields: a row that
+    /// terminalized on its provider result keeps that outcome and records the
+    /// Tier-2 result separately. Callers counting reopens or parks must use
+    /// this rather than `terminal_outcome` alone.
+    #[must_use]
+    pub fn adjudicated_outcome(&self) -> Option<CiRouteOutcome> {
+        self.tier2_resolution.or(self.terminal_outcome)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -439,11 +551,12 @@ impl CiRouteAttempt {
 /// Everything needed to open a reservation.
 #[derive(Clone, Debug)]
 pub struct CiRouteReservation {
+    pub subject: CiRouteSubject,
     /// Caller-computed hash of the immutable evidence identity plus action.
-    /// Its uniqueness is what permits at most one provider-call episode.
+    /// Its uniqueness within the subject is what permits at most one
+    /// provider-call episode.
     pub provider_action_key: String,
     pub identity: CiEvidenceIdentity,
-    pub task_id: String,
     pub origin_state: CiOriginState,
     pub class: CiClass,
     pub action: CiAction,
@@ -476,8 +589,9 @@ pub enum CiReserveOutcome {
     /// A fresh reservation was committed. Provider mutation remains forbidden
     /// until the caller wins [`CiRouteAttemptRepository::charge_and_begin_calling`].
     Reserved(Box<CiRouteAttempt>),
-    /// This exact evidence identity already has an attempt row. A duplicate
-    /// poll or a restart landed here; the existing row is authoritative.
+    /// This exact evidence identity already has an attempt row *for this
+    /// subject*. A duplicate poll or a restart landed here; the existing row
+    /// is authoritative.
     AlreadyPresent(Box<CiRouteAttempt>),
     /// The budgets were already spent, so no reservation was created and no
     /// Tier-1 action is possible for this evidence.
@@ -495,7 +609,14 @@ pub enum CiChargeOutcome {
     /// The observed identity no longer matches; the row is now terminal
     /// `superseded_pre_call` with no charge and no lease.
     SupersededPreCall(Box<CiRouteAttempt>),
-    /// Still current, but the budgets are spent. No charge, no call.
+    /// Still current, but the budgets were spent between the reservation and
+    /// this call. No charge and no provider call.
+    ///
+    /// Note the asymmetry with [`CiReservedRecovery::RetryExhausted`]: this is
+    /// the *live* path, so it only stamps `retry_exhausted_at` and leaves the
+    /// row `reserved`. It does **not** open a Tier-2 lease, because the caller
+    /// is still running and owns that decision. The recovery path opens the
+    /// lease itself precisely because no caller is left to make it.
     BudgetExhausted {
         attempt: Box<CiRouteAttempt>,
         counts: CiBudgetCounts,
@@ -509,7 +630,7 @@ pub enum CiChargeOutcome {
 /// two "nothing to do" shapes.
 #[derive(Clone, Debug)]
 pub enum CiReservedRecovery {
-    /// No row with that key.
+    /// No row with that key for that subject.
     NotFound,
     /// The row is not a recoverable `reserved` row: either it has advanced
     /// past `reserved`, or its reservation timeout has not elapsed yet.
@@ -522,14 +643,18 @@ pub enum CiReservedRecovery {
         attempt: Box<CiRouteAttempt>,
         counts: CiBudgetCounts,
     },
-    /// Current identity, budget spent: routed through retry exhaustion, with
-    /// at most one Tier-2 lease opened.
+    /// Current identity, budget spent: routed through retry exhaustion.
     RetryExhausted {
         attempt: Box<CiRouteAttempt>,
         counts: CiBudgetCounts,
-        /// `Some` when this call opened the lease, `None` when a lease for
-        /// that current-evidence key was already open (the "at most one"
-        /// half of the contract).
+        /// `Some` when this call opened the lease.
+        ///
+        /// `None` means no lease could be opened — either this row already
+        /// routed to Tier 2, or **another row holds the head lease**. The
+        /// second case leaves this row `reserved` with no route out of its own
+        /// accord, so W2 must re-drive `recover_reserved` after the holding
+        /// lease resolves, or close the row explicitly. It is not
+        /// self-healing.
         tier2_lease_id: Option<String>,
     },
 }
@@ -583,9 +708,12 @@ pub enum CiTier2LeaseOutcome {
         attempt: Box<CiRouteAttempt>,
         lease_id: String,
     },
-    /// A lease for that key is already open — possibly on this very row.
-    /// Mutually exclusive by construction.
-    AlreadyLeased(Box<CiRouteAttempt>),
+    /// Another row on this subject holds the open lease for that
+    /// current-evidence key. Mutually exclusive by construction.
+    KeyHeldElsewhere(Box<CiRouteAttempt>),
+    /// This row has already used its one trip to Tier 2 — the lease is open,
+    /// or it resolved and may not be reopened.
+    AlreadyRoutedToTier2(Box<CiRouteAttempt>),
     /// The compare-and-set failed: the identity changed or a newer
     /// passing/merged observation already terminalized the row. The row is
     /// closed as `superseded_before_lead` with no lease and no Lead dispatch.
@@ -651,6 +779,12 @@ impl CiTier2Resolution {
     }
 
     fn validate(&self) -> Result<()> {
+        if self.outcome.is_provider_finalization() {
+            return Err(DbError::InvalidData(format!(
+                "`{}` asserts a provider call and cannot be a Tier-2 resolution",
+                self.outcome.as_str()
+            )));
+        }
         match self.outcome {
             CiRouteOutcome::RepairReopened => {
                 if self.reopen_mode != Some(CiReopenMode::Repair) {
@@ -739,17 +873,23 @@ impl CiRouteAttemptRepository {
         Self { db }
     }
 
-    /// Fetch one attempt by its provider-action key.
+    /// Fetch one attempt by its subject and provider-action key.
     ///
     /// # Errors
     ///
     /// Database failures, or a row carrying a value outside a durable
     /// vocabulary.
-    pub async fn get(&self, provider_action_key: &str) -> Result<Option<CiRouteAttempt>> {
+    pub async fn get(
+        &self,
+        subject: &CiRouteSubject,
+        provider_action_key: &str,
+    ) -> Result<Option<CiRouteAttempt>> {
         self.db.ensure_initialized().await?;
         let row = sqlx::query(&format!(
-            "SELECT {ROW_COLUMNS} FROM ci_route_attempts WHERE provider_action_key = $1"
+            "SELECT {ROW_COLUMNS} FROM ci_route_attempts WHERE {BY_PK}"
         ))
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .fetch_optional(self.db.pool())
         .await?;
@@ -763,25 +903,27 @@ impl CiRouteAttemptRepository {
     /// Database failures.
     pub async fn budget_counts(
         &self,
+        subject: &CiRouteSubject,
         retry_budget_key: &str,
         head_budget_key: &str,
     ) -> Result<CiBudgetCounts> {
         self.db.ensure_initialized().await?;
-        let signature: Option<i64> = sqlx::query_scalar(
-            "SELECT charged_count FROM ci_route_budget_counters WHERE scope = 'signature' AND counter_key = $1",
-        )
-        .bind(retry_budget_key)
-        .fetch_optional(self.db.pool())
-        .await?;
-        let head: Option<i64> = sqlx::query_scalar(
-            "SELECT charged_count FROM ci_route_budget_counters WHERE scope = 'head' AND counter_key = $1",
-        )
-        .bind(head_budget_key)
-        .fetch_optional(self.db.pool())
-        .await?;
+        let read = |scope: &'static str, key: String| async move {
+            let count: Option<i64> = sqlx::query_scalar(
+                "SELECT charged_count FROM ci_route_budget_counters \
+                 WHERE subject_kind = $1 AND subject_id = $2 AND scope = $3 AND counter_key = $4",
+            )
+            .bind(subject.kind.as_str())
+            .bind(&subject.id)
+            .bind(scope)
+            .bind(key)
+            .fetch_optional(self.db.pool())
+            .await?;
+            Ok::<i64, DbError>(count.unwrap_or(0))
+        };
         Ok(CiBudgetCounts {
-            signature: signature.unwrap_or(0),
-            head: head.unwrap_or(0),
+            signature: read("signature", retry_budget_key.to_owned()).await?,
+            head: read("head", head_budget_key.to_owned()).await?,
         })
     }
 
@@ -798,12 +940,20 @@ impl CiRouteAttemptRepository {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
 
-        if let Some(existing) = fetch_in_tx(&mut tx, &input.provider_action_key).await? {
+        if let Some(existing) =
+            fetch_in_tx(&mut tx, &input.subject, &input.provider_action_key).await?
+        {
             tx.commit().await?;
             return Ok(CiReserveOutcome::AlreadyPresent(Box::new(existing)));
         }
 
-        let counts = lock_budgets(&mut tx, &input.retry_budget_key, &input.head_budget_key).await?;
+        let counts = lock_budgets(
+            &mut tx,
+            &input.subject,
+            &input.retry_budget_key,
+            &input.head_budget_key,
+        )
+        .await?;
         if counts.is_exhausted() {
             tx.commit().await?;
             return Ok(CiReserveOutcome::BudgetExhausted(counts));
@@ -816,11 +966,13 @@ impl CiRouteAttemptRepository {
         // unique violation. The unique key is still what enforces one row per
         // evidence identity — this only decides how the loser is *told*.
         let inserted = sqlx::query(
-            "INSERT INTO ci_route_attempts (provider_action_key, lane, pr_number, pr_head_sha, run_id, run_head_sha, dequeue_id, \
-             task_id, origin_state, class, action, transient_fingerprint, retry_budget_key, head_budget_key, action_phase) \
-             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,'reserved') \
-             ON CONFLICT (provider_action_key) DO NOTHING",
+            "INSERT INTO ci_route_attempts (subject_kind, subject_id, provider_action_key, lane, pr_number, pr_head_sha, run_id, run_head_sha, dequeue_id, \
+             origin_state, class, action, transient_fingerprint, retry_budget_key, head_budget_key, action_phase) \
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,'reserved') \
+             ON CONFLICT (subject_kind, subject_id, provider_action_key) DO NOTHING",
         )
+        .bind(input.subject.kind.as_str())
+        .bind(&input.subject.id)
         .bind(&input.provider_action_key)
         .bind(input.identity.lane.as_str())
         .bind(input.identity.pr_number)
@@ -828,7 +980,6 @@ impl CiRouteAttemptRepository {
         .bind(input.identity.run_id)
         .bind(&input.identity.run_head_sha)
         .bind(input.identity.dequeue_id.as_deref())
-        .bind(&input.task_id)
         .bind(input.origin_state.as_str())
         .bind(input.class.as_str())
         .bind(input.action.as_str())
@@ -838,7 +989,7 @@ impl CiRouteAttemptRepository {
         .execute(&mut *tx)
         .await?;
 
-        let row = fetch_in_tx(&mut tx, &input.provider_action_key)
+        let row = fetch_in_tx(&mut tx, &input.subject, &input.provider_action_key)
             .await?
             .ok_or_else(|| DbError::Internal("reserved route row disappeared".to_owned()))?;
         tx.commit().await?;
@@ -863,9 +1014,10 @@ impl CiRouteAttemptRepository {
     ///
     /// # Errors
     ///
-    /// Database failures.
+    /// Database failures, or no such reservation.
     pub async fn charge_and_begin_calling(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
         owner_incarnation_id: &str,
         observed_identity: &CiEvidenceIdentity,
@@ -873,10 +1025,12 @@ impl CiRouteAttemptRepository {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
 
-        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+        let Some(attempt) = fetch_locked(&mut tx, subject, provider_action_key).await? else {
             tx.commit().await?;
             return Err(DbError::InvalidData(format!(
-                "no ci route attempt for provider_action_key `{provider_action_key}`"
+                "no ci route attempt for `{}`/`{}`/`{provider_action_key}`",
+                subject.kind.as_str(),
+                subject.id
             )));
         };
 
@@ -888,27 +1042,34 @@ impl CiRouteAttemptRepository {
         if !attempt.identity.matches(observed_identity) {
             let superseded = terminalize_in_tx(
                 &mut tx,
+                subject,
                 provider_action_key,
                 CiRouteOutcome::SupersededPreCall,
                 Some(&identity_evidence_json(observed_identity)),
-                None,
             )
             .await?;
             tx.commit().await?;
             return Ok(CiChargeOutcome::SupersededPreCall(Box::new(superseded)));
         }
 
-        let counts =
-            lock_budgets(&mut tx, &attempt.retry_budget_key, &attempt.head_budget_key).await?;
+        let counts = lock_budgets(
+            &mut tx,
+            subject,
+            &attempt.retry_budget_key,
+            &attempt.head_budget_key,
+        )
+        .await?;
         if counts.is_exhausted() {
-            sqlx::query(
+            sqlx::query(&format!(
                 "UPDATE ci_route_attempts SET retry_exhausted_at = now(), updated_at = now() \
-                 WHERE provider_action_key = $1 AND retry_exhausted_at IS NULL",
-            )
+                 WHERE {BY_PK} AND retry_exhausted_at IS NULL"
+            ))
+            .bind(subject.kind.as_str())
+            .bind(&subject.id)
             .bind(provider_action_key)
             .execute(&mut *tx)
             .await?;
-            let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+            let refreshed = fetch_in_tx(&mut tx, subject, provider_action_key)
                 .await?
                 .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
             tx.commit().await?;
@@ -918,19 +1079,26 @@ impl CiRouteAttemptRepository {
             });
         }
 
-        let charged =
-            charge_budgets_in_tx(&mut tx, &attempt.retry_budget_key, &attempt.head_budget_key)
-                .await?;
-
-        // The CAS. `action_phase = 'reserved'` in the WHERE clause is
-        // redundant under the row lock we already hold and is kept anyway:
-        // it makes the single-winner property readable at the statement.
-        let updated = sqlx::query(
-            "UPDATE ci_route_attempts \
-             SET action_phase = 'calling', calling_at = now(), owner_incarnation_id = $2, \
-                 charged_signature_count = $3, charged_head_count = $4, updated_at = now() \
-             WHERE provider_action_key = $1 AND action_phase = 'reserved'",
+        let charged = charge_budgets_in_tx(
+            &mut tx,
+            subject,
+            &attempt.retry_budget_key,
+            &attempt.head_budget_key,
         )
+        .await?;
+
+        // The CAS. `action_phase = 'reserved'` in the WHERE clause is what
+        // makes a double charge impossible independently of the row lock: a
+        // caller that got as far as incrementing but lost the phase race
+        // fails here and rolls its increment back with the transaction.
+        let updated = sqlx::query(&format!(
+            "UPDATE ci_route_attempts \
+             SET action_phase = 'calling', calling_at = now(), owner_incarnation_id = $4, \
+                 charged_signature_count = $5, charged_head_count = $6, updated_at = now() \
+             WHERE {BY_PK} AND action_phase = 'reserved'"
+        ))
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .bind(owner_incarnation_id)
         .bind(charged.signature)
@@ -943,7 +1111,7 @@ impl CiRouteAttemptRepository {
             ));
         }
 
-        let calling = fetch_in_tx(&mut tx, provider_action_key)
+        let calling = fetch_in_tx(&mut tx, subject, provider_action_key)
             .await?
             .ok_or_else(|| DbError::Internal("calling route row disappeared".to_owned()))?;
         tx.commit().await?;
@@ -961,32 +1129,35 @@ impl CiRouteAttemptRepository {
     /// which a late result from a drained process is rejected rather than
     /// silently overwriting a recovery.
     ///
+    /// This is the **only** path to a provider-finalization outcome;
+    /// [`Self::terminalize`] refuses them.
+    ///
     /// # Errors
     ///
     /// Database failures, or an outcome outside the provider-terminal set.
     pub async fn finalize_calling(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
         owner_incarnation_id: &str,
         outcome: CiRouteOutcome,
         provider_error_json: Option<&str>,
     ) -> Result<bool> {
         self.db.ensure_initialized().await?;
-        if !matches!(
-            outcome,
-            CiRouteOutcome::Retriggered | CiRouteOutcome::Reenqueued | CiRouteOutcome::ActionFailed
-        ) {
+        if !outcome.is_provider_finalization() {
             return Err(DbError::InvalidData(format!(
                 "`{}` is not a provider finalization outcome",
                 outcome.as_str()
             )));
         }
-        let updated = sqlx::query(
+        let updated = sqlx::query(&format!(
             "UPDATE ci_route_attempts \
-             SET action_phase = 'terminal', terminal_outcome = $3, terminalized_at = now(), \
-                 provider_error = $4::jsonb, updated_at = now() \
-             WHERE provider_action_key = $1 AND action_phase = 'calling' AND owner_incarnation_id = $2",
-        )
+             SET action_phase = 'terminal', terminal_outcome = $5, terminalized_at = now(), \
+                 provider_error = $6::jsonb, updated_at = now() \
+             WHERE {BY_PK} AND action_phase = 'calling' AND owner_incarnation_id = $4"
+        ))
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .bind(owner_incarnation_id)
         .bind(outcome.as_str())
@@ -1002,28 +1173,57 @@ impl CiRouteAttemptRepository {
     /// second call — from a duplicate poll, a startup sweep, or a delayed Lead
     /// result — observes `false` and must not treat the row as freshly closed.
     ///
+    /// **Two fences, both deliberate.** This sits beside the owner-scoped
+    /// [`Self::finalize_calling`], and an unfenced sibling would be a way
+    /// around it:
+    ///
+    /// * a provider-finalization outcome is rejected outright, so nothing but
+    ///   the `calling` owner can ever claim the provider was called; and
+    /// * a row in `calling` is refused, so a sweep cannot close a route whose
+    ///   provider future is still live. Such a row belongs to its owner and
+    ///   leaves `calling` only through that owner's finalizer or through
+    ///   [`Self::recover_calling_owner`].
+    ///
     /// # Errors
     ///
-    /// Database failures.
+    /// Database failures, a provider-finalization outcome, or a `calling` row.
     pub async fn terminalize(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
         outcome: CiRouteOutcome,
         superseded_by_evidence_json: Option<&str>,
     ) -> Result<bool> {
         self.db.ensure_initialized().await?;
-        let updated = sqlx::query(
-            "UPDATE ci_route_attempts \
-             SET action_phase = 'terminal', terminal_outcome = $2, terminalized_at = now(), \
-                 superseded_by_evidence = COALESCE($3::jsonb, superseded_by_evidence), updated_at = now() \
-             WHERE provider_action_key = $1 AND action_phase <> 'terminal'",
+        if outcome.is_provider_finalization() {
+            return Err(DbError::InvalidData(format!(
+                "`{}` may only be written by the calling owner through finalize_calling",
+                outcome.as_str()
+            )));
+        }
+        let mut tx = self.db.pool().begin().await?;
+        let Some(attempt) = fetch_locked(&mut tx, subject, provider_action_key).await? else {
+            tx.commit().await?;
+            return Ok(false);
+        };
+        if attempt.action_phase == CiActionPhase::Calling {
+            tx.commit().await?;
+            return Err(DbError::InvalidTransition(format!(
+                "route `{provider_action_key}` is owned by incarnation `{}` in phase calling; \
+                 it can only be closed by that owner or by startup recovery",
+                attempt.owner_incarnation_id.as_deref().unwrap_or("<none>")
+            )));
+        }
+        let wrote = terminalize_cas_in_tx(
+            &mut tx,
+            subject,
+            provider_action_key,
+            outcome,
+            superseded_by_evidence_json,
         )
-        .bind(provider_action_key)
-        .bind(outcome.as_str())
-        .bind(superseded_by_evidence_json)
-        .execute(self.db.pool())
         .await?;
-        Ok(updated.rows_affected() == 1)
+        tx.commit().await?;
+        Ok(wrote)
     }
 
     /// Pre-call recovery. See the module docs for the three-outcome contract.
@@ -1037,6 +1237,7 @@ impl CiRouteAttemptRepository {
     /// Database failures.
     pub async fn recover_reserved(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
         observed_identity: &CiEvidenceIdentity,
         recovering_incarnation_id: &str,
@@ -1046,7 +1247,7 @@ impl CiRouteAttemptRepository {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
 
-        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+        let Some(attempt) = fetch_locked(&mut tx, subject, provider_action_key).await? else {
             tx.commit().await?;
             return Ok(CiReservedRecovery::NotFound);
         };
@@ -1061,10 +1262,12 @@ impl CiRouteAttemptRepository {
         // subtracting it in Rust would compare two clocks, and a coordinator
         // whose clock runs behind Postgres would read every reservation as
         // young and never recover one.
-        let eligible: bool = sqlx::query_scalar(
-            "SELECT reserved_at <= now() - make_interval(secs => $2::double precision) \
-             FROM ci_route_attempts WHERE provider_action_key = $1",
-        )
+        let eligible: bool = sqlx::query_scalar(&format!(
+            "SELECT reserved_at <= now() - make_interval(secs => $4::double precision) \
+             FROM ci_route_attempts WHERE {BY_PK}"
+        ))
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .bind(reservation_timeout_secs as f64)
         .fetch_one(&mut *tx)
@@ -1077,58 +1280,72 @@ impl CiRouteAttemptRepository {
         if !attempt.identity.matches(observed_identity) {
             let superseded = terminalize_in_tx(
                 &mut tx,
+                subject,
                 provider_action_key,
                 CiRouteOutcome::SupersededPreCall,
                 Some(&identity_evidence_json(observed_identity)),
-                None,
             )
             .await?;
             tx.commit().await?;
             return Ok(CiReservedRecovery::SupersededPreCall(Box::new(superseded)));
         }
 
-        let counts =
-            lock_budgets(&mut tx, &attempt.retry_budget_key, &attempt.head_budget_key).await?;
+        let counts = lock_budgets(
+            &mut tx,
+            subject,
+            &attempt.retry_budget_key,
+            &attempt.head_budget_key,
+        )
+        .await?;
 
         if counts.is_exhausted() {
-            sqlx::query(
+            sqlx::query(&format!(
                 "UPDATE ci_route_attempts \
                  SET retry_exhausted_at = COALESCE(retry_exhausted_at, now()), \
                      pre_call_resumptions = pre_call_resumptions + 1, updated_at = now() \
-                 WHERE provider_action_key = $1",
-            )
+                 WHERE {BY_PK}"
+            ))
+            .bind(subject.kind.as_str())
+            .bind(&subject.id)
             .bind(provider_action_key)
             .execute(&mut *tx)
             .await?;
-            let lease_id = open_tier2_lease_in_tx(
+            let grant = open_tier2_lease_in_tx(
                 &mut tx,
+                subject,
                 provider_action_key,
                 tier2_lease_key,
                 CiTier2Reason::RetryExhausted,
             )
             .await?;
-            let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+            let refreshed = fetch_in_tx(&mut tx, subject, provider_action_key)
                 .await?
                 .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
             tx.commit().await?;
             return Ok(CiReservedRecovery::RetryExhausted {
                 attempt: Box::new(refreshed),
                 counts,
-                tier2_lease_id: lease_id,
+                tier2_lease_id: grant.opened_id(),
             });
         }
 
-        let charged =
-            charge_budgets_in_tx(&mut tx, &attempt.retry_budget_key, &attempt.head_budget_key)
-                .await?;
-
-        let updated = sqlx::query(
-            "UPDATE ci_route_attempts \
-             SET action_phase = 'calling', calling_at = now(), owner_incarnation_id = $2, \
-                 charged_signature_count = $3, charged_head_count = $4, \
-                 pre_call_resumptions = pre_call_resumptions + 1, updated_at = now() \
-             WHERE provider_action_key = $1 AND action_phase = 'reserved'",
+        let charged = charge_budgets_in_tx(
+            &mut tx,
+            subject,
+            &attempt.retry_budget_key,
+            &attempt.head_budget_key,
         )
+        .await?;
+
+        let updated = sqlx::query(&format!(
+            "UPDATE ci_route_attempts \
+             SET action_phase = 'calling', calling_at = now(), owner_incarnation_id = $4, \
+                 charged_signature_count = $5, charged_head_count = $6, \
+                 pre_call_resumptions = pre_call_resumptions + 1, updated_at = now() \
+             WHERE {BY_PK} AND action_phase = 'reserved'"
+        ))
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .bind(recovering_incarnation_id)
         .bind(charged.signature)
@@ -1141,7 +1358,7 @@ impl CiRouteAttemptRepository {
             ));
         }
 
-        let resumed = fetch_in_tx(&mut tx, provider_action_key)
+        let resumed = fetch_in_tx(&mut tx, subject, provider_action_key)
             .await?
             .ok_or_else(|| DbError::Internal("resumed route row disappeared".to_owned()))?;
         tx.commit().await?;
@@ -1157,38 +1374,42 @@ impl CiRouteAttemptRepository {
     /// The predicates, in the order they are checked:
     ///
     /// 1. the caller attests exclusive advisory-lock ownership;
-    /// 2. the caller attests a quiescence proof that is not
+    /// 2. the row is still `calling`;
+    /// 3. its owner is the exact named former owner, and differs from the
+    ///    recovering incarnation;
+    /// 4. the caller attests a quiescence proof that is not
     ///    [`CiQuiescenceProof::None`] — and for a graceful drain, the former
     ///    incarnation must actually carry `provider_actions_drained_at`;
-    /// 3. the row is still `calling`;
-    /// 4. its owner is the exact named former owner, and differs from the
-    ///    recovering incarnation;
     /// 5. `calling_at` is at least `calling_recovery_timeout_secs` old.
     ///
-    /// Only then does it compare-and-set. Passing all five and still losing —
-    /// because the former owner's finalizer committed first — is legal and is
-    /// recorded as `cas_lost`.
+    /// Only then does it compare-and-set.
+    ///
+    /// `observed_identity` is **not** optional, deliberately. A caller that
+    /// cannot observe the current identity must not call this at all: passing
+    /// "unknown" would resolve to `superseded_after_call` and silently suppress
+    /// the Tier-2 adjudication a possibly-current row is owed.
     ///
     /// # Errors
     ///
     /// Database failures.
     pub async fn recover_calling_owner(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
-        observed_identity: Option<&CiEvidenceIdentity>,
+        observed_identity: &CiEvidenceIdentity,
         authority: &CiCallingRecoveryAuthority,
         tier2_lease_key: &str,
     ) -> Result<CiCallingRecovery> {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
 
-        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+        let Some(attempt) = fetch_locked(&mut tx, subject, provider_action_key).await? else {
             tx.commit().await?;
             return Ok(CiCallingRecovery::NotFound);
         };
 
-        // (1) lock ownership — a periodic sweep or a non-leader runtime stops
-        // here and can never open Tier 2.
+        // (1-3) lock ownership, phase, and exact owner. A periodic sweep or a
+        // non-leader runtime stops here and can never open Tier 2.
         let deferral = if !authority.holds_exclusive_lock {
             Some(CiCallingRecoveryReason::LockNotHeld)
         } else if attempt.action_phase != CiActionPhase::Calling {
@@ -1203,8 +1424,16 @@ impl CiRouteAttemptRepository {
         };
 
         if let Some(reason) = deferral {
-            record_calling_recovery(&mut tx, provider_action_key, authority, reason, false, None)
-                .await?;
+            record_calling_recovery(
+                &mut tx,
+                subject,
+                provider_action_key,
+                authority,
+                reason,
+                false,
+                None,
+            )
+            .await?;
             tx.commit().await?;
             return Ok(CiCallingRecovery::Deferred {
                 attempt: Box::new(attempt),
@@ -1212,7 +1441,7 @@ impl CiRouteAttemptRepository {
             });
         }
 
-        // (2) quiescence. `None` is never enough, and a claimed graceful
+        // (4) quiescence. `None` is never enough, and a claimed graceful
         // drain is checked against the former incarnation's own record rather
         // than believed.
         let quiescent = match authority.quiescence_proof {
@@ -1231,6 +1460,7 @@ impl CiRouteAttemptRepository {
         if !quiescent {
             record_calling_recovery(
                 &mut tx,
+                subject,
                 provider_action_key,
                 authority,
                 CiCallingRecoveryReason::LiveOwnerDeferred,
@@ -1245,11 +1475,13 @@ impl CiRouteAttemptRepository {
             });
         }
 
-        // (3) the 300s floor, again measured by the database clock.
-        let elapsed: bool = sqlx::query_scalar(
-            "SELECT calling_at <= now() - make_interval(secs => $2::double precision) \
-             FROM ci_route_attempts WHERE provider_action_key = $1",
-        )
+        // (5) the 300s floor, again measured by the database clock.
+        let elapsed: bool = sqlx::query_scalar(&format!(
+            "SELECT calling_at <= now() - make_interval(secs => $4::double precision) \
+             FROM ci_route_attempts WHERE {BY_PK}"
+        ))
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .bind(authority.calling_recovery_timeout_secs as f64)
         .fetch_one(&mut *tx)
@@ -1257,6 +1489,7 @@ impl CiRouteAttemptRepository {
         if !elapsed {
             record_calling_recovery(
                 &mut tx,
+                subject,
                 provider_action_key,
                 authority,
                 CiCallingRecoveryReason::TimeoutNotElapsed,
@@ -1274,25 +1507,27 @@ impl CiRouteAttemptRepository {
         // The external outcome is unknowable and is never queried or replayed.
         // A still-current row becomes `outcome_unknown` and keeps its charge;
         // an obsolete one becomes `superseded_after_call`.
-        let still_current = observed_identity.is_some_and(|obs| attempt.identity.matches(obs));
+        let still_current = attempt.identity.matches(observed_identity);
         let outcome = if still_current {
             CiRouteOutcome::OutcomeUnknown
         } else {
             CiRouteOutcome::SupersededAfterCall
         };
 
-        let won = sqlx::query(
+        let won = sqlx::query(&format!(
             "UPDATE ci_route_attempts \
-             SET owner_incarnation_id = $3, action_phase = 'terminal', terminal_outcome = $4, \
-                 terminalized_at = now(), superseded_by_evidence = COALESCE($5::jsonb, superseded_by_evidence), \
+             SET owner_incarnation_id = $5, action_phase = 'terminal', terminal_outcome = $6, \
+                 terminalized_at = now(), superseded_by_evidence = COALESCE($7::jsonb, superseded_by_evidence), \
                  updated_at = now() \
-             WHERE provider_action_key = $1 AND action_phase = 'calling' AND owner_incarnation_id = $2",
-        )
+             WHERE {BY_PK} AND action_phase = 'calling' AND owner_incarnation_id = $4"
+        ))
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .bind(&authority.former_owner_incarnation)
         .bind(&authority.recovering_incarnation)
         .bind(outcome.as_str())
-        .bind(observed_identity.map(identity_evidence_json))
+        .bind(identity_evidence_json(observed_identity))
         .execute(&mut *tx)
         .await?;
 
@@ -1304,11 +1539,12 @@ impl CiRouteAttemptRepository {
         // being observable is a lost CAS being silently treated as a win, and
         // the audit row makes it falsifiable if the locking ever changes.
         if won.rows_affected() != 1 {
-            let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+            let refreshed = fetch_in_tx(&mut tx, subject, provider_action_key)
                 .await?
                 .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
             record_calling_recovery(
                 &mut tx,
+                subject,
                 provider_action_key,
                 authority,
                 CiCallingRecoveryReason::CasLost,
@@ -1326,20 +1562,23 @@ impl CiRouteAttemptRepository {
         let lease_id = if still_current {
             open_tier2_lease_in_tx(
                 &mut tx,
+                subject,
                 provider_action_key,
                 tier2_lease_key,
                 CiTier2Reason::OutcomeUnknown,
             )
             .await?
+            .opened_id()
         } else {
             None
         };
 
-        let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+        let refreshed = fetch_in_tx(&mut tx, subject, provider_action_key)
             .await?
             .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
         record_calling_recovery(
             &mut tx,
+            subject,
             provider_action_key,
             authority,
             CiCallingRecoveryReason::StartupOwnerHandoff,
@@ -1363,11 +1602,23 @@ impl CiRouteAttemptRepository {
     /// passing or merged observation. A failed guard closes the row
     /// `superseded_before_lead` and opens nothing.
     ///
+    /// A row routes to Tier 2 **at most once, ever**. Both the open lease and
+    /// a resolved one refuse a second adjudication; only the partial unique
+    /// index is released on resolution, and that release is for a *different*
+    /// row carrying genuinely newer evidence.
+    ///
+    /// `tier2_lease_key` is derived by wave 2 from **(PR number, PR-head
+    /// SHA)** — never the lane, the run id, or the dequeue id. A lane-scoped
+    /// key would allow two concurrent Lead adjudications for one PR head and
+    /// defeat the head-level hold. The subject scoping supplies repository
+    /// identity, so the key does not need to.
+    ///
     /// # Errors
     ///
     /// Database failures.
     pub async fn open_tier2_lease(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
         observed_identity: &CiEvidenceIdentity,
         tier2_lease_key: &str,
@@ -1376,7 +1627,7 @@ impl CiRouteAttemptRepository {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
 
-        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+        let Some(attempt) = fetch_locked(&mut tx, subject, provider_action_key).await? else {
             tx.commit().await?;
             return Ok(CiTier2LeaseOutcome::NotFound);
         };
@@ -1395,51 +1646,64 @@ impl CiRouteAttemptRepository {
         if !attempt.identity.matches(observed_identity) || terminal_blocks_lease {
             let closed = terminalize_in_tx(
                 &mut tx,
+                subject,
                 provider_action_key,
                 CiRouteOutcome::SupersededBeforeLead,
                 Some(&identity_evidence_json(observed_identity)),
-                None,
             )
             .await?;
             tx.commit().await?;
             return Ok(CiTier2LeaseOutcome::SupersededBeforeLead(Box::new(closed)));
         }
 
-        let lease_id =
-            open_tier2_lease_in_tx(&mut tx, provider_action_key, tier2_lease_key, reason).await?;
-        let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+        let grant = open_tier2_lease_in_tx(
+            &mut tx,
+            subject,
+            provider_action_key,
+            tier2_lease_key,
+            reason,
+        )
+        .await?;
+        let refreshed = fetch_in_tx(&mut tx, subject, provider_action_key)
             .await?
             .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
         tx.commit().await?;
-        Ok(match lease_id {
-            Some(id) => CiTier2LeaseOutcome::Opened {
+        Ok(match grant {
+            Tier2Grant::Opened(id) => CiTier2LeaseOutcome::Opened {
                 attempt: Box::new(refreshed),
                 lease_id: id,
             },
-            None => CiTier2LeaseOutcome::AlreadyLeased(Box::new(refreshed)),
+            Tier2Grant::AlreadyRoutedToTier2 => {
+                CiTier2LeaseOutcome::AlreadyRoutedToTier2(Box::new(refreshed))
+            }
+            Tier2Grant::KeyHeldElsewhere => {
+                CiTier2LeaseOutcome::KeyHeldElsewhere(Box::new(refreshed))
+            }
         })
     }
 
     /// Bind a dispatched Lead session to an open lease.
     ///
     /// Fenced to the exact lease id so a stale caller cannot attach a session
-    /// to a lease that has already been resolved and reopened for newer
-    /// evidence.
+    /// to a lease that has already been resolved.
     ///
     /// # Errors
     ///
     /// Database failures.
     pub async fn attach_lead_session(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
         lease_id: &str,
         lead_session_id: &str,
     ) -> Result<bool> {
         self.db.ensure_initialized().await?;
-        let updated = sqlx::query(
-            "UPDATE ci_route_attempts SET lead_session_id = $3, updated_at = now() \
-             WHERE provider_action_key = $1 AND tier2_lease_id = $2 AND tier2_lease_state = 'open'",
-        )
+        let updated = sqlx::query(&format!(
+            "UPDATE ci_route_attempts SET lead_session_id = $5, updated_at = now() \
+             WHERE {BY_PK} AND tier2_lease_id = $4 AND tier2_lease_state = 'open'"
+        ))
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .bind(lease_id)
         .bind(lead_session_id)
@@ -1453,9 +1717,10 @@ impl CiRouteAttemptRepository {
     /// Resolving the lease releases the current-evidence key, and — for a row
     /// that has not already terminalized on its provider outcome — writes the
     /// route's single terminal outcome. A row that *did* terminalize earlier
-    /// (`action_failed`, `outcome_unknown`) keeps that outcome: the Tier-2
-    /// resolution is recorded on `tier2_resolution` instead, because
-    /// terminalization is write-once.
+    /// (`action_failed`, `outcome_unknown`) keeps that outcome and records the
+    /// adjudication in `tier2_resolution`, because terminalization is
+    /// write-once. Use [`CiRouteAttempt::adjudicated_outcome`] to read it back
+    /// without caring which case applied.
     ///
     /// # Errors
     ///
@@ -1463,6 +1728,7 @@ impl CiRouteAttemptRepository {
     /// outcome.
     pub async fn resolve_tier2_lease(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
         lease_id: &str,
         observed_identity: &CiEvidenceIdentity,
@@ -1472,7 +1738,7 @@ impl CiRouteAttemptRepository {
         resolution.validate()?;
         let mut tx = self.db.pool().begin().await?;
 
-        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+        let Some(attempt) = fetch_locked(&mut tx, subject, provider_action_key).await? else {
             tx.commit().await?;
             return Ok(false);
         };
@@ -1487,66 +1753,59 @@ impl CiRouteAttemptRepository {
         // transition it authorizes. A head, lane, or dequeue change since
         // dispatch closes the route without any board mutation.
         if !attempt.identity.matches(observed_identity) {
-            sqlx::query(
-                "UPDATE ci_route_attempts \
-                 SET tier2_lease_state = 'resolved', tier2_resolved_at = now(), \
-                     tier2_resolution = 'superseded_before_apply', updated_at = now() \
-                 WHERE provider_action_key = $1 AND tier2_lease_id = $2",
-            )
-            .bind(provider_action_key)
-            .bind(lease_id)
-            .execute(&mut *tx)
-            .await?;
-            terminalize_in_tx(
+            resolve_lease_in_tx(
                 &mut tx,
+                subject,
+                provider_action_key,
+                lease_id,
+                &CiTier2Resolution::plain(CiRouteOutcome::SupersededBeforeApply),
+            )
+            .await?;
+            terminalize_cas_in_tx(
+                &mut tx,
+                subject,
                 provider_action_key,
                 CiRouteOutcome::SupersededBeforeApply,
                 Some(&identity_evidence_json(observed_identity)),
-                None,
             )
             .await?;
             tx.commit().await?;
             return Ok(false);
         }
 
-        sqlx::query(
-            "UPDATE ci_route_attempts \
-             SET tier2_lease_state = 'resolved', tier2_resolved_at = now(), tier2_resolution = $3, \
-                 reopen_mode = $4, diagnostic_reason = $5, park_justification = $6, updated_at = now() \
-             WHERE provider_action_key = $1 AND tier2_lease_id = $2",
+        resolve_lease_in_tx(&mut tx, subject, provider_action_key, lease_id, resolution).await?;
+        terminalize_cas_in_tx(
+            &mut tx,
+            subject,
+            provider_action_key,
+            resolution.outcome,
+            None,
         )
-        .bind(provider_action_key)
-        .bind(lease_id)
-        .bind(resolution.outcome.as_str())
-        .bind(resolution.reopen_mode.map(CiReopenMode::as_str))
-        .bind(resolution.diagnostic_reason.map(CiDiagnosticReason::as_str))
-        .bind(resolution.park_justification.as_deref())
-        .execute(&mut *tx)
         .await?;
-
-        terminalize_in_tx(&mut tx, provider_action_key, resolution.outcome, None, None).await?;
         tx.commit().await?;
         Ok(true)
     }
 
-    /// Close every non-terminal route for a PR because CI passed or the PR
-    /// merged.
+    /// Close every `reserved` route for a PR because CI passed or it merged.
     ///
     /// Charges are **not** refunded — a spent slot stays spent. Any open
     /// Tier-2 lease is resolved so its current-evidence key is released and a
     /// delayed Lead result finds nothing to apply to.
+    ///
+    /// A `calling` row is deliberately left alone: its provider future may be
+    /// in flight, and closing it here would steal the row from a live owner
+    /// and make its own finalizer a silent no-op. Such a row drains through
+    /// that owner or through startup recovery, which is what the rollback
+    /// quiescence gate waits for.
     ///
     /// Returns the number of routes closed.
     ///
     /// # Errors
     ///
     /// Database failures, or an outcome other than `passed`/`merged`.
-    ///
-    /// Scoped by `task_id` as well as `pr_number`: a PR number is unique only
-    /// within one repository, and this repository holds every project's rows.
     pub async fn close_routes_for_newer_outcome(
         &self,
-        task_id: &str,
+        subject: &CiRouteSubject,
         pr_number: i64,
         outcome: CiRouteOutcome,
         observed_evidence_json: Option<&str>,
@@ -1562,21 +1821,25 @@ impl CiRouteAttemptRepository {
         sqlx::query(
             "UPDATE ci_route_attempts \
              SET tier2_lease_state = 'resolved', tier2_resolved_at = now(), \
-                 tier2_resolution = COALESCE(tier2_resolution, $3), updated_at = now() \
-             WHERE task_id = $1 AND pr_number = $2 AND tier2_lease_state = 'open'",
+                 tier2_resolution = COALESCE(tier2_resolution, $4), updated_at = now() \
+             WHERE subject_kind = $1 AND subject_id = $2 AND pr_number = $3 \
+               AND tier2_lease_state = 'open'",
         )
-        .bind(task_id)
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(pr_number)
         .bind(outcome.as_str())
         .execute(&mut *tx)
         .await?;
         let closed = sqlx::query(
             "UPDATE ci_route_attempts \
-             SET action_phase = 'terminal', terminal_outcome = $3, terminalized_at = now(), \
-                 superseded_by_evidence = COALESCE($4::jsonb, superseded_by_evidence), updated_at = now() \
-             WHERE task_id = $1 AND pr_number = $2 AND action_phase <> 'terminal'",
+             SET action_phase = 'terminal', terminal_outcome = $4, terminalized_at = now(), \
+                 superseded_by_evidence = COALESCE($5::jsonb, superseded_by_evidence), updated_at = now() \
+             WHERE subject_kind = $1 AND subject_id = $2 AND pr_number = $3 \
+               AND action_phase = 'reserved'",
         )
-        .bind(task_id)
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(pr_number)
         .bind(outcome.as_str())
         .bind(observed_evidence_json)
@@ -1611,23 +1874,26 @@ impl CiRouteAttemptRepository {
         })
     }
 
-    /// The evidence identities that are still non-terminal, i.e. the routed
-    /// failed identities the rollback gate must see advance, pass, or merge.
+    /// The routes that are still non-terminal, i.e. the routed failed
+    /// identities the rollback gate must see advance, pass, or merge.
     ///
     /// # Errors
     ///
     /// Database failures.
-    pub async fn non_terminal_identities(&self) -> Result<Vec<(String, CiEvidenceIdentity)>> {
+    pub async fn non_terminal_identities(
+        &self,
+    ) -> Result<Vec<(CiRouteSubject, String, CiEvidenceIdentity)>> {
         self.db.ensure_initialized().await?;
         let rows = sqlx::query(&format!(
             "SELECT {ROW_COLUMNS} FROM ci_route_attempts WHERE action_phase <> 'terminal' \
-             ORDER BY reserved_at, provider_action_key"
+             ORDER BY reserved_at, subject_kind, subject_id, provider_action_key"
         ))
         .fetch_all(self.db.pool())
         .await?;
         rows.iter()
             .map(|row| {
-                CiRouteAttempt::from_row(row).map(|a| (a.provider_action_key.clone(), a.identity))
+                CiRouteAttempt::from_row(row)
+                    .map(|a| (a.subject, a.provider_action_key, a.identity))
             })
             .collect()
     }
@@ -1639,6 +1905,7 @@ impl CiRouteAttemptRepository {
     /// Database failures.
     pub async fn calling_recovery_audit(
         &self,
+        subject: &CiRouteSubject,
         provider_action_key: &str,
     ) -> Result<Vec<CiCallingRecoveryRecord>> {
         self.db.ensure_initialized().await?;
@@ -1646,8 +1913,12 @@ impl CiRouteAttemptRepository {
             "SELECT id, provider_action_key, former_owner_incarnation, recovering_incarnation, \
                     holds_exclusive_lock, quiescence_proof, recovery_reason, \
                     calling_recovery_timeout_secs, cas_won, resulting_outcome \
-             FROM ci_route_calling_recoveries WHERE provider_action_key = $1 ORDER BY id",
+             FROM ci_route_calling_recoveries \
+             WHERE subject_kind = $1 AND subject_id = $2 AND provider_action_key = $3 \
+             ORDER BY id",
         )
+        .bind(subject.kind.as_str())
+        .bind(&subject.id)
         .bind(provider_action_key)
         .fetch_all(self.db.pool())
         .await?;
@@ -1700,11 +1971,14 @@ pub struct CiCallingRecoveryRecord {
 
 async fn fetch_in_tx(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     provider_action_key: &str,
 ) -> Result<Option<CiRouteAttempt>> {
     let row = sqlx::query(&format!(
-        "SELECT {ROW_COLUMNS} FROM ci_route_attempts WHERE provider_action_key = $1"
+        "SELECT {ROW_COLUMNS} FROM ci_route_attempts WHERE {BY_PK}"
     ))
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(provider_action_key)
     .fetch_optional(&mut **tx)
     .await?;
@@ -1718,18 +1992,21 @@ async fn fetch_in_tx(
 /// prove is a plain row reference.
 async fn fetch_locked(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     provider_action_key: &str,
 ) -> Result<Option<CiRouteAttempt>> {
-    let locked: Option<(String,)> = sqlx::query_as(
-        "SELECT provider_action_key FROM ci_route_attempts WHERE provider_action_key = $1 FOR UPDATE",
-    )
+    let locked: Option<(String,)> = sqlx::query_as(&format!(
+        "SELECT provider_action_key FROM ci_route_attempts WHERE {BY_PK} FOR UPDATE"
+    ))
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(provider_action_key)
     .fetch_optional(&mut **tx)
     .await?;
     if locked.is_none() {
         return Ok(None);
     }
-    fetch_in_tx(tx, provider_action_key).await
+    fetch_in_tx(tx, subject, provider_action_key).await
 }
 
 /// Materialize and lock both counter rows, returning their current values.
@@ -1738,32 +2015,40 @@ async fn fetch_locked(
 /// creating a counter is not charging it.
 async fn lock_budgets(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     retry_budget_key: &str,
     head_budget_key: &str,
 ) -> Result<CiBudgetCounts> {
     // Deterministic order (signature then head) so two transactions charging
     // the same pair can never deadlock against each other.
-    let signature = lock_counter(tx, "signature", retry_budget_key).await?;
-    let head = lock_counter(tx, "head", head_budget_key).await?;
+    let signature = lock_counter(tx, subject, "signature", retry_budget_key).await?;
+    let head = lock_counter(tx, subject, "head", head_budget_key).await?;
     Ok(CiBudgetCounts { signature, head })
 }
 
 async fn lock_counter(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     scope: &str,
     counter_key: &str,
 ) -> Result<i64> {
     sqlx::query(
-        "INSERT INTO ci_route_budget_counters (scope, counter_key, charged_count) VALUES ($1, $2, 0) \
-         ON CONFLICT (scope, counter_key) DO NOTHING",
+        "INSERT INTO ci_route_budget_counters (subject_kind, subject_id, scope, counter_key, charged_count) \
+         VALUES ($1, $2, $3, $4, 0) \
+         ON CONFLICT (subject_kind, subject_id, scope, counter_key) DO NOTHING",
     )
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(scope)
     .bind(counter_key)
     .execute(&mut **tx)
     .await?;
     let count: i64 = sqlx::query_scalar(
-        "SELECT charged_count FROM ci_route_budget_counters WHERE scope = $1 AND counter_key = $2 FOR UPDATE",
+        "SELECT charged_count FROM ci_route_budget_counters \
+         WHERE subject_kind = $1 AND subject_id = $2 AND scope = $3 AND counter_key = $4 FOR UPDATE",
     )
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(scope)
     .bind(counter_key)
     .fetch_one(&mut **tx)
@@ -1779,16 +2064,18 @@ async fn lock_counter(
 /// was still listening.
 async fn charge_budgets_in_tx(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     retry_budget_key: &str,
     head_budget_key: &str,
 ) -> Result<CiBudgetCounts> {
-    let signature = charge_counter(tx, "signature", retry_budget_key).await?;
-    let head = charge_counter(tx, "head", head_budget_key).await?;
+    let signature = charge_counter(tx, subject, "signature", retry_budget_key).await?;
+    let head = charge_counter(tx, subject, "head", head_budget_key).await?;
     Ok(CiBudgetCounts { signature, head })
 }
 
 async fn charge_counter(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     scope: &str,
     counter_key: &str,
 ) -> Result<i64> {
@@ -1797,9 +2084,11 @@ async fn charge_counter(
          SET charged_count = charged_count + 1, \
              first_charged_at = COALESCE(first_charged_at, now()), \
              last_charged_at = now() \
-         WHERE scope = $1 AND counter_key = $2 \
+         WHERE subject_kind = $1 AND subject_id = $2 AND scope = $3 AND counter_key = $4 \
          RETURNING charged_count",
     )
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(scope)
     .bind(counter_key)
     .fetch_one(&mut **tx)
@@ -1807,76 +2096,160 @@ async fn charge_counter(
     Ok(count)
 }
 
-async fn terminalize_in_tx(
+/// The write-once terminal compare-and-set. Returns whether it wrote.
+async fn terminalize_cas_in_tx(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     provider_action_key: &str,
     outcome: CiRouteOutcome,
     superseded_by_evidence_json: Option<&str>,
-    provider_error_json: Option<&str>,
-) -> Result<CiRouteAttempt> {
-    sqlx::query(
+) -> Result<bool> {
+    let updated = sqlx::query(&format!(
         "UPDATE ci_route_attempts \
-         SET action_phase = 'terminal', terminal_outcome = $2, terminalized_at = now(), \
-             superseded_by_evidence = COALESCE($3::jsonb, superseded_by_evidence), \
-             provider_error = COALESCE($4::jsonb, provider_error), updated_at = now() \
-         WHERE provider_action_key = $1 AND action_phase <> 'terminal'",
-    )
+         SET action_phase = 'terminal', terminal_outcome = $4, terminalized_at = now(), \
+             superseded_by_evidence = COALESCE($5::jsonb, superseded_by_evidence), updated_at = now() \
+         WHERE {BY_PK} AND action_phase <> 'terminal'"
+    ))
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(provider_action_key)
     .bind(outcome.as_str())
     .bind(superseded_by_evidence_json)
-    .bind(provider_error_json)
     .execute(&mut **tx)
     .await?;
-    fetch_in_tx(tx, provider_action_key)
+    Ok(updated.rows_affected() == 1)
+}
+
+async fn terminalize_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
+    provider_action_key: &str,
+    outcome: CiRouteOutcome,
+    superseded_by_evidence_json: Option<&str>,
+) -> Result<CiRouteAttempt> {
+    terminalize_cas_in_tx(
+        tx,
+        subject,
+        provider_action_key,
+        outcome,
+        superseded_by_evidence_json,
+    )
+    .await?;
+    fetch_in_tx(tx, subject, provider_action_key)
         .await?
         .ok_or_else(|| DbError::Internal("terminalized route row disappeared".to_owned()))
 }
 
-/// Open the lease, or report that the current-evidence key already has one.
+async fn resolve_lease_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
+    provider_action_key: &str,
+    lease_id: &str,
+    resolution: &CiTier2Resolution,
+) -> Result<()> {
+    sqlx::query(&format!(
+        "UPDATE ci_route_attempts \
+         SET tier2_lease_state = 'resolved', tier2_resolved_at = now(), tier2_resolution = $5, \
+             reopen_mode = $6, diagnostic_reason = $7, park_justification = $8, updated_at = now() \
+         WHERE {BY_PK} AND tier2_lease_id = $4"
+    ))
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
+    .bind(provider_action_key)
+    .bind(lease_id)
+    .bind(resolution.outcome.as_str())
+    .bind(resolution.reopen_mode.map(CiReopenMode::as_str))
+    .bind(resolution.diagnostic_reason.map(CiDiagnosticReason::as_str))
+    .bind(resolution.park_justification.as_deref())
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Why a Tier-2 lease request did or did not produce a lease.
+enum Tier2Grant {
+    Opened(String),
+    /// This row has already used its one trip to Tier 2 (open or resolved).
+    AlreadyRoutedToTier2,
+    /// Another row on this subject holds the open lease for that key.
+    KeyHeldElsewhere,
+}
+
+impl Tier2Grant {
+    fn opened_id(self) -> Option<String> {
+        match self {
+            Self::Opened(id) => Some(id),
+            _ => None,
+        }
+    }
+}
+
+/// Open the lease, or explain why not.
 ///
-/// The mutual exclusion is the partial unique index, not this function: two
-/// concurrent transactions both reach the INSERT-equivalent UPDATE and one of
-/// them violates the index. `ON CONFLICT` is unavailable for an UPDATE, so the
-/// contention is resolved by checking for an existing open lease under the
-/// row/key locks the callers already hold.
+/// Two distinct refusals, deliberately not collapsed:
+///
+/// * **once-ever** — `tier2_lease_state IS NULL` in the UPDATE guard. The
+///   proposal says failed or unknown provider evidence "may route **once** to
+///   Tier 2", and a resolved lease must therefore not be reopenable. A guard
+///   of `IS DISTINCT FROM 'open'` would give only *concurrent* uniqueness: an
+///   `action_failed` row whose adjudication already landed could be re-leased,
+///   re-adjudicated, and would carry a stale `tier2_resolution` while its
+///   state flipped back to open.
+/// * **mutual exclusion** — another row already holds the key. The partial
+///   unique index is the real enforcement; this lookup exists so the loser
+///   gets an outcome instead of a constraint violation.
 async fn open_tier2_lease_in_tx(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     provider_action_key: &str,
     tier2_lease_key: &str,
     reason: CiTier2Reason,
-) -> Result<Option<String>> {
+) -> Result<Tier2Grant> {
     let existing: Option<(String,)> = sqlx::query_as(
         "SELECT provider_action_key FROM ci_route_attempts \
-         WHERE tier2_lease_key = $1 AND tier2_lease_state = 'open' FOR UPDATE",
+         WHERE subject_kind = $1 AND subject_id = $2 AND tier2_lease_key = $3 \
+           AND tier2_lease_state = 'open' FOR UPDATE",
     )
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(tier2_lease_key)
     .fetch_optional(&mut **tx)
     .await?;
-    if existing.is_some() {
-        return Ok(None);
+    if let Some((holder,)) = existing {
+        return Ok(if holder == provider_action_key {
+            Tier2Grant::AlreadyRoutedToTier2
+        } else {
+            Tier2Grant::KeyHeldElsewhere
+        });
     }
+
     let lease_id = uuid::Uuid::now_v7().to_string();
-    let updated = sqlx::query(
+    let updated = sqlx::query(&format!(
         "UPDATE ci_route_attempts \
-         SET tier2_lease_id = $2, tier2_lease_key = $3, tier2_lease_state = 'open', \
-             tier2_lease_reason = $4, tier2_leased_at = now(), updated_at = now() \
-         WHERE provider_action_key = $1 AND tier2_lease_state IS DISTINCT FROM 'open'",
-    )
+         SET tier2_lease_id = $4, tier2_lease_key = $5, tier2_lease_state = 'open', \
+             tier2_lease_reason = $6, tier2_leased_at = now(), updated_at = now() \
+         WHERE {BY_PK} AND tier2_lease_state IS NULL"
+    ))
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(provider_action_key)
     .bind(&lease_id)
     .bind(tier2_lease_key)
     .bind(reason.as_str())
     .execute(&mut **tx)
     .await?;
-    if updated.rows_affected() == 1 {
-        Ok(Some(lease_id))
+    Ok(if updated.rows_affected() == 1 {
+        Tier2Grant::Opened(lease_id)
     } else {
-        Ok(None)
-    }
+        // Not `KeyHeldElsewhere`: the key lookup above found nothing, so the
+        // only way to miss here is this row's own lease having resolved.
+        Tier2Grant::AlreadyRoutedToTier2
+    })
 }
 
 async fn record_calling_recovery(
     tx: &mut Transaction<'_, Postgres>,
+    subject: &CiRouteSubject,
     provider_action_key: &str,
     authority: &CiCallingRecoveryAuthority,
     reason: CiCallingRecoveryReason,
@@ -1885,13 +2258,17 @@ async fn record_calling_recovery(
 ) -> Result<()> {
     sqlx::query(
         "INSERT INTO ci_route_calling_recoveries \
-           (id, provider_action_key, former_owner_incarnation, recovering_incarnation, \
-            holds_exclusive_lock, quiescence_proof, recovery_reason, calling_recovery_timeout_secs, \
-            observed_calling_at, cas_won, resulting_outcome) \
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8, \
-                 (SELECT calling_at FROM ci_route_attempts WHERE provider_action_key = $2), $9, $10)",
+           (id, subject_kind, subject_id, provider_action_key, former_owner_incarnation, \
+            recovering_incarnation, holds_exclusive_lock, quiescence_proof, recovery_reason, \
+            calling_recovery_timeout_secs, observed_calling_at, cas_won, resulting_outcome) \
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, \
+                 (SELECT calling_at FROM ci_route_attempts \
+                   WHERE subject_kind = $2 AND subject_id = $3 AND provider_action_key = $4), \
+                 $11, $12)",
     )
     .bind(uuid::Uuid::now_v7().to_string())
+    .bind(subject.kind.as_str())
+    .bind(&subject.id)
     .bind(provider_action_key)
     .bind(&authority.former_owner_incarnation)
     .bind(&authority.recovering_incarnation)

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
@@ -1,0 +1,1925 @@
+//! Durable CI evidence-route attempts (proposal `nafu`, wave 1).
+//!
+//! This is the whole persistence layer for the CI routing contract: the
+//! reservation that proves no provider call happened, the single-winner
+//! compare-and-set that grants call ownership, the monotonic retry budgets,
+//! the owner-scoped finalization, the startup-only owner handoff, and the
+//! mutually exclusive Tier-2 (Lead) lease. The coordinator that *uses* it
+//! lands in waves 2 and 3; nothing here calls a provider, dispatches a
+//! worker, or touches the board.
+//!
+//! # Why a `reserved` phase exists at all
+//!
+//! Everything hard about this contract reduces to one question a crashed
+//! coordinator cannot answer from memory: *did I already call GitHub?* The
+//! answer has to be readable from the repository alone, because there is
+//! deliberately no provider read/correlation API in scope — asking the
+//! provider "did you get my request?" is exactly the subsystem the proposal
+//! refuses to build.
+//!
+//! So the row is committed **before** the call, in phase `reserved`, and
+//! provider mutation is forbidden while it is in that phase. A `reserved`
+//! row found after a restart is therefore *proof* that no call happened.
+//! That proof is what makes recovery cheap: the row is resumed, not
+//! abandoned and not escalated. [`CiRouteAttemptRepository::recover_reserved`]
+//! has exactly three outcomes and no fourth:
+//!
+//! | Situation | Outcome | Cost |
+//! | --- | --- | --- |
+//! | Evidence identity is obsolete | terminal `superseded_pre_call` | nothing: no charge, no lease, no Lead, no worker |
+//! | Identity current, budget remains | resume the **same row** through one CAS | exactly one charge and one provider-call episode, however many recoveries run |
+//! | Identity current, budget exhausted | route through retry exhaustion | no charge, at most one Tier-2 lease |
+//!
+//! The middle row is the one worth stating twice: N concurrent recoveries and
+//! N restarts converge on **one** winner and **one** charge, because the
+//! charge is welded to the `reserved` -> `calling` compare-and-set inside a
+//! single transaction that holds the row with `SELECT ... FOR UPDATE`. The
+//! `pre_call_resumptions` counter records how many recoveries ran; it has no
+//! influence on the charge, which is the point of recording it.
+//!
+//! # Why `calling` recovery is so much more restricted
+//!
+//! A `calling` row proves the opposite: a call episode was authorized, and
+//! its result may be in flight at the provider right now. Taking that row
+//! from a *live* owner would allow two episodes for one evidence identity.
+//! Elapsed wall-clock time cannot distinguish "the owner died" from "the
+//! owner is slow", so this module never infers death from time alone. See
+//! [`CiRouteAttemptRepository::recover_calling_owner`]: it demands attested
+//! exclusive-advisory-lock ownership, an explicit quiescence proof (graceful
+//! drain recorded on the former incarnation, or process termination), an
+//! owner mismatch, and the 300-second floor — and even then it can lose its
+//! compare-and-set to the former owner's own finalizer, which is legal and
+//! recorded.
+//!
+//! Every recovery *attempt* writes a row to `ci_route_calling_recoveries`,
+//! including the ones that correctly did nothing. A sweep that left a live
+//! owner alone has to be observable, or the claim "we never steal a live
+//! owner's row" cannot be falsified by a test.
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Postgres, Row, Transaction};
+
+use crate::Result;
+use crate::database::Database;
+use crate::error::DbError;
+
+/// Charged Tier-1 actions allowed per retry-budget key (lane + PR + PR-head
+/// SHA + transient fingerprint).
+pub const CI_SIGNATURE_BUDGET_LIMIT: i64 = 2;
+
+/// Charged Tier-1 actions allowed per PR head, shared **across both lanes**.
+pub const CI_HEAD_BUDGET_LIMIT: i64 = 4;
+
+/// Default age a `reserved` row must reach before a recovery sweep may touch
+/// it.
+///
+/// Unlike [`CI_CALLING_RECOVERY_TIMEOUT_SECS`] the proposal does not fix this
+/// number — it says only "the configured reservation timeout". It is a
+/// liveness/latency knob rather than a safety one: the safety comes from the
+/// compare-and-set, and a too-short value costs at worst a redundant recovery
+/// that loses its CAS. Callers may pass their own.
+pub const CI_RESERVATION_RECOVERY_TIMEOUT_SECS: i64 = 60;
+
+/// Minimum age of `calling_at` before a startup owner handoff is even
+/// considered. Fixed by the proposal.
+pub const CI_CALLING_RECOVERY_TIMEOUT_SECS: i64 = 300;
+
+const ROW_COLUMNS: &str = "provider_action_key, lane, pr_number, pr_head_sha, run_id, run_head_sha, dequeue_id, \
+    task_id, origin_state, class, action, transient_fingerprint, retry_budget_key, head_budget_key, \
+    action_phase, terminal_outcome, \
+    to_char(reserved_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS reserved_at, \
+    to_char(calling_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS calling_at, \
+    to_char(terminalized_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS terminalized_at, \
+    owner_incarnation_id, pre_call_resumptions, charged_signature_count, charged_head_count, \
+    to_char(retry_exhausted_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS retry_exhausted_at, \
+    tier2_lease_id, tier2_lease_key, tier2_lease_state, tier2_lease_reason, \
+    to_char(tier2_leased_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS tier2_leased_at, \
+    tier2_resolution, lead_session_id, reopen_mode, diagnostic_reason, park_justification, \
+    provider_error::text AS provider_error, superseded_by_evidence::text AS superseded_by_evidence";
+
+// ---------------------------------------------------------------------------
+// Vocabularies
+// ---------------------------------------------------------------------------
+
+/// A trivial two-way string mapping.
+///
+/// Every durable vocabulary below is spelled exactly once in Rust and once in
+/// migration 191's `CHECK ... IN (...)`. Keeping the two in one place per enum
+/// is what stops a new variant from binding as an unchecked string that the
+/// CHECK then rejects at 3am instead of at compile time.
+macro_rules! durable_enum {
+    ($(#[$meta:meta])* $name:ident { $($(#[$vmeta:meta])* $variant:ident => $text:literal),+ $(,)? }) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $name {
+            $($(#[$vmeta])* $variant),+
+        }
+
+        impl $name {
+            /// The durable spelling.
+            #[must_use]
+            pub fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $text),+
+                }
+            }
+
+            /// Parse a durable spelling, rejecting anything outside the
+            /// migration's CHECK vocabulary.
+            ///
+            /// # Errors
+            ///
+            /// [`DbError::InvalidData`] for an unknown spelling.
+            pub fn parse(value: &str) -> Result<Self> {
+                match value {
+                    $($text => Ok(Self::$variant),)+
+                    other => Err(DbError::InvalidData(format!(
+                        concat!("invalid ", stringify!($name), " `{}`"), other
+                    ))),
+                }
+            }
+        }
+    };
+}
+
+durable_enum! {
+    /// Which CI surface produced the evidence.
+    CiLane {
+        PrHead => "pr_head",
+        MergeGroup => "merge_group",
+    }
+}
+
+durable_enum! {
+    /// The deterministic classification of a complete terminal evidence set.
+    CiClass {
+        Inconclusive => "inconclusive",
+        CausalFailure => "causal_failure",
+        Unknown => "unknown",
+    }
+}
+
+durable_enum! {
+    /// The route decision recorded for the attempt.
+    CiAction {
+        RerunRun => "rerun_run",
+        Reenqueue => "reenqueue",
+        AskLead => "ask_lead",
+        Hold => "hold",
+        Discard => "discard",
+    }
+}
+
+durable_enum! {
+    /// The board state the route was opened from.
+    CiOriginState {
+        PrDraft => "pr_draft",
+        PrReview => "pr_review",
+    }
+}
+
+durable_enum! {
+    /// Non-terminal action phases plus the terminal marker.
+    ///
+    /// `Reserved` and `Calling` are the two non-terminal phases; `Terminal`
+    /// always accompanies a [`CiRouteOutcome`].
+    CiActionPhase {
+        Reserved => "reserved",
+        Calling => "calling",
+        Terminal => "terminal",
+    }
+}
+
+durable_enum! {
+    /// The closed terminal vocabulary.
+    ///
+    /// There is deliberately no `abandoned`: a row proven not to have called
+    /// the provider is resumed, superseded, or exhausted.
+    CiRouteOutcome {
+        SupersededPreCall => "superseded_pre_call",
+        Retriggered => "retriggered",
+        Reenqueued => "reenqueued",
+        SupersededAfterCall => "superseded_after_call",
+        OutcomeUnknown => "outcome_unknown",
+        ActionFailed => "action_failed",
+        Held => "held",
+        SupersededBeforeLead => "superseded_before_lead",
+        SupersededBeforeApply => "superseded_before_apply",
+        RepairReopened => "repair_reopened",
+        DiagnosticReopened => "diagnostic_reopened",
+        Parked => "parked",
+        Superseded => "superseded",
+        Passed => "passed",
+        Merged => "merged",
+    }
+}
+
+durable_enum! {
+    /// Why a Tier-2 lease was opened.
+    CiTier2Reason {
+        CausalFailure => "causal_failure",
+        EvidenceUnknown => "evidence_unknown",
+        ProviderActionFailed => "provider_action_failed",
+        OutcomeUnknown => "outcome_unknown",
+        RetryExhausted => "retry_exhausted",
+    }
+}
+
+durable_enum! {
+    /// The two mutually exclusive validated `reopen` payload modes.
+    CiReopenMode {
+        Repair => "repair",
+        Diagnose => "diagnose",
+    }
+}
+
+durable_enum! {
+    /// The closed diagnostic-reason set a `diagnose` reopen must cite.
+    CiDiagnosticReason {
+        EvidenceIncomplete => "evidence_incomplete",
+        ProviderActionFailed => "provider_action_failed",
+        NoGroundedRemedy => "no_grounded_remedy",
+        NoRepositoryCommand => "no_repository_command",
+    }
+}
+
+durable_enum! {
+    /// State of the current-evidence Tier-2 hold.
+    CiTier2LeaseState {
+        Open => "open",
+        Resolved => "resolved",
+    }
+}
+
+durable_enum! {
+    /// How a former `calling` owner's provider futures were proven gone.
+    ///
+    /// Note what is absent: elapsed time. The 300-second floor is a
+    /// *necessary* condition layered on top of one of these proofs, never a
+    /// substitute for one.
+    CiQuiescenceProof {
+        /// Leadership cancellation closed action admission, joined every
+        /// leader-owned provider-action future, and recorded
+        /// `provider_actions_drained_at` before releasing the advisory lock.
+        GracefulDrain => "graceful_drain",
+        /// The owning process died, which destroyed its futures before its
+        /// advisory-lock session could close.
+        ProcessTerminated => "process_terminated",
+        /// No proof. Recorded on deferrals so the deferral is auditable.
+        None => "none",
+    }
+}
+
+durable_enum! {
+    /// Why a `calling` recovery attempt did or did not take the row.
+    CiCallingRecoveryReason {
+        StartupOwnerHandoff => "startup_owner_handoff",
+        LiveOwnerDeferred => "live_owner_deferred",
+        NotCalling => "not_calling",
+        OwnerMismatch => "owner_mismatch",
+        TimeoutNotElapsed => "timeout_not_elapsed",
+        LockNotHeld => "lock_not_held",
+        CasLost => "cas_lost",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/// The immutable evidence identity a route attempt is bound to.
+///
+/// Stored expanded on the row (not only as the caller's hash) so a recovery
+/// sweep can compare a freshly observed identity against it without
+/// recomputing the caller's hash function — and so a supersession is
+/// explainable by reading the row.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CiEvidenceIdentity {
+    pub lane: CiLane,
+    pub pr_number: i64,
+    pub pr_head_sha: String,
+    pub run_id: i64,
+    pub run_head_sha: String,
+    /// Merge-group dequeue event identity. `None` for the PR-head lane.
+    pub dequeue_id: Option<String>,
+}
+
+impl CiEvidenceIdentity {
+    /// Whether a freshly observed identity is the *same* evidence.
+    ///
+    /// Full equality on every field, deliberately. The lane table treats a
+    /// changed PR head, a changed run, a changed merge group, and a changed
+    /// dequeue event all as supersession, so there is no field here that may
+    /// drift while the route stays authorized.
+    #[must_use]
+    pub fn matches(&self, observed: &Self) -> bool {
+        self == observed
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
+/// One durable route attempt.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CiRouteAttempt {
+    pub provider_action_key: String,
+    pub identity: CiEvidenceIdentity,
+    pub task_id: String,
+    pub origin_state: CiOriginState,
+    pub class: CiClass,
+    pub action: CiAction,
+    pub transient_fingerprint: String,
+    pub retry_budget_key: String,
+    pub head_budget_key: String,
+
+    pub action_phase: CiActionPhase,
+    pub terminal_outcome: Option<CiRouteOutcome>,
+    pub reserved_at: String,
+    pub calling_at: Option<String>,
+    pub terminalized_at: Option<String>,
+
+    pub owner_incarnation_id: Option<String>,
+    pub pre_call_resumptions: i64,
+    pub charged_signature_count: Option<i64>,
+    pub charged_head_count: Option<i64>,
+    pub retry_exhausted_at: Option<String>,
+
+    pub tier2_lease_id: Option<String>,
+    pub tier2_lease_key: Option<String>,
+    pub tier2_lease_state: Option<CiTier2LeaseState>,
+    pub tier2_lease_reason: Option<CiTier2Reason>,
+    pub tier2_leased_at: Option<String>,
+    pub tier2_resolution: Option<CiRouteOutcome>,
+    pub lead_session_id: Option<String>,
+
+    pub reopen_mode: Option<CiReopenMode>,
+    pub diagnostic_reason: Option<CiDiagnosticReason>,
+    pub park_justification: Option<String>,
+
+    pub provider_error: Option<String>,
+    pub superseded_by_evidence: Option<String>,
+}
+
+impl CiRouteAttempt {
+    fn from_row(row: &sqlx::postgres::PgRow) -> Result<Self> {
+        fn opt_enum<T>(value: Option<String>, f: fn(&str) -> Result<T>) -> Result<Option<T>> {
+            match value {
+                Some(v) => f(&v).map(Some),
+                None => Ok(None),
+            }
+        }
+        Ok(Self {
+            provider_action_key: row.try_get("provider_action_key")?,
+            identity: CiEvidenceIdentity {
+                lane: CiLane::parse(row.try_get::<String, _>("lane")?.as_str())?,
+                pr_number: row.try_get("pr_number")?,
+                pr_head_sha: row.try_get("pr_head_sha")?,
+                run_id: row.try_get("run_id")?,
+                run_head_sha: row.try_get("run_head_sha")?,
+                dequeue_id: row.try_get("dequeue_id")?,
+            },
+            task_id: row.try_get("task_id")?,
+            origin_state: CiOriginState::parse(row.try_get::<String, _>("origin_state")?.as_str())?,
+            class: CiClass::parse(row.try_get::<String, _>("class")?.as_str())?,
+            action: CiAction::parse(row.try_get::<String, _>("action")?.as_str())?,
+            transient_fingerprint: row.try_get("transient_fingerprint")?,
+            retry_budget_key: row.try_get("retry_budget_key")?,
+            head_budget_key: row.try_get("head_budget_key")?,
+            action_phase: CiActionPhase::parse(row.try_get::<String, _>("action_phase")?.as_str())?,
+            terminal_outcome: opt_enum(row.try_get("terminal_outcome")?, CiRouteOutcome::parse)?,
+            reserved_at: row.try_get("reserved_at")?,
+            calling_at: row.try_get("calling_at")?,
+            terminalized_at: row.try_get("terminalized_at")?,
+            owner_incarnation_id: row.try_get("owner_incarnation_id")?,
+            pre_call_resumptions: row.try_get("pre_call_resumptions")?,
+            charged_signature_count: row.try_get("charged_signature_count")?,
+            charged_head_count: row.try_get("charged_head_count")?,
+            retry_exhausted_at: row.try_get("retry_exhausted_at")?,
+            tier2_lease_id: row.try_get("tier2_lease_id")?,
+            tier2_lease_key: row.try_get("tier2_lease_key")?,
+            tier2_lease_state: opt_enum(
+                row.try_get("tier2_lease_state")?,
+                CiTier2LeaseState::parse,
+            )?,
+            tier2_lease_reason: opt_enum(row.try_get("tier2_lease_reason")?, CiTier2Reason::parse)?,
+            tier2_leased_at: row.try_get("tier2_leased_at")?,
+            tier2_resolution: opt_enum(row.try_get("tier2_resolution")?, CiRouteOutcome::parse)?,
+            lead_session_id: row.try_get("lead_session_id")?,
+            reopen_mode: opt_enum(row.try_get("reopen_mode")?, CiReopenMode::parse)?,
+            diagnostic_reason: opt_enum(
+                row.try_get("diagnostic_reason")?,
+                CiDiagnosticReason::parse,
+            )?,
+            park_justification: row.try_get("park_justification")?,
+            provider_error: row.try_get("provider_error")?,
+            superseded_by_evidence: row.try_get("superseded_by_evidence")?,
+        })
+    }
+
+    /// Whether the row has reached its single terminal outcome.
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        self.action_phase == CiActionPhase::Terminal
+    }
+
+    /// Whether the row currently holds an **open** Tier-2 lease.
+    #[must_use]
+    pub fn holds_open_tier2_lease(&self) -> bool {
+        self.tier2_lease_state == Some(CiTier2LeaseState::Open)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inputs and outcomes
+// ---------------------------------------------------------------------------
+
+/// Everything needed to open a reservation.
+#[derive(Clone, Debug)]
+pub struct CiRouteReservation {
+    /// Caller-computed hash of the immutable evidence identity plus action.
+    /// Its uniqueness is what permits at most one provider-call episode.
+    pub provider_action_key: String,
+    pub identity: CiEvidenceIdentity,
+    pub task_id: String,
+    pub origin_state: CiOriginState,
+    pub class: CiClass,
+    pub action: CiAction,
+    pub transient_fingerprint: String,
+    /// lane + PR + PR-head SHA + transient fingerprint. Excludes run and
+    /// dequeue ids so equivalent later evidence shares one budget.
+    pub retry_budget_key: String,
+    /// PR + PR-head SHA. Shared across both lanes.
+    pub head_budget_key: String,
+}
+
+/// Charged slot counts for one budget pair.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CiBudgetCounts {
+    pub signature: i64,
+    pub head: i64,
+}
+
+impl CiBudgetCounts {
+    /// Whether either ceiling is already at or beyond its limit.
+    #[must_use]
+    pub fn is_exhausted(self) -> bool {
+        self.signature >= CI_SIGNATURE_BUDGET_LIMIT || self.head >= CI_HEAD_BUDGET_LIMIT
+    }
+}
+
+/// Result of [`CiRouteAttemptRepository::reserve`].
+#[derive(Clone, Debug)]
+pub enum CiReserveOutcome {
+    /// A fresh reservation was committed. Provider mutation remains forbidden
+    /// until the caller wins [`CiRouteAttemptRepository::charge_and_begin_calling`].
+    Reserved(Box<CiRouteAttempt>),
+    /// This exact evidence identity already has an attempt row. A duplicate
+    /// poll or a restart landed here; the existing row is authoritative.
+    AlreadyPresent(Box<CiRouteAttempt>),
+    /// The budgets were already spent, so no reservation was created and no
+    /// Tier-1 action is possible for this evidence.
+    BudgetExhausted(CiBudgetCounts),
+}
+
+/// Result of the `reserved` -> `calling` compare-and-set.
+#[derive(Clone, Debug)]
+pub enum CiChargeOutcome {
+    /// This caller is the single winner and owns the provider-call episode.
+    Charged {
+        attempt: Box<CiRouteAttempt>,
+        counts: CiBudgetCounts,
+    },
+    /// The observed identity no longer matches; the row is now terminal
+    /// `superseded_pre_call` with no charge and no lease.
+    SupersededPreCall(Box<CiRouteAttempt>),
+    /// Still current, but the budgets are spent. No charge, no call.
+    BudgetExhausted {
+        attempt: Box<CiRouteAttempt>,
+        counts: CiBudgetCounts,
+    },
+    /// The row had already left `reserved` — another caller won, or it is
+    /// already terminal.
+    NotReserved(Box<CiRouteAttempt>),
+}
+
+/// Result of pre-call recovery. Exactly three productive outcomes, plus the
+/// two "nothing to do" shapes.
+#[derive(Clone, Debug)]
+pub enum CiReservedRecovery {
+    /// No row with that key.
+    NotFound,
+    /// The row is not a recoverable `reserved` row: either it has advanced
+    /// past `reserved`, or its reservation timeout has not elapsed yet.
+    NotEligible(Box<CiRouteAttempt>),
+    /// Obsolete identity: terminal `superseded_pre_call`, uncharged.
+    SupersededPreCall(Box<CiRouteAttempt>),
+    /// Current identity with budget: the **same row** advanced to `calling`
+    /// under one compare-and-set winner, charging exactly once.
+    Resumed {
+        attempt: Box<CiRouteAttempt>,
+        counts: CiBudgetCounts,
+    },
+    /// Current identity, budget spent: routed through retry exhaustion, with
+    /// at most one Tier-2 lease opened.
+    RetryExhausted {
+        attempt: Box<CiRouteAttempt>,
+        counts: CiBudgetCounts,
+        /// `Some` when this call opened the lease, `None` when a lease for
+        /// that current-evidence key was already open (the "at most one"
+        /// half of the contract).
+        tier2_lease_id: Option<String>,
+    },
+}
+
+/// Authority a caller must attest before a `calling` row may be taken.
+///
+/// Every field is a *proof obligation the database cannot discharge itself*.
+/// The repository verifies what it can (owner mismatch, the 300s floor, the
+/// former incarnation's recorded `provider_actions_drained_at`) and refuses
+/// outright when the caller cannot attest the rest.
+#[derive(Clone, Debug)]
+pub struct CiCallingRecoveryAuthority {
+    /// The recovering coordinator's new immutable incarnation.
+    pub recovering_incarnation: String,
+    /// The exact former owner this handoff is fenced to.
+    pub former_owner_incarnation: String,
+    /// The recovering coordinator holds the exclusive coordinator advisory
+    /// lock for `recovering_incarnation`. A periodic sweep or a non-leader
+    /// runtime passes `false` here and is refused.
+    pub holds_exclusive_lock: bool,
+    /// How the former owner's provider futures were proven gone.
+    pub quiescence_proof: CiQuiescenceProof,
+    /// Floor on `calling_at` age. Defaults to
+    /// [`CI_CALLING_RECOVERY_TIMEOUT_SECS`].
+    pub calling_recovery_timeout_secs: i64,
+}
+
+/// Result of a `calling` owner handoff attempt.
+#[derive(Clone, Debug)]
+pub enum CiCallingRecovery {
+    NotFound,
+    /// The attempt legally did nothing. An audit row was still written.
+    Deferred {
+        attempt: Box<CiRouteAttempt>,
+        reason: CiCallingRecoveryReason,
+    },
+    /// The handoff won: the row is terminal, its charge retained, and no
+    /// provider query or replay occurred.
+    Recovered {
+        attempt: Box<CiRouteAttempt>,
+        outcome: CiRouteOutcome,
+        tier2_lease_id: Option<String>,
+    },
+}
+
+/// Result of opening a Tier-2 lease.
+#[derive(Clone, Debug)]
+pub enum CiTier2LeaseOutcome {
+    /// This caller opened the unique lease for that current-evidence key.
+    Opened {
+        attempt: Box<CiRouteAttempt>,
+        lease_id: String,
+    },
+    /// A lease for that key is already open — possibly on this very row.
+    /// Mutually exclusive by construction.
+    AlreadyLeased(Box<CiRouteAttempt>),
+    /// The compare-and-set failed: the identity changed or a newer
+    /// passing/merged observation already terminalized the row. The row is
+    /// closed as `superseded_before_lead` with no lease and no Lead dispatch.
+    SupersededBeforeLead(Box<CiRouteAttempt>),
+    NotFound,
+}
+
+/// A validated Tier-2 resolution, applied atomically with the guard.
+#[derive(Clone, Debug)]
+pub struct CiTier2Resolution {
+    pub outcome: CiRouteOutcome,
+    pub reopen_mode: Option<CiReopenMode>,
+    pub diagnostic_reason: Option<CiDiagnosticReason>,
+    pub park_justification: Option<String>,
+}
+
+impl CiTier2Resolution {
+    /// A validated repair reopen. The verification command itself is
+    /// validated by the supervisor in wave 4; what is durable here is that
+    /// the reopen was a *repair*, which is what makes a later diagnostic
+    /// reason on the same row a contradiction the CHECK rejects.
+    #[must_use]
+    pub fn repair() -> Self {
+        Self {
+            outcome: CiRouteOutcome::RepairReopened,
+            reopen_mode: Some(CiReopenMode::Repair),
+            diagnostic_reason: None,
+            park_justification: None,
+        }
+    }
+
+    /// A validated diagnostic reopen citing one closed reason.
+    #[must_use]
+    pub fn diagnose(reason: CiDiagnosticReason) -> Self {
+        Self {
+            outcome: CiRouteOutcome::DiagnosticReopened,
+            reopen_mode: Some(CiReopenMode::Diagnose),
+            diagnostic_reason: Some(reason),
+            park_justification: None,
+        }
+    }
+
+    /// A park with a cited infrastructure dead-end.
+    #[must_use]
+    pub fn park(justification: impl Into<String>) -> Self {
+        Self {
+            outcome: CiRouteOutcome::Parked,
+            reopen_mode: None,
+            diagnostic_reason: None,
+            park_justification: Some(justification.into()),
+        }
+    }
+
+    /// The plain outcomes that carry no reopen payload.
+    #[must_use]
+    pub fn plain(outcome: CiRouteOutcome) -> Self {
+        Self {
+            outcome,
+            reopen_mode: None,
+            diagnostic_reason: None,
+            park_justification: None,
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        match self.outcome {
+            CiRouteOutcome::RepairReopened => {
+                if self.reopen_mode != Some(CiReopenMode::Repair) {
+                    return Err(DbError::InvalidData(
+                        "repair_reopened requires reopen_mode=repair".to_owned(),
+                    ));
+                }
+                if self.diagnostic_reason.is_some() {
+                    return Err(DbError::InvalidData(
+                        "repair_reopened forbids a diagnostic reason".to_owned(),
+                    ));
+                }
+            }
+            CiRouteOutcome::DiagnosticReopened => {
+                if self.reopen_mode != Some(CiReopenMode::Diagnose) {
+                    return Err(DbError::InvalidData(
+                        "diagnostic_reopened requires reopen_mode=diagnose".to_owned(),
+                    ));
+                }
+                if self.diagnostic_reason.is_none() {
+                    return Err(DbError::InvalidData(
+                        "diagnostic_reopened requires a closed diagnostic reason".to_owned(),
+                    ));
+                }
+            }
+            CiRouteOutcome::Parked => {
+                if !self
+                    .park_justification
+                    .as_deref()
+                    .is_some_and(|j| !j.trim().is_empty())
+                {
+                    return Err(DbError::InvalidData(
+                        "parked requires a cited justification".to_owned(),
+                    ));
+                }
+            }
+            _ => {
+                if self.reopen_mode.is_some() || self.diagnostic_reason.is_some() {
+                    return Err(DbError::InvalidData(format!(
+                        "{} carries no reopen payload",
+                        self.outcome.as_str()
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The repository-checkable half of the rollback quiescence report.
+///
+/// The in-process half (registered provider-action futures) belongs to the
+/// coordinator and is not knowable from here. Wave 5 pairs the two.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CiRouteQuiescence {
+    pub reserved_rows: i64,
+    pub calling_rows: i64,
+    pub open_tier2_leases: i64,
+    /// Open leases that already have a Lead session attached — a dispatched
+    /// adjudication whose result has not been applied.
+    pub unapplied_lead_results: i64,
+}
+
+impl CiRouteQuiescence {
+    /// Whether every repository-visible count is zero.
+    #[must_use]
+    pub fn is_quiescent(self) -> bool {
+        self.reserved_rows == 0
+            && self.calling_rows == 0
+            && self.open_tier2_leases == 0
+            && self.unapplied_lead_results == 0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+pub struct CiRouteAttemptRepository {
+    db: Database,
+}
+
+impl CiRouteAttemptRepository {
+    #[must_use]
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Fetch one attempt by its provider-action key.
+    ///
+    /// # Errors
+    ///
+    /// Database failures, or a row carrying a value outside a durable
+    /// vocabulary.
+    pub async fn get(&self, provider_action_key: &str) -> Result<Option<CiRouteAttempt>> {
+        self.db.ensure_initialized().await?;
+        let row = sqlx::query(&format!(
+            "SELECT {ROW_COLUMNS} FROM ci_route_attempts WHERE provider_action_key = $1"
+        ))
+        .bind(provider_action_key)
+        .fetch_optional(self.db.pool())
+        .await?;
+        row.as_ref().map(CiRouteAttempt::from_row).transpose()
+    }
+
+    /// Read both monotonic counters without charging either.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn budget_counts(
+        &self,
+        retry_budget_key: &str,
+        head_budget_key: &str,
+    ) -> Result<CiBudgetCounts> {
+        self.db.ensure_initialized().await?;
+        let signature: Option<i64> = sqlx::query_scalar(
+            "SELECT charged_count FROM ci_route_budget_counters WHERE scope = 'signature' AND counter_key = $1",
+        )
+        .bind(retry_budget_key)
+        .fetch_optional(self.db.pool())
+        .await?;
+        let head: Option<i64> = sqlx::query_scalar(
+            "SELECT charged_count FROM ci_route_budget_counters WHERE scope = 'head' AND counter_key = $1",
+        )
+        .bind(head_budget_key)
+        .fetch_optional(self.db.pool())
+        .await?;
+        Ok(CiBudgetCounts {
+            signature: signature.unwrap_or(0),
+            head: head.unwrap_or(0),
+        })
+    }
+
+    /// Phase 1 of the action protocol: lock and read both budgets, reject
+    /// exhausted thresholds, and insert the unique evidence row as `reserved`.
+    ///
+    /// Committing before the call is the entire point — see the module docs.
+    /// Provider mutation is forbidden while the row is `reserved`.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn reserve(&self, input: &CiRouteReservation) -> Result<CiReserveOutcome> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+
+        if let Some(existing) = fetch_in_tx(&mut tx, &input.provider_action_key).await? {
+            tx.commit().await?;
+            return Ok(CiReserveOutcome::AlreadyPresent(Box::new(existing)));
+        }
+
+        let counts = lock_budgets(&mut tx, &input.retry_budget_key, &input.head_budget_key).await?;
+        if counts.is_exhausted() {
+            tx.commit().await?;
+            return Ok(CiReserveOutcome::BudgetExhausted(counts));
+        }
+
+        // `ON CONFLICT DO NOTHING` rather than a bare INSERT. The read above
+        // cannot lock a row that does not exist yet, so two concurrent pollers
+        // both see "absent"; the budget lock then serializes them and the
+        // loser's insert must resolve to `AlreadyPresent` rather than a raw
+        // unique violation. The unique key is still what enforces one row per
+        // evidence identity — this only decides how the loser is *told*.
+        let inserted = sqlx::query(
+            "INSERT INTO ci_route_attempts (provider_action_key, lane, pr_number, pr_head_sha, run_id, run_head_sha, dequeue_id, \
+             task_id, origin_state, class, action, transient_fingerprint, retry_budget_key, head_budget_key, action_phase) \
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,'reserved') \
+             ON CONFLICT (provider_action_key) DO NOTHING",
+        )
+        .bind(&input.provider_action_key)
+        .bind(input.identity.lane.as_str())
+        .bind(input.identity.pr_number)
+        .bind(&input.identity.pr_head_sha)
+        .bind(input.identity.run_id)
+        .bind(&input.identity.run_head_sha)
+        .bind(input.identity.dequeue_id.as_deref())
+        .bind(&input.task_id)
+        .bind(input.origin_state.as_str())
+        .bind(input.class.as_str())
+        .bind(input.action.as_str())
+        .bind(&input.transient_fingerprint)
+        .bind(&input.retry_budget_key)
+        .bind(&input.head_budget_key)
+        .execute(&mut *tx)
+        .await?;
+
+        let row = fetch_in_tx(&mut tx, &input.provider_action_key)
+            .await?
+            .ok_or_else(|| DbError::Internal("reserved route row disappeared".to_owned()))?;
+        tx.commit().await?;
+        Ok(if inserted.rows_affected() == 1 {
+            CiReserveOutcome::Reserved(Box::new(row))
+        } else {
+            CiReserveOutcome::AlreadyPresent(Box::new(row))
+        })
+    }
+
+    /// Phases 2 and 3: revalidate identity, then atomically compare-and-set
+    /// `reserved` -> `calling` while incrementing both monotonic counters.
+    ///
+    /// **Only the winner may call the provider.** Concurrent callers serialize
+    /// on the row lock and every loser sees a non-`reserved` phase.
+    ///
+    /// The charge is committed in the same transaction as the phase change, so
+    /// a crash immediately after this returns leaves a `calling` row that is
+    /// already charged — which is exactly the conservative direction: slots
+    /// are never released once an action reaches `calling`, regardless of what
+    /// the provider answered.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn charge_and_begin_calling(
+        &self,
+        provider_action_key: &str,
+        owner_incarnation_id: &str,
+        observed_identity: &CiEvidenceIdentity,
+    ) -> Result<CiChargeOutcome> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+
+        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+            tx.commit().await?;
+            return Err(DbError::InvalidData(format!(
+                "no ci route attempt for provider_action_key `{provider_action_key}`"
+            )));
+        };
+
+        if attempt.action_phase != CiActionPhase::Reserved {
+            tx.commit().await?;
+            return Ok(CiChargeOutcome::NotReserved(Box::new(attempt)));
+        }
+
+        if !attempt.identity.matches(observed_identity) {
+            let superseded = terminalize_in_tx(
+                &mut tx,
+                provider_action_key,
+                CiRouteOutcome::SupersededPreCall,
+                Some(&identity_evidence_json(observed_identity)),
+                None,
+            )
+            .await?;
+            tx.commit().await?;
+            return Ok(CiChargeOutcome::SupersededPreCall(Box::new(superseded)));
+        }
+
+        let counts =
+            lock_budgets(&mut tx, &attempt.retry_budget_key, &attempt.head_budget_key).await?;
+        if counts.is_exhausted() {
+            sqlx::query(
+                "UPDATE ci_route_attempts SET retry_exhausted_at = now(), updated_at = now() \
+                 WHERE provider_action_key = $1 AND retry_exhausted_at IS NULL",
+            )
+            .bind(provider_action_key)
+            .execute(&mut *tx)
+            .await?;
+            let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+                .await?
+                .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
+            tx.commit().await?;
+            return Ok(CiChargeOutcome::BudgetExhausted {
+                attempt: Box::new(refreshed),
+                counts,
+            });
+        }
+
+        let charged =
+            charge_budgets_in_tx(&mut tx, &attempt.retry_budget_key, &attempt.head_budget_key)
+                .await?;
+
+        // The CAS. `action_phase = 'reserved'` in the WHERE clause is
+        // redundant under the row lock we already hold and is kept anyway:
+        // it makes the single-winner property readable at the statement.
+        let updated = sqlx::query(
+            "UPDATE ci_route_attempts \
+             SET action_phase = 'calling', calling_at = now(), owner_incarnation_id = $2, \
+                 charged_signature_count = $3, charged_head_count = $4, updated_at = now() \
+             WHERE provider_action_key = $1 AND action_phase = 'reserved'",
+        )
+        .bind(provider_action_key)
+        .bind(owner_incarnation_id)
+        .bind(charged.signature)
+        .bind(charged.head)
+        .execute(&mut *tx)
+        .await?;
+        if updated.rows_affected() != 1 {
+            return Err(DbError::Internal(
+                "reserved->calling compare-and-set lost under a held row lock".to_owned(),
+            ));
+        }
+
+        let calling = fetch_in_tx(&mut tx, provider_action_key)
+            .await?
+            .ok_or_else(|| DbError::Internal("calling route row disappeared".to_owned()))?;
+        tx.commit().await?;
+        Ok(CiChargeOutcome::Charged {
+            attempt: Box::new(calling),
+            counts: charged,
+        })
+    }
+
+    /// Phase 4: the owner records its own provider result.
+    ///
+    /// **Owner-scoped.** The compare-and-set carries the caller's
+    /// `owner_incarnation_id`, so a former owner whose row was legally handed
+    /// off writes nothing and observes `false`. That is the whole mechanism by
+    /// which a late result from a drained process is rejected rather than
+    /// silently overwriting a recovery.
+    ///
+    /// # Errors
+    ///
+    /// Database failures, or an outcome outside the provider-terminal set.
+    pub async fn finalize_calling(
+        &self,
+        provider_action_key: &str,
+        owner_incarnation_id: &str,
+        outcome: CiRouteOutcome,
+        provider_error_json: Option<&str>,
+    ) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        if !matches!(
+            outcome,
+            CiRouteOutcome::Retriggered | CiRouteOutcome::Reenqueued | CiRouteOutcome::ActionFailed
+        ) {
+            return Err(DbError::InvalidData(format!(
+                "`{}` is not a provider finalization outcome",
+                outcome.as_str()
+            )));
+        }
+        let updated = sqlx::query(
+            "UPDATE ci_route_attempts \
+             SET action_phase = 'terminal', terminal_outcome = $3, terminalized_at = now(), \
+                 provider_error = $4::jsonb, updated_at = now() \
+             WHERE provider_action_key = $1 AND action_phase = 'calling' AND owner_incarnation_id = $2",
+        )
+        .bind(provider_action_key)
+        .bind(owner_incarnation_id)
+        .bind(outcome.as_str())
+        .bind(provider_error_json)
+        .execute(self.db.pool())
+        .await?;
+        Ok(updated.rows_affected() == 1)
+    }
+
+    /// Write-once terminalization for every non-provider route close.
+    ///
+    /// Returns `true` only for the caller that actually wrote the outcome. A
+    /// second call — from a duplicate poll, a startup sweep, or a delayed Lead
+    /// result — observes `false` and must not treat the row as freshly closed.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn terminalize(
+        &self,
+        provider_action_key: &str,
+        outcome: CiRouteOutcome,
+        superseded_by_evidence_json: Option<&str>,
+    ) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        let updated = sqlx::query(
+            "UPDATE ci_route_attempts \
+             SET action_phase = 'terminal', terminal_outcome = $2, terminalized_at = now(), \
+                 superseded_by_evidence = COALESCE($3::jsonb, superseded_by_evidence), updated_at = now() \
+             WHERE provider_action_key = $1 AND action_phase <> 'terminal'",
+        )
+        .bind(provider_action_key)
+        .bind(outcome.as_str())
+        .bind(superseded_by_evidence_json)
+        .execute(self.db.pool())
+        .await?;
+        Ok(updated.rows_affected() == 1)
+    }
+
+    /// Pre-call recovery. See the module docs for the three-outcome contract.
+    ///
+    /// `tier2_lease_key` is the current-evidence lease scope used only in the
+    /// exhausted branch; it is passed in because its derivation is the
+    /// coordinator's (wave 2's) contract, not the repository's.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn recover_reserved(
+        &self,
+        provider_action_key: &str,
+        observed_identity: &CiEvidenceIdentity,
+        recovering_incarnation_id: &str,
+        reservation_timeout_secs: i64,
+        tier2_lease_key: &str,
+    ) -> Result<CiReservedRecovery> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+
+        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+            tx.commit().await?;
+            return Ok(CiReservedRecovery::NotFound);
+        };
+
+        if attempt.action_phase != CiActionPhase::Reserved {
+            tx.commit().await?;
+            return Ok(CiReservedRecovery::NotEligible(Box::new(attempt)));
+        }
+
+        // Eligibility is measured against the DATABASE clock, from the same
+        // `now()` that stamped `reserved_at`. Rendering the timestamp and
+        // subtracting it in Rust would compare two clocks, and a coordinator
+        // whose clock runs behind Postgres would read every reservation as
+        // young and never recover one.
+        let eligible: bool = sqlx::query_scalar(
+            "SELECT reserved_at <= now() - make_interval(secs => $2::double precision) \
+             FROM ci_route_attempts WHERE provider_action_key = $1",
+        )
+        .bind(provider_action_key)
+        .bind(reservation_timeout_secs as f64)
+        .fetch_one(&mut *tx)
+        .await?;
+        if !eligible {
+            tx.commit().await?;
+            return Ok(CiReservedRecovery::NotEligible(Box::new(attempt)));
+        }
+
+        if !attempt.identity.matches(observed_identity) {
+            let superseded = terminalize_in_tx(
+                &mut tx,
+                provider_action_key,
+                CiRouteOutcome::SupersededPreCall,
+                Some(&identity_evidence_json(observed_identity)),
+                None,
+            )
+            .await?;
+            tx.commit().await?;
+            return Ok(CiReservedRecovery::SupersededPreCall(Box::new(superseded)));
+        }
+
+        let counts =
+            lock_budgets(&mut tx, &attempt.retry_budget_key, &attempt.head_budget_key).await?;
+
+        if counts.is_exhausted() {
+            sqlx::query(
+                "UPDATE ci_route_attempts \
+                 SET retry_exhausted_at = COALESCE(retry_exhausted_at, now()), \
+                     pre_call_resumptions = pre_call_resumptions + 1, updated_at = now() \
+                 WHERE provider_action_key = $1",
+            )
+            .bind(provider_action_key)
+            .execute(&mut *tx)
+            .await?;
+            let lease_id = open_tier2_lease_in_tx(
+                &mut tx,
+                provider_action_key,
+                tier2_lease_key,
+                CiTier2Reason::RetryExhausted,
+            )
+            .await?;
+            let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+                .await?
+                .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
+            tx.commit().await?;
+            return Ok(CiReservedRecovery::RetryExhausted {
+                attempt: Box::new(refreshed),
+                counts,
+                tier2_lease_id: lease_id,
+            });
+        }
+
+        let charged =
+            charge_budgets_in_tx(&mut tx, &attempt.retry_budget_key, &attempt.head_budget_key)
+                .await?;
+
+        let updated = sqlx::query(
+            "UPDATE ci_route_attempts \
+             SET action_phase = 'calling', calling_at = now(), owner_incarnation_id = $2, \
+                 charged_signature_count = $3, charged_head_count = $4, \
+                 pre_call_resumptions = pre_call_resumptions + 1, updated_at = now() \
+             WHERE provider_action_key = $1 AND action_phase = 'reserved'",
+        )
+        .bind(provider_action_key)
+        .bind(recovering_incarnation_id)
+        .bind(charged.signature)
+        .bind(charged.head)
+        .execute(&mut *tx)
+        .await?;
+        if updated.rows_affected() != 1 {
+            return Err(DbError::Internal(
+                "reserved->calling resumption lost under a held row lock".to_owned(),
+            ));
+        }
+
+        let resumed = fetch_in_tx(&mut tx, provider_action_key)
+            .await?
+            .ok_or_else(|| DbError::Internal("resumed route row disappeared".to_owned()))?;
+        tx.commit().await?;
+        Ok(CiReservedRecovery::Resumed {
+            attempt: Box::new(resumed),
+            counts: charged,
+        })
+    }
+
+    /// Startup-only owner handoff for a `calling` row.
+    ///
+    /// Every rejection path writes an audit row, so a deferral is observable.
+    /// The predicates, in the order they are checked:
+    ///
+    /// 1. the caller attests exclusive advisory-lock ownership;
+    /// 2. the caller attests a quiescence proof that is not
+    ///    [`CiQuiescenceProof::None`] — and for a graceful drain, the former
+    ///    incarnation must actually carry `provider_actions_drained_at`;
+    /// 3. the row is still `calling`;
+    /// 4. its owner is the exact named former owner, and differs from the
+    ///    recovering incarnation;
+    /// 5. `calling_at` is at least `calling_recovery_timeout_secs` old.
+    ///
+    /// Only then does it compare-and-set. Passing all five and still losing —
+    /// because the former owner's finalizer committed first — is legal and is
+    /// recorded as `cas_lost`.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn recover_calling_owner(
+        &self,
+        provider_action_key: &str,
+        observed_identity: Option<&CiEvidenceIdentity>,
+        authority: &CiCallingRecoveryAuthority,
+        tier2_lease_key: &str,
+    ) -> Result<CiCallingRecovery> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+
+        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+            tx.commit().await?;
+            return Ok(CiCallingRecovery::NotFound);
+        };
+
+        // (1) lock ownership — a periodic sweep or a non-leader runtime stops
+        // here and can never open Tier 2.
+        let deferral = if !authority.holds_exclusive_lock {
+            Some(CiCallingRecoveryReason::LockNotHeld)
+        } else if attempt.action_phase != CiActionPhase::Calling {
+            Some(CiCallingRecoveryReason::NotCalling)
+        } else if attempt.owner_incarnation_id.as_deref()
+            != Some(authority.former_owner_incarnation.as_str())
+            || authority.former_owner_incarnation == authority.recovering_incarnation
+        {
+            Some(CiCallingRecoveryReason::OwnerMismatch)
+        } else {
+            None
+        };
+
+        if let Some(reason) = deferral {
+            record_calling_recovery(&mut tx, provider_action_key, authority, reason, false, None)
+                .await?;
+            tx.commit().await?;
+            return Ok(CiCallingRecovery::Deferred {
+                attempt: Box::new(attempt),
+                reason,
+            });
+        }
+
+        // (2) quiescence. `None` is never enough, and a claimed graceful
+        // drain is checked against the former incarnation's own record rather
+        // than believed.
+        let quiescent = match authority.quiescence_proof {
+            CiQuiescenceProof::None => false,
+            CiQuiescenceProof::ProcessTerminated => true,
+            CiQuiescenceProof::GracefulDrain => {
+                let drained: Option<Option<String>> = sqlx::query_scalar(
+                    "SELECT provider_actions_drained_at FROM coordinator_incarnations WHERE id = $1",
+                )
+                .bind(&authority.former_owner_incarnation)
+                .fetch_optional(&mut *tx)
+                .await?;
+                matches!(drained, Some(Some(_)))
+            }
+        };
+        if !quiescent {
+            record_calling_recovery(
+                &mut tx,
+                provider_action_key,
+                authority,
+                CiCallingRecoveryReason::LiveOwnerDeferred,
+                false,
+                None,
+            )
+            .await?;
+            tx.commit().await?;
+            return Ok(CiCallingRecovery::Deferred {
+                attempt: Box::new(attempt),
+                reason: CiCallingRecoveryReason::LiveOwnerDeferred,
+            });
+        }
+
+        // (3) the 300s floor, again measured by the database clock.
+        let elapsed: bool = sqlx::query_scalar(
+            "SELECT calling_at <= now() - make_interval(secs => $2::double precision) \
+             FROM ci_route_attempts WHERE provider_action_key = $1",
+        )
+        .bind(provider_action_key)
+        .bind(authority.calling_recovery_timeout_secs as f64)
+        .fetch_one(&mut *tx)
+        .await?;
+        if !elapsed {
+            record_calling_recovery(
+                &mut tx,
+                provider_action_key,
+                authority,
+                CiCallingRecoveryReason::TimeoutNotElapsed,
+                false,
+                None,
+            )
+            .await?;
+            tx.commit().await?;
+            return Ok(CiCallingRecovery::Deferred {
+                attempt: Box::new(attempt),
+                reason: CiCallingRecoveryReason::TimeoutNotElapsed,
+            });
+        }
+
+        // The external outcome is unknowable and is never queried or replayed.
+        // A still-current row becomes `outcome_unknown` and keeps its charge;
+        // an obsolete one becomes `superseded_after_call`.
+        let still_current = observed_identity.is_some_and(|obs| attempt.identity.matches(obs));
+        let outcome = if still_current {
+            CiRouteOutcome::OutcomeUnknown
+        } else {
+            CiRouteOutcome::SupersededAfterCall
+        };
+
+        let won = sqlx::query(
+            "UPDATE ci_route_attempts \
+             SET owner_incarnation_id = $3, action_phase = 'terminal', terminal_outcome = $4, \
+                 terminalized_at = now(), superseded_by_evidence = COALESCE($5::jsonb, superseded_by_evidence), \
+                 updated_at = now() \
+             WHERE provider_action_key = $1 AND action_phase = 'calling' AND owner_incarnation_id = $2",
+        )
+        .bind(provider_action_key)
+        .bind(&authority.former_owner_incarnation)
+        .bind(&authority.recovering_incarnation)
+        .bind(outcome.as_str())
+        .bind(observed_identity.map(identity_evidence_json))
+        .execute(&mut *tx)
+        .await?;
+
+        // Belt and braces. This transaction has held the row lock since
+        // `fetch_locked`, so a finalizer racing us blocked before its own
+        // UPDATE and this compare-and-set cannot actually lose today — the
+        // owner-mismatch and phase deferrals above catch a finalizer that
+        // committed *first*. It is kept because the alternative to a lost CAS
+        // being observable is a lost CAS being silently treated as a win, and
+        // the audit row makes it falsifiable if the locking ever changes.
+        if won.rows_affected() != 1 {
+            let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+                .await?
+                .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
+            record_calling_recovery(
+                &mut tx,
+                provider_action_key,
+                authority,
+                CiCallingRecoveryReason::CasLost,
+                false,
+                None,
+            )
+            .await?;
+            tx.commit().await?;
+            return Ok(CiCallingRecovery::Deferred {
+                attempt: Box::new(refreshed),
+                reason: CiCallingRecoveryReason::CasLost,
+            });
+        }
+
+        let lease_id = if still_current {
+            open_tier2_lease_in_tx(
+                &mut tx,
+                provider_action_key,
+                tier2_lease_key,
+                CiTier2Reason::OutcomeUnknown,
+            )
+            .await?
+        } else {
+            None
+        };
+
+        let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+            .await?
+            .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
+        record_calling_recovery(
+            &mut tx,
+            provider_action_key,
+            authority,
+            CiCallingRecoveryReason::StartupOwnerHandoff,
+            true,
+            Some(outcome),
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(CiCallingRecovery::Recovered {
+            attempt: Box::new(refreshed),
+            outcome,
+            tier2_lease_id: lease_id,
+        })
+    }
+
+    /// Open the unique Tier-2 lease for a current-evidence key.
+    ///
+    /// The compare-and-set is the guard the proposal requires *before* Lead
+    /// dispatch: the stored identity must still equal the observed current
+    /// identity and the row must not already have been closed by a newer
+    /// passing or merged observation. A failed guard closes the row
+    /// `superseded_before_lead` and opens nothing.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn open_tier2_lease(
+        &self,
+        provider_action_key: &str,
+        observed_identity: &CiEvidenceIdentity,
+        tier2_lease_key: &str,
+        reason: CiTier2Reason,
+    ) -> Result<CiTier2LeaseOutcome> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+
+        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+            tx.commit().await?;
+            return Ok(CiTier2LeaseOutcome::NotFound);
+        };
+
+        // A row already terminalized by a newer passing/merged observation is
+        // exactly the "newer outcome" half of the guard: the pass/merge path
+        // closes route keys, so `is_terminal` covers it. `outcome_unknown` and
+        // `action_failed` are the two terminal outcomes that legally still
+        // open a lease.
+        let terminal_blocks_lease = attempt.is_terminal()
+            && !matches!(
+                attempt.terminal_outcome,
+                Some(CiRouteOutcome::OutcomeUnknown) | Some(CiRouteOutcome::ActionFailed)
+            );
+
+        if !attempt.identity.matches(observed_identity) || terminal_blocks_lease {
+            let closed = terminalize_in_tx(
+                &mut tx,
+                provider_action_key,
+                CiRouteOutcome::SupersededBeforeLead,
+                Some(&identity_evidence_json(observed_identity)),
+                None,
+            )
+            .await?;
+            tx.commit().await?;
+            return Ok(CiTier2LeaseOutcome::SupersededBeforeLead(Box::new(closed)));
+        }
+
+        let lease_id =
+            open_tier2_lease_in_tx(&mut tx, provider_action_key, tier2_lease_key, reason).await?;
+        let refreshed = fetch_in_tx(&mut tx, provider_action_key)
+            .await?
+            .ok_or_else(|| DbError::Internal("route row disappeared".to_owned()))?;
+        tx.commit().await?;
+        Ok(match lease_id {
+            Some(id) => CiTier2LeaseOutcome::Opened {
+                attempt: Box::new(refreshed),
+                lease_id: id,
+            },
+            None => CiTier2LeaseOutcome::AlreadyLeased(Box::new(refreshed)),
+        })
+    }
+
+    /// Bind a dispatched Lead session to an open lease.
+    ///
+    /// Fenced to the exact lease id so a stale caller cannot attach a session
+    /// to a lease that has already been resolved and reopened for newer
+    /// evidence.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn attach_lead_session(
+        &self,
+        provider_action_key: &str,
+        lease_id: &str,
+        lead_session_id: &str,
+    ) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        let updated = sqlx::query(
+            "UPDATE ci_route_attempts SET lead_session_id = $3, updated_at = now() \
+             WHERE provider_action_key = $1 AND tier2_lease_id = $2 AND tier2_lease_state = 'open'",
+        )
+        .bind(provider_action_key)
+        .bind(lease_id)
+        .bind(lead_session_id)
+        .execute(self.db.pool())
+        .await?;
+        Ok(updated.rows_affected() == 1)
+    }
+
+    /// Apply a Lead result under the same atomic identity guard.
+    ///
+    /// Resolving the lease releases the current-evidence key, and — for a row
+    /// that has not already terminalized on its provider outcome — writes the
+    /// route's single terminal outcome. A row that *did* terminalize earlier
+    /// (`action_failed`, `outcome_unknown`) keeps that outcome: the Tier-2
+    /// resolution is recorded on `tier2_resolution` instead, because
+    /// terminalization is write-once.
+    ///
+    /// # Errors
+    ///
+    /// Database failures, or a resolution whose payload contradicts its
+    /// outcome.
+    pub async fn resolve_tier2_lease(
+        &self,
+        provider_action_key: &str,
+        lease_id: &str,
+        observed_identity: &CiEvidenceIdentity,
+        resolution: &CiTier2Resolution,
+    ) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        resolution.validate()?;
+        let mut tx = self.db.pool().begin().await?;
+
+        let Some(attempt) = fetch_locked(&mut tx, provider_action_key).await? else {
+            tx.commit().await?;
+            return Ok(false);
+        };
+        if attempt.tier2_lease_id.as_deref() != Some(lease_id)
+            || attempt.tier2_lease_state != Some(CiTier2LeaseState::Open)
+        {
+            tx.commit().await?;
+            return Ok(false);
+        }
+
+        // The supervisor-side guard, evaluated in the same transaction as the
+        // transition it authorizes. A head, lane, or dequeue change since
+        // dispatch closes the route without any board mutation.
+        if !attempt.identity.matches(observed_identity) {
+            sqlx::query(
+                "UPDATE ci_route_attempts \
+                 SET tier2_lease_state = 'resolved', tier2_resolved_at = now(), \
+                     tier2_resolution = 'superseded_before_apply', updated_at = now() \
+                 WHERE provider_action_key = $1 AND tier2_lease_id = $2",
+            )
+            .bind(provider_action_key)
+            .bind(lease_id)
+            .execute(&mut *tx)
+            .await?;
+            terminalize_in_tx(
+                &mut tx,
+                provider_action_key,
+                CiRouteOutcome::SupersededBeforeApply,
+                Some(&identity_evidence_json(observed_identity)),
+                None,
+            )
+            .await?;
+            tx.commit().await?;
+            return Ok(false);
+        }
+
+        sqlx::query(
+            "UPDATE ci_route_attempts \
+             SET tier2_lease_state = 'resolved', tier2_resolved_at = now(), tier2_resolution = $3, \
+                 reopen_mode = $4, diagnostic_reason = $5, park_justification = $6, updated_at = now() \
+             WHERE provider_action_key = $1 AND tier2_lease_id = $2",
+        )
+        .bind(provider_action_key)
+        .bind(lease_id)
+        .bind(resolution.outcome.as_str())
+        .bind(resolution.reopen_mode.map(CiReopenMode::as_str))
+        .bind(resolution.diagnostic_reason.map(CiDiagnosticReason::as_str))
+        .bind(resolution.park_justification.as_deref())
+        .execute(&mut *tx)
+        .await?;
+
+        terminalize_in_tx(&mut tx, provider_action_key, resolution.outcome, None, None).await?;
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    /// Close every non-terminal route for a PR because CI passed or the PR
+    /// merged.
+    ///
+    /// Charges are **not** refunded — a spent slot stays spent. Any open
+    /// Tier-2 lease is resolved so its current-evidence key is released and a
+    /// delayed Lead result finds nothing to apply to.
+    ///
+    /// Returns the number of routes closed.
+    ///
+    /// # Errors
+    ///
+    /// Database failures, or an outcome other than `passed`/`merged`.
+    ///
+    /// Scoped by `task_id` as well as `pr_number`: a PR number is unique only
+    /// within one repository, and this repository holds every project's rows.
+    pub async fn close_routes_for_newer_outcome(
+        &self,
+        task_id: &str,
+        pr_number: i64,
+        outcome: CiRouteOutcome,
+        observed_evidence_json: Option<&str>,
+    ) -> Result<u64> {
+        self.db.ensure_initialized().await?;
+        if !matches!(outcome, CiRouteOutcome::Passed | CiRouteOutcome::Merged) {
+            return Err(DbError::InvalidData(format!(
+                "`{}` is not a newer-outcome close",
+                outcome.as_str()
+            )));
+        }
+        let mut tx = self.db.pool().begin().await?;
+        sqlx::query(
+            "UPDATE ci_route_attempts \
+             SET tier2_lease_state = 'resolved', tier2_resolved_at = now(), \
+                 tier2_resolution = COALESCE(tier2_resolution, $3), updated_at = now() \
+             WHERE task_id = $1 AND pr_number = $2 AND tier2_lease_state = 'open'",
+        )
+        .bind(task_id)
+        .bind(pr_number)
+        .bind(outcome.as_str())
+        .execute(&mut *tx)
+        .await?;
+        let closed = sqlx::query(
+            "UPDATE ci_route_attempts \
+             SET action_phase = 'terminal', terminal_outcome = $3, terminalized_at = now(), \
+                 superseded_by_evidence = COALESCE($4::jsonb, superseded_by_evidence), updated_at = now() \
+             WHERE task_id = $1 AND pr_number = $2 AND action_phase <> 'terminal'",
+        )
+        .bind(task_id)
+        .bind(pr_number)
+        .bind(outcome.as_str())
+        .bind(observed_evidence_json)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(closed.rows_affected())
+    }
+
+    /// The repository-visible half of the rollback quiescence gate.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn quiescence_counts(&self) -> Result<CiRouteQuiescence> {
+        self.db.ensure_initialized().await?;
+        let row = sqlx::query(
+            "SELECT \
+               COUNT(*) FILTER (WHERE action_phase = 'reserved') AS reserved_rows, \
+               COUNT(*) FILTER (WHERE action_phase = 'calling') AS calling_rows, \
+               COUNT(*) FILTER (WHERE tier2_lease_state = 'open') AS open_tier2_leases, \
+               COUNT(*) FILTER (WHERE tier2_lease_state = 'open' AND lead_session_id IS NOT NULL) AS unapplied_lead_results \
+             FROM ci_route_attempts",
+        )
+        .fetch_one(self.db.pool())
+        .await?;
+        Ok(CiRouteQuiescence {
+            reserved_rows: row.try_get("reserved_rows")?,
+            calling_rows: row.try_get("calling_rows")?,
+            open_tier2_leases: row.try_get("open_tier2_leases")?,
+            unapplied_lead_results: row.try_get("unapplied_lead_results")?,
+        })
+    }
+
+    /// The evidence identities that are still non-terminal, i.e. the routed
+    /// failed identities the rollback gate must see advance, pass, or merge.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn non_terminal_identities(&self) -> Result<Vec<(String, CiEvidenceIdentity)>> {
+        self.db.ensure_initialized().await?;
+        let rows = sqlx::query(&format!(
+            "SELECT {ROW_COLUMNS} FROM ci_route_attempts WHERE action_phase <> 'terminal' \
+             ORDER BY reserved_at, provider_action_key"
+        ))
+        .fetch_all(self.db.pool())
+        .await?;
+        rows.iter()
+            .map(|row| {
+                CiRouteAttempt::from_row(row).map(|a| (a.provider_action_key.clone(), a.identity))
+            })
+            .collect()
+    }
+
+    /// Every recovery attempt recorded against one route, newest last.
+    ///
+    /// # Errors
+    ///
+    /// Database failures.
+    pub async fn calling_recovery_audit(
+        &self,
+        provider_action_key: &str,
+    ) -> Result<Vec<CiCallingRecoveryRecord>> {
+        self.db.ensure_initialized().await?;
+        let rows = sqlx::query(
+            "SELECT id, provider_action_key, former_owner_incarnation, recovering_incarnation, \
+                    holds_exclusive_lock, quiescence_proof, recovery_reason, \
+                    calling_recovery_timeout_secs, cas_won, resulting_outcome \
+             FROM ci_route_calling_recoveries WHERE provider_action_key = $1 ORDER BY id",
+        )
+        .bind(provider_action_key)
+        .fetch_all(self.db.pool())
+        .await?;
+        rows.iter()
+            .map(|row| {
+                Ok(CiCallingRecoveryRecord {
+                    id: row.try_get("id")?,
+                    provider_action_key: row.try_get("provider_action_key")?,
+                    former_owner_incarnation: row.try_get("former_owner_incarnation")?,
+                    recovering_incarnation: row.try_get("recovering_incarnation")?,
+                    holds_exclusive_lock: row.try_get("holds_exclusive_lock")?,
+                    quiescence_proof: CiQuiescenceProof::parse(
+                        row.try_get::<String, _>("quiescence_proof")?.as_str(),
+                    )?,
+                    recovery_reason: CiCallingRecoveryReason::parse(
+                        row.try_get::<String, _>("recovery_reason")?.as_str(),
+                    )?,
+                    calling_recovery_timeout_secs: row.try_get("calling_recovery_timeout_secs")?,
+                    cas_won: row.try_get("cas_won")?,
+                    resulting_outcome: match row
+                        .try_get::<Option<String>, _>("resulting_outcome")?
+                    {
+                        Some(v) => Some(CiRouteOutcome::parse(&v)?),
+                        None => None,
+                    },
+                })
+            })
+            .collect()
+    }
+}
+
+/// One recorded `calling` recovery attempt, including the legal no-ops.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CiCallingRecoveryRecord {
+    pub id: String,
+    pub provider_action_key: String,
+    pub former_owner_incarnation: Option<String>,
+    pub recovering_incarnation: String,
+    pub holds_exclusive_lock: bool,
+    pub quiescence_proof: CiQuiescenceProof,
+    pub recovery_reason: CiCallingRecoveryReason,
+    pub calling_recovery_timeout_secs: i64,
+    pub cas_won: bool,
+    pub resulting_outcome: Option<CiRouteOutcome>,
+}
+
+// ---------------------------------------------------------------------------
+// Transaction helpers
+// ---------------------------------------------------------------------------
+
+async fn fetch_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    provider_action_key: &str,
+) -> Result<Option<CiRouteAttempt>> {
+    let row = sqlx::query(&format!(
+        "SELECT {ROW_COLUMNS} FROM ci_route_attempts WHERE provider_action_key = $1"
+    ))
+    .bind(provider_action_key)
+    .fetch_optional(&mut **tx)
+    .await?;
+    row.as_ref().map(CiRouteAttempt::from_row).transpose()
+}
+
+/// Take the row lock, then re-read through the rendering projection.
+///
+/// Two statements rather than one because `ROW_COLUMNS` contains `to_char`
+/// expressions and Postgres rejects `FOR UPDATE` on a projection it cannot
+/// prove is a plain row reference.
+async fn fetch_locked(
+    tx: &mut Transaction<'_, Postgres>,
+    provider_action_key: &str,
+) -> Result<Option<CiRouteAttempt>> {
+    let locked: Option<(String,)> = sqlx::query_as(
+        "SELECT provider_action_key FROM ci_route_attempts WHERE provider_action_key = $1 FOR UPDATE",
+    )
+    .bind(provider_action_key)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if locked.is_none() {
+        return Ok(None);
+    }
+    fetch_in_tx(tx, provider_action_key).await
+}
+
+/// Materialize and lock both counter rows, returning their current values.
+///
+/// The rows are created at zero if absent so the lock has something to hold;
+/// creating a counter is not charging it.
+async fn lock_budgets(
+    tx: &mut Transaction<'_, Postgres>,
+    retry_budget_key: &str,
+    head_budget_key: &str,
+) -> Result<CiBudgetCounts> {
+    // Deterministic order (signature then head) so two transactions charging
+    // the same pair can never deadlock against each other.
+    let signature = lock_counter(tx, "signature", retry_budget_key).await?;
+    let head = lock_counter(tx, "head", head_budget_key).await?;
+    Ok(CiBudgetCounts { signature, head })
+}
+
+async fn lock_counter(
+    tx: &mut Transaction<'_, Postgres>,
+    scope: &str,
+    counter_key: &str,
+) -> Result<i64> {
+    sqlx::query(
+        "INSERT INTO ci_route_budget_counters (scope, counter_key, charged_count) VALUES ($1, $2, 0) \
+         ON CONFLICT (scope, counter_key) DO NOTHING",
+    )
+    .bind(scope)
+    .bind(counter_key)
+    .execute(&mut **tx)
+    .await?;
+    let count: i64 = sqlx::query_scalar(
+        "SELECT charged_count FROM ci_route_budget_counters WHERE scope = $1 AND counter_key = $2 FOR UPDATE",
+    )
+    .bind(scope)
+    .bind(counter_key)
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok(count)
+}
+
+/// Increment both counters by one and return the new values.
+///
+/// There is no decrement anywhere in this module. That is the whole of
+/// "monotonic and conservative": a slot spent by an action that reached
+/// `calling` is never returned, whatever the provider said or whether anyone
+/// was still listening.
+async fn charge_budgets_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    retry_budget_key: &str,
+    head_budget_key: &str,
+) -> Result<CiBudgetCounts> {
+    let signature = charge_counter(tx, "signature", retry_budget_key).await?;
+    let head = charge_counter(tx, "head", head_budget_key).await?;
+    Ok(CiBudgetCounts { signature, head })
+}
+
+async fn charge_counter(
+    tx: &mut Transaction<'_, Postgres>,
+    scope: &str,
+    counter_key: &str,
+) -> Result<i64> {
+    let count: i64 = sqlx::query_scalar(
+        "UPDATE ci_route_budget_counters \
+         SET charged_count = charged_count + 1, \
+             first_charged_at = COALESCE(first_charged_at, now()), \
+             last_charged_at = now() \
+         WHERE scope = $1 AND counter_key = $2 \
+         RETURNING charged_count",
+    )
+    .bind(scope)
+    .bind(counter_key)
+    .fetch_one(&mut **tx)
+    .await?;
+    Ok(count)
+}
+
+async fn terminalize_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    provider_action_key: &str,
+    outcome: CiRouteOutcome,
+    superseded_by_evidence_json: Option<&str>,
+    provider_error_json: Option<&str>,
+) -> Result<CiRouteAttempt> {
+    sqlx::query(
+        "UPDATE ci_route_attempts \
+         SET action_phase = 'terminal', terminal_outcome = $2, terminalized_at = now(), \
+             superseded_by_evidence = COALESCE($3::jsonb, superseded_by_evidence), \
+             provider_error = COALESCE($4::jsonb, provider_error), updated_at = now() \
+         WHERE provider_action_key = $1 AND action_phase <> 'terminal'",
+    )
+    .bind(provider_action_key)
+    .bind(outcome.as_str())
+    .bind(superseded_by_evidence_json)
+    .bind(provider_error_json)
+    .execute(&mut **tx)
+    .await?;
+    fetch_in_tx(tx, provider_action_key)
+        .await?
+        .ok_or_else(|| DbError::Internal("terminalized route row disappeared".to_owned()))
+}
+
+/// Open the lease, or report that the current-evidence key already has one.
+///
+/// The mutual exclusion is the partial unique index, not this function: two
+/// concurrent transactions both reach the INSERT-equivalent UPDATE and one of
+/// them violates the index. `ON CONFLICT` is unavailable for an UPDATE, so the
+/// contention is resolved by checking for an existing open lease under the
+/// row/key locks the callers already hold.
+async fn open_tier2_lease_in_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    provider_action_key: &str,
+    tier2_lease_key: &str,
+    reason: CiTier2Reason,
+) -> Result<Option<String>> {
+    let existing: Option<(String,)> = sqlx::query_as(
+        "SELECT provider_action_key FROM ci_route_attempts \
+         WHERE tier2_lease_key = $1 AND tier2_lease_state = 'open' FOR UPDATE",
+    )
+    .bind(tier2_lease_key)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if existing.is_some() {
+        return Ok(None);
+    }
+    let lease_id = uuid::Uuid::now_v7().to_string();
+    let updated = sqlx::query(
+        "UPDATE ci_route_attempts \
+         SET tier2_lease_id = $2, tier2_lease_key = $3, tier2_lease_state = 'open', \
+             tier2_lease_reason = $4, tier2_leased_at = now(), updated_at = now() \
+         WHERE provider_action_key = $1 AND tier2_lease_state IS DISTINCT FROM 'open'",
+    )
+    .bind(provider_action_key)
+    .bind(&lease_id)
+    .bind(tier2_lease_key)
+    .bind(reason.as_str())
+    .execute(&mut **tx)
+    .await?;
+    if updated.rows_affected() == 1 {
+        Ok(Some(lease_id))
+    } else {
+        Ok(None)
+    }
+}
+
+async fn record_calling_recovery(
+    tx: &mut Transaction<'_, Postgres>,
+    provider_action_key: &str,
+    authority: &CiCallingRecoveryAuthority,
+    reason: CiCallingRecoveryReason,
+    cas_won: bool,
+    outcome: Option<CiRouteOutcome>,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO ci_route_calling_recoveries \
+           (id, provider_action_key, former_owner_incarnation, recovering_incarnation, \
+            holds_exclusive_lock, quiescence_proof, recovery_reason, calling_recovery_timeout_secs, \
+            observed_calling_at, cas_won, resulting_outcome) \
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8, \
+                 (SELECT calling_at FROM ci_route_attempts WHERE provider_action_key = $2), $9, $10)",
+    )
+    .bind(uuid::Uuid::now_v7().to_string())
+    .bind(provider_action_key)
+    .bind(&authority.former_owner_incarnation)
+    .bind(&authority.recovering_incarnation)
+    .bind(authority.holds_exclusive_lock)
+    .bind(authority.quiescence_proof.as_str())
+    .bind(reason.as_str())
+    .bind(authority.calling_recovery_timeout_secs)
+    .bind(cas_won)
+    .bind(outcome.map(CiRouteOutcome::as_str))
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+/// Render an observed identity for the `superseded_by_evidence` audit column.
+///
+/// Recording *what defeated the compare-and-set* is not the same as making
+/// that evidence authoritative — the obsolete row still performs no action.
+fn identity_evidence_json(identity: &CiEvidenceIdentity) -> String {
+    serde_json::json!({
+        "observed": {
+            "lane": identity.lane.as_str(),
+            "pr_number": identity.pr_number,
+            "pr_head_sha": identity.pr_head_sha,
+            "run_id": identity.run_id,
+            "run_head_sha": identity.run_head_sha,
+            "dequeue_id": identity.dequeue_id,
+        }
+    })
+    .to_string()
+}

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
@@ -149,7 +149,7 @@ const BY_PK: &str = "subject_kind = $1 AND subject_id = $2 AND provider_action_k
 /// A trivial two-way string mapping.
 ///
 /// Every durable vocabulary below is spelled exactly once in Rust and once in
-/// migration 191's `CHECK ... IN (...)`. Keeping the two in one place per enum
+/// migration 193's `CHECK ... IN (...)`. Keeping the two in one place per enum
 /// is what stops a new variant from binding as an unchecked string that the
 /// CHECK then rejects at 3am instead of at compile time.
 macro_rules! durable_enum {
@@ -195,7 +195,7 @@ durable_enum! {
     /// is carried alongside it. Every key on the table is scoped by it.
     CiSubjectKind {
         /// A board task. The only kind wave 1 writes, and the only kind with
-        /// database-enforced referential integrity (migration 191 derives
+        /// database-enforced referential integrity (migration 193 derives
         /// `task_id` from the subject and puts the foreign key on it).
         Task => "task",
         /// Reserved for a proposal-branch PR, which has no owning task and
@@ -1665,7 +1665,7 @@ impl CiRouteAttemptRepository {
     /// is a task today and one PR maps to one task, so no two subjects share a
     /// PR head and the distinction is invisible. It stops being invisible the
     /// moment a non-task subject shares a head — see the `tier2_lease_key`
-    /// note in migration 191.
+    /// note in migration 193.
     ///
     /// # Errors
     ///

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
@@ -60,6 +60,25 @@
 //! compare-and-set to the former owner's own finalizer, which is legal and
 //! recorded.
 //!
+//! That restriction is worth stating as one invariant, because it was
+//! previously enforced in some paths and not others:
+//!
+//! > **A row in `calling` is closed only by its own owner's
+//! > [`CiRouteAttemptRepository::finalize_calling`], or by
+//! > [`CiRouteAttemptRepository::recover_calling_owner`] under a quiescent
+//! > startup handoff. Nothing else may terminalize it.**
+//!
+//! It is enforced structurally, in [`terminalize_cas_in_tx`] — the single
+//! statement every non-owner terminalization funnels through — rather than by
+//! each call site remembering. The reason is what a miss costs: closing a live
+//! `calling` row makes the owner's own compare-and-set fail, so a real
+//! provider result is discarded with nothing reported. The public methods that
+//! can be handed such a row ([`CiRouteAttemptRepository::terminalize`],
+//! [`CiRouteAttemptRepository::open_tier2_lease`],
+//! [`CiRouteAttemptRepository::resolve_tier2_lease`]) additionally check the
+//! phase *before* writing, so the outcome each reports stays truthful instead
+//! of announcing a supersession the fence silently refused.
+//!
 //! Every recovery *attempt* writes a row to `ci_route_calling_recoveries`,
 //! including the ones that correctly did nothing. A sweep that left a live
 //! owner alone has to be observable, or the claim "we never steal a live
@@ -355,6 +374,14 @@ durable_enum! {
 /// [`CiRouteAttemptRepository::reserve`] answer "already present" for *foreign*
 /// evidence, so the colliding route would silently never exist. Scoping by
 /// subject makes that class impossible rather than unlikely.
+///
+/// The cost, stated plainly because it is the flip side of that fix: every
+/// per-key limit is **per subject**. The Tier-2 head hold, the signature and
+/// head retry budgets, and the pass/merge close all stop at the subject
+/// boundary. With one task per PR that boundary never splits a PR head, so
+/// nothing observes it. The first non-task subject to share a PR head with a
+/// task subject gets a doubled head budget and a second concurrent Lead
+/// adjudication for that head, and owns deciding what to do about it.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CiRouteSubject {
     pub kind: CiSubjectKind,
@@ -714,6 +741,14 @@ pub enum CiTier2LeaseOutcome {
     /// This row has already used its one trip to Tier 2 — the lease is open,
     /// or it resolved and may not be reopened.
     AlreadyRoutedToTier2(Box<CiRouteAttempt>),
+    /// The row is in `calling`: a provider call is in flight and the row
+    /// belongs to that owner. Nothing was leased, nothing was closed.
+    ///
+    /// This is a legal race, not a caller error — a poller can read a row as
+    /// `reserved`, decide to escalate, and lose to another poller's charge in
+    /// between. The route is adjudicated (or not) after the owner's provider
+    /// result lands, or after startup recovery, never by taking it here.
+    OwnedByProviderCall(Box<CiRouteAttempt>),
     /// The compare-and-set failed: the identity changed or a newer
     /// passing/merged observation already terminalized the row. The row is
     /// closed as `superseded_before_lead` with no lease and no Lead dispatch.
@@ -1610,8 +1645,27 @@ impl CiRouteAttemptRepository {
     /// `tier2_lease_key` is derived by wave 2 from **(PR number, PR-head
     /// SHA)** — never the lane, the run id, or the dequeue id. A lane-scoped
     /// key would allow two concurrent Lead adjudications for one PR head and
-    /// defeat the head-level hold. The subject scoping supplies repository
-    /// identity, so the key does not need to.
+    /// defeat the hold. The subject scoping supplies repository identity, so
+    /// the key does not need to.
+    ///
+    /// **Head scope is a choice among three conflicting spec statements, not a
+    /// derivation.** Proposal `nafu` calls this an "evidence-scoped route
+    /// lease" (lane transitions table, which would include the run id), "at
+    /// most one Lead adjudication for current evidence" (Idempotency, which is
+    /// ambiguous), and "a head-level hold" (Risks). Head scope is the most
+    /// conservative reading and the only one under which the retry-storm
+    /// safeguard exists, so it was chosen — but a wave that reads the
+    /// lane-transitions wording literally would widen the hold and reintroduce
+    /// concurrent adjudications for one head. Resolve the spec before
+    /// changing it.
+    ///
+    /// The hold is **per subject**, not global: the unique index is
+    /// `(subject_kind, subject_id, tier2_lease_key)`, so two different
+    /// subjects can hold the identical key open simultaneously. Every subject
+    /// is a task today and one PR maps to one task, so no two subjects share a
+    /// PR head and the distinction is invisible. It stops being invisible the
+    /// moment a non-task subject shares a head — see the `tier2_lease_key`
+    /// note in migration 191.
     ///
     /// # Errors
     ///
@@ -1631,6 +1685,23 @@ impl CiRouteAttemptRepository {
             tx.commit().await?;
             return Ok(CiTier2LeaseOutcome::NotFound);
         };
+
+        // A row whose provider call is in flight belongs to its owner, and
+        // this is a benign race rather than a caller bug: W2 can read a row as
+        // `reserved`, decide to escalate, and have another poller charge it to
+        // `calling` before this call lands.
+        //
+        // Returning early matters twice over. It stops the supersession branch
+        // below from stealing the row — which it used to do, flipping a live
+        // `calling` row to terminal `superseded_before_lead` and making the
+        // owner's `finalize_calling` a silent no-op. And it keeps the reported
+        // outcome honest: with only the structural fence in
+        // `terminalize_cas_in_tx`, the write would be refused but this method
+        // would still announce `SupersededBeforeLead`.
+        if attempt.action_phase == CiActionPhase::Calling {
+            tx.commit().await?;
+            return Ok(CiTier2LeaseOutcome::OwnedByProviderCall(Box::new(attempt)));
+        }
 
         // A row already terminalized by a newer passing/merged observation is
         // exactly the "newer outcome" half of the guard: the pass/merge path
@@ -1745,6 +1816,16 @@ impl CiRouteAttemptRepository {
         if attempt.tier2_lease_id.as_deref() != Some(lease_id)
             || attempt.tier2_lease_state != Some(CiTier2LeaseState::Open)
         {
+            tx.commit().await?;
+            return Ok(false);
+        }
+
+        // Same fence as `open_tier2_lease`, for the same reason: the
+        // supersession branch below terminalizes, and a `calling` row belongs
+        // to its owner. Unreachable while `open_tier2_lease` refuses to lease
+        // a `calling` row — which is exactly why it is here. This repository
+        // does not rely on one guard holding somewhere else.
+        if attempt.action_phase == CiActionPhase::Calling {
             tx.commit().await?;
             return Ok(false);
         }
@@ -2097,6 +2178,27 @@ async fn charge_counter(
 }
 
 /// The write-once terminal compare-and-set. Returns whether it wrote.
+///
+/// **`action_phase <> 'calling'` is a structural fence, not a caller
+/// courtesy.** A `calling` row's provider future may be in flight; closing it
+/// here would steal it, and the owner's own `finalize_calling` — which is
+/// compare-and-set against `action_phase = 'calling'` — would then return
+/// `false` and silently discard a real provider result.
+///
+/// The fence lives in this helper rather than at each call site because every
+/// non-owner terminalization funnels through here, and the cost of one call
+/// site forgetting it is a lost provider outcome that nothing reports. No
+/// legitimate caller needs it: `charge_and_begin_calling` and
+/// `recover_reserved` only reach terminalization from `reserved`,
+/// `close_routes_for_newer_outcome` carries its own `= 'reserved'` predicate,
+/// and `recover_calling_owner` — the one path that may legally take a
+/// `calling` row — uses its own owner-fenced UPDATE and never comes through
+/// here.
+///
+/// Callers that could be handed a `calling` row must still check the phase
+/// themselves *before* calling, so the outcome they report stays truthful: a
+/// silent `false` here would otherwise let them announce a supersession that
+/// did not happen.
 async fn terminalize_cas_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     subject: &CiRouteSubject,
@@ -2108,7 +2210,7 @@ async fn terminalize_cas_in_tx(
         "UPDATE ci_route_attempts \
          SET action_phase = 'terminal', terminal_outcome = $4, terminalized_at = now(), \
              superseded_by_evidence = COALESCE($5::jsonb, superseded_by_evidence), updated_at = now() \
-         WHERE {BY_PK} AND action_phase <> 'terminal'"
+         WHERE {BY_PK} AND action_phase <> 'terminal' AND action_phase <> 'calling'"
     ))
     .bind(subject.kind.as_str())
     .bind(&subject.id)

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
@@ -1,0 +1,1746 @@
+//! Acceptance tests for the `nafu` wave-1 durable CI routing layer.
+//!
+//! The proposal's database acceptance row asks for: migration round trip;
+//! unique evidence reservation; `reserved`/`calling` transitions; immutable
+//! owner incarnation; reservation eligibility; monotonic budgets; owner-scoped
+//! finalization; exclusive owner-handoff compare-and-set; exactly-once
+//! terminalization; unique current-evidence Tier-2 lease; obsolete-route
+//! suppression across reload.
+//!
+//! Two things every test here does deliberately:
+//!
+//! * **It asserts the side effect, not the return label.** A test that only
+//!   checked `matches!(outcome, Resumed { .. })` would stay green if the body
+//!   charged twice, or zero times. So the assertions are on the counter rows
+//!   the mechanism WRITES: `budget_counts`, `owner_incarnation_id`,
+//!   `terminal_outcome`, `pre_call_resumptions`.
+//! * **Recovery tests go through a genuinely new `Database` handle**
+//!   (`reopen_test`), not a second call on the live object. A restart that is
+//!   only a second method call proves the opposite of durability.
+
+use crate::database::Database;
+use crate::repositories::ci_route_attempt::{
+    CI_CALLING_RECOVERY_TIMEOUT_SECS, CI_HEAD_BUDGET_LIMIT, CI_SIGNATURE_BUDGET_LIMIT, CiAction,
+    CiActionPhase, CiCallingRecovery, CiCallingRecoveryAuthority, CiCallingRecoveryReason,
+    CiChargeOutcome, CiClass, CiDiagnosticReason, CiEvidenceIdentity, CiLane, CiOriginState,
+    CiQuiescenceProof, CiReopenMode, CiReserveOutcome, CiReservedRecovery, CiRouteAttempt,
+    CiRouteAttemptRepository, CiRouteOutcome, CiRouteReservation, CiTier2LeaseOutcome,
+    CiTier2LeaseState, CiTier2Reason, CiTier2Resolution,
+};
+use crate::repositories::coordinator_incarnation::CoordinatorIncarnationRepository;
+use crate::repositories::test_support::{UsageTestTaskSeed, make_project, seed_task_row};
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+struct Fixture {
+    db: Database,
+    project_id: String,
+    task_id: String,
+}
+
+async fn fixture() -> Fixture {
+    let db = Database::open_in_memory().expect("ephemeral test database");
+    let project = make_project(&db, std::path::Path::new("ci-route")).await;
+    let task_id = seed_task_row(
+        &db,
+        UsageTestTaskSeed {
+            project_id: &project.id,
+            status: "pr_draft",
+            close_reason: None,
+            total_reopen_count: 0,
+        },
+    )
+    .await;
+    Fixture {
+        db,
+        project_id: project.id,
+        task_id,
+    }
+}
+
+fn repo(db: &Database) -> CiRouteAttemptRepository {
+    CiRouteAttemptRepository::new(db.clone())
+}
+
+/// A brand-new repository built from nothing but the connection string — the
+/// only honest way to express "the process died and came back".
+fn reopened(db: &Database) -> (Database, CiRouteAttemptRepository) {
+    let dsn = db.test_dsn().expect("ephemeral database exposes a DSN");
+    let handle = Database::reopen_test(&dsn).expect("reopen after simulated restart");
+    let repository = CiRouteAttemptRepository::new(handle.clone());
+    (handle, repository)
+}
+
+fn incarnation() -> String {
+    uuid::Uuid::now_v7().to_string()
+}
+
+fn pr_head_identity(run_id: i64, head: &str) -> CiEvidenceIdentity {
+    CiEvidenceIdentity {
+        lane: CiLane::PrHead,
+        pr_number: 4242,
+        pr_head_sha: head.to_owned(),
+        run_id,
+        run_head_sha: head.to_owned(),
+        dequeue_id: None,
+    }
+}
+
+fn merge_group_identity(run_id: i64, head: &str, dequeue: &str) -> CiEvidenceIdentity {
+    CiEvidenceIdentity {
+        lane: CiLane::MergeGroup,
+        pr_number: 4242,
+        pr_head_sha: head.to_owned(),
+        run_id,
+        run_head_sha: head.to_owned(),
+        dequeue_id: Some(dequeue.to_owned()),
+    }
+}
+
+/// Distinct evidence, one shared signature budget and one shared head budget —
+/// which is the arrangement the ceilings exist to bound.
+fn reservation(
+    task_id: &str,
+    key: &str,
+    identity: CiEvidenceIdentity,
+    fingerprint: &str,
+) -> CiRouteReservation {
+    let head_budget_key = format!("head:{}:{}", identity.pr_number, identity.pr_head_sha);
+    let retry_budget_key = format!(
+        "sig:{}:{}:{}:{fingerprint}",
+        identity.lane.as_str(),
+        identity.pr_number,
+        identity.pr_head_sha
+    );
+    let origin_state = match identity.lane {
+        CiLane::PrHead => CiOriginState::PrDraft,
+        CiLane::MergeGroup => CiOriginState::PrReview,
+    };
+    let action = match identity.lane {
+        CiLane::PrHead => CiAction::RerunRun,
+        CiLane::MergeGroup => CiAction::Reenqueue,
+    };
+    CiRouteReservation {
+        provider_action_key: key.to_owned(),
+        identity,
+        task_id: task_id.to_owned(),
+        origin_state,
+        class: CiClass::Inconclusive,
+        action,
+        transient_fingerprint: fingerprint.to_owned(),
+        retry_budget_key,
+        head_budget_key,
+    }
+}
+
+fn unwrap_reserved(outcome: CiReserveOutcome) -> CiRouteAttempt {
+    match outcome {
+        CiReserveOutcome::Reserved(attempt) => *attempt,
+        other => panic!("expected a fresh reservation, got {other:?}"),
+    }
+}
+
+/// Age a row's `reserved_at`/`calling_at` backwards so an eligibility floor is
+/// crossed without the test sleeping. The clock being moved is the DATABASE's,
+/// which is the same clock the eligibility predicate reads.
+async fn age_reserved(db: &Database, key: &str, seconds: i64) {
+    sqlx::query("UPDATE ci_route_attempts SET reserved_at = now() - make_interval(secs => $2::double precision) WHERE provider_action_key = $1")
+        .bind(key)
+        .bind(seconds as f64)
+        .execute(db.pool())
+        .await
+        .expect("age reserved_at");
+}
+
+async fn age_calling(db: &Database, key: &str, seconds: i64) {
+    sqlx::query("UPDATE ci_route_attempts SET calling_at = now() - make_interval(secs => $2::double precision) WHERE provider_action_key = $1")
+        .bind(key)
+        .bind(seconds as f64)
+        .execute(db.pool())
+        .await
+        .expect("age calling_at");
+}
+
+/// Register an incarnation that has completed the full graceful drain, so a
+/// handoff test is exercising the real predicate rather than a bare boolean.
+async fn drained_incarnation(db: &Database) -> String {
+    let id = incarnation();
+    let repository = CoordinatorIncarnationRepository::new(db.clone());
+    repository
+        .register(&id)
+        .await
+        .expect("register incarnation");
+    assert!(repository.mark_draining(&id).await.expect("mark draining"));
+    assert!(
+        repository
+            .mark_provider_actions_drained(&id)
+            .await
+            .expect("mark drained")
+    );
+    id
+}
+
+fn authority(
+    former: &str,
+    recovering: &str,
+    proof: CiQuiescenceProof,
+    lock: bool,
+) -> CiCallingRecoveryAuthority {
+    CiCallingRecoveryAuthority {
+        recovering_incarnation: recovering.to_owned(),
+        former_owner_incarnation: former.to_owned(),
+        holds_exclusive_lock: lock,
+        quiescence_proof: proof,
+        calling_recovery_timeout_secs: CI_CALLING_RECOVERY_TIMEOUT_SECS,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Migration round trip
+// ---------------------------------------------------------------------------
+
+/// Migration 191 round trip: every column the repository binds survives a
+/// write and a read back through a *different* connection pool.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn migration_round_trips_every_route_attempt_field() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = merge_group_identity(9001, "headsha-round-trip", "dequeue-77");
+    let input = reservation(&f.task_id, "key-round-trip", identity.clone(), "fp-a");
+    let reserved = unwrap_reserved(repository.reserve(&input).await.unwrap());
+
+    assert_eq!(reserved.action_phase, CiActionPhase::Reserved);
+    assert!(reserved.terminal_outcome.is_none());
+    assert!(reserved.owner_incarnation_id.is_none());
+    assert!(!reserved.reserved_at.is_empty());
+
+    // Read back through a genuinely new handle: the row is on disk, not in an
+    // object we are still holding.
+    let (handle, restarted) = reopened(&f.db);
+    let loaded = restarted
+        .get("key-round-trip")
+        .await
+        .unwrap()
+        .expect("row survives reload");
+
+    assert_eq!(loaded.identity, identity);
+    assert_eq!(loaded.task_id, f.task_id);
+    assert_eq!(loaded.origin_state, CiOriginState::PrReview);
+    assert_eq!(loaded.class, CiClass::Inconclusive);
+    assert_eq!(loaded.action, CiAction::Reenqueue);
+    assert_eq!(loaded.transient_fingerprint, "fp-a");
+    assert_eq!(loaded.retry_budget_key, input.retry_budget_key);
+    assert_eq!(loaded.head_budget_key, input.head_budget_key);
+    assert_eq!(loaded.pre_call_resumptions, 0);
+    assert!(loaded.charged_signature_count.is_none());
+    assert!(loaded.tier2_lease_id.is_none());
+
+    // And the two additive coordinator-incarnation drain columns round trip.
+    let drained = drained_incarnation(&f.db).await;
+    let lease = CoordinatorIncarnationRepository::new(handle.clone())
+        .get(&drained)
+        .await
+        .unwrap()
+        .expect("incarnation survives reload");
+    assert!(lease.draining_at.is_some());
+    assert!(lease.provider_actions_drained_at.is_some());
+}
+
+/// `mark_provider_actions_drained` refuses an incarnation that never entered
+/// `draining`. Otherwise a caller could mint the exclusion proof the next
+/// incarnation relies on without ever closing action admission.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn drain_proof_requires_admission_to_have_closed_first() {
+    let f = fixture().await;
+    let repository = CoordinatorIncarnationRepository::new(f.db.clone());
+    let id = incarnation();
+    repository.register(&id).await.unwrap();
+
+    assert!(
+        !repository.mark_provider_actions_drained(&id).await.unwrap(),
+        "drain proof must not be writable before draining starts"
+    );
+    let row = repository.get(&id).await.unwrap().unwrap();
+    assert!(row.provider_actions_drained_at.is_none());
+
+    assert!(repository.mark_draining(&id).await.unwrap());
+    assert!(repository.mark_provider_actions_drained(&id).await.unwrap());
+    // Both are write-once.
+    assert!(!repository.mark_draining(&id).await.unwrap());
+    assert!(!repository.mark_provider_actions_drained(&id).await.unwrap());
+}
+
+// ---------------------------------------------------------------------------
+// Unique evidence reservation
+// ---------------------------------------------------------------------------
+
+/// A duplicate poll for the same evidence identity gets the existing row, not
+/// a second one — and critically, not a second charge opportunity.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn duplicate_poll_reserves_one_row_for_one_evidence_identity() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let input = reservation(
+        &f.task_id,
+        "key-dup",
+        pr_head_identity(1, "headsha-dup"),
+        "fp-a",
+    );
+
+    let first = repository.reserve(&input).await.unwrap();
+    assert!(matches!(first, CiReserveOutcome::Reserved(_)));
+
+    // A second poller, and then a restarted one, both collide on the key.
+    let second = repository.reserve(&input).await.unwrap();
+    let (_handle, restarted) = reopened(&f.db);
+    let third = restarted.reserve(&input).await.unwrap();
+    assert!(matches!(second, CiReserveOutcome::AlreadyPresent(_)));
+    assert!(matches!(third, CiReserveOutcome::AlreadyPresent(_)));
+
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ci_route_attempts")
+        .fetch_one(f.db.pool())
+        .await
+        .unwrap();
+    assert_eq!(rows, 1, "one evidence identity must own exactly one row");
+
+    // Reserving never charges. Only `calling` does.
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(counts.signature, 0);
+    assert_eq!(counts.head, 0);
+}
+
+// ---------------------------------------------------------------------------
+// reserved -> calling, and owner identity
+// ---------------------------------------------------------------------------
+
+/// The happy path, asserted on state rather than on the returned variant: one
+/// winner, one charge on each budget, and an owner recorded on the row.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reserved_advances_to_calling_once_and_charges_both_budgets() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-happy");
+    let input = reservation(&f.task_id, "key-happy", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+
+    let owner = incarnation();
+    let charged = repository
+        .charge_and_begin_calling("key-happy", &owner, &identity)
+        .await
+        .unwrap();
+    let CiChargeOutcome::Charged { attempt, counts } = charged else {
+        panic!("expected a charge, got {charged:?}");
+    };
+    assert_eq!(attempt.action_phase, CiActionPhase::Calling);
+    assert_eq!(
+        attempt.owner_incarnation_id.as_deref(),
+        Some(owner.as_str())
+    );
+    assert!(attempt.calling_at.is_some());
+    assert_eq!(counts.signature, 1);
+    assert_eq!(counts.head, 1);
+    assert_eq!(attempt.charged_signature_count, Some(1));
+    assert_eq!(attempt.charged_head_count, Some(1));
+
+    // A second caller — a duplicate poll — finds the row already advanced and
+    // must not charge again.
+    let loser = incarnation();
+    let again = repository
+        .charge_and_begin_calling("key-happy", &loser, &identity)
+        .await
+        .unwrap();
+    assert!(matches!(again, CiChargeOutcome::NotReserved(_)));
+
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(
+        (counts.signature, counts.head),
+        (1, 1),
+        "a losing caller must not charge"
+    );
+    let row = repository.get("key-happy").await.unwrap().unwrap();
+    assert_eq!(
+        row.owner_incarnation_id.as_deref(),
+        Some(owner.as_str()),
+        "the owner incarnation is immutable except through owner handoff"
+    );
+}
+
+/// A PR head that moved between the reservation and the call: no charge, no
+/// lease, terminal `superseded_pre_call`, and the defeating evidence recorded.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn identity_change_before_calling_supersedes_uncharged() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-old");
+    let input = reservation(&f.task_id, "key-stale", identity, "fp-a");
+    repository.reserve(&input).await.unwrap();
+
+    let observed = pr_head_identity(2, "headsha-new");
+    let outcome = repository
+        .charge_and_begin_calling("key-stale", &incarnation(), &observed)
+        .await
+        .unwrap();
+    let CiChargeOutcome::SupersededPreCall(attempt) = outcome else {
+        panic!("expected supersession, got {outcome:?}");
+    };
+
+    assert_eq!(
+        attempt.terminal_outcome,
+        Some(CiRouteOutcome::SupersededPreCall)
+    );
+    assert!(attempt.owner_incarnation_id.is_none(), "no call ownership");
+    assert!(attempt.charged_signature_count.is_none(), "no charge");
+    assert!(!attempt.holds_open_tier2_lease(), "no Tier-2 lease");
+    let evidence = attempt
+        .superseded_by_evidence
+        .expect("the defeating evidence is recorded");
+    assert!(evidence.contains("headsha-new"));
+
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!((counts.signature, counts.head), (0, 0));
+}
+
+// ---------------------------------------------------------------------------
+// Pre-call recovery — the core of the wave
+// ---------------------------------------------------------------------------
+
+/// A reservation younger than the timeout is not recoverable, and recovery
+/// leaves it exactly as it found it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reservation_below_the_timeout_is_not_eligible_for_recovery() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-young");
+    let input = reservation(&f.task_id, "key-young", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+
+    let outcome = repository
+        .recover_reserved("key-young", &identity, &incarnation(), 300, "lease-young")
+        .await
+        .unwrap();
+    let CiReservedRecovery::NotEligible(attempt) = outcome else {
+        panic!("expected ineligibility, got {outcome:?}");
+    };
+    assert_eq!(attempt.action_phase, CiActionPhase::Reserved);
+    assert_eq!(attempt.pre_call_resumptions, 0);
+
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!((counts.signature, counts.head), (0, 0));
+}
+
+/// **The wave's central invariant.** Three recoveries — two of them through
+/// fresh `Database` handles standing in for restarts — race for a still-current
+/// `reserved` row with budget remaining. Exactly one wins, the row is resumed
+/// rather than replaced, each budget is charged exactly once, and no Tier-2
+/// lease or Lead session is created.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn repeated_recovery_of_current_reserved_row_resumes_one_winner_and_charges_once() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-resume");
+    let input = reservation(&f.task_id, "key-resume", identity.clone(), "fp-a");
+    let reserved = unwrap_reserved(repository.reserve(&input).await.unwrap());
+    age_reserved(&f.db, "key-resume", 600).await;
+
+    let (_h1, restart_one) = reopened(&f.db);
+    let (_h2, restart_two) = reopened(&f.db);
+    let winner_incarnation = incarnation();
+
+    let first = restart_one
+        .recover_reserved(
+            "key-resume",
+            &identity,
+            &winner_incarnation,
+            60,
+            "lease-resume",
+        )
+        .await
+        .unwrap();
+    let second = restart_two
+        .recover_reserved("key-resume", &identity, &incarnation(), 60, "lease-resume")
+        .await
+        .unwrap();
+    let third = repository
+        .recover_reserved("key-resume", &identity, &incarnation(), 60, "lease-resume")
+        .await
+        .unwrap();
+
+    let CiReservedRecovery::Resumed { attempt, counts } = first else {
+        panic!("first recovery must resume, got {first:?}");
+    };
+    assert_eq!(
+        attempt.provider_action_key, reserved.provider_action_key,
+        "resumption advances the SAME row, it does not create a new one"
+    );
+    assert_eq!((counts.signature, counts.head), (1, 1));
+    assert!(matches!(second, CiReservedRecovery::NotEligible(_)));
+    assert!(matches!(third, CiReservedRecovery::NotEligible(_)));
+
+    let final_counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(
+        (final_counts.signature, final_counts.head),
+        (1, 1),
+        "three recoveries must charge exactly once"
+    );
+
+    let row = repository.get("key-resume").await.unwrap().unwrap();
+    assert_eq!(row.action_phase, CiActionPhase::Calling);
+    assert_eq!(
+        row.owner_incarnation_id.as_deref(),
+        Some(winner_incarnation.as_str()),
+        "the single winner owns the provider-call episode"
+    );
+    assert_eq!(row.pre_call_resumptions, 1);
+    assert!(row.tier2_lease_id.is_none(), "no Tier-2 lease");
+    assert!(row.lead_session_id.is_none(), "no Lead session");
+    assert_eq!(
+        rows_in_state(&f.db, "calling").await,
+        1,
+        "exactly one provider-call episode is authorized"
+    );
+}
+
+/// The same invariant under genuine concurrency rather than sequencing.
+///
+/// The previous test runs its recoveries one after another, so it proves the
+/// phase check. This one launches them *simultaneously* on separate pools, so
+/// the only thing standing between them is the row lock inside the
+/// transaction. If that lock were missing, both would read `reserved`, both
+/// would charge, and the counter would read 2.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_recoveries_of_one_reserved_row_charge_exactly_once() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-race-resume");
+    let input = reservation(&f.task_id, "key-race-resume", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    age_reserved(&f.db, "key-race-resume", 600).await;
+
+    let (_h1, a) = reopened(&f.db);
+    let (_h2, b) = reopened(&f.db);
+    let (_h3, c) = reopened(&f.db);
+    let id_a = identity.clone();
+    let id_b = identity.clone();
+    let id_c = identity.clone();
+    let inc_a = incarnation();
+    let inc_b = incarnation();
+    let inc_c = incarnation();
+
+    let (ra, rb, rc) = tokio::join!(
+        a.recover_reserved("key-race-resume", &id_a, &inc_a, 60, "lease-race"),
+        b.recover_reserved("key-race-resume", &id_b, &inc_b, 60, "lease-race"),
+        c.recover_reserved("key-race-resume", &id_c, &inc_c, 60, "lease-race"),
+    );
+
+    let resumed = [ra.unwrap(), rb.unwrap(), rc.unwrap()]
+        .into_iter()
+        .filter(|outcome| matches!(outcome, CiReservedRecovery::Resumed { .. }))
+        .count();
+    assert_eq!(resumed, 1, "exactly one concurrent recovery may resume");
+
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(
+        (counts.signature, counts.head),
+        (1, 1),
+        "three concurrent recoveries must charge exactly once"
+    );
+    let row = repository.get("key-race-resume").await.unwrap().unwrap();
+    assert_eq!(row.pre_call_resumptions, 1);
+    assert_eq!(rows_in_state(&f.db, "calling").await, 1);
+}
+
+/// Concurrent duplicate polls for one evidence identity: one row, one charge
+/// opportunity. Without the pre-insert lock both would insert and one would
+/// surface a raw unique-violation error instead of `AlreadyPresent`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_reservations_of_one_identity_yield_one_row() {
+    let f = fixture().await;
+    let input = reservation(
+        &f.task_id,
+        "key-race-reserve",
+        pr_head_identity(1, "headsha-race-reserve"),
+        "fp-a",
+    );
+    let (_h1, a) = reopened(&f.db);
+    let (_h2, b) = reopened(&f.db);
+
+    let (ra, rb) = tokio::join!(a.reserve(&input), b.reserve(&input));
+    let outcomes = [ra.unwrap(), rb.unwrap()];
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|o| matches!(o, CiReserveOutcome::Reserved(_)))
+            .count(),
+        1,
+        "exactly one concurrent poll creates the row"
+    );
+
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ci_route_attempts")
+        .fetch_one(f.db.pool())
+        .await
+        .unwrap();
+    assert_eq!(rows, 1);
+}
+
+/// Recovery of an obsolete `reserved` row: terminal, uncharged, no lease.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_of_obsolete_reserved_row_supersedes_without_cost() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let input = reservation(
+        &f.task_id,
+        "key-obsolete",
+        pr_head_identity(1, "headsha-old"),
+        "fp-a",
+    );
+    repository.reserve(&input).await.unwrap();
+    age_reserved(&f.db, "key-obsolete", 600).await;
+
+    let (_handle, restarted) = reopened(&f.db);
+    let outcome = restarted
+        .recover_reserved(
+            "key-obsolete",
+            &pr_head_identity(2, "headsha-new"),
+            &incarnation(),
+            60,
+            "lease-obsolete",
+        )
+        .await
+        .unwrap();
+    let CiReservedRecovery::SupersededPreCall(attempt) = outcome else {
+        panic!("expected supersession, got {outcome:?}");
+    };
+    assert_eq!(
+        attempt.terminal_outcome,
+        Some(CiRouteOutcome::SupersededPreCall)
+    );
+    assert!(attempt.charged_signature_count.is_none());
+    assert!(!attempt.holds_open_tier2_lease());
+
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!((counts.signature, counts.head), (0, 0));
+    assert_eq!(rows_in_state(&f.db, "calling").await, 0);
+}
+
+/// Recovery of a still-current `reserved` row whose budget is spent: no charge
+/// and no call, but at most one Tier-2 lease — however many recoveries run.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_of_exhausted_reserved_row_routes_to_one_tier_two_lease() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(3, "headsha-exhausted");
+    let input = reservation(&f.task_id, "key-exhausted", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    age_reserved(&f.db, "key-exhausted", 600).await;
+
+    // Spend the signature budget through two other, distinct runs.
+    spend_signature_budget(&f, &identity, "fp-a").await;
+    let before = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(before.signature, CI_SIGNATURE_BUDGET_LIMIT);
+
+    let (_handle, restarted) = reopened(&f.db);
+    let first = restarted
+        .recover_reserved(
+            "key-exhausted",
+            &identity,
+            &incarnation(),
+            60,
+            "lease-exhausted",
+        )
+        .await
+        .unwrap();
+    let CiReservedRecovery::RetryExhausted {
+        attempt,
+        counts,
+        tier2_lease_id,
+    } = first
+    else {
+        panic!("expected retry exhaustion, got {first:?}");
+    };
+    assert_eq!(counts.signature, CI_SIGNATURE_BUDGET_LIMIT);
+    assert!(attempt.retry_exhausted_at.is_some());
+    assert!(
+        tier2_lease_id.is_some(),
+        "exhaustion opens the Tier-2 lease"
+    );
+    assert_eq!(
+        attempt.tier2_lease_reason,
+        Some(CiTier2Reason::RetryExhausted)
+    );
+    assert!(attempt.owner_incarnation_id.is_none(), "no call ownership");
+
+    // A second recovery must not open a second lease or charge anything.
+    let second = repository
+        .recover_reserved(
+            "key-exhausted",
+            &identity,
+            &incarnation(),
+            60,
+            "lease-exhausted",
+        )
+        .await
+        .unwrap();
+    let CiReservedRecovery::RetryExhausted { tier2_lease_id, .. } = second else {
+        panic!("expected retry exhaustion again");
+    };
+    assert!(tier2_lease_id.is_none(), "at most one Tier-2 lease");
+
+    let after = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(
+        (after.signature, after.head),
+        (before.signature, before.head),
+        "exhausted recovery charges nothing"
+    );
+    let open: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ci_route_attempts WHERE tier2_lease_state = 'open'",
+    )
+    .fetch_one(f.db.pool())
+    .await
+    .unwrap();
+    assert_eq!(open, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Monotonic budgets
+// ---------------------------------------------------------------------------
+
+/// The signature ceiling: two charged actions per retry-budget key, then the
+/// third distinct run is refused a reservation entirely.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn signature_budget_stops_at_two_and_never_decrements() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-sig");
+    let input = reservation(&f.task_id, "key-sig-1", identity.clone(), "fp-a");
+
+    for run in 1..=CI_SIGNATURE_BUDGET_LIMIT {
+        let id = pr_head_identity(run, "headsha-sig");
+        let key = format!("key-sig-{run}");
+        let res = reservation(&f.task_id, &key, id.clone(), "fp-a");
+        assert!(matches!(
+            repository.reserve(&res).await.unwrap(),
+            CiReserveOutcome::Reserved(_)
+        ));
+        let charged = repository
+            .charge_and_begin_calling(&key, &incarnation(), &id)
+            .await
+            .unwrap();
+        assert!(matches!(charged, CiChargeOutcome::Charged { .. }));
+        // The provider answered with an error; the slot is NOT returned.
+        // (`ignored` is not the owner, so this finalization writes nothing —
+        // the point here is only that no code path exists that decrements.)
+        assert!(
+            !repository
+                .finalize_calling(&key, "ignored", CiRouteOutcome::ActionFailed, None)
+                .await
+                .unwrap()
+        );
+    }
+
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(counts.signature, CI_SIGNATURE_BUDGET_LIMIT);
+    assert!(counts.is_exhausted());
+
+    let third = reservation(
+        &f.task_id,
+        "key-sig-3",
+        pr_head_identity(3, "headsha-sig"),
+        "fp-a",
+    );
+    let outcome = repository.reserve(&third).await.unwrap();
+    let CiReserveOutcome::BudgetExhausted(reported) = outcome else {
+        panic!("expected exhaustion, got {outcome:?}");
+    };
+    assert_eq!(reported.signature, CI_SIGNATURE_BUDGET_LIMIT);
+    let rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ci_route_attempts WHERE provider_action_key = 'key-sig-3'",
+    )
+    .fetch_one(f.db.pool())
+    .await
+    .unwrap();
+    assert_eq!(rows, 0, "an exhausted budget reserves nothing");
+}
+
+/// The head ceiling is shared **across both lanes**: a changed fingerprint
+/// starts a fresh signature budget but still counts against the same head, and
+/// the fourth charge closes it for every lane.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn head_budget_is_shared_across_lanes_and_survives_reload() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let head = "headsha-shared";
+
+    // Two PR-head charges under fingerprint A, then two merge-group charges
+    // under fingerprint B: four distinct signature slots, one head budget.
+    let plan: [(CiEvidenceIdentity, &str); 4] = [
+        (pr_head_identity(1, head), "fp-a"),
+        (pr_head_identity(2, head), "fp-a"),
+        (merge_group_identity(3, head, "dq-1"), "fp-b"),
+        (merge_group_identity(4, head, "dq-2"), "fp-b"),
+    ];
+    for (index, (identity, fingerprint)) in plan.iter().enumerate() {
+        let key = format!("key-head-{index}");
+        let res = reservation(&f.task_id, &key, identity.clone(), fingerprint);
+        assert!(
+            matches!(
+                repository.reserve(&res).await.unwrap(),
+                CiReserveOutcome::Reserved(_)
+            ),
+            "charge {index} must reserve"
+        );
+        assert!(matches!(
+            repository
+                .charge_and_begin_calling(&key, &incarnation(), identity)
+                .await
+                .unwrap(),
+            CiChargeOutcome::Charged { .. }
+        ));
+    }
+
+    let head_key = format!("head:4242:{head}");
+    let (_handle, restarted) = reopened(&f.db);
+    let counts = restarted
+        .budget_counts("sig:pr_head:4242:headsha-shared:fp-a", &head_key)
+        .await
+        .unwrap();
+    assert_eq!(
+        counts.head, CI_HEAD_BUDGET_LIMIT,
+        "the head budget counts both lanes and survives a restart"
+    );
+
+    // A fifth attempt on a brand-new fingerprint has a fresh signature budget
+    // and is still refused by the head ceiling.
+    let fresh = reservation(
+        &f.task_id,
+        "key-head-4",
+        pr_head_identity(5, head),
+        "fp-fresh",
+    );
+    let counts = restarted
+        .budget_counts(&fresh.retry_budget_key, &fresh.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(counts.signature, 0, "a changed fingerprint starts fresh");
+    let outcome = restarted.reserve(&fresh).await.unwrap();
+    assert!(matches!(outcome, CiReserveOutcome::BudgetExhausted(_)));
+
+    // A changed PR head starts both budgets over.
+    let new_head = reservation(
+        &f.task_id,
+        "key-newhead",
+        pr_head_identity(6, "headsha-moved"),
+        "fp-a",
+    );
+    assert!(matches!(
+        restarted.reserve(&new_head).await.unwrap(),
+        CiReserveOutcome::Reserved(_)
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Owner-scoped finalization and exactly-once terminalization
+// ---------------------------------------------------------------------------
+
+/// Finalization is fenced to the exact owner: a former owner's late result
+/// writes nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn finalization_is_scoped_to_the_exact_calling_owner() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-final");
+    let input = reservation(&f.task_id, "key-final", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    let owner = incarnation();
+    repository
+        .charge_and_begin_calling("key-final", &owner, &identity)
+        .await
+        .unwrap();
+
+    let impostor = incarnation();
+    assert!(
+        !repository
+            .finalize_calling("key-final", &impostor, CiRouteOutcome::Retriggered, None)
+            .await
+            .unwrap(),
+        "a non-owner cannot finalize"
+    );
+    let row = repository.get("key-final").await.unwrap().unwrap();
+    assert_eq!(row.action_phase, CiActionPhase::Calling);
+
+    assert!(
+        repository
+            .finalize_calling("key-final", &owner, CiRouteOutcome::Retriggered, None)
+            .await
+            .unwrap()
+    );
+    let row = repository.get("key-final").await.unwrap().unwrap();
+    assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::Retriggered));
+
+    // Exactly-once: the owner's own retry finds nothing left to write.
+    assert!(
+        !repository
+            .finalize_calling("key-final", &owner, CiRouteOutcome::ActionFailed, None)
+            .await
+            .unwrap()
+    );
+    let row = repository.get("key-final").await.unwrap().unwrap();
+    assert_eq!(
+        row.terminal_outcome,
+        Some(CiRouteOutcome::Retriggered),
+        "a terminal outcome is never rewritten"
+    );
+}
+
+/// `terminalize` writes once and reports honestly to every later caller,
+/// including one that arrives after a simulated restart.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn terminalization_happens_exactly_once_across_reload() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let input = reservation(
+        &f.task_id,
+        "key-term",
+        pr_head_identity(1, "headsha-term"),
+        "fp-a",
+    );
+    repository.reserve(&input).await.unwrap();
+
+    assert!(
+        repository
+            .terminalize("key-term", CiRouteOutcome::Held, None)
+            .await
+            .unwrap()
+    );
+    assert!(
+        !repository
+            .terminalize("key-term", CiRouteOutcome::Held, None)
+            .await
+            .unwrap()
+    );
+
+    let (_handle, restarted) = reopened(&f.db);
+    assert!(
+        !restarted
+            .terminalize("key-term", CiRouteOutcome::DiagnosticReopened, None)
+            .await
+            .unwrap(),
+        "a startup sweep must not re-close a terminal row"
+    );
+    let row = restarted.get("key-term").await.unwrap().unwrap();
+    assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::Held));
+    assert!(row.terminalized_at.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Calling owner handoff
+// ---------------------------------------------------------------------------
+
+/// A live `calling` owner is untouchable. Every illegal recovery shape — no
+/// lock, no quiescence proof, timeout not elapsed, wrong former owner — leaves
+/// the row unchanged and opens no Tier-2 lease, and every one of them is
+/// recorded so the deferral is auditable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_calling_owner_is_never_recovered() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-live");
+    let input = reservation(&f.task_id, "key-live", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    let owner = incarnation();
+    repository
+        .charge_and_begin_calling("key-live", &owner, &identity)
+        .await
+        .unwrap();
+
+    let recovering = incarnation();
+    let (_handle, sweeper) = reopened(&f.db);
+
+    // 1. A periodic sweep that does not hold the exclusive lock.
+    let deferred = sweeper
+        .recover_calling_owner(
+            "key-live",
+            Some(&identity),
+            &authority(
+                &owner,
+                &recovering,
+                CiQuiescenceProof::ProcessTerminated,
+                false,
+            ),
+            "lease-live",
+        )
+        .await
+        .unwrap();
+    assert_deferred(&deferred, CiCallingRecoveryReason::LockNotHeld);
+
+    // 2. Lock held, but the owner is alive: no quiescence proof exists.
+    let deferred = sweeper
+        .recover_calling_owner(
+            "key-live",
+            Some(&identity),
+            &authority(&owner, &recovering, CiQuiescenceProof::None, true),
+            "lease-live",
+        )
+        .await
+        .unwrap();
+    assert_deferred(&deferred, CiCallingRecoveryReason::LiveOwnerDeferred);
+
+    // 3. A *claimed* graceful drain that the former incarnation never recorded
+    //    is not a proof. This is the case that makes the drain column load
+    //    bearing rather than decorative.
+    CoordinatorIncarnationRepository::new(f.db.clone())
+        .register(&owner)
+        .await
+        .unwrap();
+    let deferred = sweeper
+        .recover_calling_owner(
+            "key-live",
+            Some(&identity),
+            &authority(&owner, &recovering, CiQuiescenceProof::GracefulDrain, true),
+            "lease-live",
+        )
+        .await
+        .unwrap();
+    assert_deferred(&deferred, CiCallingRecoveryReason::LiveOwnerDeferred);
+
+    // 4. Process death is proven, but `calling_at` has not aged past the floor.
+    let deferred = sweeper
+        .recover_calling_owner(
+            "key-live",
+            Some(&identity),
+            &authority(
+                &owner,
+                &recovering,
+                CiQuiescenceProof::ProcessTerminated,
+                true,
+            ),
+            "lease-live",
+        )
+        .await
+        .unwrap();
+    assert_deferred(&deferred, CiCallingRecoveryReason::TimeoutNotElapsed);
+
+    // 5. Aged out, but fenced to the wrong former owner.
+    age_calling(&f.db, "key-live", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
+    let deferred = sweeper
+        .recover_calling_owner(
+            "key-live",
+            Some(&identity),
+            &authority(
+                &incarnation(),
+                &recovering,
+                CiQuiescenceProof::ProcessTerminated,
+                true,
+            ),
+            "lease-live",
+        )
+        .await
+        .unwrap();
+    assert_deferred(&deferred, CiCallingRecoveryReason::OwnerMismatch);
+
+    // The row is exactly as the owner left it, and nothing escalated.
+    let row = repository.get("key-live").await.unwrap().unwrap();
+    assert_eq!(row.action_phase, CiActionPhase::Calling);
+    assert_eq!(row.owner_incarnation_id.as_deref(), Some(owner.as_str()));
+    assert!(row.tier2_lease_id.is_none());
+    assert!(row.lead_session_id.is_none());
+
+    // Five deferrals, five audit rows, none of them claiming a win.
+    let audit = repository.calling_recovery_audit("key-live").await.unwrap();
+    assert_eq!(audit.len(), 5);
+    assert!(audit.iter().all(|r| !r.cas_won));
+
+    // And the owner can still finalize, because nothing took its row.
+    assert!(
+        repository
+            .finalize_calling("key-live", &owner, CiRouteOutcome::Retriggered, None)
+            .await
+            .unwrap()
+    );
+}
+
+/// A legal startup handoff: exclusive lock, proven drain, aged out, exact
+/// former owner. It runs twice; the second run loses because the row is no
+/// longer `calling`. One handoff, one retained charge, no provider replay, and
+/// at most one Tier-2 lease.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn quiescent_owner_handoff_recovers_calling_once() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-handoff");
+    let input = reservation(&f.task_id, "key-handoff", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+
+    // The former owner completed the full graceful drain before releasing the
+    // advisory lock.
+    let former = drained_incarnation(&f.db).await;
+    repository
+        .charge_and_begin_calling("key-handoff", &former, &identity)
+        .await
+        .unwrap();
+    age_calling(&f.db, "key-handoff", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
+
+    let recovering = incarnation();
+    let (_handle, restarted) = reopened(&f.db);
+    let first = restarted
+        .recover_calling_owner(
+            "key-handoff",
+            Some(&identity),
+            &authority(&former, &recovering, CiQuiescenceProof::GracefulDrain, true),
+            "lease-handoff",
+        )
+        .await
+        .unwrap();
+    let CiCallingRecovery::Recovered {
+        attempt,
+        outcome,
+        tier2_lease_id,
+    } = first
+    else {
+        panic!("expected a handoff, got {first:?}");
+    };
+    assert_eq!(outcome, CiRouteOutcome::OutcomeUnknown);
+    assert_eq!(
+        attempt.owner_incarnation_id.as_deref(),
+        Some(recovering.as_str())
+    );
+    assert_eq!(
+        attempt.charged_signature_count,
+        Some(1),
+        "the handoff retains the charge"
+    );
+    assert!(tier2_lease_id.is_some());
+
+    // A second startup sweep finds nothing to take.
+    let second = restarted
+        .recover_calling_owner(
+            "key-handoff",
+            Some(&identity),
+            &authority(
+                &former,
+                &incarnation(),
+                CiQuiescenceProof::GracefulDrain,
+                true,
+            ),
+            "lease-handoff",
+        )
+        .await
+        .unwrap();
+    assert_deferred(&second, CiCallingRecoveryReason::NotCalling);
+
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(
+        (counts.signature, counts.head),
+        (1, 1),
+        "two handoffs must not double-charge"
+    );
+    let open: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ci_route_attempts WHERE tier2_lease_state = 'open'",
+    )
+    .fetch_one(f.db.pool())
+    .await
+    .unwrap();
+    assert_eq!(open, 1, "at most one Tier-2 lease");
+
+    let audit = repository
+        .calling_recovery_audit("key-handoff")
+        .await
+        .unwrap();
+    assert_eq!(audit.len(), 2);
+    assert_eq!(
+        audit[0].recovery_reason,
+        CiCallingRecoveryReason::StartupOwnerHandoff
+    );
+    assert!(audit[0].cas_won);
+    assert_eq!(
+        audit[0].former_owner_incarnation.as_deref(),
+        Some(former.as_str())
+    );
+    assert_eq!(audit[0].quiescence_proof, CiQuiescenceProof::GracefulDrain);
+    assert!(!audit[1].cas_won);
+}
+
+/// A provider result that committed before the handoff wins. Recovery cannot
+/// overwrite it and records the loss.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn provider_finalizer_wins_the_owner_handoff_race() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-race");
+    let input = reservation(&f.task_id, "key-race", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    let former = drained_incarnation(&f.db).await;
+    repository
+        .charge_and_begin_calling("key-race", &former, &identity)
+        .await
+        .unwrap();
+    age_calling(&f.db, "key-race", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
+
+    // The old owner's finalizer commits first.
+    assert!(
+        repository
+            .finalize_calling("key-race", &former, CiRouteOutcome::Reenqueued, None)
+            .await
+            .unwrap()
+    );
+
+    let outcome = repository
+        .recover_calling_owner(
+            "key-race",
+            Some(&identity),
+            &authority(
+                &former,
+                &incarnation(),
+                CiQuiescenceProof::GracefulDrain,
+                true,
+            ),
+            "lease-race",
+        )
+        .await
+        .unwrap();
+    assert_deferred(&outcome, CiCallingRecoveryReason::NotCalling);
+
+    let row = repository.get("key-race").await.unwrap().unwrap();
+    assert_eq!(
+        row.terminal_outcome,
+        Some(CiRouteOutcome::Reenqueued),
+        "a committed provider outcome is authoritative"
+    );
+    assert_eq!(row.owner_incarnation_id.as_deref(), Some(former.as_str()));
+    assert!(row.tier2_lease_id.is_none());
+}
+
+/// After a legal handoff of an **obsolete** row: no Tier-2 lease, no board or
+/// worker consequence, charge retained.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn obsolete_row_handoff_closes_superseded_after_call() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-gone");
+    let input = reservation(&f.task_id, "key-gone", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    let former = drained_incarnation(&f.db).await;
+    repository
+        .charge_and_begin_calling("key-gone", &former, &identity)
+        .await
+        .unwrap();
+    age_calling(&f.db, "key-gone", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
+
+    let outcome = repository
+        .recover_calling_owner(
+            "key-gone",
+            Some(&pr_head_identity(2, "headsha-moved")),
+            &authority(
+                &former,
+                &incarnation(),
+                CiQuiescenceProof::ProcessTerminated,
+                true,
+            ),
+            "lease-gone",
+        )
+        .await
+        .unwrap();
+    let CiCallingRecovery::Recovered {
+        attempt,
+        outcome,
+        tier2_lease_id,
+    } = outcome
+    else {
+        panic!("expected a handoff");
+    };
+    assert_eq!(outcome, CiRouteOutcome::SupersededAfterCall);
+    assert!(tier2_lease_id.is_none(), "an obsolete row opens no Tier 2");
+    assert_eq!(attempt.charged_signature_count, Some(1));
+
+    let counts = repository
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!((counts.signature, counts.head), (1, 1));
+}
+
+// ---------------------------------------------------------------------------
+// Tier-2 lease
+// ---------------------------------------------------------------------------
+
+/// Two routes on the same current evidence contend for one lease. Exactly one
+/// gets it; the loser opens nothing, and the winner's lease survives a reload.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let head = "headsha-lease";
+    let first_identity = pr_head_identity(1, head);
+    let second_identity = pr_head_identity(2, head);
+    repository
+        .reserve(&reservation(
+            &f.task_id,
+            "key-lease-1",
+            first_identity.clone(),
+            "fp-a",
+        ))
+        .await
+        .unwrap();
+    repository
+        .reserve(&reservation(
+            &f.task_id,
+            "key-lease-2",
+            second_identity.clone(),
+            "fp-b",
+        ))
+        .await
+        .unwrap();
+
+    let lease_key = format!("tier2:pr_head:4242:{head}");
+    let first = repository
+        .open_tier2_lease(
+            "key-lease-1",
+            &first_identity,
+            &lease_key,
+            CiTier2Reason::CausalFailure,
+        )
+        .await
+        .unwrap();
+    let CiTier2LeaseOutcome::Opened { lease_id, .. } = first else {
+        panic!("expected the first opener to win, got {first:?}");
+    };
+
+    let (_handle, restarted) = reopened(&f.db);
+    let second = restarted
+        .open_tier2_lease(
+            "key-lease-2",
+            &second_identity,
+            &lease_key,
+            CiTier2Reason::EvidenceUnknown,
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(second, CiTier2LeaseOutcome::AlreadyLeased(_)),
+        "a second route on the same current evidence cannot open a Lead adjudication"
+    );
+
+    let open: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ci_route_attempts WHERE tier2_lease_state = 'open'",
+    )
+    .fetch_one(f.db.pool())
+    .await
+    .unwrap();
+    assert_eq!(open, 1);
+
+    // The dispatched Lead session binds to the exact lease.
+    assert!(
+        restarted
+            .attach_lead_session("key-lease-1", &lease_id, "session-alpha")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !restarted
+            .attach_lead_session("key-lease-1", "not-the-lease", "session-beta")
+            .await
+            .unwrap()
+    );
+
+    let quiescence = restarted.quiescence_counts().await.unwrap();
+    assert_eq!(quiescence.open_tier2_leases, 1);
+    assert_eq!(quiescence.unapplied_lead_results, 1);
+    assert!(!quiescence.is_quiescent());
+
+    // Resolving releases the current-evidence key for genuinely newer evidence.
+    assert!(
+        restarted
+            .resolve_tier2_lease(
+                "key-lease-1",
+                &lease_id,
+                &first_identity,
+                &CiTier2Resolution::repair(),
+            )
+            .await
+            .unwrap()
+    );
+    let row = restarted.get("key-lease-1").await.unwrap().unwrap();
+    assert_eq!(row.tier2_lease_state, Some(CiTier2LeaseState::Resolved));
+    assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::RepairReopened));
+    assert_eq!(row.reopen_mode, Some(CiReopenMode::Repair));
+    assert!(row.diagnostic_reason.is_none());
+
+    let third = restarted
+        .open_tier2_lease(
+            "key-lease-2",
+            &second_identity,
+            &lease_key,
+            CiTier2Reason::EvidenceUnknown,
+        )
+        .await
+        .unwrap();
+    assert!(matches!(third, CiTier2LeaseOutcome::Opened { .. }));
+}
+
+/// An identity change before Lead dispatch closes the route
+/// `superseded_before_lead` and opens no lease; an identity change while Lead
+/// is pending closes it `superseded_before_apply` and applies nothing. Both
+/// survive a reload.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn obsolete_routes_are_suppressed_before_lead_and_before_apply() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+
+    // (a) before dispatch
+    let stale = pr_head_identity(1, "headsha-before-lead");
+    repository
+        .reserve(&reservation(
+            &f.task_id,
+            "key-before-lead",
+            stale.clone(),
+            "fp-a",
+        ))
+        .await
+        .unwrap();
+    let outcome = repository
+        .open_tier2_lease(
+            "key-before-lead",
+            &pr_head_identity(2, "headsha-moved"),
+            "tier2:before-lead",
+            CiTier2Reason::CausalFailure,
+        )
+        .await
+        .unwrap();
+    let CiTier2LeaseOutcome::SupersededBeforeLead(attempt) = outcome else {
+        panic!("expected pre-dispatch suppression, got {outcome:?}");
+    };
+    assert_eq!(
+        attempt.terminal_outcome,
+        Some(CiRouteOutcome::SupersededBeforeLead)
+    );
+    assert!(attempt.tier2_lease_id.is_none(), "no lease was opened");
+    assert!(attempt.lead_session_id.is_none(), "no Lead session");
+
+    // (b) after dispatch, before apply
+    let pending = merge_group_identity(3, "headsha-pending", "dq-1");
+    repository
+        .reserve(&reservation(
+            &f.task_id,
+            "key-before-apply",
+            pending.clone(),
+            "fp-b",
+        ))
+        .await
+        .unwrap();
+    let opened = repository
+        .open_tier2_lease(
+            "key-before-apply",
+            &pending,
+            "tier2:before-apply",
+            CiTier2Reason::CausalFailure,
+        )
+        .await
+        .unwrap();
+    let CiTier2LeaseOutcome::Opened { lease_id, .. } = opened else {
+        panic!("expected an opened lease");
+    };
+    repository
+        .attach_lead_session("key-before-apply", &lease_id, "session-pending")
+        .await
+        .unwrap();
+
+    // The merge group re-formed under a different dequeue while Lead thought.
+    let (_handle, restarted) = reopened(&f.db);
+    let applied = restarted
+        .resolve_tier2_lease(
+            "key-before-apply",
+            &lease_id,
+            &merge_group_identity(3, "headsha-pending", "dq-2"),
+            &CiTier2Resolution::diagnose(CiDiagnosticReason::EvidenceIncomplete),
+        )
+        .await
+        .unwrap();
+    assert!(!applied, "a failed guard applies nothing");
+
+    let row = restarted.get("key-before-apply").await.unwrap().unwrap();
+    assert_eq!(
+        row.terminal_outcome,
+        Some(CiRouteOutcome::SupersededBeforeApply)
+    );
+    assert_eq!(row.tier2_lease_state, Some(CiTier2LeaseState::Resolved));
+    assert!(
+        row.reopen_mode.is_none() && row.diagnostic_reason.is_none(),
+        "a suppressed result leaves no reopen payload behind"
+    );
+    assert!(restarted.quiescence_counts().await.unwrap().is_quiescent());
+}
+
+/// A newer passing observation closes every open route for the PR without
+/// refunding a charge, and a Lead result that arrives afterwards applies
+/// nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn newer_passing_outcome_closes_routes_without_refunding_charges() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-pass");
+    let input = reservation(&f.task_id, "key-pass", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    let owner = incarnation();
+    repository
+        .charge_and_begin_calling("key-pass", &owner, &identity)
+        .await
+        .unwrap();
+    repository
+        .finalize_calling("key-pass", &owner, CiRouteOutcome::ActionFailed, None)
+        .await
+        .unwrap();
+    let opened = repository
+        .open_tier2_lease(
+            "key-pass",
+            &identity,
+            "tier2:pass",
+            CiTier2Reason::ProviderActionFailed,
+        )
+        .await
+        .unwrap();
+    let CiTier2LeaseOutcome::Opened { lease_id, .. } = opened else {
+        panic!("action_failed must still be able to open Tier 2");
+    };
+
+    // A second, still-reserved route on the same PR.
+    let other = reservation(
+        &f.task_id,
+        "key-pass-2",
+        pr_head_identity(2, "headsha-pass"),
+        "fp-b",
+    );
+    repository.reserve(&other).await.unwrap();
+
+    // And a route with the SAME PR number belonging to a different task, i.e.
+    // a different repository. A PR number is unique only within one repo, and
+    // this table holds every project's rows.
+    let foreign_task = seed_task_row(
+        &f.db,
+        UsageTestTaskSeed {
+            project_id: &f.project_id,
+            status: "pr_draft",
+            close_reason: None,
+            total_reopen_count: 0,
+        },
+    )
+    .await;
+    repository
+        .reserve(&reservation(
+            &foreign_task,
+            "key-pass-foreign",
+            pr_head_identity(9, "headsha-foreign"),
+            "fp-c",
+        ))
+        .await
+        .unwrap();
+
+    let closed = repository
+        .close_routes_for_newer_outcome(&f.task_id, 4242, CiRouteOutcome::Passed, None)
+        .await
+        .unwrap();
+    assert_eq!(closed, 1, "only the non-terminal route needed closing");
+    let foreign = repository.get("key-pass-foreign").await.unwrap().unwrap();
+    assert!(
+        !foreign.is_terminal(),
+        "another task's identically numbered PR must be untouched"
+    );
+
+    let (_handle, restarted) = reopened(&f.db);
+    let other_row = restarted.get("key-pass-2").await.unwrap().unwrap();
+    assert_eq!(other_row.terminal_outcome, Some(CiRouteOutcome::Passed));
+
+    let counts = restarted
+        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(
+        (counts.signature, counts.head),
+        (1, 1),
+        "passing does not refund a spent slot"
+    );
+
+    // The delayed Lead result now has no open lease to apply to.
+    assert!(
+        !restarted
+            .resolve_tier2_lease(
+                "key-pass",
+                &lease_id,
+                &identity,
+                &CiTier2Resolution::repair()
+            )
+            .await
+            .unwrap()
+    );
+    let row = restarted.get("key-pass").await.unwrap().unwrap();
+    assert_eq!(
+        row.terminal_outcome,
+        Some(CiRouteOutcome::ActionFailed),
+        "the provider outcome remains the route's single terminal fact"
+    );
+
+    // This PR's own work is drained. The one remaining `reserved` row is the
+    // other task's, which is exactly what the rollback gate should still see.
+    let quiescence = restarted.quiescence_counts().await.unwrap();
+    assert_eq!(quiescence.calling_rows, 0);
+    assert_eq!(quiescence.open_tier2_leases, 0);
+    assert_eq!(quiescence.unapplied_lead_results, 0);
+    assert_eq!(quiescence.reserved_rows, 1);
+    assert!(!quiescence.is_quiescent());
+}
+
+/// Contradictory Tier-2 payloads are rejected before they can be persisted:
+/// a repair carrying a diagnostic reason, a diagnose without one, a park
+/// without a citation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tier_two_resolution_payloads_are_mutually_exclusive() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-payload");
+    repository
+        .reserve(&reservation(
+            &f.task_id,
+            "key-payload",
+            identity.clone(),
+            "fp-a",
+        ))
+        .await
+        .unwrap();
+    let opened = repository
+        .open_tier2_lease(
+            "key-payload",
+            &identity,
+            "tier2:payload",
+            CiTier2Reason::CausalFailure,
+        )
+        .await
+        .unwrap();
+    let CiTier2LeaseOutcome::Opened { lease_id, .. } = opened else {
+        panic!("expected a lease");
+    };
+
+    let contradictions = [
+        CiTier2Resolution {
+            outcome: CiRouteOutcome::RepairReopened,
+            reopen_mode: Some(CiReopenMode::Repair),
+            diagnostic_reason: Some(CiDiagnosticReason::NoGroundedRemedy),
+            park_justification: None,
+        },
+        CiTier2Resolution {
+            outcome: CiRouteOutcome::DiagnosticReopened,
+            reopen_mode: Some(CiReopenMode::Diagnose),
+            diagnostic_reason: None,
+            park_justification: None,
+        },
+        CiTier2Resolution {
+            outcome: CiRouteOutcome::Parked,
+            reopen_mode: None,
+            diagnostic_reason: None,
+            park_justification: Some("   ".to_owned()),
+        },
+    ];
+    for resolution in &contradictions {
+        assert!(
+            repository
+                .resolve_tier2_lease("key-payload", &lease_id, &identity, resolution)
+                .await
+                .is_err(),
+            "contradictory payload {:?} must be rejected",
+            resolution.outcome
+        );
+    }
+    let row = repository.get("key-payload").await.unwrap().unwrap();
+    assert!(row.terminal_outcome.is_none(), "nothing was persisted");
+
+    // The valid park does land, with its citation.
+    assert!(
+        repository
+            .resolve_tier2_lease(
+                "key-payload",
+                &lease_id,
+                &identity,
+                &CiTier2Resolution::park("runner image pull is failing fleet-wide"),
+            )
+            .await
+            .unwrap()
+    );
+    let row = repository.get("key-payload").await.unwrap().unwrap();
+    assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::Parked));
+    assert!(
+        row.park_justification
+            .as_deref()
+            .is_some_and(|j| j.contains("fleet-wide"))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers used by more than one test
+// ---------------------------------------------------------------------------
+
+async fn rows_in_state(db: &Database, phase: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM ci_route_attempts WHERE action_phase = $1")
+        .bind(phase)
+        .fetch_one(db.pool())
+        .await
+        .unwrap()
+}
+
+/// Spend the whole signature budget for `identity`'s key through distinct
+/// runs, so a later attempt on the same signature is genuinely exhausted.
+async fn spend_signature_budget(f: &Fixture, identity: &CiEvidenceIdentity, fingerprint: &str) {
+    let repository = repo(&f.db);
+    for run in 100..(100 + CI_SIGNATURE_BUDGET_LIMIT) {
+        let mut spent = identity.clone();
+        spent.run_id = run;
+        let key = format!("key-spend-{run}");
+        repository
+            .reserve(&reservation(&f.task_id, &key, spent.clone(), fingerprint))
+            .await
+            .unwrap();
+        let charged = repository
+            .charge_and_begin_calling(&key, &incarnation(), &spent)
+            .await
+            .unwrap();
+        assert!(matches!(charged, CiChargeOutcome::Charged { .. }));
+    }
+}
+
+fn assert_deferred(outcome: &CiCallingRecovery, expected: CiCallingRecoveryReason) {
+    match outcome {
+        CiCallingRecovery::Deferred { reason, .. } => assert_eq!(*reason, expected),
+        other => panic!("expected deferral {expected:?}, got {other:?}"),
+    }
+}

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
@@ -24,8 +24,8 @@ use crate::repositories::ci_route_attempt::{
     CiActionPhase, CiCallingRecovery, CiCallingRecoveryAuthority, CiCallingRecoveryReason,
     CiChargeOutcome, CiClass, CiDiagnosticReason, CiEvidenceIdentity, CiLane, CiOriginState,
     CiQuiescenceProof, CiReopenMode, CiReserveOutcome, CiReservedRecovery, CiRouteAttempt,
-    CiRouteAttemptRepository, CiRouteOutcome, CiRouteReservation, CiTier2LeaseOutcome,
-    CiTier2LeaseState, CiTier2Reason, CiTier2Resolution,
+    CiRouteAttemptRepository, CiRouteOutcome, CiRouteReservation, CiRouteSubject,
+    CiTier2LeaseOutcome, CiTier2LeaseState, CiTier2Reason, CiTier2Resolution,
 };
 use crate::repositories::coordinator_incarnation::CoordinatorIncarnationRepository;
 use crate::repositories::test_support::{UsageTestTaskSeed, make_project, seed_task_row};
@@ -38,6 +38,7 @@ struct Fixture {
     db: Database,
     project_id: String,
     task_id: String,
+    subject: CiRouteSubject,
 }
 
 async fn fixture() -> Fixture {
@@ -53,10 +54,12 @@ async fn fixture() -> Fixture {
         },
     )
     .await;
+    let subject = CiRouteSubject::task(&task_id);
     Fixture {
         db,
         project_id: project.id,
         task_id,
+        subject,
     }
 }
 
@@ -75,6 +78,15 @@ fn reopened(db: &Database) -> (Database, CiRouteAttemptRepository) {
 
 fn incarnation() -> String {
     uuid::Uuid::now_v7().to_string()
+}
+
+/// The canonical Tier-2 lease key wave 2 must derive.
+///
+/// **(PR number, PR-head SHA)** and nothing else. No lane, no run id, no
+/// dequeue id: the hold is per PR head across both lanes, and the subject
+/// scoping already supplies repository identity.
+fn tier2_lease_key(pr_number: i64, head_sha: &str) -> String {
+    format!("tier2:{pr_number}:{head_sha}")
 }
 
 fn pr_head_identity(run_id: i64, head: &str) -> CiEvidenceIdentity {
@@ -102,7 +114,7 @@ fn merge_group_identity(run_id: i64, head: &str, dequeue: &str) -> CiEvidenceIde
 /// Distinct evidence, one shared signature budget and one shared head budget —
 /// which is the arrangement the ceilings exist to bound.
 fn reservation(
-    task_id: &str,
+    subject: &CiRouteSubject,
     key: &str,
     identity: CiEvidenceIdentity,
     fingerprint: &str,
@@ -123,9 +135,9 @@ fn reservation(
         CiLane::MergeGroup => CiAction::Reenqueue,
     };
     CiRouteReservation {
+        subject: subject.clone(),
         provider_action_key: key.to_owned(),
         identity,
-        task_id: task_id.to_owned(),
         origin_state,
         class: CiClass::Inconclusive,
         action,
@@ -208,7 +220,7 @@ async fn migration_round_trips_every_route_attempt_field() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = merge_group_identity(9001, "headsha-round-trip", "dequeue-77");
-    let input = reservation(&f.task_id, "key-round-trip", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-round-trip", identity.clone(), "fp-a");
     let reserved = unwrap_reserved(repository.reserve(&input).await.unwrap());
 
     assert_eq!(reserved.action_phase, CiActionPhase::Reserved);
@@ -220,13 +232,13 @@ async fn migration_round_trips_every_route_attempt_field() {
     // object we are still holding.
     let (handle, restarted) = reopened(&f.db);
     let loaded = restarted
-        .get("key-round-trip")
+        .get(&f.subject, "key-round-trip")
         .await
         .unwrap()
         .expect("row survives reload");
 
     assert_eq!(loaded.identity, identity);
-    assert_eq!(loaded.task_id, f.task_id);
+    assert_eq!(loaded.task_id.as_deref(), Some(f.task_id.as_str()));
     assert_eq!(loaded.origin_state, CiOriginState::PrReview);
     assert_eq!(loaded.class, CiClass::Inconclusive);
     assert_eq!(loaded.action, CiAction::Reenqueue);
@@ -283,7 +295,7 @@ async fn duplicate_poll_reserves_one_row_for_one_evidence_identity() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let input = reservation(
-        &f.task_id,
+        &f.subject,
         "key-dup",
         pr_head_identity(1, "headsha-dup"),
         "fp-a",
@@ -307,7 +319,7 @@ async fn duplicate_poll_reserves_one_row_for_one_evidence_identity() {
 
     // Reserving never charges. Only `calling` does.
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(counts.signature, 0);
@@ -325,12 +337,12 @@ async fn reserved_advances_to_calling_once_and_charges_both_budgets() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-happy");
-    let input = reservation(&f.task_id, "key-happy", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-happy", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
 
     let owner = incarnation();
     let charged = repository
-        .charge_and_begin_calling("key-happy", &owner, &identity)
+        .charge_and_begin_calling(&f.subject, "key-happy", &owner, &identity)
         .await
         .unwrap();
     let CiChargeOutcome::Charged { attempt, counts } = charged else {
@@ -351,13 +363,13 @@ async fn reserved_advances_to_calling_once_and_charges_both_budgets() {
     // must not charge again.
     let loser = incarnation();
     let again = repository
-        .charge_and_begin_calling("key-happy", &loser, &identity)
+        .charge_and_begin_calling(&f.subject, "key-happy", &loser, &identity)
         .await
         .unwrap();
     assert!(matches!(again, CiChargeOutcome::NotReserved(_)));
 
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(
@@ -365,7 +377,11 @@ async fn reserved_advances_to_calling_once_and_charges_both_budgets() {
         (1, 1),
         "a losing caller must not charge"
     );
-    let row = repository.get("key-happy").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-happy")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         row.owner_incarnation_id.as_deref(),
         Some(owner.as_str()),
@@ -380,12 +396,12 @@ async fn identity_change_before_calling_supersedes_uncharged() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-old");
-    let input = reservation(&f.task_id, "key-stale", identity, "fp-a");
+    let input = reservation(&f.subject, "key-stale", identity, "fp-a");
     repository.reserve(&input).await.unwrap();
 
     let observed = pr_head_identity(2, "headsha-new");
     let outcome = repository
-        .charge_and_begin_calling("key-stale", &incarnation(), &observed)
+        .charge_and_begin_calling(&f.subject, "key-stale", &incarnation(), &observed)
         .await
         .unwrap();
     let CiChargeOutcome::SupersededPreCall(attempt) = outcome else {
@@ -405,7 +421,7 @@ async fn identity_change_before_calling_supersedes_uncharged() {
     assert!(evidence.contains("headsha-new"));
 
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!((counts.signature, counts.head), (0, 0));
@@ -422,11 +438,18 @@ async fn reservation_below_the_timeout_is_not_eligible_for_recovery() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-young");
-    let input = reservation(&f.task_id, "key-young", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-young", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
 
     let outcome = repository
-        .recover_reserved("key-young", &identity, &incarnation(), 300, "lease-young")
+        .recover_reserved(
+            &f.subject,
+            "key-young",
+            &identity,
+            &incarnation(),
+            300,
+            "lease-young",
+        )
         .await
         .unwrap();
     let CiReservedRecovery::NotEligible(attempt) = outcome else {
@@ -436,7 +459,7 @@ async fn reservation_below_the_timeout_is_not_eligible_for_recovery() {
     assert_eq!(attempt.pre_call_resumptions, 0);
 
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!((counts.signature, counts.head), (0, 0));
@@ -452,7 +475,7 @@ async fn repeated_recovery_of_current_reserved_row_resumes_one_winner_and_charge
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-resume");
-    let input = reservation(&f.task_id, "key-resume", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-resume", identity.clone(), "fp-a");
     let reserved = unwrap_reserved(repository.reserve(&input).await.unwrap());
     age_reserved(&f.db, "key-resume", 600).await;
 
@@ -462,6 +485,7 @@ async fn repeated_recovery_of_current_reserved_row_resumes_one_winner_and_charge
 
     let first = restart_one
         .recover_reserved(
+            &f.subject,
             "key-resume",
             &identity,
             &winner_incarnation,
@@ -471,11 +495,25 @@ async fn repeated_recovery_of_current_reserved_row_resumes_one_winner_and_charge
         .await
         .unwrap();
     let second = restart_two
-        .recover_reserved("key-resume", &identity, &incarnation(), 60, "lease-resume")
+        .recover_reserved(
+            &f.subject,
+            "key-resume",
+            &identity,
+            &incarnation(),
+            60,
+            "lease-resume",
+        )
         .await
         .unwrap();
     let third = repository
-        .recover_reserved("key-resume", &identity, &incarnation(), 60, "lease-resume")
+        .recover_reserved(
+            &f.subject,
+            "key-resume",
+            &identity,
+            &incarnation(),
+            60,
+            "lease-resume",
+        )
         .await
         .unwrap();
 
@@ -491,7 +529,7 @@ async fn repeated_recovery_of_current_reserved_row_resumes_one_winner_and_charge
     assert!(matches!(third, CiReservedRecovery::NotEligible(_)));
 
     let final_counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(
@@ -500,7 +538,11 @@ async fn repeated_recovery_of_current_reserved_row_resumes_one_winner_and_charge
         "three recoveries must charge exactly once"
     );
 
-    let row = repository.get("key-resume").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-resume")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.action_phase, CiActionPhase::Calling);
     assert_eq!(
         row.owner_incarnation_id.as_deref(),
@@ -520,16 +562,31 @@ async fn repeated_recovery_of_current_reserved_row_resumes_one_winner_and_charge
 /// The same invariant under genuine concurrency rather than sequencing.
 ///
 /// The previous test runs its recoveries one after another, so it proves the
-/// phase check. This one launches them *simultaneously* on separate pools, so
-/// the only thing standing between them is the row lock inside the
-/// transaction. If that lock were missing, both would read `reserved`, both
-/// would charge, and the counter would read 2.
+/// phase check. This one launches them *simultaneously* on separate pools.
+///
+/// Be precise about what fails without the row lock, because it is not a
+/// double charge. Two mechanisms are stacked, and the outer one is about
+/// ergonomics rather than correctness:
+///
+/// * remove `FOR UPDATE` and the losers get past the phase read, increment the
+///   counters, then **lose the `action_phase = 'reserved'` compare-and-set**.
+///   The transaction rolls back, so the counter still reads `(1, 1)` — the
+///   phase CAS plus rollback is what actually prevents the double charge.
+///   What the caller sees instead is `Err("reserved->calling resumption lost
+///   under a held row lock")`, which is why this test's `unwrap` is the thing
+///   that fails.
+/// * the row lock turns that lost race into a clean `NotEligible` for the
+///   losers, which is what lets a duplicate poll be a no-op rather than an
+///   error the coordinator has to interpret.
+///
+/// So: asserting `(1, 1)` proves the charge is exactly once; asserting that
+/// exactly one caller returns `Resumed` without erroring proves the lock.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn concurrent_recoveries_of_one_reserved_row_charge_exactly_once() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-race-resume");
-    let input = reservation(&f.task_id, "key-race-resume", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-race-resume", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
     age_reserved(&f.db, "key-race-resume", 600).await;
 
@@ -544,9 +601,30 @@ async fn concurrent_recoveries_of_one_reserved_row_charge_exactly_once() {
     let inc_c = incarnation();
 
     let (ra, rb, rc) = tokio::join!(
-        a.recover_reserved("key-race-resume", &id_a, &inc_a, 60, "lease-race"),
-        b.recover_reserved("key-race-resume", &id_b, &inc_b, 60, "lease-race"),
-        c.recover_reserved("key-race-resume", &id_c, &inc_c, 60, "lease-race"),
+        a.recover_reserved(
+            &f.subject,
+            "key-race-resume",
+            &id_a,
+            &inc_a,
+            60,
+            "lease-race"
+        ),
+        b.recover_reserved(
+            &f.subject,
+            "key-race-resume",
+            &id_b,
+            &inc_b,
+            60,
+            "lease-race"
+        ),
+        c.recover_reserved(
+            &f.subject,
+            "key-race-resume",
+            &id_c,
+            &inc_c,
+            60,
+            "lease-race"
+        ),
     );
 
     let resumed = [ra.unwrap(), rb.unwrap(), rc.unwrap()]
@@ -556,7 +634,7 @@ async fn concurrent_recoveries_of_one_reserved_row_charge_exactly_once() {
     assert_eq!(resumed, 1, "exactly one concurrent recovery may resume");
 
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(
@@ -564,7 +642,11 @@ async fn concurrent_recoveries_of_one_reserved_row_charge_exactly_once() {
         (1, 1),
         "three concurrent recoveries must charge exactly once"
     );
-    let row = repository.get("key-race-resume").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-race-resume")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.pre_call_resumptions, 1);
     assert_eq!(rows_in_state(&f.db, "calling").await, 1);
 }
@@ -576,7 +658,7 @@ async fn concurrent_recoveries_of_one_reserved_row_charge_exactly_once() {
 async fn concurrent_reservations_of_one_identity_yield_one_row() {
     let f = fixture().await;
     let input = reservation(
-        &f.task_id,
+        &f.subject,
         "key-race-reserve",
         pr_head_identity(1, "headsha-race-reserve"),
         "fp-a",
@@ -608,7 +690,7 @@ async fn recovery_of_obsolete_reserved_row_supersedes_without_cost() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let input = reservation(
-        &f.task_id,
+        &f.subject,
         "key-obsolete",
         pr_head_identity(1, "headsha-old"),
         "fp-a",
@@ -619,6 +701,7 @@ async fn recovery_of_obsolete_reserved_row_supersedes_without_cost() {
     let (_handle, restarted) = reopened(&f.db);
     let outcome = restarted
         .recover_reserved(
+            &f.subject,
             "key-obsolete",
             &pr_head_identity(2, "headsha-new"),
             &incarnation(),
@@ -638,7 +721,7 @@ async fn recovery_of_obsolete_reserved_row_supersedes_without_cost() {
     assert!(!attempt.holds_open_tier2_lease());
 
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!((counts.signature, counts.head), (0, 0));
@@ -652,14 +735,14 @@ async fn recovery_of_exhausted_reserved_row_routes_to_one_tier_two_lease() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(3, "headsha-exhausted");
-    let input = reservation(&f.task_id, "key-exhausted", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-exhausted", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
     age_reserved(&f.db, "key-exhausted", 600).await;
 
     // Spend the signature budget through two other, distinct runs.
     spend_signature_budget(&f, &identity, "fp-a").await;
     let before = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(before.signature, CI_SIGNATURE_BUDGET_LIMIT);
@@ -667,6 +750,7 @@ async fn recovery_of_exhausted_reserved_row_routes_to_one_tier_two_lease() {
     let (_handle, restarted) = reopened(&f.db);
     let first = restarted
         .recover_reserved(
+            &f.subject,
             "key-exhausted",
             &identity,
             &incarnation(),
@@ -698,6 +782,7 @@ async fn recovery_of_exhausted_reserved_row_routes_to_one_tier_two_lease() {
     // A second recovery must not open a second lease or charge anything.
     let second = repository
         .recover_reserved(
+            &f.subject,
             "key-exhausted",
             &identity,
             &incarnation(),
@@ -712,7 +797,7 @@ async fn recovery_of_exhausted_reserved_row_routes_to_one_tier_two_lease() {
     assert!(tier2_lease_id.is_none(), "at most one Tier-2 lease");
 
     let after = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(
@@ -740,18 +825,18 @@ async fn signature_budget_stops_at_two_and_never_decrements() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-sig");
-    let input = reservation(&f.task_id, "key-sig-1", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-sig-1", identity.clone(), "fp-a");
 
     for run in 1..=CI_SIGNATURE_BUDGET_LIMIT {
         let id = pr_head_identity(run, "headsha-sig");
         let key = format!("key-sig-{run}");
-        let res = reservation(&f.task_id, &key, id.clone(), "fp-a");
+        let res = reservation(&f.subject, &key, id.clone(), "fp-a");
         assert!(matches!(
             repository.reserve(&res).await.unwrap(),
             CiReserveOutcome::Reserved(_)
         ));
         let charged = repository
-            .charge_and_begin_calling(&key, &incarnation(), &id)
+            .charge_and_begin_calling(&f.subject, &key, &incarnation(), &id)
             .await
             .unwrap();
         assert!(matches!(charged, CiChargeOutcome::Charged { .. }));
@@ -760,21 +845,27 @@ async fn signature_budget_stops_at_two_and_never_decrements() {
         // the point here is only that no code path exists that decrements.)
         assert!(
             !repository
-                .finalize_calling(&key, "ignored", CiRouteOutcome::ActionFailed, None)
+                .finalize_calling(
+                    &f.subject,
+                    &key,
+                    "ignored",
+                    CiRouteOutcome::ActionFailed,
+                    None
+                )
                 .await
                 .unwrap()
         );
     }
 
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(counts.signature, CI_SIGNATURE_BUDGET_LIMIT);
     assert!(counts.is_exhausted());
 
     let third = reservation(
-        &f.task_id,
+        &f.subject,
         "key-sig-3",
         pr_head_identity(3, "headsha-sig"),
         "fp-a",
@@ -812,7 +903,7 @@ async fn head_budget_is_shared_across_lanes_and_survives_reload() {
     ];
     for (index, (identity, fingerprint)) in plan.iter().enumerate() {
         let key = format!("key-head-{index}");
-        let res = reservation(&f.task_id, &key, identity.clone(), fingerprint);
+        let res = reservation(&f.subject, &key, identity.clone(), fingerprint);
         assert!(
             matches!(
                 repository.reserve(&res).await.unwrap(),
@@ -822,7 +913,7 @@ async fn head_budget_is_shared_across_lanes_and_survives_reload() {
         );
         assert!(matches!(
             repository
-                .charge_and_begin_calling(&key, &incarnation(), identity)
+                .charge_and_begin_calling(&f.subject, &key, &incarnation(), identity)
                 .await
                 .unwrap(),
             CiChargeOutcome::Charged { .. }
@@ -832,7 +923,11 @@ async fn head_budget_is_shared_across_lanes_and_survives_reload() {
     let head_key = format!("head:4242:{head}");
     let (_handle, restarted) = reopened(&f.db);
     let counts = restarted
-        .budget_counts("sig:pr_head:4242:headsha-shared:fp-a", &head_key)
+        .budget_counts(
+            &f.subject,
+            "sig:pr_head:4242:headsha-shared:fp-a",
+            &head_key,
+        )
         .await
         .unwrap();
     assert_eq!(
@@ -843,13 +938,13 @@ async fn head_budget_is_shared_across_lanes_and_survives_reload() {
     // A fifth attempt on a brand-new fingerprint has a fresh signature budget
     // and is still refused by the head ceiling.
     let fresh = reservation(
-        &f.task_id,
+        &f.subject,
         "key-head-4",
         pr_head_identity(5, head),
         "fp-fresh",
     );
     let counts = restarted
-        .budget_counts(&fresh.retry_budget_key, &fresh.head_budget_key)
+        .budget_counts(&f.subject, &fresh.retry_budget_key, &fresh.head_budget_key)
         .await
         .unwrap();
     assert_eq!(counts.signature, 0, "a changed fingerprint starts fresh");
@@ -858,7 +953,7 @@ async fn head_budget_is_shared_across_lanes_and_survives_reload() {
 
     // A changed PR head starts both budgets over.
     let new_head = reservation(
-        &f.task_id,
+        &f.subject,
         "key-newhead",
         pr_head_identity(6, "headsha-moved"),
         "fp-a",
@@ -880,42 +975,72 @@ async fn finalization_is_scoped_to_the_exact_calling_owner() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-final");
-    let input = reservation(&f.task_id, "key-final", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-final", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
     let owner = incarnation();
     repository
-        .charge_and_begin_calling("key-final", &owner, &identity)
+        .charge_and_begin_calling(&f.subject, "key-final", &owner, &identity)
         .await
         .unwrap();
 
     let impostor = incarnation();
     assert!(
         !repository
-            .finalize_calling("key-final", &impostor, CiRouteOutcome::Retriggered, None)
+            .finalize_calling(
+                &f.subject,
+                "key-final",
+                &impostor,
+                CiRouteOutcome::Retriggered,
+                None
+            )
             .await
             .unwrap(),
         "a non-owner cannot finalize"
     );
-    let row = repository.get("key-final").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-final")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.action_phase, CiActionPhase::Calling);
 
     assert!(
         repository
-            .finalize_calling("key-final", &owner, CiRouteOutcome::Retriggered, None)
+            .finalize_calling(
+                &f.subject,
+                "key-final",
+                &owner,
+                CiRouteOutcome::Retriggered,
+                None
+            )
             .await
             .unwrap()
     );
-    let row = repository.get("key-final").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-final")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::Retriggered));
 
     // Exactly-once: the owner's own retry finds nothing left to write.
     assert!(
         !repository
-            .finalize_calling("key-final", &owner, CiRouteOutcome::ActionFailed, None)
+            .finalize_calling(
+                &f.subject,
+                "key-final",
+                &owner,
+                CiRouteOutcome::ActionFailed,
+                None
+            )
             .await
             .unwrap()
     );
-    let row = repository.get("key-final").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-final")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         row.terminal_outcome,
         Some(CiRouteOutcome::Retriggered),
@@ -930,7 +1055,7 @@ async fn terminalization_happens_exactly_once_across_reload() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let input = reservation(
-        &f.task_id,
+        &f.subject,
         "key-term",
         pr_head_identity(1, "headsha-term"),
         "fp-a",
@@ -939,13 +1064,13 @@ async fn terminalization_happens_exactly_once_across_reload() {
 
     assert!(
         repository
-            .terminalize("key-term", CiRouteOutcome::Held, None)
+            .terminalize(&f.subject, "key-term", CiRouteOutcome::Held, None)
             .await
             .unwrap()
     );
     assert!(
         !repository
-            .terminalize("key-term", CiRouteOutcome::Held, None)
+            .terminalize(&f.subject, "key-term", CiRouteOutcome::Held, None)
             .await
             .unwrap()
     );
@@ -953,12 +1078,21 @@ async fn terminalization_happens_exactly_once_across_reload() {
     let (_handle, restarted) = reopened(&f.db);
     assert!(
         !restarted
-            .terminalize("key-term", CiRouteOutcome::DiagnosticReopened, None)
+            .terminalize(
+                &f.subject,
+                "key-term",
+                CiRouteOutcome::DiagnosticReopened,
+                None
+            )
             .await
             .unwrap(),
         "a startup sweep must not re-close a terminal row"
     );
-    let row = restarted.get("key-term").await.unwrap().unwrap();
+    let row = restarted
+        .get(&f.subject, "key-term")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::Held));
     assert!(row.terminalized_at.is_some());
 }
@@ -976,11 +1110,11 @@ async fn live_calling_owner_is_never_recovered() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-live");
-    let input = reservation(&f.task_id, "key-live", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-live", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
     let owner = incarnation();
     repository
-        .charge_and_begin_calling("key-live", &owner, &identity)
+        .charge_and_begin_calling(&f.subject, "key-live", &owner, &identity)
         .await
         .unwrap();
 
@@ -990,8 +1124,9 @@ async fn live_calling_owner_is_never_recovered() {
     // 1. A periodic sweep that does not hold the exclusive lock.
     let deferred = sweeper
         .recover_calling_owner(
+            &f.subject,
             "key-live",
-            Some(&identity),
+            &identity,
             &authority(
                 &owner,
                 &recovering,
@@ -1007,8 +1142,9 @@ async fn live_calling_owner_is_never_recovered() {
     // 2. Lock held, but the owner is alive: no quiescence proof exists.
     let deferred = sweeper
         .recover_calling_owner(
+            &f.subject,
             "key-live",
-            Some(&identity),
+            &identity,
             &authority(&owner, &recovering, CiQuiescenceProof::None, true),
             "lease-live",
         )
@@ -1025,8 +1161,9 @@ async fn live_calling_owner_is_never_recovered() {
         .unwrap();
     let deferred = sweeper
         .recover_calling_owner(
+            &f.subject,
             "key-live",
-            Some(&identity),
+            &identity,
             &authority(&owner, &recovering, CiQuiescenceProof::GracefulDrain, true),
             "lease-live",
         )
@@ -1037,8 +1174,9 @@ async fn live_calling_owner_is_never_recovered() {
     // 4. Process death is proven, but `calling_at` has not aged past the floor.
     let deferred = sweeper
         .recover_calling_owner(
+            &f.subject,
             "key-live",
-            Some(&identity),
+            &identity,
             &authority(
                 &owner,
                 &recovering,
@@ -1055,8 +1193,9 @@ async fn live_calling_owner_is_never_recovered() {
     age_calling(&f.db, "key-live", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
     let deferred = sweeper
         .recover_calling_owner(
+            &f.subject,
             "key-live",
-            Some(&identity),
+            &identity,
             &authority(
                 &incarnation(),
                 &recovering,
@@ -1070,21 +1209,34 @@ async fn live_calling_owner_is_never_recovered() {
     assert_deferred(&deferred, CiCallingRecoveryReason::OwnerMismatch);
 
     // The row is exactly as the owner left it, and nothing escalated.
-    let row = repository.get("key-live").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-live")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.action_phase, CiActionPhase::Calling);
     assert_eq!(row.owner_incarnation_id.as_deref(), Some(owner.as_str()));
     assert!(row.tier2_lease_id.is_none());
     assert!(row.lead_session_id.is_none());
 
     // Five deferrals, five audit rows, none of them claiming a win.
-    let audit = repository.calling_recovery_audit("key-live").await.unwrap();
+    let audit = repository
+        .calling_recovery_audit(&f.subject, "key-live")
+        .await
+        .unwrap();
     assert_eq!(audit.len(), 5);
     assert!(audit.iter().all(|r| !r.cas_won));
 
     // And the owner can still finalize, because nothing took its row.
     assert!(
         repository
-            .finalize_calling("key-live", &owner, CiRouteOutcome::Retriggered, None)
+            .finalize_calling(
+                &f.subject,
+                "key-live",
+                &owner,
+                CiRouteOutcome::Retriggered,
+                None
+            )
             .await
             .unwrap()
     );
@@ -1099,14 +1251,14 @@ async fn quiescent_owner_handoff_recovers_calling_once() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-handoff");
-    let input = reservation(&f.task_id, "key-handoff", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-handoff", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
 
     // The former owner completed the full graceful drain before releasing the
     // advisory lock.
     let former = drained_incarnation(&f.db).await;
     repository
-        .charge_and_begin_calling("key-handoff", &former, &identity)
+        .charge_and_begin_calling(&f.subject, "key-handoff", &former, &identity)
         .await
         .unwrap();
     age_calling(&f.db, "key-handoff", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
@@ -1115,8 +1267,9 @@ async fn quiescent_owner_handoff_recovers_calling_once() {
     let (_handle, restarted) = reopened(&f.db);
     let first = restarted
         .recover_calling_owner(
+            &f.subject,
             "key-handoff",
-            Some(&identity),
+            &identity,
             &authority(&former, &recovering, CiQuiescenceProof::GracefulDrain, true),
             "lease-handoff",
         )
@@ -1145,8 +1298,9 @@ async fn quiescent_owner_handoff_recovers_calling_once() {
     // A second startup sweep finds nothing to take.
     let second = restarted
         .recover_calling_owner(
+            &f.subject,
             "key-handoff",
-            Some(&identity),
+            &identity,
             &authority(
                 &former,
                 &incarnation(),
@@ -1160,7 +1314,7 @@ async fn quiescent_owner_handoff_recovers_calling_once() {
     assert_deferred(&second, CiCallingRecoveryReason::NotCalling);
 
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(
@@ -1177,7 +1331,7 @@ async fn quiescent_owner_handoff_recovers_calling_once() {
     assert_eq!(open, 1, "at most one Tier-2 lease");
 
     let audit = repository
-        .calling_recovery_audit("key-handoff")
+        .calling_recovery_audit(&f.subject, "key-handoff")
         .await
         .unwrap();
     assert_eq!(audit.len(), 2);
@@ -1201,11 +1355,11 @@ async fn provider_finalizer_wins_the_owner_handoff_race() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-race");
-    let input = reservation(&f.task_id, "key-race", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-race", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
     let former = drained_incarnation(&f.db).await;
     repository
-        .charge_and_begin_calling("key-race", &former, &identity)
+        .charge_and_begin_calling(&f.subject, "key-race", &former, &identity)
         .await
         .unwrap();
     age_calling(&f.db, "key-race", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
@@ -1213,15 +1367,22 @@ async fn provider_finalizer_wins_the_owner_handoff_race() {
     // The old owner's finalizer commits first.
     assert!(
         repository
-            .finalize_calling("key-race", &former, CiRouteOutcome::Reenqueued, None)
+            .finalize_calling(
+                &f.subject,
+                "key-race",
+                &former,
+                CiRouteOutcome::Reenqueued,
+                None
+            )
             .await
             .unwrap()
     );
 
     let outcome = repository
         .recover_calling_owner(
+            &f.subject,
             "key-race",
-            Some(&identity),
+            &identity,
             &authority(
                 &former,
                 &incarnation(),
@@ -1234,7 +1395,11 @@ async fn provider_finalizer_wins_the_owner_handoff_race() {
         .unwrap();
     assert_deferred(&outcome, CiCallingRecoveryReason::NotCalling);
 
-    let row = repository.get("key-race").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-race")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         row.terminal_outcome,
         Some(CiRouteOutcome::Reenqueued),
@@ -1251,19 +1416,20 @@ async fn obsolete_row_handoff_closes_superseded_after_call() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-gone");
-    let input = reservation(&f.task_id, "key-gone", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-gone", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
     let former = drained_incarnation(&f.db).await;
     repository
-        .charge_and_begin_calling("key-gone", &former, &identity)
+        .charge_and_begin_calling(&f.subject, "key-gone", &former, &identity)
         .await
         .unwrap();
     age_calling(&f.db, "key-gone", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
 
     let outcome = repository
         .recover_calling_owner(
+            &f.subject,
             "key-gone",
-            Some(&pr_head_identity(2, "headsha-moved")),
+            &pr_head_identity(2, "headsha-moved"),
             &authority(
                 &former,
                 &incarnation(),
@@ -1287,7 +1453,7 @@ async fn obsolete_row_handoff_closes_superseded_after_call() {
     assert_eq!(attempt.charged_signature_count, Some(1));
 
     let counts = repository
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!((counts.signature, counts.head), (1, 1));
@@ -1297,18 +1463,23 @@ async fn obsolete_row_handoff_closes_superseded_after_call() {
 // Tier-2 lease
 // ---------------------------------------------------------------------------
 
-/// Two routes on the same current evidence contend for one lease. Exactly one
-/// gets it; the loser opens nothing, and the winner's lease survives a reload.
+/// Two routes on the same PR head contend for one Lead adjudication, and they
+/// are deliberately **in different lanes**.
+///
+/// That is the head-level hold: at most one Lead adjudication may be open per
+/// PR head across both lanes. It works only because the lease key excludes
+/// the lane — a lane-scoped key would give two concurrent adjudications for one
+/// head and defeat the retry-storm safeguard entirely.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
+async fn current_evidence_tier_two_leases_are_mutually_exclusive_across_lanes() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let head = "headsha-lease";
     let first_identity = pr_head_identity(1, head);
-    let second_identity = pr_head_identity(2, head);
+    let second_identity = merge_group_identity(2, head, "dq-lease");
     repository
         .reserve(&reservation(
-            &f.task_id,
+            &f.subject,
             "key-lease-1",
             first_identity.clone(),
             "fp-a",
@@ -1317,7 +1488,7 @@ async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
         .unwrap();
     repository
         .reserve(&reservation(
-            &f.task_id,
+            &f.subject,
             "key-lease-2",
             second_identity.clone(),
             "fp-b",
@@ -1325,9 +1496,16 @@ async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
         .await
         .unwrap();
 
-    let lease_key = format!("tier2:pr_head:4242:{head}");
+    // One key for both lanes. Adding the lane here is the mistake this test
+    // exists to catch.
+    let lease_key = tier2_lease_key(4242, head);
+    assert!(
+        !lease_key.contains("pr_head") && !lease_key.contains("merge_group"),
+        "the Tier-2 lease key must not carry the lane"
+    );
     let first = repository
         .open_tier2_lease(
+            &f.subject,
             "key-lease-1",
             &first_identity,
             &lease_key,
@@ -1342,6 +1520,7 @@ async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
     let (_handle, restarted) = reopened(&f.db);
     let second = restarted
         .open_tier2_lease(
+            &f.subject,
             "key-lease-2",
             &second_identity,
             &lease_key,
@@ -1350,8 +1529,9 @@ async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
         .await
         .unwrap();
     assert!(
-        matches!(second, CiTier2LeaseOutcome::AlreadyLeased(_)),
-        "a second route on the same current evidence cannot open a Lead adjudication"
+        matches!(second, CiTier2LeaseOutcome::KeyHeldElsewhere(_)),
+        "a merge-group route on the same PR head cannot open a second Lead \
+         adjudication while the PR-head route holds the hold, got {second:?}"
     );
 
     let open: i64 = sqlx::query_scalar(
@@ -1365,13 +1545,13 @@ async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
     // The dispatched Lead session binds to the exact lease.
     assert!(
         restarted
-            .attach_lead_session("key-lease-1", &lease_id, "session-alpha")
+            .attach_lead_session(&f.subject, "key-lease-1", &lease_id, "session-alpha")
             .await
             .unwrap()
     );
     assert!(
         !restarted
-            .attach_lead_session("key-lease-1", "not-the-lease", "session-beta")
+            .attach_lead_session(&f.subject, "key-lease-1", "not-the-lease", "session-beta")
             .await
             .unwrap()
     );
@@ -1385,6 +1565,7 @@ async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
     assert!(
         restarted
             .resolve_tier2_lease(
+                &f.subject,
                 "key-lease-1",
                 &lease_id,
                 &first_identity,
@@ -1393,7 +1574,11 @@ async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
             .await
             .unwrap()
     );
-    let row = restarted.get("key-lease-1").await.unwrap().unwrap();
+    let row = restarted
+        .get(&f.subject, "key-lease-1")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.tier2_lease_state, Some(CiTier2LeaseState::Resolved));
     assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::RepairReopened));
     assert_eq!(row.reopen_mode, Some(CiReopenMode::Repair));
@@ -1401,6 +1586,7 @@ async fn current_evidence_tier_two_leases_are_mutually_exclusive() {
 
     let third = restarted
         .open_tier2_lease(
+            &f.subject,
             "key-lease-2",
             &second_identity,
             &lease_key,
@@ -1424,7 +1610,7 @@ async fn obsolete_routes_are_suppressed_before_lead_and_before_apply() {
     let stale = pr_head_identity(1, "headsha-before-lead");
     repository
         .reserve(&reservation(
-            &f.task_id,
+            &f.subject,
             "key-before-lead",
             stale.clone(),
             "fp-a",
@@ -1433,6 +1619,7 @@ async fn obsolete_routes_are_suppressed_before_lead_and_before_apply() {
         .unwrap();
     let outcome = repository
         .open_tier2_lease(
+            &f.subject,
             "key-before-lead",
             &pr_head_identity(2, "headsha-moved"),
             "tier2:before-lead",
@@ -1454,7 +1641,7 @@ async fn obsolete_routes_are_suppressed_before_lead_and_before_apply() {
     let pending = merge_group_identity(3, "headsha-pending", "dq-1");
     repository
         .reserve(&reservation(
-            &f.task_id,
+            &f.subject,
             "key-before-apply",
             pending.clone(),
             "fp-b",
@@ -1463,6 +1650,7 @@ async fn obsolete_routes_are_suppressed_before_lead_and_before_apply() {
         .unwrap();
     let opened = repository
         .open_tier2_lease(
+            &f.subject,
             "key-before-apply",
             &pending,
             "tier2:before-apply",
@@ -1474,7 +1662,7 @@ async fn obsolete_routes_are_suppressed_before_lead_and_before_apply() {
         panic!("expected an opened lease");
     };
     repository
-        .attach_lead_session("key-before-apply", &lease_id, "session-pending")
+        .attach_lead_session(&f.subject, "key-before-apply", &lease_id, "session-pending")
         .await
         .unwrap();
 
@@ -1482,6 +1670,7 @@ async fn obsolete_routes_are_suppressed_before_lead_and_before_apply() {
     let (_handle, restarted) = reopened(&f.db);
     let applied = restarted
         .resolve_tier2_lease(
+            &f.subject,
             "key-before-apply",
             &lease_id,
             &merge_group_identity(3, "headsha-pending", "dq-2"),
@@ -1491,7 +1680,11 @@ async fn obsolete_routes_are_suppressed_before_lead_and_before_apply() {
         .unwrap();
     assert!(!applied, "a failed guard applies nothing");
 
-    let row = restarted.get("key-before-apply").await.unwrap().unwrap();
+    let row = restarted
+        .get(&f.subject, "key-before-apply")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         row.terminal_outcome,
         Some(CiRouteOutcome::SupersededBeforeApply)
@@ -1512,19 +1705,26 @@ async fn newer_passing_outcome_closes_routes_without_refunding_charges() {
     let f = fixture().await;
     let repository = repo(&f.db);
     let identity = pr_head_identity(1, "headsha-pass");
-    let input = reservation(&f.task_id, "key-pass", identity.clone(), "fp-a");
+    let input = reservation(&f.subject, "key-pass", identity.clone(), "fp-a");
     repository.reserve(&input).await.unwrap();
     let owner = incarnation();
     repository
-        .charge_and_begin_calling("key-pass", &owner, &identity)
+        .charge_and_begin_calling(&f.subject, "key-pass", &owner, &identity)
         .await
         .unwrap();
     repository
-        .finalize_calling("key-pass", &owner, CiRouteOutcome::ActionFailed, None)
+        .finalize_calling(
+            &f.subject,
+            "key-pass",
+            &owner,
+            CiRouteOutcome::ActionFailed,
+            None,
+        )
         .await
         .unwrap();
     let opened = repository
         .open_tier2_lease(
+            &f.subject,
             "key-pass",
             &identity,
             "tier2:pass",
@@ -1538,7 +1738,7 @@ async fn newer_passing_outcome_closes_routes_without_refunding_charges() {
 
     // A second, still-reserved route on the same PR.
     let other = reservation(
-        &f.task_id,
+        &f.subject,
         "key-pass-2",
         pr_head_identity(2, "headsha-pass"),
         "fp-b",
@@ -1558,9 +1758,10 @@ async fn newer_passing_outcome_closes_routes_without_refunding_charges() {
         },
     )
     .await;
+    let foreign_subject = CiRouteSubject::task(&foreign_task);
     repository
         .reserve(&reservation(
-            &foreign_task,
+            &foreign_subject,
             "key-pass-foreign",
             pr_head_identity(9, "headsha-foreign"),
             "fp-c",
@@ -1569,22 +1770,30 @@ async fn newer_passing_outcome_closes_routes_without_refunding_charges() {
         .unwrap();
 
     let closed = repository
-        .close_routes_for_newer_outcome(&f.task_id, 4242, CiRouteOutcome::Passed, None)
+        .close_routes_for_newer_outcome(&f.subject, 4242, CiRouteOutcome::Passed, None)
         .await
         .unwrap();
     assert_eq!(closed, 1, "only the non-terminal route needed closing");
-    let foreign = repository.get("key-pass-foreign").await.unwrap().unwrap();
+    let foreign = repository
+        .get(&foreign_subject, "key-pass-foreign")
+        .await
+        .unwrap()
+        .unwrap();
     assert!(
         !foreign.is_terminal(),
         "another task's identically numbered PR must be untouched"
     );
 
     let (_handle, restarted) = reopened(&f.db);
-    let other_row = restarted.get("key-pass-2").await.unwrap().unwrap();
+    let other_row = restarted
+        .get(&f.subject, "key-pass-2")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(other_row.terminal_outcome, Some(CiRouteOutcome::Passed));
 
     let counts = restarted
-        .budget_counts(&input.retry_budget_key, &input.head_budget_key)
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
         .await
         .unwrap();
     assert_eq!(
@@ -1597,6 +1806,7 @@ async fn newer_passing_outcome_closes_routes_without_refunding_charges() {
     assert!(
         !restarted
             .resolve_tier2_lease(
+                &f.subject,
                 "key-pass",
                 &lease_id,
                 &identity,
@@ -1605,7 +1815,11 @@ async fn newer_passing_outcome_closes_routes_without_refunding_charges() {
             .await
             .unwrap()
     );
-    let row = restarted.get("key-pass").await.unwrap().unwrap();
+    let row = restarted
+        .get(&f.subject, "key-pass")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         row.terminal_outcome,
         Some(CiRouteOutcome::ActionFailed),
@@ -1632,7 +1846,7 @@ async fn tier_two_resolution_payloads_are_mutually_exclusive() {
     let identity = pr_head_identity(1, "headsha-payload");
     repository
         .reserve(&reservation(
-            &f.task_id,
+            &f.subject,
             "key-payload",
             identity.clone(),
             "fp-a",
@@ -1641,6 +1855,7 @@ async fn tier_two_resolution_payloads_are_mutually_exclusive() {
         .unwrap();
     let opened = repository
         .open_tier2_lease(
+            &f.subject,
             "key-payload",
             &identity,
             "tier2:payload",
@@ -1675,20 +1890,25 @@ async fn tier_two_resolution_payloads_are_mutually_exclusive() {
     for resolution in &contradictions {
         assert!(
             repository
-                .resolve_tier2_lease("key-payload", &lease_id, &identity, resolution)
+                .resolve_tier2_lease(&f.subject, "key-payload", &lease_id, &identity, resolution)
                 .await
                 .is_err(),
             "contradictory payload {:?} must be rejected",
             resolution.outcome
         );
     }
-    let row = repository.get("key-payload").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-payload")
+        .await
+        .unwrap()
+        .unwrap();
     assert!(row.terminal_outcome.is_none(), "nothing was persisted");
 
     // The valid park does land, with its citation.
     assert!(
         repository
             .resolve_tier2_lease(
+                &f.subject,
                 "key-payload",
                 &lease_id,
                 &identity,
@@ -1697,13 +1917,518 @@ async fn tier_two_resolution_payloads_are_mutually_exclusive() {
             .await
             .unwrap()
     );
-    let row = repository.get("key-payload").await.unwrap().unwrap();
+    let row = repository
+        .get(&f.subject, "key-payload")
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::Parked));
     assert!(
         row.park_justification
             .as_deref()
             .is_some_and(|j| j.contains("fleet-wide"))
     );
+}
+
+// ---------------------------------------------------------------------------
+// The live exhausted path, and the two write-once outcome fields
+// ---------------------------------------------------------------------------
+
+/// The budgets can be spent between a reservation and its charge — a peer
+/// route on the same signature got there first. This is the LIVE exhausted
+/// path and it behaves differently from the recovery one on purpose: it stamps
+/// `retry_exhausted_at`, leaves the row `reserved`, charges nothing, and opens
+/// no Tier-2 lease, because the caller is still running and owns that
+/// decision.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn charge_on_a_reserved_row_whose_budget_was_spent_meanwhile_is_refused() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(7, "headsha-live-exhausted");
+    let input = reservation(&f.subject, "key-live-exhausted", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+
+    // Two peer routes on the same signature spend the budget after our row
+    // was already reserved.
+    spend_signature_budget(&f, &identity, "fp-a").await;
+
+    let outcome = repository
+        .charge_and_begin_calling(&f.subject, "key-live-exhausted", &incarnation(), &identity)
+        .await
+        .unwrap();
+    let CiChargeOutcome::BudgetExhausted { attempt, counts } = outcome else {
+        panic!("expected the live exhausted path, got {outcome:?}");
+    };
+    assert_eq!(counts.signature, CI_SIGNATURE_BUDGET_LIMIT);
+    assert_eq!(
+        attempt.action_phase,
+        CiActionPhase::Reserved,
+        "the live path leaves the row reserved for the caller to route"
+    );
+    assert!(attempt.retry_exhausted_at.is_some());
+    assert!(attempt.owner_incarnation_id.is_none(), "no call ownership");
+    assert!(attempt.charged_signature_count.is_none(), "no charge");
+    assert!(
+        !attempt.has_routed_to_tier2(),
+        "the live path opens no lease; that is the recovery path's job"
+    );
+
+    // And the budget really did not move.
+    let after = repository
+        .budget_counts(&f.subject, &input.retry_budget_key, &input.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(after.signature, CI_SIGNATURE_BUDGET_LIMIT);
+    // The only `calling` rows are the two peers that spent the budget; the
+    // refused row never got call ownership, which the phase assertion above
+    // already established.
+    assert_eq!(
+        rows_in_state(&f.db, "calling").await,
+        CI_SIGNATURE_BUDGET_LIMIT
+    );
+}
+
+/// The case the two write-once outcome fields exist for: a route that
+/// terminalized on a provider error, then legally routed to Tier 2 once, and
+/// came back with a repair reopen.
+///
+/// `terminal_outcome` keeps `action_failed` — the route really did fail at the
+/// provider and that fact is not rewritable. The adjudication lands in
+/// `tier2_resolution`. Anything counting reopens must read
+/// `adjudicated_outcome()`, or it silently drops every reopen that followed a
+/// provider failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn provider_failure_then_tier_two_records_both_outcomes() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-both");
+    let input = reservation(&f.subject, "key-both", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    let owner = incarnation();
+    repository
+        .charge_and_begin_calling(&f.subject, "key-both", &owner, &identity)
+        .await
+        .unwrap();
+    assert!(
+        repository
+            .finalize_calling(
+                &f.subject,
+                "key-both",
+                &owner,
+                CiRouteOutcome::ActionFailed,
+                Some(r#"{"status":422,"message":"workflow run is not re-runnable"}"#),
+            )
+            .await
+            .unwrap()
+    );
+
+    let opened = repository
+        .open_tier2_lease(
+            &f.subject,
+            "key-both",
+            &identity,
+            "tier2:both",
+            CiTier2Reason::ProviderActionFailed,
+        )
+        .await
+        .unwrap();
+    let CiTier2LeaseOutcome::Opened { lease_id, .. } = opened else {
+        panic!("an action_failed row may route once to Tier 2");
+    };
+    assert!(
+        repository
+            .attach_lead_session(&f.subject, "key-both", &lease_id, "session-both")
+            .await
+            .unwrap()
+    );
+    assert!(
+        repository
+            .resolve_tier2_lease(
+                &f.subject,
+                "key-both",
+                &lease_id,
+                &identity,
+                &CiTier2Resolution::repair(),
+            )
+            .await
+            .unwrap()
+    );
+
+    let (_handle, restarted) = reopened(&f.db);
+    let row = restarted
+        .get(&f.subject, "key-both")
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        row.terminal_outcome,
+        Some(CiRouteOutcome::ActionFailed),
+        "the provider failure is the route's single terminal fact"
+    );
+    assert_eq!(
+        row.tier2_resolution,
+        Some(CiRouteOutcome::RepairReopened),
+        "the adjudication lands in the second write-once field"
+    );
+    assert_eq!(
+        row.adjudicated_outcome(),
+        Some(CiRouteOutcome::RepairReopened),
+        "downstream reopen/park queries MUST read this, not terminal_outcome"
+    );
+    assert_eq!(row.reopen_mode, Some(CiReopenMode::Repair));
+    assert_eq!(row.tier2_lease_state, Some(CiTier2LeaseState::Resolved));
+    assert!(
+        row.provider_error
+            .as_deref()
+            .is_some_and(|e| e.contains("not re-runnable"))
+    );
+
+    // The route has used its one trip. A second adjudication is refused even
+    // though the lease is no longer open — uniqueness here is once-ever, not
+    // merely concurrent.
+    let again = restarted
+        .open_tier2_lease(
+            &f.subject,
+            "key-both",
+            &identity,
+            "tier2:both",
+            CiTier2Reason::ProviderActionFailed,
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(again, CiTier2LeaseOutcome::AlreadyRoutedToTier2(_)),
+        "`may route once to Tier 2` means once ever, got {again:?}"
+    );
+    let row = restarted
+        .get(&f.subject, "key-both")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.tier2_lease_state, Some(CiTier2LeaseState::Resolved));
+    assert_eq!(row.tier2_lease_id.as_deref(), Some(lease_id.as_str()));
+}
+
+/// An exhausted recovery that cannot get the head lease because another route
+/// already holds it. This leaves the row `reserved` with no route out of its
+/// own accord: it is **not** self-healing, and W2 must re-drive recovery once
+/// the holding lease resolves.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exhausted_recovery_blocked_by_a_peer_head_lease_strands_the_row() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let head = "headsha-strand";
+    let lease_key = tier2_lease_key(4242, head);
+
+    // A peer route on the same PR head takes the one head lease.
+    let peer_identity = pr_head_identity(1, head);
+    repository
+        .reserve(&reservation(
+            &f.subject,
+            "key-strand-peer",
+            peer_identity.clone(),
+            "fp-peer",
+        ))
+        .await
+        .unwrap();
+    let peer_lease = repository
+        .open_tier2_lease(
+            &f.subject,
+            "key-strand-peer",
+            &peer_identity,
+            &lease_key,
+            CiTier2Reason::CausalFailure,
+        )
+        .await
+        .unwrap();
+    let CiTier2LeaseOutcome::Opened {
+        lease_id: peer_lease_id,
+        ..
+    } = peer_lease
+    else {
+        panic!("the peer must take the head lease");
+    };
+
+    // Our row reserves, then its signature budget is spent by other runs.
+    let identity = pr_head_identity(2, head);
+    let input = reservation(&f.subject, "key-strand", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    age_reserved(&f.db, "key-strand", 600).await;
+    spend_signature_budget(&f, &identity, "fp-a").await;
+
+    let outcome = repository
+        .recover_reserved(
+            &f.subject,
+            "key-strand",
+            &identity,
+            &incarnation(),
+            60,
+            &lease_key,
+        )
+        .await
+        .unwrap();
+    let CiReservedRecovery::RetryExhausted {
+        attempt,
+        tier2_lease_id,
+        ..
+    } = outcome
+    else {
+        panic!("expected retry exhaustion, got {outcome:?}");
+    };
+    assert!(
+        tier2_lease_id.is_none(),
+        "the peer holds the one head lease, so no lease is granted"
+    );
+    assert!(!attempt.has_routed_to_tier2());
+
+    // THE STRAND. The row is exhausted, current, non-terminal, and holds no
+    // lease. Nothing in this layer will move it again on its own.
+    assert_eq!(attempt.action_phase, CiActionPhase::Reserved);
+    assert!(attempt.retry_exhausted_at.is_some());
+    let quiescence = repository.quiescence_counts().await.unwrap();
+    assert!(
+        quiescence.reserved_rows >= 1,
+        "a stranded row keeps the rollback gate open, which is the point"
+    );
+
+    // W2's obligation: once the holding adjudication resolves, re-drive
+    // recovery. Only then does the stranded row get its Tier-2 lease.
+    assert!(
+        repository
+            .resolve_tier2_lease(
+                &f.subject,
+                "key-strand-peer",
+                &peer_lease_id,
+                &peer_identity,
+                &CiTier2Resolution::diagnose(CiDiagnosticReason::NoGroundedRemedy),
+            )
+            .await
+            .unwrap()
+    );
+    let retried = repository
+        .recover_reserved(
+            &f.subject,
+            "key-strand",
+            &identity,
+            &incarnation(),
+            60,
+            &lease_key,
+        )
+        .await
+        .unwrap();
+    let CiReservedRecovery::RetryExhausted { tier2_lease_id, .. } = retried else {
+        panic!("expected retry exhaustion again");
+    };
+    assert!(
+        tier2_lease_id.is_some(),
+        "re-driving recovery after the peer released the key must now lease"
+    );
+}
+
+/// `terminalize` is the unfenced-looking sibling of the owner-scoped
+/// `finalize_calling`, so it carries two fences of its own. Without them it
+/// would be a way to claim the provider was called, or to close a route whose
+/// provider future is still in flight.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn terminalize_refuses_provider_outcomes_and_live_calling_rows() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-fence");
+    let input = reservation(&f.subject, "key-fence", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+
+    // Fence 1: a provider-finalization outcome is refused even on a plain
+    // `reserved` row. Only the calling owner may assert a provider call.
+    for outcome in [
+        CiRouteOutcome::Retriggered,
+        CiRouteOutcome::Reenqueued,
+        CiRouteOutcome::ActionFailed,
+    ] {
+        assert!(
+            repository
+                .terminalize(&f.subject, "key-fence", outcome, None)
+                .await
+                .is_err(),
+            "terminalize must not be able to write `{}`",
+            outcome.as_str()
+        );
+    }
+    let row = repository
+        .get(&f.subject, "key-fence")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(row.terminal_outcome.is_none(), "nothing was written");
+
+    // Fence 2: a row owned in `calling` may not be closed out from under its
+    // owner. Its provider future may be in flight right now.
+    let owner = incarnation();
+    repository
+        .charge_and_begin_calling(&f.subject, "key-fence", &owner, &identity)
+        .await
+        .unwrap();
+    let refused = repository
+        .terminalize(&f.subject, "key-fence", CiRouteOutcome::Held, None)
+        .await;
+    assert!(refused.is_err(), "a live calling row must not be closable");
+    let row = repository
+        .get(&f.subject, "key-fence")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.action_phase, CiActionPhase::Calling);
+    assert_eq!(row.owner_incarnation_id.as_deref(), Some(owner.as_str()));
+
+    // The owner can still finalize, because nothing stole its row.
+    assert!(
+        repository
+            .finalize_calling(
+                &f.subject,
+                "key-fence",
+                &owner,
+                CiRouteOutcome::Retriggered,
+                None
+            )
+            .await
+            .unwrap()
+    );
+
+    // A pass/merge observation likewise leaves a `calling` row alone.
+    let live = pr_head_identity(3, "headsha-fence");
+    repository
+        .reserve(&reservation(
+            &f.subject,
+            "key-fence-live",
+            live.clone(),
+            "fp-b",
+        ))
+        .await
+        .unwrap();
+    let live_owner = incarnation();
+    repository
+        .charge_and_begin_calling(&f.subject, "key-fence-live", &live_owner, &live)
+        .await
+        .unwrap();
+    let closed = repository
+        .close_routes_for_newer_outcome(&f.subject, 4242, CiRouteOutcome::Merged, None)
+        .await
+        .unwrap();
+    assert_eq!(closed, 0, "there was no `reserved` row left to close");
+    let row = repository
+        .get(&f.subject, "key-fence-live")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        row.action_phase,
+        CiActionPhase::Calling,
+        "a merge observation must not steal a row from a live provider call"
+    );
+    assert!(
+        repository
+            .finalize_calling(
+                &f.subject,
+                "key-fence-live",
+                &live_owner,
+                CiRouteOutcome::Reenqueued,
+                None
+            )
+            .await
+            .unwrap(),
+        "the owner's finalizer must still win after the merge observation"
+    );
+}
+
+/// Every key on this table is subject-scoped, so a route on one subject can
+/// never swallow an identically keyed route on another.
+///
+/// Before the scoping, a colliding `provider_action_key` made `reserve` answer
+/// `AlreadyPresent` for foreign evidence and that route silently never
+/// existed; a colliding `tier2_lease_key` made the Lead adjudication never
+/// open. Both are exercised here with deliberately identical keys.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn identical_keys_on_two_subjects_do_not_collide() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let other_task = seed_task_row(
+        &f.db,
+        UsageTestTaskSeed {
+            project_id: &f.project_id,
+            status: "pr_draft",
+            close_reason: None,
+            total_reopen_count: 0,
+        },
+    )
+    .await;
+    let other = CiRouteSubject::task(&other_task);
+
+    // The SAME action key, budget keys, and lease key on both subjects.
+    let identity = pr_head_identity(1, "headsha-collide");
+    let mine = reservation(&f.subject, "key-collide", identity.clone(), "fp-a");
+    let theirs = reservation(&other, "key-collide", identity.clone(), "fp-a");
+    assert_eq!(mine.provider_action_key, theirs.provider_action_key);
+    assert_eq!(mine.retry_budget_key, theirs.retry_budget_key);
+
+    assert!(matches!(
+        repository.reserve(&mine).await.unwrap(),
+        CiReserveOutcome::Reserved(_)
+    ));
+    assert!(
+        matches!(
+            repository.reserve(&theirs).await.unwrap(),
+            CiReserveOutcome::Reserved(_)
+        ),
+        "a foreign subject's identical key must still create its own route"
+    );
+
+    let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ci_route_attempts")
+        .fetch_one(f.db.pool())
+        .await
+        .unwrap();
+    assert_eq!(rows, 2);
+
+    // Budgets are independent too.
+    repository
+        .charge_and_begin_calling(&f.subject, "key-collide", &incarnation(), &identity)
+        .await
+        .unwrap();
+    let theirs_counts = repository
+        .budget_counts(&other, &theirs.retry_budget_key, &theirs.head_budget_key)
+        .await
+        .unwrap();
+    assert_eq!(
+        (theirs_counts.signature, theirs_counts.head),
+        (0, 0),
+        "one subject's charge must not spend another's budget"
+    );
+
+    // And so is the Tier-2 head lease.
+    let lease_key = tier2_lease_key(4242, "headsha-collide");
+    let theirs_lease = repository
+        .open_tier2_lease(
+            &other,
+            "key-collide",
+            &identity,
+            &lease_key,
+            CiTier2Reason::CausalFailure,
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(theirs_lease, CiTier2LeaseOutcome::Opened { .. }),
+        "a foreign subject must get its own Lead adjudication, got {theirs_lease:?}"
+    );
+
+    // The generated task_id column tracks the subject and carries the real
+    // foreign key; the database derives it and refuses a direct write.
+    let row = repository
+        .get(&other, "key-collide")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.task_id.as_deref(), Some(other_task.as_str()));
+    assert_eq!(row.subject, other);
 }
 
 // ---------------------------------------------------------------------------
@@ -1727,11 +2452,11 @@ async fn spend_signature_budget(f: &Fixture, identity: &CiEvidenceIdentity, fing
         spent.run_id = run;
         let key = format!("key-spend-{run}");
         repository
-            .reserve(&reservation(&f.task_id, &key, spent.clone(), fingerprint))
+            .reserve(&reservation(&f.subject, &key, spent.clone(), fingerprint))
             .await
             .unwrap();
         let charged = repository
-            .charge_and_begin_calling(&key, &incarnation(), &spent)
+            .charge_and_begin_calling(&f.subject, &key, &incarnation(), &spent)
             .await
             .unwrap();
         assert!(matches!(charged, CiChargeOutcome::Charged { .. }));

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
@@ -2432,6 +2432,254 @@ async fn identical_keys_on_two_subjects_do_not_collide() {
 }
 
 // ---------------------------------------------------------------------------
+// A live `calling` row belongs to its owner, whichever door you knock on
+// ---------------------------------------------------------------------------
+
+/// The Tier-2 doors must not steal a row whose provider call is in flight.
+///
+/// `open_tier2_lease` used to: handed a superseding observed identity, its
+/// guard branch terminalized the row `superseded_before_lead` even in
+/// `calling`, and the owner's later `finalize_calling` then returned `false`
+/// and dropped a real provider result on the floor with nothing reported. That
+/// is the same steal already fenced out of `terminalize` and
+/// `close_routes_for_newer_outcome`; this proves the third and fourth doors
+/// are shut too.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tier_two_doors_never_close_a_live_calling_row() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-inflight");
+    let input = reservation(&f.subject, "key-inflight", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+    let owner = incarnation();
+    repository
+        .charge_and_begin_calling(&f.subject, "key-inflight", &owner, &identity)
+        .await
+        .unwrap();
+
+    // The PR head moved while the provider call was in flight. This is the
+    // exact input that used to steal the row.
+    let superseding = pr_head_identity(2, "headsha-moved");
+    let outcome = repository
+        .open_tier2_lease(
+            &f.subject,
+            "key-inflight",
+            &superseding,
+            &tier2_lease_key(4242, "headsha-moved"),
+            CiTier2Reason::CausalFailure,
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, CiTier2LeaseOutcome::OwnedByProviderCall(_)),
+        "a row in calling belongs to its owner, got {outcome:?}"
+    );
+
+    // Nothing moved: not the phase, not the owner, not the lease.
+    let row = repository
+        .get(&f.subject, "key-inflight")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.action_phase, CiActionPhase::Calling);
+    assert!(row.terminal_outcome.is_none());
+    assert_eq!(row.owner_incarnation_id.as_deref(), Some(owner.as_str()));
+    assert!(!row.has_routed_to_tier2());
+
+    // The specific durable lie this prevents. The row is CHARGED — a provider
+    // call really was authorized and really did execute — so recording it as
+    // `superseded_before_lead` would mean the table says "we never called the
+    // provider" about a row whose own counters say we did. Being authoritative
+    // about that one fact is the entire reason this table exists.
+    assert_eq!(row.charged_signature_count, Some(1));
+    assert_eq!(row.charged_head_count, Some(1));
+    assert!(
+        row.superseded_by_evidence.is_none(),
+        "a charged, in-flight call must never be recorded as a supersession"
+    );
+
+    // THE POINT: the owner's provider result still lands. Before the fix this
+    // returned `false` and the result was lost.
+    assert!(
+        repository
+            .finalize_calling(
+                &f.subject,
+                "key-inflight",
+                &owner,
+                CiRouteOutcome::Retriggered,
+                None,
+            )
+            .await
+            .unwrap(),
+        "the owner's finalizer must still win; a stolen row makes it a silent no-op"
+    );
+    let row = repository
+        .get(&f.subject, "key-inflight")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.terminal_outcome, Some(CiRouteOutcome::Retriggered));
+}
+
+/// The same fence in the helper every non-owner terminalization funnels
+/// through, exercised directly rather than via one public method.
+///
+/// A row that legally holds an open Tier-2 lease is charged to `calling` out
+/// from under the adjudication, and the delayed Lead result then arrives with
+/// a superseding identity — the branch that terminalizes
+/// `superseded_before_apply`. It must apply nothing and close nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_delayed_lead_result_cannot_close_a_row_that_is_now_calling() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let identity = pr_head_identity(1, "headsha-delayed");
+    let input = reservation(&f.subject, "key-delayed", identity.clone(), "fp-a");
+    repository.reserve(&input).await.unwrap();
+
+    let opened = repository
+        .open_tier2_lease(
+            &f.subject,
+            "key-delayed",
+            &identity,
+            &tier2_lease_key(4242, "headsha-delayed"),
+            CiTier2Reason::CausalFailure,
+        )
+        .await
+        .unwrap();
+    let CiTier2LeaseOutcome::Opened { lease_id, .. } = opened else {
+        panic!("expected a lease on a reserved row");
+    };
+    repository
+        .attach_lead_session(&f.subject, "key-delayed", &lease_id, "session-delayed")
+        .await
+        .unwrap();
+
+    // The row is charged to `calling` while Lead is thinking.
+    let owner = incarnation();
+    let charged = repository
+        .charge_and_begin_calling(&f.subject, "key-delayed", &owner, &identity)
+        .await
+        .unwrap();
+    assert!(matches!(charged, CiChargeOutcome::Charged { .. }));
+
+    // Lead answers late, against evidence that has since moved.
+    let applied = repository
+        .resolve_tier2_lease(
+            &f.subject,
+            "key-delayed",
+            &lease_id,
+            &pr_head_identity(9, "headsha-elsewhere"),
+            &CiTier2Resolution::repair(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        !applied,
+        "a delayed result applies nothing to a calling row"
+    );
+
+    let row = repository
+        .get(&f.subject, "key-delayed")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        row.action_phase,
+        CiActionPhase::Calling,
+        "the row must still belong to its provider-call owner"
+    );
+    assert!(row.terminal_outcome.is_none());
+    assert!(row.reopen_mode.is_none());
+    assert!(
+        repository
+            .finalize_calling(
+                &f.subject,
+                "key-delayed",
+                &owner,
+                CiRouteOutcome::ActionFailed,
+                None,
+            )
+            .await
+            .unwrap(),
+        "the owner's finalizer must still win"
+    );
+}
+
+/// The Tier-2 head hold is **per subject**, not global — the documented
+/// consequence of scoping every key by subject.
+///
+/// This is not a bug to fix; it is the price of making a key collision unable
+/// to swallow a foreign route, and it is invisible while every subject is a
+/// task and one PR maps to one task. The test exists so the boundary is
+/// pinned: if someone later widens the index to make the hold global, this
+/// fails and they are forced to notice the lost-route class reopening.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_tier_two_head_hold_stops_at_the_subject_boundary() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+    let other_task = seed_task_row(
+        &f.db,
+        UsageTestTaskSeed {
+            project_id: &f.project_id,
+            status: "pr_draft",
+            close_reason: None,
+            total_reopen_count: 0,
+        },
+    )
+    .await;
+    let other = CiRouteSubject::task(&other_task);
+
+    let head = "headsha-shared-hold";
+    let identity = pr_head_identity(1, head);
+    let lease_key = tier2_lease_key(4242, head);
+
+    for (subject, key) in [(&f.subject, "key-hold-mine"), (&other, "key-hold-theirs")] {
+        repository
+            .reserve(&reservation(subject, key, identity.clone(), "fp-a"))
+            .await
+            .unwrap();
+        let outcome = repository
+            .open_tier2_lease(
+                subject,
+                key,
+                &identity,
+                &lease_key,
+                CiTier2Reason::CausalFailure,
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, CiTier2LeaseOutcome::Opened { .. }),
+            "the hold is per subject, so `{key}` must get its own adjudication"
+        );
+    }
+
+    // Two Lead adjudications, one PR head, two subjects. Documented in
+    // migration 191 as what the first non-task subject inherits.
+    let open: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM ci_route_attempts WHERE tier2_lease_state = 'open'",
+    )
+    .fetch_one(f.db.pool())
+    .await
+    .unwrap();
+    assert_eq!(open, 2);
+
+    // And the head budget is per subject too: the same head key charges
+    // independently on each side.
+    let head_key = format!("head:4242:{head}");
+    for subject in [&f.subject, &other] {
+        let counts = repository
+            .budget_counts(subject, "sig:unused", &head_key)
+            .await
+            .unwrap();
+        assert_eq!(
+            counts.head, 0,
+            "each subject starts its own head budget for the same PR head"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers used by more than one test
 // ---------------------------------------------------------------------------
 

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
@@ -213,7 +213,7 @@ fn authority(
 // Migration round trip
 // ---------------------------------------------------------------------------
 
-/// Migration 191 round trip: every column the repository binds survives a
+/// Migration 193 round trip: every column the repository binds survives a
 /// write and a read back through a *different* connection pool.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn migration_round_trips_every_route_attempt_field() {
@@ -2655,7 +2655,7 @@ async fn the_tier_two_head_hold_stops_at_the_subject_boundary() {
     }
 
     // Two Lead adjudications, one PR head, two subjects. Documented in
-    // migration 191 as what the first non-task subject inherits.
+    // migration 193 as what the first non-task subject inherits.
     let open: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM ci_route_attempts WHERE tier2_lease_state = 'open'",
     )

--- a/server/crates/djinn-db/src/repositories/coordinator_incarnation.rs
+++ b/server/crates/djinn-db/src/repositories/coordinator_incarnation.rs
@@ -27,11 +27,11 @@ pub struct CoordinatorIncarnation {
     pub registered_at: String,
     pub last_renewed_at: String,
     /// Set when leadership cancellation closed provider-action admission
-    /// (migration 191). Present without `provider_actions_drained_at` means
+    /// (migration 193). Present without `provider_actions_drained_at` means
     /// the drain started and has not finished.
     pub draining_at: Option<String>,
     /// Set only after the registered provider-action scope is empty
-    /// (migration 191). This is the timestamp that turns advisory-lock
+    /// (migration 193). This is the timestamp that turns advisory-lock
     /// release into an *exclusion proof* for CI route `calling` rows: until
     /// it exists, a former owner's provider future may still be live and
     /// `ci_route_attempt::recover_calling_owner` refuses the handoff.

--- a/server/crates/djinn-db/src/repositories/coordinator_incarnation.rs
+++ b/server/crates/djinn-db/src/repositories/coordinator_incarnation.rs
@@ -26,6 +26,16 @@ pub struct CoordinatorIncarnation {
     pub id: String,
     pub registered_at: String,
     pub last_renewed_at: String,
+    /// Set when leadership cancellation closed provider-action admission
+    /// (migration 191). Present without `provider_actions_drained_at` means
+    /// the drain started and has not finished.
+    pub draining_at: Option<String>,
+    /// Set only after the registered provider-action scope is empty
+    /// (migration 191). This is the timestamp that turns advisory-lock
+    /// release into an *exclusion proof* for CI route `calling` rows: until
+    /// it exists, a former owner's provider future may still be live and
+    /// `ci_route_attempt::recover_calling_owner` refuses the handoff.
+    pub provider_actions_drained_at: Option<String>,
 }
 
 pub struct CoordinatorIncarnationRepository {
@@ -100,13 +110,65 @@ impl CoordinatorIncarnationRepository {
         Uuid::parse_str(incarnation_id)
             .map_err(|_| DbError::InvalidData("incarnation_id must be a UUID".to_owned()))?;
         Ok(sqlx::query_as::<_, CoordinatorIncarnation>(
-            r#"SELECT id, registered_at, last_renewed_at
+            r#"SELECT id, registered_at, last_renewed_at, draining_at, provider_actions_drained_at
                FROM coordinator_incarnations
                WHERE id = $1"#,
         )
         .bind(incarnation_id)
         .fetch_optional(self.db.pool())
         .await?)
+    }
+
+    /// Mark this incarnation as draining: leadership cancellation has closed
+    /// provider-action admission, so no new route may enter `calling`.
+    ///
+    /// Write-once and fenced to the exact incarnation. Draining is a one-way
+    /// door — an incarnation that started draining never resumes admitting.
+    ///
+    /// # Errors
+    ///
+    /// Database failures, or a non-UUID incarnation id.
+    pub async fn mark_draining(&self, incarnation_id: &str) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        Uuid::parse_str(incarnation_id)
+            .map_err(|_| DbError::InvalidData("incarnation_id must be a UUID".to_owned()))?;
+        let result = sqlx::query(
+            r#"UPDATE coordinator_incarnations
+               SET draining_at = to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+               WHERE id = $1 AND draining_at IS NULL"#,
+        )
+        .bind(incarnation_id)
+        .execute(self.db.pool())
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Record that every leader-owned provider-action future and finalizer has
+    /// exited and the registered action scope is empty.
+    ///
+    /// **This must be written before the advisory-lock session is released**,
+    /// and only after admission is closed — which is why it refuses a row that
+    /// never entered `draining`. A caller that could stamp this without
+    /// draining would hand the next incarnation a proof it did not earn, and
+    /// the next incarnation would use it to take a `calling` row whose
+    /// provider future is still alive.
+    ///
+    /// # Errors
+    ///
+    /// Database failures, or a non-UUID incarnation id.
+    pub async fn mark_provider_actions_drained(&self, incarnation_id: &str) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        Uuid::parse_str(incarnation_id)
+            .map_err(|_| DbError::InvalidData("incarnation_id must be a UUID".to_owned()))?;
+        let result = sqlx::query(
+            r#"UPDATE coordinator_incarnations
+               SET provider_actions_drained_at = to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+               WHERE id = $1 AND draining_at IS NOT NULL AND provider_actions_drained_at IS NULL"#,
+        )
+        .bind(incarnation_id)
+        .execute(self.db.pool())
+        .await?;
+        Ok(result.rows_affected() > 0)
     }
 
     /// Report whether the incarnation is **live** (its lease has been renewed

--- a/server/crates/djinn-db/src/repositories/mod.rs
+++ b/server/crates/djinn-db/src/repositories/mod.rs
@@ -4,6 +4,9 @@ pub mod build_admission_denial;
 pub mod build_lease;
 pub mod build_pod_permit;
 pub mod chat_interruption_notice;
+pub mod ci_route_attempt;
+#[cfg(test)]
+pub mod ci_route_attempt_tests;
 pub mod code_chunk;
 pub mod commit_file_changes;
 pub mod coordinator_incarnation;

--- a/server/crates/djinn-db/src/repositories/test_support.rs
+++ b/server/crates/djinn-db/src/repositories/test_support.rs
@@ -1148,11 +1148,21 @@ pub async fn make_coordinator_incarnation_vanish_after_first_read(
         .execute(db.pool())
         .await
         .unwrap();
+    // The view must project EVERY column `CoordinatorIncarnationRepository`
+    // selects, not just the ones this fixture varies. A column added to the
+    // real table and forgotten here turns the first read into a *lookup
+    // error*, and the branch this fixture exists to reach is never entered —
+    // the test still fails, but on the wrong classification, and the reason is
+    // three crates away. Migration 191's `draining_at` /
+    // `provider_actions_drained_at` are NULL here because a vanished lease has
+    // no drain history to report.
     let sql = format!(
         r#"CREATE VIEW coordinator_incarnations AS
            SELECT '{incarnation_id}'::varchar AS id,
                   '{registered_at}'::varchar AS registered_at,
-                  '{last_renewed_at}'::varchar AS last_renewed_at
+                  '{last_renewed_at}'::varchar AS last_renewed_at,
+                  NULL::varchar AS draining_at,
+                  NULL::varchar AS provider_actions_drained_at
            WHERE nextval('ci_access_count') = 1"#
     );
     sqlx::query(&sql).execute(db.pool()).await.unwrap();
@@ -1199,11 +1209,17 @@ pub async fn make_coordinator_incarnation_error_after_first_read(
     .execute(db.pool())
     .await
     .unwrap();
+    // Same completeness requirement as the vanish fixture above: project
+    // every column the repository selects, or the guard fires on the wrong
+    // read and this fixture silently starts testing the `get()` error branch
+    // instead of the `is_live()` one.
     let sql = format!(
         r#"CREATE VIEW coordinator_incarnations AS
            SELECT '{incarnation_id}'::varchar AS id,
                   '{registered_at}'::varchar AS registered_at,
-                  '{last_renewed_at}'::varchar AS last_renewed_at
+                  '{last_renewed_at}'::varchar AS last_renewed_at,
+                  NULL::varchar AS draining_at,
+                  NULL::varchar AS provider_actions_drained_at
            WHERE ci_error_guard()"#
     );
     sqlx::query(&sql).execute(db.pool()).await.unwrap();

--- a/server/crates/djinn-db/src/repositories/test_support.rs
+++ b/server/crates/djinn-db/src/repositories/test_support.rs
@@ -1153,7 +1153,7 @@ pub async fn make_coordinator_incarnation_vanish_after_first_read(
     // real table and forgotten here turns the first read into a *lookup
     // error*, and the branch this fixture exists to reach is never entered —
     // the test still fails, but on the wrong classification, and the reason is
-    // three crates away. Migration 191's `draining_at` /
+    // three crates away. Migration 193's `draining_at` /
     // `provider_actions_drained_at` are NULL here because a vanished lease has
     // no drain history to report.
     let sql = format!(

--- a/server/crates/djinn-db/tests/compaction_hardening/boundary.rs
+++ b/server/crates/djinn-db/tests/compaction_hardening/boundary.rs
@@ -248,11 +248,20 @@ async fn nullable_trigger_telemetry_round_trips() {
         // Repository initialization validates the current migration ledger.
         // Apply any later, unrelated migrations only after migration 134 has
         // transformed the pre-change row, then expose that schema to the API.
-        let latest_version = migration_entries()
-            .last()
-            .map(|(version, _)| *version)
-            .expect("at least one migration");
-        for version in (MIGRATION_134 + 1)..=latest_version {
+        //
+        // Iterate the migrations that EXIST rather than the integer range
+        // between 135 and the newest. Version numbers are only guaranteed to
+        // be strictly increasing (`tests/migrations_immutable.rs`), never
+        // contiguous: a number claimed by a branch that is later abandoned or
+        // renumbered leaves a permanent hole, and a range loop turns that hole
+        // into `panic!("migration N exists")` in a test that has nothing to do
+        // with N.
+        let later: Vec<u64> = migration_entries()
+            .into_iter()
+            .map(|(version, _)| version)
+            .filter(|version| *version > MIGRATION_134)
+            .collect();
+        for version in later {
             apply_migration(&mut migration, version).await;
         }
         record_applied_migrations(&mut migration).await;


### PR DESCRIPTION
**Wave 1 of 5** for approved proposal [nafu](https://code.djinnai.io/proposals/019fccac-e07d-7493-a1bc-18996e7d439a) — the `djinn-db` durable foundation for CI route attempts. Bottom of a stack; W2 builds on it and is open as a follow-up PR.

Entirely additive and **inert**: three new tables, two nullable columns, one repository. No production caller exists yet — the coordinator wiring is W2/W3.

## What it provides

`ci_route_attempts`, `ci_route_budget_counters`, `ci_route_calling_recoveries`, plus `draining_at` / `provider_actions_drained_at` on `coordinator_incarnations`.

The hard part is **pre-call recovery**. A `reserved` row is repository-local proof that no provider call happened, so recovery has exactly three outcomes and deliberately **no abandonment**:

- obsolete identity → terminal `superseded_pre_call`, uncharged, no lease, no board or worker action
- current identity with budget → **resume the same row** through one compare-and-set winner, charging exactly once no matter how many recoveries run
- current identity with exhausted budget → terminalise through the retry-exhaustion route

## Two design decisions worth review

**Subject polymorphism with real referential integrity.** Route rows are scoped by `(subject_kind, subject_id)`, both `NOT NULL`, with:

```sql
task_id VARCHAR(36)
  GENERATED ALWAYS AS (CASE WHEN subject_kind = 'task' THEN subject_id END) STORED
  REFERENCES tasks(id) ON DELETE CASCADE
```

The FK rejects a dangling task subject, `ON DELETE CASCADE` fires through the generated column, and `GENERATED ALWAYS` refuses a direct write — including under `OVERRIDING SYSTEM VALUE` — so the repository *physically cannot* desynchronise it from `subject_id`. All three verified against real PostgreSQL 16.14.

This closes a real defect: `CiEvidenceId` in the spec has no repository field, and `provider_action_key` is the global PK. A key collision would have made `reserve()` return `AlreadyPresent` for *foreign* evidence — a silently non-existent route, not a merged budget. The PK, the Tier-2 lease index, and the budget-counter PK are all now subject-scoped, closing that class at the schema level rather than by convention.

**A stated integrity trade:** a non-task subject generates NULL and has no DB-enforced referential integrity. The migration header says so, and says the wave that first writes one owns proving its subject exists.

**Splitting `terminal_outcome` from `tier2_resolution`.** The spec's single 15-value terminal set can't hold both a provider outcome and a Lead result, yet says `action_failed` "may route once to Tier 2." `adjudicated_outcome()` unions them, preferring the Tier-2 result. **Obligation for W2/W4/W5:** any reopen or park query must read both columns — reading `terminal_outcome` alone silently drops every reopen that followed a provider failure.

## Known open item

`open_tier2_lease` can still flip a live `calling` row to `terminal/superseded_before_lead`, making the owner's `finalize_calling` return `false` and silently discard the provider result — `terminalize_cas_in_tx` guards only on `action_phase <> 'terminal'`, bypassing the fence that `terminalize` itself applies. An auditor **demonstrated this with a probe test**, not by inference. A follow-up commit fences it; W2 already guards caller-side as defence in depth.

## Verification

`cargo test -p djinn-db ci_route_attempt` — **28 executed, 28 passed**. Full `-p djinn-db`: 1771 tests, 0 failures. `-p djinn-coordinator`: 2069, 0 failures. fmt, clippy `-D warnings`, migration-immutability, raw-SQL-boundary and crate-boundary guards all clean. `baselines/phase1.json` byte-identical to main.

Independently audited twice on separate checkouts. Every fix is mutation-proven: removing `FOR UPDATE` kills the concurrent-recovery test; neutering the terminal guard and charge kills 13 of 23; reverting the once-ever Tier-2 guard reproduces the exact predicted corruption (`tier2_lease_state: Some(Open)` beside a stale `tier2_resolution`); reverting the fixture views reproduces the original coordinator-test blocker.

One repo defect fixed in passing: `tests/compaction_hardening/boundary.rs` iterated `(MIGRATION_134 + 1)..=latest_version`, assuming migration numbers are contiguous, while `migrations_immutable.rs` guarantees only *strictly increasing*. This branch is the first to leave a gap and it panicked. A sweep found no other contiguity assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
