### PR TITLE
ci: make the nextest timing lane advisory so an Actions outage stops discarding green runs

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -2087,6 +2087,18 @@ jobs:
           path: server/nextest-timing/timing-${{ matrix.shardIndex }}.json
           if-no-files-found: warn
           retention-days: 30
+  # ADVISORY LANE. The quality gate routes this job's result through
+  # `advisory`, not `check` — a failure here is annotated and does not block.
+  # The full justification, and the 2026-08-06 incident that forced it, is on
+  # `SERVER_TEST_TIMING` in the `quality-gate` job.
+  #
+  # Do not try to make this job zero-`uses:` to dodge `Set up job` action
+  # resolution: the upload cannot be expressed as `gh api`. The REST API has no
+  # artifact-create endpoint, and the internal upload service requires
+  # ACTIONS_RUNTIME_TOKEN, which the runner injects for JavaScript/container
+  # action steps only and NOT for `run:` steps. Dropping the two
+  # download-artifact steps alone buys nothing: resolution is ONE batched call
+  # per job, so any single remaining `uses:` keeps the job exposed.
   nextest-timing-publish:
     name: Publish Nextest Timing
     needs:
@@ -2576,6 +2588,38 @@ jobs:
           AARCH64: ${{ needs.preflight.outputs.aarch64 }}:${{ needs.server-aarch64-check.result }}
           SERVER_TEST_PLAN: ${{ needs.preflight.outputs.serverTest }}:${{ needs.nextest-plan.result }}
           SERVER_TEST_SHARDS: ${{ needs.preflight.outputs.serverTest }}:${{ needs.server-test.result }}
+          # ADVISORY (routed through `advisory`, not `check`, below). This is
+          # the only lane in this gate that does not block, and it is the only
+          # one that may be: it publishes the shard TIMING artifact, which the
+          # planner consumes to balance shards by duration. The planner's own
+          # contract, stated at its restore loop, is that timing "influence[s]
+          # balancing only, never selection" — every failure mode there already
+          # falls through to "using cold-start balancing" and the run proceeds.
+          # So a missing timing artifact is, by construction, not a correctness
+          # signal; the next run just cold-starts (or picks an older candidate
+          # from the five pages it pages through).
+          #
+          # Why it had to change: on 2026-08-06 GitHub Actions could not resolve
+          # action download info ("Service Unavailable" / "Internal Server
+          # Error") for actions/{up,down}load-artifact@v4. Action resolution is
+          # one batched API call per JOB, made during `Set up job` before any
+          # step runs, so a job dies whole. On run 31113025510, 22 of 27 jobs
+          # were green INCLUDING all eight test shards; `Publish Nextest Timing`
+          # died at setup, and this gate fail-closed on it and discarded 212
+          # job-minutes of green test signal.
+          #
+          # This lane cannot be made structurally immune the way the
+          # `quality-gate` job itself is (zero `uses:`, so it never makes the
+          # resolution call): publishing an artifact REQUIRES
+          # actions/upload-artifact. There is no REST endpoint to create an
+          # artifact, and the internal upload API needs ACTIONS_RUNTIME_TOKEN,
+          # which the runner injects only for JavaScript/container action steps
+          # and NOT for `run:` steps. Downgrading the lane is therefore the fix,
+          # and it is a strictly better one: it also covers runner-allocation
+          # failures, artifact-API 5xx at runtime, and the 10-minute timeout.
+          #
+          # NOT a general "tolerate infra death" policy. Only telemetry lanes
+          # qualify. A test shard that dies at `Set up job` ran zero tests.
           SERVER_TEST_TIMING: ${{ needs.preflight.outputs.serverTest }}:${{ needs.nextest-timing-publish.result }}
           SQLX: ${{ needs.preflight.outputs.sqlxFreshness }}:${{ needs.server-sqlx-freshness.result }}
           MEMORY: ${{ needs.preflight.outputs.memoryEval }}:${{ needs.memory-eval.result }}
@@ -2592,9 +2636,25 @@ jobs:
             if [ "$selected" = false ] && [ "$result" = skipped ]; then return; fi
             echo "lane $lane selected=$selected result=$result"; return 1
           }
+          # Advisory lanes are annotated loudly and never block.
+          #
+          # ONLY legitimate for a lane that produces TELEMETRY: one whose output
+          # cannot change which tests run, whether they passed, or what ships.
+          # A lane that executes or verifies anything must stay on `check`.
+          # In particular this must never be extended to a test shard: a shard
+          # that dies at `Set up job` ran zero tests, and passing it would be a
+          # green-with-zero-executions trap.
+          advisory() {
+            local lane=$1 pair=$2 selected=${2%%:*} result=${2#*:}
+            if check "$@"; then return 0; fi
+            echo "::warning title=Advisory lane $lane did not succeed::lane $lane selected=$selected result=$result. This lane is telemetry-only and does NOT block the merge, but it did not do its job — investigate before the next planner run."
+            return 0
+          }
           check server-guards "$GUARDS"; check clippy "$CLIPPY"
           check deploy-render-gate "$RENDER_GATE"; check cutover-preflight "$CUTOVER_PREFLIGHT"
           check aarch64 "$AARCH64"
-          check server-test-plan "$SERVER_TEST_PLAN"; check server-test-shards "$SERVER_TEST_SHARDS"; check server-test-timing "$SERVER_TEST_TIMING"
+          check server-test-plan "$SERVER_TEST_PLAN"; check server-test-shards "$SERVER_TEST_SHARDS"
+          # Timing is the ONE advisory lane. See the SERVER_TEST_TIMING comment above.
+          advisory server-test-timing "$SERVER_TEST_TIMING"
           check sqlx-freshness "$SQLX"; check memory-eval "$MEMORY"
           check local-dev-contracts "$TILT_CONTRACTS"; check qa-smoke "$QA_SMOKE"; check ui "$UI"


### PR DESCRIPTION
## Problem

GitHub resolves every `uses:` in a job with **one batched API call per JOB**, during `Set up job`, before any step runs. On 2026-08-06 that call started returning `Service Unavailable` / `Internal Server Error` for `actions/download-artifact@v4` and `actions/upload-artifact@v4`, and the affected jobs died whole — no steps, no logs, nothing to retry into.

Worst case observed: **run 31113025510 had 22 of 27 jobs green, including all 8 test shards.** The only failure was `Publish Nextest Timing` dying at `Set up job`. The quality gate fail-closed on it and discarded **212 job-minutes** of green test signal.

The `quality-gate` job itself survived every time, because it has zero `uses:` and therefore never makes the resolution call at all.

## What this changes

One thing: the `SERVER_TEST_TIMING` lane becomes **advisory** in the gate. Nothing else moves.

A new `advisory()` helper wraps the existing `check()`:

```bash
advisory() {
  local lane=$1 pair=$2 selected=${2%%:*} result=${2#*:}
  if check "$@"; then return 0; fi
  echo "::warning title=Advisory lane $lane did not succeed::lane $lane selected=$selected result=$result. This lane is telemetry-only and does NOT block the merge, but it did not do its job — investigate before the next planner run."
  return 0
}
```

and `check server-test-timing` becomes `advisory server-test-timing`. `check()` is untouched; every other lane still calls it.

### Exactly what the gate now does when the timing lane fails

1. `check server-test-timing` is no longer called; `advisory` is.
2. `advisory` delegates to the **unmodified** `check`, so the success criteria are identical — `selected=true`/`result=success`, or `selected=false`/`result=skipped`.
3. On any other combination `check` prints its usual `lane server-test-timing selected=… result=…` line and returns 1.
4. `advisory` catches that, emits a `::warning` annotation (visible on the run summary and on the PR checks tab), and returns **0**.
5. The gate script continues to `check sqlx-freshness …` and the remaining lanes, all of which still fail closed.

Net effect: an infra death of `Publish Nextest Timing` costs a warning annotation instead of 212 job-minutes.

## Why the timing lane specifically

It is telemetry, not correctness:

- The planner's own restore loop states the contract: timing *"influence[s] balancing only, never selection"* (`quality-gate.yml:1544-1546`).
- Every failure path in that restore already logs *"using cold-start balancing"* and proceeds (`:1488`, `:1508`, `:1635`). A missing generation is already a supported, non-fatal state — the restore pages back through 5 pages of candidates inside a 7-day freshness window, so one skipped generation is a non-event.
- The job's `if:` already requires `needs.server-test.result == 'success'`, so **all 8 shards have passed before this job even starts**. Its failure can never mask a test failure.

Downgrading the lane is also strictly broader than a `uses:`-removal would have been: it equally covers runner-allocation failures, artifact-API 5xx *at runtime*, and the job's 10-minute timeout.

## What this deliberately does NOT do

**It does not make the gate tolerate `Set up job` deaths generally.** A test shard that dies at setup ran zero tests; passing it would be a green-with-zero-executions trap. Both `advisory()` and the `SERVER_TEST_TIMING` comment say so explicitly, and the constraint is proven by test below.

## Finding: `nextest-timing-publish` cannot be made zero-`uses:`

The original plan for this PR was to also rewrite the job's three `uses:` into `gh api` calls, following the house idiom at `:1503`, `:1559` and `:1897`. **The two downloads can be; the upload cannot.**

- The Actions REST API has **no artifact-create endpoint** — `/actions/artifacts` is read/delete only, so `gh api` has nothing to call.
- The internal artifact upload service requires `ACTIONS_RUNTIME_TOKEN`, which the runner injects for **JavaScript/container action steps only, not for `run:` steps**. (This is precisely why third-party actions like `crazy-max/ghaction-github-runtime` exist — to export it to subsequent steps. Doing that would reintroduce a `uses:`, and a third-party one at that.)

And since resolution is one batched call per job, **removing 2 of 3 `uses:` buys nothing** — any single remaining `uses:` keeps the job fully exposed. Shipping that rewrite would have added ~40 lines of bash that *look* like they confer setup immunity while changing nothing, so it is not in this PR. The finding is recorded as a comment on the job so the next person doesn't re-derive it.

## Verification

- `actionlint .github/workflows/quality-gate.yml` — clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` — parses, 20 jobs.
- `node --test scripts/ci-nextest-plan.test.mjs` — 62/62 pass (this file statically asserts against the workflow text).
- `node --test scripts/ci-qa-smoke-workflow.test.mjs scripts/ci-source-text.test.mjs` — pass.
- The gate step's `run:` script was extracted from the YAML and **executed** against the real env-var shapes:

| `SERVER_TEST_SHARDS` | `SERVER_TEST_TIMING` | exit | expected |
|---|---|---|---|
| `true:success` | `true:success` | 0 | 0 |
| `true:success` | `true:failure` | 0 + `::warning` | 0 |
| `true:success` | `true:cancelled` | 0 + `::warning` | 0 |
| `true:success` | `true:skipped` | 0 + `::warning` | 0 |
| `true:failure` | `true:success` | **1** | 1 — shards still block |
| `true:skipped` | `true:skipped` | **1** | 1 — shard setup-death still blocks |

The last two rows are the load-bearing controls: a shard that fails, or that dies at `Set up job` and lands as `skipped`, still fails the gate.
