### PR TITLE
perf(provider): make the GitHub API request timeout injectable (30.0s -> 0.12s test)

### DIFF
--- a/server/crates/djinn-provider/src/github_api.rs
+++ b/server/crates/djinn-provider/src/github_api.rs
@@ -41,6 +41,7 @@ mod types;
 mod write_errors;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use reqwest::Client;
 use tokio::sync::RwLock;
@@ -64,6 +65,11 @@ pub use write_errors::{
 
 /// GitHub REST API v3 base URL.
 pub const GITHUB_API_BASE: &str = "https://api.github.com";
+
+/// Default per-request timeout applied to every outbound GitHub API call.
+///
+/// Override with [`GitHubApiClient::with_request_timeout`].
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// GitHub REST API v3 client.
 ///
@@ -198,9 +204,24 @@ impl GitHubApiClient {
         )
     }
 
+    /// Return a client identical to `self` but with a different per-request
+    /// timeout, replacing the [`DEFAULT_REQUEST_TIMEOUT`] the constructors
+    /// apply.
+    ///
+    /// Production paths should keep the default; this exists so tests can
+    /// exercise the real timeout path against a mock server without waiting
+    /// 30 seconds of wall clock for it to elapse.
+    pub fn with_request_timeout(self, timeout: Duration) -> Self {
+        Self::build_with_timeout(self.auth, self.base_url, timeout)
+    }
+
     fn build(auth: AuthMode, base_url: String) -> Self {
+        Self::build_with_timeout(auth, base_url, DEFAULT_REQUEST_TIMEOUT)
+    }
+
+    fn build_with_timeout(auth: AuthMode, base_url: String, timeout: Duration) -> Self {
         let http = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
+            .timeout(timeout)
             .user_agent("djinn-server/0.1 (+https://github.com/djinnos/server)")
             .build()
             .expect("failed to build reqwest client");

--- a/server/crates/djinn-provider/tests/ci_artifact_scope_boundary.rs
+++ b/server/crates/djinn-provider/tests/ci_artifact_scope_boundary.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use djinn_provider::github_api::{GitHubApiClient, GitHubErrorSource};
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -214,17 +216,23 @@ async fn artifact_download_over_compressed_budget_is_rejected_with_run_context()
     assert!(error.body.contains("32 MiB"));
 }
 
+/// Drives a real elapsed request timeout, not a synthesized error: the client
+/// is built with a short timeout and the mock stalls past it, so the assertion
+/// still covers the transport timeout path and its error formatting.
 #[tokio::test]
 async fn artifact_timeout_includes_operation_and_run_context() {
+    const TIMEOUT: Duration = Duration::from_millis(50);
+
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path(
             "/repos/task-owner/task-repository/actions/artifacts/7/zip",
         ))
-        .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(31)))
+        .respond_with(ResponseTemplate::new(200).set_delay(TIMEOUT * 20))
         .mount(&server)
         .await;
     let error = client(&server)
+        .with_request_timeout(TIMEOUT)
         .download_artifact(OWNER, REPO, RUN_ID, ARTIFACT_ID)
         .await
         .unwrap_err();


### PR DESCRIPTION
## Problem

`server/crates/djinn-provider/src/github_api.rs` hardcoded a 30-second reqwest timeout in `build()`. To observe a real timeout, `artifact_timeout_includes_operation_and_run_context` stalled a wiremock response for 31 seconds — making it the only test in the suite whose duration is dominated by a hardcoded wait.

## Change

- `DEFAULT_REQUEST_TIMEOUT` (30s) replaces the inline literal.
- `build()` now delegates to a new `build_with_timeout(auth, base_url, timeout)`.
- New `GitHubApiClient::with_request_timeout(Duration)` returns a client rebuilt through that same path.

No production caller is touched — every existing constructor still gets 30s. The crate has no config struct or builder for the client (the established idiom is the `for_*_with_base_url` test-oriented constructors), so this is a chained override in the same spirit rather than a parallel configuration mechanism or a `#[cfg(test)]` hook.

The test now uses a 50ms client timeout against a 1s (`TIMEOUT * 20`) mock delay.

## Test wall time

| | duration |
|---|---|
| before | **30.04s** |
| after | **0.12s** |

```
# before
test artifact_timeout_includes_operation_and_run_context ... ok
test result: ok. 1 passed; ... finished in 30.04s

# after
test artifact_timeout_includes_operation_and_run_context ... ok
test result: ok. 1 passed; ... finished in 0.12s
```

Whole-file wall time drops from ~30.1s to 1.07s. Full `cargo test -p djinn-provider` is green (590 lib + all integration targets); `cargo clippy -p djinn-provider --all-targets` is clean.

## Vacuity proof

The test must still prove a **real elapsed timeout** produces a **real error through the real formatting path**. Two probes, both reverted:

**Probe A — break the error-context formatting.** In `checks.rs::artifact_context`, dropped `{run_context}{failure_context}` from the `format!`:

```
assertion failed: error.body.contains("run 42")
test result: FAILED. 0 passed; 1 failed;
```

**Probe B — make the timeout not elapse.** Changed the mock delay from `TIMEOUT * 20` to `TIMEOUT / 10`, so the response arrives before the client timeout:

```
called `Result::unwrap_err()` on an `Ok` value: DownloadedArtifact { bytes: [], ... }
test result: FAILED. 0 passed; 1 failed;
```

Probe B is the important one: the error only exists because the timeout genuinely elapses. Nothing was replaced with a directly-constructed error.

For the record, the error body observed after the change (captured with a temporary `println!`, since removed) is byte-identical in shape to the pre-change one:

```
GitHub Actions operation download_artifact for run 42 transport failure (including timeout): error sending request for url (http://127.0.0.1:42737/repos/task-owner/task-repository/actions/artifacts/7/zip)
```

## Other dependents on the 30s default

Grepped: `from_secs(30)` in this crate's client had exactly one site, and `set_delay` across `server/crates/` appears in only this test plus `djinn-agent` handlers that key off their own `ARTIFACT_HINT_TIMEOUT` const (unaffected). No other test depends on the 30s client default.