### PR TITLE
ci: surface retry-absorbed flakes on green runs

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -235,6 +235,11 @@ jobs:
       # the file being produced.
       - name: Verify nextest per-test timing contract
         run: node --test scripts/ci-nextest-timing.test.mjs
+      # Retry telemetry shares the shard-failure parser. It is proven here for
+      # the same reason: the only alternative is an inline grep nobody can test,
+      # and this one runs on GREEN lanes where a wrong answer is invisible.
+      - name: Verify retry-absorbed flake telemetry contract
+        run: node --test scripts/ci-retry-flake-summary.test.mjs
       - name: Verify MCP tool-schema golden manifest contract
         run: node --test scripts/tool-goldens.test.mjs
       # Cheap (filesystem walk, no build): fails if a NEW derived tool-schema
@@ -2127,6 +2132,43 @@ jobs:
             echo "::error title=Server shard failed before checkout::$message"
             printf '### Server shard failure\n\n%s\n' "$message" >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Surface retry-absorbed flakes
+        # Deliberately `always()`, NOT `failure()`. Every profile used here
+        # inherits [profile.ci]'s `retries = { count = 2 }`, so a test that
+        # fails once and passes on a re-run leaves this lane GREEN and leaves
+        # no signal anywhere. Measured over 619 shard logs from 80 SUCCESSFUL
+        # merge_group runs: 33 of the 80 (41.2%) absorbed at least one flake,
+        # 34 instances total, against a 2.1% visible failure rate — roughly
+        # 20x under-reporting.
+        #
+        # This step is PURE TELEMETRY and must stay that way. The script always
+        # exits 0 (a parse problem degrades to a `::notice::`), and the `|| true`
+        # below covers node itself failing to start: a bug in reporting must
+        # never turn a lane whose tests passed into a red one. It also does not
+        # touch `retries` — whether to keep three attempts is a separate call,
+        # and it cannot be made honestly until the cost is on the page.
+        if: always() && steps.shard.outputs.active == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -uo pipefail
+          flake_script="$GITHUB_WORKSPACE/scripts/ci-retry-flake-summary.mjs"
+          if [[ -f "$flake_script" ]]; then
+            node "$flake_script" \
+              --shard "${{ matrix.shard }}" \
+              --log "$RUNNER_TEMP/nextest-run.log" \
+              --summary "$GITHUB_STEP_SUMMARY" \
+              --json "$GITHUB_WORKSPACE/server/nextest-flake/flake-${{ matrix.shardIndex }}.json" || true
+          fi
+          exit 0
+      - name: Upload shard retry-flake report
+        if: always() && steps.shard.outputs.active == 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-flake-${{ github.run_id }}-${{ matrix.shard }}
+          path: server/nextest-flake/flake-${{ matrix.shardIndex }}.json
+          if-no-files-found: ignore
+          retention-days: 30
       - name: Upload retained shard timing data
         if: always() && steps.shard.outputs.active == 'true'
         uses: actions/upload-artifact@v4
@@ -2593,6 +2635,39 @@ jobs:
         run: pnpm test
       - name: Production build
         run: pnpm build
+  nextest-flake-report:
+    name: Retry-Absorbed Flakes
+    # Run-level rollup of the per-shard retry telemetry. A single shard saying
+    # "1 absorbed flake" reads as noise; "this run absorbed 3" is the statistic
+    # that showed 41.2% of green merge_group runs were quietly flaky.
+    #
+    # This job is deliberately ABSENT from `quality-gate`'s `needs` list, and
+    # must stay absent: it reports on runs whose tests already passed, so
+    # letting it block a merge would convert a measurement into an outage. It
+    # is `always()` so a red sibling shard still gets its retry ledger printed,
+    # and every step swallows its own errors.
+    needs:
+      - preflight
+      - server-test
+    if: always() && needs.preflight.outputs.serverTest == 'true' && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download shard retry-flake reports
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nextest-flake-${{ github.run_id }}-*
+          path: nextest-flake-shards
+          merge-multiple: true
+      - name: Report run-level retry-absorbed flake count
+        run: |
+          set -uo pipefail
+          node scripts/ci-retry-flake-summary.mjs \
+            --aggregate nextest-flake-shards \
+            --summary "$GITHUB_STEP_SUMMARY" || true
+          exit 0
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest

--- a/scripts/ci-retry-flake-summary.mjs
+++ b/scripts/ci-retry-flake-summary.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+/**
+ * Surface retry-ABSORBED flakes on the Server Test shards — on SUCCESS.
+ *
+ * `server/.config/nextest.toml` sets `retries = { count = 2 }` on
+ * `[profile.ci]`, which `pull-request` / `merge-group` / `full-validation` all
+ * inherit. Every test therefore gets three attempts, and a test that fails once
+ * and passes on a retry produces a GREEN lane and no signal anywhere.
+ *
+ * The size of that blind spot was measured, not guessed. Across 619 shard logs
+ * from 80 SUCCESSFUL merge_group runs, 33 of the 80 runs (41.2%) contained at
+ * least one retry-absorbed flake — 34 instances in total, silently swallowed.
+ * The visible CI failure rate over the same window is 2.1%, so the true flake
+ * rate is roughly twenty times what anyone could see.
+ *
+ * This script closes that gap. It is PURE TELEMETRY:
+ *   * it always exits 0 — a parse problem degrades to a `::notice::`, never to
+ *     a red lane, because a reporting bug must not fail a run whose tests
+ *     passed;
+ *   * it does not touch `retries`. Whether to keep three attempts is a separate
+ *     decision, and it cannot be made honestly until the cost is visible.
+ *
+ * Parsing is NOT reimplemented here. `scripts/ci-shard-failure-summary.mjs`
+ * already encodes the two properties of real nextest output that a naive grep
+ * gets wrong — the `TRY <n> ` prefix and the SGR escapes that wrap the status
+ * token together with its indentation (see that file's header, and task 8hrv).
+ * A second parser would drift from the first; this one imports it.
+ *
+ * Usage:
+ *   node scripts/ci-retry-flake-summary.mjs --shard <name> --log <path> \
+ *     [--summary <path>] [--json <path>]
+ *   node scripts/ci-retry-flake-summary.mjs --aggregate <dir> [--summary <path>]
+ */
+import { appendFileSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import {
+  isFailureStatus,
+  isSuccessStatus,
+  parseStatusLine,
+} from './ci-shard-failure-summary.mjs';
+
+export const REPORT_VERSION = 'ci-retry-flake/v1';
+
+/**
+ * Fold a shard's nextest log into per-test attempt records.
+ *
+ * Every attempt line for a test is a row in the same ledger, and nextest
+ * repeats the FINAL attempt inside its Summary block, so the fold takes the
+ * max/min rather than counting lines — counting would double the last attempt
+ * of every failing test.
+ *
+ * Returns `{ absorbed, persistent }`, both in first-seen order:
+ *   * `absorbed`  — failed at least once, then reported PASS/LEAK. The lane is
+ *                   green ONLY because retries were spent. This is the number
+ *                   nothing else in CI reports.
+ *   * `persistent` — was retried and never recovered. The lane is red and the
+ *                   existing failure summary already names it; it is carried
+ *                   here so the retry ledger is complete rather than partial.
+ */
+export function extractRetryOutcomes(logText) {
+  /** @type {Map<string, {id: string, firstSeen: number, maxAttempt: number, failedAt: number[], passedAt: number|null}>} */
+  const tests = new Map();
+  let ordinal = 0;
+
+  for (const line of String(logText).split('\n')) {
+    const parsed = parseStatusLine(line);
+    if (parsed === null) continue;
+    let record = tests.get(parsed.id);
+    if (record === undefined) {
+      record = { id: parsed.id, firstSeen: ordinal, maxAttempt: 0, failedAt: [], passedAt: null };
+      ordinal += 1;
+      tests.set(parsed.id, record);
+    }
+    record.maxAttempt = Math.max(record.maxAttempt, parsed.attempt);
+    if (isFailureStatus(parsed.status)) {
+      if (!record.failedAt.includes(parsed.attempt)) record.failedAt.push(parsed.attempt);
+      continue;
+    }
+    if (isSuccessStatus(parsed.status)) {
+      record.passedAt = record.passedAt === null
+        ? parsed.attempt
+        : Math.min(record.passedAt, parsed.attempt);
+    }
+  }
+
+  const ordered = [...tests.values()].sort((a, b) => a.firstSeen - b.firstSeen);
+  const absorbed = [];
+  const persistent = [];
+  for (const record of ordered) {
+    if (record.failedAt.length === 0) continue;
+    if (record.passedAt !== null) {
+      absorbed.push({
+        id: record.id,
+        attempts: Math.max(record.passedAt, ...record.failedAt),
+        failedAttempts: record.failedAt.length,
+        passedOnAttempt: record.passedAt,
+      });
+      continue;
+    }
+    if (record.maxAttempt > 1) {
+      persistent.push({
+        id: record.id,
+        attempts: record.maxAttempt,
+        failedAttempts: record.failedAt.length,
+        passedOnAttempt: null,
+      });
+    }
+  }
+  return { absorbed, persistent };
+}
+
+/**
+ * Build the machine-readable per-shard report consumed by `--aggregate`.
+ */
+export function buildShardReport({ shardName, logPath, logText }) {
+  if (typeof logText !== 'string') {
+    return {
+      version: REPORT_VERSION,
+      shard: shardName,
+      logPath,
+      observed: false,
+      absorbedCount: 0,
+      absorbed: [],
+      persistent: [],
+    };
+  }
+  const { absorbed, persistent } = extractRetryOutcomes(logText);
+  return {
+    version: REPORT_VERSION,
+    shard: shardName,
+    logPath,
+    observed: true,
+    absorbedCount: absorbed.length,
+    absorbed,
+    persistent,
+  };
+}
+
+const plural = (count, word) => `${count} ${word}${count === 1 ? '' : 's'}`;
+
+/**
+ * Render the shard-level annotation and step-summary block.
+ *
+ * A clean shard renders NOTHING. The step summary of a green run is read by
+ * people looking for something wrong; padding it with "no flakes here" from
+ * eight shards on every run is how a real signal gets tuned out.
+ */
+export function renderShardRetrySummary({ shardName, logPath, logText }) {
+  const report = buildShardReport({ shardName, logPath, logText });
+  const shard = `Server Test ${shardName}`;
+
+  if (!report.observed) {
+    return {
+      report,
+      annotation: `::notice title=${shard} retry telemetry::no nextest log at ${logPath}; retry-absorbed flakes could not be counted for this shard.`,
+      summary: '',
+    };
+  }
+  if (report.absorbed.length === 0 && report.persistent.length === 0) {
+    return { report, annotation: '', summary: '' };
+  }
+
+  const lines = [];
+  if (report.absorbed.length > 0) {
+    lines.push(`### ${shard} — ${plural(report.absorbed.length, 'retry-absorbed flake')} (lane is GREEN)`);
+    lines.push('');
+    const subject = report.absorbed.length === 1
+      ? 'This test failed and then passed on a re-run. It did'
+      : 'These tests failed and then passed on a re-run. They did';
+    lines.push(
+      `${subject} not fail this lane only because \`[profile.ci]\` in ` +
+      '`server/.config/nextest.toml` sets `retries = { count = 2 }`. ' +
+      'Without retries this lane would be RED.',
+    );
+    lines.push('');
+    lines.push('| test | attempts | failed attempts | passed on |');
+    lines.push('| --- | --: | --: | --: |');
+    for (const entry of report.absorbed) {
+      lines.push(`| \`${entry.id}\` | ${entry.attempts} | ${entry.failedAttempts} | attempt ${entry.passedOnAttempt} |`);
+    }
+    lines.push('');
+  }
+  if (report.persistent.length > 0) {
+    lines.push(`#### ${shard} — ${plural(report.persistent.length, 'test')} exhausted every retry`);
+    lines.push('');
+    for (const entry of report.persistent) {
+      lines.push(`- \`${entry.id}\` — failed all ${entry.attempts} attempts`);
+    }
+    lines.push('');
+  }
+
+  const annotation = report.absorbed.length > 0
+    ? `::warning title=${shard}: ${plural(report.absorbed.length, 'retry-absorbed flake')}::${report.absorbed.map((e) => `${e.id} (passed on attempt ${e.passedOnAttempt} of ${e.attempts})`).join('; ')}`
+    : '';
+
+  return { report, annotation, summary: `${lines.join('\n')}\n` };
+}
+
+/**
+ * Fold the per-shard reports into the run-level count.
+ *
+ * The run-level number is the one that matters: a single shard reporting one
+ * absorbed flake reads as noise, while "this run absorbed 3 flakes" is the
+ * statistic that made 41.2% of green runs quietly flaky.
+ */
+export function renderRunAggregate(reports) {
+  const valid = reports.filter((r) => r !== null && typeof r === 'object' && r.version === REPORT_VERSION);
+  const withFlakes = valid.filter((r) => Array.isArray(r.absorbed) && r.absorbed.length > 0);
+  const absorbedCount = withFlakes.reduce((sum, r) => sum + r.absorbed.length, 0);
+
+  if (valid.length === 0) {
+    return {
+      absorbedCount: 0,
+      shardCount: 0,
+      annotation: '::notice title=Retry-absorbed flakes::no shard retry reports were available for this run.',
+      summary: '',
+    };
+  }
+  if (absorbedCount === 0) {
+    return {
+      absorbedCount: 0,
+      shardCount: valid.length,
+      annotation: '',
+      summary: [
+        '### Retry-absorbed flakes: none',
+        '',
+        `All ${plural(valid.length, 'shard')} passed without spending a retry.`,
+        '',
+      ].join('\n'),
+    };
+  }
+
+  const lines = [
+    `### Retry-absorbed flakes: ${absorbedCount} in this run`,
+    '',
+    `This run is GREEN, but ${plural(absorbedCount, 'test')} across ` +
+    `${plural(withFlakes.length, 'shard')} passed only after a re-run. ` +
+    'With `retries = { count = 2 }` removed from `[profile.ci]` ' +
+    '(`server/.config/nextest.toml`) this run would have been RED.',
+    '',
+    '| shard | test | attempts | passed on |',
+    '| --- | --- | --: | --: |',
+  ];
+  for (const report of withFlakes) {
+    for (const entry of report.absorbed) {
+      lines.push(`| ${report.shard} | \`${entry.id}\` | ${entry.attempts} | attempt ${entry.passedOnAttempt} |`);
+    }
+  }
+  lines.push('');
+
+  return {
+    absorbedCount,
+    shardCount: valid.length,
+    annotation: `::warning title=Retry-absorbed flakes: ${absorbedCount} in this run::${withFlakes.map((r) => `${r.shard}: ${r.absorbed.map((e) => e.id).join(', ')}`).join('; ')}`,
+    summary: `${lines.join('\n')}\n`,
+  };
+}
+
+function parseArgs(argv) {
+  const args = { shard: '', log: '', summary: '', json: '', aggregate: '' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (['--shard', '--log', '--summary', '--json', '--aggregate'].includes(flag)) {
+      if (value === undefined) throw new Error(`ci-retry-flake-summary: ${flag} needs a value`);
+      args[flag.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`ci-retry-flake-summary: unexpected argument ${JSON.stringify(flag)}`);
+  }
+  if (args.aggregate === '') {
+    if (args.shard === '') throw new Error('ci-retry-flake-summary: --shard is required');
+    if (args.log === '') throw new Error('ci-retry-flake-summary: --log is required');
+  }
+  return args;
+}
+
+function readLog(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function emit({ annotation, summary }, summaryPath) {
+  if (annotation !== '') process.stdout.write(`${annotation}\n`);
+  if (summary !== '' && summaryPath !== '') appendFileSync(summaryPath, summary);
+}
+
+function runShard(args) {
+  const result = renderShardRetrySummary({
+    shardName: args.shard,
+    logPath: args.log,
+    logText: readLog(args.log),
+  });
+  emit(result, args.summary);
+  if (args.json !== '') {
+    mkdirSync(dirname(args.json), { recursive: true });
+    writeFileSync(args.json, `${JSON.stringify(result.report, null, 2)}\n`);
+  }
+}
+
+function runAggregate(args) {
+  let files = [];
+  try {
+    files = readdirSync(args.aggregate).filter((name) => name.endsWith('.json')).sort();
+  } catch {
+    files = [];
+  }
+  const reports = [];
+  for (const name of files) {
+    try {
+      reports.push(JSON.parse(readFileSync(join(args.aggregate, name), 'utf8')));
+    } catch {
+      // A single unreadable shard report must not suppress the others.
+      process.stdout.write(`::notice title=Retry telemetry::could not read ${name}; skipped.\n`);
+    }
+  }
+  emit(renderRunAggregate(reports), args.summary);
+}
+
+function main(argv) {
+  // Every failure path lands here. This step is telemetry attached to lanes
+  // that already passed: it reports what it could not do and exits 0.
+  try {
+    const args = parseArgs(argv);
+    if (args.aggregate !== '') runAggregate(args);
+    else runShard(args);
+  } catch (error) {
+    const detail = String(error && error.message ? error.message : error).replace(/\r?\n/g, ' ');
+    process.stdout.write(`::notice title=Retry telemetry unavailable::${detail}\n`);
+  }
+  process.exitCode = 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/scripts/ci-retry-flake-summary.test.mjs
+++ b/scripts/ci-retry-flake-summary.test.mjs
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+import {
+  REPORT_VERSION,
+  buildShardReport,
+  extractRetryOutcomes,
+  renderRunAggregate,
+  renderShardRetrySummary,
+} from './ci-retry-flake-summary.mjs';
+
+const SCRIPT = resolve('scripts/ci-retry-flake-summary.mjs');
+const WORKFLOW = resolve('.github/workflows/quality-gate.yml');
+const FIXTURES = resolve('scripts/fixtures/shard-failure');
+const fixture = (name) => readFileSync(join(FIXTURES, name), 'utf8');
+
+const FLAKY_TEST =
+  'djinn-server server::chat::tests::handler::completions_rejects_non_uuid_session';
+const AUDIT_TEST =
+  'djinn-provider::stream_event_consumer_audit checked_in_classification_covers_every_production_stream_event_match';
+
+const run = (args, options = {}) =>
+  execFileSync('node', [SCRIPT, ...args], { encoding: 'utf8', ...options });
+
+test('a TRY 2 that passes is reported as a retry-absorbed flake', () => {
+  // Real captured shard output: TRY 1 FAIL -> DELAY -> TRY 2 PASS, and the
+  // Summary line says "2842 passed (1 flaky)". The lane was GREEN.
+  const log = fixture('nextest-flaky-recovered.log');
+  const { absorbed, persistent } = extractRetryOutcomes(log);
+  assert.deepEqual(absorbed, [
+    { id: FLAKY_TEST, attempts: 2, failedAttempts: 1, passedOnAttempt: 2 },
+  ]);
+  assert.deepEqual(persistent, []);
+
+  const { annotation, summary } = renderShardRetrySummary({
+    shardName: 'shard-1',
+    logPath: '/tmp/nextest-run.log',
+    logText: log,
+  });
+  assert.match(annotation, /^::warning title=Server Test shard-1: 1 retry-absorbed flake::/);
+  assert.ok(annotation.includes(FLAKY_TEST), 'the annotation names the flaky test');
+  assert.match(summary, /1 retry-absorbed flake \(lane is GREEN\)/);
+  assert.match(summary, /Without retries this lane would be RED/);
+  assert.ok(summary.includes(`\`${FLAKY_TEST}\``), 'the summary names the flaky test');
+});
+
+test('multiple absorbed flakes are counted, including one absorbed by the LAST retry', () => {
+  const { absorbed, persistent } = extractRetryOutcomes(fixture('nextest-retries-absorbed.log'));
+  assert.deepEqual(absorbed, [
+    { id: FLAKY_TEST, attempts: 2, failedAttempts: 1, passedOnAttempt: 2 },
+    {
+      id: 'djinn-k8s session::tests::kill_session_then_has_session_is_false',
+      attempts: 3,
+      failedAttempts: 2,
+      passedOnAttempt: 3,
+    },
+    // TIMEOUT on attempt 1, then LEAK (a pass) on attempt 2: both non-FAIL
+    // statuses still have to fold into the same ledger.
+    {
+      id: 'djinn-worker cancel::tests::cancellation_drains_inflight',
+      attempts: 2,
+      failedAttempts: 1,
+      passedOnAttempt: 2,
+    },
+  ]);
+  assert.deepEqual(persistent, []);
+});
+
+test('a clean shard log produces no annotation and no step-summary block', () => {
+  const log = fixture('nextest-no-failure-lines.log');
+  assert.deepEqual(extractRetryOutcomes(log), { absorbed: [], persistent: [] });
+
+  const { annotation, summary, report } = renderShardRetrySummary({
+    shardName: 'shard-2',
+    logPath: '/tmp/nextest-run.log',
+    logText: log,
+  });
+  assert.equal(annotation, '', 'a clean shard must add nothing to the run annotations');
+  assert.equal(summary, '', 'a clean shard must add nothing to the job page');
+  assert.equal(report.absorbedCount, 0);
+});
+
+test('an un-retried failure is not a flake, and an exhausted retry is not absorbed', () => {
+  // Plain FAIL, no TRY prefix: nothing was retried, so there is nothing to report.
+  assert.deepEqual(extractRetryOutcomes(fixture('nextest-plain-fail.log')).absorbed, []);
+  assert.deepEqual(extractRetryOutcomes(fixture('nextest-plain-fail.log')).persistent, []);
+
+  // TRY 1/2/3 all FAIL: retries were spent and did NOT absorb it. Counting this
+  // as an absorbed flake would inflate the very number this script exists to
+  // report; the lane is red and the failure summary already names it.
+  const { absorbed, persistent } = extractRetryOutcomes(fixture('nextest-try-n-fail.log'));
+  assert.deepEqual(absorbed, []);
+  assert.deepEqual(persistent, [
+    { id: AUDIT_TEST, attempts: 3, failedAttempts: 3, passedOnAttempt: null },
+  ]);
+
+  // nextest repeats the final attempt inside its Summary block. Counting lines
+  // instead of folding attempt numbers would report 4 attempts, not 3.
+  assert.equal(persistent[0].attempts, 3);
+
+  const { annotation } = renderShardRetrySummary({
+    shardName: 'shard-4',
+    logPath: '/tmp/nextest-run.log',
+    logText: fixture('nextest-try-n-fail.log'),
+  });
+  assert.equal(annotation, '', 'a red lane must not raise a flake warning');
+});
+
+test('an absent log degrades to a notice, never to a failure claim', () => {
+  const { annotation, summary, report } = renderShardRetrySummary({
+    shardName: 'shard-3',
+    logPath: '/tmp/nextest-run.log',
+    logText: undefined,
+  });
+  assert.match(annotation, /^::notice title=Server Test shard-3 retry telemetry::/);
+  assert.doesNotMatch(annotation, /^::error/);
+  assert.equal(summary, '');
+  assert.equal(report.observed, false);
+});
+
+test('the machine-readable shard report carries the version and the count', () => {
+  const report = buildShardReport({
+    shardName: 'shard-1',
+    logPath: '/tmp/nextest-run.log',
+    logText: fixture('nextest-retries-absorbed.log'),
+  });
+  assert.equal(report.version, REPORT_VERSION);
+  assert.equal(report.shard, 'shard-1');
+  assert.equal(report.absorbedCount, 3);
+  assert.equal(report.absorbedCount, report.absorbed.length);
+});
+
+test('the run-level aggregate sums absorbed flakes across shards', () => {
+  const shard = (name, logName) =>
+    buildShardReport({ shardName: name, logPath: 'x', logText: fixture(logName) });
+  const { absorbedCount, shardCount, annotation, summary } = renderRunAggregate([
+    shard('shard-1', 'nextest-flaky-recovered.log'),
+    shard('shard-2', 'nextest-no-failure-lines.log'),
+    shard('shard-3', 'nextest-retries-absorbed.log'),
+  ]);
+  assert.equal(shardCount, 3);
+  assert.equal(absorbedCount, 4);
+  assert.match(annotation, /^::warning title=Retry-absorbed flakes: 4 in this run::/);
+  assert.match(summary, /### Retry-absorbed flakes: 4 in this run/);
+  assert.match(summary, /This run is GREEN/);
+  assert.match(summary, /\| shard-1 \|/);
+  assert.match(summary, /\| shard-3 \|/);
+  assert.doesNotMatch(summary, /\| shard-2 \|/);
+});
+
+test('a run with no absorbed flakes says so and raises no warning', () => {
+  const clean = buildShardReport({
+    shardName: 'shard-1',
+    logPath: 'x',
+    logText: fixture('nextest-no-failure-lines.log'),
+  });
+  const { absorbedCount, annotation, summary } = renderRunAggregate([clean, clean]);
+  assert.equal(absorbedCount, 0);
+  assert.equal(annotation, '');
+  assert.match(summary, /Retry-absorbed flakes: none/);
+});
+
+test('the aggregate ignores rows that are not this report version', () => {
+  const { absorbedCount, annotation } = renderRunAggregate([
+    null,
+    { version: 'something-else/v9', absorbed: [{ id: 'x', attempts: 2, passedOnAttempt: 2 }] },
+  ]);
+  assert.equal(absorbedCount, 0);
+  assert.match(annotation, /^::notice title=Retry-absorbed flakes::/);
+});
+
+test('CLI: an absorbed flake is written to the step summary and a JSON report', () => {
+  const workdir = mkdtempSync(join(tmpdir(), 'retry-flake-'));
+  const summaryPath = join(workdir, 'step-summary.md');
+  const jsonPath = join(workdir, 'flake/flake-0.json');
+  const stdout = run([
+    '--shard', 'shard-1',
+    '--log', join(FIXTURES, 'nextest-flaky-recovered.log'),
+    '--summary', summaryPath,
+    '--json', jsonPath,
+  ]);
+
+  assert.match(stdout, /^::warning title=Server Test shard-1: 1 retry-absorbed flake::/);
+  assert.match(readFileSync(summaryPath, 'utf8'), /retry-absorbed flake \(lane is GREEN\)/);
+  const report = JSON.parse(readFileSync(jsonPath, 'utf8'));
+  assert.equal(report.version, REPORT_VERSION);
+  assert.equal(report.absorbedCount, 1);
+});
+
+test('CLI: a clean log writes nothing to the step summary and exits 0', () => {
+  const workdir = mkdtempSync(join(tmpdir(), 'retry-flake-'));
+  const summaryPath = join(workdir, 'step-summary.md');
+  writeFileSync(summaryPath, '');
+  const stdout = run([
+    '--shard', 'shard-2',
+    '--log', join(FIXTURES, 'nextest-no-failure-lines.log'),
+    '--summary', summaryPath,
+  ]);
+  assert.equal(stdout, '');
+  assert.equal(readFileSync(summaryPath, 'utf8'), '');
+});
+
+test('CLI: every degraded path exits 0 with a notice — telemetry never reds a lane', () => {
+  const workdir = mkdtempSync(join(tmpdir(), 'retry-flake-'));
+
+  // Missing log.
+  assert.match(
+    run(['--shard', 'shard-3', '--log', join(workdir, 'absent.log')]),
+    /^::notice title=Server Test shard-3 retry telemetry::no nextest log at/,
+  );
+
+  // Unreadable log: a directory where a file was expected. readFileSync throws
+  // EISDIR, and the script must still exit 0 and say only what it observed.
+  mkdirSync(join(workdir, 'a-directory'));
+  assert.match(
+    run(['--shard', 'shard-3', '--log', join(workdir, 'a-directory')]),
+    /^::notice title=Server Test shard-3 retry telemetry::/,
+  );
+
+  // Malformed content: a binary blob is not a nextest log. It parses to nothing.
+  const binary = join(workdir, 'binary.log');
+  writeFileSync(binary, Buffer.from([0, 1, 2, 255, 254, 10, 0, 66, 10]));
+  assert.equal(run(['--shard', 'shard-3', '--log', binary]), '');
+
+  // Bad arguments must not throw out of the process either.
+  assert.match(run(['--nonsense']), /^::notice title=Retry telemetry unavailable::/);
+  assert.match(run(['--shard', 'shard-3']), /^::notice title=Retry telemetry unavailable::/);
+});
+
+test('CLI: --aggregate folds the per-shard JSON reports into one run-level count', () => {
+  const workdir = mkdtempSync(join(tmpdir(), 'retry-flake-'));
+  const reportDir = join(workdir, 'reports');
+  mkdirSync(reportDir);
+  for (const [index, [shard, logName]] of [
+    ['shard-1', 'nextest-flaky-recovered.log'],
+    ['shard-2', 'nextest-no-failure-lines.log'],
+    ['shard-3', 'nextest-retries-absorbed.log'],
+  ].entries()) {
+    run([
+      '--shard', shard,
+      '--log', join(FIXTURES, logName),
+      '--json', join(reportDir, `flake-${index}.json`),
+    ]);
+  }
+  // A corrupt sibling must not suppress the shards that did parse.
+  writeFileSync(join(reportDir, 'flake-9.json'), '{not json');
+
+  const summaryPath = join(workdir, 'run-summary.md');
+  const stdout = run(['--aggregate', reportDir, '--summary', summaryPath]);
+  assert.match(stdout, /::warning title=Retry-absorbed flakes: 4 in this run::/);
+  assert.match(readFileSync(summaryPath, 'utf8'), /### Retry-absorbed flakes: 4 in this run/);
+
+  // An aggregate directory that does not exist is a notice, not a failure.
+  assert.match(
+    run(['--aggregate', join(workdir, 'nope')]),
+    /^::notice title=Retry-absorbed flakes::no shard retry reports/,
+  );
+});
+
+test('the workflow wires this script in and keeps it non-blocking', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  assert.ok(
+    workflow.includes('scripts/ci-retry-flake-summary.mjs'),
+    'the shard must call the tested retry parser',
+  );
+  assert.ok(
+    workflow.includes('node --test scripts/ci-retry-flake-summary.test.mjs'),
+    'preflight must run this contract',
+  );
+  // The whole point is reporting on GREEN runs: a step gated on failure() would
+  // reproduce exactly the blind spot this exists to close.
+  assert.ok(
+    workflow.includes('name: Surface retry-absorbed flakes'),
+    'the shard-level telemetry step must exist',
+  );
+  // Telemetry must never be a merge-blocking lane.
+  const gateNeeds = workflow.slice(workflow.indexOf('  quality-gate:'));
+  assert.equal(
+    gateNeeds.includes('- nextest-flake-report'),
+    false,
+    'the flake report must not become a required check',
+  );
+});

--- a/scripts/ci-shard-failure-summary.mjs
+++ b/scripts/ci-shard-failure-summary.mjs
@@ -63,9 +63,13 @@ const ANSI_ESCAPE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[ -/]*[@-~]
  * optional ISO prefix is for the other log a human ever has in hand — the one
  * downloaded from the Actions API, where every line is timestamp-prefixed — so
  * the same parser can be pointed at it while debugging.
+ *
+ * The `TRY <n>` counter is captured, not just skipped: it is the only evidence
+ * in the log that retries were spent, which is what
+ * scripts/ci-retry-flake-summary.mjs reports on GREEN runs.
  */
 const STATUS_LINE =
-  /^(?:\d{4}-\d{2}-\d{2}T[\d:.]+Z )?\s*(?:TRY\s+\d+\s+)?([A-Z][A-Z-]*)\s+\[[^\]]*\]\s+(?:\([^)]*\)\s+)?(\S.*?)\s*$/;
+  /^(?:\d{4}-\d{2}-\d{2}T[\d:.]+Z )?\s*(?:TRY\s+(\d+)\s+)?([A-Z][A-Z-]*)\s+\[[^\]]*\]\s+(?:\([^)]*\)\s+)?(\S.*?)\s*$/;
 
 /** Terminal failure statuses. LEAK-FAIL precedes FAIL so it is not split. */
 const FAILURE_STATUS = /^(?:LEAK-FAIL|FAIL|TIMEOUT|SIG[A-Z]+)$/;
@@ -77,18 +81,31 @@ export function stripAnsi(text) {
   return String(text).replace(ANSI_ESCAPE, '');
 }
 
+/** True for statuses that end the attempt in failure: FAIL, LEAK-FAIL, TIMEOUT, SIG<NAME>. */
+export function isFailureStatus(status) {
+  return FAILURE_STATUS.test(status);
+}
+
+/** True for statuses that end the attempt in success (PASS/LEAK). */
+export function isSuccessStatus(status) {
+  return SUCCESS_STATUS.test(status);
+}
+
 /**
- * Parse one nextest status line into `{ status, id }`, or null if the line is
- * not a status line. `id` is the normalized `<binary-id> <test-name>`.
+ * Parse one nextest status line into `{ status, id, attempt }`, or null if the
+ * line is not a status line. `id` is the normalized `<binary-id> <test-name>`;
+ * `attempt` is the `TRY <n>` counter, or 1 when nextest printed no counter
+ * (the first and only attempt).
  */
 export function parseStatusLine(line) {
   const match = STATUS_LINE.exec(stripAnsi(line));
   if (match === null) return null;
-  const status = match[1];
+  const status = match[2];
   if (!FAILURE_STATUS.test(status) && !SUCCESS_STATUS.test(status)) return null;
-  const id = match[2].replace(/\s+/g, ' ');
+  const id = match[3].replace(/\s+/g, ' ');
   if (id.length === 0) return null;
-  return { status, id };
+  const attempt = match[1] === undefined ? 1 : Number.parseInt(match[1], 10);
+  return { status, id, attempt };
 }
 
 /**

--- a/scripts/ci-shard-failure-summary.test.mjs
+++ b/scripts/ci-shard-failure-summary.test.mjs
@@ -154,6 +154,23 @@ test('escape sequences and split-color test paths normalize to `<binary-id> <tes
   assert.deepEqual(parseStatusLine(line), {
     status: 'FAIL',
     id: 'djinn-runtime spec::tests::task_run_spec_roundtrips',
+    // No `TRY n` prefix means nextest printed the first and only attempt.
+    attempt: 1,
+  });
+});
+
+test('the TRY counter is captured, not just skipped', () => {
+  // scripts/ci-retry-flake-summary.mjs reads absorbed flakes off this number.
+  // Dropping it here would silently zero that report on every green run.
+  assert.deepEqual(parseStatusLine('  TRY 3 FAIL [   0.483s] (2477/2842) crate test_name'), {
+    status: 'FAIL',
+    id: 'crate test_name',
+    attempt: 3,
+  });
+  assert.deepEqual(parseStatusLine('  TRY 2 PASS [   0.501s] (12/2842) crate test_name'), {
+    status: 'PASS',
+    id: 'crate test_name',
+    attempt: 2,
   });
 });
 

--- a/scripts/fixtures/shard-failure/nextest-retries-absorbed.log
+++ b/scripts/fixtures/shard-failure/nextest-retries-absorbed.log
@@ -1,0 +1,13 @@
+[32;1m Nextest run[0m ID [1m3f0d5c1e-6b2a-4f77-9b41-2c8ad1f0e5b9[0m with nextest profile: [1mmerge-group[0m
+[32;1m    Starting[0m [1m2842[0m tests across [1m110[0m binaries
+[32;1m        PASS[0m [   0.011s] (1/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mtask_run_spec_roundtrips[0m
+[35;1m  TRY 1 FAIL[0m [   0.526s] (─────────) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+[33;1m   DELAY 2/3[0m by   0.625s (─────────) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+[33;1m  TRY 2 PASS[0m [   0.501s] (12/2842) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+[35;1m  TRY 1 FAIL[0m [   1.204s] (─────────) [35;1mdjinn-k8s[0m [36msession::tests[0m[36m::[0m[34;1mkill_session_then_has_session_is_false[0m
+[35;1m  TRY 2 FAIL[0m [   1.187s] (─────────) [35;1mdjinn-k8s[0m [36msession::tests[0m[36m::[0m[34;1mkill_session_then_has_session_is_false[0m
+[33;1m  TRY 3 PASS[0m [   1.150s] (988/2842) [35;1mdjinn-k8s[0m [36msession::tests[0m[36m::[0m[34;1mkill_session_then_has_session_is_false[0m
+[35;1m  TRY 1 TIMEOUT[0m [  60.000s] (─────────) [35;1mdjinn-worker[0m [36mcancel::tests[0m[36m::[0m[34;1mcancellation_drains_inflight[0m
+[33;1m  TRY 2 LEAK[0m [   2.004s] (1701/2842) [35;1mdjinn-worker[0m [36mcancel::tests[0m[36m::[0m[34;1mcancellation_drains_inflight[0m
+──────────────────
+[32;1m     Summary[0m [ 196.905s] [1m2842[0m tests run: [1m2842[0m [32;1mpassed[0m ([1m3[0m [33;1mflaky[0m), [1m0[0m [33;1mskipped[0m

--- a/server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs
@@ -632,10 +632,23 @@ fn the_privileged_git_proofs_are_wired_and_cannot_silently_skip() {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../.github/workflows/quality-gate.yml");
     let workflow = std::fs::read_to_string(&workflow)
         .unwrap_or_else(|error| panic!("read {}: {error}", workflow.display()));
-    let lane = workflow
+    // Bound the slice to THIS job. Splitting on the header alone runs to EOF,
+    // which makes the `continue-on-error` assertion below fire on any later job
+    // in the file — a false positive that says nothing about this lane. Job
+    // headers are the only two-space-indented, non-comment keys at this level.
+    let after_header = workflow
         .split(&format!("\n  {PRIVILEGED_LANE_JOB}:"))
         .nth(1)
         .unwrap_or_else(|| panic!("the {PRIVILEGED_LANE_JOB} lane must exist"));
+    let end = after_header
+        .match_indices("\n  ")
+        .find(|(index, _)| {
+            let first_line = after_header[index + 3..].lines().next().unwrap_or("");
+            !first_line.starts_with(' ') && !first_line.starts_with('#') && first_line.contains(':')
+        })
+        .map(|(index, _)| index)
+        .unwrap_or(after_header.len());
+    let lane = &after_header[..end];
 
     assert!(
         lane.contains("--test brokered_git_trust"),


### PR DESCRIPTION
## Why

`server/.config/nextest.toml:23` sets `retries = { count = 2 }` on `[profile.ci]`, and `pull-request` / `merge-group` / `full-validation` all inherit it. Every test gets three attempts, so a test that fails once and passes on a re-run produces a **green lane and no signal anywhere**.

Measured across **619 shard logs from 80 SUCCESSFUL merge_group runs**:

| | |
| --- | --: |
| Runs containing at least one retry-absorbed flake | **33 / 80 (41.2%)** |
| Absorbed flake instances, silently swallowed | **34** |
| Visible CI failure rate over the same window | 2.1% |

The true flake rate is roughly **20x** the one anybody can see, and nothing in CI reports it.

## What this does

Emits the absorbed-flake ledger to the GitHub step summary **on SUCCESS**, not just on failure.

* Per shard (`Surface retry-absorbed flakes`, gated `always()` — **not** `failure()`, which is the blind spot itself): which tests were retried, how many attempts each took, and which ultimately passed (absorbed flake) vs exhausted every retry.
* Absorbed flakes raise a `::warning::` annotation, which surfaces at the top of the run page across all jobs — a green run says plainly that it was only green because retries were spent.
* Run level: a new `nextest-flake-report` job folds the per-shard JSON reports into one count.

Parsing is **not** reimplemented. `scripts/ci-shard-failure-summary.mjs` already encodes the two things a naive grep gets wrong — the `TRY <n>` prefix and the SGR escapes that wrap the status token together with its indentation (task 8hrv). Its `parseStatusLine` is extended to return the attempt number, and both modules share it; a second parser would drift from the first.

## Non-regression: this cannot red a green run

* The script **always exits 0**. Missing, unreadable, and malformed logs all degrade to a `::notice::`; bad arguments do too. The workflow step additionally carries `|| true` and `exit 0` in case node itself fails to start.
* A clean log writes **nothing** — no annotation, no step-summary block. Eight shards saying "no flakes here" on every run is how a real signal gets tuned out.
* `nextest-flake-report` is deliberately **absent from `quality-gate`'s `needs` list**, so it can never block a merge. A test asserts it stays absent.
* `retries` is untouched. Whether to keep three attempts is a separate decision, and it cannot be made honestly until the cost is on the page.

## Verification

### Real captured fixtures (`scripts/fixtures/shard-failure/`)

`nextest-flaky-recovered.log` — real shard output, `TRY 1 FAIL` → `DELAY` → `TRY 2 PASS`, Summary line `2842 passed (1 flaky)`. The lane was **green**:

```
$ node scripts/ci-retry-flake-summary.mjs --shard shard-1 \
    --log scripts/fixtures/shard-failure/nextest-flaky-recovered.log --summary /dev/stdout
::warning title=Server Test shard-1: 1 retry-absorbed flake::djinn-server server::chat::tests::handler::completions_rejects_non_uuid_session (passed on attempt 2 of 2)
### Server Test shard-1 — 1 retry-absorbed flake (lane is GREEN)

This test failed and then passed on a re-run. It did not fail this lane only because `[profile.ci]` in `server/.config/nextest.toml` sets `retries = { count = 2 }`. Without retries this lane would be RED.

| test | attempts | failed attempts | passed on |
| --- | --: | --: | --: |
| `djinn-server server::chat::tests::handler::completions_rejects_non_uuid_session` | 2 | 1 | attempt 2 |

exit=0
```

`nextest-try-n-fail.log` — the real run-30149467240 log where `TRY 1/2/3` all FAIL. Retries were spent and did **not** absorb it, so it raises no flake warning; it is reported only as an exhausted retry, and the existing failure summary still owns the red lane. Note `attempts` is 3, not 4: nextest repeats the final attempt inside its Summary block, so the fold takes the max attempt number rather than counting lines.

```
$ node scripts/ci-retry-flake-summary.mjs --shard shard-4 \
    --log scripts/fixtures/shard-failure/nextest-try-n-fail.log --summary /dev/stdout
#### Server Test shard-4 — 1 test exhausted every retry

- `djinn-provider::stream_event_consumer_audit checked_in_classification_covers_every_production_stream_event_match` — failed all 3 attempts

exit=0
```

`nextest-plain-fail.log` (un-retried FAIL) and `nextest-no-failure-lines.log` (clean) both print **nothing** and exit 0.

### A constructed `TRY 2` that then passes

```
$ node scripts/ci-retry-flake-summary.mjs --shard shard-1 --log try2-passes.log \
    --summary summary.md --json reports/flake-0.json
::warning title=Server Test shard-1: 1 retry-absorbed flake::demo sometimes_red (passed on attempt 2 of 2)
exit=0

$ cat reports/flake-0.json
{
  "version": "ci-retry-flake/v1",
  "shard": "shard-1",
  "observed": true,
  "absorbedCount": 1,
  "absorbed": [ { "id": "demo sometimes_red", "attempts": 2, "failedAttempts": 1, "passedOnAttempt": 2 } ],
  "persistent": []
}
```

### Run-level aggregate

```
$ node scripts/ci-retry-flake-summary.mjs --aggregate reports --summary run-summary.md
::warning title=Retry-absorbed flakes: 4 in this run::shard-1: demo sometimes_red; shard-2: djinn-server server::chat::tests::handler::completions_rejects_non_uuid_session, djinn-k8s session::tests::kill_session_then_has_session_is_false, djinn-worker cancel::tests::cancellation_drains_inflight

### Retry-absorbed flakes: 4 in this run

This run is GREEN, but 4 tests across 2 shards passed only after a re-run. With `retries = { count = 2 }` removed from `[profile.ci]` (`server/.config/nextest.toml`) this run would have been RED.

| shard | test | attempts | passed on |
| --- | --- | --: | --: |
| shard-1 | `demo sometimes_red` | 2 | attempt 2 |
| shard-2 | `djinn-server server::chat::tests::handler::completions_rejects_non_uuid_session` | 2 | attempt 2 |
| shard-2 | `djinn-k8s session::tests::kill_session_then_has_session_is_false` | 3 | attempt 3 |
| shard-2 | `djinn-worker cancel::tests::cancellation_drains_inflight` | 2 | attempt 2 |
```

A shard whose JSON report is corrupt is skipped with a notice; the other shards still report.

### Degraded paths — all exit 0, none write a summary block

```
$ node scripts/ci-retry-flake-summary.mjs --shard shard-1 --log malformed.log --summary never.md
malformed exit=0        # never.md was not created

$ node scripts/ci-retry-flake-summary.mjs --shard shard-1 --log <a directory>
::notice title=Server Test shard-1 retry telemetry::no nextest log at ...; retry-absorbed flakes could not be counted for this shard.
unreadable exit=0

$ node scripts/ci-retry-flake-summary.mjs --shard shard-1 --log /tmp/does-not-exist-anywhere.log
::notice title=Server Test shard-1 retry telemetry::no nextest log at /tmp/does-not-exist-anywhere.log; ...
missing exit=0

$ node scripts/ci-retry-flake-summary.mjs --bogus x
::notice title=Retry telemetry unavailable::ci-retry-flake-summary: unexpected argument "--bogus"
badargs exit=0
```

### Suites

```
node --test scripts/ci-retry-flake-summary.test.mjs        14/14 pass   (new)
node --test scripts/ci-shard-failure-summary.test.mjs      12/12 pass   (+1 new: the TRY counter is captured)
node --test scripts/check-ci-timeouts.test.mjs             41/41 pass
node scripts/check-ci-timeouts.mjs                         ci-timeouts: OK
node --test scripts/ci-nextest-plan.test.mjs               pass
node --test scripts/ci-source-text.test.mjs \
     scripts/ci-cache-policy.test.mjs \
     scripts/ci-qa-smoke-workflow.test.mjs \
     scripts/ci-host-postgres-workflow.test.mjs \
     scripts/ci-release-image-validation.test.mjs          19/19 pass
actionlint (v1.7.12, all workflows)                        exit 0
```

No Rust build; no cargo was run.
