### PR TITLE
perf(tests): open one database per launcher-admission test, not per matrix cell

### DIFF
--- a/server/crates/djinn-db/tests/launcher_admission_compatibility_matrix.rs
+++ b/server/crates/djinn-db/tests/launcher_admission_compatibility_matrix.rs
@@ -92,22 +92,47 @@ impl Artifact {
     }
 }
 
-/// Seed a project selecting one artifact, and hand back a resolver bound to
-/// `mode` + `inventory`.
-async fn resolve(
-    artifact: &Artifact,
-    mode: LauncherAuthorityProtocol,
-    inventory: LegacyDigestInventory,
-) -> djinn_db::Result<Option<djinn_db::DispatchImage>> {
+/// The one project and the one catalog image every case in a test resolves
+/// through.
+///
+/// A `Database::open_in_memory()` is a `CREATE DATABASE … TEMPLATE` clone, so
+/// paying for one per matrix cell dominated this file's wall time. The clone is
+/// hoisted to one per test instead, and [`resolve`] restores the pristine state
+/// itself — see the note there for why that is exact rather than approximate.
+async fn fixture_db() -> Database {
     let db = Database::open_in_memory().unwrap();
     db.ensure_initialized().await.unwrap();
-    djinn_db::test_support::seed_legacy_launcher_authority_for_test(&db).await;
     ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
         .create_with_id("p1", "p-1", "test", "p1")
         .await
         .unwrap();
     let images = ImageRepository::new(db.clone());
     images.create("i1", "Fixture", None, "{}").await.unwrap();
+    images.set_project_image("p1", Some("i1")).await.unwrap();
+    db
+}
+
+/// Point the fixture project's artifact at `artifact`, and hand back a resolver
+/// bound to `mode` + `inventory`.
+///
+/// **Why sharing `db` across cases is exact, not merely convenient.** The
+/// resolution reads exactly two rows: the single `images` row the project
+/// selects, and the `launcher_authority_mode` singleton. Both are OVERWRITTEN
+/// in full here before every case — `mark_ready` assigns `status`, `tag`,
+/// `registry_digest` and `launcher_authority_protocol` unconditionally, and
+/// `seed_legacy_launcher_authority_for_test` resets the singleton to exactly
+/// migration 167's seed (`leaf-v1` at epoch 0). Nothing is appended to and
+/// nothing accumulates, so the rows a case resolves against are the rows a
+/// freshly cloned database would have held. `resolve_dispatch_image` is a pure
+/// read, so a case cannot leave a trace for the next one either way.
+async fn resolve(
+    db: &Database,
+    artifact: &Artifact,
+    mode: LauncherAuthorityProtocol,
+    inventory: LegacyDigestInventory,
+) -> djinn_db::Result<Option<djinn_db::DispatchImage>> {
+    djinn_db::test_support::seed_legacy_launcher_authority_for_test(db).await;
+    let images = ImageRepository::new(db.clone());
     images
         .mark_ready(
             "i1",
@@ -117,12 +142,12 @@ async fn resolve(
         )
         .await
         .expect("the fixture must be writable through the real repository");
-    images.set_project_image("p1", Some("i1")).await.unwrap();
 
     // The authority mode is the DURABLE singleton migration 167 seeds, flipped
     // through z3gi's own drain fence — not a value this test hands the
-    // resolver. A fresh database has no live permits, so the fence lets the
-    // flip through and the resolution reads a mode that is really stored.
+    // resolver. Nothing here ever admits a build pod permit, so the drain
+    // census stays empty for every case and the fence lets each flip through
+    // exactly as it does on a fresh database.
     let modes = LauncherAuthorityModeRepository::new(db.clone());
     let epoch = modes
         .read()
@@ -155,6 +180,7 @@ async fn resolve(
 /// `admitted == mode` fails naming both protocols.
 #[tokio::test]
 async fn every_admitted_combination_has_exactly_one_effective_authority() {
+    let db = fixture_db().await;
     let mut admitted_cells = 0;
     for mode in LauncherAuthorityProtocol::ALL {
         for artifact in [
@@ -166,7 +192,7 @@ async fn every_admitted_combination_has_exactly_one_effective_authority() {
             // The inventory vouches for the legacy artifact, so the only thing
             // that can reject it in this sweep is the mode.
             let inventory = inventoried("1eeac9de");
-            let resolved = resolve(&artifact, mode, inventory).await;
+            let resolved = resolve(&db, &artifact, mode, inventory).await;
 
             let Ok(Some(image)) = resolved else {
                 continue; // rejected; the rejection sweeps below cover why
@@ -212,9 +238,11 @@ async fn every_admitted_combination_has_exactly_one_effective_authority() {
 /// "uninventoried" assertion below then resolves instead of erroring.
 #[tokio::test]
 async fn a_missing_protocol_is_admitted_only_for_an_exact_inventoried_digest() {
+    let db = fixture_db().await;
     let artifact = Artifact::legacy_no_handshake();
 
     let admitted = resolve(
+        &db,
         &artifact,
         LauncherAuthorityProtocol::LeafV1,
         inventoried("1eeac9de"),
@@ -230,6 +258,7 @@ async fn a_missing_protocol_is_admitted_only_for_an_exact_inventoried_digest() {
 
     // A different digest, correctly formed, that the inventory does not list.
     let rejected = resolve(
+        &db,
         &artifact,
         LauncherAuthorityProtocol::LeafV1,
         inventoried("d1ffe2ed"),
@@ -254,11 +283,13 @@ async fn a_missing_protocol_is_admitted_only_for_an_exact_inventoried_digest() {
 /// `decide_admission`. Both `expect_err`s below then return `Ok`.
 #[tokio::test]
 async fn no_missing_protocol_artifact_survives_resize_v2() {
+    let db = fixture_db().await;
     for inventory in [
         inventoried("1eeac9de"), // even vouched for
         LegacyDigestInventory::Unconfigured,
     ] {
         let error = resolve(
+            &db,
             &Artifact::legacy_no_handshake(),
             LauncherAuthorityProtocol::ResizeV2,
             inventory,
@@ -290,6 +321,7 @@ async fn no_missing_protocol_artifact_survives_resize_v2() {
 /// malformed sweep then resolves.
 #[tokio::test]
 async fn a_mutable_tag_without_a_verified_digest_never_dispatches() {
+    let db = fixture_db().await;
     // Not canonical: short, uppercase, wrong algorithm, and a bare tag.
     for bad in [
         "sha256:abc",
@@ -303,6 +335,7 @@ async fn a_mutable_tag_without_a_verified_digest_never_dispatches() {
             digest: Some(bad.to_owned()),
         };
         let error = resolve(
+            &db,
             &artifact,
             LauncherAuthorityProtocol::LeafV1,
             LegacyDigestInventory::Unconfigured,
@@ -319,6 +352,7 @@ async fn a_mutable_tag_without_a_verified_digest_never_dispatches() {
 
     // The digestless legacy row: resolvable, but carrying no authority.
     let undigested = resolve(
+        &db,
         &Artifact::legacy_no_handshake_undigested(),
         LauncherAuthorityProtocol::LeafV1,
         LegacyDigestInventory::Unconfigured,
@@ -344,12 +378,14 @@ async fn a_mutable_tag_without_a_verified_digest_never_dispatches() {
 /// `decide_admission` with `true`. Both directions then resolve.
 #[tokio::test]
 async fn an_explicit_protocol_mismatch_is_refused_in_both_directions() {
+    let db = fixture_db().await;
     for mode in LauncherAuthorityProtocol::ALL {
         for declared in LauncherAuthorityProtocol::ALL {
             if declared == mode {
                 continue;
             }
             let error = resolve(
+                &db,
                 &Artifact::declaring(declared),
                 mode,
                 LegacyDigestInventory::Unconfigured,
@@ -373,7 +409,9 @@ async fn an_explicit_protocol_mismatch_is_refused_in_both_directions() {
 /// absent one). The first assertion then resolves.
 #[tokio::test]
 async fn an_unusable_inventory_rejects_rather_than_falling_back() {
+    let db = fixture_db().await;
     let error = resolve(
+        &db,
         &Artifact::legacy_no_handshake(),
         LauncherAuthorityProtocol::LeafV1,
         LegacyDigestInventory::Unusable(InventoryFault::SignatureInvalid),
@@ -388,6 +426,7 @@ async fn an_unusable_inventory_rejects_rather_than_falling_back() {
     // A DECLARING artifact does not consult the inventory at all, so a broken
     // inventory must not take the whole catalog down with it.
     let declaring = resolve(
+        &db,
         &Artifact::declaring(LauncherAuthorityProtocol::LeafV1),
         LauncherAuthorityProtocol::LeafV1,
         LegacyDigestInventory::Unusable(InventoryFault::SignatureInvalid),
@@ -411,9 +450,11 @@ async fn an_unusable_inventory_rejects_rather_than_falling_back() {
 /// dispatching across the upgrade. Configuring an inventory arms it.
 #[tokio::test]
 async fn arming_the_inventory_is_what_narrows_an_undeclared_artifact() {
+    let db = fixture_db().await;
     let artifact = Artifact::legacy_no_handshake();
 
     let unarmed = resolve(
+        &db,
         &artifact,
         LauncherAuthorityProtocol::LeafV1,
         LegacyDigestInventory::Unconfigured,
@@ -429,6 +470,7 @@ async fn arming_the_inventory_is_what_narrows_an_undeclared_artifact() {
     // The same artifact, once an inventory exists that does not list it.
     assert!(
         resolve(
+            &db,
             &artifact,
             LauncherAuthorityProtocol::LeafV1,
             inventoried("d1ffe2ed"),
@@ -447,6 +489,7 @@ async fn arming_the_inventory_is_what_narrows_an_undeclared_artifact() {
 /// [`decide_admission`] returns for the same inputs.
 #[tokio::test]
 async fn the_repository_seam_reports_exactly_what_the_decision_returns() {
+    let db = fixture_db().await;
     for mode in LauncherAuthorityProtocol::ALL {
         for inventory in [
             LegacyDigestInventory::Unconfigured,
@@ -466,7 +509,7 @@ async fn the_repository_seam_reports_exactly_what_the_decision_returns() {
                     artifact.digest.as_deref(),
                     &inventory,
                 );
-                let observed = resolve(&artifact, mode, inventory.clone()).await;
+                let observed = resolve(&db, &artifact, mode, inventory.clone()).await;
                 match (expected, observed) {
                     (Ok(AdmissionDecision::Admitted(protocol)), Ok(Some(image))) => {
                         assert_eq!(


### PR DESCRIPTION
## What

`Database::open_in_memory()` is a `CREATE DATABASE … TEMPLATE` clone against the shared test Postgres. Several DB tests paid for one **inside a loop**. This PR hoists that clone out of the loops in **one** file — `server/crates/djinn-db/tests/launcher_admission_compatibility_matrix.rs` — and deliberately leaves `tribunal_evidence_return_v1.rs` alone.

`resolve()` at `:97` opened a fresh database on every call. `the_repository_seam_reports_exactly_what_the_decision_returns` walks a 4×4×4 matrix, so that one test created **64 databases**; the other six `resolve()` callers created 2–8 apiece. After this change each test creates **one**.

## Measured before / after

Baseline, measured on this branch's merge-base with `cargo nextest run -p djinn-db --test launcher_admission_compatibility_matrix --test tribunal_evidence_return_v1 --test-threads 4`:

| test | DB clones before → after | before |
|---|---|---|
| `the_repository_seam_reports_exactly_what_the_decision_returns` | 64 → 1 | **TIMED OUT at 90.0s** (nextest `terminate-after`) |
| `every_admitted_combination_has_exactly_one_effective_authority` | 8 → 1 | 32.47s |
| `a_mutable_tag_without_a_verified_digest_never_dispatches` | 5 → 1 | 31.68s |
| `a_missing_protocol_is_admitted_only_for_an_exact_inventoried_digest` | 2 → 1 | 19.20s |
| `an_explicit_protocol_mismatch_is_refused_in_both_directions` | 2 → 1 | 19.19s |
| `an_unusable_inventory_rejects_rather_than_falling_back` | 2 → 1 | 14.09s |
| `no_missing_protocol_artifact_survives_resize_v2` | 2 → 1 | 12.85s |
| `arming_the_inventory_is_what_narrows_an_undeclared_artifact` | 2 → 1 | 10.24s |
| *(unchanged)* `an_unreadable_authority_singleton_refuses_every_dispatch` | 1 → 1 | 11.77s |

**85 clones → 8 for the file.** The absolute "before" numbers above are inflated: the local test Postgres was saturated by ~10 concurrent agents, and `ensure_test_template` serialises every clone behind an advisory lock, so each clone was costing tens of seconds rather than the ~1–2s it costs on an idle machine. The **clone counts** are the load-independent claim, and the wall time of each of these tests is dominated by them: after the change every one of these tests performs a single clone plus a handful of single-row `UPDATE`s.

The "after" wall times are **reasoned, not measured** — see *Verification* below.

## Isolation justification, per test

`resolve()` now takes a `&Database`. Isolation is **(b): explicit per-iteration restoration**, and the argument is the same for all seven converted tests because they all go through that single helper:

The fixture holds exactly the cardinality a freshly cloned database held — **one** `projects` row and **one** `images` row — and `resolve()` rewrites both inputs the resolution reads, before every case:

1. `ImageRepository::mark_ready` is an unconditional `UPDATE … WHERE id = 'i1'` that assigns `status`, `tag`, `registry_digest`, `launcher_authority_protocol` and `last_error`. Every field `resolve_dispatch_image` reads is therefore written by *this* case; nothing is appended to and nothing accumulates. The fields `mark_ready` does not touch (`name`, `description`, `config`) are constants in the fixture and were constants on a fresh database too.
2. `seed_legacy_launcher_authority_for_test` resets the durable `launcher_authority_mode` singleton to migration 167's seed (`leaf-v1`, `epoch = 0`) before the per-case flip, so the epoch CAS and the drain fence start from the state a fresh clone presents rather than from whatever the previous case left.
3. `resolve_dispatch_image` → `resolve_dispatch_image_row` + `admit_dispatch_image` is a **pure read** (`SELECT selected_image_id …`, the image row, the authority singleton). It writes nothing, so a case cannot leave a trace for the next one even indirectly.
4. Nothing in this file ever inserts a `build_pod_permits` row, so the authority flip's drain census is empty for every case exactly as it is on a fresh database. If that ever stopped being true the existing `assert!(matches!(…, Flipped | Unchanged))` in `resolve()` fails loudly rather than silently.

**The assertions were grepped for the dangerous patterns first.** The whole file contains exactly one SQL statement (`DELETE FROM launcher_authority_mode` at `:637`) and it is inside a test this PR does not touch. There is **no** `count(*)`, no `fetch_one`/`fetch_all`, no `ORDER BY`, no "the only row" and no row-count assertion anywhere in the seven converted tests — every assertion is against the `DispatchImage` value returned by *this* case's call, or against the rendered error string of *this* case's call. That is what makes the shared database safe here and is the reason this file, rather than the other one, was the safe hoist.

Per-case discrimination is preserved and is self-protecting: in the 64-cell test, `expected` is recomputed per cell from `decide_admission(mode, artifact.declared, artifact.digest, &inventory)` and is **not constant** across cells (it ranges over `Admitted(LeafV1)`, `Admitted(ResizeV2)`, `Undeclarable`, and four distinct rejections). A stale `images` row from the previous cell would therefore produce either a value mismatch on `image.authority_protocol` or an `Ok`/`Err` shape mismatch that lands in the `panic!` catch-all arm. Cross-contamination in this test cannot pass silently — it can only fail.

### Left alone

* **`an_unreadable_authority_singleton_refuses_every_dispatch`** — **(c)**. It `DELETE`s the `launcher_authority_mode` singleton to prove the resolver reads durable state rather than defaulting. That is a destructive write to the one row every other case depends on, and it already opens exactly one database. It keeps its private database and is untouched.

* **All 9 tests in `server/crates/djinn-db/tests/tribunal_evidence_return_v1.rs`** — **(c), not hoisted.** This is the file the count-based screen was for, and it fails that screen everywhere:
  * its `rows()` helper is literally `SELECT count(*) FROM {table}` with **no predicate**, and it is called in 22 places;
  * `assert_rejection_state` asserts that census is `0` across six relations and that `typed_evidence_transitions` is **exactly 1** — both become tautologically false the moment an earlier case in the same test has written anything;
  * `tribunal_evidence_return_v1_exercises_every_method_and_status_rule` asserts `check_results == 1` and `issues == 0|1`;
  * `tribunal_evidence_return_v1_every_fixture_is_submitted_and_normalized` does `SELECT outcome FROM typed_evidence_validation_results` with `fetch_one` and **no `WHERE`** — a textbook "the only row" read — plus five `ORDER BY`-ed `fetch_all` vector comparisons, also unscoped;
  * `normalized_counts` is six more unscoped counts.

  Making this file safe means rewriting every one of those censuses to be scoped to the case's own attempt/finding. That is a correct-in-principle change (each relation reaches its attempt through a `NOT NULL` FK, and `typed_evidence_validation_results.attempt_id` is `UNIQUE`), but the failure mode of getting one of those scoping joins subtly wrong is a census that returns `0` for the wrong reason — which turns "the rejection left nothing behind" into an assertion that can never fail. A silently vacuous conformance test is a worse outcome than the ~120s it costs, so this file is left exactly as it is.

  A separate PR can do it, and should land with the scoped censuses actually exercised.

## Verification

Honest statement of what was and was not run locally.

**Run before the local machine was taken out of service:**
* The baseline table above — a full `cargo nextest run` of both test binaries on the unmodified code, from which the clone counts and the "before" times are taken. All 18 non-timing-out tests passed.
* `cargo test -p djinn-db --test launcher_admission_compatibility_matrix --test tribunal_evidence_return_v1 --no-run` on the modified code: **compiled clean**, no errors and no warnings.

**Not run:** the modified tests themselves, the repeat/`--test-threads` sweep, and the deliberate-mutation non-vacuity probe. The local box is saturated by ~10 concurrent agents (16 backends queued on the test-template advisory lock at the time of writing, and the 64-cell test was killed by nextest's 90s `terminate-after` under that load), so running cargo here was stopped. **Compilation and test results are verified in CI**, and the isolation argument above is deliberately made from reading the schema and the repository code rather than from repeated runs — every claim in it is a static property (an unconditional `UPDATE`, a pure read, an absent `count(*)`), not an observation of a particular interleaving.

The non-vacuity probe that was planned and should be re-run by anyone reviewing this: delete the `mark_ready` call from `resolve()` so each case reads the previous case's artifact, and confirm `the_repository_seam_reports_exactly_what_the_decision_returns` fails. It must, per the discrimination argument above.

## Scope

`tests/` only. No `src/` files touched.
