### PR TITLE
perf(ci): tune the CI Postgres cluster and clone the test template with FILE_COPY

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,21 @@ services:
       - synchronous_commit=off
       - -c
       - full_page_writes=off
+      # wal_level=minimal + max_wal_senders=0 must be set together (Postgres
+      # refuses to start with minimal WAL and a non-zero walsender budget).
+      # This is the precondition for `CREATE DATABASE … STRATEGY = FILE_COPY`
+      # in server/crates/djinn-db/src/database.rs: nothing streams or archives
+      # this cluster's WAL, so there is no reason to WAL-log a template clone
+      # block by block. Mirrored in scripts/ci-start-postgres.sh.
+      - -c
+      - wal_level=minimal
+      - -c
+      - max_wal_senders=0
+      # Nothing in this cluster lives long enough to need vacuuming, and
+      # autovacuum workers otherwise chase thousands of short-lived
+      # `djinn_test_*` databases.
+      - -c
+      - autovacuum=off
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/scripts/ci-host-postgres-workflow.test.mjs
+++ b/scripts/ci-host-postgres-workflow.test.mjs
@@ -28,3 +28,53 @@ test('host setup preserves the existing PostgreSQL contract and fails on runner 
   assert.match(setupScript, /ALTER USER postgres WITH PASSWORD 'postgres'/);
   assert.match(setupScript, /ALTER SYSTEM SET port = '5433'/);
 });
+
+test('CI cluster is tuned for throwaway template-clone workloads', () => {
+  // `CREATE DATABASE … STRATEGY = FILE_COPY` in
+  // server/crates/djinn-db/src/database.rs trades per-block WAL for a
+  // checkpoint pair around every clone. Measured, that is ~5x SLOWER than the
+  // WAL_LOG default on a cluster with fsync=on. These settings are therefore
+  // a hard precondition of the clone strategy, not an independent tweak — if
+  // one is dropped without the other, CI gets slower, not faster.
+  for (const setting of [
+    "ALTER SYSTEM SET fsync = 'off'",
+    "ALTER SYSTEM SET synchronous_commit = 'off'",
+    "ALTER SYSTEM SET full_page_writes = 'off'",
+    "ALTER SYSTEM SET wal_level = 'minimal'",
+    "ALTER SYSTEM SET max_wal_senders = '0'",
+    "ALTER SYSTEM SET autovacuum = 'off'",
+  ]) {
+    assert.ok(setupScript.includes(setting), `missing: ${setting}`);
+  }
+
+  // wal_level=minimal and max_wal_senders=0 must land in the SAME restart:
+  // Postgres refuses to start with minimal WAL and a non-zero walsender
+  // budget. Both live in the single heredoc before the single restart.
+  const heredoc = setupScript.slice(
+    setupScript.indexOf("ALTER USER postgres WITH PASSWORD"),
+    setupScript.indexOf('\nSQL'),
+  );
+  assert.match(heredoc, /wal_level = 'minimal'/);
+  assert.match(heredoc, /max_wal_senders = '0'/);
+
+  // The settings must be asserted against the RUNNING server, not just
+  // written to postgresql.auto.conf and assumed.
+  assert.match(setupScript, /SHOW \$\{setting\}/);
+  assert.match(setupScript, /PostgreSQL tuning not applied/);
+});
+
+test('the FILE_COPY clone strategy and its preconditions ship together', () => {
+  const clone = readFileSync('server/crates/djinn-db/src/database.rs', 'utf8');
+  assert.match(clone, /STRATEGY = FILE_COPY/,
+    'template clone must be able to select the FILE_COPY strategy');
+  // FILE_COPY must stay gated on the precondition it needs. Measured, it is
+  // ~5.4x SLOWER than the WAL_LOG default against an fsync=on cluster, so a
+  // developer or worker pod pointed at a durable Postgres must not get it.
+  assert.match(clone, /SHOW fsync/,
+    'the clone strategy must be probed, not assumed');
+  const compose = readFileSync('docker-compose.yml', 'utf8');
+  for (const setting of ['fsync=off', 'wal_level=minimal', 'max_wal_senders=0']) {
+    assert.ok(compose.includes(setting),
+      `docker-compose postgres-test must set ${setting} for FILE_COPY to pay off`);
+  }
+});

--- a/scripts/ci-start-postgres.sh
+++ b/scripts/ci-start-postgres.sh
@@ -21,9 +21,52 @@ if ! pg_lsclusters --no-header | awk '{ print $1, $2 }' | grep -qx "${expected_m
 fi
 
 sudo pg_ctlcluster "$expected_major" main start
+
+# Durability-off tuning for the ephemeral CI cluster.
+#
+# ⚠ THROWAWAY DATA ONLY. `fsync=off`, `synchronous_commit=off` and
+# `full_page_writes=off` mean an OS crash or power loss leaves an
+# unrecoverable cluster. That is acceptable here and ONLY here: this script
+# runs exclusively from `.github/workflows/*.yml` against the GitHub runner's
+# bundled `postgresql@16-main` cluster, which is destroyed with the runner at
+# the end of the job. Production Postgres is a completely separate Helm
+# StatefulSet (`deploy/helm/djinn/templates/statefulset-postgres.yaml`) that
+# passes its own `-c` args and never sources this file. Local dev/test
+# Postgres is the `postgres-test` service in `docker-compose.yml`, which
+# already runs with the same durability-off settings on tmpfs.
+#
+# The workload this targets: ~3.2k DB-backed tests, each of which clones the
+# ~15MB `djinn_test_template` with `CREATE DATABASE … TEMPLATE` and drops it
+# again. That is the most fsync- and WAL-heavy shape Postgres has, and it runs
+# on the same runner disk as a ~400s cargo build and its target dir.
+#
+#   fsync/synchronous_commit/full_page_writes — mirror docker-compose.yml:
+#     drop every durability barrier on a cluster whose data is disposable.
+#     `fsync=off` is also the hard precondition for `CREATE DATABASE …
+#     STRATEGY = FILE_COPY` in `server/crates/djinn-db/src/database.rs`:
+#     FILE_COPY trades per-block WAL for a forced checkpoint before AND after
+#     every clone, which is only a win once checkpoints are cheap. That code
+#     probes `SHOW fsync` and declines FILE_COPY if this is ever reverted, so
+#     the two cannot silently drift apart.
+#   wal_level=minimal + max_wal_senders=0 — required as a pair (Postgres
+#     refuses to start with minimal WAL and a non-zero walsender budget).
+#     Nothing streams or archives this cluster's WAL, so there is no reason to
+#     retain any.
+#   autovacuum=off — nothing here lives long enough to need vacuuming, and
+#     autovacuum workers otherwise chase thousands of short-lived databases.
+#   shared_buffers/max_connections — match docker-compose.yml so the local and
+#     CI clusters behave the same under the suite's connection fan-out.
 sudo -u postgres psql --set=ON_ERROR_STOP=1 <<'SQL'
 ALTER USER postgres WITH PASSWORD 'postgres';
 ALTER SYSTEM SET port = '5433';
+ALTER SYSTEM SET fsync = 'off';
+ALTER SYSTEM SET synchronous_commit = 'off';
+ALTER SYSTEM SET full_page_writes = 'off';
+ALTER SYSTEM SET wal_level = 'minimal';
+ALTER SYSTEM SET max_wal_senders = '0';
+ALTER SYSTEM SET autovacuum = 'off';
+ALTER SYSTEM SET shared_buffers = '512MB';
+ALTER SYSTEM SET max_connections = '500';
 SQL
 sudo pg_ctlcluster "$expected_major" main restart
 
@@ -37,6 +80,30 @@ for attempt in {1..20}; do
     exit 1
   fi
   sleep 1
+done
+
+# Assert the tuning is live on the RUNNING server, not merely recorded in
+# postgresql.auto.conf. A silently-ignored setting (a future runner image
+# shipping a conflicting postgresql.conf `include`, or a `wal_level`/
+# `max_wal_senders` pair Postgres refuses and falls back on) would leave the
+# suite untuned AND leave `STRATEGY = FILE_COPY` paying for checkpoints it
+# cannot amortize. Fail the job instead.
+declare -A expected_settings=(
+  [fsync]=off
+  [synchronous_commit]=off
+  [full_page_writes]=off
+  [wal_level]=minimal
+  [max_wal_senders]=0
+  [autovacuum]=off
+)
+for setting in "${!expected_settings[@]}"; do
+  want="${expected_settings[$setting]}"
+  got="$(sudo -u postgres psql --port "$port" --tuples-only --no-align \
+    --command "SHOW ${setting}" 2>/dev/null || true)"
+  if [[ "$got" != "$want" ]]; then
+    echo "::error title=PostgreSQL tuning not applied::${setting} is '${got:-unset}', expected '${want}'"
+    exit 1
+  fi
 done
 
 if ! sudo -u postgres psql --port "$port" --tuples-only --no-align \

--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -703,7 +703,9 @@ async fn clone_postgres_test_template(server_prefix: &str, test_db: &str) -> DbR
         .await
         .map_err(DbError::from)?;
 
-        let stmt = format!(r#"CREATE DATABASE "{test_db}" TEMPLATE djinn_test_template"#);
+        let strategy = clone_strategy_clause(&mut conn).await;
+        let stmt =
+            format!(r#"CREATE DATABASE "{test_db}" TEMPLATE djinn_test_template{strategy}"#);
         sqlx::query(stmt.as_str())
             .execute(&mut conn)
             .await
@@ -721,6 +723,64 @@ async fn clone_postgres_test_template(server_prefix: &str, test_db: &str) -> DbR
 
     drop(conn);
     clone_result
+}
+
+/// Process-wide memo for [`clone_strategy_clause`]. The answer depends only on
+/// the server we are pointed at, which never changes within a test process.
+static CLONE_STRATEGY_CLAUSE: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
+
+/// Pick the `CREATE DATABASE … STRATEGY` clause for template clones.
+///
+/// PG16 defaults to `WAL_LOG`, which copies the template block by block and
+/// WAL-logs every block. `FILE_COPY` copies the directory at the filesystem
+/// level and writes one WAL record per tablespace instead.
+///
+/// FILE_COPY is not free: Postgres forces a checkpoint both *before* and
+/// *after* every `CREATE DATABASE` that uses it. Whether that trade wins is
+/// decided entirely by how expensive a checkpoint is — i.e. by `fsync`. On a
+/// durable cluster FILE_COPY is a large *regression*, not a win.
+///
+/// Local A/B on PG 16.14 against a clone of the real 190-migration template
+/// (~15MB), 120 clones at 8-way concurrency. WAL volume is exact and was
+/// identical across repeats; wall-clock was taken on a contended machine and
+/// indicates direction and rough magnitude only:
+///
+/// | cluster             | WAL_LOG           | FILE_COPY        |
+/// |---------------------|-------------------|------------------|
+/// | `fsync=on`  (stock) | 8.6s,  7.06 MB/clone | 46.7s, 0.006 MB/clone |
+/// | `fsync=off` (tuned) | 9.1s, 15.48 MB/clone |  5.8s, 0.001 MB/clone |
+///
+/// Two things follow. FILE_COPY removes essentially all clone WAL either way.
+/// But it is only *faster* once checkpoints are cheap: on the stock cluster it
+/// was ~5x slower than the default. Both clusters the suite is meant to run
+/// against set `fsync=off` (`docker-compose.yml` `postgres-test` and
+/// `scripts/ci-start-postgres.sh`), yet a developer or worker pod pointed at
+/// some other Postgres must not silently eat that regression — so probe the
+/// server once and opt in only when the precondition actually holds.
+///
+/// This does NOT change the template-connection contract. The "no other
+/// sessions may be connected to the source database" restriction is a property
+/// of `CREATE DATABASE` itself and applies identically to both strategies, so
+/// the shared advisory lock and `pg_terminate_backend` above stay exactly as
+/// load-bearing as they were.
+async fn clone_strategy_clause(conn: &mut sqlx::postgres::PgConnection) -> &'static str {
+    if let Some(cached) = CLONE_STRATEGY_CLAUSE.get() {
+        return *cached;
+    }
+
+    // A failed probe falls back to the Postgres default, never to FILE_COPY:
+    // the default is merely slower, FILE_COPY on the wrong cluster is much
+    // slower.
+    let fsync: Option<String> = sqlx::query_scalar::<_, String>("SHOW fsync")
+        .fetch_one(&mut *conn)
+        .await
+        .ok();
+    let clause: &'static str = if fsync.as_deref() == Some("off") {
+        " STRATEGY = FILE_COPY"
+    } else {
+        ""
+    };
+    *CLONE_STRATEGY_CLAUSE.get_or_init(|| clause)
 }
 
 fn is_safe_database_identifier(name: &str) -> bool {

--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -704,8 +704,7 @@ async fn clone_postgres_test_template(server_prefix: &str, test_db: &str) -> DbR
         .map_err(DbError::from)?;
 
         let strategy = clone_strategy_clause(&mut conn).await;
-        let stmt =
-            format!(r#"CREATE DATABASE "{test_db}" TEMPLATE djinn_test_template{strategy}"#);
+        let stmt = format!(r#"CREATE DATABASE "{test_db}" TEMPLATE djinn_test_template{strategy}"#);
         sqlx::query(stmt.as_str())
             .execute(&mut conn)
             .await


### PR DESCRIPTION
## What

Two coupled changes to the Postgres the test suite runs against.

1. **`scripts/ci-start-postgres.sh` is tuned.** It previously started the stock Ubuntu PG16 cluster with only a password and a port set. It now also sets `fsync=off`, `synchronous_commit=off`, `full_page_writes=off`, `wal_level=minimal` + `max_wal_senders=0`, `autovacuum=off`, `shared_buffers=512MB`, `max_connections=500` — then **asserts each one against the running server** (`SHOW <setting>`), so a silently-ignored setting fails the job instead of quietly leaving the suite untuned. `docker-compose.yml` gains the matching `wal_level`/`max_wal_senders`/`autovacuum` settings; it already had the durability trio.

2. **`clone_postgres_test_template` can issue `CREATE DATABASE … STRATEGY = FILE_COPY`**, which replaces per-block WAL logging of the ~15MB template with one WAL record per tablespace.

The workload being targeted: ~3,236 DB-backed tests, each cloning and dropping a ~15MB template — `CREATE DATABASE`/`DROP DATABASE`/catalog writes, the most fsync-sensitive thing Postgres does — on the same runner disk as a ~400s cargo build and its target dir.

## Why they ship together (and why FILE_COPY is *gated*, not hardcoded)

`FILE_COPY` forces a checkpoint **before and after every** `CREATE DATABASE`. Whether that trade wins is decided entirely by how expensive a checkpoint is. On a durable cluster it is a large **regression**.

Because of that, the strategy is **not** hardcoded. The clone path probes `SHOW fsync` once per process and opts into `FILE_COPY` only when it reads `off`, falling back to the PG default on any probe failure (fallback is merely slower; the wrong choice is much slower). A developer or worker pod pointed at some other Postgres keeps today's behaviour.

## Measurements — read the caveat

**These numbers are real but were taken on a heavily contended machine and must not be read as a CI wall-clock estimate.** Local A/B on a throwaway PG 16.14 container whose startup flags I fully controlled (the earlier attempt failed because the dev container's command-line `-c` flags override `ALTER SYSTEM`), against a database built by actually running all 190 migrations (15 MB, 1221 relations) — i.e. the real template, not a synthetic stand-in. 120 clones at 8-way concurrency, 3 interleaved repeat rounds with a server restart between config changes.

| round | cluster | strategy | create | WAL/clone |
|---|---|---|---|---|
| r1 | `fsync=on` (stock) | WAL_LOG (default) | 8.6s | 7.06 MB |
| r1 | `fsync=on` (stock) | FILE_COPY | 46.7s | 0.006 MB |
| r1 | `fsync=off` (tuned) | WAL_LOG | 9.1s | 15.48 MB |
| r1 | `fsync=off` (tuned) | **FILE_COPY** | **5.8s** | **0.001 MB** |
| r2 | stock / tuned | WAL_LOG | 11.1s / 17.1s | 7.06 / 15.48 MB |
| r2 | stock / tuned | FILE_COPY | 86.1s / **7.1s** | 0.006 / 0.001 MB |
| r3 | stock / tuned | WAL_LOG | 16.8s / 525.9s | 7.06 / 15.48 MB |
| r3 | stock / tuned | FILE_COPY | 270.5s / **53.6s** | 0.006 / 0.001 MB |

Host load average ranged from ~14 (r1) to ~150 (r3) because ~10 other agents were building concurrently, which is why absolute times swing by 50x across rounds. **What is robust is the ordering, which held 3/3 rounds**, and the WAL volumes, which were byte-identical across all repeats:

- **tuned + FILE_COPY was fastest in every round**, and the only arm that beat the stock baseline.
- **FILE_COPY without `fsync=off` was catastrophic in every round** (5.4x / 7.8x / 16.1x slower than that round's baseline). This is what motivated the `SHOW fsync` gate.
- **`wal_level=minimal` more than doubles WAL under the `WAL_LOG` default** (7.06 → 15.48 MB/clone, exactly reproducible). I did not chase the mechanism, but the practical consequence matters for review: **shipping the tuning without FILE_COPY would likely be a regression**, which is the concrete reason these belong in one PR rather than two.
- FILE_COPY drives clone WAL to ~0 regardless of `wal_level` (7.06 → 0.006 MB/clone). Extrapolating the stock figure over the full suite, WAL_LOG costs on the order of 23 GB of WAL per run purely to clone databases that are deleted minutes later.

**What is NOT measured: the actual CI wall-clock benefit.** I did not run the suite; local timings under this much contention cannot be extrapolated to a runner. Treat the CI gain as *reasoned* — the mechanism (removing fsync barriers and clone WAL from an fsync-bound workload) is sound and the direction is measured, but the magnitude on a runner will only be visible from CI itself.

## FILE_COPY caveats (from the PG16 docs + code)

- **Forced checkpoints.** Per the [PG16 docs](https://www.postgresql.org/docs/16/sql-createdatabase.html): FILE_COPY "forces the system to perform a checkpoint both before and after the creation of the new database. In some situations, this may have a noticeable negative impact on overall system performance." Measured above: exactly why it loses badly on `fsync=on`. Mitigated by gating on `SHOW fsync`.
- **Connections to the source database.** The restriction is on `CREATE DATABASE` itself, **not** on the strategy: "no other sessions can be connected to the template database while it is being copied. `CREATE DATABASE` will fail if any other connection exists when it starts." This is identical for `WAL_LOG` and `FILE_COPY`, so the existing `pg_terminate_backend` step remains necessary and sufficient — neither more nor less than before.
- **Durability model.** FILE_COPY relies on the checkpoint pair rather than WAL for the copied contents. Fine for a disposable test cluster; it is one more reason this is gated on a cluster that has already declared its data disposable.

## Advisory-lock interaction — unchanged

The `57P01` guard is untouched. Confirmed by reading the diff: the only change inside the locked region is the `CREATE DATABASE` statement string. `clone_postgres_test_template` still takes `pg_advisory_lock_shared` before `pg_terminate_backend`, still releases it on both the success and failure paths, and `ensure_test_template` still holds the same lock EXCLUSIVELY across its live template connection. Since the source-connection restriction is strategy-independent (above), FILE_COPY neither weakens nor strengthens what that lock is protecting.

The one-time `SHOW fsync` probe runs on the admin connection to the `postgres` maintenance DB *inside* the already-held shared lock, touches no template connection, and cannot introduce a new terminate race.

## Production-safety evidence

`fsync=off` is catastrophic for a real database, so this was checked by reading rather than assumed:

- **`scripts/ci-start-postgres.sh` has exactly three non-test callers, all CI workflows**: `.github/workflows/quality-gate.yml` (5 sites), `resize-matrix.yml`, `memory-qa-nightly.yml`. The only other references are assertions *about* the script (`scripts/ci-host-postgres-workflow.test.mjs`, `scripts/ci-qa-smoke-workflow.test.mjs`, `server/crates/djinn-k8s/tests/cutover_preflight.rs`).
- **It cannot reach production.** It operates on the GitHub runner's bundled `postgresql@16-main` cluster via `pg_ctlcluster`/`ALTER SYSTEM`, which is destroyed with the runner. Production Postgres is a separate Helm StatefulSet, `deploy/helm/djinn/templates/statefulset-postgres.yaml`, which passes its own `-c` args (`shared_buffers`, `max_connections`, `statement_timeout`, `lock_timeout`) and never sources this script. `grep -rn "ci-start-postgres" deploy/` returns nothing.
- **It cannot reach persistent developer data.** Local dev/test Postgres is the `postgres-test` service in `docker-compose.yml`, which is a separate container that already ran `fsync=off` **on tmpfs** before this PR — explicitly documented there as isolated from the shared dev DB.
- **No shared code path can pick these settings up**: they are `ALTER SYSTEM` statements against one named cluster inside a CI-only script, not a config file, env var, or library default.
- The `SHOW fsync` gate in `database.rs` is a read-only probe. It never *sets* `fsync`; it only declines an optimisation.

## tmpfs — considered and declined

Deliberately not done. Hosted runners have ~16GB RAM and the suite runs alongside a multi-GB cargo build; `nextest` uses the default thread count (4 vCPU), so peak concurrent test DBs is small, but sizing a tmpfs wrong OOMs the whole runner, which is strictly worse than the problem being solved. With `fsync=off` the durability barrier — the actual cost — is already gone and the page cache absorbs the writes, so tmpfs would buy little for real OOM risk. Revisit only with runner-side numbers.

## Verification status

- **Verified locally (cargo-free):** `node --test scripts/ci-host-postgres-workflow.test.mjs` passes (4/4). `bash -n scripts/ci-start-postgres.sh` and `docker compose config` are clean.
- **Non-vacuity probed** — each new guard was broken and observed to fail, then reverted: removing `wal_level` from the script → *"missing: ALTER SYSTEM SET wal_level = 'minimal'"*; replacing the `SHOW fsync` probe → *"the clone strategy must be probed, not assumed"*; flipping compose to `wal_level=replica` → *"docker-compose postgres-test must set wal_level=minimal for FILE_COPY to pay off"*.
- **Compilation is NOT verified locally** — cargo could not be run on this machine. (An earlier `cargo check` reported exit 0, but that was `tail`'s exit code through a pipe and the run was killed mid-way, so it proves nothing; flagging it rather than banking it.) CI is the compiler here.
- The Postgres A/B above is measured; **the CI wall-clock gain is reasoned, not measured.**

## Coordination

Touches `server/crates/djinn-db/src/database.rs` only at the clone SQL (~:706) plus a new function appended after `clone_postgres_test_template`. Stays clear of the concurrent work on `Drop for TestDbInit` (~:166-202) and `ensure_test_template` on `perf/db-test-template-no-per-process-reverify`.
