### PR TITLE
ci: stop a cancelled run from manufacturing a required-check failure

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -223,6 +223,12 @@ jobs:
         run: node --test scripts/ci-cache-policy.test.mjs
       - name: Verify qa-smoke workflow contract
         run: node --test scripts/ci-qa-smoke-workflow.test.mjs
+      # Sweeps EVERY workflow, not just this one: an artifact upload that is
+      # reachable on a cancelled run while `if-no-files-found: error` is set
+      # turns a cancellation into a manufactured step failure. That is how run
+      # 31137003502 reddened the Quality Gate with all lanes green.
+      - name: Verify artifact uploads cannot manufacture a cancellation failure
+        run: node --test scripts/ci-artifact-upload-guards.test.mjs
       - name: Verify host PostgreSQL workflow contract
         run: node --test scripts/ci-host-postgres-workflow.test.mjs
       - name: Verify release image validation contract
@@ -2403,6 +2409,7 @@ jobs:
       - name: Validate fixtures
         run: cargo run -p djinn-memory-eval -- validate-fixtures
       - name: Run Phase 1 benchmark
+        id: phase1_run
         env:
           DJINN_TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/postgres
         run: cargo run -p djinn-memory-eval -- run
@@ -2410,8 +2417,19 @@ jobs:
         env:
           DJINN_TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5433/postgres
         run: cargo run -p djinn-memory-eval -- compare
+      # Same hazard as the qa-smoke evidence upload below; see the long comment
+      # there for the run-31137003502 chain. memory-eval is likewise a
+      # Quality-Gate-checked lane, so `always()` here would let a cancellation
+      # manufacture a `failure` on a required check. `phase1_run` is the step
+      # that writes phase1-report.json — if it never ran, neither report exists
+      # and there is nothing this upload could legitimately find.
+      #
+      # `if-no-files-found: error` stays for the same reason: past these guards
+      # the benchmark executed, and an executed benchmark that emits no report
+      # is a real defect. (Only the "no path matched anything" case errors, so
+      # a run that produced the report but not the summary still uploads.)
       - name: Upload Phase 1 report artifacts
-        if: always()
+        if: ${{ !cancelled() && steps.phase1_run.outcome != 'skipped' }}
         uses: actions/upload-artifact@v4
         with:
           name: memory-eval-phase1-report
@@ -2481,6 +2499,7 @@ jobs:
           cargo test -p djinn-slot --no-run
           cargo test -p djinn-db --no-run
       - name: Run deterministic qa smoke and coverage gate
+        id: qa_smoke_run
         run: |
           set +e
           target/debug/djinn-qa run --qa-profile smoke-ci --concurrency 8 --repo-root .. --evidence-dir qa/evidence/smoke-ci
@@ -2494,8 +2513,37 @@ jobs:
           if [ "$runner_status" -ne 0 ] || [ "$coverage_status" -ne 0 ]; then
             exit 1
           fi
+      # This guard is NOT `always()`, and the difference is a merge-blocker.
+      #
+      # `always()` also fires when the RUN was cancelled. Run 31137003502 on
+      # PR #3064 was cancelled externally at 01:14:02; every lane had already
+      # SUCCEEDED at 01:12:26 and no job failed. But cancellation ended
+      # "Precompile selected smoke test binaries" as `cancelled`, which left
+      # "Run deterministic qa smoke and coverage gate" `skipped`, so
+      # qa/evidence/smoke-ci was never created. This upload ran anyway on
+      # `always()`, `if-no-files-found: error` fired on the empty path, and the
+      # STEP failed — flipping qa-smoke's result from `cancelled` to `failure`
+      # and reddening the sole required check. A cancellation was laundered
+      # into a test-shaped failure, and the log blamed qa-smoke for a defect
+      # that did not exist.
+      #
+      # `!cancelled()` keeps the real intent — evidence from a smoke run that
+      # RAN and FAILED is exactly what an investigator needs, so `failure()` is
+      # still covered — while refusing to invent an artifact error out of a
+      # producer the runner never allowed to start. The `outcome != 'skipped'`
+      # clause closes the same hazard's other door: when an earlier step (the
+      # template build, the runner build, the precompile) fails on its own, the
+      # smoke step is skipped rather than cancelled, and uploading then would
+      # bury that genuine root cause under a spurious artifact error.
+      #
+      # `if-no-files-found: error` deliberately STAYS. Past those two guards
+      # the smoke step actually executed, and a smoke step that executes and
+      # leaves no evidence behind is an evidence-integrity hole, not a
+      # non-event: the coverage gate would have nothing to have been computed
+      # from. That must stay loud, or qa-smoke can go green having proven
+      # nothing.
       - name: Upload qa smoke evidence
-        if: always()
+        if: ${{ !cancelled() && steps.qa_smoke_run.outcome != 'skipped' }}
         uses: actions/upload-artifact@v4
         with:
           name: qa-smoke-evidence

--- a/scripts/ci-artifact-upload-guards.test.mjs
+++ b/scripts/ci-artifact-upload-guards.test.mjs
@@ -1,0 +1,158 @@
+// Guard: a CANCELLED run must never be laundered into a FAILED required check.
+//
+// THE DEFECT THIS EXISTS TO PREVENT
+//
+// Run 31137003502 on PR #3064 was cancelled externally at 01:14:02. Every lane
+// had already SUCCEEDED at 01:12:26 and no job failed. The `Quality Gate`
+// required check nevertheless ended `failure` and blocked the PR. The chain:
+//
+//   1. cancellation ended qa-smoke's "Precompile selected smoke test binaries"
+//      as `cancelled`;
+//   2. so "Run deterministic qa smoke and coverage gate" was `skipped`, and
+//      qa/evidence/smoke-ci was never created;
+//   3. but "Upload qa smoke evidence" was guarded `if: always()`, and
+//      `always()` fires on cancellation too, so it RAN;
+//   4. `actions/upload-artifact@v4` with `if-no-files-found: error` found
+//      nothing, emitted `##[error]No files were found with the provided
+//      path`, and FAILED the step;
+//   5. that flipped qa-smoke's job result from `cancelled` to `failure`, and
+//      the fail-closed Quality Gate reported a test-shaped failure.
+//
+// Nothing was broken. The failure was manufactured by the guard, and it also
+// destroyed the diagnostic signal: the run reads as "qa-smoke broke".
+//
+// THE RULE
+//
+// An `actions/upload-artifact` step may combine a cancellation-permissive
+// guard (`always()`) with `if-no-files-found: error` only if it cannot be
+// reached with its producer skipped. Since that is not decidable from text,
+// the combination is banned outright. Either the guard must exclude
+// cancellation (`!cancelled()`, or `success() || failure()`), or the missing
+// path must be non-fatal (`warn`/`ignore`).
+//
+// The ban is deliberately narrow. `always()` on a step that only echoes, or
+// that tests for its own inputs (`if [[ -f "$SUMMARY" ]]`), cannot manufacture
+// anything and is left alone — as are `always()` teardown steps, which are the
+// whole point of `always()`.
+
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+import { scriptCode } from './lib/source-text.mjs';
+
+const WORKFLOW_DIR = resolve('.github/workflows');
+
+function workflowFiles() {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .sort();
+}
+
+// Split a workflow into steps by the `- ` list marker at any indentation that
+// introduces a mapping. Comments are stripped first so prose about `always()`
+// (there is a lot of it in this repo) is never mistaken for a guard.
+function uploadSteps(source) {
+  const lines = scriptCode(source).split('\n');
+  const found = [];
+  let current = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const marker = line.match(/^(\s*)-\s+\S/);
+    if (marker) {
+      if (current) found.push(current);
+      current = { indent: marker[1].length, lines: [line], start: index + 1 };
+      continue;
+    }
+    if (!current) continue;
+    // A line indented no further than the step's own `-` ends the step.
+    const indent = line.search(/\S/);
+    if (indent >= 0 && indent <= current.indent) {
+      found.push(current);
+      current = null;
+      continue;
+    }
+    current.lines.push(line);
+  }
+  if (current) found.push(current);
+
+  return found
+    .map((step) => ({ ...step, text: step.lines.join('\n') }))
+    .filter((step) => /\bactions\/upload-artifact@/.test(step.text));
+}
+
+function stepGuard(step) {
+  return step.text.match(/^\s*if:\s*(.+?)\s*$/m)?.[1];
+}
+
+function ifNoFilesFound(step) {
+  return step.text.match(/^\s*if-no-files-found:\s*(\S+)\s*$/m)?.[1];
+}
+
+// `always()` is true even when the run was cancelled. Any guard that reduces
+// to it — bare, or ANDed with unrelated conditions as in
+// `always() && steps.shard.outputs.active == 'true'` — is permissive.
+function permitsCancellation(guard) {
+  if (guard === undefined) return false; // default `if` is `success()`
+  return /\balways\(\)/.test(guard);
+}
+
+test('no artifact upload can turn a cancelled run into a failed step', () => {
+  const offenders = [];
+  for (const file of workflowFiles()) {
+    const source = readFileSync(join(WORKFLOW_DIR, file), 'utf8');
+    for (const step of uploadSteps(source)) {
+      const guard = stepGuard(step);
+      if (!permitsCancellation(guard)) continue;
+      if (ifNoFilesFound(step) !== 'error') continue;
+      const name = step.text.match(/name:\s*(.+)/)?.[1] ?? '(unnamed)';
+      offenders.push(`${file}:${step.start} "${name}" — if: ${guard}`);
+    }
+  }
+
+  assert.deepEqual(offenders, [],
+    'these upload steps combine a cancellation-permissive guard with '
+    + '`if-no-files-found: error`, so a cancelled run manufactures a step '
+    + 'failure on a lane where nothing broke. Use `!cancelled()` (or '
+    + '`success() || failure()`), or downgrade to `warn`/`ignore`:\n'
+    + offenders.join('\n'));
+});
+
+// The regexes above must actually catch the shipped defect, or this file is a
+// guard that asserts nothing. Replay run 31137003502's exact step text.
+test('the guard catches the run-31137003502 step shape', () => {
+  const regressed = [
+    'jobs:',
+    '  qa-smoke:',
+    '    steps:',
+    '      - name: Upload qa smoke evidence',
+    '        if: always()',
+    '        uses: actions/upload-artifact@v4',
+    '        with:',
+    '          name: qa-smoke-evidence',
+    '          path: qa/evidence/smoke-ci',
+    '          if-no-files-found: error',
+    '          retention-days: 30',
+  ].join('\n');
+
+  const [step] = uploadSteps(regressed);
+  assert.ok(step, 'the step splitter must find the upload step');
+  assert.equal(stepGuard(step), 'always()');
+  assert.equal(ifNoFilesFound(step), 'error');
+  assert.equal(permitsCancellation(stepGuard(step)), true);
+
+  // ...and must NOT flag the fix, nor the safe variants already in the tree.
+  assert.equal(permitsCancellation("${{ !cancelled() && steps.qa_smoke_run.outcome != 'skipped' }}"), false);
+  assert.equal(permitsCancellation('success() || failure()'), false);
+  assert.equal(permitsCancellation(undefined), false);
+  assert.equal(permitsCancellation("always() && steps.shard.outputs.active == 'true'"), true);
+
+  // A comment mentioning always() is prose, not a guard.
+  const commented = regressed
+    .replace('        if: always()', '        # once guarded by if: always()\n        if: !cancelled()');
+  const [safe] = uploadSteps(commented);
+  assert.equal(permitsCancellation(stepGuard(safe)), false,
+    'a stripped comment must not be read as a step guard');
+});

--- a/scripts/ci-qa-smoke-workflow.test.mjs
+++ b/scripts/ci-qa-smoke-workflow.test.mjs
@@ -286,7 +286,7 @@ test('qa-smoke builds, precompiles, and directly executes in deterministic order
     'no qa-smoke step may use nested cargo-run lock execution');
 });
 
-test('qa-smoke preserves rooted evidence and uploads it even after failures', () => {
+test('qa-smoke preserves rooted evidence and uploads it after failures but not cancellation', () => {
   const qa = parseJobs(readFileSync(WORKFLOW, 'utf8')).jobs.get('qa-smoke');
   assert.ok(qa, 'qa-smoke job must exist');
   const run = stepText(namedStep(qa, 'Run deterministic qa smoke and coverage gate'));
@@ -299,12 +299,88 @@ test('qa-smoke preserves rooted evidence and uploads it even after failures', ()
 
   const upload = namedStep(qa, 'Upload qa smoke evidence');
   const uploadSource = stepText(upload);
-  assert.match(uploadSource, /^ {8}if:\s*always\(\)\s*$/m, 'evidence upload must be unconditional');
+  // NOT `always()`. See the new-contract test below and the workflow comment:
+  // `always()` also fires on cancellation, and combined with
+  // `if-no-files-found: error` it manufactured a qa-smoke `failure` on the
+  // fully-green, externally-cancelled run 31137003502.
+  assert.doesNotMatch(uploadSource, /^ {8}if:.*\balways\(\)/m,
+    'evidence upload must not run on a cancelled run');
   assert.match(uploadSource, /actions\/upload-artifact@v4/, 'evidence must be an artifact');
   assert.match(uploadSource, /^ {10}path:\s*qa\/evidence\/smoke-ci\s*$/m,
     'artifact path must be rooted at qa/evidence/smoke-ci');
   assert.match(uploadSource, /^ {10}if-no-files-found:\s*error\s*$/m,
     'missing smoke evidence must fail the job');
+});
+
+// Evaluate a step `if:` the way the Actions runner does, for the two inputs
+// that decide this defect: the job's status so far, and the outcome of the
+// step that PRODUCES the evidence. Asserting behaviour rather than an exact
+// string keeps the contract honest without pinning one spelling — both
+// `!cancelled() && …` and `success() || failure()` are legitimate answers to
+// the cancellation half.
+function evaluateGuard(expression, { jobStatus, producerOutcome }) {
+  const resolved = expression
+    .replace(/^\$\{\{\s*/, '')
+    .replace(/\s*\}\}$/, '')
+    .replace(/\balways\(\)/g, 'true')
+    .replace(/\bcancelled\(\)/g, String(jobStatus === 'cancelled'))
+    .replace(/\bsuccess\(\)/g, String(jobStatus === 'success'))
+    .replace(/\bfailure\(\)/g, String(jobStatus === 'failure'))
+    .replace(/\bsteps\.[A-Za-z0-9_]+\.outcome\b/g, JSON.stringify(producerOutcome))
+    .replace(/'/g, '"')
+    // `!=` is parked on a sentinel first so the `==` rewrite cannot see it
+    // and turn `!=` into `!===`.
+    .replace(/!=/g, '\u0000')
+    .replace(/==/g, '===')
+    .replace(/\u0000/g, '!==');
+
+  // Fail closed rather than eval anything unexpected: if a future guard uses a
+  // context this evaluator does not model, that must be a loud test failure,
+  // not a silently-true assertion.
+  assert.match(resolved, /^[\s\w!&|()="<>.]*$/,
+    `guard uses an expression this test cannot model: ${expression}`);
+  return Boolean(new Function(`"use strict"; return (${resolved});`)());
+}
+
+test('cancellation cannot manufacture a qa-smoke failure', () => {
+  const qa = parseJobs(readFileSync(WORKFLOW, 'utf8')).jobs.get('qa-smoke');
+  assert.ok(qa, 'qa-smoke job must exist');
+
+  const producer = namedStep(qa, 'Run deterministic qa smoke and coverage gate');
+  const producerId = stepText(producer).match(/^ {8}id:\s*(\S+)\s*$/m)?.[1];
+  assert.ok(producerId, 'the smoke step must carry an id so the upload can key on its outcome');
+
+  const guard = stepText(namedStep(qa, 'Upload qa smoke evidence')).match(/^ {8}if:\s*(.+?)\s*$/m)?.[1];
+  assert.ok(guard, 'the evidence upload must carry an explicit guard');
+  assert.ok(guard.includes(producerId),
+    'the evidence upload must key on the smoke step it uploads the output of');
+
+  // THE REGRESSION. Run 31137003502: cancelled externally, so the precompile
+  // ended `cancelled` and the smoke step never ran. `if-no-files-found: error`
+  // on a path that was never created is a step failure, so the upload MUST NOT
+  // run here — otherwise a cancellation becomes a required-check failure.
+  assert.equal(evaluateGuard(guard, { jobStatus: 'cancelled', producerOutcome: 'skipped' }), false,
+    'a cancelled run must not run the evidence upload');
+
+  // The same hazard's other door: an earlier step (template build, runner
+  // build, precompile) fails on its own, so the smoke step is `skipped` and
+  // wrote nothing. Uploading would bury that real root cause under a spurious
+  // "No files were found" error.
+  assert.equal(evaluateGuard(guard, { jobStatus: 'failure', producerOutcome: 'skipped' }), false,
+    'a skipped producer must not trigger the evidence upload');
+
+  // ...while the ORIGINAL intent survives intact: evidence from a smoke run
+  // that actually ran is uploaded whether it passed or failed. The failing
+  // case is the one an investigator most needs.
+  assert.equal(evaluateGuard(guard, { jobStatus: 'failure', producerOutcome: 'failure' }), true,
+    'evidence from a smoke run that RAN and FAILED must still upload');
+  assert.equal(evaluateGuard(guard, { jobStatus: 'success', producerOutcome: 'success' }), true,
+    'evidence from a passing smoke run must still upload');
+
+  // `always()` is exactly what shipped, and it fails the first assertion —
+  // proving these cases discriminate rather than passing on anything.
+  assert.equal(evaluateGuard('always()', { jobStatus: 'cancelled', producerOutcome: 'skipped' }), true,
+    'the shipped always() guard must be shown to run on cancellation');
 });
 
 test('Quality Gate aggregates qa-smoke results fail-closed', () => {


### PR DESCRIPTION
## The bug

CI run [`31137003502`](https://github.com/djinnos/djinn/actions/runs/31137003502) (PR #3064) was **cancelled externally** at 01:14:02 on 2026-08-07. Every lane had SUCCEEDED by 01:12:26. **No job failed.** Yet the `Quality Gate` required check ended `failure` and blocked the PR.

### Evidence chain

1. Run cancelled externally → `qa-smoke` step 9 *"Precompile selected smoke test binaries"* ends `cancelled`.
2. Step 10 *"Run deterministic qa smoke and coverage gate"* is therefore `skipped`, so `qa/evidence/smoke-ci` is **never created**.
3. Step 11 *"Upload qa smoke evidence"* (`quality-gate.yml:2497-2502`) was guarded **`if: always()`** — and `always()` fires on cancellation too — so it **ran anyway**. `actions/upload-artifact@v4` with `if-no-files-found: error` emitted:
   ```
   ##[error]No files were found with the provided path: qa/evidence/smoke-ci. No artifacts will be uploaded.
   ```
   and the **step failed**.
4. That flipped `qa-smoke`'s job result from `cancelled` to `failure`, and the fail-closed `Quality Gate` reported it.

**Net:** a cancellation was laundered into a *test-shaped failure* on the sole required check. It also destroyed the diagnostic signal — the run reads as "qa-smoke broke" when nothing did.

## The fix

Both offending uploads are now guarded on `!cancelled() && <producer>.outcome != 'skipped'`, keying on an `id` added to the step that actually produces the artifact.

| | before | after |
|---|---|---|
| `qa-smoke` → *Upload qa smoke evidence* | `if: always()` | `if: ${{ !cancelled() && steps.qa_smoke_run.outcome != 'skipped' }}` |
| `memory-eval` → *Upload Phase 1 report artifacts* | `if: always()` | `if: ${{ !cancelled() && steps.phase1_run.outcome != 'skipped' }}` |

**Intent is preserved.** `!cancelled()` still covers `failure()`, so evidence from a smoke run that **ran and failed** — the case an investigator most needs — still uploads. What it refuses is inventing an artifact error out of a producer the runner never allowed to start.

The `outcome != 'skipped'` clause closes the *same hazard's other door*: when an earlier step (template build, runner build, precompile) fails on its own, the producer is `skipped` rather than `cancelled`, and uploading then would bury that genuine root cause under a spurious "No files were found" error.

**`if-no-files-found: error` deliberately STAYS on both** — the "loud" choice. Past those two guards the producer *actually executed*, and a smoke step that executes and leaves no evidence behind is an evidence-integrity hole, not a non-event: the coverage gate would have had nothing to compute from. Downgrading to `warn` here would let `qa-smoke` go green having proven nothing. (Only the "no path matched anything at all" case errors, so memory-eval producing the report but not the summary still uploads.)

## Sweep

All 14 `if: always()` guards across all 9 workflows, every artifact-upload and post-processing step audited for the "producer skipped → consumer errors on missing input" hazard.

| # | Site | Guard | Verdict |
|---|---|---|---|
| 1 | `quality-gate.yml:2497` **Upload qa smoke evidence** | `always()` + `if-no-files-found: error` | 🔴 **FIXED** — the reported bug |
| 2 | `quality-gate.yml:2413` **Upload Phase 1 report artifacts** (memory-eval) | `always()` + `if-no-files-found: error` | 🔴 **FIXED** — identical pattern, also a gate-checked lane |
| 3 | `quality-gate.yml:464` Report warm footprint | `always()` | ✅ Safe — `echo`/`du`/`df` only, `2>/dev/null` fallbacks, no input dependency |
| 4 | `quality-gate.yml:477` Log cache family and restore status | `always()` | ✅ Safe — pure `echo` |
| 5 | `quality-gate.yml:962` Fingerprint census (after clippy) | `always()` | ✅ Safe — `ls … 2>/dev/null \| wc -l`, `${before:-0}` default |
| 6 | `quality-gate.yml:2089` Upload retained shard timing data | `always() && steps.shard.outputs.active` | ✅ Safe — `if-no-files-found: **warn**` cannot fail the step |
| 7 | `quality-gate.yml:2442` Write job summary (memory-eval) | `always()` | ✅ Safe — tests for its own input with `[[ -f "$SUMMARY" ]]` |
| 8 | `quality-gate.yml:2588` **Quality Gate job itself** | `always() && event != push` | ✅ Intentional — the aggregator must run to fail closed. See recommendation below |
| 9 | `release.yml:227` | `always()` + `if-no-files-found: **warn**` | ✅ Safe — warn cannot fail |
| 10 | `memory-qa-nightly.yml:158` Upload Phase 2 QA artifacts | `always()` + `if-no-files-found: **warn**` | ✅ Safe — already documents this exact reasoning in-file; also non-gating |
| 11 | `memory-qa-nightly.yml:172` Write Phase 2 job summary | `always()` | ✅ Safe — `[[ -f ]]` guarded with an `else` branch |
| 12 | `cache-prune.yml:98` Report remaining budget | `always()` | ✅ Safe — queries the GitHub API directly, no producer step; non-gating workflow |
| 13-15 | `resize-kind.yml:106,212`, `resize-matrix.yml:166`, `kueue-cluster-harness.yml:131` | `always() && keep_on_failure != 'true'` | ✅ Intentional — teardown steps; `always()` **is** the point (both files say so in a comment) |

Uploads with `if-no-files-found: error` but **no** `if:` guard (`quality-gate.yml:179,1662,2212`; `release.yml:270,380,386,392`) default to `if: success()` and cannot be reached with a skipped producer. Safe.

**No non-`always()` cancellation-permissive guards existed** (`success() || failure()`: zero hits).

## Gate recommendation: do NOT change it — and I have not

The `Quality Gate` `check()` helper passes only `selected=true && result=success`, so a `cancelled` lane fails. **This is correct and is left untouched.**

A cancelled test shard means **its tests never ran**. Teaching the gate to treat `cancelled` as a pass would be a textbook green-with-zero-executions trap: a well-timed cancellation would become a way to land unverified code through the sole required check. The blast radius is every gated lane at once.

The defect was never that the gate failed on cancellation. It is that **a cancellation manufactured a `failure`** one layer below. With this PR the gate still fails a cancelled run — but it now reports `lane qa-smoke selected=true result=cancelled`, which is honest and immediately actionable, instead of `result=failure`, which sent readers hunting a test defect that did not exist. Re-running the cancelled run is the correct remedy in both cases; only now does the log say so.

## Verification

- ✅ `actionlint` clean (exit 0, all 9 workflows).
- ✅ `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/quality-gate.yml'))"` OK.
- ✅ **Failure mode simulated locally.** Modelling both real mechanisms (GitHub step-condition evaluation + `upload-artifact`'s `if-no-files-found` decision, run against a genuinely absent path):

  | Scenario | evidence on disk | honest result | OLD `always()` | NEW guard |
  |---|---|---|---|---|
  | **A.** run 31137003502: cancelled mid-precompile | ABSENT | `cancelled` | upload **RAN** → `##[error]No files were found…` → job=**`failure`** ❌ **launders cancelled→failure** | upload skipped → job=`cancelled` ✅ |
  | **B.** earlier step failed, smoke skipped | ABSENT | `failure` | upload RAN → spurious artifact error masks root cause | upload skipped ✅ |
  | **C.** smoke RAN and failed | present | `failure` | uploaded 1 file | uploaded 1 file ✅ **evidence preserved** |
  | **D.** smoke RAN and passed | present | `success` | uploaded 1 file | uploaded 1 file ✅ **evidence preserved** |

- ✅ **New sweep guard proven to discriminate.** `scripts/ci-artifact-upload-guards.test.mjs` replayed against the **pre-fix** tree (`origin/main`) fails with exactly:
  ```
  quality-gate.yml:2413 "Upload Phase 1 report artifacts" — if: always()
  quality-gate.yml:2497 "Upload qa smoke evidence" — if: always()
  ```
  and passes on this branch. It also self-tests its own parser against the shipped step text, so it cannot silently degrade into a guard that asserts nothing.
- ✅ **Node CI suites: 151/151 pass** across `check-ci-timeouts`, `ci-cache-policy`, `ci-changed-scope`, `ci-file-size-report`, `ci-host-postgres-workflow`, `ci-mold-trixie-apt-smoke`, `ci-nextest-plan`, `ci-qa-smoke-workflow`, `ci-release-image-validation`, `ci-shard-failure-summary`, `ci-source-text`, `ci-artifact-upload-guards`. Plus `tool-goldens` 23/23.
- ✅ The existing static guard `ci-qa-smoke-workflow.test.mjs` asserted `if: always()` verbatim, so it *required* the bug. Updated to encode the new contract, and extended with a test that evaluates the guard expression under all four producer/job states rather than pinning one spelling — `success() || failure()` would also satisfy the cancellation half.
- No Rust build; no `cargo` run.

## Notes for reviewers

- New guard is registered in `ci-contracts` so the sweep is enforced repo-wide going forward.
- Changes are localized to lines ~2409-2430 and ~2499-2545 plus one step in `ci-contracts`; several agents are concurrently editing this file around ~2023/~2090/~2588, so expect a trivial rebase.
