### PR TITLE
fix(ci): bound the build-lease-cap rustc visibility probe and stop it decoding rlibs

### DIFF
--- a/server/crates/djinn-coordinator/src/build_lease_cap.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_cap.rs
@@ -212,6 +212,8 @@ impl BuildLeaseService {
 #[cfg(test)]
 mod capacity_tests {
     use super::*;
+    use std::time::Duration;
+
     #[test]
     fn compile_bound_precondition_exhausts_launcher_and_authority_modes() {
         for launcher in [
@@ -240,9 +242,32 @@ mod capacity_tests {
         }
     }
 
+    /// Wall-clock bound on the compile-fail visibility probe below.
+    ///
+    /// The probe shells out to `rustc`. It used to do so with no bound at all,
+    /// which is how it turned into a HARD CI failure rather than a flake: in
+    /// run 30727348884 nextest's `slow-timeout = { period = "30s",
+    /// terminate-after = 3 }` (`.config/nextest.toml`) terminated it on all
+    /// three attempts, 90s apiece, and reported a bare TMT with no stderr, no
+    /// exit status, and nothing to distinguish "the visibility property
+    /// regressed" from "the toolchain was starved for disk". Retries cannot
+    /// help — every attempt re-runs the same cold-I/O work under the same
+    /// load — so the useful thing a retry budget can buy is not another
+    /// attempt but an ATTRIBUTABLE failure, which is what this bound produces.
+    ///
+    /// 60s sits below nextest's 90s termination point on purpose, so this
+    /// assertion is what fires first and the panic message is what the lane
+    /// reports.
+    const VISIBILITY_PROBE_TIMEOUT: Duration = Duration::from_secs(60);
+
     #[test]
     fn build_lease_cap_api_visibility() {
-        use std::{fs, process::Command, time::SystemTime};
+        use std::{
+            fs::{self, File},
+            process::{Command, Stdio},
+            thread::sleep,
+            time::{Instant, SystemTime},
+        };
 
         let deps = std::env::current_exe()
             .expect("current test executable")
@@ -272,8 +297,34 @@ mod capacity_tests {
             "/tests/ui/build_lease_cap_private.rs"
         );
         let output_dir = tempfile::tempdir().expect("compile-fail output directory");
-        let output = Command::new("rustc")
-            .args(["--edition=2021", "--crate-type=bin"])
+        let stderr_path = output_dir.path().join("probe.stderr");
+        let stderr_sink = File::create(&stderr_path).expect("compile-fail stderr sink");
+
+        // `--emit=metadata` is the cost fix, and it is safe precisely BECAUSE
+        // of what this probe asserts. Every diagnostic below is a name
+        // resolution / field privacy error, all of which are produced during
+        // type checking; nothing downstream of typeck is needed to observe
+        // them, and the probe never links because it never compiles.
+        //
+        // What the flag buys is the crate loader's behaviour. With no object
+        // code requested, `-L dependency` lookups for `djinn-coordinator`'s
+        // transitive crates are satisfied from their `.rmeta` instead of being
+        // decoded out of their `.rlib`. That directory is the whole workspace's
+        // `target/debug/deps`: thousands of entries, several stale ~113MB
+        // `libdjinn_coordinator-*.rlib` candidates among them, cold-restored by
+        // `rust-cache` on CI while the sibling test processes in the same shard
+        // compete for the same disk. Reading metadata sidecars instead of
+        // fully-linked archives is the difference between the probe being
+        // cheap and the probe being the reason a shard goes red.
+        //
+        // Diagnostics are unchanged: a rustc that rejected the flag, or a probe
+        // that stopped emitting these errors, fails the assertions below with
+        // the captured stderr attached rather than passing vacuously.
+        //
+        // Stderr goes to a file rather than a pipe so this cannot deadlock on a
+        // full pipe buffer while the test is polling for exit.
+        let mut probe = Command::new("rustc")
+            .args(["--edition=2021", "--crate-type=bin", "--emit=metadata"])
             .arg(source)
             .arg("--extern")
             .arg(format!("djinn_coordinator={}", coordinator_rlib.display()))
@@ -281,18 +332,59 @@ mod capacity_tests {
             .arg(format!("dependency={}", deps.display()))
             .arg("--out-dir")
             .arg(output_dir.path())
-            .output()
-            .expect("run rustc visibility probe");
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(stderr_sink))
+            .spawn()
+            .expect("spawn rustc visibility probe");
 
+        let started = Instant::now();
+        let timed_out = loop {
+            if probe
+                .try_wait()
+                .expect("poll rustc visibility probe")
+                .is_some()
+            {
+                break false;
+            }
+            if started.elapsed() >= VISIBILITY_PROBE_TIMEOUT {
+                let _ = probe.kill();
+                break true;
+            }
+            sleep(Duration::from_millis(25));
+        };
+        // Unconditional, on both paths: `Child::wait` returns the status
+        // `try_wait` already cached, so this reaps the killed probe without
+        // changing what the successful path observes.
+        let status = probe.wait().expect("reap rustc visibility probe");
+        let budget = VISIBILITY_PROBE_TIMEOUT;
+        let elapsed = started.elapsed();
+        let search_path = deps.display();
         assert!(
-            !output.status.success(),
-            "visibility probe unexpectedly compiled"
+            !timed_out,
+            "rustc visibility probe did not finish within {budget:?} (elapsed {elapsed:?}) and \
+             was killed. The API-visibility property was NOT evaluated: this is a toolchain or \
+             disk-contention stall reading {search_path}, not a visibility regression, and \
+             re-running will reproduce it."
         );
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(stderr.contains("field `cap` of struct `BuildLeaseService` is private"));
+
+        let stderr = fs::read_to_string(&stderr_path).expect("read visibility probe stderr");
         assert!(
-            stderr.contains("field `derived_fallback` of struct `BuildLeaseService` is private")
+            !status.success(),
+            "visibility probe unexpectedly compiled: BuildLeaseService's private cap state is \
+             reachable from outside the crate"
         );
-        assert!(stderr.contains("no method named `set_cap_directly`"));
+        assert!(
+            stderr.contains("field `cap` of struct `BuildLeaseService` is private"),
+            "visibility probe stderr did not report `cap` as private:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("field `derived_fallback` of struct `BuildLeaseService` is private"),
+            "visibility probe stderr did not report `derived_fallback` as private:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("no method named `set_cap_directly`"),
+            "visibility probe stderr did not reject `set_cap_directly`:\n{stderr}"
+        );
     }
 }


### PR DESCRIPTION
## The failure

`djinn-coordinator::build_lease::cap::capacity_tests::build_lease_cap_api_visibility`
(`server/crates/djinn-coordinator/src/build_lease_cap.rs`) caused a **hard CI failure** in run
[30727348884](https://github.com/djinnos/djinn/actions/runs/30727348884) — terminated on 3/3
attempts at 90s each. Not a flake that a retry absorbs: a red lane, 270s of runner time, and a
bare TMT with no stderr and no exit status.

## Mechanism

It is not an async test and has nothing to do with the runtime. It is a plain `#[test]` that
shells out to `rustc`:

- **no timeout at all** on the subprocess, and
- `-L dependency=<workspace target/debug/deps>` — a directory holding thousands of entries,
  including several stale `libdjinn_coordinator-*.rlib` candidates at ~113 MB apiece, which the
  crate loader must decode to disambiguate.

On CI that directory is cold-restored by `Swatinem/rust-cache` while the other test processes in
the same shard compete for the same disk. `.config/nextest.toml` sets
`slow-timeout = { period = "30s", terminate-after = 3 }`, so the sequence is: 30s → slow, 60s →
slow, 90s → terminated, retry, repeat. **Retries structurally cannot help**, because each attempt
re-runs identical cold-I/O work under identical load. The retry budget was buying nothing.

## What changed

Two changes to the probe, nothing to the property it asserts.

**1. `--emit=metadata` (the cost fix).** Every diagnostic this test asserts on is a
name-resolution or field-privacy error, all of which rustc produces during type checking. Nothing
downstream of typeck is needed to observe them, and the probe never links because it never
compiles. Requesting no object code changes the crate loader's behaviour: `-L dependency` lookups
for `djinn-coordinator`'s transitive crates are satisfied from their `.rmeta` sidecars instead of
being decoded out of `.rlib` archives. That is exactly the same crate-loading path `cargo check`
uses, and it is the path this repo's own CI already relies on — `quality-gate.yml` documents that
the clippy-warmed `server-quality` cache family "carries rmeta only".

**2. A 60s wall-clock bound (the attribution fix).** 60s sits deliberately below nextest's 90s
termination point, so if the probe does stall, *this* assertion fires first and the lane reports a
message that names the condition and the search path, instead of an opaque TMT that reads
identically to a real visibility regression. Supporting details: stderr is captured to a file
rather than a pipe, so the poll loop cannot deadlock against a full pipe buffer; `Child::wait()`
is called on both the normal and the killed path, so the probe is always reaped.

### Before / after — reasoned, not measured

Timings are stated as reasoned rather than measured: the local machine is currently saturated by
~10 concurrent agents (load average >130 on 16 cores), and reproducing this specific failure means
doing precisely the disk thrashing that is the subject of the fix. The mechanism is established by
code reading, and **CI on this PR is the measurement**.

| | before | after |
|---|---|---|
| worst case observed | terminated at 90s × 3 attempts (run 30727348884) | bounded at 60s, single attempt, with an attributable message |
| dominant I/O | metadata decoded from `.rlib` archives across a multi-thousand-entry cold dir | metadata read from `.rmeta` sidecars for transitive deps |
| failure signal on stall | `TMT` — no stderr, no status | named assertion quoting the elapsed time and the `-L` path |

The `--extern` for `djinn_coordinator` itself still points at the `.rlib`, deliberately: crate
*discovery* is byte-identical to `main`, so the only behavioural delta is the emit mode.
Pointing `--extern` at the pipelined `.rmeta` would cut the single largest read (~113 MB → ~10 MB)
and is a reasonable follow-up, but it is a second unverified change and this PR keeps to one.

## Non-vacuity: the probe still fails if the visibility property is violated

This is the load-bearing claim, so here is the full chain rather than a claim that it was checked.

The probe compiles `tests/ui/build_lease_cap_private.rs`, an **external** crate:

```rust
use djinn_coordinator::build_lease::BuildLeaseService;

fn external_code_cannot_bypass_snapshot_adoption(service: &BuildLeaseService) {
    let _ = &service.cap;
    let _ = &service.derived_fallback;
    service.set_cap_directly(99);
}
```

The test asserts **four** things about the result, all unchanged by this PR:

1. `!status.success()` — the external crate must not compile.
2. stderr contains ``field `cap` of struct `BuildLeaseService` is private``
3. stderr contains ``field `derived_fallback` of struct `BuildLeaseService` is private``
4. stderr contains ``no method named `set_cap_directly` ``

Why each violation is still caught:

- Make `cap` **pub** → rustc stops emitting diagnostic (2). Assertion 2 fails. Note this is caught
  *even though the crate still fails to compile* on the other two errors, which is why the test
  asserts the individual diagnostics rather than just the exit status — assertion 1 alone would be
  satisfied by the surviving errors and would pass vacuously.
- Make `derived_fallback` **pub** → assertion 3 fails, by the same argument.
- Add a `pub fn set_cap_directly` → assertion 4 fails.
- Make **all three** public → the probe compiles, `status.success()` is true, assertion 1 fails.

Neither change can weaken this:

- `--emit=metadata` does not skip type checking — it *requires* it, since metadata is the output
  of typeck. Privacy and method-resolution errors are emitted at exactly the same point in the
  pipeline as before. It only suppresses codegen and linking, phases the probe never reached
  because it errors out first.
- The timeout is a **fail-closed** guard: it can only turn a pass into a failure, never a failure
  into a pass. Its own assertion (`!timed_out`) runs *before* the stderr is even read, and it
  states explicitly that the property was not evaluated.
- Every `stderr.contains` assertion now attaches the captured stderr to its failure message, so a
  future rustc wording change surfaces as "did not report `cap` as private: <actual stderr>"
  rather than a bare boolean.

The one thing CI must confirm is that `--emit=metadata` still produces those three diagnostics on
the pinned stable toolchain. If it does not, this test goes red on this PR with the full rustc
stderr in the failure message — a contained, self-diagnosing failure, not a silent pass.

## Options considered and rejected

**`trybuild`** — rejected on evidence, not taste. It is not a workspace dependency today, and
reading `trybuild-1.0.118/src/cargo.rs` shows why it would be worse here rather than better:

```rust
fn cargo_target_dir(project: &Project) -> impl Iterator<Item = (&'static str, PathBuf)> {
    iter::once((
        "CARGO_TARGET_DIR",
        path!(project.target_dir / "tests" / "trybuild"),
    ))
}
```

trybuild builds its scratch project in a **separate** `CARGO_TARGET_DIR` with `CARGO_INCREMENTAL=0`,
and runs `cargo clean --package <project>` before each case. It therefore does not reuse
`target/debug/deps` at all — it compiles `djinn-coordinator`'s dependency graph from scratch.
`cargo tree -p djinn-coordinator --edges normal,build` resolves to **623** distinct
package@version entries. Trading a subprocess that reads a big directory for a nested `cargo`
invocation that compiles 623 crates into a directory `rust-cache` does not warm is not a fix. It
also nests `cargo` inside a nextest-run test, and it replaces substring assertions with a checked-in
`.stderr` golden that breaks on every rustc diagnostic-wording change — a maintenance cost this
repo has already paid several times over in golden fanout.

**Move it into the Clippy/lint job** — rejected: it would break the test outright. The probe
locates `libdjinn_coordinator-*.rlib` in the deps directory, and `quality-gate.yml` states that the
clippy-warmed quality cache family "carries rmeta only". There is no rlib in that lane. It also
only relocates the unbounded subprocess rather than bounding it.

## Notes

- Scope: one file, one test. No production code touched.
- Not enqueued, not merged.
