### PR TITLE
fix(tests): replace wall-clock luck with happens-before edges in two flaky tests

### DIFF
--- a/server/crates/djinn-agent/src/extension/handlers/ci_artifact.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/ci_artifact.rs
@@ -82,10 +82,17 @@ async fn fetch_artifact_with_timeout(
         timeout,
         #[cfg(test)]
         None,
+        #[cfg(test)]
+        None,
     )
     .await
 }
 
+/// `cancellation` is a test-only seam. Production always mints its own token,
+/// and the only thing that ever cancels it is the deadline arm below. A test
+/// that holds the same token can therefore fire the deadline's effect on an
+/// in-flight renderer at a point it chooses, instead of betting that a wall
+/// clock lands between two events it does not control.
 async fn fetch_artifact_with_timeout_inner(
     client: &GitHubApiClient,
     owner: &str,
@@ -94,8 +101,12 @@ async fn fetch_artifact_with_timeout_inner(
     name: &str,
     timeout: Duration,
     #[cfg(test)] render_hook: Option<RenderTestHook>,
+    #[cfg(test)] cancellation: Option<CancellationToken>,
 ) -> Result<String, String> {
     let deadline = tokio::time::Instant::now() + timeout;
+    #[cfg(test)]
+    let cancellation = cancellation.unwrap_or_default();
+    #[cfg(not(test))]
     let cancellation = CancellationToken::new();
     let render_cancellation = RenderCancellation {
         deadline: Some(deadline),
@@ -567,6 +578,29 @@ mod tests {
         assert!(!error.contains("must-not-escape"));
     }
 
+    /// The operation deadline reaching a renderer that is ALREADY RUNNING
+    /// returns the bare timeout error and no fragment of the artifact.
+    ///
+    /// The deadline is fired through the seam rather than by a wall clock. The
+    /// only thing `timeout_at`'s expiry does to an in-flight renderer is
+    /// `cancellation.cancel()`, and this test performs exactly that write —
+    /// after `started_rx` proves the blocking renderer is inside the archive.
+    /// That ordering used to be bought with a 30ms deadline and three real
+    /// loopback round-trips before `spawn_blocking` even ran, so on a loaded
+    /// machine the deadline landed BEFORE the renderer started, `started_tx`
+    /// was dropped with the abandoned future, and `started_rx.await` panicked —
+    /// about 6 runs in 80 observed. Nothing below now depends on elapsed time.
+    ///
+    /// It is also strictly more than the old version proved: with the deadline
+    /// far away, `timeout_at` resolves `Ok(Err(RENDER_CANCELLED))` and the
+    /// assertion runs through the `RENDER_CANCELLED` mapping arm. The wall-clock
+    /// version always took the outer `Err(_)` arm instead, so that mapping was
+    /// never exercised here at all.
+    ///
+    /// NAMED FAILING MUTATION: delete the
+    /// `Ok(Err(error)) if error == RENDER_CANCELLED => Err(fetch_timeout_error())`
+    /// arm, so a cancelled render reports its internal marker. This test then
+    /// fails on the error equality.
     #[tokio::test]
     async fn fetch_deadline_expires_during_active_rendering_without_partial_report() {
         let server = MockServer::start().await;
@@ -602,6 +636,8 @@ mod tests {
             completed: completed.clone(),
         };
         let client = client(&server);
+        let cancellation = CancellationToken::new();
+        let operation_cancellation = cancellation.clone();
         let fetch = tokio::spawn(async move {
             fetch_artifact_with_timeout_inner(
                 &client,
@@ -609,13 +645,18 @@ mod tests {
                 REPO,
                 explicit(10),
                 "report",
-                Duration::from_millis(30),
+                // Far enough out that no amount of scheduling delay lets the
+                // real deadline decide anything. The cancel below is what fires.
+                Duration::from_secs(300),
                 Some(hook),
+                Some(operation_cancellation),
             )
             .await
         });
+        // HAPPENS-BEFORE: the renderer is provably inside `spawn_blocking` and
+        // holding the archive before the deadline's effect is applied.
         started_rx.await.expect("renderer did not start");
-        tokio::time::sleep(Duration::from_millis(60)).await;
+        cancellation.cancel();
         release_tx.send(()).unwrap();
 
         let error = fetch.await.unwrap().unwrap_err();

--- a/server/crates/djinn-agent/src/extension/handlers/ci_artifact.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/ci_artifact.rs
@@ -93,6 +93,10 @@ async fn fetch_artifact_with_timeout(
 /// that holds the same token can therefore fire the deadline's effect on an
 /// in-flight renderer at a point it chooses, instead of betting that a wall
 /// clock lands between two events it does not control.
+// The `#[cfg(test)]` seams push this one over clippy's 7-argument limit in test
+// builds only; splitting a private helper that exists to keep one call path
+// would obscure it for no benefit.
+#[allow(clippy::too_many_arguments)]
 async fn fetch_artifact_with_timeout_inner(
     client: &GitHubApiClient,
     owner: &str,

--- a/server/src/task_run_resize_reconcile.rs
+++ b/server/src/task_run_resize_reconcile.rs
@@ -362,6 +362,30 @@ pub struct ResizeReconcilePass {
     pub pre_birth_scan_failed: bool,
 }
 
+/// What one sweep OBSERVED, before it drove anything.
+///
+/// Carries the partially-filled [`ResizeReconcilePass`] — mode, `scanned`,
+/// `scan_failed` — so that [`TaskRunResizeReconciler::drive`] finishes the same
+/// record [`TaskRunResizeReconciler::run_pass`] would have produced. The rows
+/// are deliberately opaque: nothing outside this module may act on them, and
+/// the only reason the seam is public is that a driver race is not a statement
+/// about the durable compare-and-swap unless both drivers are known to have
+/// read the same row.
+#[derive(Debug)]
+pub struct ResizeReconcileScan {
+    mode: ResizeReconcileMode,
+    pass: ResizeReconcilePass,
+    rows: Vec<BuildPodPermitRow>,
+}
+
+impl ResizeReconcileScan {
+    /// Rows the durable nonterminal scan returned.
+    #[must_use]
+    pub const fn scanned(&self) -> usize {
+        self.pass.scanned
+    }
+}
+
 /// Emit completed-pass summaries separately for each durable ledger.
 ///
 /// A pass advances the `build_pod_permits` lifecycle before it may release a
@@ -482,7 +506,27 @@ impl TaskRunResizeReconciler {
     }
 
     /// One sweep over every nonterminal resize row.
+    ///
+    /// Exactly [`Self::scan`] followed by [`Self::drive`], and the only shape
+    /// production ever uses.
     pub async fn run_pass(&self) -> ResizeReconcilePass {
+        let scan = self.scan().await;
+        self.drive(scan).await
+    }
+
+    /// The OBSERVING half of one sweep: read the durable rows, decide nothing.
+    ///
+    /// Separated from [`Self::drive`] because "two drivers raced over one row"
+    /// is only a statement about the compare-and-swap when both drivers
+    /// actually OBSERVED the same row. A test that starts two whole passes
+    /// together is instead betting that the second driver's SELECT lands before
+    /// the first driver's CAS commits; when it does not, the second driver
+    /// either reads a row already moved to `drop_required` (which `claim`
+    /// waves through without a CAS, producing a second PATCH) or reads nothing
+    /// at all. Joining the scans first and the drives second removes that bet
+    /// without removing the race: the CAS is still what serialises them, and
+    /// deleting it still doubles the PATCH count.
+    pub async fn scan(&self) -> ResizeReconcileScan {
         self.passes.fetch_add(1, Ordering::SeqCst);
         let mode = self.gate.mode();
         let mut pass = ResizeReconcilePass {
@@ -490,7 +534,11 @@ impl TaskRunResizeReconciler {
             ..ResizeReconcilePass::default()
         };
         if mode == ResizeReconcileMode::Off {
-            return pass;
+            return ResizeReconcileScan {
+                mode,
+                pass,
+                rows: Vec::new(),
+            };
         }
 
         // THE DURABLE READ. Not a cache, not an in-process registry of live
@@ -505,10 +553,27 @@ impl TaskRunResizeReconciler {
                      stranded rows keep their lease until the next tick"
                 );
                 pass.scan_failed = true;
-                return pass;
+                return ResizeReconcileScan {
+                    mode,
+                    pass,
+                    rows: Vec::new(),
+                };
             }
         };
         pass.scanned = rows.len();
+        ResizeReconcileScan { mode, pass, rows }
+    }
+
+    /// The ACTING half of one sweep, over the rows [`Self::scan`] observed.
+    pub async fn drive(&self, scan: ResizeReconcileScan) -> ResizeReconcilePass {
+        let ResizeReconcileScan {
+            mode,
+            mut pass,
+            rows,
+        } = scan;
+        if mode == ResizeReconcileMode::Off || pass.scan_failed {
+            return pass;
+        }
 
         for row in rows {
             let task_run_id = row.task_run_id.clone();

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -1736,8 +1736,8 @@ async fn two_concurrent_drivers_issue_exactly_one_patch() {
         .skipped
         .iter()
         .chain(right_pass.skipped.iter())
+        .filter(|&(_, reason)| *reason == SkipReason::ClaimLost)
         .cloned()
-        .filter(|(_, reason)| *reason == SkipReason::ClaimLost)
         .collect();
     assert_eq!(
         claim_lost,

--- a/server/tests/task_run_resize_recovery.rs
+++ b/server/tests/task_run_resize_recovery.rs
@@ -1649,6 +1649,31 @@ async fn a_settled_but_unreleasable_outcome_still_holds_the_lease() {
 /// The reconciler has no prior claim on a row resting in a lift state: it must
 /// WIN the compare-and-swap into `drop_required` before it may touch the Pod.
 ///
+/// # Why the pass is split, and what is still a race
+///
+/// Both drivers are still two separate processes with separate pools, both
+/// still run concurrently against ONE real Postgres, and the durable
+/// compare-and-swap is still the only thing that decides which of them wins —
+/// which of the two wins is not fixed here and does not matter.
+///
+/// What IS fixed is that both drivers observed the row in the SAME state. A
+/// bare `join!` over two whole passes did not fix that, and could not: it bet
+/// that the right driver's `list_nonterminal_resize` landed before the left
+/// driver's CAS committed. Losing that bet cost about 6 runs in 80 observed,
+/// in two distinct shapes:
+///
+/// * the right driver reads the row already at `drop_required`, for which
+///   `claim` returns `true` WITHOUT a compare-and-swap (it is a self-transition
+///   the drop resumes idempotently) — so both drivers PATCH, and
+///   `resize_patches() == 1` fails; or
+/// * the left driver finishes the whole pass first, the right driver scans zero
+///   rows and is merely IDLE — so no `ClaimLost` is reported at all.
+///
+/// Joining the SCANS establishes the missing happens-before edge, then joining
+/// the DRIVES races the CAS proper. The assertion below is correspondingly
+/// stronger than it was: exactly one `ClaimLost`, not "at least one, if the
+/// scheduler cooperated".
+///
 /// NAMED FAILING MUTATION: delete the `claim` call (drive `drop_to_birth`
 /// directly, as the worker's own terminal path does) and this fails with a
 /// doubled PATCH counter — both drivers actuate the same drop.
@@ -1681,22 +1706,44 @@ async fn two_concurrent_drivers_issue_exactly_one_patch() {
     let left_reconciler = left.reconciler(None, Arc::new(ArmedGate));
     let right_reconciler = right.reconciler(None, Arc::new(ArmedGate));
 
-    let (left_pass, right_pass) =
-        tokio::join!(left_reconciler.run_pass(), right_reconciler.run_pass(),);
+    // ── THE BARRIER: both drivers OBSERVE, neither has acted. ──
+    let (left_scan, right_scan) = tokio::join!(left_reconciler.scan(), right_reconciler.scan());
+    assert_eq!(
+        (left_scan.scanned(), right_scan.scanned()),
+        (1, 1),
+        "both drivers must have read the SAME durable row, or the race below is \
+         not a race over one row at all"
+    );
+    assert_eq!(
+        permit_state(&db, &task_run_id).await,
+        BuildPodPermitState::Lifted,
+        "precondition: an observing pass writes nothing, so the row both \
+         drivers are about to contend for is still resting in its lift state"
+    );
+
+    // ── THE RACE: two concurrent drives, one durable compare-and-swap. ──
+    let (left_pass, right_pass) = tokio::join!(
+        left_reconciler.drive(left_scan),
+        right_reconciler.drive(right_scan)
+    );
 
     let resumed = left_pass.resumed + right_pass.resumed;
     assert_eq!(
         resumed, 1,
         "exactly one driver may claim the row; left={left_pass:?} right={right_pass:?}"
     );
-    assert!(
-        left_pass
-            .skipped
-            .iter()
-            .chain(right_pass.skipped.iter())
-            .any(|(_, reason)| *reason == SkipReason::ClaimLost),
-        "the losing driver must be REJECTED, not merely idle; \
-         left={left_pass:?} right={right_pass:?}"
+    let claim_lost: Vec<(String, SkipReason)> = left_pass
+        .skipped
+        .iter()
+        .chain(right_pass.skipped.iter())
+        .cloned()
+        .filter(|(_, reason)| *reason == SkipReason::ClaimLost)
+        .collect();
+    assert_eq!(
+        claim_lost,
+        vec![(task_run_id.clone(), SkipReason::ClaimLost)],
+        "the losing driver must be REJECTED by the compare-and-swap, not merely \
+         idle; left={left_pass:?} right={right_pass:?}"
     );
     assert_eq!(
         cluster.resize_patches(),


### PR DESCRIPTION
Two flaky tests, each reported at ~7.5% (6 of 80 runs), each substituting wall-clock luck for a happens-before edge the codebase already had the seams to express.

Both fixes are **determinism** fixes, not margin-widening ones. Nothing here enlarges a timeout to make a race less likely; each replaces the timing bet with an ordering constraint, so correctness follows from structure rather than from a pass rate.

## Targets confirmed still live on `main`

Rebased on `916ac5050`. Both mechanisms verified present at that base before any edit — worth stating explicitly, since the flakiness sample window (08-03 → 08-07) straddles other fixes and at least one other reported target turned out to be already dead:

| target | check on `origin/main` | result |
|---|---|---|
| `ci_artifact.rs:612` | `Duration::from_millis(30)` + `:617` `started_rx.await.expect(...)` + `:618` `sleep(60ms)` | present, unguarded |
| `task_run_resize_recovery.rs:1685` | `tokio::join!(left_reconciler.run_pass(), right_reconciler.run_pass(),)` | present, no barrier |

`git log --since=2026-07-20` on both files: `ci_artifact.rs` last touched by #2513 (unrelated, workspace shell launch context); `task_run_resize_recovery.rs` by #2872/#2894/#2897/#2904, all concerning the strand predicate and the drop-transit grace — none added a barrier or moved the deadline. Neither flake has been fixed.

---

## Flake 1 — `djinn-agent::extension::handlers::ci_artifact::tests::fetch_deadline_expires_during_active_rendering_without_partial_report`

### Mechanism (verified against the code, not just the report)

`fetch_artifact_with_timeout_inner` wraps the whole operation in `timeout_at(deadline, operation)`. The operation must complete **three real loopback HTTP round-trips** (resolve run → list artifacts → download zip, `:105-125`) before it reaches `spawn_blocking` (`:126`), which is the only thing that fires `started_tx`. The test set that deadline at **30ms**.

When the round-trips exceed 30ms, `timeout_at` drops `operation`. `render_hook` — and with it `started_tx` — is dropped as part of the abandoned async block, so `started_rx.await.expect("renderer did not start")` panics.

One correction to the original report: the failure requires the timeout to fire **before `spawn_blocking` is reached**. If the blocking task has already been queued, dropping the `JoinHandle` does not cancel it, the closure still runs and still sends `started_tx`, and the test survives. So the flake is precisely "3 HTTP round-trips took longer than 30ms", which is exactly what `--test-threads 4` buys you on a loaded machine.

The sibling at `:527` uses the same 30ms and does not flake because it only asserts *that* the deadline fired, not *where* it landed. It is left untouched.

### Fix

Expose the existing `CancellationToken` (`:99-103`) as a `#[cfg(test)]` parameter. The only effect a fired deadline has on an already-running renderer is `cancellation.cancel()` (`:142`), so the test performs that exact write itself — **after** `started_rx` has resolved and therefore proven the blocking renderer is inside the archive. The real timeout goes to 300s so elapsed wall time cannot decide anything, and the `sleep(60ms)` is deleted.

```
started_rx.await.expect("renderer did not start");   // happens-before edge
cancellation.cancel();                                // the deadline's only effect
release_tx.send(()).unwrap();
```

### Why this is strictly more coverage than before

With the deadline far away, `timeout_at` resolves `Ok(Err(RENDER_CANCELLED))`, so the assertion now runs through the `RENDER_CANCELLED => fetch_timeout_error()` mapping arm (`:139`). The wall-clock version always took the outer `Err(_)` arm (`:141`) instead — both produce the same string, so the assertion could not tell them apart, and **that mapping arm was never exercised by this test at all**. It is now.

### Non-vacuity (reasoned, not run — see verification note)

Delete the `Ok(Err(error)) if error == RENDER_CANCELLED => Err(fetch_timeout_error())` arm. Control then falls to `Ok(Err(error)) => Err(error)`, the cancelled render surfaces its internal marker `"artifact ZIP rendering cancelled at operation deadline"`, and `assert_eq!(error, fetch_timeout_error())` fails on the string comparison. The test cannot pass without that mapping, because with a 300s deadline the outer `Err(_)` arm is unreachable — there is no second path to the same string. Recorded as a NAMED FAILING MUTATION in the test's doc comment.

---

## Flake 2 — `djinn-server::task_run_resize_recovery::two_concurrent_drivers_issue_exactly_one_patch`

### Mechanism (verified against the code)

No barrier: overlap was pure tokio scheduling on a current-thread runtime, and both drivers own independent lazy pools whose first query pays connection setup. Two bad interleavings, both confirmed in the source:

**(a) right scans after left's CAS commits.** It reads `state = DropRequired`. `strandedness` (`task_run_resize_reconcile.rs:768-771`) sees `owner_is_gone == true` and returns `OwnerGone`, which `acts()`. Then `claim` (`:860-866`) matches only `BirthConfirmed | LiftApplying | Lifted` and short-circuits everything else via `_ => return true` — **no compare-and-swap is issued**. The right driver proceeds straight to `resume`, so `cluster.resize_patches()` reads 2 and `assert_eq!(..., 1)` fails.

**(b) left finishes the whole pass first.** The permit is already `Released`, which is outside the nonterminal scan set, so the right driver scans zero rows and is merely *idle* — no `ClaimLost` is produced and `.any(ClaimLost)` fails.

### Fix

Split `run_pass` into `scan()` + `drive(scan)` and join them separately.

```
let (left_scan, right_scan) = join!(left.scan(), right.scan());   // BARRIER
assert_eq!((left_scan.scanned(), right_scan.scanned()), (1, 1));  // both saw the row
assert_eq!(permit_state(..), Lifted);                             // nothing was written
let (left_pass, right_pass) = join!(left.drive(left_scan), right.drive(right_scan));  // RACE
```

Both drivers now provably observe the row at `lifted`, which is the one state for which `claim` actually issues the compare-and-swap.

### This is still a real concurrent test

The requirement was not to turn this into a sequential test that asserts the same thing trivially, and it is not:

- Two separate `Rebuilt` processes, separate pools, separate `in_flight` sets, one real Postgres.
- The drives run **concurrently** under `join!`. Which driver wins is not fixed and does not matter; the assertions are symmetric over left/right.
- The durable CAS in `transition_resize_lifecycle` is still the only thing that serialises them. Nothing in the test picks the winner.
- What is removed is only the bet on *which state the second driver reads* — not the bet on *who wins*.

### Assertion strengthened

Because both drivers are now known to have contended, the loser's rejection is no longer probabilistic. `.any(|r| r == ClaimLost)` becomes an exact equality: the collected `ClaimLost` skips must be exactly `vec![(task_run_id, ClaimLost)]` — one, for this task run, and no other. The old form would have passed if zero drivers had contended and some unrelated row had produced a `ClaimLost`.

### Non-vacuity (reasoned, not run)

Delete the `if !self.claim(&row) { ...; continue; }` guard in `drive` (i.e. drive `drop_to_birth` directly, as the worker's own terminal path does). Both drivers then pass the barrier holding a `lifted` row, both skip the CAS, both call `resume`, and both PATCH the same Pod — `cluster.resize_patches()` reads 2 against `assert_eq!(..., 1)`, `resumed` reads 2 against `assert_eq!(..., 1)`, and the `ClaimLost` vector is empty against a one-element expectation. Three independent assertions fail. Crucially the barrier does **not** mask this: it guarantees both drivers reach the claim site with a claimable row, which is what makes the doubled PATCH deterministic rather than occasional. Recorded as a NAMED FAILING MUTATION.

### Production-code change: `run_pass` split

`run_pass` is now literally `self.drive(self.scan().await).await`. Behaviour is preserved point for point:

| original `run_pass` | after the split |
|---|---|
| `passes.fetch_add(1)` once per pass | in `scan()`; `run_pass` calls `scan()` once |
| `gate.mode()` read once per pass | in `scan()`, carried on the scan |
| `mode == Off` → return, **no pre-birth reap** | `scan()` returns empty rows; `drive` returns on the same `Off` check before `reap_pre_birth` |
| scan error → `scan_failed = true`, return, **no pre-birth reap** | `scan()` sets the flag; `drive` returns on `pass.scan_failed` before `reap_pre_birth` |
| `pass.scanned = rows.len()` | set in `scan()`, carried through |
| row loop, then `reap_pre_birth` | unchanged, in `drive` |

`ResizeReconcileScan` keeps its `rows` private and exposes only `scanned()`, so nothing outside the module can act on the scanned rows.

**Every call site checked** (`grep -rn "run_pass"` across `server/`, excluding `target/`):

- `server/src/task_run_resize_reconcile.rs:1082` — the production `spawn` loop. Unchanged signature.
- `server/tests/task_run_resize_recovery.rs` — 17 call sites, all `run_pass()`, all unchanged except the one under test.
- `server/tests/task_run_resize_faults.rs:597` — unchanged.
- `server/crates/djinn-coordinator/*` — `run_pass_with_watchdog`, an unrelated symbol on `CoordinatorActor`.

No other crate names `TaskRunResizeReconciler`; the only non-test composition is `AppState::become_leader` → `task_run_resize_reconcile::spawn`, which calls `run_pass` and is untouched.

---

## Verification

Per instruction from the operator, **no cargo was run for this change** — local test load had to be given up to CI. Compilation, clippy and the test outcomes are verified by CI on this PR. Everything above is therefore reasoned from the source rather than measured, and labelled as such:

- **Measured:** nothing. The 7.5% / 6-of-80 figures are the reported historical rates from the flakiness investigation and are carried over, not reproduced here.
- **Reasoned:** the two mechanisms (each traced to specific lines in the current code, with one correction to the flake-1 description above), both non-vacuity arguments, and the `run_pass` behavioural equivalence table.
- **To be confirmed by CI:** the build, and the flake-rate improvement.

Because both fixes are ordering fixes rather than widened bounds, the residual failure probability is not a tuning question. Flake 1 has no remaining dependence on elapsed time at all. Flake 2 retains one real-time bound — the 5s `with_row_budget`, a genuine `tokio::time::timeout` with no clock seam behind it (`RecordingClock` governs the drop's backoff, not the pass budget) — which is deliberately **left at its shared default**: it is not the flake mechanism, and raising it would convert a fast, clean failure into a long hang if the drop ever did wedge.

Since I could not compile-check the `run_pass` split, it was kept deliberately conservative — a pure extract-and-sequence with no change to control flow. If CI reports a build error, it should be in that split and is straightforward to triage.
