### PR TITLE
perf(db): stop re-verifying the test template in every nextest process

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -64,6 +64,50 @@ env:
   # exactly where runner-host failures surface and where nobody currently has
   # anything to look at.
   CI_RUNNER_DISK_WARN_GB: "22"
+  # ---------------------------------------------------------------------------
+  # Postgres test template build + verification (shared body, defined ONCE here)
+  #
+  # Invoked by every DB-backed job as `bash -c "$CI_BUILD_TEST_TEMPLATE"` from
+  # `server/`. It builds `djinn_test_template`, PROVES it is fully migrated, and
+  # only then exports `DJINN_TEST_TEMPLATE_PREBUILT=1` for the rest of the job.
+  #
+  # Why the export matters. `cargo nextest` runs every test in its own PROCESS,
+  # so the per-process `TEMPLATE_READY` latch in
+  # `server/crates/djinn-db/src/template_bootstrap.rs` never fired in CI. Every
+  # one of the ~12k DB-backed tests re-took the template advisory lock in
+  # EXCLUSIVE mode, re-ran `UPDATE pg_database SET datistemplate = TRUE` (a
+  # shared-catalog write) and re-walked all ~190 embedded migrations — while
+  # every peer's `CREATE DATABASE … TEMPLATE` queued behind that same lock in
+  # SHARED mode. `DJINN_TEST_TEMPLATE_PREBUILT=1` turns that whole maintenance
+  # window into an early return.
+  #
+  # Why the grep matters, and why it is not optional. The flag ASSERTS the
+  # template is fully migrated; if it is exported over a template that is not,
+  # every test silently runs against an empty/stale schema. `cargo test --test
+  # <target> -- --ignored <filter>` exits 0 when the filter matches NO tests, so
+  # a renamed or deleted `setup_test_template` would otherwise look exactly like
+  # a successful build. `setup_test_template` therefore verifies each embedded
+  # migration is applied to the template with a matching checksum, that the
+  # reserved designated-operator row exists, and that `datistemplate` is set —
+  # then prints this sentinel. No sentinel, no export, and the step fails.
+  #
+  # `set -o pipefail` is likewise load-bearing: without it the `| tee` would
+  # mask a failing `cargo test`.
+  CI_BUILD_TEST_TEMPLATE: |
+    set -euo pipefail
+    until pg_isready -h 127.0.0.1 -p 5433 -U postgres >/dev/null 2>&1; do sleep 1; done
+    psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS djinn_test_template"
+    psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE djinn_test_template"
+    SQLX_OFFLINE=true DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres \
+      cargo test -p djinn-db --test setup_test_template -- --ignored --nocapture \
+      | tee "$RUNNER_TEMP/setup-test-template.log"
+    psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'"
+    if ! grep -q 'DJINN_TEST_TEMPLATE_VERIFIED' "$RUNNER_TEMP/setup-test-template.log"; then
+      echo "::error title=Test template not verified::setup_test_template did not print DJINN_TEST_TEMPLATE_VERIFIED. The template was NOT proven migrated, so DJINN_TEST_TEMPLATE_PREBUILT will not be exported. Check that the test still exists and still runs under --ignored."
+      exit 1
+    fi
+    echo "DJINN_TEST_TEMPLATE_PREBUILT=1" >> "$GITHUB_ENV"
+    echo "::notice title=Test template prebuilt::djinn_test_template verified; DB tests will skip the per-process template re-verify."
   # Invoked by the heavy jobs as `bash -c "$CI_RUNNER_DISK_PREFLIGHT"`. Kept as
   # a workflow-level env body rather than copied per job so the threshold and
   # the reclaim set exist in exactly one place; a composite action would be the
@@ -1113,14 +1157,13 @@ jobs:
             DJINN_MIGRATE_OPERATOR_GITHUB_ID=9000000002 \
             DJINN_MIGRATE_OPERATOR_LOGIN=djinn-ci-migration-operator \
             cargo test -p djinn-db --test apply_migrations -- --ignored --nocapture
-      - name: Build Postgres test template
+      - name: Build and verify Postgres test template
+        # Body: CI_BUILD_TEST_TEMPLATE at the top of this file. It exports
+        # DJINN_TEST_TEMPLATE_PREBUILT=1 only after proving the template is
+        # fully migrated.
         env:
           PGPASSWORD: postgres
-        run: |
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS djinn_test_template"
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE djinn_test_template"
-          SQLX_OFFLINE=true DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres cargo test -p djinn-db --test setup_test_template -- --ignored
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'"
+        run: bash -c "$CI_BUILD_TEST_TEMPLATE"
       - uses: taiki-e/install-action@nextest
       - name: Prove the cutover preflight against a live render and real Postgres
         run: |
@@ -1838,15 +1881,37 @@ jobs:
             DJINN_MIGRATE_OPERATOR_GITHUB_ID=9000000002 \
             DJINN_MIGRATE_OPERATOR_LOGIN=djinn-ci-migration-operator \
             cargo test -p djinn-db --test apply_migrations -- --ignored --nocapture
-      - name: Build Postgres test template
+      - name: Build and verify Postgres test template
+        # Body: CI_BUILD_TEST_TEMPLATE at the top of this file. It exports
+        # DJINN_TEST_TEMPLATE_PREBUILT=1 only after proving the template is
+        # fully migrated — which is what lets every test process in this shard
+        # skip the exclusive-lock template re-verify.
+        env:
+          PGPASSWORD: postgres
+        run: bash -c "$CI_BUILD_TEST_TEMPLATE"
+      - name: Start leaked test-database reaper (background)
+        # Pairs with DJINN_TEST_DB_REAPER=external on the nextest step below.
+        # With that set, `TestDbInit::drop` no longer connects + terminates +
+        # DROPs (a joined, synchronous ~16 MB unlink on the critical path of
+        # every DB test, in a process that exits immediately afterwards so
+        # there is nowhere else to put it). This loop becomes the only thing
+        # reclaiming the clones, so it must actually reap: it prints a running
+        # total every sweep, and its predicate — `djinn_test_<32 hex>` only,
+        # older than any test may run, and with no live session — cannot touch
+        # `djinn_test_template` or a running test's database. See
+        # scripts/djinn-test-db-reaper.sh.
+        working-directory: ${{ github.workspace }}
         env:
           PGPASSWORD: postgres
         run: |
-          until pg_isready -h 127.0.0.1 -p 5433 -U postgres >/dev/null 2>&1; do sleep 1; done
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS djinn_test_template"
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE djinn_test_template"
-          SQLX_OFFLINE=true DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres cargo test -p djinn-db --test setup_test_template -- --ignored
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'"
+          # --max-outstanding is the disk bound, and it is the reason skipping
+          # the in-test DROP cannot fill the runner: 128 clones x ~16 MB caps
+          # the backlog at ~2 GB regardless of how fast the suite gets. Without
+          # it, peak usage scales with test throughput (see the script header).
+          nohup ./scripts/djinn-test-db-reaper.sh --loop --interval-seconds 10 \
+            --min-age-seconds 150 --max-outstanding 128 \
+            > "$RUNNER_TEMP/test-db-reaper.log" 2>&1 &
+          echo "test-db reaper started"
       - name: Create test vault key
         run: |
           mkdir -p /var/tmp/djinn-test-vault
@@ -1993,6 +2058,12 @@ jobs:
         if: steps.shard.outputs.active == 'true'
         env:
           NEXTEST_PROFILE: ${{ github.event_name == 'pull_request' && 'pull-request' || github.event_name == 'merge_group' && 'merge-group' || 'full-validation' }}
+          # Hand per-test database teardown to the background reaper started
+          # above. Scoped to THIS step: no other step in this job opens a
+          # template clone, and nothing outside CI ever sets it, so local runs
+          # and worker pods keep the synchronous DROP. See
+          # `external_test_db_reaper` in server/crates/djinn-db/src/database.rs.
+          DJINN_TEST_DB_REAPER: external
           # NOTE: there is deliberately NO `RUST_MIN_STACK` here. One used to be
           # (`8388608`, added in 1b4641fc0 "eliminate coordinator shard
           # stack-overflow failures"), and it masked a real defect for eleven
@@ -2386,15 +2457,13 @@ jobs:
             DJINN_MIGRATE_OPERATOR_GITHUB_ID=9000000002 \
             DJINN_MIGRATE_OPERATOR_LOGIN=djinn-ci-migration-operator \
             cargo test -p djinn-db --test apply_migrations -- --ignored --nocapture
-      - name: Build Postgres test template
+      - name: Build and verify Postgres test template
+        # Body: CI_BUILD_TEST_TEMPLATE at the top of this file. It exports
+        # DJINN_TEST_TEMPLATE_PREBUILT=1 only after proving the template is
+        # fully migrated.
         env:
           PGPASSWORD: postgres
-        run: |
-          until pg_isready -h 127.0.0.1 -p 5433 -U postgres >/dev/null 2>&1; do sleep 1; done
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS djinn_test_template"
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE djinn_test_template"
-          SQLX_OFFLINE=true DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres cargo test -p djinn-db --test setup_test_template -- --ignored
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'"
+        run: bash -c "$CI_BUILD_TEST_TEMPLATE"
       - name: Create test vault key
         run: |
           mkdir -p /var/tmp/djinn-test-vault
@@ -2464,15 +2533,14 @@ jobs:
           echo "rustc=$(rustc --version || echo 'unknown')"
           echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
           echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
-      - name: Build migrated Postgres template
+      - name: Build and verify migrated Postgres template
+        # Body: CI_BUILD_TEST_TEMPLATE at the top of this file. It exports
+        # DJINN_TEST_TEMPLATE_PREBUILT=1 only after proving the template is
+        # fully migrated. Note the shared body DROPs the template first; this
+        # job previously relied on a fresh runner never having one.
         env:
           PGPASSWORD: postgres
-        run: |
-          set -euo pipefail
-          until pg_isready -h 127.0.0.1 -p 5433 -U postgres >/dev/null 2>&1; do sleep 1; done
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE djinn_test_template"
-          SQLX_OFFLINE=true DJINN_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5433/postgres cargo test -p djinn-db --test setup_test_template -- --ignored
-          psql -h 127.0.0.1 -p 5433 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'"
+        run: bash -c "$CI_BUILD_TEST_TEMPLATE"
       - name: Build qa runner once
         run: cargo build -p djinn-qa
       - name: Precompile selected smoke test binaries

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TEST_DB_MIGRATION_GITHUB_LOGIN ?=
 # Postgres (docker-compose.yml → `postgres-test` service at :5433) plus the
 # test harness targets that depend on it.
 
-.PHONY: help dev test-db-migrate test-db-postgres-template test-vault test-db-reset sqlx-prepare sqlx-check sqlx-verify tool-goldens tool-goldens-check tool-goldens-manifest test test-all validate-taskrun-backstop check-boundaries verify-cache-cleanup verify-incident-observability check-retirement-manifest
+.PHONY: help dev test-db-migrate test-db-postgres-template test-vault test-db-sweep test-db-reset sqlx-prepare sqlx-check sqlx-verify tool-goldens tool-goldens-check tool-goldens-manifest test test-all validate-taskrun-backstop check-boundaries verify-cache-cleanup verify-incident-observability check-retirement-manifest
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -171,6 +171,17 @@ tool-goldens-check: ## Fail if any committed MCP tool-schema golden is stale —
 		exit 1; \
 	fi
 	@echo "MCP tool-schema goldens are up to date."
+
+test-db-sweep: ## Drop leaked djinn_test_<uuid> clone DBs (keeps the template and the schema)
+	@# Each clone is ~16 MB. A hard-killed run (SIGKILL, nextest
+	@# `terminate-after`, a cancelled agent) never runs `TestDbInit::drop`, so
+	@# they strand — 183 of them, 2.9 GB, were sitting on the local :5433 server
+	@# when this target was written. Unlike `test-db-reset` this keeps the
+	@# server, the `djinn` database and `djinn_test_template` intact, so it is
+	@# safe to run at any time, including while a suite is running: the sweeper
+	@# only touches `djinn_test_<32 hex>` databases that are both older than any
+	@# test may run and have no live session. See scripts/djinn-test-db-reaper.sh.
+	@$(CURDIR)/scripts/djinn-test-db-reaper.sh
 
 test-db-reset: ## Wipe and restart the test Postgres — cleans out djinn_test_* DBs
 	docker compose stop postgres-test

--- a/scripts/ci-qa-smoke-workflow.test.mjs
+++ b/scripts/ci-qa-smoke-workflow.test.mjs
@@ -151,6 +151,22 @@ function stepText(step) {
   return blockCode(step);
 }
 
+// Extract a top-level `env:` block-scalar body (e.g. CI_BUILD_TEST_TEMPLATE,
+// CI_RUNNER_DISK_PREFLIGHT). Jobs invoke these as `bash -c "$NAME"`, so a
+// contract about what the work DOES has to read the body, not the call site.
+function sharedEnvBody(source, name) {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => new RegExp(`^  ${name}:\\s*\\|`).test(line));
+  if (start === -1) fail(`workflow must define a shared env body named ${name}`);
+  const body = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && !/^ {4}/.test(line)) break;
+    body.push(line);
+  }
+  if (body.every((line) => line.trim() === '')) fail(`shared env body ${name} must not be empty`);
+  return body.join('\n');
+}
+
 function namedStep(job, name) {
   const step = steps(job).find((candidate) => stepName(candidate) === name);
   assert.ok(step, `${job.id} must contain the ${name} step`);
@@ -244,13 +260,23 @@ test('qa-smoke owns only a restore-only test cache and a disposable host databas
     'clone ownership must use the disposable maintenance database');
   assert.match(source, /^ {6}DATABASE_URL:\s*postgres:\/\/postgres:postgres@127\.0\.0\.1:5433\/djinn_test_template\s*$/m,
     'SQLx compilation must use the migrated template database');
-  assert.match(source, /CREATE DATABASE djinn_test_template/, 'qa-smoke must create its template database');
-  assert.match(source, /cargo test -p djinn-db --test setup_test_template -- --ignored/,
-    'qa-smoke must build the template through the repository-owned migration runner before compiling SQLx consumers');
+  // The template build moved into the shared `CI_BUILD_TEST_TEMPLATE` env body
+  // (same convention as CI_RUNNER_DISK_PREFLIGHT), so qa-smoke must invoke it
+  // AND that body must still do the work. Asserting only the invocation would
+  // let an empty body pass; asserting only the body would let qa-smoke skip it.
+  assert.match(source, /bash -c "\$CI_BUILD_TEST_TEMPLATE"/,
+    'qa-smoke must build its template through the shared CI_BUILD_TEST_TEMPLATE body');
+  const buildTemplateBody = sharedEnvBody(readFileSync(WORKFLOW, 'utf8'), 'CI_BUILD_TEST_TEMPLATE');
+  assert.match(buildTemplateBody, /CREATE DATABASE djinn_test_template/,
+    'the shared template body must create the template database');
+  assert.match(buildTemplateBody, /cargo test -p djinn-db --test setup_test_template -- --ignored/,
+    'the shared template body must build the template through the repository-owned migration runner before compiling SQLx consumers');
   assert.doesNotMatch(source, /sqlx\s+migrate\s+run|migrations_postgres(?:\/|\\)/,
     'qa-smoke must not bypass the repository-owned migration runner');
-  assert.match(source, /UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'/,
-    'qa-smoke must mark its dedicated database as a template');
+  assert.doesNotMatch(buildTemplateBody, /sqlx\s+migrate\s+run|migrations_postgres(?:\/|\\)/,
+    'the shared template body must not bypass the repository-owned migration runner either');
+  assert.match(buildTemplateBody, /UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'/,
+    'the shared template body must mark the dedicated database as a template');
   assertQaJobHasNoLiveDependencies(qa);
 });
 
@@ -259,7 +285,7 @@ test('qa-smoke builds, precompiles, and directly executes in deterministic order
   assert.ok(qa, 'qa-smoke job must exist');
   const source = blockCode(qa);
   assertStepOrder(qa, [
-    'Build migrated Postgres template',
+    'Build and verify migrated Postgres template',
     'Build qa runner once',
     'Precompile selected smoke test binaries',
     'Run deterministic qa smoke and coverage gate',

--- a/scripts/djinn-test-db-reaper.sh
+++ b/scripts/djinn-test-db-reaper.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# Reclaim `djinn_test_<uuidv7>` clone databases left behind by the DB test
+# harness.
+#
+# Two callers, one predicate:
+#
+#   * CI (`--loop`): `.github/workflows/quality-gate.yml` starts this in the
+#     background and sets `DJINN_TEST_DB_REAPER=external` for the test step, so
+#     `TestDbInit::drop` skips its synchronous `DROP DATABASE` (see
+#     `server/crates/djinn-db/src/database.rs`). The reaper is then the ONLY
+#     thing bounding the runner's disk, which is why it must actually reap —
+#     `--loop` prints a running total so a wedged reaper is visible in the job
+#     log rather than silently filling the runner.
+#
+#   * Local (`make test-db-sweep`): one shot. Hard-killed runs (SIGKILL, nextest
+#     `terminate-after`) skip `Drop` entirely and strand ~16 MB per test; this
+#     is how you get that space back without `make test-db-reset`, which also
+#     destroys and rebuilds the template.
+#
+# The safety predicate — both callers use it — is:
+#
+#   1. the name matches `djinn_test_<32 lowercase hex>` exactly, so
+#      `djinn_test_template` and any human-named database can never match; AND
+#   2. the UUIDv7 embedded in the name (its first 48 bits are a unix
+#      millisecond timestamp) is older than --min-age-seconds; AND
+#   3. no backend is currently connected to it.
+#
+# (2) and (3) are both required. (3) alone would race the window between
+# `CREATE DATABASE … TEMPLATE` and the lazily-connected pool's first query.
+# (2) alone would kill a legitimately long-running test. Together, a database
+# has to have been created longer ago than any test may run AND have no live
+# session before it is touched. `DROP DATABASE` is issued WITHOUT `WITH
+# (FORCE)` on purpose: if a session appears between the query and the drop,
+# Postgres refuses and the reaper moves on instead of destroying a live test's
+# database.
+set -euo pipefail
+
+PSQL_URL="${DJINN_TEST_DATABASE_URL:-postgres://postgres:postgres@127.0.0.1:5433/postgres}"
+# Longer than any single test can run: nextest's `slow-timeout` in
+# `server/.config/nextest.toml` is `period = 30s, terminate-after = 3`, so a
+# test process is killed at 90s. 150s leaves a margin over that hard ceiling.
+MIN_AGE_SECONDS=150
+INTERVAL_SECONDS=15
+LOOP=0
+# Hard ceiling on how many finished-but-unreclaimed clones may accumulate.
+#
+# Needed because --min-age-seconds bounds LATENCY, not VOLUME: peak outstanding
+# is roughly (test threads / test duration) x (min-age + interval), so the
+# faster the suite gets the more disk it holds. At ~16 MB per clone and 4-way
+# concurrency, a 0.5s test would park ~1.2 GB/minute of min-age. A hosted
+# runner that has just built ~12 GB of artifacts cannot absorb that, and its
+# failure mode is the runner process dying on ENOSPC (see
+# CI_RUNNER_DISK_PREFLIGHT in .github/workflows/quality-gate.yml), not a test
+# failure anyone can read.
+#
+# Above the cap the age requirement drops to MIN_AGE_FLOOR_SECONDS. That stays
+# safe because age is NOT what proves a test is finished — "no live session"
+# is. The age guard exists only to cover the window between `CREATE DATABASE …
+# TEMPLATE` returning and the lazily-connected pool's first query, and in
+# `Database::ensure_initialized` those are adjacent statements (sub-10ms), so
+# even the floor is a ~1000x margin. A test that is still running holds a
+# pooled connection (sqlx idle_timeout defaults to 10 minutes, far beyond
+# nextest's 90s hard kill) and is therefore invisible to every query here.
+MAX_OUTSTANDING=0
+MIN_AGE_FLOOR_SECONDS=10
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: djinn-test-db-reaper.sh [--loop] [--interval-seconds N] [--min-age-seconds N] [--url DSN]
+
+  --loop                 sweep forever (CI); default is a single sweep
+  --interval-seconds N   seconds between sweeps in --loop mode (default 15)
+  --min-age-seconds N    only reap clones created more than N seconds ago (default 150)
+  --max-outstanding N    hard cap on unreclaimed clones; above it the age requirement
+                         drops to 10s so disk stays bounded (default 0 = no cap)
+  --url DSN              admin DSN (default $DJINN_TEST_DATABASE_URL, else the :5433 dev server)
+USAGE
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --loop) LOOP=1; shift ;;
+    --interval-seconds) INTERVAL_SECONDS="${2:?--interval-seconds needs a value}"; shift 2 ;;
+    --min-age-seconds) MIN_AGE_SECONDS="${2:?--min-age-seconds needs a value}"; shift 2 ;;
+    --max-outstanding) MAX_OUTSTANDING="${2:?--max-outstanding needs a value}"; shift 2 ;;
+    --url) PSQL_URL="${2:?--url needs a value}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+case "$MIN_AGE_SECONDS" in ''|*[!0-9]*) echo "--min-age-seconds must be a non-negative integer" >&2; exit 2 ;; esac
+case "$INTERVAL_SECONDS" in ''|*[!0-9]*) echo "--interval-seconds must be a positive integer" >&2; exit 2 ;; esac
+case "$MAX_OUTSTANDING" in ''|*[!0-9]*) echo "--max-outstanding must be a non-negative integer" >&2; exit 2 ;; esac
+
+# `djinn_test_` is 11 characters, so the UUIDv7 hex starts at 1-based offset 12
+# and its first 12 hex digits are the 48-bit millisecond timestamp. Ordering by
+# datname is therefore ordering by creation time — oldest reaped first.
+select_orphans_sql() {
+  local age="$1"
+  cat <<SQL
+SELECT d.datname
+  FROM pg_database d
+ WHERE d.datname ~ '^djinn_test_[0-9a-f]{32}\$'
+   AND to_timestamp((('x' || substr(d.datname, 12, 12))::bit(48)::bigint) / 1000.0)
+       < now() - make_interval(secs => ${age})
+   AND NOT EXISTS (
+         SELECT 1 FROM pg_stat_activity a WHERE a.datname = d.datname
+       )
+ ORDER BY d.datname
+SQL
+}
+
+sweep() {
+  local dropped=0 failed=0 db
+  local orphans age="$MIN_AGE_SECONDS"
+  if [ "$MAX_OUTSTANDING" -gt 0 ]; then
+    # Count what is already finished and unreclaimed. Above the cap, fall back
+    # to the floor age so the backlog is actually cleared instead of merely
+    # being aged; see MAX_OUTSTANDING above for why that stays safe.
+    local outstanding
+    outstanding="$(psql "$PSQL_URL" --tuples-only --no-align --quiet \
+      --command "$(select_orphans_sql "$MIN_AGE_FLOOR_SECONDS")" 2>/dev/null | grep -c . || true)"
+    case "$outstanding" in ''|*[!0-9]*) outstanding=0 ;; esac
+    if [ "$outstanding" -gt "$MAX_OUTSTANDING" ]; then
+      age="$MIN_AGE_FLOOR_SECONDS"
+      echo "djinn-test-db-reaper: ${outstanding} outstanding clones exceed cap ${MAX_OUTSTANDING}; reaping down to ${age}s"
+    fi
+  fi
+  if ! orphans="$(psql "$PSQL_URL" --tuples-only --no-align --quiet --command "$(select_orphans_sql "$age")")"; then
+    echo "djinn-test-db-reaper: could not query $PSQL_URL" >&2
+    return 1
+  fi
+  for db in $orphans; do
+    # No `WITH (FORCE)`: a database that acquired a session since the query
+    # above must be left alone, and a plain DROP is what enforces that.
+    if psql "$PSQL_URL" --quiet --command "DROP DATABASE \"$db\"" >/dev/null 2>&1; then
+      dropped=$((dropped + 1))
+    else
+      failed=$((failed + 1))
+    fi
+  done
+  echo "djinn-test-db-reaper: dropped=${dropped} skipped=${failed}"
+  return 0
+}
+
+if [ "$LOOP" = "1" ]; then
+  total=0
+  while true; do
+    line="$(sweep || true)"
+    n="${line##*dropped=}"
+    n="${n%% *}"
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    total=$((total + n))
+    echo "${line} total=${total}"
+    sleep "$INTERVAL_SECONDS"
+  done
+else
+  sweep
+fi

--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -163,8 +163,34 @@ struct TestDbInit {
     test_db: String,
 }
 
+/// Whether an **external** sweeper owns reclamation of `djinn_test_*` clones.
+///
+/// The teardown below is synchronous and `join()`ed, so it sits on the critical
+/// path of every DB-backed test: a fresh admin connection, a
+/// `pg_terminate_backend` scan of `pg_stat_activity`, and a `DROP DATABASE`
+/// that unlinks the ~16 MB of files a template clone copies. Under `cargo
+/// nextest` there is no later moment to do it in — the process exits right
+/// after the test — so simply detaching the thread would not run it at all.
+///
+/// `DJINN_TEST_DB_REAPER=external` says the surrounding harness runs
+/// `scripts/djinn-test-db-reaper.sh` (or equivalent) alongside the suite and
+/// will reclaim the clones out of band. Only CI sets it, and only in the job
+/// that actually starts the reaper. **Unset — every local run, every worker
+/// pod — teardown is unchanged**, so local Postgres never accumulates more
+/// leaked clones than it does today.
+fn external_test_db_reaper() -> bool {
+    static EXTERNAL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *EXTERNAL.get_or_init(|| {
+        std::env::var("DJINN_TEST_DB_REAPER")
+            .is_ok_and(|raw| raw.trim().eq_ignore_ascii_case("external"))
+    })
+}
+
 impl Drop for TestDbInit {
     fn drop(&mut self) {
+        if external_test_db_reaper() {
+            return;
+        }
         let server_prefix = self.server_prefix.clone();
         let test_db = self.test_db.clone();
         // `Drop` is sync and may run on a current-thread test runtime (where
@@ -671,6 +697,12 @@ async fn clone_postgres_test_template(server_prefix: &str, test_db: &str) -> DbR
     let admin_url = format!("{server_prefix}/postgres");
     let opts = sqlx::postgres::PgConnectOptions::from_str(&admin_url).map_err(DbError::from)?;
     let mut conn = opts.connect().await.map_err(DbError::from)?;
+
+    // Raw connection: none of the pool's `after_connect` guards apply here, so
+    // bound the lock wait explicitly. Without this the acquisition below is an
+    // unbounded wait behind a bootstrap that holds the lock across a full sqlx
+    // migrate. See `ADVISORY_LOCK_WAIT_TIMEOUT_MS` in `template_bootstrap`.
+    template_bootstrap::bound_advisory_lock_wait(&mut conn).await?;
 
     // Take the template advisory lock in SHARED mode for the terminate+clone
     // window. `ensure_test_template` holds the same lock EXCLUSIVELY while it

--- a/server/crates/djinn-db/src/template_bootstrap.rs
+++ b/server/crates/djinn-db/src/template_bootstrap.rs
@@ -73,6 +73,46 @@ static TEMPLATE_BOOTSTRAP_SEMAPHORE: std::sync::OnceLock<Arc<Semaphore>> =
 /// for the single first-test bootstrap.
 static TEMPLATE_READY: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
+/// Environment latch for "this template was already built **and verified** by
+/// the harness that launched me; do not re-verify".
+///
+/// [`TEMPLATE_READY`] above is per-**process**, and `cargo nextest` runs every
+/// test in its own process. So in CI the fast path above never fires: each of
+/// the ~12k test processes re-took the EXCLUSIVE advisory lock, re-ran
+/// `UPDATE pg_database SET datistemplate = TRUE` (a shared-catalog write), and
+/// re-walked all ~190 embedded migrations against the template — while every
+/// peer's `clone_postgres_test_template` queued behind that exclusive lock in
+/// SHARED mode. One serialized maintenance window per test, on a lock every
+/// test also needs to clone through.
+///
+/// Setting `DJINN_TEST_TEMPLATE_PREBUILT=1` (or `true`) asserts that the
+/// template is already present, marked, and fully migrated, so
+/// [`ensure_test_template`] returns immediately and the clone path takes the
+/// shared lock uncontended.
+///
+/// **This is an assertion the setter must prove, not a hint.** It is set by
+/// `.github/workflows/quality-gate.yml` only *after* its "Build Postgres test
+/// template" step has run `tests/setup_test_template.rs`, which now verifies
+/// every embedded migration is applied to the template with a matching
+/// checksum and prints a sentinel the workflow greps for before exporting the
+/// variable. Nothing sets it locally, so local/worker-pod runs keep today's
+/// self-healing bootstrap (create-if-missing, migrate-forward, rebuild on a
+/// diverged history).
+static TEMPLATE_PREBUILT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+/// Whether the environment asserts a pre-built, pre-verified template.
+///
+/// Read once per process: `std::env::var` is not free and this is on the hot
+/// path of every DB-backed test.
+fn template_prebuilt() -> bool {
+    *TEMPLATE_PREBUILT.get_or_init(|| {
+        std::env::var("DJINN_TEST_TEMPLATE_PREBUILT").is_ok_and(|raw| {
+            let raw = raw.trim();
+            raw.eq_ignore_ascii_case("1") || raw.eq_ignore_ascii_case("true")
+        })
+    })
+}
+
 fn bootstrap_semaphore() -> Arc<Semaphore> {
     TEMPLATE_BOOTSTRAP_SEMAPHORE
         .get_or_init(|| Arc::new(Semaphore::new(1)))
@@ -91,6 +131,43 @@ fn bootstrap_semaphore() -> Arc<Semaphore> {
 /// (all shared) never block each other.
 pub(crate) const TEMPLATE_ADVISORY_LOCK_ID: i64 = 0x6a5b4c3d2e1f0a9b;
 
+/// Upper bound on how long either side may WAIT for the template advisory lock.
+///
+/// Both `pg_advisory_lock` (exclusive, below) and `pg_advisory_lock_shared`
+/// (in `clone_postgres_test_template`) run on raw `PgConnection`s, which do
+/// **not** go through the pool's `after_connect` hook — so they inherited none
+/// of the pool's `statement_timeout` / `lock_timeout` guards and the wait was
+/// unbounded. Under `--test-threads 4` against one Postgres server that is an
+/// unbounded wait on a lock held across a full sqlx migrate, and it presents as
+/// an unattributable nextest slow-timeout kill rather than as a lock problem
+/// (e.g. `batch_completion_suppressed_when_active_planner_on_epic`, ~5% of
+/// runs).
+///
+/// `lock_timeout` does apply to advisory locks — verified against PostgreSQL 16:
+/// a contended `SELECT pg_advisory_lock(...)` under `SET lock_timeout = '2s'`
+/// returns `55P03 canceling statement due to lock timeout` at 2.01s, where the
+/// same statement without it blocks indefinitely.
+///
+/// 60s matches the local-semaphore budget in [`acquire_bootstrap_permit`] and
+/// sits under nextest's hard kill (`slow-timeout` `period = 30s`,
+/// `terminate-after = 3` => 90s), so a wedged lock now surfaces as a named
+/// Postgres error inside the test instead of a killed process with no cause.
+const ADVISORY_LOCK_WAIT_TIMEOUT_MS: u32 = 60_000;
+
+/// Bound how long `conn` will wait for a lock before erroring.
+///
+/// Session-scoped, and both callers use a short-lived connection they close
+/// immediately afterwards, so this can never reach pooled query traffic.
+pub(crate) async fn bound_advisory_lock_wait(
+    conn: &mut sqlx::postgres::PgConnection,
+) -> DbResult<()> {
+    sqlx::query(&format!("SET lock_timeout = {ADVISORY_LOCK_WAIT_TIMEOUT_MS}"))
+        .execute(conn)
+        .await
+        .map_err(DbError::from)?;
+    Ok(())
+}
+
 /// Ensure the `djinn_test_template` database exists and is migrated.
 ///
 /// Idempotent: if the template already exists and is marked as a template, this
@@ -100,8 +177,11 @@ pub(crate) const TEMPLATE_ADVISORY_LOCK_ID: i64 = 0x6a5b4c3d2e1f0a9b;
 /// Uses both a local semaphore (per-process) and a Postgres advisory lock
 /// (cross-process) so parallel tests / worker pods don't collide.
 pub(crate) async fn ensure_test_template(server_prefix: &str) -> DbResult<()> {
-    // Fast path: the template was already created/verified in this process.
-    if TEMPLATE_READY.get().is_some() {
+    // Fast path: the template was already created/verified in this process, or
+    // the harness that launched this process proved it before launching us
+    // (see `TEMPLATE_PREBUILT`). The second case is what makes the fast path
+    // reachable at all under `cargo nextest`, which forks a process per test.
+    if TEMPLATE_READY.get().is_some() || template_prebuilt() {
         return Ok(());
     }
 
@@ -116,6 +196,10 @@ pub(crate) async fn ensure_test_template(server_prefix: &str) -> DbResult<()> {
     let admin_url = format!("{server_prefix}/postgres");
     let opts = sqlx::postgres::PgConnectOptions::from_str(&admin_url).map_err(DbError::from)?;
     let mut conn = opts.connect().await.map_err(DbError::from)?;
+
+    // Never wait forever for the lock: this is a raw connection, so it has none
+    // of the pool's guards. See `ADVISORY_LOCK_WAIT_TIMEOUT_MS`.
+    bound_advisory_lock_wait(&mut conn).await?;
 
     // Cross-process serialization: take an EXCLUSIVE advisory lock for the
     // duration of our maintenance work on the template — including the

--- a/server/crates/djinn-db/src/template_bootstrap.rs
+++ b/server/crates/djinn-db/src/template_bootstrap.rs
@@ -161,10 +161,12 @@ const ADVISORY_LOCK_WAIT_TIMEOUT_MS: u32 = 60_000;
 pub(crate) async fn bound_advisory_lock_wait(
     conn: &mut sqlx::postgres::PgConnection,
 ) -> DbResult<()> {
-    sqlx::query(&format!("SET lock_timeout = {ADVISORY_LOCK_WAIT_TIMEOUT_MS}"))
-        .execute(conn)
-        .await
-        .map_err(DbError::from)?;
+    sqlx::query(&format!(
+        "SET lock_timeout = {ADVISORY_LOCK_WAIT_TIMEOUT_MS}"
+    ))
+    .execute(conn)
+    .await
+    .map_err(DbError::from)?;
     Ok(())
 }
 

--- a/server/crates/djinn-db/tests/setup_test_template.rs
+++ b/server/crates/djinn-db/tests/setup_test_template.rs
@@ -64,5 +64,102 @@ async fn setup_test_template() {
     .execute(&mut conn)
     .await
     .expect("mark template");
+    drop(conn);
+
+    let applied = verify_template_is_fully_migrated(&admin_url, &template_url).await;
     println!("djinn_test_template ready at {template_url}");
+    // Sentinel consumed by `.github/workflows/quality-gate.yml`. It is the ONLY
+    // thing that licenses the workflow to export `DJINN_TEST_TEMPLATE_PREBUILT=1`,
+    // which makes every test process skip `ensure_test_template`. A grep for it
+    // is required because `cargo test --test <t> -- --ignored <filter>` exits 0
+    // when the filter matches no tests: without the sentinel, a renamed or
+    // deleted test would look like a successful template build and every DB test
+    // would then run against whatever `CREATE DATABASE` left behind.
+    println!("DJINN_TEST_TEMPLATE_VERIFIED migrations={applied}");
+}
+
+/// Prove the template is a real, fully-migrated clone source.
+///
+/// Asserts, against the embedded migrator that production uses:
+/// * `datistemplate` is set (otherwise `CREATE DATABASE … TEMPLATE` refuses),
+/// * every embedded up-migration is recorded in `_sqlx_migrations`,
+/// * each recorded row has `success = true` and a checksum equal to the
+///   embedded migration's — so a template built from a different checkout, or
+///   one whose migrator died halfway, fails here rather than silently serving
+///   an unmigrated schema to ~12k tests,
+/// * the reserved designated-operator row exists.
+///
+/// Returns the number of applied migrations.
+async fn verify_template_is_fully_migrated(admin_url: &str, template_url: &str) -> usize {
+    use sqlx::Connection;
+    use sqlx::postgres::PgConnection;
+
+    const TEMPLATE_OPERATOR_ID: &str = "00000000-0000-7000-8000-000000000001";
+
+    let mut admin = PgConnection::connect(admin_url)
+        .await
+        .expect("connect admin for template verification");
+    let is_template: Option<bool> = sqlx::query_scalar(
+        "SELECT datistemplate FROM pg_database WHERE datname = 'djinn_test_template'",
+    )
+    .fetch_optional(&mut admin)
+    .await
+    .expect("read datistemplate");
+    assert_eq!(
+        is_template,
+        Some(true),
+        "djinn_test_template must exist and be marked datistemplate"
+    );
+    drop(admin);
+
+    let embedded = sqlx::migrate!("./migrations_postgres");
+    let expected: Vec<(i64, Vec<u8>)> = embedded
+        .iter()
+        .filter(|migration| !migration.migration_type.is_down_migration())
+        .map(|migration| (migration.version, migration.checksum.to_vec()))
+        .collect();
+    assert!(
+        !expected.is_empty(),
+        "embedded migrator resolved zero up-migrations"
+    );
+
+    let mut conn = PgConnection::connect(template_url)
+        .await
+        .expect("connect template for verification");
+    let applied: Vec<(i64, Vec<u8>, bool)> =
+        sqlx::query_as("SELECT version, checksum, success FROM _sqlx_migrations")
+            .fetch_all(&mut conn)
+            .await
+            .expect("read _sqlx_migrations from the template");
+
+    for (version, checksum, success) in &applied {
+        assert!(*success, "migration {version} is recorded as failed");
+        let embedded_checksum = expected
+            .iter()
+            .find(|(candidate, _)| candidate == version)
+            .map(|(_, checksum)| checksum);
+        assert_eq!(
+            embedded_checksum,
+            Some(checksum),
+            "migration {version} in the template does not match the embedded migration"
+        );
+    }
+    for (version, _) in &expected {
+        assert!(
+            applied.iter().any(|(applied, _, _)| applied == version),
+            "embedded migration {version} is not applied to djinn_test_template"
+        );
+    }
+
+    let operators: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE id = $1")
+        .bind(TEMPLATE_OPERATOR_ID)
+        .fetch_one(&mut conn)
+        .await
+        .expect("count reserved template operator");
+    assert_eq!(
+        operators, 1,
+        "reserved designated-operator row is missing from djinn_test_template"
+    );
+
+    expected.len()
 }


### PR DESCRIPTION
## The mechanism

`ensure_test_template` (`server/crates/djinn-db/src/template_bootstrap.rs`) fast-paths on `TEMPLATE_READY`, which is a `OnceLock` — a **per-process** latch. `cargo nextest` runs every test in its own **process**, so that fast path never fires in CI.

Every DB-backed test therefore:

1. took `pg_advisory_lock` in **EXCLUSIVE** mode,
2. under it ran `UPDATE pg_database SET datistemplate = TRUE` (a shared-catalog write),
3. and re-walked all 190 embedded migrations against the template,

while every peer's `clone_postgres_test_template` queued behind that same lock in **SHARED** mode. One serialized maintenance window per test, on the exact lock every test also needs in order to clone. With `--test-threads 4` against one Postgres server, all four lanes sit in that queue.

---

## Changes

### 1. `DJINN_TEST_TEMPLATE_PREBUILT=1` skips the per-process re-verify

CI already builds the template in a dedicated step. The flag makes `ensure_test_template` return `Ok(())` immediately, so the exclusive lock is never taken and the clone path takes the shared lock uncontended.

Nothing sets the flag locally or in worker pods, so **local dev keeps today's self-healing behaviour** — create-if-missing, migrate-forward, rebuild on a diverged history.

### 2. `DJINN_TEST_DB_REAPER=external` takes the `DROP DATABASE` off the critical path

`impl Drop for TestDbInit` spawns a thread and `.join()`s it, putting a fresh admin connection + `pg_terminate_backend` scan + `DROP DATABASE` of a ~16 MB clone on the critical path of every test.

**Simply removing the `.join()` does not work.** Under nextest the process exits immediately after the test returns, so a detached thread would essentially never run and every clone would leak — including locally. So the drop is skipped only when an external sweeper is declared, and this PR ships that sweeper: `scripts/djinn-test-db-reaper.sh`, run as a background loop in the `server-test` shard and as `make test-db-sweep` locally.

### 3. Both advisory-lock acquisitions are now bounded (from the parallel flakiness investigation)

`pg_advisory_lock` (`template_bootstrap.rs`) and `pg_advisory_lock_shared` (`database.rs`) both run on raw `PgConnection`s, which never go through the pool's `after_connect` hook — so they inherited none of its `statement_timeout` / `lock_timeout` guards and the wait was **unbounded**, on a lock held across a full sqlx migrate. Both now `SET lock_timeout = 60000` first (under nextest's 90s hard kill, matching the existing 60s local-semaphore budget), so a wedged lock surfaces as a named Postgres error inside the test instead of an unattributable killed process.

### 4. `make test-db-sweep`

Reclaims leaked `djinn_test_<uuid>` clones without destroying the template, unlike `test-db-reset`.

---

## Precondition proof for Fix 1 — the flag is an assertion, and it is proven, not assumed

The flag asserts the template is fully migrated. If it is exported over a template that is not, ~12k tests run against a broken schema. So the precondition is **checked, and the check gates the export**:

- **The pre-build step is unconditional** in all four DB-backed jobs (`cutover-preflight`, `server-test`, `memory-eval`, `qa-smoke`) — no `if:`, and every `psql` uses `-v ON_ERROR_STOP=1`.
- **Same server prefix, same template name.** `server-test` sets none of `TEST_POSTGRES_URL` / `DJINN_TEST_DATABASE_URL` / `DJINN_DATABASE_URL`, so `test_database_base_url()` falls through to `DEFAULT_TEST_DATABASE_URL` = `postgres://postgres:postgres@127.0.0.1:5433/postgres` — the identical prefix the pre-build step uses. The template name is hardcoded `djinn_test_template` on both sides.
- **The silent-failure mode is closed.** `cargo test --test <target> -- --ignored <filter>` exits **0** when the filter matches no tests, so a renamed or deleted `setup_test_template` would look exactly like a successful build. `setup_test_template` now verifies the template against the embedded migrator — every version applied, checksums equal, `success = true`, `datistemplate` set, reserved operator row present — and prints `DJINN_TEST_TEMPLATE_VERIFIED migrations=<n>`. The workflow greps for that sentinel and **only then** appends `DJINN_TEST_TEMPLATE_PREBUILT=1` to `$GITHUB_ENV`. No sentinel, no flag, and the step fails.
- `set -o pipefail` is in the shared body so the `| tee` cannot mask a failing `cargo test`.

All four sites now call one shared workflow-level body (`CI_BUILD_TEST_TEMPLATE`), following the existing `CI_RUNNER_DISK_PREFLIGHT` convention, so the build and its proof cannot drift apart across jobs.

## Local-dev safety argument for Fix 2

- **The env var is never set locally.** It is set on exactly one step (`Run planner-selected shard tests`) in exactly one job — the one that starts the reaper. Unset, `TestDbInit::drop` is byte-for-byte today's behaviour, so local Postgres cannot accumulate more leaked clones than it does now.
- **The reaper's predicate cannot touch a live test.** It requires all three of: name matches `^djinn_test_[0-9a-f]{32}$` (so `djinn_test_template` can never match), the UUIDv7 timestamp embedded in the name is older than the age threshold, **and** no backend is connected. `DROP DATABASE` is issued without `WITH (FORCE)` on purpose — if a session appears between the query and the drop, Postgres refuses and the reaper moves on.
- **Disk is hard-bounded.** `--min-age-seconds` bounds latency, not volume: peak outstanding scales with test *throughput*, so the faster this PR makes the suite, the more disk a naive reaper would hold (~16 MB × 4 threads × min-age / test duration). `--max-outstanding 128` caps the backlog at ~2 GB regardless of throughput; above the cap the age requirement drops to a 10s floor, which stays safe because *age is not what proves a test is finished — "no live session" is*. The age guard only covers the window between `CREATE DATABASE … TEMPLATE` returning and the lazily-connected pool's first query, and in `Database::ensure_initialized` those are adjacent statements.

---

## Evidence

### Verified by execution (before the no-local-cargo rule took effect)

| Claim | Evidence |
|---|---|
| Everything compiles, no new lint | `cargo clippy -p djinn-db --all-targets` clean, run **after** all Rust edits in this PR |
| The new verifier works on a good template | `setup_test_template` passed and printed `DJINN_TEST_TEMPLATE_VERIFIED migrations=190` against a freshly built template |
| `lock_timeout` really does bound `pg_advisory_lock` | PostgreSQL 16: a contended `SELECT pg_advisory_lock(...)` under `SET lock_timeout='2s'` returned `55P03 canceling statement due to lock timeout` at **2.01s**; the same statement without it blocked past a 4s cutoff |
| Teardown cost that Fix 2 removes | 8 samples of connect + `pg_terminate_backend` + `DROP DATABASE` on real 16 MB clones: **58–455 ms**, median ~65 ms — on a local tmpfs/`fsync=off` server, i.e. a floor for a CI runner's real disk |
| Clone size / leak scale | 16 MB per clone; **183** stranded `djinn_test_*` databases (2.9 GB) on the local dev server |
| The reaper actually reaps | One `make test-db-sweep`-equivalent sweep dropped **174 of 175** stranded databases; the survivor was `djinn_test_template` |
| The age guard genuinely gates | 5 fabricated clones, `--min-age-seconds 3600`, no cap → `dropped=0` |
| The `--max-outstanding` override fires and clears the backlog | Same 5 clones, `--min-age-seconds 3600 --max-outstanding 2` → `5 outstanding clones exceed cap 2; reaping down to 10s`, `dropped=5` |
| A live session protects a clone | Two clones, one holding an open session: the session-less one was reaped, the live one survived **both** a `--min-age-seconds 0` sweep and a cap-override sweep. Template untouched throughout |

### Non-vacuity — verified, and by accident the strongest evidence here

This was not a synthetic probe. Mid-benchmark, an interrupted run left the template **half-migrated at 95 of 190 migrations** (`select count(*) from _sqlx_migrations` → 95, versions 1–95; `tasks` and `task_attempts` present but 95 migrations stale). The next arm ran **with `DJINN_TEST_TEMPLATE_PREBUILT=1` set against that broken template**:

```
arm=C tests=140 failed=132 wall=5.82s
    FAIL  djinn-db repositories::task::writes::created_by_tests::create_with_blockers_wires_edge_atomically_and_holds_from_ready
    FAIL  djinn-db repositories::task::writes::execution_context_tests::execution_context_round_trips_through_create_and_get
```

**132 of 140 tests failed.** So:

- the flag cannot make DB tests pass vacuously — they genuinely depend on the migrated schema and fail loudly without it; and
- this is exactly the state the sentinel gate exists to catch. `verify_template_is_fully_migrated` asserts every embedded version is present in `_sqlx_migrations`; at 95 of 190 the `embedded migration N is not applied to djinn_test_template` assertion fires, no sentinel is printed, the workflow step fails, and `DJINN_TEST_TEMPLATE_PREBUILT` is never exported. The failure mode this PR could have introduced is the one the gate provably blocks.

### NOT measured — stated as reasoned, to be confirmed by this PR's CI

I do **not** have a clean before/after tests-per-second number, and I am not going to present one. The measurement was cut short: this dev box was running ~10 concurrent agents (one of them a `cargo nextest run -p djinn-db` against the same server), the baseline arm was SIGTERM'd at 83/140 tests, and the comparison arm ran against the half-migrated template above. Per the user's standing instruction I then stopped running cargo locally entirely.

What the numbers I *do* have imply, as reasoning:

- **Fix 1** removes, per test process, one exclusive advisory-lock acquisition, one shared-catalog `UPDATE`, and one 190-row migration walk — all inside a window every other test lane is blocked on. The reported CI profile (84% of server suite time in a smooth 3.5–7s hump centred on 5.1s, no sleeps involved, 13x worse than local at 9.3 tests/s) is the shape of exactly this serialization, which is why removing it should dominate.
- **Fix 2** removes a further measured 58–455 ms per test.
- **Fix 3** should reduce the contention amplifying the known flakes (`batch_completion_suppressed_when_active_planner_on_epic` at ~5%, plus five others), and converts any remaining lock wedge from an unattributable slow-timeout kill into a named `55P03` error. I have not measured a flake-rate change and am not claiming one.

**Compilation of the final tree and the full test suite are verified by this PR's CI, not locally.** The only edits made after the last clean local `clippy` run are the bash reaper and the workflow YAML; both were syntax-checked (`bash -n`, `yaml.safe_load`) and the workflow wiring asserted programmatically (all four call sites converted, reaper started before the nextest step, no leftover inline template builds).

### Revert seams

Fix 2 is the higher-risk half, since it trades a synchronous drop for a background one. It is one line: delete `DJINN_TEST_DB_REAPER: external` from the `Run planner-selected shard tests` step and teardown reverts to today's behaviour in CI, leaving Fixes 1 and 3 intact. Likewise, removing the `DJINN_TEST_TEMPLATE_PREBUILT` export from `CI_BUILD_TEST_TEMPLATE` reverts Fix 1 while keeping the template verification.
