### PR TITLE
Stop a schema contract test from guarding a superseded migration

### DIFF
--- a/server/crates/djinn-db/tests/model_turn_admission_schema.rs
+++ b/server/crates/djinn-db/tests/model_turn_admission_schema.rs
@@ -216,16 +216,24 @@ async fn fresh_initialization_installs_v1_marker_and_enforces_credential_identit
     .await;
 }
 
+/// Migration 173 is the sole definer of the admission *tables*, and applied
+/// migrations are immutable (`scripts/check-migrations-immutable.sh`), so its
+/// identity/no-secret shape can be read straight from the file.
+///
+/// The retention *trigger* is deliberately NOT asserted here. A trigger can be
+/// replaced by any later migration — 176 already replaced 173's — so a text
+/// assertion against a fixed migration number silently stops describing the
+/// live schema the moment that happens. See
+/// `bounded_observation_trigger_contract_matches_the_effective_schema`, which
+/// reads the trigger back out of the catalog of a fully migrated database.
 #[test]
-fn migration_has_bounded_non_secret_observation_contract() {
+fn migration_has_non_secret_admission_identity_contract() {
     let migration = std::fs::read_to_string(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/migrations_postgres/173_model_turn_admission.sql"
     ))
     .expect("read migration 173");
     for required in [
-        "model_turn_observations_bounded",
-        "OFFSET 256",
         "model_turn_lease_terminals",
         "REFERENCES credentials(id)",
         "model_turn_admission_schema",
@@ -243,6 +251,87 @@ fn migration_has_bounded_non_secret_observation_contract() {
         !migration.contains("encrypted_value"),
         "admission storage must not duplicate credential material"
     );
+}
+
+/// Assert the retention trigger that a fully migrated database actually
+/// installs, not the text of whichever migration happened to define it first.
+///
+/// Migration 173 installed an `AFTER INSERT` trigger that took the parent
+/// pool row `FOR UPDATE` *after* the foreign-key check had already taken
+/// `FOR KEY SHARE` on that same row, so two same-pool inserts could deadlock
+/// upgrading one another's FK locks. Migration 176 replaced it with a
+/// `BEFORE INSERT` trigger that takes a per-pool advisory lock before the FK
+/// check runs and trims to 255 existing rows so the incoming row lands on the
+/// 256-row bound. Reading the catalog keeps this contract attached to the
+/// effective schema: a migration 191+ that replaces or drops the trigger is
+/// checked against these properties instead of sailing past a stale string
+/// match on a superseded file.
+#[tokio::test]
+async fn bounded_observation_trigger_contract_matches_the_effective_schema() {
+    // Keep the suffix short: the generated database name is
+    // `djinn_model_turn_{suffix}_{32 hex}`, and Postgres truncates identifiers
+    // at 63 bytes.
+    with_temp_database("trigger", |database_url| async move {
+        djinn_db::test_support::apply_all_migrations_to_fresh_database(&database_url).await;
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .expect("connect migrated database");
+
+        let installed: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM pg_trigger \
+             WHERE tgrelid = 'model_turn_observations'::regclass AND NOT tgisinternal",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("count the user triggers on model_turn_observations");
+        assert_eq!(
+            installed, 1,
+            "exactly one user trigger must bound model_turn_observations; \
+             dropping or duplicating the retention trigger is a regression"
+        );
+
+        let (row_level, before_insert_timing, on_insert, body): (bool, bool, bool, String) =
+            sqlx::query_as(
+                "SELECT (t.tgtype::int & 1) = 1, (t.tgtype::int & 2) = 2, \
+                        (t.tgtype::int & 4) = 4, coalesce(p.prosrc, '') \
+                   FROM pg_trigger t \
+                   JOIN pg_proc p ON p.oid = t.tgfoid \
+                  WHERE t.tgrelid = 'model_turn_observations'::regclass \
+                    AND NOT t.tgisinternal \
+                    AND t.tgname = 'model_turn_observations_bounded'",
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("read the installed retention trigger from the catalog");
+
+        assert!(
+            row_level && before_insert_timing && on_insert,
+            "retention must run as a BEFORE INSERT row trigger so its per-pool lock is \
+             taken before the foreign-key check locks the parent pool row; observed \
+             row_level={row_level} before={before_insert_timing} insert={on_insert}"
+        );
+        assert!(
+            body.contains("pg_advisory_xact_lock(NEW.pool_id)"),
+            "retention must serialize on a transaction-scoped per-pool advisory lock; \
+             installed body: {body}"
+        );
+        assert!(
+            !body.contains("model_turn_pools"),
+            "retention must not lock or read the parent pool row — that is the \
+             FOR UPDATE lock upgrade that deadlocked against the foreign-key \
+             FOR KEY SHARE; installed body: {body}"
+        );
+        assert!(
+            body.contains("OFFSET 255"),
+            "a BEFORE INSERT trim must retain 255 existing rows so the incoming row \
+             lands exactly on the 256-row bound; installed body: {body}"
+        );
+
+        pool.close().await;
+    })
+    .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What this is

A schema-contract test was pinned to a **superseded** migration, so it passed while
asserting a contract the live schema no longer has.

This started as an investigation into the `djinn-db::model_turn_admission_schema::observation_retention_serializes_concurrent_pool_inserts`
flake (reported at 16.2%, 13 of 80 sampled merge_group runs, absorbed by `retries = 2`).
The intended fix was a new migration changing the retention trigger's
`SELECT … FOR UPDATE` to `FOR NO KEY UPDATE`. **That migration was not written**, because
the deadlock it targets is already fixed on `main` — see "Why no migration" below. What the
investigation did turn up is a real defect, and that is what this PR ships.

## The defect

`server/crates/djinn-db/tests/model_turn_admission_schema.rs` asserted:

```rust
let migration = std::fs::read_to_string(".../173_model_turn_admission.sql")…;
for required in ["model_turn_observations_bounded", "OFFSET 256", …] {
    assert!(migration.contains(required), …);
}
```

Migration **176** (`176_typed_tribunal_evidence.sql:175-198`) replaced that trigger
entirely:

```sql
DROP TRIGGER model_turn_observations_bounded ON model_turn_observations;
CREATE OR REPLACE FUNCTION trim_model_turn_observations() RETURNS trigger AS $$
BEGIN
    PERFORM pg_advisory_xact_lock(NEW.pool_id);
    DELETE FROM model_turn_observations … OFFSET 255;
    RETURN NEW;
END; $$ LANGUAGE plpgsql;
CREATE TRIGGER model_turn_observations_bounded
BEFORE INSERT ON model_turn_observations
FOR EACH ROW EXECUTE FUNCTION trim_model_turn_observations();
```

So the live trigger is `BEFORE INSERT` with an advisory lock and `OFFSET 255`, while the
test asserted `AFTER INSERT`-era text and `OFFSET 256`.

**Why the assertion was vacuous.** Applied migrations are immutable —
`scripts/check-migrations-immutable.sh` fails the build on any Modify/Rename/Delete of a
migration present on the base ref. A text assertion over migration 173's bytes therefore
*cannot* fail: the only thing that could break it is the one edit CI already forbids. It
guarded a dead definition. Drop the real trigger, flip it back to `AFTER INSERT`, or
restore the deadlocking `FOR UPDATE` upgrade, and this test stayed green.

## The fix

Assert the trigger a fully migrated database actually installs, read back out of the
catalog rather than out of whichever migration happened to define it first:

- exactly **one** non-internal trigger on `model_turn_observations`;
- `tgtype` bits prove **row-level BEFORE INSERT** timing — this is the property that makes
  the per-pool lock precede the foreign-key check;
- the function body takes `pg_advisory_xact_lock(NEW.pool_id)`;
- the body **never mentions `model_turn_pools`** — that is exactly the parent-row lock
  upgrade that deadlocked against the FK's `FOR KEY SHARE`;
- the body trims at `OFFSET 255`, so a `BEFORE INSERT` trim leaves the incoming row landing
  on the 256-row bound.

Deriving from the catalog is what makes this robust to the *next* replacement: a migration
191+ that redefines or drops the trigger is checked against these properties instead of
sailing past a stale string match. Re-pinning the same text assertion to 176 would have
reproduced the identical bug one migration later.

The file-text test keeps only migration 173's table identity / no-secret contract
(`REFERENCES credentials(id)`, `model_turn_lease_terminals`, no `owner_user_id`, no
`encrypted_value`), which 173 does solely define, and is renamed
`migration_has_non_secret_admission_identity_contract` to say so.

## How the new assertion fails if the trigger regresses

Ran the exact catalog queries the test issues against three schema states (Postgres 16,
throwaway container, since destroyed):

| state | row_level | before | insert | advisory_lock | no parent-row lock | OFFSET 255 |
|---|---|---|---|---|---|---|
| **(a) live 176 shape** | t | t | t | t | t | t |
| **(b) regressed to the 173 shape** | t | **f** | t | **f** | **f** | **f** |
| **(c) trigger dropped** | — trigger count `0`, row query returns 0 rows — |

(a) passes all five assertions. (b) fails four of them. (c) fails `assert_eq!(installed, 1)`
and then `fetch_one` returns `RowNotFound`. The old test passed in all three states.

## Why no migration (the original brief)

The `FOR UPDATE` → `FOR NO KEY UPDATE` migration would have **reverted** migration 176 on a
deployed schema. 176's advisory lock is strictly better: it takes no row lock on
`model_turn_pools` at all, so it cannot contend with ordinary pool writers, whereas
`FOR NO KEY UPDATE` would serialise every observation insert against them.

Only migrations 173 and 176 mention `trim_model_turn_observations` /
`model_turn_observations_bounded`, so 176 is the effective definition.

Measured at the SQL level (two concurrent same-pool inserts on a clock-synchronised
barrier, 12 iterations each):

| trigger shape | `deadlock detected` or wrong retention |
|---|---|
| 173 (`FOR UPDATE`, AFTER INSERT, OFFSET 256) | **5 / 12 (42%)** |
| 176 (`pg_advisory_xact_lock`, BEFORE INSERT, OFFSET 255) — current `main` | **0 / 12**, retention exact (count 256, min 1, max 256) |

The 16.2% CI figure almost certainly spans runs from before 2026-08-04: the test only became
barrier-deterministic on 08-03 (`f67c8a3f4`) and 176 landed 08-04 (`680490f67`, PR #2991).
In the most recent successful merge_group run (`31135508802`, 2026-08-07) the test logs a
first-try `PASS [3.033s]` with no retry marker. If the flake is still observed on runs dated
after 08-04, the cause is something other than the lock-upgrade deadlock and needs
re-triage.

## Migration-version convention (recorded for the next author)

Worth writing down since the brief asked whether a timestamp scheme exists — it does not:

- Versions are allocated **sequentially, `max(existing) + 1`**. All 190 migrations in
  `server/crates/djinn-db/migrations_postgres/` are `1_…`–`190_…`; next free is **191**.
  No timestamp-based allocation has been adopted.
- `scripts/check-migrations-immutable.sh` enforces two things: (1) no Modify/Rename/Delete
  of a migration present on the base ref — schema changes must always be a new migration;
  (2) no two files claiming the same numeric prefix.
- The duplicate-prefix check compares against the **merge ref**, so it only fires in the
  **merge_group** lane. A PR that picks `max+1` at authoring time stays green on its own
  branch and is rejected at the queue if another migration lands while it waits.

## Verification

No cargo was run (build sandbox unavailable): CI compiles this. Changes are confined to one
test file; no migration, no `.sqlx/` regeneration (no new/changed queries reach the offline
cache — the new queries are runtime `query_as`/`query_scalar`, not the compile-time macros),
so `Server sqlx Freshness` has nothing to object to.
