### PR TITLE
Spend the resize drop gate's budget on the injected clock

### DIFF
--- a/server/src/task_run_resize_drop.rs
+++ b/server/src/task_run_resize_drop.rs
@@ -815,6 +815,11 @@ impl TaskRunResizeDrop {
 /// property survives the timeout and `0ppk-3`'s reconciler picks the row up.
 /// Bounding the quarantine loop itself instead would end an apiserver outage
 /// with the lease released and a Pod still holding a lifted ceiling.
+///
+/// Spent through the bridge's injected [`ResizeDropClock`], not through
+/// `tokio::time` — see [`TaskRunResizeDropBridge::confirm_drop`]. In production
+/// that clock is [`SystemResizeDropClock`], whose `sleep` **is**
+/// `tokio::time::sleep`, so this stays 45 seconds of real wall clock.
 pub const DROP_GATE_BUDGET: Duration = Duration::from_secs(45);
 
 /// Where the bridge gets its apiserver surface.
@@ -942,12 +947,33 @@ impl TaskRunResizeDropGate for TaskRunResizeDropBridge {
             invocation_id: Some(request.invocation_id.clone()),
             cause: ResizeDropCause::NormalExit,
         };
-        match tokio::time::timeout(self.budget, mechanism.drop_to_birth(&drop_request)).await {
-            Ok(outcome) if outcome.releases_lease() => ResizeDropVerdict::Releasable,
-            Ok(outcome) => ResizeDropVerdict::Held {
+        // THE BUDGET IS SPENT ON THE INJECTED CLOCK, never on `tokio::time`.
+        // The drop's backoff schedule and its 30-second confirmation window are
+        // already measured with `self.clock`; a `tokio::time::timeout` wrapped
+        // around them would be a SECOND, UNINJECTED timeline, and whichever of
+        // the two expired first decided the verdict. In production both are the
+        // same timeline — `SystemResizeDropClock::sleep` is `tokio::time::sleep`,
+        // so `DROP_GATE_BUDGET` still bounds this RPC at 45 seconds of real wall
+        // clock. In a fixture that injects a clock, the gate now gives up on the
+        // fixture's terms instead of on whatever the machine happened to be
+        // doing: under a contended Postgres a real timeout could expire before
+        // the mechanism had even written `drop_required`, so the "nonterminal
+        // resize state it reached" the budget's own doc promises was never
+        // reached, and a test asserting against it read `Lifted`.
+        //
+        // `biased` so a drop that settles in the same poll the budget expires in
+        // is reported as settled: the answer we have beats the one we gave up on.
+        let settled = tokio::select! {
+            biased;
+            outcome = mechanism.drop_to_birth(&drop_request) => Some(outcome),
+            () = self.clock.sleep(self.budget) => None,
+        };
+        match settled {
+            Some(outcome) if outcome.releases_lease() => ResizeDropVerdict::Releasable,
+            Some(outcome) => ResizeDropVerdict::Held {
                 detail: format!("{outcome:?}"),
             },
-            Err(_) => ResizeDropVerdict::Held {
+            None => ResizeDropVerdict::Held {
                 detail: format!(
                     "the drop for task run {} did not settle within {:?}; the permit row \
                      retains its resize state and the lease stays held",

--- a/server/tests/task_run_resize_faults.rs
+++ b/server/tests/task_run_resize_faults.rs
@@ -34,7 +34,9 @@ use djinn_k8s::pod_resize::PodResizeError;
 use djinn_k8s::pod_resize_fixture::{ApiFault, StoredTaskRunPod};
 use djinn_k8s::runtime::{JobAdmission, LauncherObservationError, ObservedLauncherSidecar};
 use djinn_server::task_run_resize_bootstrap::TaskRunPodSurface;
-use djinn_server::task_run_resize_drop::{ResizeDropClock, TaskRunResizeDropBridge};
+use djinn_server::task_run_resize_drop::{
+    DROP_CONFIRMATION_BUDGET, DROP_MAX_BACKOFF, ResizeDropClock, TaskRunResizeDropBridge,
+};
 use djinn_server::task_run_resize_reconcile::{
     ResizeReconcileGate, ResizeReconcileMode, ResizeReconcilePass, SkipReason,
     TaskRunResizeReconciler,
@@ -49,6 +51,18 @@ const CEILING: &str = "4";
 const CEILING_MILLICORES: i64 = 4000;
 const LIFTED_MILLICORES: u64 = 4000;
 const BUILD_SLOT_CAP: i64 = 8;
+
+/// The `release_lease` gate's wait budget in these fixtures, spent on
+/// [`StallingClock`] and not on the wall clock.
+///
+/// DERIVED from the drop's own confirmation window rather than written as a
+/// number. What a test of the held-lease boundary needs is "strictly longer
+/// than the window the drop may spend before it quarantines", and `apply_drop`
+/// cannot leave that window later than [`DROP_CONFIRMATION_BUDGET`] measured on
+/// this same clock. The quarantine therefore precedes the gate's answer for a
+/// structural reason, at any value of the drop's backoff constants and at any
+/// speed of the machine underneath.
+const GATE_BUDGET: Duration = Duration::from_secs(DROP_CONFIRMATION_BUDGET.as_secs() + 5);
 
 // ── The apiserver surface ──────────────────────────────────────────────────
 
@@ -82,24 +96,63 @@ impl TaskRunPodSurface for FixtureSurface {
     }
 }
 
-/// A clock that never waits and, after `stall_after` sleeps, never returns.
+/// The one timeline in this file: virtual, and driven entirely by the drop.
 ///
-/// The stall is what keeps the unbounded quarantine loop inside the gate's own
-/// wait budget without the test spending 45 real seconds on it.
+/// Two roles share it, told apart by the only thing that distinguishes them and
+/// nothing more clever than that — the duration asked for. `TaskRunResizeDrop`'s
+/// schedule is capped at [`DROP_MAX_BACKOFF`], so:
+///
+/// * a sleep **at or under** that cap is one of the drop's own backoffs. It
+///   ADVANCES virtual time and returns immediately, which is what lets a test
+///   spend the drop's 30-second confirmation window in microseconds.
+/// * a sleep **longer** than it is the budget `TaskRunResizeDropBridge` spends
+///   in `confirm_drop`. It OBSERVES virtual time, and expires only once the
+///   drop's own backoffs have carried the clock past it.
+///
+/// Why that matters: the gate used to bound itself with a real
+/// `tokio::time::timeout` while the drop it was bounding ran on this injected
+/// clock — two timelines, and the wall-clock one decided the verdict. A sibling
+/// test's `CREATE DATABASE … TEMPLATE` stalling the shared cluster past the
+/// budget was enough to make the gate answer before `require_drop` had written
+/// `drop_required`, so the assertion about a QUARANTINED row read `Lifted`
+/// (CI run `30884032730`). With both roles on this clock, "the drop quarantines
+/// before the gate gives up" is a consequence of the drop's own schedule, and
+/// Postgres may take as long as it likes.
+///
+/// `stall_after` is a BACKSTOP, not the mechanism: after that many backoffs the
+/// drop parks forever, and because a parked drop can never advance this clock
+/// again, every instant a budget wait is still owed has effectively passed —
+/// so the clock publishes that rather than leaving the waiter hung.
 struct StallingClock {
     base: tokio::time::Instant,
-    offset: std::sync::Mutex<Duration>,
+    /// Virtual time since [`Self::new`], published so a budget wait is woken by
+    /// the very backoffs that advance it.
+    elapsed: tokio::sync::watch::Sender<Duration>,
     sleeps: std::sync::Mutex<usize>,
     stall_after: usize,
 }
 
 impl StallingClock {
     fn new(stall_after: usize) -> Self {
+        let (elapsed, _) = tokio::sync::watch::channel(Duration::ZERO);
         Self {
             base: tokio::time::Instant::now(),
-            offset: std::sync::Mutex::new(Duration::ZERO),
+            elapsed,
             sleeps: std::sync::Mutex::new(0),
             stall_after,
+        }
+    }
+
+    /// Block until virtual time reaches `deadline`.
+    async fn observe_until(&self, deadline: Duration) {
+        let mut ticks = self.elapsed.subscribe();
+        while *ticks.borrow_and_update() < deadline {
+            if ticks.changed().await.is_err() {
+                // The clock outlives every waiter, so this is unreachable.
+                // Parking rather than returning keeps a clock that was dropped
+                // from ever being read as an expired budget.
+                std::future::pending::<()>().await;
+            }
         }
     }
 }
@@ -107,17 +160,29 @@ impl StallingClock {
 #[async_trait]
 impl ResizeDropClock for StallingClock {
     fn now(&self) -> tokio::time::Instant {
-        self.base + *self.offset.lock().expect("clock")
+        self.base + *self.elapsed.borrow()
     }
 
     async fn sleep(&self, duration: Duration) {
+        if duration > DROP_MAX_BACKOFF {
+            // The gate's budget. It observes the timeline; it never moves it.
+            let deadline = *self.elapsed.borrow() + duration;
+            self.observe_until(deadline).await;
+            return;
+        }
+
         let count = {
             let mut sleeps = self.sleeps.lock().expect("clock");
             *sleeps += 1;
-            *self.offset.lock().expect("clock") += duration;
             *sleeps
         };
+        self.elapsed.send_modify(|elapsed| *elapsed += duration);
         if count >= self.stall_after {
+            // Parked for good. Nothing left can advance this clock, so let any
+            // budget wait see the rest of its window pass: a broken budget then
+            // fails an assertion instead of hanging the suite.
+            self.elapsed
+                .send_modify(|elapsed| *elapsed += Duration::from_secs(86_400));
             std::future::pending::<()>().await;
         }
         tokio::task::yield_now().await;
@@ -325,6 +390,11 @@ fn status_millicores(cluster: &StoredTaskRunPod) -> Option<u64> {
 
 /// A `DirectServices` over the real coordinator lease service, with the real
 /// server-side drop bridge installed as the terminal gate.
+///
+/// `gate_budget` is spent on `clock`, not on the wall clock — see
+/// [`StallingClock`]. For a drop that settles it is unreachable by
+/// construction, and for one that does not it expires exactly where the drop's
+/// own schedule puts it.
 fn direct_services(
     ledgers: &Ledgers,
     surface: Arc<dyn TaskRunPodSurface>,
@@ -418,6 +488,16 @@ async fn occupying_lease(services: &DirectServices, identity: &LeaseIdentity) ->
 ///
 /// Note which ledger each assertion reads. Asserting only that the permit row
 /// changed would be a success log from the wrong store.
+///
+/// # Nothing here is decided by the wall clock
+///
+/// Every quantity that orders this test — the drop's backoff schedule, its
+/// `DROP_CONFIRMATION_BUDGET`, and the gate's own [`GATE_BUDGET`] — is measured
+/// by the injected [`StallingClock`]. The drop's backoffs are what carry that
+/// clock forward, so the gate cannot answer until the drop has spent more
+/// virtual time than its own confirmation window allows, which it can only do
+/// from inside the quarantine loop. A contended Postgres makes this test
+/// slower; it cannot make it fail.
 #[tokio::test]
 async fn a_quarantined_drop_holds_the_build_lease_in_the_other_ledger() {
     let ledgers = Ledgers::lifted("held").await;
@@ -425,12 +505,12 @@ async fn a_quarantined_drop_holds_the_build_lease_in_the_other_ledger() {
     let services = direct_services(
         &ledgers,
         surface,
-        Arc::new(StallingClock::new(24)),
-        // Leave enough wall-clock budget for the durable `lifted -> drop_required`
-        // transition even when CI's shared Postgres is contended. The stalling
-        // clock still makes the quarantine loop pending, so this timeout tests
-        // the held-lease boundary rather than racing the transition itself.
-        Duration::from_secs(2),
+        // 64 backoffs is a BACKSTOP against a drop that stops making progress,
+        // not the thing that ends the wait: crossing GATE_BUDGET takes the drop
+        // its 30-second confirmation window (17 backoffs) plus a handful of
+        // quarantine-loop backoffs, all of them virtual.
+        Arc::new(StallingClock::new(64)),
+        GATE_BUDGET,
     );
 
     let identity = ledgers.lease_identity();
@@ -462,22 +542,33 @@ async fn a_quarantined_drop_holds_the_build_lease_in_the_other_ledger() {
         })
         .await;
 
+    // LEDGER 2 FIRST, and deliberately so. `LeaseUnavailable` is the handler's
+    // answer for EVERY unsettled drop, so reading it first reports the same
+    // verdict whether the gate held the lease for the right reason or gave up
+    // before the drop had taken durable ownership of the row at all. That is
+    // exactly how CI run `30884032730` presented: the `LeaseUnavailable`
+    // assertion passed, and the failure surfaced three lines later as
+    // `the permit must still owe a drop: Lifted` — a symptom, at the wrong
+    // assertion, with the real cause (a wall-clock budget expiring inside a
+    // fixture whose clock was injected) invisible. Naming the lifecycle state
+    // first makes a genuine failure attributable.
+    let permit = ledgers.permit_state().await;
+    assert_eq!(
+        permit,
+        BuildPodPermitState::Quarantined,
+        "the drop's own {DROP_CONFIRMATION_BUDGET:?} confirmation window is \
+         shorter than the gate's {GATE_BUDGET:?} budget and BOTH are measured \
+         on the injected clock, so the row must have been quarantined before \
+         the gate could answer. Any other state is a broken drop — a `Lifted` \
+         or `DropApplying` row here means the quarantine transition itself was \
+         lost, not that the machine was slow"
+    );
+
     // The handler must NOT report a release.
     assert!(
         matches!(released, LeaseResult::LeaseUnavailable),
-        "an unsettled drop must not acknowledge terminal: {released:?}"
-    );
-
-    // LEDGER 2: the permit is in a nonterminal resize state.
-    let permit = ledgers.permit_state().await;
-    assert!(
-        matches!(
-            permit,
-            BuildPodPermitState::DropRequired
-                | BuildPodPermitState::DropApplying
-                | BuildPodPermitState::Quarantined
-        ),
-        "the permit must still owe a drop: {permit:?}"
+        "an unsettled drop must not acknowledge terminal; the permit is \
+         {permit:?} and the handler answered {released:?}"
     );
 
     // LEDGER 1, after — THE ASSERTION THAT MATTERS. `build_leases`, not


### PR DESCRIPTION
## The mechanism

`TaskRunResizeDropBridge::confirm_drop` bounded the drop with a real
`tokio::time::timeout`:

```rust
match tokio::time::timeout(self.budget, mechanism.drop_to_birth(&drop_request)).await {
```

The mechanism it bounds measures *its whole schedule* on the injected
`ResizeDropClock`: `let deadline = self.clock.now() + self.budget` in
`apply_drop`, and `self.clock.sleep(backoff)` in both `apply_drop` and
`confirm_absence`. So the gate was a **second, uninjected timeline**, and
whichever of the two expired first decided the verdict.

In production the two happen to coincide, which is why this never showed there.
In a fixture they are unrelated — the injected clock is virtual, the timeout is
not — so the gate gave up after however long the *real work* took.

`a_quarantined_drop_holds_the_build_lease_in_the_other_ledger` ran with a 50ms
budget, while `require_drop` needs a `SELECT` plus an `UPDATE` against the
shared template-cloned Postgres, and sibling tests issuing
`CREATE DATABASE … TEMPLATE` stall that cluster well past 50ms. The gate then
answered `Held` before the row had left `lifted`, and the test failed at
`the permit must still owe a drop: Lifted` — CI run `30884032730`, plus 4/80
locally. Commit `e4c68df78` widened the budget 50ms → 2s; that is a bigger
margin on the same race, not its removal.

## The fix

```rust
let settled = tokio::select! {
    biased;
    outcome = mechanism.drop_to_birth(&drop_request) => Some(outcome),
    () = self.clock.sleep(self.budget) => None,
};
```

One timeline. Whatever governs the drop's backoff schedule now also governs the
budget that bounds it, and nothing in the verdict is decided by an uninjected
clock. `biased` so a drop that settles in the same poll the budget expires in is
reported as settled.

### Production still bounds real time at 45s

Verified by inspection, on every path that reaches this code:

* `DROP_GATE_BUDGET` is unchanged at `Duration::from_secs(45)`.
* The only production construction of the bridge is
  `TaskRunResizeDropBridge::from_env` (`server/src/server/state/mod.rs:577`),
  which sets `clock: Arc::new(SystemResizeDropClock)` and
  `budget: DROP_GATE_BUDGET`.
* `SystemResizeDropClock::sleep` is `tokio::time::sleep(duration).await` — a
  real timer. `select!`-ing on it is the same wall-clock bound
  `tokio::time::timeout` gave, including dropping the loser future.
* `with_surface` (caller-supplied clock) and `with_budget` are reached only from
  `server/tests/task_run_resize_faults.rs` and
  `server/tests/task_run_resize_recovery.rs`.

### Every `confirm_drop` call site

* `server/crates/djinn-agent/src/direct_services.rs:1066` — the `release_lease`
  handler, the only caller. Signature and `ResizeDropVerdict` mapping unchanged,
  so it type-checks unchanged.
* `server/crates/djinn-agent/src/task_run_resize_drop_gate.rs:66` — the trait
  declaration. Untouched.
* `task_run_resize_recovery.rs` never sends `release_lease` (stated in its own
  module header) and so never reaches the gate; the reconciler calls
  `resize_drop_mechanism()` directly and never spends the gate budget.
* `DROP_TRANSIT_GRACE`'s derivation from `DROP_GATE_BUDGET`
  (`task_run_resize_reconcile.rs:177`) stays correct: the handler still waits at
  most `DROP_GATE_BUDGET` of real time.

## The fixture clock

`StallingClock` becomes a single virtual timeline with two roles, told apart by
the duration asked for. `TaskRunResizeDrop`'s schedule is capped at
`DROP_MAX_BACKOFF`, so:

* a sleep at or under that cap is one of the drop's own backoffs — it
  **advances** virtual time and returns immediately;
* a longer sleep is the gate's budget — it **observes** virtual time and expires
  only once the drop's own backoffs have carried the clock past it.

The fixture's budget is now derived rather than written as a number:
`GATE_BUDGET = DROP_CONFIRMATION_BUDGET + 5s`. `apply_drop` cannot leave its
confirmation window later than `DROP_CONFIRMATION_BUDGET` **on this same clock**,
so the row is quarantined strictly before the gate may answer — for a structural
reason, at any value of the backoff constants and at any speed of the machine.
`stall_after` drops from 24 to 64 and becomes a pure backstop; a parked drop also
publishes the rest of the window, so a broken budget wait fails an assertion
instead of hanging the suite.

## Teeth kept, and sharpened

* The named failing mutation is untouched: make `DirectServices::release_lease`
  call `BuildLeaseService::release` unconditionally and the `build_leases`
  assertions still read `Terminal` and still fail. Nothing about *what* the test
  reads changed — both ledgers, plus the enforced 4000m init-container status.
* The permit assertion got **stronger**, not weaker: `Quarantined` exactly,
  instead of `DropRequired | DropApplying | Quarantined`. If the quarantine
  transition is lost, or the drop settles when it should not, or the durable
  lifecycle stops moving, the test fails — it can no longer be satisfied by a
  row that merely got partway.
* The masking assert is fixed. `LeaseUnavailable` is the handler's answer for
  *every* unsettled drop, so asserting it first reported the same verdict whether
  the gate held the lease for the right reason or gave up before the drop owned
  the row — which is exactly why the flake surfaced three lines later, at the
  wrong assertion. The lifecycle state is now read first, and the
  `LeaseUnavailable` message carries the permit state with it.

## Verification

Per the reviewer's instruction this change is verified **by reasoning and code
reading, not by execution** — no cargo was run for it. The argument above is
structural: the flake required two timelines, and after this change there is one.

**Flake-rate improvement is to be confirmed by CI.** No rates are claimed here.

## Flake 2 is a different mechanism — deliberately not in this PR

`task_run_resize_drop::tests::the_quarantine_loop_is_unbounded_across_an_apiserver_outage`
(1/80, run `30934589615`) does **not** use `tokio::time::timeout`, and no gate is
involved — it drives `TaskRunResizeDrop` directly. Its fragility is a bounded
spin:

```rust
for _ in 0..2000 { if drop.quarantine_attempts() >= 1 { break; } tokio::task::yield_now().await; }
…
for _ in 0..20_000 { if clock.sleeps().len() >= STALL_AFTER { break; } tokio::task::yield_now().await; }
```

`yield_now` reschedules; it does not wait. While the spawned drop is blocked on a
Postgres round trip the loop burns its whole iteration budget in microseconds,
falls through, and the test asserts `quarantine_attempts() > 8` against a drop
that has not started. Same family (real-world timing deciding something the
injected clock should), different mechanism — an iteration-count budget rather
than a wall-clock one. Fixing it means replacing the two spins with condition
waits that cannot be exhausted early; left out of this PR on the reviewer's
instruction rather than forced into its story.
