### PR TITLE
Give the model-health breaker a clock seam, and stop charging coordinator startup to a lock-contention budget

### DIFF
--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -424,14 +424,43 @@ pub struct HealthTracker {
     /// by the coordinator at its redispatch streak/cooldown site. Independent of
     /// the `(scope, model)` breaker buckets above.
     task_failures: Arc<Mutex<HashMap<String, TaskFailureSignal>>>,
+    /// The time source every breaker transition reads.
+    ///
+    /// Cooldown deadlines, half-open reclassification and the rolling
+    /// trip-rate window are all *time* predicates, so without a seam here the
+    /// only way to test them is to race the wall clock: a test that trips the
+    /// breaker and then reads it back is really asserting that the five-second
+    /// [`INITIAL_COOLDOWN`] outlasts whatever else the test does in between.
+    /// That is the mechanism behind the `debug_dispatch_state` and `/metrics`
+    /// wedge-fixture flakes — under a loaded runner the cooldown truthfully
+    /// expired mid-test and `debug_snapshot` correctly reported `half_open`.
+    ///
+    /// Held inside the shared handle (not per-clone) so every clone of a
+    /// tracker observes the same clock: `AppState` hands clones to the
+    /// coordinator, the metrics scraper and the debug endpoint, and they must
+    /// agree on what time it is.
+    clock: Arc<dyn Clock>,
 }
 
 impl HealthTracker {
     pub fn new() -> Self {
+        Self::with_clock(Arc::new(SystemClock::new()))
+    }
+
+    /// Like [`new`](Self::new), but every breaker transition reads the supplied
+    /// clock instead of the system one — the deterministic-test seam.
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(HashMap::new())),
             task_failures: Arc::new(Mutex::new(HashMap::new())),
+            clock,
         }
+    }
+
+    /// The single monotonic read for this tracker. Every cooldown deadline,
+    /// availability check and trip-window prune goes through here.
+    fn now(&self) -> Instant {
+        self.clock.now_instant()
     }
 
     /// Record the most recent typed provider failure for a task (side-channel
@@ -516,7 +545,7 @@ impl HealthTracker {
     /// exhausted chain. Instead, this advances a separate breaker-eligible
     /// consecutive-failure counter scoped to chain exhaustions only.
     pub fn apply_breaker_check_for(&self, scope: Option<&str>, model_id: &str) {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let mut map = self.inner.lock().unwrap();
         let key = HealthKey::new(scope, model_id);
         let Some(state) = map.get_mut(&key) else {
@@ -569,7 +598,7 @@ impl HealthTracker {
     /// Record a successful invocation.  Resets consecutive failure counter;
     /// clears auto-disable state if the cooldown has expired.
     pub fn record_success(&self, scope: Option<&str>, model_id: &str) {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let mut map = self.inner.lock().unwrap();
         let state = map.entry(HealthKey::new(scope, model_id)).or_default();
         state.consecutive_failures = 0;
@@ -598,7 +627,7 @@ impl HealthTracker {
     /// Record a failed invocation.  Trips the circuit breaker when the
     /// consecutive failure threshold is reached.
     pub fn record_failure(&self, scope: Option<&str>, model_id: &str) {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let mut map = self.inner.lock().unwrap();
         let key = HealthKey::new(scope, model_id);
         let state = map.entry(key.clone()).or_default();
@@ -677,7 +706,7 @@ impl HealthTracker {
     /// `InvalidRequest` and `InvalidOutput` continue through
     /// [`record_failure`]/[`record_stall`] and still trip at three strikes.
     pub fn record_transient_failure(&self, scope: Option<&str>, model_id: &str) {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let mut map = self.inner.lock().unwrap();
         let key = HealthKey::new(scope, model_id);
         let state = map.entry(key.clone()).or_default();
@@ -760,7 +789,7 @@ impl HealthTracker {
     /// genuine trip — ratcheting the cap and counting toward the hard-disable
     /// ceiling. A single success fully resets that streak.
     pub fn record_stall(&self, scope: Option<&str>, model_id: &str, escalate: bool) {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let mut map = self.inner.lock().unwrap();
         let key = HealthKey::new(scope, model_id);
         let state = map.entry(key.clone()).or_default();
@@ -847,7 +876,7 @@ impl HealthTracker {
     /// Returns `true` when the `(scope, model)` bucket is not circuit-breaker
     /// disabled (or when its cooldown has expired).
     pub fn is_available(&self, scope: Option<&str>, model_id: &str) -> bool {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let map = self.inner.lock().unwrap();
         map.get(&HealthKey::new(scope, model_id))
             .is_none_or(|s| s.is_available(now))
@@ -872,7 +901,7 @@ impl HealthTracker {
 
     /// Return health state for all tracked buckets, sorted by `(scope, model)`.
     pub fn all_health(&self) -> Vec<ModelHealth> {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let map = self.inner.lock().unwrap();
         let mut health: Vec<_> = map.iter().map(|(key, s)| s.to_health(key, now)).collect();
         health.sort_by(|a, b| {
@@ -899,8 +928,11 @@ impl HealthTracker {
                 .collect()
         };
 
-        let now = SystemClock::new().now_instant();
-        let wall_now = ::time::OffsetDateTime::now_utc();
+        let now = self.now();
+        // Wall time comes from the same seam as the monotonic read so the
+        // rendered `until` deadline stays consistent with the `open`/`half_open`
+        // classification computed from `now` (and so both are test-controlled).
+        let wall_now = ::time::OffsetDateTime::from(self.clock.now());
         let mut snapshot: Vec<_> = entries
             .into_iter()
             .filter_map(
@@ -945,7 +977,7 @@ impl HealthTracker {
     /// `djinn_breaker_state{scope,model}` gauge as Closed=`0.0`, HalfOpen=`0.5`,
     /// Open=`1.0`.
     pub fn breaker_metric_snapshot(&self) -> Vec<BreakerMetricSnapshot> {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let map = self.inner.lock().unwrap();
         let mut snapshot: Vec<_> = map
             .iter()
@@ -978,7 +1010,7 @@ impl HealthTracker {
 
     /// Replace all tracked health state with a persisted snapshot.
     pub fn restore_all(&self, snapshot: Vec<ModelHealth>) {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let mut map = self.inner.lock().unwrap();
         map.clear();
         for health in snapshot {
@@ -1029,7 +1061,7 @@ impl HealthTracker {
     /// Return health state for a single `(scope, model)` bucket (returns zero
     /// state if untracked).
     pub fn model_health(&self, scope: Option<&str>, model_id: &str) -> ModelHealth {
-        let now = SystemClock::new().now_instant();
+        let now = self.now();
         let key = HealthKey::new(scope, model_id);
         let map = self.inner.lock().unwrap();
         map.get(&key)

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -450,6 +450,24 @@ pub enum BootTokenExchangeResult {
 
 impl AppState {
     pub fn new(db: Database, cancel: CancellationToken) -> Self {
+        Self::new_with_health_clock(db, cancel, Arc::new(djinn_core::clock::SystemClock::new()))
+    }
+
+    /// Like [`new`](Self::new), but the model-health circuit breaker reads
+    /// `health_clock` instead of the system clock.
+    ///
+    /// The breaker's observable state — `open` vs `half_open`, the rendered
+    /// cooldown deadline, the `djinn_breaker_state` gauge — is a pure function
+    /// of "how long ago did this bucket trip". A fixture that trips the breaker
+    /// and then asserts on it through the HTTP surface is therefore racing the
+    /// five-second `INITIAL_COOLDOWN` against its own setup work. Injecting a
+    /// `TestClock` here removes the race by construction rather than by
+    /// widening the cooldown.
+    pub fn new_with_health_clock(
+        db: Database,
+        cancel: CancellationToken,
+        health_clock: Arc<dyn djinn_core::clock::Clock>,
+    ) -> Self {
         let runtime = DatabaseRuntimeManager::new(
             crate::db::runtime::DatabaseRuntimeConfig::postgres(db.bootstrap_info().target.clone()),
         );
@@ -460,6 +478,7 @@ impl AppState {
             djinn_core::doctor::RetrievalHealthConfig::default(),
             Arc::new(djinn_telemetry::memory_retrieval::MemoryRetrievalMetrics::new()),
             KnowledgeInjectionConfig::default(),
+            health_clock,
         )
     }
 
@@ -478,9 +497,11 @@ impl AppState {
             retrieval_config,
             retrieval_metrics,
             knowledge_injection_config,
+            Arc::new(djinn_core::clock::SystemClock::new()),
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_inner(
         db: Database,
         db_runtime: DatabaseRuntimeManager,
@@ -488,6 +509,7 @@ impl AppState {
         retrieval_config: djinn_core::doctor::RetrievalHealthConfig,
         retrieval_metrics: Arc<djinn_telemetry::memory_retrieval::MemoryRetrievalMetrics>,
         knowledge_injection_config: KnowledgeInjectionConfig,
+        health_clock: Arc<dyn djinn_core::clock::Clock>,
     ) -> Self {
         let (events, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         let mirror = Arc::new(MirrorManager::new(mirrors_root()));
@@ -587,7 +609,7 @@ impl AppState {
                     provider_catalog_refresh::refresh_interval_from_env(),
                 provider_catalog_refresh_started: AtomicBool::new(false),
                 build_epoch_loop_started: AtomicBool::new(false),
-                health_tracker: HealthTracker::new(),
+                health_tracker: HealthTracker::with_clock(health_clock),
                 retrieval_config,
                 retrieval_metrics,
                 knowledge_injection_config,

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -3857,6 +3857,7 @@ mod build_epoch_bridge_tests {
             djinn_core::doctor::RetrievalHealthConfig::default(),
             Arc::new(djinn_telemetry::memory_retrieval::MemoryRetrievalMetrics::new()),
             KnowledgeInjectionConfig::default(),
+            Arc::new(djinn_core::clock::SystemClock::new()),
         )
     }
 
@@ -4188,6 +4189,7 @@ mod build_epoch_bridge_tests {
             djinn_core::doctor::RetrievalHealthConfig::default(),
             Arc::new(djinn_telemetry::memory_retrieval::MemoryRetrievalMetrics::new()),
             resolved,
+            Arc::new(djinn_core::clock::SystemClock::new()),
         );
 
         assert_eq!(state.agent_context().knowledge_injection, resolved);

--- a/server/src/server/tests/metrics_debug_dispatch.rs
+++ b/server/src/server/tests/metrics_debug_dispatch.rs
@@ -1,6 +1,11 @@
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header::CONTENT_TYPE};
+use djinn_core::clock::TestClock;
 use djinn_db::{CreateUserAuthSession, SessionAuthRepository, UserRepository};
+use djinn_provider::catalog::HealthTracker;
 use http_body_util::BodyExt;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
@@ -12,39 +17,69 @@ use crate::test_helpers;
 const WEDGE_SCOPE: &str = "u-wedge";
 const WEDGE_MODEL: &str = "claude-test";
 
+/// The breaker's `INITIAL_COOLDOWN`. Not importable (it is private to
+/// `djinn-provider`), so it is restated here purely to drive the test clock
+/// past it in the half-open leg below.
+const BREAKER_INITIAL_COOLDOWN: Duration = Duration::from_secs(5);
+
 static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 struct WedgedDispatchState {
     app: axum::Router,
     db: djinn_db::Database,
+    health: HealthTracker,
+    clock: Arc<TestClock>,
     scope: &'static str,
     model: &'static str,
 }
 
+impl WedgedDispatchState {
+    /// Wedge dispatch by exhausting the breaker's three-strike ladder.
+    ///
+    /// This is deliberately `record_failure` at exactly
+    /// `CIRCUIT_BREAKER_THRESHOLD` strikes: the fixture is asserting on the
+    /// ordinary genuine-failure path, and the `consecutive_failures == 3`
+    /// assertion below is only meaningful if the third strike is what tripped
+    /// it. Because the tracker reads `self.clock`, the resulting five-second
+    /// cooldown cannot expire underneath the assertions no matter how long the
+    /// surrounding HTTP/DB work actually takes.
+    fn wedge(&self) {
+        for _ in 0..3 {
+            self.health.record_failure(Some(self.scope), self.model);
+        }
+    }
+}
+
+/// Build the wedge fixture with time frozen.
+///
+/// Nothing is wedged yet: callers seed whatever database state they need
+/// *first* and call [`WedgedDispatchState::wedge`] last, so no unrelated setup
+/// sits inside the trip→assert window. With the injected clock that ordering is
+/// belt-and-braces rather than load-bearing, but it keeps the window minimal.
+#[allow(clippy::disallowed_methods)] // test: real monotonic base for the TestClock
 async fn setup_wedged_dispatch_state() -> WedgedDispatchState {
     let db = test_helpers::create_test_db();
-    let state = AppState::new(db.clone(), CancellationToken::new());
+    // A fixed wall time so the rendered `until` deadline is reproducible, and a
+    // monotonic base that only this test advances.
+    let clock = Arc::new(TestClock::new(
+        SystemTime::UNIX_EPOCH + Duration::from_secs(1_770_000_000),
+        std::time::Instant::now(),
+    ));
+    let cancel = CancellationToken::new();
+    let state = AppState::new_with_health_clock(db.clone(), cancel, clock.clone());
     state.initialize_agent_handles_for_tests().await;
+    let health = state.health_tracker().clone();
 
     // Use the breaker wedge because it is the least flaky end-to-end signal:
-    // three synthetic stalled invocations open the per-user/model breaker
+    // three synthetic provider failures open the per-user/model breaker
     // synchronously, and both `/metrics` and `/debug/dispatch-state` read that
-    // shared tracker without needing a real worker pod or log scraping. A
-    // regular failure opens for only five seconds, which can truthfully become
-    // half-open while this test seeds its database-backed admin session under a
-    // loaded CI runner. A stall is the production failover transition with a
-    // five-minute minimum cooldown; it keeps this intentionally wedged state
-    // open while preserving the observable three-failure count.
-    for _ in 0..3 {
-        state
-            .health_tracker()
-            .record_stall(Some(WEDGE_SCOPE), WEDGE_MODEL, true);
-    }
-
+    // shared tracker without needing a real worker pod or log scraping.
     let app = server::router(state, false);
     WedgedDispatchState {
         app,
         db,
+        health,
+        clock,
         scope: WEDGE_SCOPE,
         model: WEDGE_MODEL,
     }
@@ -54,6 +89,7 @@ async fn setup_wedged_dispatch_state() -> WedgedDispatchState {
 async fn metrics_endpoint_reports_wedged_dispatch_via_metrics_alone() {
     let _guard = TEST_LOCK.lock().await;
     let wedged = setup_wedged_dispatch_state().await;
+    wedged.wedge();
 
     let response = wedged
         .app
@@ -90,8 +126,13 @@ async fn metrics_endpoint_reports_wedged_dispatch_via_metrics_alone() {
 async fn debug_dispatch_state_returns_wedge_to_admin_and_403_to_non_admin() {
     let _guard = TEST_LOCK.lock().await;
     let wedged = setup_wedged_dispatch_state().await;
+    // Seed both database-backed sessions BEFORE tripping the breaker: this is
+    // the slowest work in the test (two user upserts plus two session inserts
+    // over a four-connection pool shared with a starting coordinator) and it
+    // has nothing to do with the wedge.
     let admin_cookie = seed_session(&wedged.db, 101, "admin-wedge", true).await;
     let user_cookie = seed_session(&wedged.db, 102, "user-wedge", false).await;
+    wedged.wedge();
 
     let admin_response = request_debug_dispatch_state(&wedged.app, Some(&admin_cookie)).await;
     assert_eq!(admin_response.status(), StatusCode::OK);
@@ -129,6 +170,30 @@ async fn debug_dispatch_state_returns_wedge_to_admin_and_403_to_non_admin() {
 
     let user_response = request_debug_dispatch_state(&wedged.app, Some(&user_cookie)).await;
     assert_eq!(user_response.status(), StatusCode::FORBIDDEN);
+
+    // The other side of the seam: the `open` reading above is a *time*
+    // predicate, and it is this test — not the runner's load — that decides
+    // when the cooldown lapses. Advancing past `INITIAL_COOLDOWN` must flip the
+    // very same bucket to `half_open`.
+    wedged
+        .clock
+        .advance_mono(BREAKER_INITIAL_COOLDOWN + Duration::from_secs(1));
+    let expired = request_debug_dispatch_state(&wedged.app, Some(&admin_cookie)).await;
+    assert_eq!(expired.status(), StatusCode::OK);
+    let expired_json = response_json(expired).await;
+    let expired_breaker = expired_json["breaker"]
+        .as_array()
+        .expect("breaker must be an array")
+        .iter()
+        .find(|entry| entry["scope"] == wedged.scope && entry["model"] == wedged.model)
+        .expect("the wedged bucket must still be reported after its cooldown lapses")
+        .clone();
+    assert_eq!(
+        expired_breaker["state"], "half_open",
+        "an elapsed cooldown must reclassify as half_open — if this stays `open` \
+         the breaker is no longer reading the injected clock, and the `open` \
+         assertion above proves nothing"
+    );
 }
 
 fn breaker_metric_line<'a>(text: &'a str, scope: &str, model: &str) -> Option<&'a str> {


### PR DESCRIPTION
Three flakes in the debug-dispatch / metrics area, plus the missing seam underneath two of them.

> **Verification status, stated up front.** Per an explicit mid-task instruction from the maintainer, **nothing in this PR was compiled or executed locally** — no `cargo check`/`build`/`test`/`clippy`/`fmt`/`nextest`. The machine is running ~10 agents against a ~2800-unit workspace. **CI is the compiler here.** Everything below labelled *reasoned* is an argument from the code, not from a run. **No flake rates are claimed; the improvement is to be confirmed by CI.** The one thing I did do exhaustively is a by-inspection type/callsite audit of the widely-used type this touches — see [Blind-change risk audit](#blind-change-risk-audit).

---

## 1. `HealthTracker` had no clock seam — this is the substantive change

`eccaea4d2` is titled *"Repair **deterministic** debug dispatch breaker regression"*, but its one-line change is not deterministic and nothing in it could be: all of `HealthTracker`'s time reads were `SystemClock::new().now_instant()` calls with no injection point, despite `djinn_core::clock::{Clock, TestClock}` existing and being used as a seam by `TaskRunSupervisor`, `LeaseInvocationRunner`, `SlotHost` and others in this same tree.

That matters because every observable the wedge fixtures assert on is a *time* predicate:

| observable | where | predicate |
|---|---|---|
| `state: "open"` vs `"half_open"` | `health.rs` `debug_snapshot` | `now >= cooldown_until` |
| `totals.open_breakers` | `server/src/server/debug.rs:81` | counts `state == "open"` |
| `djinn_breaker_state{…} 1` vs `0.5` | `health.rs` `breaker_metric_snapshot` | `is_available(now)` |

So a fixture that trips the breaker and then reads it back over HTTP is really asserting *"the five-second `INITIAL_COOLDOWN` outlasts my own setup work"*. On a loaded runner it does not, and `debug_snapshot` then correctly reports `half_open` — the test failed while the production code was right.

**This PR gives `HealthTracker` an `Arc<dyn Clock>`**, following the existing `with_clock` idiom in this repo:

```rust
pub fn new() -> Self { Self::with_clock(Arc::new(SystemClock::new())) }
pub fn with_clock(clock: Arc<dyn Clock>) -> Self { … }
fn now(&self) -> Instant { self.clock.now_instant() }
```

* The seam is **conservative and additive**: `new()` and `Default` keep their signatures and default to `SystemClock`, so **no existing caller changes**.
* The clock lives inside the handle that `Clone` shares, so the coordinator, the metrics scraper and the debug endpoint — all of which hold clones of `AppState`'s tracker — agree on what time it is.
* All **eleven** time reads now go through `self.now()`, not the three named in the issue. Leaving eight behind would have produced a tracker whose availability check and whose cooldown deadline disagreed — a worse bug than the flake.
* `debug_snapshot`'s wall clock moves to `OffsetDateTime::from(self.clock.now())` as well, so the rendered `until` deadline stays consistent with the `open`/`half_open` classification computed two lines above it from `now`.

`AppState::new_with_health_clock(db, cancel, clock)` is the composition site; `AppState::new` delegates to it with a `SystemClock`.

## 2. Judgment call: `record_stall` → back to `record_failure`

**Decision: revert the fixture to `record_failure`.** Production `record_stall` behaviour, including `STALL_MIN_COOLDOWN`, is untouched — the revert is confined to the test fixture.

Reasoning, from reading `eccaea4d2` and the surrounding code:

1. **The commit states its own motivation, and it is timing, not semantics.** Its comment says a regular failure *"opens for only five seconds, which can truthfully become half-open while this test seeds its database-backed admin session under a loaded CI runner."* The swap to `record_stall` widens the window 60× (5s → `STALL_MIN_COOLDOWN` 5min). That is a probability reduction — real, and it would have suppressed the flake in practice — but it is not determinism, and the commit title says "deterministic". Once the clock is injectable the window cannot elapse *at all*, so the reason for the swap is gone.

2. **The swap silently changed what the fixture models, and made its own loop decorative.** `record_failure` trips only when `breaker_eligible_consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD` — the `for _ in 0..3` is load-bearing and the *third* call is the trip. `record_stall` trips **immediately, on the first call**; calls two and three bump `consecutive_failures`/`total_failures` and then hit the `if state.auto_disabled { return; }` early return. The fixture still produced the number `3` that `assert_eq!(wedge_breaker["consecutive_failures"], 3)` checks, but no longer through the ladder — the assertion had quietly become a count of raw observations rather than evidence that the three-strike threshold fired. `CIRCUIT_BREAKER_THRESHOLD` was left with no coverage at the HTTP surface at all.

3. **`record_stall(…, true)` carries production semantics the fixture does not want**: it advances `disable_ttl_trips`, calls `register_trip` into the rolling hard-disable window, and sets `last_trip_throttle`. Harmless in a one-shot fixture, but it models *"a zero-token first-LLM-call stall"*, which is not what "dispatch wedged by three provider failures" means. A fixture should model the thing it is named after.

4. **Nothing is lost.** `record_stall` has ~20 dedicated unit tests in `djinn-provider/src/catalog/health_tests.rs` covering escalation, the throttle streak, the persistent-throttle window and the hard-disable ceiling. Reverting one fixture costs it no coverage, while `record_failure` at the three-strike threshold *regains* end-to-end coverage.

So `record_stall` was a workaround wearing a semantics costume. It should not stay.

## 3. Flake 1 — the lock-contention test was measuring startup I/O

`test_debug_dispatch_state_lock_contention_under_5s` started its clock immediately after `spawn_coordinator`, which returns as soon as the actor task is spawned — it **does not await readiness**. `CoordinatorActor::run` then performs six serial Postgres startup sweeps (stale task-run reap, orphaned pending attempts, orphaned taskrun Jobs, durable dispatch-state rehydration, interrupted refinements, terminal linked-spike evidence) before it ever enters the `select!` loop that services this mailbox — and the 30s safety-net `time::interval` fires **immediately** on first poll, so a full `run_tick()` runs ahead of the queued messages under the biased select. All of that was charged to a 5s budget for what is otherwise a lock-free read of empty maps. There is in-repo precedent at `actor.rs:57-93` for a 15,046 ms tick from a pool-acquire stall.

The rewrite (renamed `…_lock_contention_stays_proportional`):

1. **Warm-up round-trip before the clock starts.** The first `debug_dispatch_state()` can only complete once the actor is serving its mailbox, so awaiting one *is* exactly the readiness barrier `spawn_coordinator` does not provide. The startup charge is excluded by construction.
2. **Measure the median of 25 warm serial round-trips** (median so a single collision with the coordinator's own tick cannot skew it).
3. **Assert that median is under 50 ms** — the leg that catches a genuine latency regression.
4. **Derive the concurrency budget** as `median × 1000 × 4`, floored at the original 5 s. **No ceiling**: clamping an adaptive budget from above just reintroduces the absolute limit it was meant to remove.

Because the floor equals the old absolute budget, the concurrency leg **can never be stricter than the test it replaces**. All added strictness lives in the new warm per-round-trip assertion.

## 4. Flake 3 — same mechanism, same fix

`metrics_endpoint_reports_wedged_dispatch_via_metrics_alone` (reported ~1/80) shares Flake 2's mechanism exactly, with a smaller window: after the trip it only builds the router and issues one `/metrics` request, but `breaker_metric_snapshot` maps an expired cooldown to `HalfOpen → 0.5`, and the test asserts the gauge line `ends_with(" 1")`. Same frozen clock, same fix. No separate change was needed.

I checked the process-global-state hypothesis and it is **refuted**, consistent with the issue: `HealthTracker` is a per-`AppState` `Arc<Mutex<HashMap<…>>>` (`health.rs:420-427`) constructed at `state/mod.rs:590` — there is no static, and the two tests already serialise on a module `TEST_LOCK`.

---

## Non-vacuity — argued in prose (not executed)

**"If the breaker never tripped, would these tests still fail?" — yes, at four independent points.**

If `record_failure` stopped tripping (threshold raised, or the trip block removed), `ModelState.auto_disabled` stays `false` for the `(u-wedge, claude-test)` bucket. Then:

* `debug_snapshot` returns `None` for every bucket with `!auto_disabled`, so `json["breaker"]` is `[]` and `.find(state == "open").expect("debug dispatch state must expose the open breaker wedge")` **panics**;
* `assert_eq!(wedge_breaker["consecutive_failures"], 3)` is never reached, and `assert_eq!(json["totals"]["open_breakers"], 1)` would independently read `0` — that total is computed at `server/src/server/debug.rs:81` by filtering the same snapshot for `state == "open"`, so it is derived from breaker state, not from a label;
* `breaker_metric_snapshot` maps `!auto_disabled → Closed → 0.0`, so `/metrics` renders `djinn_breaker_state{scope="u-wedge",model="claude-test"} 0` and `line.ends_with(" 1")` is **false** — the third test fails on a different code path from the first two.

Critically, **the clock injection cannot satisfy any of these on its own.** A `TestClock` only decides whether an *already-open* bucket has expired; it cannot create an entry in the map or set `auto_disabled`. Only `record_failure` reaching `CIRCUIT_BREAKER_THRESHOLD` does that. So the tests remain wired to real breaker state, and the seam did not make them pass for a new, hollow reason.

**"If the non-admin path returned 200, would the test still fail?" — yes.**

`request_debug_dispatch_state(&app, Some(&user_cookie))` is the *only* thing standing between the request and the handler body; if `auth::require_admin` returned `Ok`, the handler proceeds and returns `200 OK`, so `assert_eq!(user_response.status(), StatusCode::FORBIDDEN)` fails on `200 != 403`. The cookie is a real DB-backed session for a user whose `set_admin_status(&user.id, false)` was persisted — not a stub — so the assertion exercises the real lookup. The anonymous leg asserting `401` is kept separate, so a guard that merely rejected everything unauthenticated would still fail the `403` leg. Both legs survive unchanged from the original test; my only edit to that test is *when* the wedge happens.

**"Does Flake 1 still measure something real?" — yes, and it fails on a genuine latency regression.**

Two assertions, catching different shapes:

* *Uniform latency regression* — if `dispatch_state_snapshot` started doing I/O, or the actor stopped servicing its mailbox promptly, the **median warm serial round-trip** rises and `per_round < MAX_WARM_ROUND_TRIP` (50 ms) fires. This bound is safe to state absolutely *precisely because* it is measured warm and serially: the quantity that made the old assertion flaky (startup I/O in the window) is gone. For calibration, the old test permitted a 5 ms average per snapshot under 1000-way concurrency; 50 ms serially is an order of magnitude beyond that and unreachable by a lock-free read of empty maps.
* *Contention regression* — the thing the test is actually named for: a mutex held across the snapshot, or a lock held across an `.await`, is O(1) serially but super-linear under concurrency, so the aggregate blows past `median × 1000 × 4`. A merely-slow machine scales both sides together and correctly does **not** fire.

**Bonus: the fixture now contains a permanent guard that the seam is live.** The final leg advances the test clock past the cooldown and asserts the same bucket reports `half_open`. If `HealthTracker` ever reverts to reading the system clock, `advance_mono` becomes a no-op, the bucket still reads `open` a few milliseconds after tripping, and **this assertion fails**. That converts "the seam is wired up" from a claim into a test — which is the part I could not otherwise demonstrate without running anything.

## Blind-change risk audit

`HealthTracker` is widely used, so I audited it by inspection rather than by compiler:

* **Construction sites.** `grep -rn "HealthTracker\s*{"` finds **zero** struct-literal constructions outside the defining module (the fields are private, so none is possible). Every site goes through `HealthTracker::new()` (97) or `::default()` (5) — both signature-unchanged — plus the single new `with_clock` at the `AppState` composition site. **No caller needs to change.**
* **Every `self.now()` replacement.** All eleven sit as the first statement of a `&self` method (`apply_breaker_check_for`, `record_success`, `record_failure`, `record_transient_failure`, `record_stall`, `is_available`, `all_health`, `debug_snapshot`, `breaker_metric_snapshot`, `restore_all`, `model_health`), in the same position the direct `SystemClock` read occupied — before `self.inner.lock()`, so no borrow conflict and no lock is held across the clock read.
* **Trait-object viability.** `Clock` is object-safe (two `&self` methods, no generics, no `Self` return) and declares `Send + Sync`, so `Arc<dyn Clock>` keeps `HealthTracker: Clone + Send + Sync`. It is already used as `Arc<dyn Clock>` in four other crates here.
* **`OffsetDateTime::from(SystemTime)`** exists in `time` 0.3 under the `std` feature, which is on (the file already called `OffsetDateTime::now_utc()`, itself `std`-gated).
* **Imports.** `SystemClock` is still used (by `new()`), `Clock` by the field type, `Instant` by `fn now`. No import became dead.
* **Lints.** `Instant::now()` for the `TestClock` base is confined to one test helper carrying `#[allow(clippy::disallowed_methods)]`, matching the existing convention in `process_lease_recovery_tests.rs` and others. `new_inner` reaches exactly 7 parameters (clippy's `too_many_arguments` fires above 7); the `#[allow]` is belt-and-braces.
* **Formatting.** Lines were kept structurally unambiguous under rustfmt defaults (no `rustfmt.toml` in-tree, so `max_width = 100`), since I could not run `cargo fmt`. If CI's fmt check disagrees anywhere it will be a whitespace-only fixup.

## What is verified vs. reasoned

| | status |
|---|---|
| Compilation, clippy, rustfmt | **Not run locally. Verified in CI.** |
| Flake rates before/after | **Not measured. To be confirmed by CI.** No rates claimed. |
| Callsite/type audit of the `HealthTracker` seam | Verified by inspection (enumerated above) |
| Removal of wall-clock dependence | **Structural argument**: the breaker's observables are pure functions of `self.clock`; freezing the clock makes them independent of elapsed real time. Follows from the design, not from a pass rate. |
| Removal of the startup charge in Flake 1 | **Structural argument**: the measurement window now begins only after a completed round-trip, which is only possible once the actor is servicing its mailbox. |
| Non-vacuity of all three tests | **Reasoned in prose above**, plus one mechanised guard (the `half_open` leg) that fails if the seam is bypassed. |

Not enqueued, not merged.
