### PR TITLE
fix(graph): stop the child reaper stealing std's own exec-failure wait

### DIFF
--- a/server/crates/djinn-graph/src/process.rs
+++ b/server/crates/djinn-graph/src/process.rs
@@ -73,6 +73,11 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(target_os = "linux")]
 use djinn_core::clock::{Clock, SystemClock};
 
+/// Claims wait rights over a spawned child so the worker-wide `waitpid(-1)`
+/// reaper cannot collect a status that an in-process waiter already owns.
+#[cfg(target_os = "linux")]
+use djinn_core::child_ownership::spawn_owned;
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -608,8 +613,20 @@ fn run_linux_supervisor(
     // ── 2. Spawn ────────────────────────────────────────────────────────
     // Spawn errors remain the original io::Error.  The Admission is dropped
     // (releasing the reservation) if spawn fails.
-    let mut child = match cmd.spawn() {
-        Ok(child) => child,
+    //
+    // The spawn goes through [`spawn_owned`] because the EXEC-FAILURE path of
+    // `std::process::Command::spawn` waits on its own child: after reading
+    // errno off the CLOEXEC pipe, std's parent runs
+    // `assert!(p.wait().is_ok(), "wait() should either return Ok or panic")`
+    // (`std/src/sys/process/unix/unix.rs`).  The worker-wide reaper is a
+    // `waitpid(-1)` consumer, so without the spawn gate it can collect that
+    // failed-exec zombie first; std's `wait()` then returns `ECHILD`, the
+    // assert fires, and this blocking task panics — turning a plain `NotFound`
+    // for a missing binary into `ErrorKind::Other` carrying a `JoinError`.
+    // `spawn_owned` holds the gate shared across fork AND std's internal wait,
+    // while a reaper pass takes it exclusively, so the two cannot interleave.
+    let (mut child, owned_child) = match spawn_owned(|| cmd.spawn(), |child| Some(child.id())) {
+        Ok(spawned) => spawned,
         Err(err) => {
             admission.release();
             return Err(err);
@@ -628,7 +645,13 @@ fn run_linux_supervisor(
     drop(child);
 
     // Registration failure is post-spawn, so bounded cleanup owns the live group.
-    let direct = match admission.register_direct(pid, pgid) {
+    let registration = admission.register_direct(pid, pgid);
+    // The spawn-time claim covered only std's internal wait on an exec failure.
+    // A live child's status belongs to the central reaper, so release the claim
+    // as soon as its PID route exists (or failed to be installed) — holding it
+    // would make the reaper decline this PID forever and strand the supervisor.
+    owned_child.release();
+    let direct = match registration {
         Ok(direct) => direct,
         Err(err) => {
             let cleanup = cleanup_unregistered_child(reaper, pgid, stdout, stderr);

--- a/server/crates/djinn-graph/src/process_tests.rs
+++ b/server/crates/djinn-graph/src/process_tests.rs
@@ -158,13 +158,28 @@ async fn timeout_reaps_whole_process_group() {
     assert!(!out.status.success());
     assert!(killed_by_signal(&out.status).is_some());
 
-    let pgid: i32 = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .next()
-        .unwrap_or("")
-        .trim()
-        .parse()
-        .expect("child should have printed its pgid");
+    // KNOWN FLAKE, NOT YET ROOT-CAUSED (~1 in 80 runs; CI run 30961668804,
+    // shard-5, `child should have printed its pgid: ParseIntError { kind:
+    // Empty }` after 0.237s). The fixture publishes its identity through TWO
+    // extra `fork`+`exec`s (`ps`, `tr`) whose output only reaches this pipe
+    // when `tr` exits and flushes — so anything that stops the pipeline
+    // completing inside the 200ms deadline (a slow exec under CI contention, a
+    // failed `fork`, an OOM kill) loses the identity silently, and SIGTERM at
+    // the deadline discards `tr`'s buffer. The deliberate non-fix: a 640-run
+    // sweep of that exact pipeline (idle and under 48-way CPU load; 160 of them
+    // at the production 200ms deadline, the rest at 100/50/25ms) produced ZERO
+    // empty publications, so "the pipeline is merely too slow" is UNCONFIRMED,
+    // and shortening it would be a guess that hides the real cause. Carry both
+    // streams onto the panic instead, so the next occurrence names its own
+    // cause rather than needing a re-diagnosis.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let first_line = stdout.lines().next().unwrap_or("").trim();
+    let pgid: i32 = first_line.parse().unwrap_or_else(|err| {
+        panic!(
+            "child should have printed its pgid: {err}; stdout={stdout:?} stderr={:?}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
 
     // The supervisor should have already ensured the direct child's process
     // group was cleaned up.  On systems where PID 1 reaps orphans promptly,


### PR DESCRIPTION
Two `djinn-graph` process-supervision tests were reported as long-tail flakes (~1 in 80 sampled runs each) with no prior root cause. Both were diagnosed from the CI logs of the two evidence runs. **One is fixed here; the other is diagnosed but deliberately left alone**, because the only fix I could construct is a guess I cannot support with evidence.

Both flakes are still live: nothing has touched `server/crates/djinn-graph/src/process*.rs`, `child_reaper.rs` or `child_ownership.rs` since 2026-07-28 (#2700), and the evidence runs are 2026-08-04/05.

## 1. `spawn_failure_returns_original_io_error` — ROOT-CAUSED, FIXED

Run `30948600873`, `Server Test (shard-3, 2)`, `TRY 1 FAIL [0.010s]`:

```
thread 'tokio-rt-worker' (16171) panicked at
  /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/std/src/sys/process/unix/unix.rs:149:21:
wait() should either return Ok or panic

thread 'process::linux_supervisor_tests::spawn_failure_returns_original_io_error' (16167)
  panicked at crates/djinn-graph/src/process_linux_supervisor_tests.rs:311:5:
assertion `left == right` failed
  left: Other
 right: NotFound
```

### Mechanism

The toolchain hash `8bab26f4f` is rustc 1.97.1, and line 149 of that exact file is the **exec-failure arm** of `std::process::Command::spawn`:

```rust
Ok(8) => {
    let (errno, footer) = bytes.split_at(4);
    ...
    assert!(p.wait().is_ok(), "wait() should either return Ok or panic");
    return Err(Error::from_raw_os_error(errno));
}
```

So `spawn()` of a nonexistent binary is itself an in-process waiter: the forked child fails to exec, writes errno to the CLOEXEC pipe, `_exit(1)`s, and the parent must reap that zombie before it can return `NotFound`.

`run_linux_supervisor` called `cmd.spawn()` **bare**. `worker_child_reaper()` runs a `waitpid(-1)` consumer (`peek_waitable` → `waitpid(pid)`) polling every 10 ms. It declines PIDs registered in `djinn_core::child_ownership`, but `grep spawn_owned server/crates/djinn-graph/src/*.rs` returned **nothing** — djinn-graph never registered any of its spawns. When the reaper's poll lands in the microsecond window between the failed-exec child's `_exit(1)` and std's internal `p.wait()`, the reaper collects it, std's `wait()` returns `ECHILD`, the `assert!` fires, the `spawn_blocking` closure panics, and `output_with_kill_inner` maps the resulting `JoinError` through `io::Error::other` — `ErrorKind::Other`, exactly as observed.

This is the pitfall `#2700` was written for (`waitpid(-1)` steals in-process child statuses, `ECHILD` reads as a spawn failure). #2700 applied the fix to `djinn-git` and left `djinn-graph`'s own supervisor unprotected.

**This is a production bug, not a test artifact.** Any `output_with_timeout` / `output_with_kill` call whose exec fails — a missing SCIP indexer binary, a non-executable tool, `EACCES` — can panic a blocking-pool thread and surface as `Other` with the real errno discarded. The test only makes it visible because it is the one caller that asserts the errno.

### Fix

Route the spawn through `djinn_core::child_ownership::spawn_owned`. That is a real happens-before edge, not a timeout: the spawner holds `SPAWN_GATE` **shared** across `fork` *and* std's internal `wait`, while the reaper takes it **exclusively** around one wait pass (`reaper_pass()` in `child_reaper.rs:452`), so the two cannot interleave.

The claim is released immediately after `register_direct` installs the PID route: a *live* child's status belongs to the central reaper, and holding the claim would make the reaper decline that PID forever and strand the supervisor until its deadline. The release also covers the registration-failure path, so `cleanup_unregistered_child` can still see the group reach `ESRCH`.

The changed window is bounded by one `Mutex` lock (`register_direct`), i.e. microseconds, so the existing timing assertions in `process_linux_supervisor_tests` (`>= 250ms`, `>= 3500ms`, `< 6s`) are unaffected.

## 2. `timeout_reaps_whole_process_group` — MECHANISM ESTABLISHED, NOT FIXED

Run `30961668804`, `Server Test (shard-5, 4)`, `TRY 1 FAIL [0.237s]`:

```
thread 'process::tests::timeout_reaps_whole_process_group' (16031)
  panicked at crates/djinn-graph/src/process_tests.rs:167:10:
child should have printed its pgid: ParseIntError { kind: Empty }
```

### What is established

`out.stdout` was empty (or its first line was) when the 200 ms deadline kill returned at 0.237 s. The fixture publishes its identity as

```sh
ps -o pgid= -p $$ | tr -d ' '; sleep 30 & sleep 30
```

— two extra `fork`+`exec`s whose output reaches the supervisor's pipe only when `tr` exits and flushes (writes to a pipe are fully buffered). Anything that prevents the pipeline completing inside the 200 ms budget loses the identity silently, and the SIGTERM at the deadline discards `tr`'s buffer rather than flushing it. There is no synchronisation between publication and the deadline: the deadline starts at spawn, so no happens-before edge can be added without changing the `output_with_kill(cmd, timeout)` signature.

### Why there is no fix here

The obvious candidate was "the `ps | tr` pipeline is too slow under CI contention — publish with shell builtins into a file instead". **I tried to support that and failed to.** A cargo-free harness reproduced the supervisor's exact behaviour (child in its own process group, non-blocking pipe drain, SIGTERM at the deadline then SIGKILL) and ran that pipeline **640 times** — idle and under 48-way CPU load, at deadlines of 200/100/50/25 ms. **Zero empty publications**, including 160 runs at the production 200 ms deadline and 160 at 25 ms, which is 8× tighter than the real budget.

So the latency hypothesis is unconfirmed, and the residual candidates — a `fork` failure under CI pid/memory pressure, or an OOM kill of `ps`/`tr` — would write to **stderr**, which the test discards. Shortening the pipeline would reduce an unmeasured probability and destroy the evidence for whichever cause is real. That is precisely the "speculative fix that masks the mechanism" this work was told not to ship.

Instead: the mechanism and the negative result are recorded on the test, and the panic now carries stdout **and stderr**, so the next occurrence identifies its own cause instead of needing this diagnosis repeated. The assertion is unchanged — it still panics on an unparseable pgid — and neither the 200 ms deadline nor any other timeout is widened.

## Verification

**Honest statement: none of this was executed locally.** Cargo was prohibited on this machine partway through the task, so the "run both tests 100× at varied `--test-threads`, before and after" bar and the non-vacuity proofs could not be met, and no local reproduction of either flake was attempted through the test harness.

What *was* verified without cargo:

- The panic sites were read from the two CI runs directly (quoted above), so both mechanisms are evidence-based, not inferred from the test source.
- rustc 1.97.1's `sys/process/unix/unix.rs:149` was read from the local toolchain and matches the hash in the CI panic — the exec-failure `wait()` assert is confirmed, not assumed.
- `spawn_owned`'s absence from djinn-graph and the gate's shared/exclusive discipline were confirmed by reading `child_ownership.rs` and `child_reaper.rs`.
- The fix mirrors the already-tested call site at `server/crates/djinn-git/src/lib.rs:593`.
- The 640-run pipeline sweep described above (plain `sh` + a fork/setpgid/SIGTERM harness, no cargo).

**The fix in (1) is therefore unverified locally and must be confirmed by CI.** Its failure mode if wrong is loud, not silent: releasing the ownership claim too late would make the reaper decline the PID and every spawning test in the crate would time out, so a mistake shows up as a hard failure rather than a masked flake.

Follow-up, out of scope here: `process::output` and `process::status` call `cmd.output()` / `cmd.status()`, which also spawn and wait internally with no ownership claim. They are exposed to the same theft, but fixing them requires restructuring around `wait_with_output`, which is not something to do untested.
