### PR TITLE
fix(coordinator-tests): drive three flaky coordinator tests deterministically

### DIFF
--- a/server/crates/djinn-coordinator/src/rules.rs
+++ b/server/crates/djinn-coordinator/src/rules.rs
@@ -1090,52 +1090,18 @@ mod tests {
 
     /// Build a `CoordinatorActor` directly (not spawned) so a test can drive an
     /// individual method like `sweep_proposals_needing_review` deterministically.
+    ///
+    /// Thin wrapper over [`test_helpers::make_coordinator_actor_cancellable`],
+    /// which wave-module tests share. This form drops the slot pool's
+    /// cancellation token, so the pool task outlives the test body; a test that
+    /// cares (because it also wants the database pool closed before
+    /// `TestDbInit::drop` runs `DROP DATABASE`) should call the `_cancellable`
+    /// helper directly.
     fn make_coordinator_actor(
         db: &Database,
         tx: &broadcast::Sender<DjinnEventEnvelope>,
     ) -> CoordinatorActor {
-        use crate::roles::RoleRegistry;
-        use djinn_provider::catalog::health::HealthTracker;
-        use djinn_slot::{ModelSlotConfig, SlotPoolConfig, SlotPoolHandle};
-
-        let cancel = CancellationToken::new();
-        let ctx = test_helpers::agent_context_from_db(db.clone(), cancel.clone());
-        let pool = SlotPoolHandle::spawn(
-            ctx,
-            cancel.clone(),
-            SlotPoolConfig {
-                models: vec![ModelSlotConfig {
-                    model_id: DEFAULT_MODEL_ID.to_owned(),
-                    max_slots: 1,
-                    roles: ["worker"].into_iter().map(ToOwned::to_owned).collect(),
-                }],
-                role_priorities: HashMap::new(),
-            },
-        );
-        let (status_tx, _) = tokio::sync::watch::channel(SharedCoordinatorState {
-            dispatched: 0,
-            recovered: 0,
-            epic_throughput: HashMap::new(),
-            pr_errors: HashMap::new(),
-            rate_limited_until: None,
-        });
-        let (sender, receiver) = tokio::sync::mpsc::channel(8);
-        CoordinatorActor::new(
-            CoordinatorDeps::new(
-                tx.clone(),
-                cancel,
-                db.clone(),
-                pool,
-                djinn_provider::catalog::CatalogService::new(),
-                HealthTracker::new(),
-                Arc::new(RoleRegistry::new()),
-                BackgroundWorkTracker::default(),
-                djinn_lsp::LspManager::new(),
-            ),
-            receiver,
-            sender,
-            status_tx,
-        )
+        test_helpers::make_coordinator_actor_cancellable(db, tx).0
     }
 
     async fn make_fixture_user(db: &Database, purpose: &str) -> djinn_db::User {
@@ -1776,7 +1742,7 @@ mod tests {
 
         // Insert a running planner session on `planner_host`.
         let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
-        session_repo
+        let planner_session = session_repo
             .create(CreateSessionParams {
                 project_id: &project.id,
                 task_id: Some(&planner_host.id),
@@ -1790,12 +1756,42 @@ mod tests {
             .await
             .unwrap();
 
-        let _handle = spawn_coordinator(&db, &tx);
+        // Drive the batch-completion pass explicitly rather than spawning a
+        // coordinator and sleeping.
+        //
+        // The old shape was `spawn_coordinator(...)` + `sleep(200ms)` + assert
+        // the planning count is 0. That assertion cannot distinguish "the
+        // reentrance guard suppressed the dispatch" from "the coordinator had
+        // not gotten around to the close event yet" — a coordinator that
+        // ignored the event entirely would have produced exactly the same 0.
+        // The sleep was standing in for a happens-before edge it could not
+        // provide, and on a loaded box (four pooled connections shared with the
+        // coordinator's startup path and its immediate first tick) the wait was
+        // long enough to blow the 90s nextest budget.
+        //
+        // Awaiting `on_task_closed` is that edge: when it returns, the pass has
+        // run to completion, so the count below is what the pass *produced*.
+        let (mut actor, cancel) = test_helpers::make_coordinator_actor_cancellable(&db, &tx);
 
-        // Closing the worker task should normally trigger batch-completion
-        // auto-dispatch — but the active planner guard must suppress it.
-        close_task(&db, &t1.id, &tx).await;
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // Closing the worker task drains the epic, so batch completion would
+        // normally fire — the active planner guard must suppress it.
+        let closed = task_repo
+            .transition(
+                &t1.id,
+                djinn_core::models::TransitionAction::Close,
+                "test",
+                "system",
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            closed.status, "closed",
+            "precondition: the only worker task must be closed, so the epic is drained"
+        );
+
+        actor.on_task_closed(&closed).await;
 
         let tasks = task_repo.list_by_epic(&epic.id).await.unwrap();
         assert_eq!(
@@ -1803,6 +1799,37 @@ mod tests {
             0,
             "reentrance guard must suppress new planning task while planner is active"
         );
+
+        // Non-vacuity witness, in-test: end the planner session and replay the
+        // very same pass on the very same fixture. Every other gate in
+        // `should_auto_dispatch_planner` is unchanged, so the only difference is
+        // the active-planner check — and now a planning task MUST appear.
+        //
+        // Together the two assertions pin the mechanism from both sides: delete
+        // the active-session guard and the first assertion fails (a planning
+        // task is created while the planner is running); make the pass a no-op
+        // and the second fails (no planning task is ever created). Neither can
+        // be satisfied by a coordinator that simply never ran.
+        let settled = session_repo
+            .settle_non_terminal_by_id(&planner_session.id)
+            .await
+            .unwrap();
+        assert!(settled, "fixture: planner session must have been running");
+
+        actor.on_task_closed(&closed).await;
+
+        let tasks = task_repo.list_by_epic(&epic.id).await.unwrap();
+        assert_eq!(
+            planning_count(&tasks),
+            1,
+            "with no active planner the identical pass must create the planning task \
+             it was suppressing — otherwise the assertion above proves nothing"
+        );
+
+        // Stop the slot-pool task and hand back every pooled connection before
+        // `TestDbInit::drop` blocks on `DROP DATABASE`.
+        cancel.cancel();
+        db.pool().close().await;
     }
 
     // ── Proposal review: incremental on epic close + backfill sweep ───────────

--- a/server/crates/djinn-coordinator/src/test_helpers.rs
+++ b/server/crates/djinn-coordinator/src/test_helpers.rs
@@ -15,6 +15,88 @@ use djinn_provider::catalog::{CatalogService, HealthTracker};
 use djinn_slot::host::SlotContext;
 use djinn_slot::reply_loop::CompactionCriticalSection;
 
+/// Build a `CoordinatorActor` directly — never spawned — together with the
+/// `CancellationToken` its slot pool was built with.
+///
+/// A test that wants a *deterministic* coordinator pass must not spawn one.
+/// `CoordinatorHandle::spawn` detaches `CoordinatorActor::run` onto
+/// the test runtime, and that task first walks the whole startup path
+/// (incarnation registration, three startup reapers, durable-dispatch
+/// rehydration, refinement recovery) and then immediately takes its first
+/// 30s tick — `tokio::time::interval` fires once straight away — which runs
+/// the full `run_tick` sweep. All of that contends for the test database's
+/// **four** pooled connections with the test body itself, so a test that
+/// spawns a coordinator and then sleeps a fixed number of milliseconds is
+/// really asserting against whatever that race happened to produce.
+///
+/// Driving `handle_event` / `on_task_closed` on an unspawned actor replaces
+/// that race with a happens-before edge: the pass is complete when the
+/// `.await` returns, so the assertion that follows observes a finished pass
+/// rather than an unstarted one.
+///
+/// The returned token is the one held by the `SlotPoolHandle` spawned
+/// here. Nothing else in the process will ever fire it, so a caller
+/// that drops it on the floor leaks that pool task for the lifetime of the
+/// test binary; cancel it (and close the pool) at the end of the test body:
+///
+/// ```ignore
+/// let (mut actor, cancel) = test_helpers::make_coordinator_actor_cancellable(&db, &tx);
+/// // ... drive passes, assert ...
+/// cancel.cancel();
+/// db.pool().close().await;
+/// ```
+pub fn make_coordinator_actor_cancellable(
+    db: &Database,
+    tx: &tokio::sync::broadcast::Sender<djinn_core::events::DjinnEventEnvelope>,
+) -> (crate::actor::CoordinatorActor, CancellationToken) {
+    use crate::roles::RoleRegistry;
+    use crate::types::{
+        BackgroundWorkTracker, CoordinatorDeps, DEFAULT_MODEL_ID, SharedCoordinatorState,
+    };
+    use djinn_slot::{ModelSlotConfig, SlotPoolConfig, SlotPoolHandle};
+    use std::collections::HashMap;
+
+    let cancel = CancellationToken::new();
+    let ctx = agent_context_from_db(db.clone(), cancel.clone());
+    let pool = SlotPoolHandle::spawn(
+        ctx,
+        cancel.clone(),
+        SlotPoolConfig {
+            models: vec![ModelSlotConfig {
+                model_id: DEFAULT_MODEL_ID.to_owned(),
+                max_slots: 1,
+                roles: ["worker"].into_iter().map(ToOwned::to_owned).collect(),
+            }],
+            role_priorities: HashMap::new(),
+        },
+    );
+    let (status_tx, _) = tokio::sync::watch::channel(SharedCoordinatorState {
+        dispatched: 0,
+        recovered: 0,
+        epic_throughput: HashMap::new(),
+        pr_errors: HashMap::new(),
+        rate_limited_until: None,
+    });
+    let (sender, receiver) = tokio::sync::mpsc::channel(8);
+    let actor = crate::actor::CoordinatorActor::new(
+        CoordinatorDeps::new(
+            tx.clone(),
+            cancel.clone(),
+            db.clone(),
+            pool,
+            CatalogService::new(),
+            djinn_provider::catalog::health::HealthTracker::new(),
+            Arc::new(RoleRegistry::new()),
+            BackgroundWorkTracker::default(),
+            djinn_lsp::LspManager::new(),
+        ),
+        receiver,
+        sender,
+        status_tx,
+    );
+    (actor, cancel)
+}
+
 pub fn test_tempdir(prefix: &str) -> tempfile::TempDir {
     tempfile::Builder::new()
         .prefix(prefix)

--- a/server/crates/djinn-coordinator/src/wave.rs
+++ b/server/crates/djinn-coordinator/src/wave.rs
@@ -288,6 +288,35 @@ mod tests {
             .await
     }
 
+    /// The exact `epic.created` envelope `EpicRepository` broadcasts, so a test
+    /// that hands it to `handle_event` drives the production routing path.
+    fn epic_created_event(epic: &djinn_core::models::Epic) -> DjinnEventEnvelope {
+        DjinnEventEnvelope::epic_created(&djinn_core::models::EpicEventPayload::bare(epic))
+    }
+
+    /// The `epic.updated` counterpart of [`epic_created_event`].
+    fn epic_updated_event(epic: &djinn_core::models::Epic) -> DjinnEventEnvelope {
+        DjinnEventEnvelope::epic_updated(&djinn_core::models::EpicEventPayload::bare(epic))
+    }
+
+    /// Count the epic's open/in-progress planning tasks *right now*.
+    ///
+    /// Unlike [`wait_for_decomp_tasks`] this does not wait: it is for tests
+    /// that drive a coordinator pass to completion themselves and therefore
+    /// already hold a happens-before edge over the write they are counting.
+    async fn open_planning_count(task_repo: &TaskRepository, epic_id: &str) -> usize {
+        task_repo
+            .list_by_epic(epic_id)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|t| {
+                matches!(t.issue_type.as_str(), "planning" | "decomposition")
+                    && matches!(t.status.as_str(), "open" | "in_progress")
+            })
+            .count()
+    }
+
     async fn wait_for_decomp_tasks(
         db: &Database,
         tx: &broadcast::Sender<DjinnEventEnvelope>,
@@ -488,8 +517,24 @@ mod tests {
 
         let project = test_helpers::create_test_project(&db).await;
         let epic_repo = EpicRepository::new(db.clone(), crate::events::event_bus_for(&tx));
-        let _handle = spawn_coordinator_with_planner(&db, &tx);
-        tokio::task::yield_now().await;
+        let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+        // Deliver the two `epic.updated` events to an unspawned actor instead
+        // of broadcasting them at a spawned coordinator and waiting.
+        //
+        // The dedupe this test exercises is entirely inside
+        // `maybe_create_planning_task`, and the coordinator processes events
+        // one at a time — so a *duplicate* was never actually reachable here.
+        // What was reachable was the intermediate `wait_for_decomp_tasks`
+        // returning empty at its 2s deadline: the spawned coordinator has to
+        // finish its whole startup path and its immediate first tick before it
+        // can drain the first event, all while sharing four pooled connections
+        // with this test body. `assert_eq!(decomp_tasks.len(), 1)` then failed
+        // with 0 — not a duplicate, just an unfinished pass.
+        //
+        // Awaiting `handle_event` removes the deadline entirely: the pass is
+        // finished when the call returns.
+        let (mut actor, cancel) = test_helpers::make_coordinator_actor_cancellable(&db, &tx);
 
         let epic = create_owned_epic(
             &db,
@@ -510,31 +555,33 @@ mod tests {
         )
         .await
         .unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let promoted = epic_repo.set_status_raw(&epic.id, "open").await.unwrap();
-        let _ = tx.send(DjinnEventEnvelope::epic_updated(
-            &djinn_core::models::EpicEventPayload::bare(&promoted),
-        ));
+        let promotion = epic_updated_event(&promoted);
 
-        let decomp_tasks = wait_for_decomp_tasks(&db, &tx, &epic.id, 1).await;
-        assert_eq!(decomp_tasks.len(), 1);
+        // Promotion to `open` creates the wave-1 planning task.
+        actor.handle_event(promotion.clone()).await;
+        assert_eq!(
+            open_planning_count(&task_repo, &epic.id).await,
+            1,
+            "closed→open promotion must create exactly one planning task"
+        );
 
-        let _ = tx.send(DjinnEventEnvelope::epic_updated(
-            &djinn_core::models::EpicEventPayload::bare(&promoted),
-        ));
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // The planner re-touching the epic re-emits an identical `epic.updated`.
+        // The `has_open_planning` dedupe must swallow it. This is the real
+        // assertion of the test, and it is non-vacuous in the strong sense:
+        // the pass above already proved this exact call *does* create a
+        // planning task when none is open, so a second identical call that
+        // leaves the count at 1 can only be the dedupe doing its job.
+        actor.handle_event(promotion).await;
+        assert_eq!(
+            open_planning_count(&task_repo, &epic.id).await,
+            1,
+            "a re-emitted epic.updated must not duplicate the open planning task"
+        );
 
-        let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
-        let tasks = task_repo.list_by_epic(&epic.id).await.unwrap();
-        let open_planning_count = tasks
-            .iter()
-            .filter(|t| {
-                matches!(t.issue_type.as_str(), "planning" | "decomposition")
-                    && matches!(t.status.as_str(), "open" | "in_progress")
-            })
-            .count();
-        assert_eq!(open_planning_count, 1);
+        cancel.cancel();
+        db.pool().close().await;
     }
 
     /// Regression (epic `lywz`, 2026-06-02): the Planner re-links the epic
@@ -713,6 +760,23 @@ mod tests {
     /// Simulates the proposal decomposition flow: epic A (foundation) and
     /// epic B (dependent) are created, then B.blocked_by=A is wired.
     /// B must NOT receive a planning task until A closes.
+    ///
+    /// Note on shape: this test used to spawn a coordinator and race it. Epic B
+    /// is deliberately created *unblocked* and the blocker edge is wired one
+    /// statement later, so a spawned coordinator that drained B's `epic.created`
+    /// before `add_blocker` committed would legitimately create a planning task
+    /// for B — the assertion below would fail without anything being wrong with
+    /// the blocker gate. The test's own comment conceded it ("its planning task
+    /// may or may not have fired by now"), and the 300ms sleep did not close the
+    /// window: the sleep sits *after* `add_blocker`, so it changes when the race
+    /// is observed, not whether it happens. The coordinator usually lost that
+    /// race only because `maybe_create_planning_task` does a `list_by_epic`
+    /// round-trip before it ever reaches the blocker gate.
+    ///
+    /// Driving `handle_event` explicitly keeps the thing under test — the edge
+    /// is still wired *after* B exists, and the gate must still read it from the
+    /// database rather than from B's stale in-memory payload — while making the
+    /// ordering a fact of the test rather than a coin flip.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn blocked_epic_does_not_get_planning_task_while_blocker_open() {
         let db = test_helpers::create_test_db();
@@ -720,8 +784,8 @@ mod tests {
 
         let project = test_helpers::create_test_project(&db).await;
         let epic_repo = EpicRepository::new(db.clone(), crate::events::event_bus_for(&tx));
-        let _handle = spawn_coordinator_with_planner(&db, &tx);
-        tokio::task::yield_now().await;
+        let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+        let (mut actor, cancel) = test_helpers::make_coordinator_actor_cancellable(&db, &tx);
 
         // Create epic A (foundation, no blockers).
         let epic_a = create_owned_epic(
@@ -744,10 +808,13 @@ mod tests {
         .await
         .unwrap();
 
-        // Epic A gets its planning task immediately (no blockers).
-        let a_tasks = wait_for_decomp_tasks(&db, &tx, &epic_a.id, 1).await;
+        // Epic A has no blockers, so its wave-1 pass creates a planning task.
+        // This is also the control for the assertion at the end: it proves this
+        // exact `epic.created` pass DOES create planning tasks, so B's zero
+        // below is suppression rather than an inert pass.
+        actor.handle_event(epic_created_event(&epic_a)).await;
         assert_eq!(
-            a_tasks.len(),
+            open_planning_count(&task_repo, &epic_a.id).await,
             1,
             "foundation epic A should get a planning task"
         );
@@ -773,30 +840,24 @@ mod tests {
         .await
         .unwrap();
 
-        // B initially has no blockers — its planning task may or may not
-        // have fired by now. Wire the blocker immediately (simulates the
-        // proposal planner wiring edges after creation).
+        // B was created unblocked; the proposal planner wires the edge a beat
+        // later. `epic_b` in hand still carries the pre-blocker payload, which
+        // is the point: the gate must read blockers from the database, not from
+        // the event payload.
         epic_repo.add_blocker(&epic_b.id, &epic_a.id).await.unwrap();
 
-        // Wait a bit for any pending dispatches to settle.
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        // Now run B's wave-1 pass. It must be suppressed while A is open.
+        actor.handle_event(epic_created_event(&epic_b)).await;
 
-        // B must NOT have an open planning task while A is still open.
-        let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
-        let b_tasks = task_repo.list_by_epic(&epic_b.id).await.unwrap();
-        let b_open_planning: Vec<_> = b_tasks
-            .iter()
-            .filter(|t| {
-                matches!(t.issue_type.as_str(), "planning" | "decomposition")
-                    && matches!(t.status.as_str(), "open" | "in_progress")
-            })
-            .collect();
-        assert!(
-            b_open_planning.is_empty(),
+        let b_open_planning = open_planning_count(&task_repo, &epic_b.id).await;
+        assert_eq!(
+            b_open_planning, 0,
             "epic B must NOT have an open planning task while blocker A is open, \
-             but found {} open planning tasks",
-            b_open_planning.len()
+             but found {b_open_planning} open planning tasks"
         );
+
+        cancel.cancel();
+        db.pool().close().await;
     }
 
     /// Regression test (two-phased): closing blocker triggers decomposition


### PR DESCRIPTION
## What

Three `djinn-coordinator` tests spawned a `CoordinatorHandle` and then waited a fixed or bounded number of milliseconds for it to react. This replaces the waits with an unspawned `CoordinatorActor` driven directly, so each pass is complete when the `.await` returns.

## Why the old shape was unsound

`CoordinatorHandle::spawn` detaches `CoordinatorActor::run`, which walks its whole startup path (incarnation registration, three startup reapers, durable-dispatch rehydration, refinement recovery) and *then* immediately takes its first tick — `tokio::time::interval` fires once straight away, so the full `run_tick` sweep runs before the actor is meaningfully idle. All of that contends for the test database's **four** pooled connections with the test body itself.

So the waits were wrong in both directions: too short under load for positive assertions, and no assertion at all for negative ones.

## Per-test mechanism

### 1. `rules::tests::batch_completion_suppressed_when_active_planner_on_epic`

Was `spawn_coordinator` + `sleep(200ms)` + assert the planning count is `0`. That `0` is also what a coordinator that never processed the close event produces, so the test would have passed against a no-op.

Now it awaits `on_task_closed` directly. It also carries an **in-test non-vacuity witness**: after the primary assertion it settles the planner session and replays the identical pass on the identical fixture, which must now create the planning task it was suppressing.

Tracing `should_auto_dispatch_planner` for this fixture:

| gate | outcome | why |
| --- | --- | --- |
| 1. close-reason filter | falls through | sibling test `batch_completion_creates_decomposition_task` closes a task the same way and *does* get a planning task, so the reason is not reshape/superseded/duplicate |
| 2. `auto_breakdown` | not evaluated | only applies to `DispatchEvent::EpicCreated`; this is `TaskClosed` |
| 2b. epic-blocker gate | falls through | the epic is created with no blockers |
| 3. active-session guard | **returns false** | the fixture's running `planner` session is on a task under this epic |

Step 3 is the only gate that can suppress. Remove it and the first assertion fails (a planning task appears while the planner is running); make the pass inert and the second fails (no planning task is ever created). Neither is satisfiable by a coordinator that simply never ran.

### 2. `wave::tests::closed_to_open_promotion_does_not_duplicate_planning_task`

Same lifecycle family, but the failure was on the **intermediate** `wait_for_decomp_tasks` 2s deadline, not on a duplicate. A duplicate was never reachable: the actor handles events serially and `maybe_create_planning_task` awaits to completion, so two `epic.updated` events cannot interleave inside it. The realistic failure is `assert_eq!(decomp_tasks.len(), 1)` seeing `0`.

Both events now go through `handle_event` — first creates, second must dedupe. The create step doubles as the control for the dedupe step.

### 3. `wave::tests::blocked_epic_does_not_get_planning_task_while_blocker_open`

**Different mechanism — not a timeout.** The fixture creates epic B *unblocked* and wires `add_blocker` one statement later, so a coordinator that drained B's `epic.created` before that INSERT committed would legitimately create a planning task for B. The test's own comment conceded this ("its planning task may or may not have fired by now"), and the 300ms sleep sits *after* `add_blocker` — it changes when the race is observed, not whether it happens. The coordinator usually lost the race only because `maybe_create_planning_task` does a `list_by_epic` round-trip before it ever reaches the blocker gate.

The edge is still wired after B exists — the gate must read blockers from the database, not from B's stale in-memory payload — but the pass now runs after it. Epic A's pass is kept as an explicit control that this same `epic.created` path *does* create planning tasks.

## Shape of the change

The shared builder moves to `test_helpers::make_coordinator_actor_cancellable`, which additionally returns the slot pool's `CancellationToken` so these tests can cancel it and `db.pool().close().await` before `TestDbInit::drop` blocks on `DROP DATABASE`.

Deliberately **additive**: `spawn_coordinator` (rules), `spawn_coordinator_with_planner` (wave), `spawn_coordinator` / `spawn_coordinator_with_tracker` (tests/mod) and `make_coordinator_actor` all keep their existing signatures, so none of their ~25 call sites change. `make_coordinator_actor` is now a thin wrapper that drops the token.

## Verification status

Honest labelling, since this was produced without a local compile:

- **Measured**: all three tests were run once on `main` before any edits (`--test-threads 4`, dedicated Postgres) and passed in ~2.2s each — confirming the targets are live and not already renamed or fixed.
- **Confirmed by inspection**: all three mechanisms are still present at `origin/main` (916ac5050) — `rules.rs` `spawn_coordinator` still returns a bare `CoordinatorHandle` with a never-cancelled token, the `sleep(200ms)` is still there, and `wave.rs` has not been touched since 2026-07-19.
- **Reasoned, not executed**: non-vacuity (argued above by tracing each gate) and the flake-rate improvement. **No measured post-change rates or wall times are claimed — to be confirmed by CI.**

Related: the unbounded advisory-lock half of the flake-1 mechanism (`template_bootstrap.rs` / `database.rs`) is being fixed separately on `perf/db-test-template-no-per-process-reverify`; this PR deliberately touches neither file.

## Follow-up (not in this PR)

The ~22 other tests that call `spawn_coordinator*` still leak their coordinator and slot-pool tasks past the test body. Migrating them to the cancellable form is a mechanical follow-up.
