### PR TITLE
4etb follow-up: clear the evidence epoch when an adjudication actually ends

### DIFF
--- a/server/crates/djinn-db/src/repositories/task/adjudication_close_tests.rs
+++ b/server/crates/djinn-db/src/repositories/task/adjudication_close_tests.rs
@@ -1187,3 +1187,92 @@ async fn an_ordinary_blocker_close_emits_no_outcome_event() {
     let refreshed = repo.get(&source.id).await.unwrap().unwrap();
     assert_eq!(refreshed.status, "open");
 }
+
+/// **AC2.** Consuming an arbitration row clears the evidence epoch, whatever
+/// decision consumed it.
+///
+/// The epoch used to be nulled ONLY by the child-close transaction, which
+/// covers `park` (it creates a child) and nothing else. `approve`,
+/// `approve_conflict`, `reopen` and `supersede` consume the row and create no
+/// child, so the epoch survived them — and because the stamp is conditional on
+/// `escalation_evidence_at IS NULL`, the NEXT escalation's stamp was a silent
+/// no-op and its park guards measured the PREVIOUS adjudication's floor.
+///
+/// This asserts the durable column across the full cycle: stamped, cleared by
+/// the consume, and a genuinely NEW value stamped by the next escalation.
+/// Without the fix the third assertion fails — the second stamp returns the
+/// stale first epoch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn consuming_an_arbitration_row_clears_the_evidence_epoch() {
+    use crate::repositories::task_arbitration::{
+        CreateArbitrationParams, TaskArbitrationRepository,
+    };
+
+    let db = Database::open_in_memory().unwrap();
+    let repo = TaskRepository::new(db.clone(), silent_bus());
+    let project = make_project(&db).await;
+    let epic_id = make_epic(&db, &project.id).await;
+    let source = repo
+        .create_fixture_with_ac(
+            &epic_id, "Source", "d", "d", "task", 1, "worker", None, None,
+        )
+        .await
+        .unwrap();
+    let arb = TaskArbitrationRepository::new(db.clone());
+    let empty = serde_json::json!([]);
+
+    // Cycle 0: stamped atomically with the row, exactly as production does.
+    let (_created, first) = arb
+        .try_create_with_evidence_epoch(CreateArbitrationParams {
+            task_id: &source.id,
+            hold_cycle: 0,
+            deadline_at: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            pr_url: None,
+            failing_ci_job_ids: &empty,
+            dossier: None,
+            directive: Some(&serde_json::json!({ "decision": "approve" })),
+            verification_command: None,
+            excluded_models: &empty,
+        })
+        .await
+        .unwrap();
+    let first = first.expect("cycle 0 stamps an epoch");
+
+    // An `approve` consumes the row and creates NO adjudication child.
+    assert!(arb.mark_consumed(&source.id, 0).await.unwrap());
+    assert!(
+        repo.escalation_evidence_at(&source.id)
+            .await
+            .unwrap()
+            .is_none(),
+        "consuming the row is the adjudication clearing: the epoch must clear with it, even \
+         though no child was created and so no child-close transaction ever runs"
+    );
+
+    // A later trigger opens cycle 1 and must get a NEW epoch, not the stale one.
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let (_created, second) = arb
+        .try_create_with_evidence_epoch(CreateArbitrationParams {
+            task_id: &source.id,
+            hold_cycle: 1,
+            deadline_at: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            pr_url: None,
+            failing_ci_job_ids: &empty,
+            dossier: None,
+            directive: None,
+            verification_command: None,
+            excluded_models: &empty,
+        })
+        .await
+        .unwrap();
+    let second = second.expect("cycle 1 stamps an epoch");
+    assert_ne!(
+        second, first,
+        "a new trigger after the adjudication cleared must stamp a NEW epoch; reusing {first} \
+         would make cycle 1's guards count attempts belonging to cycle 0"
+    );
+}

--- a/server/crates/djinn-db/src/repositories/task_arbitration.rs
+++ b/server/crates/djinn-db/src/repositories/task_arbitration.rs
@@ -364,12 +364,12 @@ impl TaskArbitrationRepository {
     /// already consumed or missing.
     pub async fn mark_consumed(&self, task_id: &str, hold_cycle: i32) -> Result<bool> {
         self.db.ensure_initialized().await?;
-        let result = sqlx::query(ARBITRATION_MARK_CONSUMED)
+        let consumed: i64 = sqlx::query_scalar(ARBITRATION_MARK_CONSUMED)
             .bind(task_id)
             .bind(hold_cycle)
-            .execute(self.db.pool())
+            .fetch_one(self.db.pool())
             .await?;
-        Ok(result.rows_affected() > 0)
+        Ok(consumed > 0)
     }
 
     /// Mark an unconsumed arbitration as failed (terminal for this cycle).
@@ -596,12 +596,56 @@ const ARBITRATION_SELECT_LIST_FOR_TASK: &str = r#"
     ORDER BY hold_cycle ASC
 "#;
 
+// 4etb: clear the canonical evidence epoch when the adjudication genuinely
+// ENDS — in the same statement that consumes the row.
+//
+// The epoch was previously nulled only by `apply_adjudication_child_close_tx`,
+// which covers `park` (it creates the child whose close runs that path) and
+// nothing else. `approve`, `approve_conflict` and `supersede` consume the row
+// and create NO child, so the epoch survived them — and because
+// `stamp_escalation_evidence_epoch_tx` is conditional on
+// `escalation_evidence_at IS NULL`, a LATER escalation's stamp was a silent
+// no-op and its park guards measured a floor from an episode already closed.
+//
+// DECISION-AWARE on purpose. Clearing on every consume is wrong and was tried:
+// a `reopen` consumes the row and hands the source ONE monitored worker
+// attempt, and that attempt is precisely the evidence the next cycle's guards
+// must weigh. Clearing there re-stamps the epoch after it, hiding it, and the
+// guards decline forever — the exact livelock this proposal exists to end.
+// (Observed as six `tests::intervention` failures.) The same reasoning excludes
+// the stale-row self-consume, which immediately opens a fresh cycle in the same
+// episode.
+//
+// Written as ONE statement with CTEs rather than an explicit transaction:
+// `mark_consumed` is called from paths already holding a transaction on
+// `tasks`, and opening a second deadlocked against them.
 const ARBITRATION_MARK_CONSUMED: &str = r#"
-    UPDATE task_arbitrations
-    SET state = 'consumed',
-        consumed_at = to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
-        updated_at = to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
-    WHERE task_id = $1 AND hold_cycle = $2 AND state = 'unconsumed'
+    WITH target AS (
+        SELECT task_id, hold_cycle,
+               (directive ->> 'decision') AS decision
+          FROM task_arbitrations
+         WHERE task_id = $1 AND hold_cycle = $2 AND state = 'unconsumed'
+    ), consumed AS (
+        UPDATE task_arbitrations a
+        SET state = 'consumed',
+            consumed_at = to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+            updated_at = to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        FROM target t
+        WHERE a.task_id = t.task_id AND a.hold_cycle = t.hold_cycle
+              AND a.state = 'unconsumed'
+        RETURNING a.task_id
+    ), cleared AS (
+        UPDATE tasks
+        SET escalation_evidence_at = NULL
+        WHERE id IN (
+                SELECT task_id FROM target
+                 WHERE decision IN ('approve', 'approve_conflict', 'supersede')
+              )
+          AND EXISTS (SELECT 1 FROM consumed)
+          AND escalation_evidence_at IS NOT NULL
+        RETURNING id
+    )
+    SELECT COUNT(*)::bigint FROM consumed
 "#;
 
 const ARBITRATION_MARK_FAILED: &str = r#"


### PR DESCRIPTION
Closes the one acceptance criterion PR #3061 left open.

## The bug

AC2 of proposal `4etb` requires that **a new trigger after an adjudication clears must stamp a new epoch**. It did not.

`escalation_evidence_at` was nulled only by `apply_adjudication_child_close_tx` — which covers `park` (it creates the child whose close runs that path) and nothing else. `approve`, `approve_conflict` and `supersede` all consume the arbitration row and create **no** child, so the epoch survived them. Because `stamp_escalation_evidence_epoch_tx` is conditional on `escalation_evidence_at IS NULL`, the next escalation's stamp was then a silent no-op, and its park guards measured a floor belonging to an episode already closed — counting attempts from a spent cycle as current evidence.

`clear_escalation_evidence_epoch` existed in the codebase with **no callers anywhere**.

## The fix

Clear the epoch in the same statement that consumes the row, filtered on the decision recorded on that row.

**Decision-aware on purpose.** Clearing on every consume is wrong, and I tried that first: a `reopen` consumes the row and hands the source one monitored worker attempt, and that attempt is precisely the evidence the next cycle's guards must weigh. Clearing there re-stamps the epoch *after* it, hides it, and the guards decline forever — the exact livelock 4etb exists to end. It surfaced as six `tests::intervention` failures. The same reasoning excludes the stale-row self-consume, which reopens a fresh cycle inside the same episode.

Two implementation choices worth flagging for review:

- **In `mark_consumed`, not at each decision site** — there are five consume sites across two crates, and a sixth added later would silently reintroduce this.
- **One CTE statement, not an explicit transaction** — `mark_consumed` is called from paths that already hold a transaction on `tasks`; opening a second deadlocked against them, which showed up as different adjudication tests failing on each run.

## Testing

`consuming_an_arbitration_row_clears_the_evidence_epoch` drives the full cycle against the durable column: stamped atomically with the row, cleared by an `approve` consume, and a genuinely **new** value stamped by the next escalation. Neutering the decision filter fails it.

`djinn-db` 1289 passed, `djinn-coordinator` 2104 passed, clippy and fmt clean.