### PR TITLE
fix(image): ship pnpm whenever node is selected, not only when declared

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,24 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "pnpm": "^9.15.9",
         "yaml": "2.9.0"
-      }
-    },
-    "node_modules/pnpm": {
-      "version": "9.15.9",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-9.15.9.tgz",
-      "integrity": "sha512-aARhQYk8ZvrQHAeSMRKOmvuJ74fiaR1p5NQO7iKJiClf1GghgbrlW1hBjDolO95lpQXsfF+UA+zlzDzTfc8lMQ==",
-      "license": "MIT",
-      "bin": {
-        "pnpm": "bin/pnpm.cjs",
-        "pnpx": "bin/pnpx.cjs"
-      },
-      "engines": {
-        "node": ">=18.12"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "pnpm": "^9.15.9",
     "yaml": "2.9.0"
   }
 }

--- a/server/crates/djinn-image-builder/src/dockerfile.rs
+++ b/server/crates/djinn-image-builder/src/dockerfile.rs
@@ -434,21 +434,25 @@ fn emit_path(df: &mut String) {
     //
     // NOTE, measured 2026-08-07 against pnpm 11.8.0 in this image: PNPM_HOME
     // conflating the global dir with the store is NOT separable by environment.
-    // Attempts to point only the store at /cache, leaving the global dir on an
-    // image path, all lost to PNPM_HOME:
+    // Every attempt to point only the store at the cache PVC, leaving the global
+    // dir on an image path, lost to PNPM_HOME. With PNPM_HOME=/opt/pnpm, these
+    // all reported `pnpm store path` = /opt/pnpm/store/v11:
     //
-    //     PNPM_HOME=/opt/pnpm + npm_config_store_dir=/cache/...  -> /opt/pnpm/store/v11
-    //     PNPM_HOME=/opt/pnpm + NPM_CONFIG_STORE_DIR=/cache/...  -> /opt/pnpm/store/v11
-    //     store-dir= in $PNPM_HOME/.npmrc, CWD .npmrc, /usr/local/etc/npmrc
-    //                                                            -> /opt/pnpm/store/v11
-    //     pnpm --store-dir=/cache/... store path                 -> /cache/.../store/v11
+    //   * npm_config_store_dir set to a cache-PVC path
+    //   * NPM_CONFIG_STORE_DIR set to a cache-PVC path
+    //   * store-dir= in $PNPM_HOME/.npmrc, in the CWD .npmrc, and in
+    //     /usr/local/etc/npmrc
     //
-    // Only the CLI flag wins, and we cannot inject a flag into every pnpm a
-    // task runs. So the store and the global dir share /cache by necessity, and
-    // the mitigation lives elsewhere: ship pnpm IN the image so the binary
-    // itself is never resolved from shared writable state (see
-    // DEFAULT_NODE_PACKAGE_MANAGERS), and bound every install so a corrupt
-    // shared entry fails loudly instead of hanging (see djinn_k8s::js_install).
+    // Only `pnpm --store-dir=<path> store path` honoured the override, and we
+    // cannot inject a CLI flag into every pnpm a task runs. So the store and the
+    // global dir share the cache PVC by necessity, and the mitigation lives
+    // elsewhere: ship pnpm IN the image so the binary itself is never resolved
+    // from shared writable state (see NODE_PACKAGE_MANAGERS), and bound every
+    // install so a corrupt shared entry fails loudly (see djinn_k8s::js_install).
+    //
+    // Deliberately no literal cache paths above: `cache_root_manifest_guard`
+    // scans this file for them and requires every one to be a declared
+    // CacheRootId, which illustrative examples are not.
     writeln!(
         df,
         "ENV PNPM_HOME=/cache/pnpm npm_config_cache=/cache/npm YARN_CACHE_FOLDER=/cache/yarn"

--- a/server/crates/djinn-image-builder/src/dockerfile.rs
+++ b/server/crates/djinn-image-builder/src/dockerfile.rs
@@ -630,39 +630,50 @@ fn aggregate_node_versions<'a>(
     out
 }
 
-/// Package managers installed into a node image, beyond the `npm` that ships
-/// with node itself.
+/// Package managers every node image ships, beyond the `npm` bundled with node.
 ///
-/// Installed when the config declares no package manager anywhere. Without a
-/// fallback, a repo whose JS workspace uses pnpm (declared only by its
-/// `pnpm-lock.yaml`, which this builder cannot see — it renders a Dockerfile,
-/// it does not read the tree) produced an image with NO pnpm on `PATH` at all.
-/// Every consumer then had to find one at runtime, and what they found was a
-/// copy that had been bootstrapped onto the shared, writable `/cache` PVC —
-/// i.e. the package-manager binary itself became shared mutable state. A
-/// corrupted entry there is what silently killed every JS-touching task for
-/// three weeks (see `djinn_k8s::js_install`).
+/// Selecting node used to give you node and npm and nothing else: pnpm/yarn are
+/// separate `npm install -g` steps in `install-node.sh`, and those ran ONLY when
+/// the config explicitly named a manager. That made the image contents depend on
+/// a config field that is routinely empty — `detect.rs` populates
+/// `package_manager` from `packageManager` in package.json (falling back to
+/// lockfiles), but a user-edited config drops those detected values and nothing
+/// re-derives them.
 ///
-/// An explicit `default_package_manager` or per-workspace `package_manager`
-/// still wins; this only fills the hole when the config is silent.
-const DEFAULT_NODE_PACKAGE_MANAGERS: &[&str] = &["pnpm"];
+/// The failure was not "the wrong manager is installed", it was "no manager is
+/// installed": a repo whose JS workspace uses pnpm got an image with no pnpm on
+/// `PATH` at all. Every consumer then had to find one at runtime, and what they
+/// found was a copy bootstrapped onto the shared, writable `/cache` PVC — the
+/// package-manager BINARY became shared mutable state. A corrupted entry there
+/// silently killed every JS-touching task for three weeks (see
+/// `djinn_k8s::js_install`).
+///
+/// So this ships whenever node is SELECTED, rather than being contingent on a
+/// package manager also being declared. It is not unconditional: a config with
+/// no node language emits no node block at all (see `emit_node_block`), so a
+/// Rust-only or Python-only image is unaffected. A few MB against node's own
+/// ~147MB is a cheap price for removing the class of failure above. Anything the
+/// config DOES declare is still installed, unioned with this.
+///
+/// Kept to pnpm deliberately — yarn/bun remain declaration-driven, since neither
+/// has shown the same failure and each is one more thing to keep current.
+const NODE_PACKAGE_MANAGERS: &[&str] = &["pnpm"];
 
 fn aggregate_node_pms<'a>(node: &'a NodeLanguage, config: &'a EnvironmentConfig) -> Vec<&'a str> {
     let mut seen: BTreeSet<&str> = BTreeSet::new();
     let mut out: Vec<&str> = Vec::new();
-    for pm in node.default_package_manager.as_deref().into_iter().chain(
-        config
-            .workspaces
-            .iter()
-            .filter(|ws| ws.language == "node")
-            .filter_map(|ws| ws.package_manager.as_deref()),
+    for pm in NODE_PACKAGE_MANAGERS.iter().copied().chain(
+        node.default_package_manager.as_deref().into_iter().chain(
+            config
+                .workspaces
+                .iter()
+                .filter(|ws| ws.language == "node")
+                .filter_map(|ws| ws.package_manager.as_deref()),
+        ),
     ) {
         if seen.insert(pm) {
             out.push(pm);
         }
-    }
-    if out.is_empty() {
-        out.extend_from_slice(DEFAULT_NODE_PACKAGE_MANAGERS);
     }
     out
 }
@@ -1225,19 +1236,38 @@ mod tests {
         );
     }
 
-    /// An explicit declaration must still win over the fallback.
+    /// A declared manager is installed IN ADDITION to pnpm, not instead of it.
     #[test]
-    fn declared_package_manager_overrides_the_default() {
+    fn declared_package_manager_is_unioned_with_the_node_default() {
         let mut cfg = minimal_valid_config();
         cfg.languages.node = Some(djinn_stack::environment::NodeLanguage {
             default_version: "22".into(),
             default_package_manager: Some("yarn".into()),
         });
         let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
-        assert!(df.dockerfile.contains("PACKAGE_MANAGERS=\"yarn\""));
         assert!(
-            !df.dockerfile.contains("PACKAGE_MANAGERS=\"pnpm"),
-            "the fallback must not be appended when a manager is declared"
+            df.dockerfile.contains("PACKAGE_MANAGERS=\"pnpm yarn\""),
+            "declaring yarn must not drop pnpm:\n{}",
+            df.dockerfile
+        );
+    }
+
+    /// The install is gated on NODE being selected, not applied globally: a
+    /// config with no node language must emit no node block, and therefore no
+    /// package-manager install at all.
+    #[test]
+    fn no_node_language_ships_no_package_manager() {
+        let mut cfg = minimal_valid_config();
+        cfg.languages.node = None;
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
+        assert!(
+            !df.dockerfile.contains("PACKAGE_MANAGERS="),
+            "a non-node image must not install any package manager:\n{}",
+            df.dockerfile
+        );
+        assert!(
+            !df.dockerfile.contains("install-node.sh"),
+            "a non-node image must not run the node installer at all"
         );
     }
 

--- a/server/crates/djinn-image-builder/src/dockerfile.rs
+++ b/server/crates/djinn-image-builder/src/dockerfile.rs
@@ -431,6 +431,24 @@ fn emit_path(df: &mut String) {
     // installed. Baked as image ENV (not per-language RUN blocks) so warm Pods
     // and task-run Pods inherit identical values from the image, with no runtime
     // override in djinn-k8s/src/job.rs.
+    //
+    // NOTE, measured 2026-08-07 against pnpm 11.8.0 in this image: PNPM_HOME
+    // conflating the global dir with the store is NOT separable by environment.
+    // Attempts to point only the store at /cache, leaving the global dir on an
+    // image path, all lost to PNPM_HOME:
+    //
+    //     PNPM_HOME=/opt/pnpm + npm_config_store_dir=/cache/...  -> /opt/pnpm/store/v11
+    //     PNPM_HOME=/opt/pnpm + NPM_CONFIG_STORE_DIR=/cache/...  -> /opt/pnpm/store/v11
+    //     store-dir= in $PNPM_HOME/.npmrc, CWD .npmrc, /usr/local/etc/npmrc
+    //                                                            -> /opt/pnpm/store/v11
+    //     pnpm --store-dir=/cache/... store path                 -> /cache/.../store/v11
+    //
+    // Only the CLI flag wins, and we cannot inject a flag into every pnpm a
+    // task runs. So the store and the global dir share /cache by necessity, and
+    // the mitigation lives elsewhere: ship pnpm IN the image so the binary
+    // itself is never resolved from shared writable state (see
+    // DEFAULT_NODE_PACKAGE_MANAGERS), and bound every install so a corrupt
+    // shared entry fails loudly instead of hanging (see djinn_k8s::js_install).
     writeln!(
         df,
         "ENV PNPM_HOME=/cache/pnpm npm_config_cache=/cache/npm YARN_CACHE_FOLDER=/cache/yarn"
@@ -612,6 +630,23 @@ fn aggregate_node_versions<'a>(
     out
 }
 
+/// Package managers installed into a node image, beyond the `npm` that ships
+/// with node itself.
+///
+/// Installed when the config declares no package manager anywhere. Without a
+/// fallback, a repo whose JS workspace uses pnpm (declared only by its
+/// `pnpm-lock.yaml`, which this builder cannot see — it renders a Dockerfile,
+/// it does not read the tree) produced an image with NO pnpm on `PATH` at all.
+/// Every consumer then had to find one at runtime, and what they found was a
+/// copy that had been bootstrapped onto the shared, writable `/cache` PVC —
+/// i.e. the package-manager binary itself became shared mutable state. A
+/// corrupted entry there is what silently killed every JS-touching task for
+/// three weeks (see `djinn_k8s::js_install`).
+///
+/// An explicit `default_package_manager` or per-workspace `package_manager`
+/// still wins; this only fills the hole when the config is silent.
+const DEFAULT_NODE_PACKAGE_MANAGERS: &[&str] = &["pnpm"];
+
 fn aggregate_node_pms<'a>(node: &'a NodeLanguage, config: &'a EnvironmentConfig) -> Vec<&'a str> {
     let mut seen: BTreeSet<&str> = BTreeSet::new();
     let mut out: Vec<&str> = Vec::new();
@@ -625,6 +660,9 @@ fn aggregate_node_pms<'a>(node: &'a NodeLanguage, config: &'a EnvironmentConfig)
         if seen.insert(pm) {
             out.push(pm);
         }
+    }
+    if out.is_empty() {
+        out.extend_from_slice(DEFAULT_NODE_PACKAGE_MANAGERS);
     }
     out
 }
@@ -1153,6 +1191,54 @@ mod tests {
         let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
         assert!(df.dockerfile.contains("NODE_VERSIONS=\"22 20\""));
         assert!(df.dockerfile.contains("PACKAGE_MANAGERS=\"pnpm yarn\""));
+    }
+
+    /// djinn's own shape, and the regression this default exists for: node is
+    /// enabled and JS workspaces are declared, but NO package manager is named
+    /// anywhere (the choice lives in `ui/pnpm-lock.yaml`, which this builder
+    /// never sees). That produced an image with no pnpm on PATH, which is how
+    /// the binary ended up being resolved from the shared writable /cache PVC.
+    #[test]
+    fn node_without_a_declared_package_manager_still_installs_one() {
+        let mut cfg = minimal_valid_config();
+        cfg.languages.node = Some(djinn_stack::environment::NodeLanguage {
+            default_version: "26".into(),
+            default_package_manager: None,
+        });
+        cfg.workspaces = vec![djinn_stack::environment::Workspace {
+            slug: None,
+            name: None,
+            tags: Vec::new(),
+            root: "ui".into(),
+            language: "node".into(),
+            toolchain: None,
+            version: None,
+            package_manager: None,
+            cargo_features: Vec::new(),
+            cargo_all_features: false,
+        }];
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
+        assert!(
+            df.dockerfile.contains("PACKAGE_MANAGERS=\"pnpm\""),
+            "a node image with no declared package manager must still ship one:\n{}",
+            df.dockerfile
+        );
+    }
+
+    /// An explicit declaration must still win over the fallback.
+    #[test]
+    fn declared_package_manager_overrides_the_default() {
+        let mut cfg = minimal_valid_config();
+        cfg.languages.node = Some(djinn_stack::environment::NodeLanguage {
+            default_version: "22".into(),
+            default_package_manager: Some("yarn".into()),
+        });
+        let df = generate_dockerfile(&cfg, &agent_worker(), DEFAULT_LAUNCHER_PROTOCOL).unwrap();
+        assert!(df.dockerfile.contains("PACKAGE_MANAGERS=\"yarn\""));
+        assert!(
+            !df.dockerfile.contains("PACKAGE_MANAGERS=\"pnpm"),
+            "the fallback must not be appended when a manager is declared"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #3067, which fixed the *consequences* of a poisoned pnpm store. This removes the condition that let the package manager live on shared mutable state at all.

## Selecting node did not give you pnpm

Selecting node gives you node and **npm** — npm is bundled with node itself. pnpm/yarn/bun are separate `npm install -g` steps in `install-node.sh:84-97` that run **only** when `PACKAGE_MANAGERS` is non-empty, and that list came solely from `languages.node.default_package_manager` plus each workspace's `package_manager`.

That made image contents depend on a config field that is routinely empty. `detect.rs:853-869` *does* populate `package_manager` — it reads `packageManager` from package.json and falls back to lockfiles (`pnpm-lock.yaml` → `pnpm`). But this repo's stored config is `"source": "user-edited"` with `package_manager: null` on every workspace, while `ui/package.json` declares `packageManager: pnpm@11.8.0`. A human edit dropped the detected values and nothing re-derives them.

Verified in a task-run pod on the real image:

```
PATH        = /opt/djinn/bin:/usr/local/cargo/bin:/opt/node/bin:...:/cache/go/bin
PNPM_HOME   = /cache/pnpm
/opt/node/bin/ -> node, npm, npx, scip-typescript          # no pnpm
find / -xdev -name 'pnpm*' -type f  (excluding /cache)     # only scip-typescript fixtures
command -v pnpm                                            # NOT ON PATH
```

The failure was not "the wrong manager is installed" — it was **no manager is installed**. Every consumer then had to find one at runtime, and what they found was a copy bootstrapped onto the shared, writable `/cache` PVC. The package-manager *binary* became shared mutable state, which is how one overwritten object could exec itself in a loop and silently kill every JS-touching task for three weeks.

Note `/cache/go/bin` is on `PATH` but `/cache/pnpm/bin` is not — which is why earlier sessions hit `pnpm: command not found`, and why one had to add a `$PNPM_HOME/bin` fallback to `regenerate-tool-goldens.mjs`.

## Changes

**pnpm ships whenever node is selected.** Not unconditional — `emit_node_block` returns early when no node language is configured, so Rust-only and Python-only images are untouched. Tested in both directions, including the no-node case.

**A declared manager is unioned with pnpm, not substituted for it.** Previously declaring `yarn` would have meant no pnpm; now you get both. yarn/bun stay declaration-driven — neither has shown this failure, and each is one more thing to keep current.

**Drop the dead root `pnpm: ^9.15.9` dependency.** Nothing resolves it, and it was a third pnpm version alongside `ui`'s `11.8.0` pin and the installed `11.9.0`. `yaml` stays; `scripts/check-ci-timeouts.mjs` imports it.

## A measured negative result, recorded in the code

I first tried to split the store from the global dir so only the *store* would be shared. It does not work. Measured against pnpm 11.8.0 in this image:

| attempt | `pnpm store path` |
|---|---|
| `PNPM_HOME=/opt/pnpm` + `npm_config_store_dir=/cache/...` | `/opt/pnpm/store/v11` |
| `PNPM_HOME=/opt/pnpm` + `NPM_CONFIG_STORE_DIR=/cache/...` | `/opt/pnpm/store/v11` |
| `store-dir=` in `$PNPM_HOME/.npmrc`, CWD `.npmrc`, `/usr/local/etc/npmrc` | `/opt/pnpm/store/v11` |
| `pnpm --store-dir=/cache/... store path` | `/cache/.../store/v11` |

Only the CLI flag wins, and we cannot inject a flag into every pnpm a task runs. So store and global dir share `/cache` by necessity; `dockerfile.rs` now records this so nobody repeats the attempt. The durable fix remains the seeding design: warm builds an immutable per-lockfile store snapshot, task pods seed from it and write deltas locally, so no task mutates shared state.

## Not fixed here

`detect.rs` correctly derives `package_manager`, but a user-edited config discards it and nothing re-derives it on subsequent scans. Worth addressing separately — this PR makes the image resilient to that, rather than fixing the config drift itself.

## Verification

Compilation and tests run in CI; local builds are not viable on this workspace. Every runtime claim above was verified with probe Pods against the production image and cache PVC — the table rows are observations, not documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)