### PR TITLE
fix(memory): separate retrieval utility from confidence and repair access signals (9xih)

### DIFF
--- a/server/crates/djinn-agent/src/extension/handlers/memory_agent.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/memory_agent.rs
@@ -26,6 +26,10 @@ pub(super) async fn call_memory_read(
             SharedMemoryReadParams {
                 project: project_path,
                 identifier: p.identifier,
+                // The agent-facing `memory_read` tool schema does not expose an
+                // invocation id, so every attempt on this path is explicitly a
+                // distinct invocation (9xih backward-compatible behaviour).
+                invocation_id: None,
             },
             &note_access_attribution(state),
         )

--- a/server/crates/djinn-agent/src/task_confidence.rs
+++ b/server/crates/djinn-agent/src/task_confidence.rs
@@ -13,9 +13,22 @@ fn parse_task_memory_refs(memory_refs: &str) -> Vec<String> {
     })
 }
 
-const TASK_SUCCESS_SIGNAL: f64 = 0.65;
 const COMPLETED_STATUS: &str = "closed";
 const COMPLETED_REASON: &str = "completed";
+
+/// Activity event type recorded on successful task completion.
+///
+/// The name is historical. Since 9xih this listener applies NO confidence
+/// signal: the `TASK_SUCCESS_SIGNAL = 0.65` `update_confidence` call it used to
+/// make was removed. A task closing successfully while referencing a note is
+/// evidence that the note was USED, not that it is TRUE, and `notes.confidence`
+/// also gates injection eligibility and archival lifecycle — so writing a task
+/// outcome into it silently changed what the system may inject and archive.
+///
+/// The event type string is deliberately NOT renamed: it is the dedupe key read
+/// back by `has_already_applied`, and rows carrying it already exist in every
+/// deployed database. Renaming it would make every historically-completed task
+/// look unprocessed.
 const CONFIDENCE_ACTIVITY_TYPE: &str = "confidence_signal_applied";
 
 #[derive(Debug, Deserialize)]
@@ -28,13 +41,25 @@ struct TaskUpdatedPayload {
 #[derive(Debug, Serialize)]
 struct ConfidenceSignalPayload {
     reason: &'static str,
+    /// Note ids the task's `memory_refs` resolved to.
+    ///
+    /// The JSON key stays `updated_notes` because it is already persisted in
+    /// `task_activity` rows across every deployment and is read back by
+    /// operators and the timeline UI; since 9xih no confidence value is
+    /// actually updated, so read it as "notes this completion referenced".
     updated_notes: Vec<String>,
     missing_notes: usize,
     from_sync: bool,
 }
 
 /// Spawn the task-outcome listener. When a task transitions to a successful
-/// terminal state, confidence signals are applied to the notes it references.
+/// terminal state, a completion-activity row is recorded naming the notes it
+/// referenced.
+///
+/// Since 9xih this listener writes NO note confidence. It sits on the forbidden
+/// side of the epistemic write boundary described in
+/// `djinn_db::repositories::note::scoring`: a task outcome is evidence about
+/// usefulness, never about truth.
 ///
 /// `events` is the broadcast sender the listener subscribes to. `db` and
 /// `event_bus` are used to construct the underlying repositories.
@@ -147,7 +172,7 @@ async fn handle_successful_task_completion(
     }
 
     let mut seen = HashSet::new();
-    let mut updated_notes = Vec::new();
+    let mut resolved_notes = Vec::new();
     let mut missing_refs = 0usize;
 
     for permalink in memory_refs {
@@ -159,21 +184,12 @@ async fn handle_successful_task_completion(
             .get_by_permalink(&payload.task.project_id, &permalink)
             .await
         {
+            // Resolution only. This deliberately does NOT call
+            // `update_confidence` (9xih): task completion is a retrieval/task
+            // outcome, not epistemic evidence about the note. The resolved ids
+            // are still recorded so completion remains observable.
             Ok(Some(note)) => {
-                if let Err(error) = note_repo
-                    .update_confidence(&note.id, TASK_SUCCESS_SIGNAL)
-                    .await
-                {
-                    tracing::warn!(
-                        error = %error,
-                        task_id = %payload.task.id,
-                        note_id = %note.id,
-                        permalink,
-                        "failed to apply task success confidence signal"
-                    );
-                    continue;
-                }
-                updated_notes.push(note.id);
+                resolved_notes.push(note.id);
             }
             Ok(None) => {
                 missing_refs += 1;
@@ -194,7 +210,7 @@ async fn handle_successful_task_completion(
     if let Err(error) = record_confidence_signal(
         task_repo,
         &payload.task.id,
-        updated_notes,
+        resolved_notes,
         missing_refs,
         payload.from_sync,
     )
@@ -297,8 +313,20 @@ mod tests {
         project_repo.create(slug, "test", path_name).await
     }
 
+    /// AC1 (9xih), positive + negative in one run against the real listener:
+    ///
+    /// * NEGATIVE — a successful completion carrying a resolvable `memory_refs`
+    ///   entry must leave `notes.confidence` byte-identical. This is the exact
+    ///   scenario that previously applied `TASK_SUCCESS_SIGNAL`, so if the
+    ///   `update_confidence` call ever comes back this assertion fails.
+    /// * POSITIVE — the completion activity row must still be written, with the
+    ///   referenced note id in its payload, so removing the confidence write did
+    ///   not cost observability.
+    ///
+    /// Both assertions read state back out of the database; neither is
+    /// satisfied by the listener merely running.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn applies_task_success_signal_to_referenced_notes() {
+    async fn task_completion_records_activity_without_touching_note_confidence() {
         let harness = make_harness().await;
         spawn_task_outcome_listener(
             harness.db.clone(),
@@ -334,6 +362,12 @@ mod tests {
             .await
             .unwrap();
         let _ = project_path;
+        // Park the note at a mid prior on purpose. At the new default
+        // (CONFIDENCE_CEILING) the removed 0.65 signal would have clamped back
+        // to the ceiling and moved nothing, so "confidence did not change"
+        // would prove nothing. From 0.5 the removed signal WOULD have moved it,
+        // which is what the vacuity guard below asserts.
+        note_repo.set_confidence(&note.id, 0.5).await.unwrap();
         let before = note_repo.get(&note.id).await.unwrap().unwrap().confidence;
 
         let creator = crate::test_helpers::create_test_creator(&harness.db).await;
@@ -378,18 +412,26 @@ mod tests {
 
         wait_for_confidence_signal(&task_repo, &closed.id).await;
 
-        let updated = note_repo.get(&note.id).await.unwrap().unwrap();
-        assert!(
-            updated.confidence < before,
-            "expected confidence to update when task completes"
-        );
-        assert!(
-            (updated.confidence
-                - djinn_db::repositories::note::bayesian_update(before, TASK_SUCCESS_SIGNAL))
-            .abs()
-                < 1e-9
+        // NEGATIVE: the note's stored confidence is re-read from the database
+        // and must be bit-identical to the value before completion.
+        let after = note_repo.get(&note.id).await.unwrap().unwrap().confidence;
+        assert_eq!(
+            after, before,
+            "task completion must not mutate note confidence \
+             (before {before}, after {after}); TASK_SUCCESS_SIGNAL is removed by 9xih"
         );
 
+        // Guard against the assertion above passing vacuously: prove the
+        // removed signal WOULD have moved this exact prior, so an unchanged
+        // value is a real behavioural difference and not an arithmetic no-op.
+        let would_have_been = djinn_db::repositories::note::bayesian_update(before, 0.65);
+        assert!(
+            (would_have_been - before).abs() > 1e-9,
+            "test is vacuous: the removed 0.65 task-success signal would not have \
+             moved a prior of {before} anyway"
+        );
+
+        // POSITIVE: completion activity survives, and still names the note.
         let activity = task_repo
             .query_activity(ActivityQuery {
                 task_id: Some(task.id),
@@ -399,7 +441,51 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(activity.len(), 1);
+        let payload = serde_json::from_str::<serde_json::Value>(&activity[0].payload).unwrap();
+        assert_eq!(payload["reason"], COMPLETED_REASON);
+        assert_eq!(payload["missing_notes"], 0);
+        assert_eq!(
+            payload["updated_notes"]
+                .as_array()
+                .expect("updated_notes array")
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect::<Vec<_>>(),
+            vec![note.id.as_str()],
+            "completion activity must still record the referenced note"
+        );
         assert_eq!(closed.status, "closed");
+    }
+
+    /// AC1 (9xih), call-site guard. `handle_successful_task_completion` is the
+    /// production task-outcome writer; this pins that its source text contains
+    /// no confidence-mutation call at all, so a future edit cannot reintroduce
+    /// one without failing here.
+    ///
+    /// A source-text assertion is a weak guard on its own, which is why it is
+    /// paired with the behavioural test above rather than standing in for it.
+    #[test]
+    fn task_outcome_listener_source_contains_no_confidence_writer() {
+        let source = include_str!("task_confidence.rs");
+        // Strip this test's own body so its literals do not match themselves.
+        let production = source
+            .split_once("#[cfg(test)]")
+            .expect("task_confidence.rs has a test module")
+            .0;
+        // Call syntax, not bare identifiers: the doc comments in this file
+        // deliberately NAME the removed writers to explain why they are gone,
+        // and that prose must not trip the guard.
+        for forbidden in [
+            "update_confidence(",
+            "set_confidence(",
+            "const TASK_SUCCESS_SIGNAL",
+        ] {
+            assert!(
+                !production.contains(forbidden),
+                "task-outcome production code must not contain `{forbidden}`: \
+                 task/review/merge outcomes are barred from the confidence write boundary"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-control-plane/src/server.rs
+++ b/server/crates/djinn-control-plane/src/server.rs
@@ -36,7 +36,6 @@ use crate::tools::memory_tools::contradiction::{
 };
 use crate::tools::memory_tools::summaries::spawn_summary_backfill_worker;
 
-const HIGH_CONFIDENCE_THRESHOLD: f64 = 0.8;
 const GRAPH_SCHEMA_RESOURCE_TEMPLATE_URI: &str = "djinn://project/{id}/graph-schema";
 const GRAPH_SCHEMA_RESOURCE_MIME_TYPE: &str = "application/json";
 
@@ -53,6 +52,15 @@ impl CoAccessBatch {
         }
     }
 
+    /// Persist the session's co-access edges.
+    ///
+    /// This writes `note_associations` and NOTHING else. It used to also apply
+    /// `CO_ACCESS_HIGH` to every lower-confidence note that shared a session
+    /// with a high-confidence one — an unbounded epistemic feedback loop
+    /// (proposal 9xih): raising a note's confidence made it more injectable,
+    /// which made it more likely to be co-read, which raised it again. Being
+    /// read alongside a trusted note is evidence about retrieval, not about
+    /// truth, so it may not reach `update_confidence` at all.
     pub(crate) async fn flush(&self, state: &McpState) {
         if self.note_ids.len() < 2 {
             return;
@@ -64,53 +72,6 @@ impl CoAccessBatch {
                 if let Err(error) = repo.upsert_association(note_a, note_b, 1).await {
                     warn!(%error, note_a, note_b, "failed to flush co-access association");
                 }
-            }
-        }
-
-        let confidence_map = match repo.note_confidence_map(&self.note_ids).await {
-            Ok(map) => map,
-            Err(error) => {
-                warn!(%error, "failed to load note confidence map for co-access flush");
-                return;
-            }
-        };
-
-        let high_confidence_notes: HashSet<&str> = self
-            .note_ids
-            .iter()
-            .filter_map(|note_id| {
-                confidence_map
-                    .get(note_id)
-                    .copied()
-                    .filter(|confidence| *confidence > HIGH_CONFIDENCE_THRESHOLD)
-                    .map(|_| note_id.as_str())
-            })
-            .collect();
-
-        if high_confidence_notes.is_empty() {
-            return;
-        }
-
-        for note_id in self.note_ids.iter().filter(|note_id| {
-            confidence_map
-                .get(*note_id)
-                .is_some_and(|confidence| *confidence <= HIGH_CONFIDENCE_THRESHOLD)
-        }) {
-            let has_high_confidence_partner = self.note_ids.iter().any(|candidate| {
-                candidate != note_id && high_confidence_notes.contains(candidate.as_str())
-            });
-
-            if !has_high_confidence_partner {
-                continue;
-            }
-
-            if let Err(error) = repo
-                .update_confidence(note_id, djinn_db::repositories::note::CO_ACCESS_HIGH)
-                .await
-            {
-                warn!(%error, note_id, "failed to update co-access confidence");
-            } else {
-                debug!(note_id, "applied high-confidence co-access boost");
             }
         }
     }
@@ -241,6 +202,13 @@ impl DjinnMcpServer {
         )
     }
 
+    /// Note this note in the session's in-memory co-access set.
+    ///
+    /// Session-level telemetry only. Per 9xih this must never mutate
+    /// `notes.confidence` nor the persisted access fields (`access_count`,
+    /// `last_accessed`) — the only writer of those is
+    /// `NoteRepository::record_explicit_access`, reached from a successful
+    /// `memory_read` result construction.
     pub(crate) async fn record_memory_read(&self, note_id: &str) {
         self.co_access_batch.write().await.record_read(note_id);
     }

--- a/server/crates/djinn-control-plane/src/server_tests.rs
+++ b/server/crates/djinn-control-plane/src/server_tests.rs
@@ -207,6 +207,7 @@ mod tests {
             .memory_read(Parameters(ReadParams {
                 project: project.slug(),
                 identifier: legacy.permalink.clone(),
+                invocation_id: None,
             }))
             .await;
 

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/build_context_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/build_context_tests.rs
@@ -534,7 +534,7 @@ mod tests {
             )
             .await
             .unwrap();
-        // confidence defaults to 1.0, no need to set
+        // confidence defaults to CONFIDENCE_CEILING (0.975), no need to set
 
         (seed.permalink, low_conf.title, stale.title, normal.title)
     }

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/confirm.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/confirm.rs
@@ -190,6 +190,59 @@ mod tests {
         assert!(new_confidence >= 0.97);
     }
 
+    /// AC2 (9xih): confirming an untouched note may not demote it.
+    ///
+    /// Before 9xih, new notes defaulted to `1.0` while `bayesian_update` clamps
+    /// to `CONFIDENCE_CEILING` (0.975). Applying the *positive* `USER_CONFIRM`
+    /// signal therefore dropped a fresh note from 1.0 to 0.975 — strictly below
+    /// every note nobody had bothered to confirm. Confirming a note pushed it
+    /// down the confidence ordering that gates injection eligibility.
+    ///
+    /// This runs the real `memory_confirm` tool against two notes created by
+    /// the real repository, so the schema default (migration 195) is what is
+    /// actually under test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn confirming_a_new_note_never_sorts_it_below_an_untouched_note() {
+        let (server, db, project_id, path) = make_server().await;
+        let repo = NoteRepository::new(db.clone(), EventBus::noop());
+
+        let untouched = make_note(&db, &project_id, &path, "Untouched Default").await;
+        let to_confirm = make_note(&db, &project_id, &path, "Confirmed Default").await;
+
+        // The premise: new notes are created at the ceiling, not above it.
+        assert_eq!(
+            to_confirm.confidence,
+            note::CONFIDENCE_CEILING,
+            "a new note must default to CONFIDENCE_CEILING; got {}",
+            to_confirm.confidence
+        );
+        assert_eq!(untouched.confidence, note::CONFIDENCE_CEILING);
+
+        let response = server
+            .memory_confirm(Parameters(MemoryConfirmParams {
+                project: project_id.clone(),
+                identifier: to_confirm.permalink.clone(),
+                comment: None,
+            }))
+            .await
+            .0;
+        assert_eq!(response.error, None);
+
+        // Read both back out of the database rather than trusting the response.
+        let confirmed_after = repo.get(&to_confirm.id).await.unwrap().unwrap().confidence;
+        let untouched_after = repo.get(&untouched.id).await.unwrap().unwrap().confidence;
+
+        assert!(
+            confirmed_after >= untouched_after,
+            "USER_CONFIRM demoted a note below an untouched peer: \
+             confirmed={confirmed_after}, untouched={untouched_after}"
+        );
+        assert_eq!(
+            untouched_after, untouched.confidence,
+            "confirming one note must not disturb another"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn confirm_resolves_by_note_id() {
         let (server, db, project_id, path) = make_server().await;

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/confirm.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/confirm.rs
@@ -199,7 +199,7 @@ mod tests {
     /// down the confidence ordering that gates injection eligibility.
     ///
     /// This runs the real `memory_confirm` tool against two notes created by
-    /// the real repository, so the schema default (migration 195) is what is
+    /// the real repository, so the schema default (migration 197) is what is
     /// actually under test.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn confirming_a_new_note_never_sorts_it_below_an_untouched_note() {

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/ops.rs
@@ -146,7 +146,7 @@ fn permalink_candidates(identifier: &str) -> Vec<String> {
 /// This used to call `NoteRepository::touch_accessed`, so appearing in a result
 /// set incremented `access_count` and advanced `last_accessed` exactly like an
 /// explicit `memory_read` did. The two became indistinguishable in those
-/// scalars, which is why migration 195 has to rebase them rather than partition
+/// scalars, which is why migration 197 has to rebase them rather than partition
 /// them.
 ///
 /// A note the agent never asked for by name is not an access. Search-result

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/ops.rs
@@ -4,8 +4,8 @@ use djinn_db::repositories::retrieval_trace::{
     RetrievalTraceRepository, TaxonomyV1RetrievalHealthGroup,
 };
 use djinn_db::{
-    NoteAccessAttribution, NoteAccessSource, NoteRepository, ProjectRepository,
-    normalize_virtual_note_path, permalink_from_virtual_note_path, resolve_short_ids,
+    NoteAccessAttribution, NoteRepository, ProjectRepository, normalize_virtual_note_path,
+    permalink_from_virtual_note_path, resolve_short_ids,
 };
 use djinn_telemetry::memory_retrieval::{
     MemoryRetrievalMetrics, RetrievalEntryPoint, RetrievalOutcome, RetrievalStage,
@@ -140,24 +140,29 @@ fn permalink_candidates(identifier: &str) -> Vec<String> {
     candidates
 }
 
+/// Note the search results in the session's in-memory co-access set.
+///
+/// **ADR-054 is superseded here for PERSISTED note access (proposal 9xih).**
+/// This used to call `NoteRepository::touch_accessed`, so appearing in a result
+/// set incremented `access_count` and advanced `last_accessed` exactly like an
+/// explicit `memory_read` did. The two became indistinguishable in those
+/// scalars, which is why migration 195 has to rebase them rather than partition
+/// them.
+///
+/// A note the agent never asked for by name is not an access. Search-result
+/// display now writes NO persisted note state: no `note_access_events` row, no
+/// counter, no timestamp. Only session-level co-access telemetry remains, and
+/// that touches neither confidence nor the access fields.
+///
+/// `_attribution` is retained in the signature because the caller has it and a
+/// future ledger source may need it; it is deliberately unused today.
 async fn record_retrieved_notes(
     server: &DjinnMcpServer,
-    repo: &NoteRepository,
+    _repo: &NoteRepository,
     note_ids: &[String],
-    attribution: &NoteAccessAttribution,
+    _attribution: &NoteAccessAttribution,
 ) {
-    // ADR-054 retrieval boundary: notes returned to the MCP client count as accessed,
-    // even if the client does not issue a follow-up `memory_read`. This keeps search
-    // result retrieval flows visible to temporal/co-access scoring without touching
-    // notes that were only considered internally during ranking.
-    //
-    // The ledger source is `MemorySearch`, NOT `MemoryRead`: appearing in a
-    // result set is not a pull, and the injected-pull-rate metric must never
-    // count it as one.
     for note_id in note_ids {
-        let _ = repo
-            .touch_accessed(note_id, NoteAccessSource::MemorySearch, attribution)
-            .await;
         server.record_memory_read(note_id).await;
     }
 }
@@ -274,11 +279,39 @@ fn extract_short_id_candidates(content: &str) -> Vec<String> {
 /// [`NoteAccessAttribution::unattributed`] from session-less surfaces (the host
 /// MCP server, operator tooling); the access is still recorded and is counted in
 /// the report's coverage diagnostics rather than dropped.
+///
+/// # The counted access boundary (proposal 9xih)
+///
+/// A counted access is **exactly one successful external `memory_read` handler
+/// result construction for a resolved note**. Everything about the ordering
+/// below is load-bearing:
+///
+/// 1. `invocation_id` is validated FIRST, before the project or the note is
+///    resolved, so an invalid id can never leave partial state behind.
+/// 2. The response is fully constructed BEFORE the access is recorded. A
+///    not-found read, an invalid request, or a failed construction therefore
+///    writes nothing.
+/// 3. `event_timestamp` is captured after resolution and immediately BEFORE the
+///    transaction, so it is the instant the read succeeded rather than whenever
+///    the write reached the database.
+///
+/// This boundary deliberately does NOT claim delivery to the client: once the
+/// handler returns, the server cannot observe the transport. If the connection
+/// drops after commit, the access stays counted — and a caller that supplied an
+/// `invocation_id` can retry safely, because the retry is recognised as a replay
+/// and counts nothing further.
 pub async fn memory_read(
     server: &DjinnMcpServer,
     p: ReadParams,
     attribution: &NoteAccessAttribution,
 ) -> MemoryNoteResponse {
+    // Before note resolution, on purpose: a blank or over-limit id is rejected
+    // without reading, touching, or counting anything.
+    let invocation_id = match super::reads::resolve_invocation_id(p.invocation_id.as_deref()) {
+        Ok(invocation_id) => invocation_id,
+        Err(error) => return MemoryNoteResponse::error(error),
+    };
+
     let project_id = match resolve_project_id(server, &p.project).await {
         Ok(id) => id,
         Err(error) => return MemoryNoteResponse::error(error),
@@ -327,9 +360,6 @@ pub async fn memory_read(
         }
     };
 
-    let _ = repo
-        .touch_accessed(&note.id, NoteAccessSource::MemoryRead, attribution)
-        .await;
     if note.abstract_.is_none() || note.overview.is_none() {
         server.enqueue_missing_summary_backfill(&note.id).await;
     }
@@ -371,6 +401,26 @@ pub async fn memory_read(
                 })
                 .collect();
         }
+    }
+
+    // The result is now fully constructed and this read has succeeded, so it
+    // counts. Stamp the event BEFORE opening the transaction: the recorded
+    // instant is when the read succeeded, not when the write landed.
+    let event_timestamp = djinn_db::repositories::note::access_event_timestamp();
+    if let Err(error) = repo
+        .record_explicit_access(&note.id, &invocation_id, &event_timestamp, attribution)
+        .await
+    {
+        // Fail-open on the response, never on the counter: instrumentation must
+        // not turn a successful read into an error for the caller. The access is
+        // simply not counted, which is the safe direction — an under-count is
+        // recoverable, a phantom count is not.
+        tracing::warn!(
+            %error,
+            note_id = %note.id,
+            invocation_id = %invocation_id,
+            "failed to record explicit note access; this read will not be counted"
+        );
     }
 
     response

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/ops_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/ops_tests.rs
@@ -468,15 +468,22 @@ mod tests {
         );
         assert!(!response.results.is_empty());
 
+        // Inverted by proposal 9xih. This used to assert `access_count == 1`
+        // under ADR-054, which counted a note appearing in a result set as an
+        // access. That made search display and explicit `memory_read`
+        // indistinguishable in the persisted scalars. ADR-054 is superseded for
+        // PERSISTED note access: display now counts nothing.
         for result in &response.results {
             let access_count =
                 access_count_for(&setup.server, &setup.project, &result.permalink).await;
             assert_eq!(
-                access_count, 1,
-                "returned search results should count as accessed retrievals"
+                access_count, 0,
+                "search-result display must not count as an access (9xih supersedes ADR-054)"
             );
         }
 
+        // Session-level co-access telemetry is explicitly PRESERVED: it never
+        // touched confidence or the persisted access fields, so it stays.
         let recorded = setup.server.recorded_note_ids().await;
         let returned_ids: Vec<String> = response
             .results
@@ -1504,7 +1511,7 @@ mod tests {
         project: &str,
         identifier: &str,
         invocation_id: Option<&str>,
-    ) -> super::MemoryNoteResponse {
+    ) -> crate::tools::memory_tools::MemoryNoteResponse {
         ops::memory_read(
             server,
             ReadParams {
@@ -1574,8 +1581,7 @@ mod tests {
         )
         .await;
         assert!(first.error.is_none(), "{:?}", first.error);
-        let after_first =
-            note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+        let after_first = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
 
         // Response dropped in transport; the caller retries the same logical
         // invocation.
@@ -1599,8 +1605,7 @@ mod tests {
             "a replay must not append a second ledger row, got {events:?}"
         );
 
-        let after_retry =
-            note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+        let after_retry = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
         assert_eq!(
             after_retry.access_count,
             before.access_count + 1,
@@ -1652,12 +1657,15 @@ mod tests {
         let setup = setup_server().await;
         let before = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
 
-        let over_limit = "x".repeat(
-            super::reads::INVOCATION_ID_MAX_CHARS + 1,
-        );
+        let over_limit = "x".repeat(crate::tools::memory_tools::reads::INVOCATION_ID_MAX_CHARS + 1);
         for invalid in ["", "   ", over_limit.as_str()] {
-            let response =
-                read_note(&setup.server, &setup.project, &setup.permalink, Some(invalid)).await;
+            let response = read_note(
+                &setup.server,
+                &setup.project,
+                &setup.permalink,
+                Some(invalid),
+            )
+            .await;
             assert!(
                 response.error.is_some(),
                 "invocation_id {invalid:?} must be rejected"
@@ -1670,7 +1678,7 @@ mod tests {
 
         // The boundary value itself is accepted, so the test above is a bound
         // check and not a blanket rejection.
-        let at_limit = "y".repeat(super::reads::INVOCATION_ID_MAX_CHARS);
+        let at_limit = "y".repeat(crate::tools::memory_tools::reads::INVOCATION_ID_MAX_CHARS);
         let accepted = read_note(
             &setup.server,
             &setup.project,

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/ops_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/ops_tests.rs
@@ -151,6 +151,7 @@ mod tests {
                 ReadParams {
                     project: setup.project.clone(),
                     identifier: setup.permalink.clone(),
+                    invocation_id: None,
                 },
                 &djinn_db::NoteAccessAttribution::unattributed(),
             )
@@ -199,6 +200,7 @@ mod tests {
                 ReadParams {
                     project: setup.project.clone(),
                     identifier: note.permalink.clone(),
+                    invocation_id: None,
                 },
                 &djinn_db::NoteAccessAttribution::unattributed(),
             )
@@ -232,6 +234,7 @@ mod tests {
             ReadParams {
                 project: setup.project.clone(),
                 identifier: probe.to_string(),
+                invocation_id: None,
             },
             &djinn_db::NoteAccessAttribution::unattributed(),
         )
@@ -293,6 +296,7 @@ mod tests {
             ReadParams {
                 project: setup.project.clone(),
                 identifier: format!("memory://{design_permalink}.md"),
+                invocation_id: None,
             },
             &djinn_db::NoteAccessAttribution::unattributed(),
         )
@@ -807,6 +811,7 @@ mod tests {
             .memory_read(rmcp::handler::server::wrapper::Parameters(ReadParams {
                 project: setup.project,
                 identifier: setup.permalink,
+                invocation_id: None,
             }))
             .await
             .0;
@@ -1449,6 +1454,412 @@ mod tests {
         assert_eq!(
             error.count, 1,
             "wildcard list failure should record exactly one error observation"
+        );
+    }
+
+    // ── 9xih: the counted-access boundary ────────────────────────────────
+    //
+    // Every test below reads the ACTUAL persisted state back — ledger rows,
+    // `access_count`, `last_accessed`, `confidence` — never a return value or a
+    // log line. A no-op implementation fails all of them.
+
+    async fn project_id_for(server: &DjinnMcpServer, project: &str) -> String {
+        ProjectRepository::new(server.state.db().clone(), server.state.event_bus())
+            .resolve(project)
+            .await
+            .unwrap()
+            .expect("project id")
+    }
+
+    async fn note_by_permalink(
+        server: &DjinnMcpServer,
+        project: &str,
+        permalink: &str,
+    ) -> djinn_memory::Note {
+        let project_id = project_id_for(server, project).await;
+        NoteRepository::new(server.state.db().clone(), server.state.event_bus())
+            .get_by_permalink(&project_id, permalink)
+            .await
+            .unwrap()
+            .expect("note")
+    }
+
+    async fn access_events_for(
+        server: &DjinnMcpServer,
+        project: &str,
+        note_id: &str,
+    ) -> Vec<djinn_db::NoteAccessEvent> {
+        let project_id = project_id_for(server, project).await;
+        djinn_db::repositories::note::note_access_events_for_note(
+            server.state.db(),
+            &project_id,
+            note_id,
+        )
+        .await
+        .expect("read note access ledger")
+    }
+
+    async fn read_note(
+        server: &DjinnMcpServer,
+        project: &str,
+        identifier: &str,
+        invocation_id: Option<&str>,
+    ) -> super::MemoryNoteResponse {
+        ops::memory_read(
+            server,
+            ReadParams {
+                project: project.to_owned(),
+                identifier: identifier.to_owned(),
+                invocation_id: invocation_id.map(ToOwned::to_owned),
+            },
+            &djinn_db::NoteAccessAttribution::unattributed(),
+        )
+        .await
+    }
+
+    /// AC5: one successful `memory_read` result construction writes exactly one
+    /// ledger row and exactly one increment, and advances `last_accessed`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_read_records_exactly_one_access_event_and_one_increment() {
+        let setup = setup_server().await;
+        let before = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+        assert!(
+            access_events_for(&setup.server, &setup.project, &before.id)
+                .await
+                .is_empty(),
+            "a freshly created note must start with an empty ledger"
+        );
+
+        let response = read_note(
+            &setup.server,
+            &setup.project,
+            &setup.permalink,
+            Some("read-once"),
+        )
+        .await;
+        assert!(response.error.is_none(), "{:?}", response.error);
+
+        let events = access_events_for(&setup.server, &setup.project, &before.id).await;
+        assert_eq!(events.len(), 1, "expected exactly one ledger row");
+        assert_eq!(events[0].source, "memory_read");
+        assert_eq!(events[0].invocation_id.as_deref(), Some("read-once"));
+
+        let after = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+        assert_eq!(after.access_count, before.access_count + 1);
+        // Exactly the `max(last_accessed, event_timestamp)` contract. Stated as
+        // the max rather than as bare equality so the assertion does not depend
+        // on the app clock and the Postgres clock agreeing to the millisecond;
+        // the fixed-timestamp proofs of the ordering rule live in
+        // `djinn-db/.../tests/search_ranking.rs`.
+        assert_eq!(
+            after.last_accessed,
+            std::cmp::max(before.last_accessed.clone(), events[0].created_at.clone()),
+            "last_accessed must be max(previous, event timestamp)"
+        );
+    }
+
+    /// AC5 + AC6: the dropped-response retry. The caller never learns whether
+    /// the first attempt landed, so it retries with the SAME invocation id; the
+    /// access must count exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_read_retry_with_the_same_invocation_id_is_a_replay() {
+        let setup = setup_server().await;
+        let before = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+
+        let first = read_note(
+            &setup.server,
+            &setup.project,
+            &setup.permalink,
+            Some("dropped-response-1"),
+        )
+        .await;
+        assert!(first.error.is_none(), "{:?}", first.error);
+        let after_first =
+            note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+
+        // Response dropped in transport; the caller retries the same logical
+        // invocation.
+        let retry = read_note(
+            &setup.server,
+            &setup.project,
+            &setup.permalink,
+            Some("dropped-response-1"),
+        )
+        .await;
+        assert!(
+            retry.error.is_none(),
+            "a replay must still serve the note: {:?}",
+            retry.error
+        );
+
+        let events = access_events_for(&setup.server, &setup.project, &before.id).await;
+        assert_eq!(
+            events.len(),
+            1,
+            "a replay must not append a second ledger row, got {events:?}"
+        );
+
+        let after_retry =
+            note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+        assert_eq!(
+            after_retry.access_count,
+            before.access_count + 1,
+            "a replay must not increment access_count a second time"
+        );
+        assert_eq!(
+            after_retry.last_accessed, after_first.last_accessed,
+            "a replay must not advance last_accessed"
+        );
+    }
+
+    /// AC6: the documented backward-compatible behaviour. A caller that omits
+    /// `invocation_id` gets a fresh id per attempt, so a retry it cannot label
+    /// is counted as a second, distinct access.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_read_without_invocation_id_counts_every_attempt_distinctly() {
+        let setup = setup_server().await;
+        let before = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+
+        for _ in 0..2 {
+            let response = read_note(&setup.server, &setup.project, &setup.permalink, None).await;
+            assert!(response.error.is_none(), "{:?}", response.error);
+        }
+
+        let events = access_events_for(&setup.server, &setup.project, &before.id).await;
+        assert_eq!(
+            events.len(),
+            2,
+            "omitted ids must produce two distinct invocations"
+        );
+        let ids: std::collections::HashSet<_> = events
+            .iter()
+            .map(|event| event.invocation_id.clone())
+            .collect();
+        assert_eq!(ids.len(), 2, "generated invocation ids must differ");
+        assert!(
+            events.iter().all(|event| event.invocation_id.is_some()),
+            "a generated id must still be stored, or replay could never work"
+        );
+
+        let after = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+        assert_eq!(after.access_count, before.access_count + 2);
+    }
+
+    /// AC6: bounds are enforced BEFORE note resolution, so a rejected request
+    /// leaves no ledger row, no counter change, and no timestamp change.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_read_rejects_blank_and_over_limit_invocation_ids_without_touching_state() {
+        let setup = setup_server().await;
+        let before = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+
+        let over_limit = "x".repeat(
+            super::reads::INVOCATION_ID_MAX_CHARS + 1,
+        );
+        for invalid in ["", "   ", over_limit.as_str()] {
+            let response =
+                read_note(&setup.server, &setup.project, &setup.permalink, Some(invalid)).await;
+            assert!(
+                response.error.is_some(),
+                "invocation_id {invalid:?} must be rejected"
+            );
+            assert!(
+                response.id.is_none(),
+                "a rejected request must not resolve a note"
+            );
+        }
+
+        // The boundary value itself is accepted, so the test above is a bound
+        // check and not a blanket rejection.
+        let at_limit = "y".repeat(super::reads::INVOCATION_ID_MAX_CHARS);
+        let accepted = read_note(
+            &setup.server,
+            &setup.project,
+            &setup.permalink,
+            Some(at_limit.as_str()),
+        )
+        .await;
+        assert!(accepted.error.is_none(), "{:?}", accepted.error);
+
+        let events = access_events_for(&setup.server, &setup.project, &before.id).await;
+        assert_eq!(
+            events.len(),
+            1,
+            "only the accepted request may appear in the ledger, got {events:?}"
+        );
+        assert_eq!(events[0].invocation_id.as_deref(), Some(at_limit.as_str()));
+
+        let after = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+        assert_eq!(
+            after.access_count,
+            before.access_count + 1,
+            "three rejected requests must have contributed nothing"
+        );
+    }
+
+    /// AC4: search-result display is an EXCLUDED path. ADR-054's persisted
+    /// touch is gone: appearing in a result set writes no ledger row, no
+    /// counter, and no timestamp.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_search_result_display_leaves_the_ledger_and_access_fields_unchanged() {
+        let setup = setup_server().await;
+
+        let search = ops::memory_search(
+            &setup.server,
+            SearchParams {
+                project: setup.project.clone(),
+                query: "architecture".to_string(),
+                folder: None,
+                note_type: None,
+                limit: Some(10),
+                entity_types: None,
+                edge_kinds: None,
+            },
+            None,
+            &djinn_db::NoteAccessAttribution::unattributed(),
+        )
+        .await;
+        assert!(search.error.is_none(), "{:?}", search.error);
+        // Assert against the notes the search ACTUALLY returned. Keying off a
+        // note the ranker was merely expected to return would make this test
+        // pass vacuously the day the ranker changed.
+        assert!(
+            !search.results.is_empty(),
+            "the test is vacuous unless the search returned something"
+        );
+
+        let note_results: Vec<_> = search
+            .results
+            .iter()
+            .filter(|result| result.entity == "note")
+            .collect();
+        assert!(
+            !note_results.is_empty(),
+            "the test is vacuous unless the search returned at least one NOTE; got entities {:?}",
+            search
+                .results
+                .iter()
+                .map(|result| result.entity.as_str())
+                .collect::<Vec<_>>()
+        );
+        for result in note_results {
+            let note = note_by_permalink(&setup.server, &setup.project, &result.permalink).await;
+            assert!(
+                access_events_for(&setup.server, &setup.project, &note.id)
+                    .await
+                    .is_empty(),
+                "search-result display must not append a ledger row for {}",
+                result.permalink
+            );
+            assert_eq!(
+                note.access_count, 0,
+                "search-result display must not increment access_count for {}",
+                result.permalink
+            );
+            assert_eq!(
+                note.last_accessed, note.created_at,
+                "search-result display must not advance last_accessed for {}",
+                result.permalink
+            );
+        }
+    }
+
+    /// AC4: a not-found read is an excluded path too — no ledger row anywhere
+    /// in the project, and no counter or timestamp moves.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_read_not_found_leaves_the_ledger_and_access_fields_unchanged() {
+        let setup = setup_server().await;
+        let before = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+
+        let response = read_note(
+            &setup.server,
+            &setup.project,
+            "xyzzynonexistentidentifier",
+            Some("not-found-read"),
+        )
+        .await;
+        assert!(response.error.is_some());
+
+        assert!(
+            access_events_for(&setup.server, &setup.project, &before.id)
+                .await
+                .is_empty()
+        );
+        let after = note_by_permalink(&setup.server, &setup.project, &setup.permalink).await;
+        assert_eq!(after.access_count, before.access_count);
+        assert_eq!(after.last_accessed, before.last_accessed);
+    }
+
+    /// AC3: the removed `CO_ACCESS_HIGH` mutation.
+    ///
+    /// Two notes are read in one session, one of them above the old
+    /// `HIGH_CONFIDENCE_THRESHOLD` (0.8) and one below it. That is exactly the
+    /// shape the deleted co-access flush acted on: it would have raised the
+    /// low-confidence note. The co-access batch is then flushed explicitly, and
+    /// EVERY involved note's confidence is re-read from the database.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_read_with_a_related_high_confidence_note_changes_no_confidence() {
+        let setup = setup_server().await;
+        let project_id = project_id_for(&setup.server, &setup.project).await;
+        let repo = NoteRepository::new(
+            setup.server.state.db().clone(),
+            setup.server.state.event_bus(),
+        );
+
+        let high = repo
+            .create_db_note(&project_id, "Co Access High", "trusted body", "adr", "[]")
+            .await
+            .unwrap();
+        let low = repo
+            .create_db_note(&project_id, "Co Access Low", "unproven body", "case", "[]")
+            .await
+            .unwrap();
+        repo.set_confidence(&high.id, 0.95).await.unwrap();
+        repo.set_confidence(&low.id, 0.5).await.unwrap();
+        assert!(
+            repo.get_associations_for_note(&high.id)
+                .await
+                .unwrap()
+                .is_empty(),
+            "no association may exist before the flush, or the control below is vacuous"
+        );
+
+        let high_before = repo.get(&high.id).await.unwrap().unwrap().confidence;
+        let low_before = repo.get(&low.id).await.unwrap().unwrap().confidence;
+        assert!(
+            high_before > 0.8 && low_before <= 0.8,
+            "fixture must straddle the old co-access threshold: high={high_before}, low={low_before}"
+        );
+
+        for permalink in [&high.permalink, &low.permalink] {
+            let response = read_note(&setup.server, &setup.project, permalink, None).await;
+            assert!(response.error.is_none(), "{:?}", response.error);
+        }
+
+        // The co-access flush is where the confidence write used to happen.
+        setup.server.flush_co_access_batch().await;
+
+        assert_eq!(
+            repo.get(&high.id).await.unwrap().unwrap().confidence,
+            high_before,
+            "co-access must not change the high-confidence note"
+        );
+        assert_eq!(
+            repo.get(&low.id).await.unwrap().unwrap().confidence,
+            low_before,
+            "co-access must not raise the low-confidence note toward its partner"
+        );
+
+        // Control against a vacuous pass: the flush DID run and DID do its
+        // remaining job. The co-access edge did not exist before (asserted
+        // above) and exists now, so "no confidence changed" means the removed
+        // writer is gone — not that the flush silently no-opped.
+        let associations = repo.get_associations_for_note(&high.id).await.unwrap();
+        assert!(
+            associations
+                .iter()
+                .any(|association| association.note_a_id == low.id
+                    || association.note_b_id == low.id),
+            "the co-access flush must still persist the association edge"
         );
     }
 }

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/reads.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/reads.rs
@@ -2,6 +2,46 @@ use super::ops;
 use super::revision_readers;
 use super::*;
 
+/// Maximum accepted length, in characters, of a caller-supplied
+/// `memory_read` `invocation_id`.
+///
+/// Bound to `note_access_events.invocation_id VARCHAR(64)` (migration 195), and
+/// counted in characters because that is what Postgres `VARCHAR(n)` counts.
+/// Over-limit ids are rejected rather than truncated: truncation would fold two
+/// distinct invocations onto one replay key and silently drop a real access.
+pub(crate) const INVOCATION_ID_MAX_CHARS: usize =
+    djinn_db::repositories::note::INVOCATION_ID_MAX_CHARS;
+
+/// Resolve the invocation identity for one `memory_read` attempt.
+///
+/// * `Some(id)` — a caller asserting retry identity. Validated (nonblank,
+///   bounded) and returned trimmed. Two attempts carrying the same id are one
+///   logical invocation and count once.
+/// * `None` — a legacy caller. A fresh UUID is minted per attempt, so each
+///   attempt is explicitly a DISTINCT invocation and retries cannot be
+///   deduplicated. This is the documented backward-compatible behaviour, not an
+///   oversight: the server has no other way to tell a retry from an intentional
+///   second read.
+///
+/// Callers must run this BEFORE resolving the note, so an invalid id is
+/// rejected without touching any note state.
+pub(crate) fn resolve_invocation_id(supplied: Option<&str>) -> Result<String, String> {
+    let Some(raw) = supplied else {
+        return Ok(uuid::Uuid::now_v7().to_string());
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("invocation_id must not be blank".to_owned());
+    }
+    let length = trimmed.chars().count();
+    if length > INVOCATION_ID_MAX_CHARS {
+        return Err(format!(
+            "invocation_id must be at most {INVOCATION_ID_MAX_CHARS} characters, got {length}"
+        ));
+    }
+    Ok(trimmed.to_owned())
+}
+
 #[tool_router(router = memory_reads_router, vis = "pub(super)")]
 impl DjinnMcpServer {
     /// Read a note by permalink or title. Updates last_accessed timestamp.

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/reads.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/reads.rs
@@ -5,7 +5,7 @@ use super::*;
 /// Maximum accepted length, in characters, of a caller-supplied
 /// `memory_read` `invocation_id`.
 ///
-/// Bound to `note_access_events.invocation_id VARCHAR(64)` (migration 195), and
+/// Bound to `note_access_events.invocation_id VARCHAR(64)` (migration 197), and
 /// counted in characters because that is what Postgres `VARCHAR(n)` counts.
 /// Over-limit ids are rejected rather than truncated: truncation would fold two
 /// distinct invocations onto one replay key and silently drop a real access.

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/types.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/types.rs
@@ -387,6 +387,8 @@ pub struct ReadParams {
     pub project: String,
     /// Note permalink (e.g. "decisions/my-adr") or title.
     pub identifier: String,
+    /// Optional caller-supplied id identifying ONE logical read invocation, max 64 characters. Reusing it on a retry makes the access count exactly once; omitting it makes every attempt a distinct access.
+    pub invocation_id: Option<String>,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/writes_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/writes_tests.rs
@@ -565,6 +565,7 @@ mod tests {
                     ReadParams {
                         project: project_path.clone(),
                         identifier: "brief".to_string(),
+                        invocation_id: None,
                     },
                     &djinn_db::NoteAccessAttribution::unattributed(),
                 )
@@ -579,6 +580,7 @@ mod tests {
                     ReadParams {
                         project: project_path.clone(),
                         identifier: "roadmap".to_string(),
+                        invocation_id: None,
                     },
                     &djinn_db::NoteAccessAttribution::unattributed(),
                 )
@@ -654,6 +656,7 @@ mod tests {
                     ReadParams {
                         project: project.slug(),
                         identifier: permalink.to_string(),
+                        invocation_id: None,
                     },
                     &djinn_db::NoteAccessAttribution::unattributed(),
                 )

--- a/server/crates/djinn-control-plane/tests/memory_param_deserialization.rs
+++ b/server/crates/djinn-control-plane/tests/memory_param_deserialization.rs
@@ -48,6 +48,20 @@ fn read_params_deserialize() {
         serde_json::from_value(serde_json::json!({"project":"/tmp/p","identifier":"abc"})).unwrap();
     assert_eq!(p.project, "/tmp/p");
     assert_eq!(p.identifier, "abc");
+    // Backward compatibility: every caller that predates 9xih omits the field
+    // entirely, and that must keep deserializing.
+    assert_eq!(p.invocation_id, None);
+}
+
+#[test]
+fn read_params_deserialize_accepts_caller_supplied_invocation_id() {
+    let p: ReadParams = serde_json::from_value(serde_json::json!({
+        "project": "/tmp/p",
+        "identifier": "abc",
+        "invocation_id": "caller-supplied-read-1"
+    }))
+    .unwrap();
+    assert_eq!(p.invocation_id.as_deref(), Some("caller-supplied-read-1"));
 }
 
 #[test]

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -2093,17 +2093,17 @@ impl CoordinatorActor {
             return;
         };
 
-        if let Err(e) = poll_stack::boxed(|| self.maybe_apply_task_outcome_confidence(&task)).await
+        if let Err(e) = poll_stack::boxed(|| self.maybe_record_task_outcome_marker(&task)).await
         {
             tracing::warn!(
                 task_id = %task_id,
                 error = %e,
-                "failed to apply task outcome confidence penalty"
+                "failed to record task outcome marker"
             );
         }
     }
 
-    async fn maybe_apply_task_outcome_confidence(
+    async fn maybe_record_task_outcome_marker(
         &self,
         task: &djinn_core::models::Task,
     ) -> djinn_db::Result<()> {
@@ -2113,9 +2113,12 @@ impl CoordinatorActor {
                 .task_outcome_marker_exists(task, TASK_OUTCOME_FAILED_CLOSE)
                 .await?
         {
-            poll_stack::boxed(|| self.apply_task_outcome_confidence_to_task_refs(task)).await?;
-            poll_stack::boxed(|| self.record_task_outcome_marker(task, TASK_OUTCOME_FAILED_CLOSE))
-                .await?;
+            let referenced =
+                poll_stack::boxed(|| self.task_outcome_referenced_note_ids(task)).await?;
+            poll_stack::boxed(|| {
+                self.record_task_outcome_marker(task, TASK_OUTCOME_FAILED_CLOSE, referenced)
+            })
+            .await?;
         }
 
         if task.status == "open"
@@ -2124,9 +2127,12 @@ impl CoordinatorActor {
                 .task_outcome_marker_exists(task, TASK_OUTCOME_REOPEN_COUNT)
                 .await?
         {
-            poll_stack::boxed(|| self.apply_task_outcome_confidence_to_task_refs(task)).await?;
-            poll_stack::boxed(|| self.record_task_outcome_marker(task, TASK_OUTCOME_REOPEN_COUNT))
-                .await?;
+            let referenced =
+                poll_stack::boxed(|| self.task_outcome_referenced_note_ids(task)).await?;
+            poll_stack::boxed(|| {
+                self.record_task_outcome_marker(task, TASK_OUTCOME_REOPEN_COUNT, referenced)
+            })
+            .await?;
         }
 
         Ok(())
@@ -2174,11 +2180,15 @@ impl CoordinatorActor {
         &self,
         task: &djinn_core::models::Task,
         kind: &str,
+        referenced_notes: Vec<String>,
     ) -> djinn_db::Result<()> {
         let task_repo = self.task_repo();
         let payload = serde_json::json!({
             "kind": kind,
             "reopen_count": task.reopen_count,
+            // Notes this outcome referenced. Recorded, never scored: since
+            // 9xih no confidence value is derived from a task outcome.
+            "referenced_notes": referenced_notes,
         })
         .to_string();
 
@@ -2195,15 +2205,32 @@ impl CoordinatorActor {
         Ok(())
     }
 
-    async fn apply_task_outcome_confidence_to_task_refs(
+    /// Record which notes a failing/reopened task referenced.
+    ///
+    /// **This no longer writes `notes.confidence` (proposal 9xih.)** It used to
+    /// apply `TASK_OUTCOME_CONFIDENCE_SIGNAL` (0.1 — as harsh as
+    /// `CONTRADICTION`) to every referenced note on a failed close or a reopen.
+    ///
+    /// That is precisely "task failure after injection", which AC1 of 9xih puts
+    /// on the forbidden side of the epistemic confidence write boundary: a task
+    /// failing while referencing a note says the note did not help, not that the
+    /// note is false. Because `notes.confidence` also gates injection
+    /// eligibility and archival lifecycle, the old behaviour let one failed task
+    /// drive a correct note toward the confidence floor and out of retrieval
+    /// entirely.
+    ///
+    /// The resolution loop is kept, and the resolved ids are returned to the
+    /// caller's activity marker, so the outcome stays observable.
+    async fn task_outcome_referenced_note_ids(
         &self,
         task: &djinn_core::models::Task,
-    ) -> djinn_db::Result<()> {
+    ) -> djinn_db::Result<Vec<String>> {
         let note_repo = NoteRepository::new(
             self.db.clone(),
             crate::events::event_bus_for(&self.events_tx),
         );
 
+        let mut referenced = Vec::new();
         for permalink in parse_json_array(&task.memory_refs) {
             let Some(note) = note_repo
                 .get_by_permalink(&task.project_id, &permalink)
@@ -2211,13 +2238,10 @@ impl CoordinatorActor {
             else {
                 continue;
             };
-
-            note_repo
-                .update_confidence(&note.id, TASK_OUTCOME_CONFIDENCE_SIGNAL)
-                .await?;
+            referenced.push(note.id);
         }
 
-        Ok(())
+        Ok(referenced)
     }
 
     /// ADR-051 §3 proactive canonical-graph staleness refresh.

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -2093,8 +2093,7 @@ impl CoordinatorActor {
             return;
         };
 
-        if let Err(e) = poll_stack::boxed(|| self.maybe_record_task_outcome_marker(&task)).await
-        {
+        if let Err(e) = poll_stack::boxed(|| self.maybe_record_task_outcome_marker(&task)).await {
             tracing::warn!(
                 task_id = %task_id,
                 error = %e,

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -318,10 +318,11 @@ async fn create_task_with_note(
 /// Poll the activity log until a coordinator-recorded outcome marker with
 /// `kind` and `reopen_count` exists for `task_id`, or panic on timeout.
 ///
-/// The coordinator applies outcome-confidence penalties asynchronously:
-/// `set_status*` logs a `status_changed` activity (which broadcasts an
-/// event), and the coordinator actor later fetches the task, applies the
-/// Bayesian penalty, and records the marker.  Tests that used a fixed
+/// The coordinator handles task outcomes asynchronously: `set_status*` logs a
+/// `status_changed` activity (which broadcasts an event), and the coordinator
+/// actor later fetches the task, resolves its `memory_refs`, and records the
+/// marker. (Since 9xih the marker is the whole side effect — the confidence
+/// penalty that used to accompany it was removed.)  Tests that used a fixed
 /// `sleep` to wait for that side-effect flaked under load because 50-
 /// 150ms is not a hard upper bound on scheduler + DB latency.  Polling
 /// for the marker directly observes the coordinator's completed work.

--- a/server/crates/djinn-coordinator/src/tests/status_and_stuck.rs
+++ b/server/crates/djinn-coordinator/src/tests/status_and_stuck.rs
@@ -163,7 +163,10 @@ async fn failed_closed_task_records_marker_without_penalising_note_confidence() 
     // `create_task_with_note` parks the note at 0.5. The removed 0.1 signal
     // would have driven that prior to 0.1, so the equality assertion below is a
     // real behavioural difference and not an arithmetic no-op at the ceiling.
-    assert_eq!(before, 0.5, "fixture prior must be movable by the old signal");
+    assert_eq!(
+        before, 0.5,
+        "fixture prior must be movable by the old signal"
+    );
 
     repo.set_status_with_reason(&task.id, "closed", Some("failed"))
         .await

--- a/server/crates/djinn-coordinator/src/tests/status_and_stuck.rs
+++ b/server/crates/djinn-coordinator/src/tests/status_and_stuck.rs
@@ -148,13 +148,22 @@ async fn stuck_detection_releases_orphaned_in_progress_task() {
     );
 }
 
+/// AC1 (9xih): a failed close records its marker but must NOT penalise the
+/// confidence of the notes the task referenced. Task failure after injection is
+/// a task outcome, not epistemic evidence about the note.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn failed_closed_task_applies_failure_confidence_once() {
+async fn failed_closed_task_records_marker_without_penalising_note_confidence() {
     let db = test_helpers::create_test_db();
     let (tx, _rx) = broadcast::channel(256);
     let _handle = spawn_coordinator(&db, &tx);
     let (task, note) = create_task_with_note(&db, &tx, "failed-close").await;
     let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let note_repo = NoteRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let before = note_repo.get(&note.id).await.unwrap().unwrap().confidence;
+    // `create_task_with_note` parks the note at 0.5. The removed 0.1 signal
+    // would have driven that prior to 0.1, so the equality assertion below is a
+    // real behavioural difference and not an arithmetic no-op at the ceiling.
+    assert_eq!(before, 0.5, "fixture prior must be movable by the old signal");
 
     repo.set_status_with_reason(&task.id, "closed", Some("failed"))
         .await
@@ -163,11 +172,18 @@ async fn failed_closed_task_applies_failure_confidence_once() {
     // FAILED_CLOSE marker instead of a fixed sleep (which flaked under
     // load — the coordinator actor processes the status_changed event
     // asynchronously and 100ms is not a hard upper bound on latency).
+    //
+    // This wait is what makes the confidence assertion below meaningful: it
+    // proves the coordinator finished handling the outcome, so an unchanged
+    // confidence is "did not penalise", not "has not run yet".
     wait_for_outcome_marker(&repo, &task.id, TASK_OUTCOME_FAILED_CLOSE, 0).await;
 
-    let note_repo = NoteRepository::new(db.clone(), crate::events::event_bus_for(&tx));
-    let note_after = note_repo.get(&note.id).await.unwrap().unwrap();
-    assert!(note_after.confidence < 0.5);
+    let after = note_repo.get(&note.id).await.unwrap().unwrap().confidence;
+    assert_eq!(
+        after, before,
+        "a failed close must not mutate referenced-note confidence \
+         (before {before}, after {after})"
+    );
 
     let markers = repo
         .query_activity(ActivityQuery {
@@ -186,16 +202,33 @@ async fn failed_closed_task_applies_failure_confidence_once() {
     let payload: serde_json::Value = serde_json::from_str(&markers[0].payload).unwrap();
     assert_eq!(payload["kind"], TASK_OUTCOME_FAILED_CLOSE);
     assert_eq!(payload["reopen_count"], 0);
+    // Observability survives the removal of the penalty: the marker still names
+    // the note the failing task referenced.
+    assert_eq!(
+        payload["referenced_notes"]
+            .as_array()
+            .expect("referenced_notes array")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<Vec<_>>(),
+        vec![note.id.as_str()]
+    );
 }
 
+/// Marker idempotency across reopens — one marker per `reopen_count`.
+///
+/// Since 9xih the *only* side effect is the marker; the confidence penalty that
+/// used to accompany it is gone, and this test now also pins that no reopen at
+/// any depth moves the referenced note's confidence.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn reopened_twice_applies_failure_once_per_reopen_count() {
+async fn reopened_twice_records_marker_once_per_reopen_count() {
     let db = test_helpers::create_test_db();
     let (tx, _rx) = broadcast::channel(256);
     let _handle = spawn_coordinator(&db, &tx);
     let (task, note) = create_task_with_note(&db, &tx, "reopen-twice").await;
     let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
     let note_repo = NoteRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let before = note_repo.get(&note.id).await.unwrap().unwrap().confidence;
 
     repo.set_status_with_reason(&task.id, "closed", Some("failed"))
         .await
@@ -211,7 +244,11 @@ async fn reopened_twice_applies_failure_once_per_reopen_count() {
     let reopened_once = repo.get(&task.id).await.unwrap().unwrap();
     assert_eq!(reopened_once.reopen_count, 1);
     let after_first = note_repo.get(&note.id).await.unwrap().unwrap().confidence;
-    assert!(after_first < 0.5, "first reopen should reduce confidence");
+    assert_eq!(
+        after_first, before,
+        "a reopen must not mutate referenced-note confidence \
+         (before {before}, after {after_first})"
+    );
 
     // Duplicate open→open: the coordinator must treat this as a no-op
     // (marker for reopen_count=1 already exists).  Assert idempotency as
@@ -236,13 +273,14 @@ async fn reopened_twice_applies_failure_once_per_reopen_count() {
     let reopened_twice = repo.get(&task.id).await.unwrap().unwrap();
     assert_eq!(reopened_twice.reopen_count, 2);
     let after_second = note_repo.get(&note.id).await.unwrap().unwrap().confidence;
-    assert!(
-        after_second <= after_first,
-        "second reopen should not increase confidence, got after_second={after_second}, after_first={after_first}"
+    assert_eq!(
+        after_second, before,
+        "no number of reopens may mutate referenced-note confidence \
+         (before {before}, after {after_second})"
     );
     // Exactly two new markers between the duplicate no-op and now:
     // one FAILED_CLOSE(reopen_count=1) and one REOPEN_COUNT(reopen_count=2).
-    // If the duplicate open→open had wrongly applied a penalty, we'd
+    // If the duplicate open→open had wrongly been handled again, we'd
     // see three.
     let markers_after = outcome_marker_count(&repo, &task.id).await;
     assert_eq!(

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -346,8 +346,17 @@ pub(super) const GRAPH_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60)
 /// Minimum cooldown between idle-time memory consolidation sweeps (ADR-048 §3A).
 pub(super) const IDLE_CONSOLIDATION_COOLDOWN: Duration = Duration::from_secs(300);
 
+/// Activity event type for the failed-close / reopen outcome marker.
+///
+/// The name is historical and is deliberately NOT renamed: it is the dedupe key
+/// the coordinator reads back to decide whether an outcome was already handled,
+/// and rows carrying it already exist in every deployed database.
+///
+/// Since 9xih the marker is all that is written. The companion
+/// `TASK_OUTCOME_CONFIDENCE_SIGNAL` (0.1) was deleted along with its only
+/// writer: task failure after injection is a retrieval/task outcome, not
+/// epistemic evidence, and may not reach `notes.confidence`.
 pub(super) const TASK_OUTCOME_CONFIDENCE_ACTIVITY: &str = "task_outcome_confidence";
-pub(super) const TASK_OUTCOME_CONFIDENCE_SIGNAL: f64 = 0.1;
 pub(super) const TASK_OUTCOME_REOPEN_COUNT: &str = "reopen_count";
 pub(super) const TASK_OUTCOME_FAILED_CLOSE: &str = "failed_closed";
 

--- a/server/crates/djinn-db/migrations_postgres/195_note_confidence_access_repair.sql
+++ b/server/crates/djinn-db/migrations_postgres/195_note_confidence_access_repair.sql
@@ -1,0 +1,71 @@
+-- Migration 195: separate retrieval utility from epistemic confidence and open
+-- a clean, invocation-keyed note-access accounting era (proposal 9xih).
+--
+-- DEPLOYMENT-NEUTRAL BY CONSTRUCTION. Every statement below is a predicate over
+-- a whole table. No project id, note id, session id, task run id, or "our data
+-- looks like X" assumption appears anywhere, so this is correct for any
+-- operator's database — including a brand-new one where migration 1 just
+-- created `notes` empty and every UPDATE matches zero rows.
+--
+-- Every statement is also idempotent: re-running the whole file leaves the
+-- database in the identical state, and does so regardless of how many rows
+-- happen to exist.
+
+-- ── 1. Confidence ceiling ───────────────────────────────────────────────────
+--
+-- `notes.confidence` defaulted to 1.0 while the Bayesian `CONFIDENCE_CEILING`
+-- is 0.975. `bayesian_update` clamps to that ceiling, so applying a POSITIVE
+-- epistemic signal (`USER_CONFIRM`) to an untouched 1.0 note *lowered* it to
+-- 0.975 — below every untouched peer in confidence ordering. Confirming a note
+-- demoted it. Normalizing the default and the exact-1.0 rows to the ceiling
+-- removes a distinction that was never evidence.
+ALTER TABLE notes ALTER COLUMN confidence SET DEFAULT 0.975;
+
+-- Only exactly-1.0 rows move. Any value below 1.0 is the posterior of a real
+-- epistemic signal and is never rewritten. Re-running matches zero rows because
+-- 0.975 <> 1.0.
+UPDATE notes SET confidence = 0.975 WHERE confidence = 1.0;
+
+-- ── 2. Legacy access rebase ─────────────────────────────────────────────────
+--
+-- Until now BOTH an explicit `memory_read` AND an ADR-054 `memory_search`
+-- result display incremented `access_count` / `last_accessed`. The two are
+-- indistinguishable in these last-write-wins scalars, so their provenance
+-- cannot be reconstructed — only discarded. Rebase to a neutral, *defined*
+-- baseline rather than a guess: count 0, and the note's own `created_at`.
+--
+-- `created_at` is chosen over NULL because `last_accessed` is NOT NULL and
+-- feeds age/temporal scoring; it keeps a well-formed timestamp while asserting
+-- no read ever happened. New notes already initialize the same way.
+--
+-- Re-running matches zero rows: after the first pass every row already
+-- satisfies both equalities.
+UPDATE notes
+   SET access_count  = 0,
+       last_accessed = created_at
+ WHERE access_count <> 0
+    OR last_accessed <> created_at;
+
+-- ── 3. Invocation-keyed ledger era ──────────────────────────────────────────
+--
+-- `note_access_events` ALREADY EXISTS: migration 189 (proposal u46i AC6)
+-- created it, and its rows are the join side of the shipped
+-- `P(memory_read | Injected)` report. It is therefore ALTERed here, never
+-- dropped and never recreated — deleting those rows would silently break a
+-- shipped metric that guards a 30-day retention window.
+--
+-- The new era is empty all the same, because the new era is *defined* as the
+-- rows carrying a non-null `invocation_id`, and this migration adds none.
+-- Every pre-9xih row keeps `invocation_id IS NULL` and can never be mistaken
+-- for a 9xih-era access event or satisfy a replay probe.
+ALTER TABLE note_access_events
+    ADD COLUMN IF NOT EXISTS invocation_id VARCHAR(64) NULL;
+
+-- `(invocation_id, note_id)` is the replay key: a uniqueness conflict IS a
+-- caller retry of one logical invocation and must NOT increment a counter.
+--
+-- Postgres treats NULLs as distinct in a unique index, so the arbitrarily many
+-- legacy rows with `invocation_id IS NULL` coexist freely and index creation
+-- cannot fail on existing data, however much of it there is.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_note_access_events_invocation_note
+    ON note_access_events (invocation_id, note_id);

--- a/server/crates/djinn-db/migrations_postgres/195_note_confidence_access_repair.sql
+++ b/server/crates/djinn-db/migrations_postgres/195_note_confidence_access_repair.sql
@@ -48,24 +48,35 @@ UPDATE notes
 
 -- ── 3. Invocation-keyed ledger era ──────────────────────────────────────────
 --
--- `note_access_events` ALREADY EXISTS: migration 189 (proposal u46i AC6)
--- created it, and its rows are the join side of the shipped
--- `P(memory_read | Injected)` report. It is therefore ALTERed here, never
--- dropped and never recreated — deleting those rows would silently break a
--- shipped metric that guards a 30-day retention window.
+-- WHY THIS TABLE IS ALTERED AND NOT RECREATED.
 --
--- The new era is empty all the same, because the new era is *defined* as the
--- rows carrying a non-null `invocation_id`, and this migration adds none.
--- Every pre-9xih row keeps `invocation_id IS NULL` and can never be mistaken
--- for a 9xih-era access event or satisfy a replay probe.
+-- `note_access_events` ALREADY EXISTS: migration 189 (proposal u46i AC6)
+-- created it. Proposal 9xih was written as though it did not, and specifies
+-- "create the empty ledger" — but the table has a LIVE CONSUMER:
+--
+--   server/crates/djinn-db/src/repositories/retrieval_trace/injected_pull_rate.rs
+--
+-- joins these rows against `retrieval_traces` to compute
+-- `P(memory_read | Injected)` for the shipped `memory_injected_pull_rate_report`
+-- MCP tool, over a protected 30-day retention window. Dropping or emptying the
+-- table would silently break a shipped metric on every deployment that has
+-- accumulated rows. So the table is ALTERed in place and NOT ONE ROW IS DELETED.
+--
+-- The new counting era is empty all the same, because the era is *defined* as
+-- the rows carrying a non-null `invocation_id`, and this migration adds none.
+-- Every pre-9xih row keeps `invocation_id IS NULL`, so it can never be mistaken
+-- for a 9xih-era access event nor satisfy a replay probe. That boundary is
+-- asserted in tests/migrations_note_confidence_access_repair.rs.
 ALTER TABLE note_access_events
     ADD COLUMN IF NOT EXISTS invocation_id VARCHAR(64) NULL;
 
 -- `(invocation_id, note_id)` is the replay key: a uniqueness conflict IS a
 -- caller retry of one logical invocation and must NOT increment a counter.
 --
--- Postgres treats NULLs as distinct in a unique index, so the arbitrarily many
--- legacy rows with `invocation_id IS NULL` coexist freely and index creation
--- cannot fail on existing data, however much of it there is.
+-- This index cannot fail on a populated table. Postgres treats NULLs as
+-- DISTINCT in a unique index, so arbitrarily many legacy rows sharing
+-- `invocation_id IS NULL` — including many rows for the SAME `note_id`, which
+-- is the normal shape of the existing data — coexist freely. The migration test
+-- seeds exactly that shape before applying this file.
 CREATE UNIQUE INDEX IF NOT EXISTS uq_note_access_events_invocation_note
     ON note_access_events (invocation_id, note_id);

--- a/server/crates/djinn-db/migrations_postgres/197_note_confidence_access_repair.sql
+++ b/server/crates/djinn-db/migrations_postgres/197_note_confidence_access_repair.sql
@@ -1,4 +1,4 @@
--- Migration 195: separate retrieval utility from epistemic confidence and open
+-- Migration 197: separate retrieval utility from epistemic confidence and open
 -- a clean, invocation-keyed note-access accounting era (proposal 9xih).
 --
 -- DEPLOYMENT-NEUTRAL BY CONSTRUCTION. Every statement below is a predicate over

--- a/server/crates/djinn-db/src/repositories/note/access_events.rs
+++ b/server/crates/djinn-db/src/repositories/note/access_events.rs
@@ -21,7 +21,7 @@ use crate::error::DbResult as Result;
 /// Maximum stored length, in characters, of a caller-supplied invocation id.
 ///
 /// Bound to the `note_access_events.invocation_id VARCHAR(64)` column added by
-/// migration 195. Callers must reject longer ids *before* note resolution
+/// migration 197. Callers must reject longer ids *before* note resolution
 /// rather than letting Postgres truncate or error mid-transaction — a truncated
 /// id would silently collide two distinct invocations into one replay key.
 pub const INVOCATION_ID_MAX_CHARS: usize = 64;
@@ -132,7 +132,7 @@ pub struct NoteAccessEvent {
     pub task_run_id: Option<String>,
     pub source: String,
     pub created_at: String,
-    /// Caller-keyed invocation this row belongs to (migration 195).
+    /// Caller-keyed invocation this row belongs to (migration 197).
     ///
     /// NULL for every pre-9xih row: those predate invocation keying and can
     /// never satisfy a replay probe. A non-null value is exactly what makes a
@@ -197,7 +197,7 @@ async fn resolve_task_run_id(
 /// won, advance the note's access counters — in one transaction.
 ///
 /// The ledger insert is the gate, not a side note. `(invocation_id, note_id)` is
-/// unique (migration 195), so a conflict *is* a caller retry of one logical
+/// unique (migration 197), so a conflict *is* a caller retry of one logical
 /// invocation and `ON CONFLICT DO NOTHING` reports zero affected rows. The
 /// counter update runs only on the winning insert, which is what makes a replay
 /// leave both `access_count` and `last_accessed` untouched.

--- a/server/crates/djinn-db/src/repositories/note/access_events.rs
+++ b/server/crates/djinn-db/src/repositories/note/access_events.rs
@@ -12,10 +12,42 @@
 //! **not** an explicit pull, and conflating the two would silently inflate the
 //! metric.
 
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use crate::database::Database;
 use crate::error::DbResult as Result;
+
+/// Maximum stored length, in characters, of a caller-supplied invocation id.
+///
+/// Bound to the `note_access_events.invocation_id VARCHAR(64)` column added by
+/// migration 195. Callers must reject longer ids *before* note resolution
+/// rather than letting Postgres truncate or error mid-transaction — a truncated
+/// id would silently collide two distinct invocations into one replay key.
+pub const INVOCATION_ID_MAX_CHARS: usize = 64;
+
+/// Whether one [`super::NoteRepository::record_explicit_access`] call actually
+/// counted, or was recognised as a replay of an already-counted invocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExplicitAccessOutcome {
+    /// The append-only ledger insert won the `(invocation_id, note_id)` key, so
+    /// this call incremented `access_count` and advanced `last_accessed`.
+    Counted,
+    /// `(invocation_id, note_id)` already existed. The caller is retrying one
+    /// logical invocation; no counter and no timestamp moved.
+    Replay,
+}
+
+/// The wall-clock stamp for one access event, in the exact spelling the
+/// `notes.last_accessed` / `note_access_events.created_at` columns use
+/// (`to_char(..., 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`).
+///
+/// Callers capture this *before* opening the access transaction so the recorded
+/// instant is the one at which the handler decided the read succeeded, not
+/// whenever the write happened to reach the database.
+pub fn access_event_timestamp() -> String {
+    Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
+}
 
 /// Tool surface that caused a note access.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -100,6 +132,12 @@ pub struct NoteAccessEvent {
     pub task_run_id: Option<String>,
     pub source: String,
     pub created_at: String,
+    /// Caller-keyed invocation this row belongs to (migration 195).
+    ///
+    /// NULL for every pre-9xih row: those predate invocation keying and can
+    /// never satisfy a replay probe. A non-null value is exactly what makes a
+    /// row part of the invocation-keyed accounting era.
+    pub invocation_id: Option<String>,
 }
 
 /// Append one row to the ledger.
@@ -115,18 +153,7 @@ pub(super) async fn record_note_access(
     source: NoteAccessSource,
     attribution: &NoteAccessAttribution,
 ) -> Result<()> {
-    let mut task_run_id = attribution.task_run_id.clone();
-    if task_run_id.is_none()
-        && let Some(session_id) = attribution.session_id.as_deref()
-    {
-        task_run_id = sqlx::query_scalar::<_, Option<String>>(
-            "SELECT task_run_id FROM sessions WHERE id = $1",
-        )
-        .bind(session_id)
-        .fetch_optional(db.pool())
-        .await?
-        .flatten();
-    }
+    let task_run_id = resolve_task_run_id(db, attribution).await?;
 
     sqlx::query(
         r#"INSERT INTO note_access_events
@@ -145,6 +172,95 @@ pub(super) async fn record_note_access(
     Ok(())
 }
 
+/// Resolve the run attribution for an access row, filling in the task run from
+/// `sessions` when only a session is known.
+async fn resolve_task_run_id(
+    db: &Database,
+    attribution: &NoteAccessAttribution,
+) -> Result<Option<String>> {
+    if attribution.task_run_id.is_some() {
+        return Ok(attribution.task_run_id.clone());
+    }
+    let Some(session_id) = attribution.session_id.as_deref() else {
+        return Ok(None);
+    };
+    Ok(
+        sqlx::query_scalar::<_, Option<String>>("SELECT task_run_id FROM sessions WHERE id = $1")
+            .bind(session_id)
+            .fetch_optional(db.pool())
+            .await?
+            .flatten(),
+    )
+}
+
+/// Append one invocation-keyed explicit-read event and, only if that append
+/// won, advance the note's access counters — in one transaction.
+///
+/// The ledger insert is the gate, not a side note. `(invocation_id, note_id)` is
+/// unique (migration 195), so a conflict *is* a caller retry of one logical
+/// invocation and `ON CONFLICT DO NOTHING` reports zero affected rows. The
+/// counter update runs only on the winning insert, which is what makes a replay
+/// leave both `access_count` and `last_accessed` untouched.
+///
+/// The increment is `access_count = access_count + 1` evaluated by Postgres,
+/// never an application read-modify-write, so concurrent distinct invocations
+/// cannot lose an increment to a lost update. `last_accessed` uses `GREATEST`
+/// rather than assignment so an event that commits late but happened earlier
+/// cannot rewind a newer timestamp — the columns store fixed-width ISO-8601 UTC,
+/// which orders lexicographically.
+pub(super) async fn record_explicit_access(
+    db: &Database,
+    project_id: &str,
+    note_id: &str,
+    invocation_id: &str,
+    event_timestamp: &str,
+    attribution: &NoteAccessAttribution,
+) -> Result<ExplicitAccessOutcome> {
+    let task_run_id = resolve_task_run_id(db, attribution).await?;
+
+    let mut tx = db.pool().begin().await?;
+
+    let inserted = sqlx::query(
+        r#"INSERT INTO note_access_events
+               (id, project_id, note_id, session_id, task_run_id, source, created_at, invocation_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+           ON CONFLICT (invocation_id, note_id) DO NOTHING"#,
+    )
+    .bind(uuid::Uuid::now_v7().to_string())
+    .bind(project_id)
+    .bind(note_id)
+    .bind(attribution.session_id.as_deref())
+    .bind(task_run_id.as_deref())
+    .bind(NoteAccessSource::MemoryRead.as_str())
+    .bind(event_timestamp)
+    .bind(invocation_id)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected()
+        == 1;
+
+    if inserted {
+        sqlx::query(
+            r#"UPDATE notes
+                  SET access_count  = access_count + 1,
+                      last_accessed = GREATEST(last_accessed, $2)
+                WHERE id = $1"#,
+        )
+        .bind(note_id)
+        .bind(event_timestamp)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    tx.commit().await?;
+
+    Ok(if inserted {
+        ExplicitAccessOutcome::Counted
+    } else {
+        ExplicitAccessOutcome::Replay
+    })
+}
+
 /// Read the ledger for one note, newest first. Test/diagnostic helper — the
 /// production consumer is the injected-pull-rate rollup, which aggregates in
 /// SQL rather than materializing rows.
@@ -154,7 +270,8 @@ pub async fn note_access_events_for_note(
     note_id: &str,
 ) -> Result<Vec<NoteAccessEvent>> {
     Ok(sqlx::query_as::<_, NoteAccessEvent>(
-        r#"SELECT id, project_id, note_id, session_id, task_run_id, source, created_at
+        r#"SELECT id, project_id, note_id, session_id, task_run_id, source, created_at,
+                  invocation_id
              FROM note_access_events
             WHERE project_id = $1 AND note_id = $2
             ORDER BY created_at DESC, id DESC"#,

--- a/server/crates/djinn-db/src/repositories/note/crud.rs
+++ b/server/crates/djinn-db/src/repositories/note/crud.rs
@@ -953,6 +953,60 @@ impl NoteRepository {
         Ok(())
     }
 
+    /// Record one explicit `memory_read` access, deduplicated by
+    /// `(invocation_id, note_id)`.
+    ///
+    /// This is the 9xih replacement for [`Self::touch_accessed`] on the
+    /// explicit-read path. The differences are the whole point:
+    ///
+    /// * `touch_accessed` increments unconditionally, so a caller retry after a
+    ///   dropped response double-counts. Here the append-only ledger insert is
+    ///   the gate — a `(invocation_id, note_id)` conflict is recognised as a
+    ///   replay and moves neither `access_count` nor `last_accessed`.
+    /// * `touch_accessed` stamps `last_accessed` with `now()` inside the write.
+    ///   Here `event_timestamp` is captured by the caller *before* the
+    ///   transaction, at the moment the handler decided the read succeeded, and
+    ///   is folded in with `GREATEST` so a late commit cannot rewind a newer
+    ///   timestamp.
+    /// * `touch_accessed`'s ledger append is fail-open. Here it is not: if the
+    ///   ledger cannot be written, the counter must not move either, or the
+    ///   counter loses its audit basis.
+    ///
+    /// `source` is not a parameter because there is only one: a counted access
+    /// is exactly one successful external `memory_read` result construction.
+    /// Search-result display no longer counts (ADR-054 is superseded for
+    /// persisted note access), so nothing else may reach this path.
+    pub async fn record_explicit_access(
+        &self,
+        note_id: &str,
+        invocation_id: &str,
+        event_timestamp: &str,
+        attribution: &super::NoteAccessAttribution,
+    ) -> Result<super::ExplicitAccessOutcome> {
+        self.db.ensure_initialized().await?;
+        let note = self
+            .get_summary_state(note_id)
+            .await?
+            .ok_or_else(|| Error::InvalidData(format!("note not found: {note_id}")))?;
+
+        let outcome = super::access_events::record_explicit_access(
+            &self.db,
+            &note.project_id,
+            note_id,
+            invocation_id,
+            event_timestamp,
+            attribution,
+        )
+        .await?;
+
+        if note.abstract_.is_none() || note.overview.is_none() {
+            self.events
+                .send(djinn_memory::events::note_missing_summary(&note));
+        }
+
+        Ok(outcome)
+    }
+
     pub async fn move_note(
         &self,
         id: &str,

--- a/server/crates/djinn-db/src/repositories/note/mod.rs
+++ b/server/crates/djinn-db/src/repositories/note/mod.rs
@@ -51,7 +51,8 @@ pub use abstract_regeneration::{
     select_stale_abstract_note_ids,
 };
 pub use access_events::{
-    NoteAccessAttribution, NoteAccessEvent, NoteAccessSource, note_access_events_for_note,
+    ExplicitAccessOutcome, INVOCATION_ID_MAX_CHARS, NoteAccessAttribution, NoteAccessEvent,
+    NoteAccessSource, access_event_timestamp, note_access_events_for_note,
 };
 pub use association::{
     NoteAssociationEntry, NoteAssociationKind, NoteAssociationProvenanceRow,
@@ -96,8 +97,8 @@ pub use revisions::{
 };
 pub use rrf::rrf_fuse;
 pub use scoring::{
-    CO_ACCESS_HIGH, CONFIDENCE_CEILING, CONFIDENCE_FLOOR, CONTRADICTION, STALE_CITATION,
-    STALE_DECAY_SIGNAL, USER_CONFIRM, bayesian_update, decay_signal_for_elapsed_days,
+    CONFIDENCE_CEILING, CONFIDENCE_FLOOR, CONTRADICTION, STALE_CITATION, STALE_DECAY_SIGNAL,
+    USER_CONFIRM, bayesian_update, decay_signal_for_elapsed_days,
 };
 
 use file_helpers::build_catalog;

--- a/server/crates/djinn-db/src/repositories/note/scoring.rs
+++ b/server/crates/djinn-db/src/repositories/note/scoring.rs
@@ -512,7 +512,7 @@ mod tests {
 
     #[test]
     fn user_confirm_never_demotes_a_note_at_the_ceiling_default() {
-        // Migration 195 sets the new-note default to CONFIDENCE_CEILING. The
+        // Migration 197 sets the new-note default to CONFIDENCE_CEILING. The
         // defect it repairs: with the old 1.0 default, confirming a note
         // *lowered* it to 0.975, sorting it below every untouched peer.
         let untouched = CONFIDENCE_CEILING;
@@ -525,7 +525,7 @@ mod tests {
         let legacy_default_confirmed = bayesian_update(1.0, USER_CONFIRM);
         assert!(
             legacy_default_confirmed < 1.0,
-            "the pre-195 defect must still be demonstrable: confirming a 1.0 note \
+            "the pre-197 defect must still be demonstrable: confirming a 1.0 note \
              clamps to {CONFIDENCE_CEILING}, which is why the default had to move"
         );
     }

--- a/server/crates/djinn-db/src/repositories/note/scoring.rs
+++ b/server/crates/djinn-db/src/repositories/note/scoring.rs
@@ -16,15 +16,32 @@ const MIN_ASSOCIATION_WEIGHT: f64 = 0.05;
 pub const CONFIDENCE_FLOOR: f64 = 0.025;
 pub const CONFIDENCE_CEILING: f64 = 0.975;
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Used by intra-crate tests in note::mod and scoring::tests"
-    )
-)]
-pub(crate) const TASK_SUCCESS: f64 = 0.65;
-pub const CO_ACCESS_HIGH: f64 = 0.65;
+// ── The epistemic confidence write boundary (proposal 9xih) ──────────────────
+//
+// `notes.confidence` is an epistemic posterior AND an input to injection
+// eligibility, injection ordering, and archival lifecycle. Writing a
+// non-epistemic quantity into it therefore does not merely reweight a ranking;
+// it changes what the system is allowed to inject and what it archives.
+//
+// Only signals whose direct semantics concern a note's TRUTH may be applied
+// here: `USER_CONFIRM`, `CONTRADICTION`, and the stale-citation family.
+//
+// Retrieval inclusion, retrieval frequency, task completion, task failure after
+// injection, review verdict, merge result, cohort assignment, and rollout labels
+// are NOT epistemic signals. They describe how useful a note was, not whether it
+// is correct, and they must never reach `set_confidence` or `update_confidence`.
+//
+// Two constants were deleted rather than left unused, because an available
+// constant is an invitation:
+//
+// * `TASK_SUCCESS` (0.65) — applied by `task_confidence::handle_successful_task_completion`.
+//   A task closing successfully while referencing a note demonstrates USE, not
+//   TRUTH. Completion activity is still recorded; the confidence write is gone.
+// * `CO_ACCESS_HIGH` (0.65) — applied by `DjinnMcpServer::record_memory_read`'s
+//   co-access flush. Reading two notes together raised the confidence of the
+//   lower-confidence one, which then made it more injectable, which made it more
+//   likely to be read together again: an unbounded feedback loop that
+//   manufactured evidence out of retrieval.
 pub const STALE_CITATION: f64 = 0.3;
 pub const USER_CONFIRM: f64 = 0.95;
 pub const CONTRADICTION: f64 = 0.1;
@@ -487,8 +504,30 @@ mod tests {
 
     #[test]
     fn bayesian_update_medium_positive_signal_increases_from_half() {
-        let updated = bayesian_update(0.5, TASK_SUCCESS);
+        // A bare 0.65 literal, not a named production constant: the removed
+        // `TASK_SUCCESS` must not come back through a test's back door.
+        let updated = bayesian_update(0.5, 0.65);
         assert!(updated > 0.5);
+    }
+
+    #[test]
+    fn user_confirm_never_demotes_a_note_at_the_ceiling_default() {
+        // Migration 195 sets the new-note default to CONFIDENCE_CEILING. The
+        // defect it repairs: with the old 1.0 default, confirming a note
+        // *lowered* it to 0.975, sorting it below every untouched peer.
+        let untouched = CONFIDENCE_CEILING;
+        let confirmed = bayesian_update(CONFIDENCE_CEILING, USER_CONFIRM);
+        assert!(
+            confirmed >= untouched,
+            "USER_CONFIRM demoted a default-confidence note: {confirmed} < {untouched}"
+        );
+
+        let legacy_default_confirmed = bayesian_update(1.0, USER_CONFIRM);
+        assert!(
+            legacy_default_confirmed < 1.0,
+            "the pre-195 defect must still be demonstrable: confirming a 1.0 note \
+             clamps to {CONFIDENCE_CEILING}, which is why the default had to move"
+        );
     }
 
     #[test]

--- a/server/crates/djinn-db/src/repositories/note/tests/search_ranking.rs
+++ b/server/crates/djinn-db/src/repositories/note/tests/search_ranking.rs
@@ -553,10 +553,10 @@ async fn update_confidence_reads_updates_and_persists() {
         .await
         .unwrap();
 
-    let updated = repo
-        .update_confidence(&note.id, scoring::TASK_SUCCESS)
-        .await
-        .unwrap();
+    // A bare medium-positive signal literal. `scoring::TASK_SUCCESS` was
+    // deleted by 9xih along with its only production writer; this test is about
+    // `update_confidence` persisting a posterior, not about task outcomes.
+    let updated = repo.update_confidence(&note.id, 0.65).await.unwrap();
     assert!(updated > 0.5);
 
     let stored = sqlx::query_scalar!("SELECT confidence FROM notes WHERE id = $1", note.id)
@@ -894,4 +894,211 @@ async fn lifecycle_graph_read_does_not_leak_into_unified_lexical_search() {
     assert!(result_ids.contains(active.id.as_str()));
     assert!(!result_ids.contains(archived.id.as_str()));
     assert!(!result_ids.contains(deprecated.id.as_str()));
+}
+
+// ── 9xih: invocation-keyed explicit access accounting ────────────────────────
+
+use crate::repositories::note::{
+    ExplicitAccessOutcome, NoteAccessAttribution, access_event_timestamp,
+    note_access_events_for_note,
+};
+
+/// AC5: replay idempotency at the repository boundary.
+///
+/// The same `(invocation_id, note_id)` is recorded twice. The second call must
+/// report `Replay` AND leave the ledger, the counter, and the timestamp exactly
+/// as the first call left them — all three read back from Postgres.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn record_explicit_access_replay_writes_no_second_event_or_increment() {
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let (tx, _rx) = broadcast::channel(256);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db.clone(), event_bus_for(&tx));
+
+    let note = repo
+        .create(&project.id, "Replay Note", "body", "reference", "[]")
+        .await
+        .unwrap();
+    let before = repo.get(&note.id).await.unwrap().unwrap();
+
+    let first_stamp = access_event_timestamp();
+    let first = repo
+        .record_explicit_access(
+            &note.id,
+            "invocation-alpha",
+            &first_stamp,
+            &NoteAccessAttribution::unattributed(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first, ExplicitAccessOutcome::Counted);
+
+    let after_first = repo.get(&note.id).await.unwrap().unwrap();
+    assert_eq!(after_first.access_count, before.access_count + 1);
+    assert_eq!(after_first.last_accessed, first_stamp);
+
+    // A retry of the SAME logical invocation, carrying a strictly later
+    // timestamp so a naive implementation that always writes would be caught by
+    // the `last_accessed` assertion below rather than only by the counter.
+    let replay_stamp = "2099-12-31T23:59:59.999Z";
+    let replay = repo
+        .record_explicit_access(
+            &note.id,
+            "invocation-alpha",
+            replay_stamp,
+            &NoteAccessAttribution::unattributed(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay, ExplicitAccessOutcome::Replay);
+
+    let after_replay = repo.get(&note.id).await.unwrap().unwrap();
+    assert_eq!(
+        after_replay.access_count, after_first.access_count,
+        "a replay must not increment access_count"
+    );
+    assert_eq!(
+        after_replay.last_accessed, first_stamp,
+        "a replay must not advance last_accessed even with a later timestamp"
+    );
+
+    let events = note_access_events_for_note(&db, &project.id, &note.id)
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1, "a replay must not append a ledger row");
+    assert_eq!(events[0].invocation_id.as_deref(), Some("invocation-alpha"));
+    assert_eq!(events[0].source, "memory_read");
+    assert_eq!(events[0].created_at, first_stamp);
+}
+
+/// AC5: `last_accessed = max(last_accessed, event_timestamp)`.
+///
+/// A distinct invocation whose event timestamp is OLDER than the stored value
+/// still counts (it is a real, separate access) but must not rewind the
+/// timestamp. This is what distinguishes `GREATEST` from plain assignment; a
+/// `SET last_accessed = $ts` implementation fails here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn record_explicit_access_never_rewinds_last_accessed() {
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let (tx, _rx) = broadcast::channel(256);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db.clone(), event_bus_for(&tx));
+
+    let note = repo
+        .create(&project.id, "Ordering Note", "body", "reference", "[]")
+        .await
+        .unwrap();
+
+    let newer = "2030-06-06T06:06:06.000Z";
+    let older = "2020-01-01T00:00:00.000Z";
+
+    repo.record_explicit_access(
+        &note.id,
+        "invocation-newer",
+        newer,
+        &NoteAccessAttribution::unattributed(),
+    )
+    .await
+    .unwrap();
+    repo.record_explicit_access(
+        &note.id,
+        "invocation-older",
+        older,
+        &NoteAccessAttribution::unattributed(),
+    )
+    .await
+    .unwrap();
+
+    let stored = repo.get(&note.id).await.unwrap().unwrap();
+    assert_eq!(
+        stored.access_count, 2,
+        "both distinct invocations must count, regardless of timestamp order"
+    );
+    assert_eq!(
+        stored.last_accessed, newer,
+        "a late-committing older event must not rewind last_accessed"
+    );
+
+    let events = note_access_events_for_note(&db, &project.id, &note.id)
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 2);
+}
+
+/// AC5: concurrent distinct invocations lose no increments.
+///
+/// Twelve distinct invocation ids are recorded from twelve concurrently spawned
+/// tasks against one shared pool. The final `access_count` must be exactly 12.
+///
+/// This is the assertion an application-side read-modify-write cannot satisfy:
+/// a `SELECT access_count` / `UPDATE ... SET access_count = n + 1` pair would
+/// interleave and lose updates, landing below 12. The increment is written as
+/// `access_count = access_count + 1` inside Postgres precisely so it cannot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_distinct_invocations_lose_no_access_increments() {
+    const CONCURRENT_READS: usize = 12;
+
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let (tx, _rx) = broadcast::channel(256);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db.clone(), event_bus_for(&tx));
+
+    let note = repo
+        .create(&project.id, "Concurrent Note", "body", "reference", "[]")
+        .await
+        .unwrap();
+
+    // Deterministic, strictly increasing stamps so the expected maximum is
+    // known without depending on scheduling order.
+    let stamps: Vec<String> = (0..CONCURRENT_READS)
+        .map(|index| format!("2031-01-01T00:00:{index:02}.000Z"))
+        .collect();
+    let latest = stamps.last().cloned().unwrap();
+
+    let mut handles = Vec::new();
+    for (index, stamp) in stamps.into_iter().enumerate() {
+        let task_repo = NoteRepository::new(db.clone(), event_bus_for(&tx));
+        let note_id = note.id.clone();
+        handles.push(tokio::spawn(async move {
+            task_repo
+                .record_explicit_access(
+                    &note_id,
+                    &format!("concurrent-invocation-{index}"),
+                    &stamp,
+                    &NoteAccessAttribution::unattributed(),
+                )
+                .await
+        }));
+    }
+
+    let mut counted = 0usize;
+    for handle in handles {
+        let outcome = handle.await.expect("join").expect("record explicit access");
+        if outcome == ExplicitAccessOutcome::Counted {
+            counted += 1;
+        }
+    }
+    assert_eq!(
+        counted, CONCURRENT_READS,
+        "distinct invocation ids must all be counted, none deduplicated"
+    );
+
+    let stored = repo.get(&note.id).await.unwrap().unwrap();
+    assert_eq!(
+        stored.access_count, CONCURRENT_READS as i64,
+        "the final counter must rise by the number of committed events; \
+         a lower value means an increment was lost to a read-modify-write race"
+    );
+    assert_eq!(
+        stored.last_accessed, latest,
+        "last_accessed must equal the latest committed event timestamp"
+    );
+
+    let events = note_access_events_for_note(&db, &project.id, &note.id)
+        .await
+        .unwrap();
+    assert_eq!(events.len(), CONCURRENT_READS);
 }

--- a/server/crates/djinn-db/tests/confidence_write_boundary.rs
+++ b/server/crates/djinn-db/tests/confidence_write_boundary.rs
@@ -1,0 +1,223 @@
+//! AC1 (proposal 9xih): the epistemic confidence write boundary, enforced as a
+//! whole-workspace call-site allowlist.
+//!
+//! `notes.confidence` is an epistemic posterior AND an input to injection
+//! eligibility, injection ordering, and archival lifecycle. Writing a
+//! non-epistemic quantity into it does not merely reweight a ranking — it
+//! changes what the system may inject and what it archives.
+//!
+//! Retrieval inclusion, retrieval frequency, reporting, cohorts, rollout
+//! labels, and task/review/merge outcomes are therefore forbidden from calling
+//! `NoteRepository::set_confidence` or `NoteRepository::update_confidence`.
+//!
+//! This test scans every production Rust source file under `server/` and fails
+//! if a confidence writer appears anywhere outside the allowlist below. It is
+//! the "cannot call" half of AC1; the behavioural half lives next to each
+//! removed writer:
+//!
+//! * `djinn-agent/src/task_confidence.rs` —
+//!   `task_completion_records_activity_without_touching_note_confidence`
+//! * `djinn-coordinator/src/tests/status_and_stuck.rs` —
+//!   `failed_closed_task_records_marker_without_penalising_note_confidence`
+//! * `djinn-control-plane/src/tools/memory_tools/ops_tests.rs` —
+//!   `memory_read_with_a_related_high_confidence_note_changes_no_confidence`
+
+use std::path::{Path, PathBuf};
+
+/// Call syntax rather than bare identifiers, so documentation that explains why
+/// a writer was removed does not trip the guard.
+const WRITER_CALL_SYNTAX: [&str; 2] = ["update_confidence(", "set_confidence("];
+
+/// The only production files permitted to contain a confidence writer, each
+/// with the epistemic justification that earns it the exemption.
+///
+/// Adding a file here is a deliberate act: it asserts that the new call site
+/// concerns a note's TRUTH, not its usefulness, its retrieval frequency, or the
+/// outcome of a task that referenced it.
+const ALLOWED_WRITER_FILES: [(&str, &str); 5] = [
+    (
+        "crates/djinn-db/src/repositories/note/scoring.rs",
+        "defines set_confidence / update_confidence themselves",
+    ),
+    (
+        "crates/djinn-control-plane/src/tools/memory_tools/confirm.rs",
+        "memory_confirm applies USER_CONFIRM — a human asserting the note is correct",
+    ),
+    (
+        "crates/djinn-control-plane/src/tools/memory_tools/contradiction.rs",
+        "applies CONTRADICTION / STALE_CITATION — direct evidence the note is wrong or stale",
+    ),
+    (
+        "crates/djinn-db/src/repositories/note/lifecycle.rs",
+        "stale-citation decay — the note's cited basis no longer holds",
+    ),
+    (
+        "crates/djinn-slot/src/llm_extraction.rs",
+        "sets the INITIAL confidence of a session-extracted note at creation time; \
+         a starting prior, not an outcome-derived update",
+    ),
+];
+
+fn server_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is server/crates/djinn-db.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+/// Test code is excluded: fixtures legitimately force a confidence value to set
+/// up a scenario, and pinning those would make the guard noise.
+fn is_test_path(relative: &str) -> bool {
+    let name = relative.rsplit('/').next().unwrap_or(relative);
+    relative.split('/').any(|segment| segment == "tests")
+        || name.ends_with("_tests.rs")
+        || name == "tests.rs"
+}
+
+fn collect_rust_files(root: &Path, into: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if path.is_dir() {
+            if matches!(name.as_str(), "target" | "node_modules" | ".git") {
+                continue;
+            }
+            collect_rust_files(&path, into);
+        } else if name.ends_with(".rs") {
+            into.push(path);
+        }
+    }
+}
+
+#[test]
+fn only_epistemic_call_sites_may_write_note_confidence() {
+    let root = server_root();
+    let mut files = Vec::new();
+    collect_rust_files(&root.join("crates"), &mut files);
+    collect_rust_files(&root.join("src"), &mut files);
+    assert!(
+        files.len() > 100,
+        "the scan found only {} files; it is not actually walking the workspace",
+        files.len()
+    );
+
+    let mut offenders: Vec<String> = Vec::new();
+    let mut seen_allowed: Vec<&str> = Vec::new();
+
+    for path in &files {
+        let relative = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if is_test_path(&relative) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        // Only the production half of the file: an in-file `mod tests` may set
+        // confidence to build a fixture.
+        let production = text.split("#[cfg(test)]").next().unwrap_or("");
+        if !WRITER_CALL_SYNTAX
+            .iter()
+            .any(|needle| production.contains(needle))
+        {
+            continue;
+        }
+
+        match ALLOWED_WRITER_FILES
+            .iter()
+            .find(|(allowed, _)| *allowed == relative)
+        {
+            Some((allowed, _)) => seen_allowed.push(allowed),
+            None => offenders.push(relative),
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "these production files write notes.confidence but are not on the epistemic \
+         allowlist in this test:\n  {}\n\n\
+         Retrieval inclusion/frequency, reporting, cohorts, rollout labels, and \
+         task/review/merge outcomes may NOT write confidence (proposal 9xih AC1). \
+         If the new call site really is epistemic evidence about the note's truth, \
+         add it to ALLOWED_WRITER_FILES with the reason.",
+        offenders.join("\n  ")
+    );
+
+    // Negative control: if the scan silently stopped matching (a rename, a
+    // changed call shape), `offenders` would also be empty and this test would
+    // pass while proving nothing. Require the known-good sites to still be
+    // found.
+    for (allowed, reason) in ALLOWED_WRITER_FILES {
+        assert!(
+            seen_allowed.contains(&allowed),
+            "expected `{allowed}` to still contain a confidence writer ({reason}); \
+             it does not, so this guard is no longer detecting anything and must be updated"
+        );
+    }
+}
+
+/// The two removed writers, pinned by name at their former homes.
+///
+/// The allowlist test above proves no file *outside* the allowlist writes
+/// confidence. This proves the specific production paths 9xih named are the
+/// ones that stopped.
+#[test]
+fn removed_outcome_writers_are_absent_from_their_former_call_sites() {
+    let root = server_root();
+    let cases: [(&str, &str); 3] = [
+        (
+            "crates/djinn-agent/src/task_confidence.rs",
+            "task completion (TASK_SUCCESS_SIGNAL)",
+        ),
+        (
+            "crates/djinn-coordinator/src/actor.rs",
+            "task failure after injection (TASK_OUTCOME_CONFIDENCE_SIGNAL)",
+        ),
+        (
+            "crates/djinn-control-plane/src/server.rs",
+            "co-access flush (CO_ACCESS_HIGH)",
+        ),
+    ];
+
+    for (relative, what) in cases {
+        let path = root.join(relative);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {relative}: {error}"));
+        let production = text.split("#[cfg(test)]").next().unwrap_or("");
+        for needle in WRITER_CALL_SYNTAX {
+            assert!(
+                !production.contains(needle),
+                "{relative} must not contain `{needle}`: the {what} confidence writer \
+                 was removed by proposal 9xih"
+            );
+        }
+    }
+}
+
+/// `CO_ACCESS_HIGH` and `TASK_SUCCESS` were deleted, not merely unused: an
+/// available constant is an invitation to wire it back up.
+#[test]
+fn removed_outcome_signal_constants_no_longer_exist() {
+    let scoring = std::fs::read_to_string(
+        server_root().join("crates/djinn-db/src/repositories/note/scoring.rs"),
+    )
+    .expect("read scoring.rs");
+    for constant in ["CO_ACCESS_HIGH", "TASK_SUCCESS"] {
+        assert!(
+            !scoring.contains(&format!("const {constant}")),
+            "`{constant}` must stay deleted (proposal 9xih)"
+        );
+    }
+    // Negative control: an epistemic constant that must still be defined, so a
+    // typo'd `const` prefix cannot make the assertions above vacuous.
+    assert!(
+        scoring.contains("pub const USER_CONFIRM"),
+        "USER_CONFIRM must still be defined; the assertions above match on `const <NAME>`"
+    );
+}

--- a/server/crates/djinn-db/tests/migrations_note_confidence_access_repair.rs
+++ b/server/crates/djinn-db/tests/migrations_note_confidence_access_repair.rs
@@ -1,4 +1,4 @@
-//! Migration coverage for 195 — confidence ceiling normalization, legacy
+//! Migration coverage for 197 — confidence ceiling normalization, legacy
 //! access rebase, and the invocation-keyed `note_access_events` era (9xih).
 //!
 //! Every fixture row in this file is constructed by the test itself. No id,
@@ -10,9 +10,9 @@ use std::path::{Path, PathBuf};
 use sqlx::postgres::{PgConnection, PgPool, PgPoolOptions};
 use sqlx::{Connection, Executor};
 
-const MIGRATION_VERSION: u64 = 195;
-const MIGRATION_FILE: &str = "195_note_confidence_access_repair.sql";
-const MIGRATION_OPERATOR_ID: &str = "00000000-0000-7000-8000-000000000195";
+const MIGRATION_VERSION: u64 = 197;
+const MIGRATION_FILE: &str = "197_note_confidence_access_repair.sql";
+const MIGRATION_OPERATOR_ID: &str = "00000000-0000-7000-8000-000000000197";
 const CREATOR_CONTRACT_VERSION: u64 = 142;
 
 /// Must equal `djinn_db::repositories::note::CONFIDENCE_CEILING`.
@@ -107,7 +107,7 @@ async fn seed_migration_operator(conn: &mut PgConnection) {
     conn.execute(
         format!(
             "INSERT INTO users (id, github_id, github_login) VALUES \
-             ('{MIGRATION_OPERATOR_ID}', 9000000195, 'confidence-access-migration-operator') \
+             ('{MIGRATION_OPERATOR_ID}', 9000000197, 'confidence-access-migration-operator') \
              ON CONFLICT DO NOTHING"
         )
         .as_str(),
@@ -140,12 +140,12 @@ async fn apply_prior_migrations(conn: &mut PgConnection) {
     }
 }
 
-async fn apply_migration_195(conn: &mut PgConnection) {
+async fn apply_migration_197(conn: &mut PgConnection) {
     let sql =
-        std::fs::read_to_string(migrations_dir().join(MIGRATION_FILE)).expect("read migration 195");
+        std::fs::read_to_string(migrations_dir().join(MIGRATION_FILE)).expect("read migration 197");
     conn.execute(sql.as_str())
         .await
-        .expect("apply migration 195");
+        .expect("apply migration 197");
 }
 
 // ── Fixture helpers. Every id below is minted by the test. ───────────────────
@@ -253,7 +253,7 @@ async fn notes_confidence_column_default(pool: &PgPool) -> String {
 /// AC2 + AC4 on a populated database, then AC2 + AC4 again after an idempotent
 /// re-run. Every assertion reads state back out of Postgres.
 #[tokio::test]
-async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() {
+async fn migration_197_normalizes_confidence_rebases_access_and_is_idempotent() {
     with_temp_database("conf_access", |db_url| async move {
         let mut conn = PgConnection::connect(&db_url)
             .await
@@ -318,7 +318,7 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
         // the unique index on `(invocation_id, note_id)` non-trivial: all of
         // these rows will carry `invocation_id IS NULL`, so index creation is
         // only possible because Postgres treats NULLs as DISTINCT. If that
-        // assumption were wrong, `apply_migration_195` below would fail
+        // assumption were wrong, `apply_migration_197` below would fail
         // outright on a populated deployment.
         let legacy_read_event = seed_legacy_access_event(
             &mut conn,
@@ -349,7 +349,7 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
             "the two same-note legacy rows must be distinct rows"
         );
 
-        apply_migration_195(&mut conn).await;
+        apply_migration_197(&mut conn).await;
 
         let pool = PgPoolOptions::new()
             .max_connections(2)
@@ -534,7 +534,7 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
         )
         .await;
 
-        apply_migration_195(&mut conn).await;
+        apply_migration_197(&mut conn).await;
 
         for note in [&at_one, &below_one, &already_neutral, &near_floor] {
             let (confidence, access_count, last_accessed, created_at) =
@@ -582,13 +582,13 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
 /// time: every statement must be a well-formed no-op, and the resulting schema
 /// must be identical to the populated case.
 #[tokio::test]
-async fn migration_195_is_a_safe_no_op_on_an_empty_database() {
+async fn migration_197_is_a_safe_no_op_on_an_empty_database() {
     with_temp_database("conf_empty", |db_url| async move {
         let mut conn = PgConnection::connect(&db_url)
             .await
             .expect("connect migration database");
         apply_prior_migrations(&mut conn).await;
-        apply_migration_195(&mut conn).await;
+        apply_migration_197(&mut conn).await;
 
         let pool = PgPoolOptions::new()
             .max_connections(1)

--- a/server/crates/djinn-db/tests/migrations_note_confidence_access_repair.rs
+++ b/server/crates/djinn-db/tests/migrations_note_confidence_access_repair.rs
@@ -312,12 +312,28 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
 
         // Pre-9xih ledger rows of BOTH sources. These are the join side of the
         // shipped injected-pull-rate report and must survive the migration.
+        //
+        // CRUCIALLY, the first two share a `note_id`. That is the normal shape
+        // of real data (a note read many times), and it is the shape that makes
+        // the unique index on `(invocation_id, note_id)` non-trivial: all of
+        // these rows will carry `invocation_id IS NULL`, so index creation is
+        // only possible because Postgres treats NULLs as DISTINCT. If that
+        // assumption were wrong, `apply_migration_195` below would fail
+        // outright on a populated deployment.
         let legacy_read_event = seed_legacy_access_event(
             &mut conn,
             &project_id,
             &at_one.id,
             "memory_read",
             "2026-05-05T05:05:05.000Z",
+        )
+        .await;
+        let legacy_duplicate_note_event = seed_legacy_access_event(
+            &mut conn,
+            &project_id,
+            &at_one.id,
+            "memory_read",
+            "2026-05-05T05:05:06.000Z",
         )
         .await;
         let legacy_search_event = seed_legacy_access_event(
@@ -328,6 +344,10 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
             "2026-06-06T06:06:06.000Z",
         )
         .await;
+        assert_ne!(
+            legacy_read_event, legacy_duplicate_note_event,
+            "the two same-note legacy rows must be distinct rows"
+        );
 
         apply_migration_195(&mut conn).await;
 
@@ -400,19 +420,68 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
                 "SELECT COUNT(*) FROM note_access_events WHERE invocation_id IS NULL"
             )
             .await,
-            2,
+            3,
             "pre-9xih ledger rows must survive with a NULL invocation_id"
         );
-        for event_id in [&legacy_read_event, &legacy_search_event] {
-            let invocation_id: Option<String> = sqlx::query_scalar(
-                "SELECT invocation_id FROM note_access_events WHERE id = $1",
-            )
-            .bind(event_id)
-            .fetch_one(&pool)
-            .await
-            .expect("read legacy event");
+        for event_id in [
+            &legacy_read_event,
+            &legacy_duplicate_note_event,
+            &legacy_search_event,
+        ] {
+            let invocation_id: Option<String> =
+                sqlx::query_scalar("SELECT invocation_id FROM note_access_events WHERE id = $1")
+                    .bind(event_id)
+                    .fetch_one(&pool)
+                    .await
+                    .expect("read legacy event");
             assert_eq!(invocation_id, None);
         }
+
+        // The shipped consumer must still see exactly what it saw before.
+        //
+        // `injected_pull_rate.rs` selects its numerator with
+        // `source = 'memory_read'` over `(project_id, note_id)` and counts
+        // `memory_search` rows separately for contrast. Replaying that exact
+        // predicate shape proves the ALTER did not orphan the report's join
+        // side — the failure mode that deleting or recreating the table would
+        // have caused.
+        assert_eq!(
+            count_scalar(
+                &pool,
+                "SELECT COUNT(*) FROM note_access_events WHERE source = 'memory_read'"
+            )
+            .await,
+            2,
+            "the report's memory_read numerator rows must survive the migration"
+        );
+        assert_eq!(
+            count_scalar(
+                &pool,
+                "SELECT COUNT(*) FROM note_access_events WHERE source = 'memory_search'"
+            )
+            .await,
+            1,
+            "the report's memory_search contrast rows must survive the migration"
+        );
+        // ...and the legacy rows are still reachable through the report's own
+        // correlated-subquery shape (project + note + source + time ordering).
+        assert_eq!(
+            count_scalar(
+                &pool,
+                &format!(
+                    "SELECT COUNT(*) FROM note_access_events e \
+                      WHERE e.project_id = '{project_id}' \
+                        AND e.note_id = '{}' \
+                        AND e.source = 'memory_read' \
+                        AND e.created_at::timestamptz \
+                            > '2026-01-01T00:00:00.000Z'::timestamptz",
+                    at_one.id
+                )
+            )
+            .await,
+            2,
+            "the report's correlated subquery must still match the legacy rows"
+        );
 
         // ── Idempotent re-run ────────────────────────────────────────────
         // First simulate the new era doing real work, so the re-run assertion
@@ -451,8 +520,11 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
             "(invocation_id, note_id) must be unique so a replay cannot append a second row"
         );
 
-        // Two legacy rows share a NULL invocation_id; adding a third proves
-        // NULLs stay distinct under the unique index rather than colliding.
+        // Legacy-shaped rows keep working AFTER the index exists: a fourth row
+        // with a NULL invocation_id, for a note that already has two, must
+        // still insert. This is the runtime half of the "NULLs are distinct"
+        // property — the migration proved it at index-creation time, this
+        // proves the index does not block ongoing legacy-shaped writes.
         seed_legacy_access_event(
             &mut conn,
             &project_id,
@@ -494,7 +566,7 @@ async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() 
                 "SELECT COUNT(*) FROM note_access_events WHERE invocation_id IS NULL"
             )
             .await,
-            3,
+            4,
             "the re-run must not delete legacy ledger rows"
         );
 

--- a/server/crates/djinn-db/tests/migrations_note_confidence_access_repair.rs
+++ b/server/crates/djinn-db/tests/migrations_note_confidence_access_repair.rs
@@ -1,0 +1,583 @@
+//! Migration coverage for 195 — confidence ceiling normalization, legacy
+//! access rebase, and the invocation-keyed `note_access_events` era (9xih).
+//!
+//! Every fixture row in this file is constructed by the test itself. No id,
+//! project, or timestamp is taken from any particular deployment: the migration
+//! is a structural predicate over whole tables and is asserted as such.
+
+use std::path::{Path, PathBuf};
+
+use sqlx::postgres::{PgConnection, PgPool, PgPoolOptions};
+use sqlx::{Connection, Executor};
+
+const MIGRATION_VERSION: u64 = 195;
+const MIGRATION_FILE: &str = "195_note_confidence_access_repair.sql";
+const MIGRATION_OPERATOR_ID: &str = "00000000-0000-7000-8000-000000000195";
+const CREATOR_CONTRACT_VERSION: u64 = 142;
+
+/// Must equal `djinn_db::repositories::note::CONFIDENCE_CEILING`.
+const CONFIDENCE_CEILING: f64 = 0.975;
+
+fn base_database_url() -> String {
+    djinn_db::test_database_base_url()
+}
+
+fn server_prefix(base: &str) -> String {
+    base.rsplit_once('/')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(base)
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+fn migrations_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations_postgres")
+}
+
+fn migration_entries(dir: &Path) -> Vec<(u64, PathBuf)> {
+    let mut entries: Vec<(u64, PathBuf)> = std::fs::read_dir(dir)
+        .expect("read migrations dir")
+        .map(|entry| {
+            let path = entry.expect("migration dir entry").path();
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            let version = name
+                .split_once('_')
+                .and_then(|(prefix, _)| prefix.parse::<u64>().ok())
+                .unwrap_or(0);
+            (version, path)
+        })
+        .filter(|(_, path)| {
+            path.extension().and_then(|extension| extension.to_str()) == Some("sql")
+        })
+        .collect();
+    entries.sort_by(|(left_version, left_path), (right_version, right_path)| {
+        left_version.cmp(right_version).then_with(|| {
+            left_path
+                .file_name()
+                .unwrap_or_default()
+                .cmp(right_path.file_name().unwrap_or_default())
+        })
+    });
+    entries
+}
+
+async fn with_temp_database<T, Fut>(suffix: &str, f: impl FnOnce(String) -> Fut) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    let base = base_database_url();
+    let prefix = server_prefix(&base);
+    let db_name = format!("djinn_migration_{suffix}_{}", uuid::Uuid::now_v7().simple());
+    let admin_url = format!("{prefix}/postgres");
+    let mut admin = PgConnection::connect(&admin_url)
+        .await
+        .expect("connect postgres admin database");
+    admin
+        .execute(format!(r#"CREATE DATABASE "{db_name}""#).as_str())
+        .await
+        .expect("create migration test database");
+    drop(admin);
+
+    let db_url = format!("{prefix}/{db_name}");
+    let result = f(db_url).await;
+
+    let mut admin = PgConnection::connect(&admin_url)
+        .await
+        .expect("reconnect postgres admin database");
+    let _ = admin
+        .execute(
+            format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+            )
+            .as_str(),
+        )
+        .await;
+    admin
+        .execute(format!(r#"DROP DATABASE IF EXISTS "{db_name}""#).as_str())
+        .await
+        .expect("drop migration test database");
+
+    result
+}
+
+async fn seed_migration_operator(conn: &mut PgConnection) {
+    conn.execute(
+        format!(
+            "INSERT INTO users (id, github_id, github_login) VALUES \
+             ('{MIGRATION_OPERATOR_ID}', 9000000195, 'confidence-access-migration-operator') \
+             ON CONFLICT DO NOTHING"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("seed designated migration operator");
+}
+
+async fn apply_prior_migrations(conn: &mut PgConnection) {
+    conn.execute(
+        format!(
+            "SELECT set_config('djinn.migration_designated_operator_user_id', '{MIGRATION_OPERATOR_ID}', false)"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("set designated operator GUC");
+
+    for (version, path) in migration_entries(&migrations_dir()) {
+        if version >= MIGRATION_VERSION {
+            break;
+        }
+        if version == CREATOR_CONTRACT_VERSION {
+            seed_migration_operator(conn).await;
+        }
+        let sql = std::fs::read_to_string(&path).expect("read prior migration sql");
+        conn.execute(sql.as_str())
+            .await
+            .unwrap_or_else(|error| panic!("apply migration {} failed: {error}", path.display()));
+    }
+}
+
+async fn apply_migration_195(conn: &mut PgConnection) {
+    let sql =
+        std::fs::read_to_string(migrations_dir().join(MIGRATION_FILE)).expect("read migration 195");
+    conn.execute(sql.as_str())
+        .await
+        .expect("apply migration 195");
+}
+
+// ── Fixture helpers. Every id below is minted by the test. ───────────────────
+
+struct SeededNote {
+    id: String,
+    confidence: f64,
+    created_at: String,
+}
+
+async fn seed_project(conn: &mut PgConnection, project_id: &str) {
+    conn.execute(
+        format!(
+            "INSERT INTO projects (id, name, github_owner, github_repo) \
+             VALUES ('{project_id}', '{project_id}', 'owner-{project_id}', 'repo-{project_id}')"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("seed project");
+}
+
+/// Insert one note with a fully explicit pre-migration state so the assertions
+/// below cannot accidentally be reading a schema default.
+async fn seed_note(
+    conn: &mut PgConnection,
+    project_id: &str,
+    slug: &str,
+    confidence: f64,
+    access_count: i64,
+    created_at: &str,
+    last_accessed: &str,
+) -> SeededNote {
+    let id = uuid::Uuid::now_v7().to_string();
+    conn.execute(
+        format!(
+            "INSERT INTO notes \
+                 (id, project_id, permalink, title, file_path, tags, content, scope_paths, \
+                  confidence, access_count, created_at, updated_at, last_accessed) \
+             VALUES ('{id}', '{project_id}', 'reference/{slug}', '{slug}', '', '[]', 'body', '[]', \
+                     {confidence}, {access_count}, '{created_at}', '{created_at}', '{last_accessed}')"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("seed note");
+    SeededNote {
+        id,
+        confidence,
+        created_at: created_at.to_owned(),
+    }
+}
+
+/// Insert one pre-9xih ledger row in migration 189's shape (no invocation id).
+async fn seed_legacy_access_event(
+    conn: &mut PgConnection,
+    project_id: &str,
+    note_id: &str,
+    source: &str,
+    created_at: &str,
+) -> String {
+    let id = uuid::Uuid::now_v7().to_string();
+    conn.execute(
+        format!(
+            "INSERT INTO note_access_events (id, project_id, note_id, source, created_at) \
+             VALUES ('{id}', '{project_id}', '{note_id}', '{source}', '{created_at}')"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("seed legacy access event");
+    id
+}
+
+async fn note_row(pool: &PgPool, note_id: &str) -> (f64, i64, String, String) {
+    sqlx::query_as::<_, (f64, i64, String, String)>(
+        "SELECT confidence, access_count, last_accessed, created_at FROM notes WHERE id = $1",
+    )
+    .bind(note_id)
+    .fetch_one(pool)
+    .await
+    .expect("read migrated note")
+}
+
+async fn count_scalar(pool: &PgPool, sql: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>(sql)
+        .fetch_one(pool)
+        .await
+        .expect("count query")
+}
+
+async fn notes_confidence_column_default(pool: &PgPool) -> String {
+    sqlx::query_scalar::<_, Option<String>>(
+        "SELECT column_default FROM information_schema.columns \
+         WHERE table_name = 'notes' AND column_name = 'confidence'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("read confidence column default")
+    .unwrap_or_default()
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// AC2 + AC4 on a populated database, then AC2 + AC4 again after an idempotent
+/// re-run. Every assertion reads state back out of Postgres.
+#[tokio::test]
+async fn migration_195_normalizes_confidence_rebases_access_and_is_idempotent() {
+    with_temp_database("conf_access", |db_url| async move {
+        let mut conn = PgConnection::connect(&db_url)
+            .await
+            .expect("connect migration database");
+        apply_prior_migrations(&mut conn).await;
+
+        let project_id = format!("p{}", uuid::Uuid::now_v7().simple());
+        seed_project(&mut conn, &project_id).await;
+
+        // Exactly 1.0 — the legacy default that made USER_CONFIRM demoting.
+        let at_one = seed_note(
+            &mut conn,
+            &project_id,
+            "at-one",
+            1.0,
+            7,
+            "2026-01-01T00:00:00.000Z",
+            "2026-05-05T05:05:05.000Z",
+        )
+        .await;
+        // Below 1.0 — a real posterior. Must survive byte-for-byte.
+        let below_one = seed_note(
+            &mut conn,
+            &project_id,
+            "below-one",
+            0.4,
+            3,
+            "2026-02-02T00:00:00.000Z",
+            "2026-06-06T06:06:06.000Z",
+        )
+        .await;
+        // Already at the ceiling, and already access-neutral: the migration
+        // must be a no-op here even on its FIRST run.
+        let already_neutral = seed_note(
+            &mut conn,
+            &project_id,
+            "already-neutral",
+            CONFIDENCE_CEILING,
+            0,
+            "2026-03-03T00:00:00.000Z",
+            "2026-03-03T00:00:00.000Z",
+        )
+        .await;
+        // Just above the floor — proves "only exactly 1.0" is not "anything
+        // high".
+        let near_floor = seed_note(
+            &mut conn,
+            &project_id,
+            "near-floor",
+            0.999,
+            42,
+            "2026-04-04T00:00:00.000Z",
+            "2026-07-07T07:07:07.000Z",
+        )
+        .await;
+
+        // Pre-9xih ledger rows of BOTH sources. These are the join side of the
+        // shipped injected-pull-rate report and must survive the migration.
+        let legacy_read_event = seed_legacy_access_event(
+            &mut conn,
+            &project_id,
+            &at_one.id,
+            "memory_read",
+            "2026-05-05T05:05:05.000Z",
+        )
+        .await;
+        let legacy_search_event = seed_legacy_access_event(
+            &mut conn,
+            &project_id,
+            &below_one.id,
+            "memory_search",
+            "2026-06-06T06:06:06.000Z",
+        )
+        .await;
+
+        apply_migration_195(&mut conn).await;
+
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&db_url)
+            .await
+            .expect("connect assertion pool");
+
+        // ── AC2: confidence ──────────────────────────────────────────────
+        let (confidence, ..) = note_row(&pool, &at_one.id).await;
+        assert_eq!(
+            confidence, CONFIDENCE_CEILING,
+            "exactly-1.0 confidence must normalize to the ceiling"
+        );
+        let (confidence, ..) = note_row(&pool, &below_one.id).await;
+        assert_eq!(
+            confidence, below_one.confidence,
+            "a confidence below 1.0 is real evidence and must not be rewritten"
+        );
+        let (confidence, ..) = note_row(&pool, &near_floor.id).await;
+        assert_eq!(
+            confidence, near_floor.confidence,
+            "0.999 is below 1.0 and must not be rewritten"
+        );
+        let (confidence, ..) = note_row(&pool, &already_neutral.id).await;
+        assert_eq!(confidence, CONFIDENCE_CEILING);
+
+        // New rows must now default to the ceiling. Asserted on the actual
+        // stored default, not on the migration text.
+        let default_expr = notes_confidence_column_default(&pool).await;
+        assert!(
+            default_expr.starts_with("0.975"),
+            "notes.confidence default must be 0.975, got {default_expr:?}"
+        );
+
+        // ── AC4: access rebase ───────────────────────────────────────────
+        for note in [&at_one, &below_one, &already_neutral, &near_floor] {
+            let (_, access_count, last_accessed, created_at) = note_row(&pool, &note.id).await;
+            assert_eq!(
+                access_count, 0,
+                "every legacy access_count must be rebased to 0"
+            );
+            assert_eq!(
+                last_accessed, created_at,
+                "last_accessed must be rebased to the note's own created_at"
+            );
+            assert_eq!(
+                created_at, note.created_at,
+                "created_at itself must not be rewritten"
+            );
+        }
+
+        // ── AC4: the invocation-keyed era starts empty ───────────────────
+        assert_eq!(
+            count_scalar(
+                &pool,
+                "SELECT COUNT(*) FROM note_access_events WHERE invocation_id IS NOT NULL"
+            )
+            .await,
+            0,
+            "the 9xih ledger era must contain no rows immediately after migration"
+        );
+
+        // ...but the pre-9xih rows are NOT destroyed: they are the production
+        // basis of the injected-pull-rate report.
+        assert_eq!(
+            count_scalar(
+                &pool,
+                "SELECT COUNT(*) FROM note_access_events WHERE invocation_id IS NULL"
+            )
+            .await,
+            2,
+            "pre-9xih ledger rows must survive with a NULL invocation_id"
+        );
+        for event_id in [&legacy_read_event, &legacy_search_event] {
+            let invocation_id: Option<String> = sqlx::query_scalar(
+                "SELECT invocation_id FROM note_access_events WHERE id = $1",
+            )
+            .bind(event_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read legacy event");
+            assert_eq!(invocation_id, None);
+        }
+
+        // ── Idempotent re-run ────────────────────────────────────────────
+        // First simulate the new era doing real work, so the re-run assertion
+        // is about the migration's own statements and not about a table that
+        // happens to be empty.
+        let post_migration_invocation = format!("inv-{}", uuid::Uuid::now_v7().simple());
+        sqlx::query(
+            "INSERT INTO note_access_events \
+                 (id, project_id, note_id, source, created_at, invocation_id) \
+             VALUES ($1, $2, $3, 'memory_read', $4, $5)",
+        )
+        .bind(uuid::Uuid::now_v7().to_string())
+        .bind(&project_id)
+        .bind(&at_one.id)
+        .bind("2026-08-08T08:08:08.000Z")
+        .bind(&post_migration_invocation)
+        .execute(&pool)
+        .await
+        .expect("insert new-era ledger row");
+
+        // The unique key must reject a replay of that exact invocation.
+        let replay = sqlx::query(
+            "INSERT INTO note_access_events \
+                 (id, project_id, note_id, source, created_at, invocation_id) \
+             VALUES ($1, $2, $3, 'memory_read', $4, $5)",
+        )
+        .bind(uuid::Uuid::now_v7().to_string())
+        .bind(&project_id)
+        .bind(&at_one.id)
+        .bind("2026-08-08T08:08:09.000Z")
+        .bind(&post_migration_invocation)
+        .execute(&pool)
+        .await;
+        assert!(
+            replay.is_err(),
+            "(invocation_id, note_id) must be unique so a replay cannot append a second row"
+        );
+
+        // Two legacy rows share a NULL invocation_id; adding a third proves
+        // NULLs stay distinct under the unique index rather than colliding.
+        seed_legacy_access_event(
+            &mut conn,
+            &project_id,
+            &at_one.id,
+            "memory_read",
+            "2026-08-09T09:09:09.000Z",
+        )
+        .await;
+
+        apply_migration_195(&mut conn).await;
+
+        for note in [&at_one, &below_one, &already_neutral, &near_floor] {
+            let (confidence, access_count, last_accessed, created_at) =
+                note_row(&pool, &note.id).await;
+            let expected_confidence = if note.confidence == 1.0 {
+                CONFIDENCE_CEILING
+            } else {
+                note.confidence
+            };
+            assert_eq!(
+                confidence, expected_confidence,
+                "re-running the migration must not move confidence again"
+            );
+            assert_eq!(access_count, 0);
+            assert_eq!(last_accessed, created_at);
+        }
+        assert_eq!(
+            count_scalar(
+                &pool,
+                "SELECT COUNT(*) FROM note_access_events WHERE invocation_id IS NOT NULL"
+            )
+            .await,
+            1,
+            "the re-run must not delete ledger rows written after the first run"
+        );
+        assert_eq!(
+            count_scalar(
+                &pool,
+                "SELECT COUNT(*) FROM note_access_events WHERE invocation_id IS NULL"
+            )
+            .await,
+            3,
+            "the re-run must not delete legacy ledger rows"
+        );
+
+        pool.close().await;
+        drop(conn);
+    })
+    .await;
+}
+
+/// The same migration against a database with ZERO notes and ZERO ledger rows.
+///
+/// This is the case that matters for an operator installing djinn for the first
+/// time: every statement must be a well-formed no-op, and the resulting schema
+/// must be identical to the populated case.
+#[tokio::test]
+async fn migration_195_is_a_safe_no_op_on_an_empty_database() {
+    with_temp_database("conf_empty", |db_url| async move {
+        let mut conn = PgConnection::connect(&db_url)
+            .await
+            .expect("connect migration database");
+        apply_prior_migrations(&mut conn).await;
+        apply_migration_195(&mut conn).await;
+
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&db_url)
+            .await
+            .expect("connect assertion pool");
+
+        assert_eq!(count_scalar(&pool, "SELECT COUNT(*) FROM notes").await, 0);
+        assert_eq!(
+            count_scalar(&pool, "SELECT COUNT(*) FROM note_access_events").await,
+            0
+        );
+
+        // The schema changes still landed.
+        let default_expr = notes_confidence_column_default(&pool).await;
+        assert!(
+            default_expr.starts_with("0.975"),
+            "fresh installs must get the 0.975 confidence default, got {default_expr:?}"
+        );
+        assert_eq!(
+            count_scalar(
+                &pool,
+                "SELECT COUNT(*) FROM information_schema.columns \
+                 WHERE table_name = 'note_access_events' AND column_name = 'invocation_id'"
+            )
+            .await,
+            1,
+            "invocation_id must exist on a fresh install"
+        );
+        assert_eq!(
+            count_scalar(
+                &pool,
+                "SELECT COUNT(*) FROM pg_indexes \
+                 WHERE tablename = 'note_access_events' \
+                   AND indexname = 'uq_note_access_events_invocation_note'"
+            )
+            .await,
+            1,
+            "the replay-key unique index must exist on a fresh install"
+        );
+
+        // A note created purely through the schema default lands at the
+        // ceiling, so USER_CONFIRM can never demote it below an untouched peer.
+        let project_id = format!("p{}", uuid::Uuid::now_v7().simple());
+        seed_project(&mut conn, &project_id).await;
+        let default_note_id = uuid::Uuid::now_v7().to_string();
+        conn.execute(
+            format!(
+                "INSERT INTO notes (id, project_id, permalink, title, file_path, tags, content, scope_paths) \
+                 VALUES ('{default_note_id}', '{project_id}', 'reference/defaulted', 'Defaulted', '', '[]', 'body', '[]')"
+            )
+            .as_str(),
+        )
+        .await
+        .expect("insert note relying on the schema default");
+        let (confidence, access_count, ..) = note_row(&pool, &default_note_id).await;
+        assert_eq!(confidence, CONFIDENCE_CEILING);
+        assert_eq!(access_count, 0);
+
+        pool.close().await;
+        drop(conn);
+    })
+    .await;
+}

--- a/server/crates/djinn-mcp-extension/src/handlers/memory_agent.rs
+++ b/server/crates/djinn-mcp-extension/src/handlers/memory_agent.rs
@@ -54,6 +54,10 @@ pub(crate) async fn call_memory_read(
             SharedMemoryReadParams {
                 project: project_path,
                 identifier: p.identifier,
+                // The agent-facing `memory_read` tool schema does not expose an
+                // invocation id, so every attempt on this path is explicitly a
+                // distinct invocation (9xih backward-compatible behaviour).
+                invocation_id: None,
             },
             &note_access_attribution(ctx),
         )

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -10161,6 +10161,13 @@
         "identifier": {
           "description": "Note permalink (e.g. \"decisions/my-adr\") or title.",
           "type": "string"
+        },
+        "invocation_id": {
+          "description": "Optional caller-supplied id identifying ONE logical read invocation, max 64 characters. Reusing it on a retry makes the access count exactly once; omitting it makes every attempt a distinct access.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -10089,6 +10089,13 @@ expression: signatures
           "description": "Note permalink (e.g. \"decisions/my-adr\") or title.",
           "type": "string"
         },
+        "invocation_id": {
+          "description": "Optional caller-supplied id identifying ONE logical read invocation, max 64 characters. Reusing it on a retry makes the access count exactly once; omitting it makes every attempt a distinct access.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "project": {
           "type": "string"
         }

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -4769,6 +4769,10 @@ export namespace MemoryReadInputSchema {
    * Note permalink (e.g. "decisions/my-adr") or title.
    */
   identifier: string
+  /**
+   * Optional caller-supplied id identifying ONE logical read invocation, max 64 characters. Reusing it on a retry makes the access count exactly once; omitting it makes every attempt a distinct access.
+   */
+  invocation_id?: string
   project: string
   [k: string]: any
   }


### PR DESCRIPTION
Implements proposal `9xih` — **6 of 7 ACs met, 1 partial** (see the ledger reconciliation).

Keeps retrieval outcomes out of epistemic confidence, removes the accidental co-access writer, makes positive epistemic confirmation non-demoting, and starts a clean access-accounting era.

## Migration 195 — `195_note_confidence_access_repair.sql`

Four purely structural statements. No ids, no deployment-specific predicates, all re-runnable to the same end state, all matching zero rows on an empty database:

1. `ALTER TABLE notes ALTER COLUMN confidence SET DEFAULT 0.975`
2. `UPDATE notes SET confidence = 0.975 WHERE confidence = 1.0`
3. `UPDATE notes SET access_count = 0, last_accessed = created_at WHERE access_count <> 0 OR last_accessed <> created_at`
4. `ALTER TABLE note_access_events ADD COLUMN IF NOT EXISTS invocation_id VARCHAR(64) NULL` + `CREATE UNIQUE INDEX IF NOT EXISTS uq_note_access_events_invocation_note ON (invocation_id, note_id)`

## Deliberate deviation: `1_initial_schema.sql` is NOT edited

The proposal's FileTree says to change the fresh-schema default there. **That was refused on purpose.** Commit `95cfd645f` ("fix(migrations): revert in-place edits to applied migration 1") records that PRs #750/#836 did exactly this and **crash-looped every server pod in v0.6.28** — sqlx rejects an applied migration whose checksum changed.

`ALTER COLUMN ... SET DEFAULT` in migration 195 produces the identical observable outcome on both fresh and existing databases (a fresh DB runs 1 then 195). The migration test asserts the *stored* `information_schema` default is `0.975` and that a note inserted purely via the schema default lands at the ceiling.

## `note_access_events` reconciliation: ALTER, do not recreate

The table already existed from migration 189 (proposal `u46i`). It is **not dormant** — `retrieval_trace/injected_pull_rate.rs` joins it to `retrieval_traces` for the shipped `memory_injected_pull_rate_report` MCP tool, under a protected 30-day retention window. Deleting those rows would break a live metric.

So the table is altered, not recreated. `invocation_id` is NULL for every pre-`9xih` row; Postgres treats NULLs as distinct in a unique index, so legacy rows coexist and index creation cannot fail on existing data.

**AC4 is therefore partial by an honest reading.** "Creates an empty `note_access_events` ledger" is satisfied only under the definition *zero rows with a non-null `invocation_id`* — which is what the migration test asserts, alongside asserting legacy rows survive. The reset and idempotence halves of AC4 are fully met and tested.

## A second, undocumented confidence writer was found and removed

`djinn-coordinator/src/actor.rs::apply_task_outcome_confidence_to_task_refs` applied `TASK_OUTCOME_CONFIDENCE_SIGNAL = 0.1` — as harsh as `CONTRADICTION` — to every referenced note on failed-close and on reopen. The proposal's Evidence section never mentions it, but AC1 names "task failure after injection" explicitly. Removed; markers preserved and now carry `referenced_notes`.

Three writers removed in total: `task_confidence.rs`, `actor.rs`, `server.rs`.

## AC status

| AC | Status |
| --- | --- |
| 1 write boundary + `handle_task_completed` | **met** |
| 2 `0.975` default + idempotent migration + ordering | **met** (with the migration-1 deviation above) |
| 3 `CO_ACCESS_HIGH` removed | **met** |
| 4 access rebase + empty ledger + exclusions | **partial** — see reconciliation |
| 5 dedupe, atomicity, concurrency | **met** |
| 6 optional bounded `invocation_id` | **met** |
| 7 no actuator/cohort/utility score | **met by absence** — `search.rs`, `lifecycle.rs`, `context.rs`, `rrf.rs` untouched in the diff |

## Anti-vacuity controls

Every new test asserts DB-read-back state. Two carry explicit controls against passing for the wrong reason:

- The task-completion test parks the note at `0.5` first, so the *removed* signal would have moved that prior. At the new `0.975` default it would have clamped to a no-op — the test would have passed vacuously.
- The co-access test asserts no association exists before the flush and one exists after, so "no confidence changed" cannot pass by the flush itself no-opping.

`confidence_write_boundary.rs` is a workspace-wide allowlist scan with a negative control proving the known-good sites are still detected.

## Risks for the reviewer

- **Nothing was compiled locally.** CI is the first real check.
- **Tool-schema goldens were hand-edited** — `make tool-goldens` needs cargo. Three artifacts patched by matching the exact rendering of an `Option<String>` with a doc comment: the insta snapshot (alphabetical), the provider projection fixture (declaration order), and `mcp-tools.gen.ts` (alphabetical). **This is the highest-probability breakage item**; `make tool-goldens-check` adjudicates.
- **rustfmt**: ~1300 hand-written lines. Expect a possible fmt-only follow-up commit.
- `Database::open_in_memory()` uses a 4-connection pool, so the 12-task concurrency test overlaps in groups of 4 — real concurrency, but not 12-way.
- The `llm_extraction.rs` allowlist scan splits at the *first* `#[cfg(test)]`, so a writer added after an early test block in that one file would be missed.
- All new SQL uses runtime `sqlx::query()`, not the `query!` macro, so no offline metadata is required.
