### PR TITLE
nafu: retire a quiescence proof nothing can soundly witness

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -1262,6 +1262,28 @@ impl CoordinatorActor {
         tracing::info!("CoordinatorActor stopped");
     }
 
+    /// Drive [`Self::run_dispatch_loop`] — the production loop, not a copy of
+    /// it — so a sibling test module can witness its cancellation arm.
+    ///
+    /// The arm is where CI-route provider actions are quiesced and this
+    /// incarnation's `provider_actions_drained_at` stamp is earned, and that
+    /// stamp is the *only* thing that ever lets a later incarnation recover a
+    /// charged `calling` row. Nothing else in this crate constructs a
+    /// `CoordinatorActor` and runs it, so until this existed the call could be
+    /// deleted outright with the whole suite still green: the drain would never
+    /// run in production, no stamp would ever be written, and every `calling`
+    /// row would strand for good.
+    ///
+    /// A shim rather than a visibility change on the loop itself, because the
+    /// proof token is deliberately unforgeable outside this module: the loop's
+    /// contract is "startup imports finished first", and a test that could
+    /// mint the token would erode it.
+    #[cfg(test)]
+    pub(crate) async fn drive_dispatch_loop_for_test(&mut self) {
+        self.run_dispatch_loop(StartupLegacySettingsImportsComplete)
+            .await;
+    }
+
     /// Enter the normal, potentially infinite dispatch loop only after the
     /// finite startup import phase has completed.
     async fn run_dispatch_loop(&mut self, _imports_complete: StartupLegacySettingsImportsComplete) {

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -170,6 +170,14 @@ mod worker_lifecycle;
 // ─── Public re-exports (matching djinn-agent facade paths) ───────────────
 
 pub use handle::CoordinatorHandle;
+/// How long leadership waits for the coordinator's provider-action drain stamp
+/// before releasing the advisory lock (proposal `nafu`).
+///
+/// Re-exported rather than restated in `server/src/leadership.rs`: it is one
+/// half of a relation whose other half is the coordinator's own drain budget,
+/// and a number spelled in two crates is a relation nothing checks. Its owning
+/// module holds both, plus the compile-time assertion that orders them.
+pub use pr_poller::ci_routing::quiescence::PROVIDER_ACTION_DRAIN_WAIT;
 pub use types::{
     AutoMergeTracker, BackgroundWorkTracker, BreakerDebugEntry, CoordinatorDebugSnapshot,
     CoordinatorDeps, CoordinatorError, CoordinatorStatus, DebugCooldown, DebugDispatchState,

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor.rs
@@ -1097,7 +1097,7 @@ pub(crate) async fn recover_calling_owners_at_startup(
 /// in the ledger that is a *fact* about where those futures went, rather than
 /// an inference from a clock.
 ///
-/// # Why an expired renewal lease is not `ProcessTerminated`
+/// # Why an expired renewal lease is not a proof
 ///
 /// It reads like process-death evidence and is not. Renewal is scoped to the
 /// coordinator's cancellation token, so it stops the instant leadership is
@@ -1109,6 +1109,20 @@ pub(crate) async fn recover_calling_owners_at_startup(
 /// `finalize_calling` is discarded, and a real episode is adjudicated
 /// `outcome_unknown`. Elapsed time is never by itself evidence that a `calling`
 /// owner is dead.
+///
+/// # Why process death is not a second proof either
+///
+/// The obvious candidate is the coordinator advisory lock: Postgres releases a
+/// session-scoped lock automatically when the holding backend goes away, so a
+/// release with no voluntary handoff behind it looks like a death certificate.
+/// It is not one. Postgres performs that release *at backend termination*,
+/// which is strictly before the client process can observe anything — so a live
+/// process whose lock connection was dropped by a failover, a restart, or a
+/// `pg_terminate_backend` is indistinguishable from a dead one for as long as
+/// it takes that process to notice and exit, with its provider futures running
+/// throughout. Bounding that interval requires elapsed time, which is the
+/// inference above. `CiQuiescenceProof` therefore has no process-death variant
+/// at all (migration 196), and this witness has exactly one input.
 ///
 /// # What "no proof" costs
 ///

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -913,13 +913,18 @@ async fn live_calling_owner_after_acceptance_is_not_recovered() {
 /// charge, and opens at most one Tier-2 lease — with no provider query and no
 /// replay.
 ///
-/// The injected `ProcessTerminated` is the repository's contract, not a claim
-/// about what production can observe. No production witness emits it:
-/// `CiIncarnationLiveness` reads exactly one fact, the former owner's
-/// `provider_actions_drained_at` stamp, because every available death signal is
-/// a clock in disguise. See `a_lapsed_owner_lease_is_not_a_quiescence_proof`
-/// below for why, and `only_the_former_owners_drain_stamp_recovers_a_calling_row`
-/// for the same recovery driven by the real witness.
+/// "Terminated" here means the owner reached the END of its own shutdown
+/// contract — admission closed, every provider future joined, its own drain
+/// stamp written — not that its process was killed. There is no killed-process
+/// proof: `CiQuiescenceProof` has only the drain stamp and the absence of one,
+/// because the only trace an abrupt death leaves is an advisory-lock release
+/// Postgres performs before the (possibly still live) client can react. See
+/// `a_lapsed_owner_lease_is_not_a_quiescence_proof` below.
+///
+/// So the former owner's ledger row is really drained here, and the injected
+/// `FixedLiveness` cannot paper over that: `recover_calling_owner` re-reads
+/// `provider_actions_drained_at` for itself before honouring a `GracefulDrain`
+/// claim.
 #[tokio::test]
 async fn terminated_owner_handoff_recovers_calling_once() {
     let f = fixture().await;
@@ -930,6 +935,25 @@ async fn terminated_owner_handoff_recovers_calling_once() {
     let fingerprint = transient_fingerprint(CiLane::PrHead, &blocking);
 
     let other = uuid::Uuid::now_v7().to_string();
+    let incarnations = djinn_db::CoordinatorIncarnationRepository::new(f.db.clone());
+    incarnations
+        .register(&other)
+        .await
+        .expect("register the former owner");
+    assert!(
+        incarnations
+            .mark_draining(&other)
+            .await
+            .expect("mark draining")
+    );
+    assert!(
+        incarnations
+            .mark_provider_actions_drained(&other)
+            .await
+            .expect("stamp the drain"),
+        "the former owner must really have drained, or the repository refuses \
+         the claim and this fixture tests a deferral instead of a handoff"
+    );
     f.routes
         .reserve(&CiRouteReservation {
             subject: f.subject.clone(),
@@ -954,7 +978,7 @@ async fn terminated_owner_handoff_recovers_calling_once() {
     let first = recover_calling_owners_at_startup(
         &f.routes,
         &FixedHead(Some(HEAD.to_owned())),
-        &FixedLiveness(CiQuiescenceProof::ProcessTerminated),
+        &FixedLiveness(CiQuiescenceProof::GracefulDrain),
         &f.incarnation,
         true,
         CiRoutingGate::Enabled,
@@ -967,7 +991,7 @@ async fn terminated_owner_handoff_recovers_calling_once() {
     let second = recover_calling_owners_at_startup(
         &f.routes,
         &FixedHead(Some(HEAD.to_owned())),
-        &FixedLiveness(CiQuiescenceProof::ProcessTerminated),
+        &FixedLiveness(CiQuiescenceProof::GracefulDrain),
         &f.incarnation,
         true,
         CiRoutingGate::Enabled,
@@ -1157,7 +1181,7 @@ async fn recovery_reasons(f: &Fixture, key: &str) -> Vec<CiCallingRecoveryReason
 /// the coordinator's cancellation token, so it stops when leadership is
 /// cancelled and not when the process exits: a leader still joining its
 /// provider futures past its drain budget reads exactly like a dead one once
-/// the expiry window passes. Deriving `ProcessTerminated` from that expiry
+/// the expiry window passes. Deriving a quiescence proof from that expiry
 /// authorises a second `rerun_failed_jobs` against evidence whose first call
 /// may still be in flight, discards the old owner's fenced `finalize_calling`,
 /// and spends a Lead session adjudicating an episode that in fact succeeded —
@@ -1167,12 +1191,17 @@ async fn recovery_reasons(f: &Fixture, key: &str) -> Vec<CiCallingRecoveryReason
 ///
 /// NAMED FAILING MUTATION: restore the deleted arm in
 /// `CiIncarnationLiveness::quiescence_proof` —
-/// `Ok(Some(_)) => match is_live(..) { Ok(Some(false)) => ProcessTerminated, .. }`.
-/// The backdated lease reads expired, so `quiescence_proof` answers
-/// `ProcessTerminated`, the first assertion fails, and the handoff below takes
-/// the row instead of deferring: `deferred` drops to 0, `outcome_unknown` rises
-/// to 1, the phase leaves `calling`, and the audit reason stops being
-/// `LiveOwnerDeferred`.
+/// `Ok(Some(_)) => match is_live(..) { Ok(Some(false)) => GracefulDrain, .. }`.
+/// The backdated lease reads expired, so `quiescence_proof` answers a proof,
+/// the first assertion fails, and the handoff below takes the row instead of
+/// deferring: `deferred` drops to 0, `outcome_unknown` rises to 1, the phase
+/// leaves `calling`, and the audit reason stops being `LiveOwnerDeferred`.
+///
+/// Note that the repository's own re-read of `provider_actions_drained_at`
+/// does NOT catch this one on its own here: this fixture's lapsed incarnation
+/// is registered but never drained, so the claim would be refused — which is
+/// why the `quiescence_proof` assertion above the handoff is asserted directly
+/// rather than inferred from the report.
 #[tokio::test]
 async fn a_lapsed_owner_lease_is_not_a_quiescence_proof() {
     let f = fixture().await;
@@ -1478,13 +1507,17 @@ async fn wait_until_admission_closed(scope: &ProviderActionScope) {
     }
 }
 
-async fn drain_stamp(f: &Fixture, incarnation: &str) -> Option<String> {
-    djinn_db::CoordinatorIncarnationRepository::new(f.db.clone())
+async fn drain_stamp_in(db: &Database, incarnation: &str) -> Option<String> {
+    djinn_db::CoordinatorIncarnationRepository::new(db.clone())
         .get(incarnation)
         .await
         .expect("ledger read")
         .expect("the incarnation is registered")
         .provider_actions_drained_at
+}
+
+async fn drain_stamp(f: &Fixture, incarnation: &str) -> Option<String> {
+    drain_stamp_in(&f.db, incarnation).await
 }
 
 /// The stamp is not written while a provider future is still in flight.
@@ -1911,6 +1944,128 @@ async fn a_joined_drain_with_no_ledger_row_does_not_claim_a_stamp() {
     assert_eq!(
         liveness.quiescence_proof(&unregistered).await,
         CiQuiescenceProof::None
+    );
+}
+
+/// The PRODUCTION cancellation arm is what runs the drain at all.
+///
+/// Every fixture above calls `quiesce_provider_actions` directly, so all of
+/// them stay green if `CoordinatorActor`'s `cancel.cancelled()` arm stops
+/// calling it. That deletion is not cosmetic: the drain would then never run in
+/// production, `provider_actions_drained_at` would never be written by anybody,
+/// `CiIncarnationLiveness` would answer `None` forever, and every charged
+/// `calling` row a leadership handover left behind would strand permanently.
+/// The one thing that makes the column producible at all is one `.await` in one
+/// `select!` arm, and nothing in this crate ran that arm.
+///
+/// So this drives the real loop, through `CoordinatorActor::new(
+/// CoordinatorDeps::new(..))` — the production constructor — with the token
+/// already cancelled, which the arm's `biased` ordering makes the arm that
+/// fires. A guard admitted before the loop starts stands in for a live
+/// `rerun_failed_jobs` future behind a `calling` row.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete `poll_stack::boxed(|| self.quiesce_provider_actions()).await;`
+///     from the arm: admission is never closed, so
+///     `wait_until_admission_closed` exhausts `PATIENCE` and panics.
+/// (b) Move the call out of the loop entirely — up into `run()` after
+///     `run_dispatch_loop` returns, which is where leadership's own cancelled
+///     `select!` arm can already have released the lock: the loop returns with
+///     admission still open and the same wait panics. (Moving it after the
+///     `break` but still inside `run_dispatch_loop` is deliberately NOT killed:
+///     the drain is still awaited before the function returns, which is the
+///     property that matters.)
+/// (c) Spawn it instead of awaiting it — `tokio::spawn(async move { … })` —
+///     which is the shape that lets leadership release the lock while a
+///     provider future is still live: admission closes, but the loop exits
+///     while the guard is held, so the `!loop_task.is_finished()` vacuity guard
+///     fails.
+/// (d) Stamp unconditionally inside the drain: the sampling loop reads a stamp
+///     while the guard is still held and fails on the first sample.
+#[tokio::test]
+async fn the_actors_cancellation_arm_earns_the_drain_stamp_before_the_loop_exits() {
+    let db = Database::open_in_memory().expect("ephemeral test database");
+    let mut actor = crate::actor::actor_with_test_db(db.clone());
+
+    // Everything the assertions need, taken before the actor is moved.
+    let incarnation = actor.coordinator_incarnation_id.clone();
+    let scope = actor.provider_action_scope.clone();
+    let cancel = actor.cancel.clone();
+
+    // `run()` registers the incarnation before reaching the loop; the loop
+    // itself does not, so the fixture stands in for that half. Without a row,
+    // `mark_draining` matches nothing and the drain reports `NotStamped`.
+    djinn_db::CoordinatorIncarnationRepository::new(db.clone())
+        .register(&incarnation)
+        .await
+        .expect("register the incarnation the actor will stamp");
+
+    // The stand-in for a live provider call behind a charged `calling` row.
+    let in_flight = scope.admit().expect("an open scope admits before shutdown");
+    assert!(
+        drain_stamp_in(&db, &incarnation).await.is_none(),
+        "nothing may be stamped before the loop has even run"
+    );
+    assert!(
+        !scope.is_admission_closed(),
+        "admission must start open, or the wait below proves nothing"
+    );
+
+    cancel.cancel();
+    let loop_task = tokio::spawn(async move { actor.drive_dispatch_loop_for_test().await });
+
+    // The arm ran and reached step 1 of the drain. This is the assertion that
+    // dies if the call is deleted or moved out of the arm.
+    wait_until_admission_closed(&scope).await;
+
+    let liveness = CiIncarnationLiveness {
+        incarnations: djinn_db::CoordinatorIncarnationRepository::new(db.clone()),
+    };
+    for sample in 0..DRAIN_SAMPLES {
+        tokio::time::sleep(DRAIN_POLL).await;
+        assert!(
+            drain_stamp_in(&db, &incarnation).await.is_none(),
+            "sample {sample}: the arm stamped while a provider future was still in flight"
+        );
+        assert_eq!(
+            liveness.quiescence_proof(&incarnation).await,
+            CiQuiescenceProof::None,
+            "sample {sample}: a recovering incarnation must find no proof yet"
+        );
+    }
+
+    // Vacuity: the window really did span a live future AND a loop that had not
+    // exited — i.e. the arm awaits the drain inline rather than detaching it.
+    assert_eq!(
+        scope.in_flight(),
+        1,
+        "the guard must still be held, or the loop above proved nothing"
+    );
+    assert!(
+        !loop_task.is_finished(),
+        "the cancellation arm must await the drain, not spawn it: a loop that \
+         exits here lets leadership release the advisory lock with a provider \
+         future still alive"
+    );
+
+    // The provider call returns; only now may the arm finish.
+    drop(in_flight);
+    tokio::time::timeout(PATIENCE, loop_task)
+        .await
+        .expect("the loop must exit once the scope empties")
+        .expect("the dispatch loop must not panic");
+
+    assert!(
+        drain_stamp_in(&db, &incarnation).await.is_some(),
+        "the production arm must EARN the stamp, or no `calling` row is ever recoverable"
+    );
+    assert_eq!(
+        liveness.quiescence_proof(&incarnation).await,
+        CiQuiescenceProof::GracefulDrain
+    );
+    assert!(
+        scope.is_drained(),
+        "and leadership releases the advisory lock on this flag"
     );
 }
 

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/quiescence.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/quiescence.rs
@@ -48,10 +48,45 @@ use crate::types::ProviderActionScope;
 /// is SIGKILLed. Exceeding it is reported, not retried: the handoff loses its
 /// graceful proof and startup recovery defers.
 ///
-/// Strictly *shorter* than leadership's own `PROVIDER_ACTION_DRAIN_WAIT`, so
-/// the ordinary outcome is "the coordinator finished and stamped", never
-/// "leadership gave up while the coordinator was still joining".
+/// Strictly *shorter* than [`PROVIDER_ACTION_DRAIN_WAIT`], so the ordinary
+/// outcome is "the coordinator finished and stamped", never "leadership gave up
+/// while the coordinator was still joining".
 pub(crate) const PROVIDER_ACTION_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long leadership waits for the drain stamp before releasing the
+/// coordinator advisory lock.
+///
+/// # Why this number lives here and not in `server/src/leadership.rs`
+///
+/// It is not independently choosable. The two budgets are one contract: the
+/// coordinator's join runs *inside* the window leadership keeps the lock open,
+/// so `PROVIDER_ACTION_DRAIN_TIMEOUT < PROVIDER_ACTION_DRAIN_WAIT` is the
+/// difference between "the coordinator finished and stamped" and "leadership
+/// gave up while the coordinator was still joining, and released the lock with
+/// the stamp attempt still outstanding". Written down in two crates the
+/// relation was documented in both and asserted in neither — so a bump to
+/// either number could invert it silently. One owner, one assertion (below),
+/// and leadership consumes it.
+///
+/// Exceeding it is reported and the lock is released without a graceful proof —
+/// degraded but safe, and the safety is entirely on the *proof* side rather
+/// than the lock side: `recover_calling_owner` takes a row only against the
+/// former owner's own `provider_actions_drained_at` stamp. A new lock owner
+/// that finds no stamp defers indefinitely, so an early release costs recovery
+/// latency and can never cost exclusion.
+pub const PROVIDER_ACTION_DRAIN_WAIT: Duration = Duration::from_secs(45);
+
+// The ordering above, enforced at compile time rather than in prose.
+//
+// A `const` assertion cannot be skipped, filtered out, or left un-run, which is
+// what a relation between two constants deserves. The unit test at the bottom
+// of this file exists as well, because a compile error names a file and a line
+// while a test failure names the consequence.
+const _: () = assert!(
+    PROVIDER_ACTION_DRAIN_TIMEOUT.as_nanos() < PROVIDER_ACTION_DRAIN_WAIT.as_nanos(),
+    "the coordinator's drain budget must expire strictly inside leadership's, or \
+     the stamp attempt outlives the window in which the advisory lock is held"
+);
 
 /// What one quiesce attempt actually achieved.
 ///
@@ -160,4 +195,39 @@ pub(crate) async fn quiesce_provider_actions(
         "CoordinatorActor: provider actions quiesced; leadership may release the lock",
     );
     CiDrainOutcome::Stamped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PROVIDER_ACTION_DRAIN_TIMEOUT, PROVIDER_ACTION_DRAIN_WAIT};
+
+    /// The two drain budgets are one contract, and this is the direction of it.
+    ///
+    /// The coordinator joins its provider futures and writes
+    /// `provider_actions_drained_at` while leadership is still holding the
+    /// advisory lock. If the coordinator's budget were the longer of the two,
+    /// leadership would release the lock first and the stamp attempt would land
+    /// (or not) *after* a new incarnation could already have acquired the lock
+    /// and run startup recovery — a stamp written into that window is a proof
+    /// about futures whose owner no longer holds the exclusion authority the
+    /// proof is read under.
+    ///
+    /// NAMED FAILING MUTATIONS: raise `PROVIDER_ACTION_DRAIN_TIMEOUT` to 45s or
+    /// above, or lower `PROVIDER_ACTION_DRAIN_WAIT` to 30s or below. Either
+    /// inverts (or ties) the relation and this fails — as does the `const _`
+    /// assertion beside the constants, which fails at compile time and so also
+    /// catches the mutation in crates that never run this filter.
+    #[test]
+    fn the_drain_budget_expires_strictly_inside_leaderships_wait() {
+        assert!(
+            PROVIDER_ACTION_DRAIN_TIMEOUT < PROVIDER_ACTION_DRAIN_WAIT,
+            "the coordinator's drain budget ({PROVIDER_ACTION_DRAIN_TIMEOUT:?}) must expire \
+             strictly inside leadership's ({PROVIDER_ACTION_DRAIN_WAIT:?}), or the stamp \
+             attempt outlives the window in which the advisory lock is still held"
+        );
+        // Vacuity: both budgets are real waits. A zeroed constant would satisfy
+        // the ordering above while quiescing nothing at all.
+        assert!(!PROVIDER_ACTION_DRAIN_TIMEOUT.is_zero());
+        assert!(!PROVIDER_ACTION_DRAIN_WAIT.is_zero());
+    }
 }

--- a/server/crates/djinn-db/migrations_postgres/196_ci_route_quiescence_proof_graceful_drain_only.sql
+++ b/server/crates/djinn-db/migrations_postgres/196_ci_route_quiescence_proof_graceful_drain_only.sql
@@ -1,0 +1,57 @@
+-- Wave 5 of proposal `nafu`: retire `process_terminated` from the
+-- `calling`-recovery quiescence vocabulary.
+--
+-- ---------------------------------------------------------------------------
+-- Why a legal-looking value is being removed rather than given a producer
+-- ---------------------------------------------------------------------------
+--
+-- 193 admitted two proofs that a former `calling` owner's provider futures were
+-- gone: its own recorded `provider_actions_drained_at` stamp, and "the process
+-- died". The first is a fact the former owner writes about itself. The second
+-- never had a producer, and after auditing every signal available to a
+-- recovering incarnation it cannot have one:
+--
+--   * The only observable that death could leave behind is the release of the
+--     session-scoped coordinator advisory lock, because Postgres releases it
+--     automatically when the holding backend goes away.
+--   * That release is performed by POSTGRES, at backend termination, which is
+--     strictly BEFORE the client process can observe anything. A live process
+--     whose lock connection was dropped by a failover, a restart, a
+--     `pg_terminate_backend`, or a blip therefore looks exactly like a dead one
+--     for as long as it takes that process to notice and exit — and its CI
+--     provider futures are still running throughout.
+--   * Bounding that interval requires elapsed time, which the proposal's AC5
+--     forbids in terms: "elapsed time, owner-lease expiry, cancellation, or
+--     advisory-lock release without provider-action drain never authorizes
+--     `calling` recovery".
+--
+-- So an involuntary lock release proves "the connection died", never "the
+-- process died", and there is no third observable. A value the schema calls
+-- legal but nothing can ever soundly produce is worse than no value at all:
+-- the next reader wires a producer to it, which is precisely the elapsed-time
+-- inference this wave removed. The remaining vocabulary is one real proof and
+-- one honest absence.
+--
+-- The cost, stated plainly: a coordinator SIGKILLed mid-provider-call leaves
+-- its charged `calling` row unrecoverable by anyone. The row is not silent —
+-- `recover_calling_owner` writes a `live_owner_deferred` audit row on every
+-- startup pass — but nothing terminalizes it. That is the conservative side of
+-- the trade, and the one the proposal asks for whenever the evidence is
+-- ambiguous.
+
+-- Any row that recorded the retired spelling is rewritten to the absence it
+-- now denotes. This is expected to touch zero rows: the CI routing feature is
+-- runtime-gated off and no shipped writer ever emitted the value. It is not
+-- optional tidiness, though — `CiQuiescenceProof::parse` rejects a spelling
+-- outside the CHECK vocabulary, so a surviving row would make
+-- `calling_recovery_audit` fail for its whole route rather than for itself.
+UPDATE ci_route_calling_recoveries
+   SET quiescence_proof = 'none'
+ WHERE quiescence_proof = 'process_terminated';
+
+ALTER TABLE ci_route_calling_recoveries
+    DROP CONSTRAINT ci_route_calling_recoveries_quiescence_check;
+
+ALTER TABLE ci_route_calling_recoveries
+    ADD CONSTRAINT ci_route_calling_recoveries_quiescence_check
+    CHECK (quiescence_proof IN ('graceful_drain', 'none'));

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
@@ -418,17 +418,30 @@ durable_enum! {
 durable_enum! {
     /// How a former `calling` owner's provider futures were proven gone.
     ///
-    /// Note what is absent: elapsed time. The 300-second floor is a
-    /// *necessary* condition layered on top of one of these proofs, never a
-    /// substitute for one.
+    /// One proof and one absence, deliberately. Note what is *not* here:
+    /// elapsed time, an expired owner lease, and process death.
+    ///
+    /// The first two are the same mistake — the 300-second floor is a
+    /// *necessary* condition layered on top of the proof, never a substitute
+    /// for one. The third looks different and is not, because it has no
+    /// admissible witness. The only trace an abrupt death could leave is the
+    /// automatic release of the session-scoped coordinator advisory lock, and
+    /// Postgres performs that release at backend termination — strictly before
+    /// the client process can observe anything. A live process whose lock
+    /// connection was dropped by a failover or a restart is therefore
+    /// indistinguishable from a dead one until it notices and exits, with its
+    /// provider futures running throughout, and closing that interval needs
+    /// exactly the elapsed-time inference the proposal forbids. See migration
+    /// 196.
     CiQuiescenceProof {
         /// Leadership cancellation closed action admission, joined every
         /// leader-owned provider-action future, and recorded
         /// `provider_actions_drained_at` before releasing the advisory lock.
+        ///
+        /// The only value that authorises a handoff — and it is re-read from
+        /// the former incarnation's own row rather than believed, so a caller
+        /// cannot assert it into existence.
         GracefulDrain => "graceful_drain",
-        /// The owning process died, which destroyed its futures before its
-        /// advisory-lock session could close.
-        ProcessTerminated => "process_terminated",
         /// No proof. Recorded on deferrals so the deferral is auditable.
         None => "none",
     }
@@ -1749,10 +1762,11 @@ impl CiRouteAttemptRepository {
 
         // (4) quiescence. `None` is never enough, and a claimed graceful
         // drain is checked against the former incarnation's own record rather
-        // than believed.
+        // than believed. There is deliberately no third arm: every attestation
+        // this repository accepts is re-derived from durable state here, so no
+        // caller can win a row by asserting a proof it did not earn.
         let quiescent = match authority.quiescence_proof {
             CiQuiescenceProof::None => false,
-            CiQuiescenceProof::ProcessTerminated => true,
             CiQuiescenceProof::GracefulDrain => {
                 let drained: Option<Option<String>> = sqlx::query_scalar(
                     "SELECT provider_actions_drained_at FROM coordinator_incarnations WHERE id = $1",

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
@@ -1107,6 +1107,92 @@ async fn terminalization_happens_exactly_once_across_reload() {
 // Calling owner handoff
 // ---------------------------------------------------------------------------
 
+/// The quiescence vocabulary is exactly one proof and one absence, in Rust and
+/// in the schema alike.
+///
+/// Migration 196 retired `process_terminated`. It was never producible: the
+/// only trace an abrupt death leaves behind is the automatic release of the
+/// coordinator advisory lock, and Postgres performs that release at backend
+/// termination — before the dying (or merely disconnected) client can react —
+/// so it proves the connection went away and never that the process did.
+/// Closing that gap needs elapsed time, which AC5 forbids.
+///
+/// A dead value that the schema still calls legal is not inert: the next reader
+/// wires a producer to it, which is exactly the elapsed-time inference this
+/// wave removed. So both halves are pinned here.
+///
+/// NAMED FAILING MUTATIONS. (a) Re-add `ProcessTerminated => "process_terminated"`
+/// to the `CiQuiescenceProof` `durable_enum!`: `parse` starts answering `Ok`
+/// and the first assertion fails. (b) Restore migration 193's wider CHECK (or
+/// drop 196's narrowed one): the INSERT succeeds and the second assertion
+/// fails. Neither mutation is caught by any other fixture, because every other
+/// caller of this repository now spells only `GracefulDrain` and `None`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn process_death_is_not_a_quiescence_proof_in_rust_or_in_the_schema() {
+    let f = fixture().await;
+    let repository = repo(&f.db);
+
+    assert!(
+        CiQuiescenceProof::parse("process_terminated").is_err(),
+        "`process_terminated` must not round trip: a spelling the enum accepts \
+         is a spelling a witness can be written for"
+    );
+    // Vacuity: `parse` really does accept the vocabulary that survives, so the
+    // assertion above is about the retired value rather than about `parse`
+    // rejecting everything.
+    assert_eq!(
+        CiQuiescenceProof::parse("graceful_drain").unwrap(),
+        CiQuiescenceProof::GracefulDrain
+    );
+    assert_eq!(
+        CiQuiescenceProof::parse("none").unwrap(),
+        CiQuiescenceProof::None
+    );
+
+    // And the database refuses it independently of Rust. The audit table has a
+    // foreign key onto the route, so a real reserved row goes in first —
+    // otherwise the INSERT would fail for the wrong reason and this would pass
+    // vacuously.
+    let input = reservation(
+        &f.subject,
+        "key-vocabulary",
+        pr_head_identity(1, "headsha-vocabulary"),
+        "fp-a",
+    );
+    repository.reserve(&input).await.unwrap();
+
+    let insert = |proof: &'static str| {
+        let db = f.db.clone();
+        let subject_id = f.subject.id.clone();
+        async move {
+            sqlx::query(
+                r#"INSERT INTO ci_route_calling_recoveries
+                     (id, subject_kind, subject_id, provider_action_key,
+                      recovering_incarnation, holds_exclusive_lock, quiescence_proof,
+                      recovery_reason, calling_recovery_timeout_secs, cas_won)
+                   VALUES ($1, 'task', $2, 'key-vocabulary', $3, TRUE, $4,
+                           'live_owner_deferred', 300, FALSE)"#,
+            )
+            .bind(uuid::Uuid::now_v7().to_string())
+            .bind(subject_id)
+            .bind(uuid::Uuid::now_v7().to_string())
+            .bind(proof)
+            .execute(db.pool())
+            .await
+        }
+    };
+
+    assert!(
+        insert("process_terminated").await.is_err(),
+        "the CHECK must refuse the retired spelling"
+    );
+    // Vacuity again: the same INSERT with a surviving spelling succeeds, so the
+    // refusal above is the CHECK and not a malformed statement.
+    insert("none")
+        .await
+        .expect("the surviving vocabulary still inserts");
+}
+
 /// A live `calling` owner is untouchable. Every illegal recovery shape — no
 /// lock, no quiescence proof, timeout not elapsed, wrong former owner — leaves
 /// the row unchanged and opens no Tier-2 lease, and every one of them is
@@ -1128,17 +1214,18 @@ async fn live_calling_owner_is_never_recovered() {
     let (_handle, sweeper) = reopened(&f.db);
 
     // 1. A periodic sweep that does not hold the exclusive lock.
+    //
+    // The proof passed here and in cases 4 and 5 is the *strongest* one the
+    // vocabulary has. That is the point: each of those deferrals must come
+    // from its own named predicate, so handing the call a proof that would
+    // otherwise be sufficient is what stops the assertion passing because the
+    // quiescence gate happened to refuse first.
     let deferred = sweeper
         .recover_calling_owner(
             &f.subject,
             "key-live",
             &identity,
-            &authority(
-                &owner,
-                &recovering,
-                CiQuiescenceProof::ProcessTerminated,
-                false,
-            ),
+            &authority(&owner, &recovering, CiQuiescenceProof::GracefulDrain, false),
             "lease-live",
         )
         .await
@@ -1177,25 +1264,34 @@ async fn live_calling_owner_is_never_recovered() {
         .unwrap();
     assert_deferred(&deferred, CiCallingRecoveryReason::LiveOwnerDeferred);
 
-    // 4. Process death is proven, but `calling_at` has not aged past the floor.
+    // 4. The drain is now genuinely recorded, so the quiescence gate is
+    //    satisfied — but `calling_at` has not aged past the floor.
+    //
+    //    Completing the owner's drain here is what makes this case test the
+    //    floor rather than re-test case 3: without it the call would defer on
+    //    `LiveOwnerDeferred` again and `TimeoutNotElapsed` would be
+    //    unreachable from this fixture.
+    let incarnations = CoordinatorIncarnationRepository::new(f.db.clone());
+    assert!(incarnations.mark_draining(&owner).await.unwrap());
+    assert!(
+        incarnations
+            .mark_provider_actions_drained(&owner)
+            .await
+            .unwrap()
+    );
     let deferred = sweeper
         .recover_calling_owner(
             &f.subject,
             "key-live",
             &identity,
-            &authority(
-                &owner,
-                &recovering,
-                CiQuiescenceProof::ProcessTerminated,
-                true,
-            ),
+            &authority(&owner, &recovering, CiQuiescenceProof::GracefulDrain, true),
             "lease-live",
         )
         .await
         .unwrap();
     assert_deferred(&deferred, CiCallingRecoveryReason::TimeoutNotElapsed);
 
-    // 5. Aged out, but fenced to the wrong former owner.
+    // 5. Aged out and provably drained, but fenced to the wrong former owner.
     age_calling(&f.db, "key-live", CI_CALLING_RECOVERY_TIMEOUT_SECS + 60).await;
     let deferred = sweeper
         .recover_calling_owner(
@@ -1205,7 +1301,7 @@ async fn live_calling_owner_is_never_recovered() {
             &authority(
                 &incarnation(),
                 &recovering,
-                CiQuiescenceProof::ProcessTerminated,
+                CiQuiescenceProof::GracefulDrain,
                 true,
             ),
             "lease-live",
@@ -1439,7 +1535,7 @@ async fn obsolete_row_handoff_closes_superseded_after_call() {
             &authority(
                 &former,
                 &incarnation(),
-                CiQuiescenceProof::ProcessTerminated,
+                CiQuiescenceProof::GracefulDrain,
                 true,
             ),
             "lease-gone",

--- a/server/src/leadership.rs
+++ b/server/src/leadership.rs
@@ -51,6 +51,17 @@
 
 use std::time::Duration;
 
+// How long leadership waits for the coordinator to quiesce its provider actions
+// before releasing the advisory lock.
+//
+// Owned by `djinn_coordinator::pr_poller::ci_routing::quiescence` rather than
+// declared here, because it is one half of a relation: it must be strictly
+// longer than the coordinator's own drain budget, or leadership gives up while
+// the coordinator is still joining and releases the lock with the stamp attempt
+// still outstanding. Spelled in two crates that relation was documented twice
+// and asserted nowhere; spelled once it carries a compile-time assertion and a
+// unit test inside the CI-routing acceptance filter.
+use djinn_coordinator::PROVIDER_ACTION_DRAIN_WAIT;
 use djinn_db::advisory_lock;
 use djinn_orchestration_types::ProviderActionScope;
 use sqlx::Connection;
@@ -75,37 +86,6 @@ pub const LOCK_OBJID: i32 = 1;
 /// held connection to detect loss. Kept short so promotion after the old pod
 /// exits is sub-deploy-window; the query is a trivial `pg_try_advisory_lock`.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
-
-/// Race for leadership, then run the active subsystems on the winner.
-///
-/// * `dsn` — Postgres DSN for the dedicated lock connection. `None` means
-///   "no advisory lock" (in-process / non-Postgres / dev): we become leader
-///   immediately. The caller passes `None` outside the Kubernetes runtime so
-///   single-process dev and tests don't depend on a reachable Postgres for the
-///   lock.
-/// * `cancel` — process-wide shutdown token. On cancel we release the lock (if
-///   held) and return.
-/// * `on_acquire` — called **exactly once**, when this process becomes leader.
-///   Starts the coordinator + slot pool, the worker RPC listener, and the other
-///   mutating/periodic subsystems.
-///
-/// This future runs for the life of the process: it does not return after
-/// `on_acquire`; it holds the lock until cancellation (or exits the process if
-/// the lock connection is lost). Spawn it as a background task alongside the
-/// HTTP server.
-/// How long leadership waits for the coordinator to quiesce its provider
-/// actions before releasing the advisory lock.
-///
-/// Strictly longer than the coordinator's own drain budget so the ordinary
-/// outcome is "the coordinator finished and stamped", never "leadership gave up
-/// while the coordinator was still joining". Exceeding it is reported and the
-/// lock is released without a graceful proof — degraded but safe, and the
-/// safety is entirely on the *proof* side rather than the lock side:
-/// `recover_calling_owner` takes a row only against the former owner's own
-/// `provider_actions_drained_at` stamp, and `CiIncarnationLiveness` reads no
-/// other fact. A new lock owner that finds no stamp defers indefinitely, so an
-/// early release costs recovery latency and can never cost exclusion.
-const PROVIDER_ACTION_DRAIN_WAIT: std::time::Duration = std::time::Duration::from_secs(45);
 
 /// Close the CI-route provider-action gate and wait for the coordinator's drain
 /// stamp (proposal `nafu`, wave 3).
@@ -152,6 +132,23 @@ async fn quiesce_provider_actions(scope: Option<&ProviderActionScope>) {
     }
 }
 
+/// Race for leadership, then run the active subsystems on the winner.
+///
+/// * `dsn` — Postgres DSN for the dedicated lock connection. `None` means
+///   "no advisory lock" (in-process / non-Postgres / dev): we become leader
+///   immediately. The caller passes `None` outside the Kubernetes runtime so
+///   single-process dev and tests don't depend on a reachable Postgres for the
+///   lock.
+/// * `cancel` — process-wide shutdown token. On cancel we release the lock (if
+///   held) and return.
+/// * `on_acquire` — called **exactly once**, when this process becomes leader.
+///   Starts the coordinator + slot pool, the worker RPC listener, and the other
+///   mutating/periodic subsystems.
+///
+/// This future runs for the life of the process: it does not return after
+/// `on_acquire`; it holds the lock until cancellation (or exits the process if
+/// the lock connection is lost). Spawn it as a background task alongside the
+/// HTTP server.
 pub async fn run_with_leadership<F, Fut>(
     dsn: Option<String>,
     cancel: CancellationToken,


### PR DESCRIPTION
Final correctness item for proposal [nafu](https://code.djinnai.io/proposals/019fccac-e07d-7493-a1bc-18996e7d439a), after all six waves landed (#3062, #3063, #3092, #3080, #3093, #3095).

## Why a quiescence proof is being deleted rather than implemented

W5 stopped `CiIncarnationLiveness` inferring `ProcessTerminated` from a 5-minute heartbeat lapse, because AC5 forbids owner-lease expiry authorizing `calling` recovery. That left `ProcessTerminated` with **no production producer**: the DB accepted it, the CHECK allowed it, a fixture injected it, and nothing could ever emit it.

The obvious repair — record a marker on voluntary advisory-lock release, and treat its absence under a new lock owner as connection-death — **does not work**, and the reason is structural rather than a narrow race:

Postgres performs the release at backend termination *strictly before* the client can observe anything. The interval between "lock becomes acquirable" and "old process learns it lost the lock" is opened by the **server**, so nothing the client does — exiting, aborting futures, writing a marker — happens inside it. Worse, **connection death is not process death**: a network partition, an RDS failover, or `pg_terminate_backend` makes a live leader with in-flight `rerun_failed_jobs` futures indistinguishable from a SIGKILLed one, and the standby acquires within ~2s of polling. Closing that gap requires bounding the client's reaction time — elapsed time — which AC5 names verbatim.

Also rejected: a per-incarnation session lock (same connection-vs-process gap), `pg_stat_activity` on the former backend (same gap), EOF detection via a listener connection (the release still precedes the FIN, and a silent partition leaves the lock *held*). A provider-side fencing token is excluded by the proposal in terms.

So `CiQuiescenceProof::ProcessTerminated` is removed from the enum and the CHECK. AC3 offers process termination as a *permitted alternative* ("cannot be recovered until … or until …"), not a required capability, so recovering only on an observed graceful drain is strictly stricter and remains compliant.

It was also a live footgun: `recover_calling_owner` accepted `ProcessTerminated` on the caller's **bare attestation**, unlike `GracefulDrain`, which it re-reads from the ledger. Any caller passing it won the row.

**Accepted, documented cost:** a coordinator SIGKILLed mid-provider-call leaves its charged `calling` row terminalizable by nobody. Not silent — a `live_owner_deferred` audit row is written every startup pass — and bounded, since a new head or run derives a fresh `provider_action_key`.

## Also closed

- **The actor's cancellation call site** was deletable with the whole suite green (nothing in the coordinator crate constructs a `CoordinatorActor`). A `#[cfg(test)]` shim drives the real private dispatch loop through a real actor, inside AC12 command 1. A shim rather than widened visibility, so the startup-imports proof token stays unforgeable.
- **The drain-budget ordering** — `PROVIDER_ACTION_DRAIN_TIMEOUT` (30s) must stay strictly inside leadership's `PROVIDER_ACTION_DRAIN_WAIT` (45s), previously documented but asserted nowhere. The constant moved into `ci_routing::quiescence`, is consumed by leadership, and is pinned by both a `const _: () = assert!(…)` and a unit test in the AC12 filter.

## Migration 196

Rewrites any surviving `process_terminated` row to `none` *before* narrowing the CHECK. Required, not tidiness: `CiQuiescenceProof::parse` rejects a spelling outside the vocabulary, so a survivor would break `calling_recovery_audit` for its whole route. 193 and 195 are byte-identical to main.

## Known residual, deliberately not fixed here

`server/src/leadership.rs`'s own `quiesce_provider_actions` call site is covered only by `server/tests/leadership_quiescence.rs`, which no AC12 command runs. The smallest honest fix is a spec edit adding that command, not a code change — flagged for the final AC audit to rule on rather than resolved unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
