### PR TITLE
nafu: close the last AC12 wiring holes and give AC11 a provenance fixture

### DIFF
--- a/server/crates/djinn-agent/src/supervisor_impl/ci_routing/guard_tests.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/ci_routing/guard_tests.rs
@@ -731,8 +731,27 @@ async fn a_rejected_repair_on_a_stale_run_absent_route_applies_nothing() {
 /// block into. Overwriting it made a task that was mid-adjudication read as
 /// `NoRoute` on the very next look.
 ///
-/// **Mutation target.** Restore the old from-scratch construction and this goes
-/// red on both the route block and the budget flag.
+/// **What this actually witnesses**, and what it does not. This fixture calls
+/// `merge_reopen_into_directive` directly; it never reaches
+/// `start_monitored_reopen`. So restoring the from-scratch
+/// `json!({"decision": .., "directive": ..})` *at the call site* leaves this
+/// green — an earlier version of this comment claimed otherwise, and that claim
+/// was wrong. The call site is pinned separately by
+/// [`the_reopen_writer_merges_into_the_existing_arbitration_directive`] below;
+/// what is pinned here is the merge semantics that call site depends on.
+///
+/// NAMED FAILING MUTATIONS, all inside `merge_reopen_into_directive`.
+/// (a) Rebuild the object from scratch (`json!({})` instead of cloning
+///     `existing`): the `ci_route` and `terminal_disposition_required`
+///     assertions fail — the route block and the cumulative-budget flag are the
+///     two facts the column carries besides the reopen itself.
+/// (b) Copy only the recognised keys forward instead of cloning: the same two
+///     assertions fail as soon as either key is missed, which is how the budget
+///     flag was lost the first time.
+/// (c) Make the `None` case inherit a default body: the two-key length
+///     assertion on `fresh` fails — a plain arbiter reopen invents nothing.
+/// (d) Drop the `is_object()` filter: the scalar case stops producing
+///     `decision: "reopen"` (it panics on `as_object_mut` instead).
 #[test]
 fn applying_a_reopen_preserves_the_route_block_and_the_budget_flag() {
     use crate::direct_services::merge_reopen_into_directive;

--- a/server/crates/djinn-agent/src/supervisor_impl/ci_routing/guard_tests.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/ci_routing/guard_tests.rs
@@ -779,3 +779,163 @@ fn applying_a_reopen_preserves_the_route_block_and_the_budget_flag() {
     let scalar = merge_reopen_into_directive(Some(&serde_json::json!("legacy text")), "d");
     assert_eq!(scalar["decision"], "reopen");
 }
+
+// ---------------------------------------------------------------------------
+// The production call sites that reach any of the above
+// ---------------------------------------------------------------------------
+
+/// One Rust source with its `//` line comments removed.
+///
+/// The guards below match on *code*. Without this, a comment that merely names
+/// the token under guard would satisfy the assertion the guard exists to make.
+/// Quote- and escape-aware, so a `//` inside a string literal is left alone
+/// rather than truncating the line it sits on.
+fn strip_line_comments(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    for line in source.lines() {
+        let bytes = line.as_bytes();
+        let mut quoted = false;
+        let mut index = 0usize;
+        let mut end = line.len();
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\\' if quoted => index += 1,
+                b'"' => quoted = !quoted,
+                b'/' if !quoted && bytes.get(index + 1) == Some(&b'/') => {
+                    end = index;
+                    break;
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+        out.push_str(&line[..end]);
+        out.push('\n');
+    }
+    out
+}
+
+/// The supervisor's Lead stage arm is what reaches the `nafu` contract at all.
+///
+/// SOURCE-LEVEL, and honestly labelled: `execute_stage` is the enclosing
+/// function, and driving it needs a live session, a slot, a provider transport
+/// and a finalize round trip — none of which this crate carries a double for.
+/// Every behavioural fixture in this file and in the sibling `tests.rs`
+/// therefore enters *below* that arm, at [`apply_under_guard`],
+/// [`stage_outcome_after_guard`], [`adjudicate`], or at the `#[cfg(test)]`
+/// projection `stage::lead_stage_outcome_routed`. So the arm itself is
+/// unwitnessed, and three separate deletions inside it leave the whole `nafu`
+/// command list green while the feature stops existing in production:
+///
+/// * dropping the `read_arbiter_directive` match reverts every Lead session to
+///   the legacy arbiter contract — the "feature disabled" row of the
+///   mixed-version matrix, permanently;
+/// * dropping the `Malformed` arm lets an unparseable `ci_route` block fall
+///   through to that legacy path, which rejects a `diagnose` payload as a
+///   `Failed` stage and parks the task at the arbiter cap — a producer bug in
+///   one JSON field parking tasks whose Lead answered correctly;
+/// * replacing `apply_lead_ci_result` with the bare projection
+///   `ci_routing::stage_outcome(&adjudication.plan)` restores exactly the
+///   wave-4 behaviour wave 5 replaced: the reopen is applied without ever
+///   winning `resolve_tier2_lease`, so a Lead result lands on evidence a newer
+///   head has already superseded.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete the `ci_routing::CiAdjudicationContext::read_arbiter_directive(`
+///     call from the `RoleKind::Lead` arm: the first assertion fails.
+/// (b) Delete the `CiDirectiveRead::Malformed(..)` arm, or make it fall through
+///     to `lead_stage_outcome`: the ordering assertion fails, because
+///     `LeadRouteSuperseded` no longer sits between the `Malformed` arm and the
+///     `Route` arm.
+/// (c) Replace `apply_lead_ci_result(..)` at the call site with
+///     `ci_routing::stage_outcome(..)` or with the `#[cfg(test)]`
+///     `lead_stage_outcome_routed(..)`: the occurrence count drops to one (the
+///     definition alone) and the call assertion fails.
+/// (d) Inline `apply_lead_ci_result`'s body at the call site: the same failure,
+///     for the same reason.
+#[test]
+fn the_supervisors_lead_stage_arm_reads_the_route_and_applies_it_under_the_guard() {
+    let code = strip_line_comments(include_str!("../stage.rs"));
+
+    assert!(
+        code.contains("ci_routing::CiAdjudicationContext::read_arbiter_directive("),
+        "the Lead stage arm must READ the route block; without this call every \
+         Lead session takes the legacy arbiter path and the feature is \
+         unreachable from production",
+    );
+
+    // The application half, and that it is the GUARDED one.
+    assert_eq!(
+        code.matches("apply_lead_ci_result(").count(),
+        2,
+        "exactly two occurrences: the definition and its single production call \
+         site. One means the call was deleted, inlined, or swapped for the \
+         pre-guard projection",
+    );
+    assert!(
+        code.contains("async fn apply_lead_ci_result("),
+        "and one of them must be the definition",
+    );
+
+    // The unparseable block fails closed, and does so BEFORE the route arm.
+    let malformed = code
+        .find("ci_routing::CiDirectiveRead::Malformed(")
+        .expect("the Lead arm must answer an unparseable route block");
+    let route_arm = code
+        .find("ci_routing::CiDirectiveRead::Route(")
+        .expect("the Lead arm must answer a parsed route block");
+    assert!(
+        malformed < route_arm,
+        "the match arms are read in order; `Malformed` must be answered before \
+         `Route`",
+    );
+    assert!(
+        code[malformed..route_arm].contains("StageOutcome::LeadRouteSuperseded"),
+        "an unguardable route block must apply nothing; falling through to the \
+         legacy path parks a task whose Lead answered correctly",
+    );
+}
+
+/// The reopen writer MERGES into the directive rather than rebuilding it.
+///
+/// SOURCE-LEVEL for one specific reason: the sibling fixture
+/// [`applying_a_reopen_preserves_the_route_block_and_the_budget_flag`] calls
+/// `merge_reopen_into_directive` directly, so its own "restore the old
+/// from-scratch construction and this goes red" note is not true of the *call
+/// site*. Restoring `json!({"decision": "reopen", "directive": directive})` at
+/// `start_monitored_reopen` leaves that fixture green, because it never reaches
+/// `start_monitored_reopen` — and the consequence is the wave-5 bug verbatim: a
+/// Lead reopen overwrites the `ci_route` block on the arbitration row it came
+/// from, so the very next read of that hold cycle answers `NoRoute` and the
+/// guard has no row to name.
+///
+/// Driving `start_monitored_reopen` behaviourally is out of reach here: it is a
+/// `DirectServices` method that needs a dispatch ledger, a slot pool and a
+/// monitored session, none of which this crate carries a double for.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Replace the call with a from-scratch `serde_json::json!({..})`: the
+///     binding assertion fails and the occurrence count drops to one.
+/// (b) Delete the call and the binding entirely: the same two failures.
+/// (c) Add a second reopen writer that rebuilds the directive: the count
+///     assertion fails, which is what forces a new writer to be looked at.
+#[test]
+fn the_reopen_writer_merges_into_the_existing_arbitration_directive() {
+    let code = strip_line_comments(include_str!("../../direct_services.rs"));
+
+    assert!(
+        code.contains("let directive_json = merge_reopen_into_directive("),
+        "`start_monitored_reopen` must MERGE the reopen payload into the row's \
+         existing directive; rebuilding it destroys the `ci_route` block the \
+         guard reads on the next look",
+    );
+    assert_eq!(
+        code.matches("merge_reopen_into_directive(").count(),
+        2,
+        "exactly two occurrences: the definition and its single call site",
+    );
+    assert!(
+        code.contains("fn merge_reopen_into_directive("),
+        "and one of them must be the definition",
+    );
+}

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_hold.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_hold.rs
@@ -47,8 +47,8 @@
 
 use djinn_db::{
     CiEvidenceIdentity, CiHoldApply, CiHoldEscalationRoute, CiHoldIdentity,
-    CiIncompleteHoldRepository, CiLane, CiOriginState, CiRouteReservation, CiRouteSubject,
-    CiTier2Reason,
+    CiIncompleteHoldRepository, CiLane, CiOriginState, CiRouteAttemptRepository,
+    CiRouteReservation, CiRouteSubject, CiTier2Reason,
 };
 
 use super::ci_routing::executor::CiTier2Handoff;
@@ -292,9 +292,38 @@ impl CoordinatorActor {
 
     /// Turn an escalated hold's durable route into one Lead session.
     ///
-    /// The handoff is rebuilt from the escalation payload rather than read back
-    /// from the row, because the payload is what the ledger actually wrote —
-    /// reading it back would only prove that `SELECT` inverts `INSERT`.
+    /// The handoff is rebuilt from the escalation payload — which is what the
+    /// ledger was asked to write — with exactly **one** value read back from
+    /// the row: the Tier-2 lease id. That one is not a `SELECT` proving that it
+    /// inverts an `INSERT`; it is the only field whose payload value can differ
+    /// from the durable one, and both paths into this function can produce that
+    /// difference:
+    ///
+    /// * [`escalation_route`] mints `tier2_lease_id` fresh on **every** call,
+    ///   and `insert_escalation_route` writes it `ON CONFLICT DO NOTHING`. When
+    ///   a run-absent route for this identity already existed
+    ///   (`route_inserted == false`), the stored lease is the pre-existing
+    ///   row's and this poll's minted id names no row at all.
+    /// * The [`CiHoldApply::AlreadyEscalated`] re-drive — the recovery for "the
+    ///   lease committed but the dispatch did not" — carries a payload minted
+    ///   after the row was written, so its id is always the wrong one.
+    ///
+    /// Binding the payload's id in either case is not a cosmetic miss.
+    /// `attach_lead_session` is fenced on the stored lease id, so the route
+    /// keeps `lead_session_id` NULL — `unapplied_lead_results` then reads
+    /// "quiescent" with an adjudication in flight — and the `tier2_lease_id`
+    /// the directive carries is the id the supervisor hands
+    /// `resolve_tier2_lease`, which is fenced on the same column. A Lead
+    /// session dispatched under a lease id no row holds can therefore never
+    /// have its result applied: the escalation would spend a session and stay
+    /// wedged, which is the exact failure this dispatch exists to prevent.
+    ///
+    /// A row that is absent, or whose lease is no longer open, dispatches
+    /// **nothing**. There is no lease to bind to and no lease to resolve under,
+    /// so a session started here could only be discarded — and the absent case
+    /// is real: `insert_escalation_route` also conflicts when a *different* row
+    /// on this subject already holds the head's Tier-2 lease, and that row's
+    /// adjudication is the one that owns the head.
     ///
     /// `evidence_references` deliberately omits a run id: there is none, and a
     /// placeholder would be a handle Lead could quote to look grounded while
@@ -312,6 +341,45 @@ impl CoordinatorActor {
                 return;
             }
         };
+        let subject = &escalation.reservation.subject;
+        let key = &escalation.reservation.provider_action_key;
+        let route = match CiRouteAttemptRepository::new(self.db.clone())
+            .get(subject, key)
+            .await
+        {
+            Ok(Some(route)) => route,
+            Ok(None) => {
+                tracing::warn!(
+                    task_id,
+                    key = %key,
+                    "ci hold: the escalated route names no row on this subject, so the \
+                     head's Tier-2 lease is held elsewhere; dispatching nothing"
+                );
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    task_id,
+                    key = %key,
+                    "ci hold: could not read the escalated route's lease; the next poll \
+                     lands on `AlreadyEscalated` and retries the dispatch"
+                );
+                return;
+            }
+        };
+        let lease_id = match (route.holds_open_tier2_lease(), route.tier2_lease_id) {
+            (true, Some(lease_id)) => lease_id,
+            _ => {
+                tracing::warn!(
+                    task_id,
+                    key = %key,
+                    "ci hold: the escalated route holds no open Tier-2 lease, so a Lead \
+                     session dispatched here could bind to nothing and resolve nothing"
+                );
+                return;
+            }
+        };
         let identity = &escalation.reservation.identity;
         let mut references = vec![identity.pr_head_sha.clone(), identity.run_head_sha.clone()];
         if let Some(dequeue) = &identity.dequeue_id {
@@ -323,7 +391,7 @@ impl CoordinatorActor {
         let handoff = CiTier2Handoff {
             subject: escalation.reservation.subject.clone(),
             provider_action_key: escalation.reservation.provider_action_key.clone(),
-            tier2_lease_id: escalation.tier2_lease_id.clone(),
+            tier2_lease_id: lease_id,
             identity: identity.clone(),
             origin_state: escalation.reservation.origin_state,
             reason: escalation.tier2_reason,
@@ -419,6 +487,13 @@ fn escalation_route(
                 &identity.pr_head_sha,
             ),
         },
+        // PROPOSED, not authoritative. `insert_escalation_route` writes this
+        // `ON CONFLICT DO NOTHING`, so it becomes the row's lease only when this
+        // poll is the one that inserts the row; every other call — a conflicting
+        // insert, and every `AlreadyEscalated` re-drive, both of which mint a
+        // fresh one here — leaves a durable lease that this value does not name.
+        // That is why `dispatch_escalated_hold` binds the lease id it reads back
+        // from the row rather than this one.
         tier2_lease_id: uuid::Uuid::now_v7().to_string(),
         tier2_lease_key: tier2_lease_key(
             &identity.subject,

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -5430,6 +5430,68 @@ async fn the_ticks_sweep_block_closes_a_stranded_reservation_and_takes_the_rollb
     );
 }
 
+/// The final argument of the call whose open paren `args` starts just after.
+///
+/// Shared by the two call-site guards below, which both need to know *what* a
+/// production call site was handed rather than merely that it exists.
+fn final_argument(args: &str) -> &str {
+    let mut depth = 1usize;
+    let mut end = args.len();
+    for (index, character) in args.char_indices() {
+        match character {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = index;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    args[..end]
+        .trim()
+        .trim_end_matches(',')
+        .rsplit(',')
+        .next()
+        .unwrap_or_default()
+        .trim()
+}
+
+/// One Rust source with its `//` line comments removed.
+///
+/// The source-level guards below match on *code*. Without this, a comment that
+/// merely names the token under guard would satisfy the assertion the guard
+/// exists to make — which is the failure mode a source guard is most vulnerable
+/// to, and the one that would let this whole family of tests be "fixed" by
+/// writing prose. Quote- and escape-aware, so a `//` inside a string literal is
+/// left alone rather than truncating the line it sits on.
+fn strip_line_comments(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    for line in source.lines() {
+        let bytes = line.as_bytes();
+        let mut quoted = false;
+        let mut index = 0usize;
+        let mut end = line.len();
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\\' if quoted => index += 1,
+                b'"' => quoted = !quoted,
+                b'/' if !quoted && bytes.get(index + 1) == Some(&b'/') => {
+                    end = index;
+                    break;
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+        out.push_str(&line[..end]);
+        out.push('\n');
+    }
+    out
+}
+
 /// The PR poller hands both lane routers the LIVE gate.
 ///
 /// Source-level, and honestly labelled as such, for exactly the reason
@@ -5455,32 +5517,6 @@ async fn the_ticks_sweep_block_closes_a_stranded_reservation_and_takes_the_rollb
 /// (d) Deleting a router call site outright: the call count no longer matches.
 #[test]
 fn the_pr_poller_hands_the_live_gate_to_both_lane_routers() {
-    // The final argument of the call whose open paren `args` starts just after.
-    fn final_argument(args: &str) -> &str {
-        let mut depth = 1usize;
-        let mut end = args.len();
-        for (index, character) in args.char_indices() {
-            match character {
-                '(' => depth += 1,
-                ')' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        end = index;
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-        args[..end]
-            .trim()
-            .trim_end_matches(',')
-            .rsplit(',')
-            .next()
-            .unwrap_or_default()
-            .trim()
-    }
-
     for (label, source, expected_calls) in [
         ("pr_watcher", include_str!("../../pr_watcher.rs"), 2usize),
         ("pr_commands", include_str!("../../pr_commands.rs"), 1usize),
@@ -5513,5 +5549,461 @@ fn the_pr_poller_hands_the_live_gate_to_both_lane_routers() {
             !source.contains("CiRoutingGate::"),
             "{label}: the poller must never name a gate posture; it reads one",
         );
+    }
+}
+
+// ===========================================================================
+// `close_ci_routes_on_success`: the callee, then its two call sites
+// ===========================================================================
+
+/// A newer pass or merge terminalizes this subject's open route and unblocks
+/// the rollback gate.
+///
+/// Behavioural, over the production repository and the production rollback
+/// report. The assertion is the stored `terminal_outcome` and the durable
+/// quiescence row, never the name of the branch the method took.
+///
+/// The chain is the one the proposal's rollback safety argument rests on: an
+/// open route row keeps `current_failed_identity_count` above zero, which keeps
+/// `permits_rollback` false, so a coordinator that never closes its routes on
+/// success can never be rolled back — the drain would sit at "1 route identity
+/// that is still the current failed evidence for its lane" forever, for a PR
+/// that merged.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete the `close_routes_for_newer_outcome` call from
+///     `close_ci_routes_on_success`: the row stays `Reserved` with
+///     `terminal_outcome: None`, and the report stays blocked.
+/// (b) Drop the `gate.owns_routes()` guard: the `DisabledClean` phase — taken
+///     first, on the same row — closes a row the disabled feature must not own.
+/// (c) Invert `if !decision.closes_route() { return; }`, or hand `classify` a
+///     capture other than `merged()`/`passing()`: nothing closes, as in (a).
+/// (d) Swap `CiRouteOutcome::Merged` and `CiRouteOutcome::Passed`: the outcome
+///     assertion fails in both halves of the loop.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn close_ci_routes_on_success_terminalizes_the_route_and_unblocks_rollback() {
+    for (merged, expected) in [
+        (false, CiRouteOutcome::Passed),
+        (true, CiRouteOutcome::Merged),
+    ] {
+        let (db, task_id, subject) = wiring_subject("ci-close-on-success").await;
+        let routes = CiRouteAttemptRepository::new(db.clone());
+        let mut actor = crate::actor::actor_with_test_db(db.clone());
+
+        let checks = [inconclusive_check("Quality Gate / test", 993)];
+        let blocking = refs(&checks);
+        let id = pr_head_identity(993);
+        let fingerprint = transient_fingerprint(CiLane::PrHead, &blocking);
+        let key = plant_reservation(&routes, &subject, &id, &fingerprint).await;
+
+        let before = route_row(&routes, &subject, &key).await;
+        assert_eq!(
+            before.action_phase,
+            CiActionPhase::Reserved,
+            "precondition: one open route for this PR",
+        );
+        assert_eq!(before.terminal_outcome, None);
+
+        // ── The disabled feature owns no routes ─────────────────────────────
+        //
+        // Taken first, and on the same row the draining phase below closes, so
+        // it is a real control rather than a separate fixture that could pass
+        // for reasons of its own.
+        actor.test_ci_routing_gate = Some(CiRoutingGate::DisabledClean);
+        actor
+            .close_ci_routes_on_success(&task_id, PR as u64, merged)
+            .await;
+        assert_eq!(
+            route_row(&routes, &subject, &key).await.action_phase,
+            CiActionPhase::Reserved,
+            "`DisabledClean` owns no route rows, so the close must not touch one",
+        );
+
+        // ── Draining, with the route still open ─────────────────────────────
+        actor.test_ci_routing_gate = Some(CiRoutingGate::Quiescing);
+        let blocked = actor
+            .record_ci_rollback_quiescence_report()
+            .await
+            .expect("quiescence report");
+        assert_eq!(
+            blocked.current_failed_identities, 1,
+            "an open route is still the current failed evidence for its lane",
+        );
+        assert!(
+            !blocked.permits_rollback,
+            "and that alone blocks a binary rollback: {:?}",
+            blocked.blocking_reasons(),
+        );
+
+        // ── The newer authoritative outcome ─────────────────────────────────
+        actor
+            .close_ci_routes_on_success(&task_id, PR as u64, merged)
+            .await;
+
+        let after = route_row(&routes, &subject, &key).await;
+        assert_eq!(
+            after.action_phase,
+            CiActionPhase::Terminal,
+            "a newer pass or merge outranks the open route, staleness included",
+        );
+        assert_eq!(
+            after.terminal_outcome,
+            Some(expected),
+            "and records which authoritative outcome closed it (merged: {merged})",
+        );
+
+        let clean = actor
+            .record_ci_rollback_quiescence_report()
+            .await
+            .expect("quiescence report");
+        assert_eq!(
+            clean.current_failed_identities, 0,
+            "the closed identity has advanced, so the high-watermark is clear",
+        );
+        assert!(
+            clean.permits_rollback,
+            "and the drain is now clean: {:?}",
+            clean.blocking_reasons(),
+        );
+        assert_eq!(
+            clean.permits_rollback,
+            clean.recomputed_verdict(),
+            "the stored verdict must agree with the function it is checked against",
+        );
+    }
+}
+
+/// Both production call sites of `close_ci_routes_on_success` still exist, in
+/// the branches whose behaviour depends on them.
+///
+/// SOURCE-LEVEL, and honestly labelled: this is not an integration test and
+/// does not pretend to be one. Both call sites sit *after*
+/// `gh_client.get_pull_request(..)` inside `poll_pr_draft_tasks`, and
+/// `resolve_installation_client` builds `GitHubApiClient::for_installation`,
+/// which hard-codes `api.github.com` — the crate carries no HTTP double and no
+/// base-URL seam on that path, so nothing here can reach either branch. The
+/// fixture above proves the callee end to end; this one proves production still
+/// reaches it.
+///
+/// It has to exist because deleting *both* calls leaves the method entirely
+/// dead — `warning: method close_ci_routes_on_success is never used` is the only
+/// signal — with the whole `nafu` command list green, while a merged PR silently
+/// stops closing its head's Tier-2 lease.
+///
+/// Comments are stripped before matching, so a comment naming the method
+/// satisfies nothing here.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete either call site: the call count is no longer 2.
+/// (b) Delete both: the same failure, one assertion earlier.
+/// (c) Inline the method's body at either site: the call token disappears, so
+///     the count fails exactly as a deletion does.
+/// (d) Pass the same flag at both sites (both `true`, or both `false`): the
+///     `["true", "false"]` assertion fails — and a merged PR would record
+///     `passed`, or a passing one `merged`.
+/// (e) Move the merged-branch call after `apply_pr_merge`, or out of the
+///     `pr.merged == Some(true)` branch entirely: the first range assertion
+///     fails.
+/// (f) Move the passing-branch call out of the `CiStatus::Passing` arm: the
+///     second range assertion fails.
+/// (g) Shadow the lane-routing method with a local `fn` of the same name in
+///     `pr_watcher.rs`: the no-local-definition assertion fails.
+#[test]
+fn the_pr_poller_closes_ci_routes_on_both_merge_and_pass() {
+    const CALL: &str = "self.close_ci_routes_on_success(";
+
+    let code = strip_line_comments(include_str!("../../pr_watcher.rs"));
+
+    let mut sites: Vec<(usize, &str)> = Vec::new();
+    let mut cursor = 0usize;
+    while let Some(offset) = code[cursor..].find(CALL) {
+        let at = cursor + offset;
+        sites.push((at, final_argument(&code[at + CALL.len()..])));
+        cursor = at + CALL.len();
+    }
+
+    assert_eq!(
+        sites.len(),
+        2,
+        "the merged branch and the passing branch each close this subject's \
+         routes; a changed count needs this test updated, not ignored",
+    );
+    assert_eq!(
+        sites
+            .iter()
+            .map(|(_, argument)| *argument)
+            .collect::<Vec<_>>(),
+        vec!["true", "false"],
+        "the merged branch closes with `merged: true` and the passing branch \
+         with `merged: false`, in that file order",
+    );
+    assert!(
+        !code.contains("fn close_ci_routes_on_success"),
+        "pr_watcher must CALL the lane-routing method, not define one of its own",
+    );
+
+    // ── Each call site sits in the branch that needs it ─────────────────────
+    let merged_branch = code
+        .find("if pr.merged == Some(true) {")
+        .expect("the merged branch is in pr_watcher.rs");
+    let apply_merge = code
+        .find("self.apply_pr_merge(")
+        .expect("the merge transition is in pr_watcher.rs");
+    let passing_arm = code
+        .find("CiStatus::Passing => {")
+        .expect("the passing arm is in pr_watcher.rs");
+    let after_the_match = passing_arm
+        + code[passing_arm..]
+            .find("if pr.mergeable == Some(false) {")
+            .expect("the conflict check follows the CI match");
+
+    assert!(
+        (merged_branch..apply_merge).contains(&sites[0].0),
+        "the merged close must run inside the merged branch and BEFORE \
+         `apply_pr_merge`, or a merge closes the task while its route rows stay \
+         open",
+    );
+    assert!(
+        (passing_arm..after_the_match).contains(&sites[1].0),
+        "the passing close must run inside the `CiStatus::Passing` arm, which is \
+         the only place a newer pass is known",
+    );
+}
+
+/// The sweep EMITS the routing report.
+///
+/// Behavioural, over the report's only production observable. That observable is
+/// a `tracing::info!` event by design — the proposal asks for reporting, not for
+/// a reporting table, and inventing a durable row to make this assertable would
+/// be inventing the thing under test. So the log is not a proxy for the
+/// behaviour, it *is* the behaviour, and `tracing_test` is how this crate
+/// already asserts on one (see
+/// `failover_chain_logging_captures_candidate_events` in
+/// `dispatch::task_dispatch`).
+///
+/// Without this, `self.emit_ci_route_report().await;` could be deleted from
+/// `sweep_ci_routes` with the entire `nafu` command list green: the sibling
+/// sweep fixture asserts the swept ROW, and every count the report reads is
+/// already asserted by `djinn-db`'s own report tests — from a caller that is not
+/// the coordinator.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete `self.emit_ci_route_report().await;` from `sweep_ci_routes`:
+///     nothing emits the event and both assertions fail.
+/// (b) Move it ABOVE `sweep_reserved_routes` in `sweep_ci_routes`: the sweep has
+///     not yet superseded the planted row, every count the early return tests is
+///     zero, the report returns silently, and both assertions fail.
+/// (c) Put it behind the `gate == CiRoutingGate::Quiescing` arm the rollback
+///     report uses: this fixture runs `Enabled`, so nothing is emitted.
+/// (d) Invert `emit_ci_route_report`'s early return (emit only when every count
+///     is zero): the same failure.
+/// (e) Drop `suppressed_before_provider_call` from the emitted fields: the
+///     second assertion fails while the first still passes, which is why the
+///     count is asserted and not only the message.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tracing_test::traced_test]
+async fn the_route_sweep_emits_the_routing_report() {
+    let (db, task_id, subject) = wiring_subject("ci-route-report-wiring").await;
+    let routes = CiRouteAttemptRepository::new(db.clone());
+
+    let mut actor = crate::actor::actor_with_test_db(db.clone());
+    actor.test_ci_routing_gate = Some(CiRoutingGate::Enabled);
+
+    // A head that has MOVED past the reservation's: the sweep supersedes the row
+    // pre-call, which is the one count that makes the report non-silent.
+    actor
+        .persist_ci_snapshot(
+            &task_id,
+            PR as u64,
+            MOVED_HEAD,
+            djinn_core::models::CiStatus::Pending,
+            Vec::new(),
+            None,
+            0,
+            None,
+        )
+        .await;
+
+    let checks = [inconclusive_check("Quality Gate / test", 994)];
+    let blocking = refs(&checks);
+    let id = pr_head_identity(994);
+    let fingerprint = transient_fingerprint(CiLane::PrHead, &blocking);
+    let key = plant_reservation(&routes, &subject, &id, &fingerprint).await;
+    djinn_db::test_support::ci_route_age_reserved_for_test(&db, &subject.id, &key, 600).await;
+
+    assert!(
+        !logs_contain("ci route report"),
+        "precondition: nothing has reported yet",
+    );
+
+    actor.last_ci_route_sweep = a_sweep_interval_ago();
+    actor.drive_tick_for_test().await;
+
+    assert_eq!(
+        route_row(&routes, &subject, &key).await.terminal_outcome,
+        Some(CiRouteOutcome::SupersededPreCall),
+        "precondition for the report: the sweep produced something to report",
+    );
+    assert!(
+        logs_contain("ci route report"),
+        "the sweep must emit the routing report without anyone asking for it",
+    );
+    assert!(
+        logs_contain("suppressed_before_provider_call=1"),
+        "and it must carry the counts, not merely the message",
+    );
+}
+
+/// AC11: the routing modules CONSUME `ci_triage`, and no branch keys on a
+/// forbidden class.
+///
+/// SOURCE-LEVEL, and it cannot be anything else. No observable distinguishes
+/// `ci_triage::is_inconclusive(blocking)` from a byte-identical copy of its body
+/// pasted into this module, so no behavioural mutation can kill a test of
+/// provenance — which is exactly why AC11 had no test at all until this one.
+/// What *is* checkable is that the call token is present and that no local
+/// definition shadows it, and that pair is precisely what "consumed rather than
+/// reimplemented" means.
+///
+/// # A fingerprint keyed on the job name is not a branch
+///
+/// `transient_fingerprint` hashes `cr.name.trim().to_lowercase()` into its
+/// preimage, so the job name genuinely *is* an input to `nafu` code. AC11
+/// forbids a branch keyed on the job name — a decision that comes out different
+/// because a check happens to be called one thing rather than another. A hash
+/// input is the opposite of that: every name is treated identically, and two
+/// runs of the same failing job share a budget precisely because the hash does
+/// not care what the job is. So the assertion below is written against
+/// *comparisons* applied to the key classes rather than against their
+/// appearance, and this paragraph is the reason it has to be.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Replace `ci_triage::is_inconclusive(blocking)` in `classify` with a local
+///     reimplementation (`blocking.iter().all(|cr| …)`): the call token is gone
+///     and the first assertion fails.
+/// (b) Copy `ci_triage`'s predicate into a routing module as
+///     `fn is_inconclusive`: the no-local-definition assertion fails.
+/// (c) Add `if cr.name.contains("Quality Gate") { … }` — or any comparison on a
+///     check name, `target.repo`, `target.owner`, or `repository_id` — anywhere
+///     in a routing module: the forbidden-branch assertion fails, naming the
+///     file and line.
+/// (d) Special-case a migration framework, a build tool, an artifact type, or a
+///     provider incident label (`"sqlx"`, `"cargo"`, `"incident"`, …): the
+///     forbidden-vocabulary assertion fails. A branch on one of those classes
+///     has to name it.
+#[test]
+fn the_routing_modules_consume_ci_triage_and_branch_on_no_forbidden_key() {
+    // Every `nafu`-owned production module in this crate. Test modules are
+    // separate files and are deliberately excluded: a fixture may say whatever
+    // it likes about a job name.
+    const ROUTING_MODULES: [(&str, &str); 8] = [
+        ("ci_routing.rs", include_str!("../../ci_routing.rs")),
+        (
+            "ci_lane_routing.rs",
+            include_str!("../../ci_lane_routing.rs"),
+        ),
+        ("ci_hold.rs", include_str!("../../ci_hold.rs")),
+        ("ci_reporting.rs", include_str!("../../ci_reporting.rs")),
+        ("ci_routing/executor.rs", include_str!("../executor.rs")),
+        ("ci_routing/gate.rs", include_str!("../gate.rs")),
+        ("ci_routing/quiescence.rs", include_str!("../quiescence.rs")),
+        (
+            "ci_routing/tier2_dispatch.rs",
+            include_str!("../tier2_dispatch.rs"),
+        ),
+    ];
+
+    // The evidence-ranking entry points AC11 requires be consumed.
+    const CONSUMED: [&str; 3] = [
+        "ci_triage::is_inconclusive(",
+        "ci_triage::check_evidence(",
+        "ci_triage::completed_after_start(",
+    ];
+
+    // Field accesses that reach a forbidden key class.
+    const FORBIDDEN_KEYS: [&str; 4] = [".name", "target.repo", "target.owner", "repository_id"];
+
+    // What turns reading a key class into branching on one.
+    const COMPARISONS: [&str; 6] = [
+        "==",
+        "!=",
+        ".contains(",
+        ".starts_with(",
+        ".ends_with(",
+        ".eq_ignore_ascii_case(",
+    ];
+
+    // Migration frameworks, build tools, artifact types, and incident labels. A
+    // branch on any of those classes has to name one of these words.
+    const FORBIDDEN_VOCABULARY: [&str; 15] = [
+        "sqlx",
+        "diesel",
+        "flyway",
+        "liquibase",
+        "alembic",
+        "cargo",
+        "gradle",
+        "maven",
+        "bazel",
+        "webpack",
+        "npm",
+        "pnpm",
+        "artifact",
+        "incident",
+        "outage",
+    ];
+
+    let classifier = strip_line_comments(ROUTING_MODULES[0].1);
+    for consumed in CONSUMED {
+        assert!(
+            classifier.contains(consumed),
+            "the classifier must CONSUME `{consumed}`: the ranking that decides \
+             Tier 1 is `ci_triage`'s, and a second copy of it here is the \
+             reimplementation AC11 forbids",
+        );
+    }
+
+    for (label, source) in ROUTING_MODULES {
+        let code = strip_line_comments(source);
+
+        for consumed in CONSUMED {
+            let local = consumed
+                .trim_start_matches("ci_triage::")
+                .trim_end_matches('(');
+            assert!(
+                !code.contains(&format!("fn {local}")),
+                "{label}: `{local}` belongs to `ci_triage`; a local definition of \
+                 it is a reimplementation, however faithful",
+            );
+        }
+
+        for (index, line) in code.lines().enumerate() {
+            if !FORBIDDEN_KEYS.iter().any(|key| line.contains(key)) {
+                continue;
+            }
+            let number = index + 1;
+            let text = line.trim();
+            for comparison in COMPARISONS {
+                assert!(
+                    !line.contains(comparison),
+                    "{label}:{number}: `{text}` applies `{comparison}` to a \
+                     forbidden key class. AC11 allows a job name, repository, or \
+                     owner to be *carried* — hashed into a fingerprint, logged, \
+                     cited as evidence, passed to the provider — and forbids a \
+                     route decision that differs because of one.",
+                );
+            }
+        }
+
+        let lowered = code.to_ascii_lowercase();
+        for forbidden in FORBIDDEN_VOCABULARY {
+            assert!(
+                !lowered.contains(forbidden),
+                "{label}: routing code must not name `{forbidden}`. A branch keyed \
+                 on a migration framework, build tool, artifact type, or provider \
+                 incident label has to name one, and AC11 forbids every such \
+                 branch — the contract is keyed on execution evidence alone.",
+            );
+        }
     }
 }

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -3282,6 +3282,147 @@ async fn an_annotation_failure_after_correlation_routes_to_guarded_tier_two() {
     );
 }
 
+/// A lane-opened Tier-2 lease becomes a Lead session, bound to that route.
+///
+/// `CiLaneRouting::settle` calls `dispatch_opened_tier2_leases`, and until this
+/// fixture existed that call could be deleted with the entire `nafu` command
+/// list green. Every other lane fixture asserts the *lease* (`1`) and the
+/// absence of a worker (`0`), and neither number moves when the dispatch is
+/// removed. The one fixture that does assert an arbitration row — the
+/// twelve-poll hold escalation — reaches Lead through `ci_hold`'s own
+/// `dispatch_escalated_hold`, a different call site entirely, so it stays green
+/// too.
+///
+/// The consequence of the deletion is precisely the wedge the comment at that
+/// call site describes: the lane withholds the legacy remediation path because
+/// an adjudication is pending, and nothing ever adjudicates. The task sits in
+/// `pr_review` with an open head-scoped lease that also blocks every other
+/// Tier-2 route for that head.
+///
+/// `lead_session_id` is asserted, not merely the arbitration count: a row that
+/// happens to exist proves the coordinator wrote *an* arbitration, while the
+/// binding proves it wrote the one **this** route is adjudicated under. That
+/// binding is also what makes `unapplied_lead_results` in the rollback
+/// quiescence report mean "a Lead was dispatched" rather than "a lease exists".
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete `self.dispatch_opened_tier2_leases(outcomes, task_id).await;`
+///     from `settle`: no arbitration row, the task stays `pr_review`, and the
+///     route row's `lead_session_count` stays `0`.
+/// (b) Read the boolean instead of the handoff in `dispatch_opened_tier2_leases`
+///     (`Tier2 { lease_opened: true, .. } => …` with no handoff to bind): there
+///     is nothing to pass to `dispatch_ci_tier2_lead`, so it cannot compile —
+///     and if it is made to, the `provider_action_key` assertion fails.
+/// (c) Move the dispatch above `fold` and into the `CompleteEmpty` arm: this
+///     route is not complete-empty, so nothing dispatches, as in (a).
+/// (d) Drop the `attach_lead_session` call from `dispatch_ci_tier2_lead`: the
+///     arbitration and the board transition still land, and the two
+///     `lead_session_*` assertions fail alone.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_lane_opened_tier2_lease_becomes_a_lead_session_bound_to_its_route() {
+    let h = lane_harness().await;
+    let provider = FakeProvider::default();
+    provider.set_check_runs(vec![causal_check("merge-group / integration", 980)]);
+
+    assert_eq!(
+        arbitration_rows(&h.db).await,
+        0,
+        "precondition: nothing has adjudicated anything yet",
+    );
+    assert_eq!(
+        djinn_db::test_support::task_status_for_test(&h.db, &h.task_id).await,
+        "pr_review",
+        "precondition: the task starts in this lane's origin state",
+    );
+
+    let disposition = h
+        .actor
+        .route_merge_group_ci_evidence(
+            &provider,
+            &h.task_id,
+            "task-short",
+            "acme",
+            "widgets",
+            PR as u64,
+            HEAD,
+            "PR_node",
+            MergeMethod::Squash,
+            &[merge_group_run(980)],
+            Some(&dequeue_event()),
+            CiRoutingGate::Enabled,
+        )
+        .await;
+
+    assert!(disposition.is_routed());
+    assert_eq!(
+        djinn_db::test_support::ci_route_lease_count_for_test(&h.db, &h.task_id).await,
+        1,
+        "precondition: a complete causal failure opens exactly one adjudication",
+    );
+
+    // ── The lease became a Lead session ─────────────────────────────────────
+    assert_eq!(
+        arbitration_rows(&h.db).await,
+        1,
+        "an opened lease must become a Lead session, or the lane suppresses the \
+         legacy path and nothing adjudicates in its place",
+    );
+    assert_eq!(
+        djinn_db::test_support::task_status_for_test(&h.db, &h.task_id).await,
+        "needs_lead_intervention",
+        "and the board must enter the only lane a Lead session runs from",
+    );
+
+    // ── …and it is bound to THIS route, not merely coincident with it ───────
+    let identity = CiEvidenceIdentity {
+        lane: CiLane::MergeGroup,
+        pr_number: PR,
+        pr_head_sha: HEAD.to_owned(),
+        run_id: Some(980),
+        run_head_sha: MERGE_GROUP_SHA.to_owned(),
+        dequeue_id: Some(DEQUEUE_ID.to_owned()),
+    };
+    let subject = CiRouteSubject::task(h.task_id.clone());
+    let key = provider_action_key(&subject, &identity, CiAction::AskLead);
+    let row = CiRouteAttemptRepository::new(h.db.clone())
+        .get(&subject, &key)
+        .await
+        .expect("route read")
+        .expect("a complete causal merge-group failure takes one Tier-2 route");
+    assert_eq!(
+        row.lead_session_count, 1,
+        "exactly one Lead session is attached to the route it adjudicates",
+    );
+    assert!(
+        row.lead_session_id
+            .as_deref()
+            .is_some_and(|id| id.starts_with(&format!("arbitration:{}:", h.task_id))),
+        "the route must name the arbitration adjudicating it, got {:?}",
+        row.lead_session_id,
+    );
+
+    let directive =
+        djinn_db::repositories::task_arbitration::TaskArbitrationRepository::new(h.db.clone())
+            .get_latest_for_task(&h.task_id)
+            .await
+            .expect("arbitration read")
+            .and_then(|record| record.directive)
+            .expect("the dispatch writes the directive the Lead session reads");
+    assert_eq!(
+        directive["ci_route"]["provider_action_key"].as_str(),
+        Some(key.as_str()),
+        "the block Lead reads must name the route the lease was opened on",
+    );
+
+    // ── And the adjudication spends nothing else ────────────────────────────
+    assert_eq!(provider.calls().mutations(), 0, "no provider mutation");
+    assert_eq!(
+        djinn_db::test_support::task_attempt_count_for_test(&h.db, &h.task_id).await,
+        0,
+        "a Tier-2 adjudication dispatches no worker",
+    );
+}
+
 /// A dequeue this poll cannot name leaves the lane to the legacy path rather
 /// than inventing an identity it could not revalidate on a later poll.
 #[tokio::test]

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -5911,6 +5911,187 @@ fn the_pr_poller_closes_ci_routes_on_both_merge_and_pass() {
     );
 }
 
+/// The end of the `{`-delimited block that starts at `open`.
+///
+/// Used by the disposition-branch guard below to tell "inside the branch" from
+/// "after the branch" — the whole difference between a legacy remedy that is
+/// *replaced* by a route and one that runs *in addition to* it.
+fn block_end(code: &str, open: usize) -> usize {
+    let bytes = code.as_bytes();
+    assert_eq!(
+        bytes[open], b'{',
+        "block_end must start on an opening brace"
+    );
+    let mut depth = 0usize;
+    for (index, byte) in bytes.iter().enumerate().skip(open) {
+        match *byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return index;
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unbalanced braces from offset {open}");
+}
+
+/// The PR-draft lane's two legacy remedies are *replaced* by a route, never run
+/// alongside one.
+///
+/// SOURCE-LEVEL, and honestly labelled, for the reason the sibling guards above
+/// carry: both branches sit after `gh_client.get_pull_request(..)` inside
+/// `poll_pr_draft_tasks`, and `resolve_installation_client` builds
+/// `GitHubApiClient::for_installation`, which hard-codes `GITHUB_API_BASE`
+/// (`api.github.com`). This crate carries no HTTP double and no base-URL seam on
+/// that path, so no fixture here can reach either branch; every behavioural
+/// fixture in this file enters at `route_pr_head_ci_evidence` and asserts what
+/// the *callee* answered.
+///
+/// The sibling guards pin the *presence* of the two router calls and the live
+/// gate. Neither pins the BRANCH SHAPE around them, and the shape is the whole
+/// contract: a `CiLaneOutcome` that routed must turn the legacy machinery OFF.
+/// Delete a guard and the legacy remedy runs **in addition to** the route rather
+/// than instead of it, so one routed failure buys both an evidence-led remedy
+/// and the old generic `PrCiFailed` reopen — the double-spent session this
+/// proposal exists to stop — with the entire `nafu` command list green, because
+/// the callee still returns exactly what every behavioural fixture asserts.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete `if !routed.is_routed() {` around `retrigger_inconclusive_run`:
+///     the guard string is gone, so the `expect` on it fails. A routed
+///     inconclusive run would then be retriggered by the route layer AND by the
+///     in-memory legacy dedupe, double-charging the same evidence.
+/// (b) Invert it to `if routed.is_routed() {`: the same `expect` fails, because
+///     the guard is matched with its `!` — and the legacy retrigger would fire
+///     only when the route layer already handled the run.
+/// (c) Move `retrigger_inconclusive_run` out of that block: the containment
+///     assertion fails.
+/// (d) Move the `continue;` INSIDE the `!routed.is_routed()` block: the
+///     "continue after the block" assertion fails — a routed inconclusive lane
+///     would fall through to the undraft path and un-draft a PR whose CI said
+///     nothing.
+/// (e) Delete `if routed.is_routed() && routed.complete_empty().is_none() {`
+///     from the failing arm, or drop its `continue;`: the corresponding
+///     `expect`/containment assertion fails, and a routed causal failure would
+///     reach `handle_ci_failure` as well as its Tier-2 route.
+/// (f) Delete `if routed.complete_empty().is_none() {` around
+///     `handle_ci_failure`: that `expect` fails. An authoritatively complete
+///     *empty* enumeration — the no-CI compatibility path, already recorded
+///     `Passing` by the route layer — would be handed to the legacy failure
+///     remedy.
+/// (g) Reorder so `handle_ci_failure` precedes either guard: the ordering
+///     assertions fail.
+/// (h) Add a second call to either legacy remedy anywhere in the file: the
+///     occurrence-count assertions fail, which is what forces a new caller to be
+///     looked at rather than silently inheriting no guard.
+#[test]
+fn a_routed_pr_draft_disposition_turns_the_legacy_remedy_off() {
+    let code = strip_line_comments(include_str!("../../pr_watcher.rs"));
+
+    let find = |needle: &str, what: &str| -> usize {
+        code.find(needle)
+            .unwrap_or_else(|| panic!("{what}: `{needle}` is not in pr_watcher.rs"))
+    };
+    let count = |needle: &str| code.matches(needle).count();
+
+    // ── Arm boundaries. Everything below is asserted WITHIN one arm, so a
+    //    guard that drifted into a neighbouring arm reads as deleted. ────────
+    let inconclusive_arm = find("CiStatus::Inconclusive => {", "the inconclusive arm");
+    let pending_arm = find(
+        "CiStatus::Pending | CiStatus::Unknown => {",
+        "the pending arm",
+    );
+    let failing_arm = find("CiStatus::Failing => {", "the failing arm");
+    let passing_arm = find("CiStatus::Passing => {", "the passing arm");
+    assert!(
+        inconclusive_arm < pending_arm && pending_arm < failing_arm && failing_arm < passing_arm,
+        "the four CI-status arms are read in file order; a changed order needs \
+         this test updated, not ignored",
+    );
+
+    // ── Inconclusive: the legacy retrigger is the else-branch of the route ──
+    const RETRIGGER: &str = "self.retrigger_inconclusive_run(";
+    const ROUTED_GUARD: &str = "if !routed.is_routed() {";
+    assert_eq!(
+        count(RETRIGGER),
+        1,
+        "one legacy retrigger call site; a second one would inherit no guard",
+    );
+    let retrigger = find(RETRIGGER, "the legacy retrigger");
+    let routed_guard = find(ROUTED_GUARD, "the routed-disposition guard");
+    assert!(
+        (inconclusive_arm..pending_arm).contains(&retrigger)
+            && (inconclusive_arm..pending_arm).contains(&routed_guard),
+        "both live in the inconclusive arm",
+    );
+    let routed_block = block_end(&code, routed_guard + ROUTED_GUARD.len() - 1);
+    assert!(
+        (routed_guard..routed_block).contains(&retrigger),
+        "the legacy retrigger must run ONLY when the route layer declined; \
+         outside that block it runs in addition to the route",
+    );
+    assert!(
+        code[routed_block..pending_arm].contains("continue;"),
+        "and the hold must be OUTSIDE that block — a routed inconclusive run \
+         holds too, it just holds without a second retrigger",
+    );
+
+    // The no-CI compatibility path is the one thing that does NOT hold.
+    let complete_empty = find(
+        "if routed.complete_empty().is_some() {",
+        "the complete-empty fall-through",
+    );
+    assert!(
+        (inconclusive_arm..routed_guard).contains(&complete_empty),
+        "an authoritatively complete EMPTY enumeration falls through to undraft \
+         before the hold, or a repository with no CI wedges in `pr_draft`",
+    );
+
+    // ── Failing: routed holds, and complete-empty is never a failure ────────
+    const LEGACY_FAILURE: &str = ".handle_ci_failure(";
+    const HOLD_GUARD: &str = "if routed.is_routed() && routed.complete_empty().is_none() {";
+    const EMPTY_GUARD: &str = "if routed.complete_empty().is_none() {";
+    assert_eq!(
+        count(LEGACY_FAILURE),
+        1,
+        "one legacy failure-remedy call site in this lane",
+    );
+    let legacy_failure = find(LEGACY_FAILURE, "the legacy failure remedy");
+    let hold_guard = find(HOLD_GUARD, "the routed-holds guard");
+    let empty_guard = find(EMPTY_GUARD, "the complete-empty guard");
+    assert!(
+        (failing_arm..passing_arm).contains(&legacy_failure)
+            && (failing_arm..passing_arm).contains(&hold_guard)
+            && (failing_arm..passing_arm).contains(&empty_guard),
+        "all three live in the failing arm",
+    );
+    assert!(
+        hold_guard < empty_guard && empty_guard < legacy_failure,
+        "the routed hold is answered first, then complete-empty, and only then \
+         is the legacy remedy reachable",
+    );
+    let hold_block = block_end(&code, hold_guard + HOLD_GUARD.len() - 1);
+    assert!(
+        code[hold_guard..hold_block].contains("continue;"),
+        "a routed causal failure must LEAVE the poll; falling out of this block \
+         hands the same evidence to `handle_ci_failure` as well",
+    );
+    assert!(
+        hold_block < empty_guard,
+        "and it must leave before the legacy remedy's own guard",
+    );
+    let empty_block = block_end(&code, empty_guard + EMPTY_GUARD.len() - 1);
+    assert!(
+        (empty_guard..empty_block).contains(&legacy_failure),
+        "the legacy failure remedy must sit INSIDE the complete-empty guard; \
+         outside it, a no-CI enumeration the route layer already recorded \
+         `Passing` gets remediated as a failure",
+    );
+}
+
 /// The sweep EMITS the routing report.
 ///
 /// Behavioural, over the report's only production observable. That observable is

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -4816,7 +4816,16 @@ async fn head_advance_clears_hold_streak() {
 ///   watermark (`Superseded`).
 ///
 /// Either way there is exactly one `escalated_at`, one run-absent route row, one
-/// open Tier-2 lease, and one Lead adjudication.
+/// open Tier-2 lease, and one Lead adjudication — bound to that route, because
+/// an arbitration row that exists and a route that names it are different
+/// claims, and only the second one `unapplied_lead_results` can read.
+///
+/// This is the escalating poll's own dispatch, where the lease id the payload
+/// minted and the one the row stores are the same value: this poll is the one
+/// that inserted the row. The other two entries into `dispatch_escalated_hold`
+/// — a conflicting insert and the `AlreadyEscalated` re-drive — cannot rely on
+/// that, and are covered by
+/// `an_escalated_hold_redrive_binds_the_lease_its_route_holds`.
 #[tokio::test]
 async fn count_eleven_race_escalates_once_at_twelve() {
     let h = lane_harness().await;
@@ -4987,6 +4996,29 @@ async fn count_eleven_race_escalates_once_at_twelve() {
     assert_eq!(row.identity.run_id, None, "absence, never a sentinel");
     assert_eq!(row.action, CiAction::AskLead);
 
+    // …and the adjudication is BOUND to that route rather than merely coincident
+    // with it. Counting `task_arbitrations` proves the escalation wrote *an*
+    // arbitration; only `lead_session_id` proves it wrote the one this route is
+    // adjudicated under, which is what `unapplied_lead_results` reads. Exactly
+    // one attach happens however the race lands: whichever poll creates the
+    // arbitration is the one that binds, and the other finds it unconsumed and
+    // answers `AlreadyInFlight` before reaching the attach.
+    let adjudication =
+        djinn_db::repositories::task_arbitration::TaskArbitrationRepository::new(h.db.clone())
+            .get_latest_for_task(&h.task_id)
+            .await
+            .expect("arbitration read")
+            .expect("the escalation dispatches one Lead session");
+    assert_eq!(
+        row.lead_session_count, 1,
+        "one Lead session attached to the escalated route, not zero and not two",
+    );
+    assert_eq!(
+        row.lead_session_id.as_deref(),
+        Some(adjudication.id.as_str()),
+        "and the route names the arbitration row adjudicating it",
+    );
+
     // And an escalation still buys no provider call, no worker, and no charge.
     assert_eq!(first.calls().mutations(), 0);
     assert_eq!(second.calls().mutations(), 0);
@@ -4999,6 +5031,284 @@ async fn count_eleven_race_escalates_once_at_twelve() {
         charged_budget_counters(&h.db).await,
         0,
         "`ask_lead` consumes no Tier-1 charge",
+    );
+}
+
+/// An escalated hold's re-drive binds the lease its ROW holds, not the one its
+/// payload minted.
+///
+/// # Why the sibling twelve-poll fixture cannot see this
+///
+/// It asserts `arbitration_rows == 1` and never reads `lead_session_*`, and the
+/// escalating poll there is also the one that INSERTS the route — so the id it
+/// minted and the id the row stores are the same value by accident of timing,
+/// and every attach matches its fence. Both other ways into
+/// `dispatch_escalated_hold` break that coincidence:
+///
+/// * `escalation_route` mints `tier2_lease_id` fresh on every call while
+///   `insert_escalation_route` writes it `ON CONFLICT DO NOTHING`, so
+///   `Escalated { route_inserted: false }` dispatches against an id no row
+///   holds; and
+/// * the `AlreadyEscalated` re-drive — the recovery for "the lease committed
+///   but the dispatch did not" — always mints its id after the row was written.
+///
+/// This fixture drives the second one, because it is the case where the
+/// re-drive is the poll that finally creates the arbitration: escalate with the
+/// dispatch unable to land, then poll again and require that the Lead session
+/// the re-drive dispatches is bound to the durable lease.
+///
+/// The escalating poll is handed a task id that names no row, which is exactly
+/// `dispatch_escalated_hold`'s own `Ok(None) => return` arm and exactly the
+/// production shape its `AlreadyEscalated` comment describes: the ledger's
+/// transaction commits the route and its open lease, and the board-side half —
+/// which cannot be in that transaction — does not happen. Nothing else about
+/// the fixture is arranged; the streak, the route, the lease and both
+/// dispatches are the production ones.
+///
+/// # Why the binding, and not just the arbitration row
+///
+/// The stored lease id fences BOTH ends of the adjudication.
+/// `attach_lead_session` writes `lead_session_id` only when the id matches, and
+/// the supervisor hands the directive's `tier2_lease_id` to
+/// `resolve_tier2_lease`, which is fenced on the same column. A Lead session
+/// dispatched under a minted id therefore looks completely successful — row,
+/// directive, board transition — while `unapplied_lead_results` reads
+/// "quiescent" and the result, whenever it arrives, can never be applied. The
+/// escalation would spend a session and stay wedged, which is the failure the
+/// re-drive exists to prevent.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Restore `tier2_lease_id: escalation.tier2_lease_id.clone()` in the
+///     handoff (i.e. drop the read-back): the re-drive's minted id names no
+///     row, so `attach_lead_session` misses its fence — `lead_session_count`
+///     stays `0` and `lead_session_id` NULL — and the directive assertion fails
+///     with the minted id in place of the stored one. Every other observable
+///     (arbitration row, directive block, board state) is unchanged, which is
+///     why nothing else here catches it.
+/// (b) Delete the `dispatch_escalated_hold` call from the `AlreadyEscalated`
+///     arm: no arbitration row exists at all, so the `expect` on the
+///     arbitration fails. The route keeps an open lease with nothing
+///     adjudicating it, and the lease is head-scoped, so it also blocks every
+///     other Tier-2 route for that head.
+/// (c) Drop the `holds_open_tier2_lease()` guard, or read the lease id without
+///     requiring the lease to be open: phase three's re-drive over a RESOLVED
+///     lease dispatches a second Lead session, opening a second hold cycle
+///     whose result `resolve_tier2_lease` can never apply — `arbitration_rows`
+///     becomes 2.
+/// (d) Bind the row's id but leave the directive on the payload's (two sources
+///     for one lease): the directive assertion fails alone, and the supervisor
+///     would resolve nothing.
+#[tokio::test]
+async fn an_escalated_hold_redrive_binds_the_lease_its_route_holds() {
+    let h = lane_harness().await;
+    let identity = pr_head_hold_identity(&h.task_id);
+    let hold_reason = crate::pr_poller::ci_routing::CiIncompleteReason::EnumerationPageFailed;
+    // Named once: every poll below is the same logical lane observation, and a
+    // second reason would start a different argument than the one under test.
+    let poll_once = async |task_id: &str| {
+        let poll = h
+            .actor
+            .reserve_ci_hold_poll(identity.clone())
+            .await
+            .expect("reservation");
+        h.actor
+            .apply_ci_hold_poll(
+                &poll,
+                &identity,
+                false,
+                CiOriginState::PrDraft,
+                hold_reason,
+                task_id,
+            )
+            .await
+    };
+
+    // ── Phase one: the lease commits and the dispatch does not ──────────────
+    let orphan_task = uuid::Uuid::now_v7().to_string();
+    for expected in 1..=djinn_db::CI_INCOMPLETE_HOLD_MAX_POLLS {
+        let absorbed = if expected == djinn_db::CI_INCOMPLETE_HOLD_MAX_POLLS {
+            crate::pr_poller::ci_hold::CiHoldAbsorption::Escalated {
+                route_inserted: true,
+            }
+        } else {
+            crate::pr_poller::ci_hold::CiHoldAbsorption::Held {
+                poll_count: expected,
+            }
+        };
+        assert_eq!(
+            poll_once(&orphan_task).await,
+            crate::pr_poller::ci_hold::CiHoldDisposition::Absorbed(absorbed),
+            "poll {expected} of {}",
+            djinn_db::CI_INCOMPLETE_HOLD_MAX_POLLS,
+        );
+    }
+
+    let subject = CiRouteSubject::task(h.task_id.clone());
+    let run_absent = CiEvidenceIdentity {
+        lane: CiLane::PrHead,
+        pr_number: PR,
+        pr_head_sha: HEAD.to_owned(),
+        run_id: None,
+        run_head_sha: HEAD.to_owned(),
+        dequeue_id: None,
+    };
+    let routes = CiRouteAttemptRepository::new(h.db.clone());
+    let key = provider_action_key(&subject, &run_absent, CiAction::AskLead);
+    let escalated = routes
+        .get(&subject, &key)
+        .await
+        .expect("route read")
+        .expect("the escalating transaction writes the run-absent route");
+    let lease_id = escalated
+        .tier2_lease_id
+        .clone()
+        .expect("the escalation opens the lease on the INSERT itself");
+    assert!(
+        escalated.holds_open_tier2_lease(),
+        "precondition: the durable lease is open and unadjudicated",
+    );
+    assert_eq!(
+        escalated.lead_session_count, 0,
+        "precondition: the dispatch did NOT land — otherwise phase two would be \
+         witnessing a binding that already existed",
+    );
+    assert_eq!(escalated.lead_session_id, None);
+    assert_eq!(
+        arbitration_rows(&h.db).await,
+        0,
+        "precondition: no Lead session was dispatched for the escalation",
+    );
+    assert_eq!(
+        djinn_db::test_support::task_status_for_test(&h.db, &h.task_id).await,
+        "pr_review",
+        "precondition: and the board never entered the Lead lane",
+    );
+
+    // ── Phase two: the re-drive is the poll that dispatches ─────────────────
+    assert_eq!(
+        poll_once(&h.task_id).await,
+        crate::pr_poller::ci_hold::CiHoldDisposition::Absorbed(
+            crate::pr_poller::ci_hold::CiHoldAbsorption::AlreadyEscalated
+        ),
+        "an escalated streak absorbs every later poll",
+    );
+
+    let arbitrations =
+        djinn_db::repositories::task_arbitration::TaskArbitrationRepository::new(h.db.clone());
+    let arbitration = arbitrations
+        .get_latest_for_task(&h.task_id)
+        .await
+        .expect("arbitration read")
+        .expect("the re-drive dispatches the Lead session the escalation could not");
+    let bound = routes
+        .get(&subject, &key)
+        .await
+        .expect("route read")
+        .expect("the route is still the run-absent one");
+    assert_eq!(
+        bound.tier2_lease_id.as_deref(),
+        Some(lease_id.as_str()),
+        "the re-drive opens no second lease, so the only id it may bind is the \
+         one the row already held",
+    );
+    assert_eq!(
+        bound.lead_session_count, 1,
+        "the re-drive's Lead session must be attached to the route it adjudicates",
+    );
+    assert_eq!(
+        bound.lead_session_id.as_deref(),
+        Some(arbitration.id.as_str()),
+        "and it must name the arbitration row this route is adjudicated under",
+    );
+    let directive = arbitration
+        .directive
+        .clone()
+        .expect("the dispatch writes the directive the Lead session reads");
+    assert_eq!(
+        directive["ci_route"]["tier2_lease_id"].as_str(),
+        Some(lease_id.as_str()),
+        "the supervisor hands this id to `resolve_tier2_lease`, which is fenced \
+         on the STORED lease: a minted id makes the adjudication unappliable",
+    );
+    assert_eq!(
+        directive["ci_route"]["provider_action_key"].as_str(),
+        Some(key.as_str()),
+        "and the directive names the route the lease belongs to",
+    );
+    assert_eq!(
+        djinn_db::test_support::ci_route_row_count_for_test(&h.db, &h.task_id).await,
+        1,
+        "one run-absent route, not one per poll",
+    );
+    assert_eq!(
+        djinn_db::test_support::ci_route_lease_count_for_test(&h.db, &h.task_id).await,
+        1,
+        "and one Tier-2 lease",
+    );
+    assert_eq!(arbitration_rows(&h.db).await, 1, "and one Lead session");
+    assert_eq!(
+        djinn_db::test_support::task_status_for_test(&h.db, &h.task_id).await,
+        "needs_lead_intervention",
+        "the re-drive escalates the board as well as binding the route",
+    );
+
+    // ── Phase three: a resolved lease ends this route's trip to Tier 2 ──────
+    //
+    // The adjudication is applied and consumed, which is what a Lead result
+    // landing looks like. Later incomplete polls keep arriving — the head's CI
+    // is still incomplete — and every one of them lands on `AlreadyEscalated`
+    // again. Dispatching there would open a SECOND hold cycle against a lease
+    // that is closed, so its result could never be applied: a session spent to
+    // be discarded.
+    assert!(
+        routes
+            .resolve_tier2_lease(
+                &subject,
+                &key,
+                &lease_id,
+                &run_absent,
+                &djinn_db::CiTier2Resolution::diagnose(
+                    djinn_db::CiDiagnosticReason::EvidenceIncomplete
+                ),
+            )
+            .await
+            .expect("resolve"),
+        "precondition: the adjudication applies and closes the lease",
+    );
+    assert!(
+        arbitrations
+            .mark_consumed(&h.task_id, arbitration.hold_cycle)
+            .await
+            .expect("consume"),
+        "precondition: and its arbitration is consumed, so nothing is in flight",
+    );
+
+    assert_eq!(
+        poll_once(&h.task_id).await,
+        crate::pr_poller::ci_hold::CiHoldDisposition::Absorbed(
+            crate::pr_poller::ci_hold::CiHoldAbsorption::AlreadyEscalated
+        ),
+    );
+    assert_eq!(
+        arbitration_rows(&h.db).await,
+        1,
+        "a route routes to Tier 2 at most once, ever: a re-drive over a resolved \
+         lease must dispatch NOTHING",
+    );
+    assert_eq!(
+        routes
+            .get(&subject, &key)
+            .await
+            .expect("route read")
+            .expect("route")
+            .lead_session_count,
+        1,
+        "and it attaches no second session to the route it can no longer resolve",
+    );
+    assert_eq!(
+        djinn_db::test_support::task_attempt_count_for_test(&h.db, &h.task_id).await,
+        0,
+        "none of this dispatches a worker",
     );
 }
 
@@ -6111,6 +6421,128 @@ fn a_routed_pr_draft_disposition_turns_the_legacy_remedy_off() {
         "the legacy failure remedy must sit INSIDE the complete-empty guard; \
          outside it, a no-CI enumeration the route layer already recorded \
          `Passing` gets remediated as a failure",
+    );
+}
+
+/// The merge-queue lane's routed disposition LEAVES `handle_queue_failure`.
+///
+/// The merge-group twin of the guard above, and source-level for the same
+/// reason: `handle_queue_failure` takes a `&GitHubApiClient` built by
+/// `resolve_installation_client` against the hard-coded `api.github.com`, so no
+/// fixture in this crate can drive it. Every behavioural merge-group fixture
+/// enters at `route_merge_group_ci_evidence` and asserts what the *callee*
+/// answered.
+///
+/// The sibling `the_pr_poller_hands_the_live_gate_to_both_lane_routers` pins
+/// that this call site exists and is handed the live gate. Neither it nor
+/// anything else pins the `return;` — and this router call sits in the MIDDLE
+/// of `handle_queue_failure`, not at its head, so without the early return a
+/// routed merge-group failure keeps running through the rest of the function
+/// and reaches both legacy remedies: the same-signature park and then the
+/// generic `PrCiFailed` reopen. One dequeue would buy an evidence-led Tier-2
+/// adjudication AND the blind reopen that adjudication exists to replace — the
+/// double-spent session this proposal is for — with the whole `nafu` command
+/// list green, because the callee still answers exactly what every behavioural
+/// fixture asserts.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete the `return;` from the `.is_routed()` branch: the containment
+///     assertion fails. In production the routed dequeue would fall through to
+///     `apply_pr_transition(PrCiFailed)` in addition to its route.
+/// (b) Replace `return;` with a bare log, or with anything that does not leave
+///     the function: same assertion, same reason.
+/// (c) Move the router call (and its branch) BELOW the reopen: the ordering
+///     assertion fails — the legacy remedy would already have been spent by the
+///     time the route layer got first refusal.
+/// (d) Invert the branch to `if !self.route_merge_group_ci_evidence(..)…`: the
+///     routed disposition would fall through to both legacy remedies and the
+///     DECLINED one would return — the same double-spend with the cases
+///     swapped, and a shape the containment check alone cannot tell apart. The
+///     unnegated-head assertion is what fails.
+/// (e) Add a second `route_merge_group_ci_evidence` call site or a second
+///     legacy remedy anywhere in the file: the occurrence counts fail, which
+///     forces a new caller to be looked at rather than silently inheriting no
+///     guard.
+#[test]
+fn a_routed_merge_group_disposition_replaces_the_legacy_queue_remedy() {
+    let code = strip_line_comments(include_str!("../../pr_commands.rs"));
+
+    let find = |needle: &str, what: &str| -> usize {
+        code.find(needle)
+            .unwrap_or_else(|| panic!("{what}: `{needle}` is not in pr_commands.rs"))
+    };
+    let count = |needle: &str| code.matches(needle).count();
+
+    const ROUTER: &str = ".route_merge_group_ci_evidence(";
+    const ROUTED: &str = ".is_routed()";
+    const LEGACY_PARK: &str = "self.escalate_ci_failure_and_park(";
+    const LEGACY_REOPEN: &str = "TransitionAction::PrCiFailed";
+
+    assert_eq!(
+        count(ROUTER),
+        1,
+        "one merge-group router call site in this file",
+    );
+    assert_eq!(
+        count(ROUTED),
+        1,
+        "one routed-disposition test, so the branch located below is that one",
+    );
+    assert_eq!(
+        count(LEGACY_PARK),
+        1,
+        "one same-signature park; a second one would inherit no guard",
+    );
+    assert_eq!(
+        count(LEGACY_REOPEN),
+        1,
+        "one generic queue reopen; a second one would inherit no guard",
+    );
+
+    let router = find(ROUTER, "the merge-group router call");
+    let routed = find(ROUTED, "the routed-disposition test");
+    let park = find(LEGACY_PARK, "the same-signature park");
+    let reopen = find(LEGACY_REOPEN, "the generic queue reopen");
+    assert!(
+        router < routed,
+        "the disposition must be read from the router's own return value",
+    );
+
+    // The branch must test the routed disposition UNNEGATED. `if !…is_routed()`
+    // keeps a `return;` inside a well-formed block — containment alone cannot
+    // tell the two apart — while returning on the declined path and handing the
+    // ROUTED one to both legacy remedies.
+    let if_start = code[..router]
+        .rfind("if ")
+        .expect("the router call must sit in an `if` condition");
+    let head: Vec<&str> = code[if_start..router].split_whitespace().collect();
+    assert_eq!(
+        head.join(" "),
+        "if self",
+        "the routed branch must be entered when the route layer HANDLED the \
+         dequeue, not when it declined",
+    );
+
+    // The branch the routed disposition opens, and where it closes. `block_end`
+    // is what tells "inside the branch" from "after it" — the whole difference
+    // between a legacy remedy REPLACED by a route and one that runs in addition
+    // to it.
+    let after_routed = routed + ROUTED.len();
+    let open = after_routed
+        + code[after_routed..]
+            .find('{')
+            .expect("the routed disposition must open a branch");
+    let block = block_end(&code, open);
+    assert!(
+        code[open..block].contains("return;"),
+        "a routed merge-group failure must LEAVE `handle_queue_failure`; falling \
+         out of this branch hands the same dequeue to the legacy remedies as well",
+    );
+    assert!(
+        block < park && park < reopen,
+        "and it must leave BEFORE either legacy remedy is reachable: the park at \
+         {park} and the reopen at {reopen} both follow the routed branch, which \
+         ends at {block}",
     );
 }
 

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -3305,6 +3305,22 @@ async fn an_annotation_failure_after_correlation_routes_to_guarded_tier_two() {
 /// binding is also what makes `unapplied_lead_results` in the rollback
 /// quiescence report mean "a Lead was dispatched" rather than "a lease exists".
 ///
+/// # What this fixture found on its first run
+///
+/// A real one, and not the call site it was written to guard. The dispatch
+/// bound the route under `format!("arbitration:{task_id}:{hold_cycle}")` — a
+/// ~50 character string — and `ci_route_attempts.lead_session_id` is
+/// `VARCHAR(36)`. Postgres refuses an over-long value rather than truncating
+/// it, the dispatch logged the resulting error at `warn` and escalated the
+/// board anyway, so every other observable effect of a Tier-2 dispatch landed
+/// while the binding never did on any lane. The two counters that read this
+/// column — `unapplied_lead_results` and the route report's `lead_invocations`
+/// — were therefore pinned at zero by construction. Nothing else could have
+/// caught it: the `tier2_dispatch` fixtures hand the dispatch a handoff whose
+/// route row does not exist, so their attach misses the fence and returns
+/// `NotFound` before the column is ever written. The dispatch now binds the
+/// arbitration row's own id.
+///
 /// NAMED FAILING MUTATIONS.
 /// (a) Delete `self.dispatch_opened_tier2_leases(outcomes, task_id).await;`
 ///     from `settle`: no arbitration row, the task stays `pr_review`, and the
@@ -3318,6 +3334,11 @@ async fn an_annotation_failure_after_correlation_routes_to_guarded_tier_two() {
 /// (d) Drop the `attach_lead_session` call from `dispatch_ci_tier2_lead`: the
 ///     arbitration and the board transition still land, and the two
 ///     `lead_session_*` assertions fail alone.
+/// (e) Bind any handle that is not a row id — the old
+///     `arbitration:{task_id}:{hold_cycle}`, or anything else over 36
+///     characters: the `UPDATE` is refused by the column type, the dispatch
+///     swallows the error, and (d)'s two assertions fail in exactly the same
+///     way. That is the mutation this fixture actually caught.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_lane_opened_tier2_lease_becomes_a_lead_session_bound_to_its_route() {
     let h = lane_harness().await;
@@ -3393,21 +3414,22 @@ async fn a_lane_opened_tier2_lease_becomes_a_lead_session_bound_to_its_route() {
         row.lead_session_count, 1,
         "exactly one Lead session is attached to the route it adjudicates",
     );
-    assert!(
-        row.lead_session_id
-            .as_deref()
-            .is_some_and(|id| id.starts_with(&format!("arbitration:{}:", h.task_id))),
-        "the route must name the arbitration adjudicating it, got {:?}",
-        row.lead_session_id,
-    );
-
-    let directive =
+    let arbitration =
         djinn_db::repositories::task_arbitration::TaskArbitrationRepository::new(h.db.clone())
             .get_latest_for_task(&h.task_id)
             .await
             .expect("arbitration read")
-            .and_then(|record| record.directive)
-            .expect("the dispatch writes the directive the Lead session reads");
+            .expect("the dispatch writes the arbitration this route is adjudicated under");
+    assert_eq!(
+        row.lead_session_id.as_deref(),
+        Some(arbitration.id.as_str()),
+        "the route must name the arbitration row adjudicating it, not merely have \
+         some session id",
+    );
+
+    let directive = arbitration
+        .directive
+        .expect("the dispatch writes the directive the Lead session reads");
     assert_eq!(
         directive["ci_route"]["provider_action_key"].as_str(),
         Some(key.as_str()),

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/tests.rs
@@ -1926,6 +1926,95 @@ fn merge_group_capture_names_the_run_head_not_the_pr_head() {
     assert_eq!(id.dequeue_id.as_deref(), Some("grp@t0"));
 }
 
+/// The merge-group lane fails closed on unusable execution evidence too.
+///
+/// The twin of [`hard_failure_with_non_positive_interval_is_not_tier_one`],
+/// which pins the same guard on the PR-head lane. The merge-group call had no
+/// fixture at all: the `blocking_evidence_completeness` line in
+/// `capture_merge_group_evidence` could be deleted outright with the whole
+/// acceptance list green, because the only other merge-group capture fixture
+/// feeds it a well-formed check and asserts `Runs`.
+///
+/// # Why the lane-level call is not redundant with `prove_complete`
+///
+/// [`CiCapture::prove_complete`] runs the identical predicate again, per run —
+/// deliberate defence in depth — so the *reason* survives the deletion. What
+/// does not survive is the identity the route is keyed on. A lane-level verdict
+/// is a `CiLaneEvidence::Incomplete`, which `ci_lane_routing::drive_lane` keys
+/// on the lane identity and `run_absent_if_required` then collapses to `run_id:
+/// None`. Without the call the lane answers `Runs([run 9])` and the identical
+/// reason is keyed on run 9 instead — a second route row, a second head-scoped
+/// Tier-2 lease and a second Lead session for one PR head, which is exactly
+/// what the `NULLS NOT DISTINCT` collapse exists to prevent. The merge lane is
+/// the one that reaches these reasons *after* a run has been named, so it is
+/// the lane on which the two identities can actually diverge.
+///
+/// NAMED FAILING MUTATION: delete
+/// `if let Some(reason) = super::ci_routing::blocking_evidence_completeness(blocking) { … }`
+/// from `capture_merge_group_evidence`. The capture becomes `Runs(..)`, the
+/// `Incomplete` arm no longer matches, and the first half panics.
+#[test]
+fn a_merge_group_capture_fails_closed_on_a_contradictory_execution_interval() {
+    let run = djinn_provider::github_api::WorkflowRun {
+        id: 9,
+        workflow_id: None,
+        name: None,
+        path: None,
+        head_branch: Some("gh-readonly-queue/main/pr-41-abc".to_owned()),
+        head_sha: "cccccccccccccccccccccccccccccccccccccccc".to_owned(),
+        status: Some("completed".to_owned()),
+        conclusion: Some("failure".to_owned()),
+    };
+
+    // A hard failure whose interval says the lane never ran. Both cannot be
+    // true, and `ci_triage` resolves the pair toward NeverExecuted — which is
+    // what would make this merge-group run look inconclusive and earn an
+    // automatic re-enqueue.
+    let mut contradictory = causal("merge-group / integration", 9);
+    contradictory.started_at = Some(T1.to_owned());
+    contradictory.completed_at = Some(T0.to_owned());
+    let runs = [contradictory];
+    let blocking = refs(&runs);
+    assert!(
+        crate::pr_poller::ci_triage::is_inconclusive(&blocking),
+        "precondition: without the lane guard this run is Tier-1 eligible, \
+         which is the false transient the capture has to refuse",
+    );
+
+    match capture_merge_group_evidence(41, HEAD, &run, "grp@t0", &checks_response(&runs), &blocking)
+    {
+        CiLaneEvidence::Incomplete(CiIncompleteReason::NonPositiveExecutionInterval) => {}
+        other => panic!("expected a fail-closed capture, got {other:?}"),
+    }
+
+    // And the reason really is one that collapses to the run-absent identity —
+    // which is the whole point of answering it at lane level rather than
+    // letting each run answer for itself.
+    assert!(
+        CiIncompleteReason::NonPositiveExecutionInterval.is_run_absent(),
+        "a lane-level fail-closed verdict must name no run, or the collapse the \
+         lane-level call exists to produce does not happen",
+    );
+
+    // Vacuity: the lane is not simply refusing every merge-group capture. The
+    // same correlated run with a usable interval still fans out per run.
+    let usable = [ran_then_cancelled("merge-group / integration", 9)];
+    let usable_blocking = refs(&usable);
+    let captured = capture_merge_group_evidence(
+        41,
+        HEAD,
+        &run,
+        "grp@t0",
+        &checks_response(&usable),
+        &usable_blocking,
+    );
+    let CiLaneEvidence::Runs(routes) = captured else {
+        panic!("a usable merge-group capture must produce per-run evidence, got {captured:?}");
+    };
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].identity.run_id, Some(9));
+}
+
 // ---------------------------------------------------------------------------
 // Routing the repository layer's outcomes
 // ---------------------------------------------------------------------------

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/tier2_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/tier2_dispatch.rs
@@ -13,7 +13,8 @@
 //!
 //! 1. write the route's keys into the arbitration row's `directive` column, so
 //!    the supervisor can name the exact row its guard must resolve;
-//! 2. bind the row to the lease with `attach_lead_session`, so the quiescence
+//! 2. bind the row to the lease with `attach_lead_session` — by its own row id,
+//!    which is what `lead_session_id` is sized to hold — so the quiescence
 //!    report can count "leases with a dispatched adjudication whose result has
 //!    not been applied";
 //! 3. `Escalate` the task into `needs_lead_intervention`, which is the only
@@ -36,7 +37,7 @@
 #[cfg(test)]
 use djinn_db::{CiLane, CiOriginState, CiTier2Reason};
 use djinn_db::{
-    CiRouteAttemptRepository,
+    CiLeadSessionAttachment, CiRouteAttemptRepository,
     repositories::task_arbitration::{CreateArbitrationParams, TaskArbitrationRepository},
 };
 
@@ -109,8 +110,12 @@ impl CoordinatorActor {
                 excluded_models: &serde_json::Value::Array(Vec::new()),
             })
             .await;
-        match created {
-            Ok(djinn_db::repositories::task_arbitration::TryCreateResult::Created(_)) => {}
+        // The id of the row that was just written, kept rather than discarded:
+        // it is the handle the route is bound to below.
+        let arbitration_id = match created {
+            Ok(djinn_db::repositories::task_arbitration::TryCreateResult::Created(record)) => {
+                record.id
+            }
             Ok(_) => return CiTier2Dispatch::AlreadyInFlight,
             Err(error) => {
                 tracing::warn!(
@@ -120,28 +125,60 @@ impl CoordinatorActor {
                 );
                 return CiTier2Dispatch::ArbitrationUnavailable;
             }
-        }
+        };
 
         // Bind the route to the session that will adjudicate it. The lease id
         // fences this: a stale caller cannot attach to a lease that has already
         // been resolved. It is what makes `unapplied_lead_results` in the
         // rollback quiescence report mean "a Lead was actually dispatched"
         // rather than "a lease exists".
+        //
+        // The bound handle is the **arbitration row's own id**. It used to be
+        // `format!("arbitration:{task_id}:{hold_cycle}")`, which is a ~50
+        // character string — and `ci_route_attempts.lead_session_id` is
+        // `VARCHAR(36)`, sized for exactly one row id. Postgres does not
+        // truncate an over-long value, it refuses the statement (22001), so
+        // EVERY Tier-2 dispatch on every lane failed to bind and the failure
+        // was invisible: the error was logged at `warn` and the dispatch
+        // carried on to escalate the board. The consequence was not cosmetic —
+        // `unapplied_lead_results` and the report's `lead_invocations` both
+        // count on this column, so both were structurally pinned at zero and a
+        // rollback could read "quiescent" with Lead adjudications in flight.
+        //
+        // The row id is also the better handle on its own terms: it names the
+        // exact `task_arbitrations` row this route is adjudicated under, rather
+        // than a string that had to be re-derived to be useful.
         let routes = CiRouteAttemptRepository::new(self.db.clone());
-        if let Err(error) = routes
+        match routes
             .attach_lead_session(
                 &handoff.subject,
                 &handoff.provider_action_key,
                 &handoff.tier2_lease_id,
-                &format!("arbitration:{}:{hold_cycle}", task.id),
+                &arbitration_id,
             )
             .await
         {
-            tracing::warn!(
-                task_id = %task.short_id,
-                %error,
-                "ci route: could not bind the Lead dispatch to its Tier-2 lease"
-            );
+            Ok(CiLeadSessionAttachment::Attached { .. }) => {}
+            // Reported, not swallowed. A fence miss means the arbitration row
+            // exists and no route names it, which is precisely the state the
+            // rollback report cannot see — and it is the shape the over-long
+            // id bug hid behind for a whole wave.
+            Ok(CiLeadSessionAttachment::NotFound) => {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    key = %handoff.provider_action_key,
+                    lease_id = %handoff.tier2_lease_id,
+                    "ci route: no open Tier-2 lease matched the Lead dispatch, so the \
+                     adjudication is not bound to its route"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    %error,
+                    "ci route: could not bind the Lead dispatch to its Tier-2 lease"
+                );
+            }
         }
 
         // Last, and only now. `Escalate` is the single production transition
@@ -179,6 +216,7 @@ impl CoordinatorActor {
             reason = handoff.reason.as_str(),
             key = %handoff.provider_action_key,
             hold_cycle,
+            arbitration_id = %arbitration_id,
             "ci route: dispatched Lead under a Tier-2 lease"
         );
         CiTier2Dispatch::Dispatched

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt.rs
@@ -2065,9 +2065,19 @@ impl CiRouteAttemptRepository {
     /// post-increment total, so a caller can tell a first attach
     /// (`session_count == 1`) from an additional one without re-reading the row.
     ///
+    /// # `lead_session_id` is a row id, not a composed handle
+    ///
+    /// The column is `VARCHAR(36)`: exactly one UUID. Postgres does not
+    /// truncate an over-long value into a `VARCHAR(n)` column, it refuses the
+    /// statement with `22001` — which arrives here as `Err`, not as
+    /// [`CiLeadSessionAttachment::NotFound`]. A caller that composes a handle
+    /// out of a task id and a counter therefore fails **every** attach while
+    /// every other effect of its dispatch lands, which is how the coordinator's
+    /// Tier-2 dispatch went a whole wave binding nothing. Pass an id.
+    ///
     /// # Errors
     ///
-    /// Database failures.
+    /// Database failures, including a `lead_session_id` longer than the column.
     pub async fn attach_lead_session(
         &self,
         subject: &CiRouteSubject,

--- a/server/crates/djinn-provider/src/github_api/tests/check_runs_completeness.rs
+++ b/server/crates/djinn-provider/src/github_api/tests/check_runs_completeness.rs
@@ -470,6 +470,110 @@ async fn ref_enumeration_pages_and_reports_its_own_completeness() {
     );
 }
 
+/// The ref walk detects its own `MAX_PAGES` ceiling — and reports it as the
+/// IRRECOVERABLE reason.
+///
+/// The PR-head walk's ceiling is pinned twice (by
+/// [`truncation_and_short_read_are_incomplete`] and by
+/// [`a_walk_that_exactly_fills_the_ceiling_is_complete`]); this walk had
+/// neither, and it is the one the `nafu` route layer actually reads. Both lane
+/// entry points enumerate through `list_check_runs_for_ref` — never through
+/// `get_pull_request`, whose response was fetched before the lane knew the head
+/// SHA its hold identity is keyed on.
+///
+/// So `else if truncated { MaxPagesTruncated }` could be deleted from
+/// `list_check_runs_for_ref` with the whole acceptance list green, and the
+/// failure would be quiet rather than loud: a truncated walk falls through to
+/// the next arm and reports `ShortRead`, which is **recoverable**. The router
+/// then takes the bounded hold and re-polls a ref whose every later walk hits
+/// the identical ceiling — twelve wasted polls and then an escalation whose
+/// reason names the wrong fact, instead of the one diagnose-only route the
+/// irrecoverable verdict earns immediately.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete the `else if truncated` arm: the first half reads `ShortRead`.
+/// (b) Delete `hit_cap = true` or the `page == MAX_PAGES` guard around it: the
+///     same failure, one step earlier.
+/// (c) Drop the `&& all_runs.len() < total_count as usize` exoneration from
+///     `truncated`: the second half — ten full pages the provider's own count
+///     says left nothing behind — reads `MaxPagesTruncated` and fails.
+/// (d) Reclassify `MaxPagesTruncated` as recoverable: the recoverability
+///     assertion fails here as well as in the partition test below, which is
+///     deliberate — this one names the consequence on the walk that produces it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ref_enumeration_reports_the_ceiling_as_irrecoverable_truncation() {
+    // --- ten full pages with runs still unseen: genuine truncation ---------
+    let server = MockServer::start().await;
+    let install_id = seed_installation_token();
+    for p in 1..=10u64 {
+        let start = (p - 1) * 100;
+        Mock::given(method("GET"))
+            .and(path_regex(REF_CHECK_RUNS_PATH))
+            .and(query_param("page", p.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(page(1500, start..start + 100)))
+            .mount(&server)
+            .await;
+    }
+
+    let client = GitHubApiClient::for_installation_with_base_url(install_id, server.uri());
+    let checks = client
+        .list_check_runs_for_ref("djinnos", "server", "queuesha")
+        .await
+        .unwrap();
+    assert_eq!(
+        checks.check_runs.len(),
+        1000,
+        "precondition: the walk really did stop at the ceiling",
+    );
+    assert_eq!(
+        checks.total_count, 1500,
+        "precondition: the provider's own count says 500 runs were left behind",
+    );
+    assert_eq!(
+        checks.completeness,
+        CheckSetCompleteness::Incomplete(CheckSetIncompleteReason::MaxPagesTruncated),
+    );
+    assert_eq!(
+        CheckSetIncompleteReason::MaxPagesTruncated.recoverability(),
+        CheckSetRecoverability::Irrecoverable,
+        "and it must be the irrecoverable verdict: a recoverable one holds and \
+         re-polls a ref that answers identically every time",
+    );
+
+    // --- Vacuity: a full ceiling the count exonerates is still complete -----
+    //
+    // Without this, deleting the exoneration from `truncated` would satisfy
+    // everything above while declaring every thousand-check ref permanently
+    // incomplete.
+    let server = MockServer::start().await;
+    let install_id = seed_installation_token();
+    for p in 1..=10u64 {
+        let start = (p - 1) * 100;
+        Mock::given(method("GET"))
+            .and(path_regex(REF_CHECK_RUNS_PATH))
+            .and(query_param("page", p.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(page(1000, start..start + 100)))
+            .mount(&server)
+            .await;
+    }
+
+    let client = GitHubApiClient::for_installation_with_base_url(install_id, server.uri());
+    let checks = client
+        .list_check_runs_for_ref("djinnos", "server", "queuesha")
+        .await
+        .unwrap();
+    assert_eq!(
+        checks.check_runs.len(),
+        checks.total_count as usize,
+        "precondition: the provider's own count agrees with what arrived",
+    );
+    assert_eq!(
+        checks.completeness,
+        CheckSetCompleteness::Complete,
+        "a walk that exactly fills the ceiling left nothing behind",
+    );
+}
+
 /// Every incomplete verdict carries its own recoverability, and the split is
 /// the one proposal `nafu` revision 58 routes on.
 ///

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -4079,6 +4079,12 @@ mod tests {
         /// Records every `transition_task` call so tests can assert exactly
         /// which board transitions a run requested (and which it must NOT).
         transitions: std::sync::Arc<std::sync::Mutex<Vec<TransitionCall>>>,
+        /// Records the arbitration-lifecycle service calls a run made, by name.
+        ///
+        /// Deliberately a second recorder rather than more entries in
+        /// `transitions`: these are not board transitions, and the fixtures that
+        /// assert an exact transition sequence must keep asserting exactly that.
+        service_calls: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     }
 
     #[async_trait]
@@ -4331,10 +4337,12 @@ mod tests {
             _verification_command: String,
             _exclude_models: Vec<String>,
         ) -> Result<(), String> {
+            self.record_service_call("start_monitored_reopen");
             Ok(())
         }
 
         async fn complete_monitored_reopen(&self, _task_id: String) -> Result<(), String> {
+            self.record_service_call("complete_monitored_reopen");
             Ok(())
         }
 
@@ -4343,7 +4351,17 @@ mod tests {
             _task_id: String,
             _is_infra_failure: bool,
         ) -> Result<bool, String> {
+            self.record_service_call("record_arbiter_session_termination");
             Ok(false)
+        }
+    }
+
+    impl ScriptedLoopGuardServices {
+        fn record_service_call(&self, name: &str) {
+            self.service_calls
+                .lock()
+                .expect("service calls mutex poisoned")
+                .push(name.to_owned());
         }
     }
 
@@ -4387,6 +4405,7 @@ mod tests {
             execute_stage_calls: execute_stage_calls.clone(),
             expected_role: RoleKind::Worker,
             transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -4462,6 +4481,7 @@ mod tests {
             execute_stage_calls: execute_stage_calls.clone(),
             expected_role: RoleKind::Worker,
             transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -4736,6 +4756,7 @@ mod tests {
                 execute_stage_calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                 expected_role: role,
                 transitions: Arc::clone(&calls),
+                service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             });
             let supervisor =
                 TaskRunSupervisor::with_test_run_observer(mirror, services, Arc::clone(&calls));
@@ -5175,6 +5196,416 @@ mod tests {
         assert!(calls.iter().any(|c| c.action == "settle:Interrupted"));
     }
 
+    // =======================================================================
+    // Proposal `nafu` wave 5 — `StageOutcome::LeadRouteSuperseded`
+    // =======================================================================
+    //
+    // Three production sites in this crate consume the variant: the telemetry
+    // label in `emit_stage_outcome_event`, the `InterruptedOrFailed` row of
+    // `session_exit_barrier_plan`, and the no-op arm of the run loop. Until
+    // this family none of them was reachable from any acceptance command —
+    // the proposal's six filters build `djinn-coordinator`, `djinn-db`,
+    // `djinn-roles`, `djinn-agent`, `djinn-provider` and `djinn-server`, and
+    // not one of them builds `djinn-supervisor`'s tests.
+    //
+    // What the variant is FOR is why that gap mattered. A Lead route that lost
+    // the atomic current-identity guard is not a role failure. `Failed` on a
+    // Lead role calls `record_arbiter_session_termination`, which increments
+    // the arbiter decision-failure counter and parks the task with a generated
+    // dossier at the cap — so a task whose only sin was a PR head that moved
+    // twice would be parked for it. Route this variant to the failure/park
+    // path and that parking behaviour comes straight back.
+
+    /// Everything one scripted Lead-flow run did, as counts and call names
+    /// rather than the name of the branch it took.
+    struct LeadCaseObservations {
+        outcome: TaskRunOutcome,
+        transitions: Vec<TransitionCall>,
+        service_calls: Vec<String>,
+        task_run_statuses: Vec<TaskRunStatus>,
+        stage_runs: usize,
+    }
+
+    /// Drive the PRODUCTION run loop (`TaskRunSupervisor::run`) through the
+    /// Lead flow with a scripted stage outcome.
+    ///
+    /// The only thing scripted is what `execute_stage` returns; the transition,
+    /// arbitration-lifecycle and task-run-status calls are the ones the real
+    /// loop makes.
+    async fn run_lead_stage_case(id: &str, outcome: StageOutcome) -> LeadCaseObservations {
+        let root = tempfile::tempdir_in(std::env::current_dir().expect("current dir"))
+            .expect("temp test root");
+        let source = root.path().join("source");
+        make_source_repo(&source);
+
+        let project_id = "project-lead-route-superseded";
+        let mirror = Arc::new(MirrorManager::new(root.path().join("mirrors")));
+        mirror
+            .ensure_mirror(project_id, &format!("file://{}", source.display()))
+            .await
+            .expect("install fixture mirror");
+
+        let transitions = Arc::new(Mutex::new(Vec::new()));
+        let service_calls = Arc::new(Mutex::new(Vec::new()));
+        let updated_statuses = Arc::new(Mutex::new(Vec::new()));
+        let stage_runs = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let services: Arc<dyn SupervisorServices> = Arc::new(ScriptedLoopGuardServices {
+            cancel: CancellationToken::new(),
+            task: fixture_task(id, project_id),
+            outcome,
+            updated_statuses: Arc::clone(&updated_statuses),
+            fail_start_transition: false,
+            execute_stage_calls: Arc::clone(&stage_runs),
+            expected_role: RoleKind::Lead,
+            transitions: Arc::clone(&transitions),
+            service_calls: Arc::clone(&service_calls),
+        });
+        let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
+        let report = supervisor
+            .run(TaskRunSpec {
+                task_run_id: format!("run-{id}"),
+                task_attempt_id: None,
+                task_id: id.into(),
+                execution_generation: 0,
+                project_id: project_id.into(),
+                trigger: TaskRunTrigger::NewTask,
+                base_branch: "main".into(),
+                task_branch: format!("djinn/{id}"),
+                flow: SupervisorFlow::Lead,
+                model_id_per_role: Default::default(),
+                read_source_project_ids: Vec::new(),
+                knowledge_injection: djinn_core::models::KnowledgeInjectionConfig::default(),
+                github_owner: None,
+                github_install_token: None,
+                commit_author_name: None,
+                commit_author_email: None,
+                resume_lifecycle_metadata: None,
+                is_evidence_spike: false,
+            })
+            .await
+            .expect("scripted supervisor run");
+
+        LeadCaseObservations {
+            outcome: report.outcome,
+            transitions: transitions
+                .lock()
+                .expect("transitions mutex poisoned")
+                .clone(),
+            service_calls: service_calls
+                .lock()
+                .expect("service calls mutex poisoned")
+                .clone(),
+            task_run_statuses: updated_statuses
+                .lock()
+                .expect("updated statuses mutex poisoned")
+                .clone(),
+            stage_runs: stage_runs.load(std::sync::atomic::Ordering::SeqCst),
+        }
+    }
+
+    /// The refused route has no durable board handoff to guarantee.
+    ///
+    /// Site: the `LeadRouteSuperseded` row of [`session_exit_barrier_plan`].
+    /// Deleting that row is a compile error (the match is exhaustive over
+    /// `StageOutcome`), so the reachable mutation is retargeting it — and that
+    /// is what this kills.
+    ///
+    /// NAMED FAILING MUTATIONS.
+    /// (a) Any `SessionExitBarrierPlan::Required { .. }` in place of
+    ///     `InterruptedOrFailed`: the first assertion fails. In production the
+    ///     supervisor would then wait for — and warn about — a transition the
+    ///     guard's whole contract forbids it from performing.
+    /// (b) `TerminalEvidenceOnly` instead: the first assertion fails, and the
+    ///     truthful-status assertion would rewrite an already-interrupted
+    ///     session as `Failed`.
+    /// (c) Merging the arm into `LeadEscalate`'s
+    ///     (`LeadInterventionComplete` → `open`): the first assertion fails —
+    ///     and that is the board mutation plus next-worker dispatch the
+    ///     variant exists to avoid.
+    #[test]
+    fn lead_route_superseded_exit_barrier_promises_no_board_handoff() {
+        let task = fixture_task("lead-route-superseded-plan", "barrier-project");
+        let plan = session_exit_barrier_plan(
+            &StageOutcome::LeadRouteSuperseded {
+                reason: "pr head moved while Lead was adjudicating".into(),
+            },
+            RoleKind::Lead,
+            &task,
+        );
+
+        assert_eq!(
+            plan,
+            SessionExitBarrierPlan::InterruptedOrFailed,
+            "the guard already wrote `superseded_before_apply` in its own \
+             transaction; there is no board handoff left for the barrier to wait on",
+        );
+
+        // Vacuity guard: `InterruptedOrFailed` is a decision this function
+        // makes, not what it returns for everything. The sibling Lead outcomes
+        // on the SAME task and role do demand a durable handoff.
+        for (sibling, expected) in [
+            (
+                StageOutcome::LeadEscalate {
+                    reason: "escalate".into(),
+                },
+                SessionExitBarrierPlan::Required {
+                    action: SessionExitBarrierAction::LeadInterventionComplete,
+                    expected_target: "open",
+                },
+            ),
+            (
+                StageOutcome::LeadParked {
+                    park_dossier_json: "{}".into(),
+                },
+                SessionExitBarrierPlan::Required {
+                    action: SessionExitBarrierAction::ArbiterPark,
+                    expected_target: "open",
+                },
+            ),
+        ] {
+            assert_eq!(
+                session_exit_barrier_plan(&sibling, RoleKind::Lead, &task),
+                expected,
+                "control: {sibling:?} still requires its durable handoff",
+            );
+        }
+
+        // And truthful terminal evidence survives the plan: an interrupted or
+        // paused session is not rewritten into a failure.
+        for status in [
+            djinn_core::models::SessionStatus::Interrupted,
+            djinn_core::models::SessionStatus::Paused,
+        ] {
+            assert_eq!(
+                settlement_status_after_exit_barrier(plan, status),
+                status,
+                "an already-{status:?} session is truthful evidence",
+            );
+        }
+    }
+
+    /// The run loop applies nothing, charges nothing, and leaves the task in
+    /// the posture the coordinator already redispatches from.
+    ///
+    /// Site: the `LeadRouteSuperseded` arm of the production run loop, driven
+    /// end to end through `TaskRunSupervisor::run` on the Lead flow. Deleting
+    /// the arm is a compile error; the reachable mutations are the ones that
+    /// make it *do* something, and each is named below.
+    ///
+    /// NAMED FAILING MUTATIONS.
+    /// (a) `result = Some(TaskRunOutcome::Failed { .. })` instead of
+    ///     `Interrupted`: the outcome assertion fails, the task-run status
+    ///     assertion fails (`Failed`, not `Interrupted`), and — because
+    ///     `complete_monitored_reopen` is skipped only for `Interrupted` — the
+    ///     empty-service-calls assertion fails too. In production that is the
+    ///     arbitration row consumed out from under the next Lead dispatch.
+    /// (b) Falling the arm through to the `StageOutcome::Failed` arm (or
+    ///     copying its body): `record_arbiter_session_termination` appears in
+    ///     `service_calls` and the assertion fails. That call is the arbiter
+    ///     decision-failure charge that parks the task at the cap — the exact
+    ///     regression the variant exists to prevent.
+    /// (c) Adding a `transition_task` of any kind (`lead_intervention_complete`,
+    ///     `arbiter_park`, `force_close`): the transition assertion fails,
+    ///     because only the pre-stage claim may reach the board.
+    /// (d) Adding a `start_monitored_reopen` so the reason is surfaced to a
+    ///     worker: it appears in `service_calls` and the assertion fails — that
+    ///     is a directive injection and a worker dispatch for evidence a newer
+    ///     head already superseded.
+    /// (e) Removing the `break` so the loop continues: `stage_runs` exceeds 1.
+    #[tokio::test]
+    async fn lead_route_superseded_run_applies_nothing_and_stays_interrupted() {
+        let observed = run_lead_stage_case(
+            "lead-route-superseded-apply",
+            StageOutcome::LeadRouteSuperseded {
+                reason: "pr head moved while Lead was adjudicating".into(),
+            },
+        )
+        .await;
+
+        // Vacuity guard: the run really reached the Lead stage. Without this
+        // every negative below would also hold for a run that aborted before
+        // the arm was ever evaluated.
+        assert_eq!(
+            observed.stage_runs, 1,
+            "the fixture must actually reach the Lead stage exactly once",
+        );
+        assert!(
+            observed
+                .transitions
+                .iter()
+                .any(|call| call.action == "lead_intervention_start"),
+            "and the pre-stage claim must have fired, or the recorder proves \
+             nothing: {:?}",
+            observed.transitions,
+        );
+
+        assert!(
+            matches!(observed.outcome, TaskRunOutcome::Interrupted),
+            "a refused route is Interrupted, never Failed: `Failed` on a Lead \
+             role feeds the arbiter decision-failure counter and parks at the \
+             cap, got {:?}",
+            observed.outcome,
+        );
+        assert_eq!(
+            observed.task_run_statuses,
+            vec![TaskRunStatus::Interrupted],
+            "and the task_run row terminalizes Interrupted, so the coordinator \
+             redispatches rather than booking a failure",
+        );
+        assert!(
+            observed.service_calls.is_empty(),
+            "the arm's contract is everything it does NOT do: no arbiter \
+             termination charge, no directive injection, and no consumption of \
+             the arbitration row (which must stay unconsumed for the next Lead \
+             dispatch). Got {:?}",
+            observed.service_calls,
+        );
+        assert!(
+            observed.transitions.iter().all(|call| matches!(
+                call.action.as_str(),
+                "lead_intervention_start" | "transition_complete:lead_intervention_start"
+            )),
+            "only the pre-stage claim may reach the board; the refused route \
+             fires no transition of its own: {:?}",
+            observed.transitions,
+        );
+    }
+
+    /// Control: the counters the arm above must not move are counters that DO
+    /// move, on the same harness, for the sibling Lead outcomes.
+    ///
+    /// Without this, every negative in
+    /// [`lead_route_superseded_run_applies_nothing_and_stays_interrupted`]
+    /// would still hold if the recorders were dead or the Lead flow never
+    /// reached the arbitration-lifecycle calls at all.
+    ///
+    /// NAMED FAILING MUTATIONS.
+    /// (a) Drop the `record_service_call` from
+    ///     `record_arbiter_session_termination` or `start_monitored_reopen` in
+    ///     the fixture: the corresponding `contains` fails here, which is what
+    ///     stops the sibling test from passing vacuously.
+    /// (b) Drop the `role_kind == RoleKind::Lead` arbiter-accounting block from
+    ///     the production `Failed` arm: the first `contains` fails.
+    /// (c) Drop the `start_monitored_reopen` call from the production
+    ///     `LeadReopen` arm: the second `contains` fails.
+    #[tokio::test]
+    async fn lead_route_superseded_siblings_prove_those_counters_do_move() {
+        let failed = run_lead_stage_case(
+            "lead-route-superseded-control-failed",
+            StageOutcome::Failed {
+                reason: "lead session ended without a decision".into(),
+                provider_failure: None,
+            },
+        )
+        .await;
+        assert!(
+            failed
+                .service_calls
+                .iter()
+                .any(|call| call.as_str() == "record_arbiter_session_termination"),
+            "control: a Lead `Failed` DOES charge the arbiter decision-failure \
+             counter — the charge that parks a task at the cap. Got {:?}",
+            failed.service_calls,
+        );
+        assert!(
+            failed.task_run_statuses.contains(&TaskRunStatus::Failed),
+            "control: and it books the run as a failure: {:?}",
+            failed.task_run_statuses,
+        );
+
+        let reopen = run_lead_stage_case(
+            "lead-route-superseded-control-reopen",
+            StageOutcome::LeadReopen {
+                reason: "repair".into(),
+                directive: "fix the missing re-export".into(),
+                verification_command: "true".into(),
+                exclude_models: vec![],
+            },
+        )
+        .await;
+        assert!(
+            reopen
+                .service_calls
+                .iter()
+                .any(|call| call.as_str() == "start_monitored_reopen"),
+            "control: a Lead reopen DOES inject a directive for the next worker: {:?}",
+            reopen.service_calls,
+        );
+        assert!(
+            reopen
+                .transitions
+                .iter()
+                .any(|call| call.action == "lead_intervention_complete"),
+            "control: and it DOES mutate the board: {:?}",
+            reopen.transitions,
+        );
+        assert_eq!(
+            reopen.stage_runs, 1,
+            "both controls ran the same single Lead stage as the fixture above",
+        );
+        assert_eq!(failed.stage_runs, 1);
+    }
+
+    /// The stage-outcome telemetry names the supersession as itself.
+    ///
+    /// Site: the `LeadRouteSuperseded` label in `emit_stage_outcome_event`,
+    /// reached through the production run loop rather than by calling the
+    /// emitter directly — an unlabelled supersession is indistinguishable from
+    /// a Lead failure in the pod log, which is the only place an operator can
+    /// see one happen.
+    ///
+    /// NAMED FAILING MUTATIONS.
+    /// (a) Relabel the arm `"failed"` (or reuse any sibling label): the
+    ///     positive assertion fails and the `outcome="failed"` ban fails.
+    /// (b) Delete the `emit_stage_outcome_event(..)` call from the run loop:
+    ///     `supervisor.stage_outcome` never appears and the first assertion
+    ///     fails — deleting the label arm itself is a compile error, so this is
+    ///     the deletion that has to be caught here.
+    /// (c) Move the emit after the outcome `match` (so a `break`ing arm skips
+    ///     it): same failure as (b), because every Lead outcome breaks.
+    #[tokio::test]
+    async fn lead_route_superseded_emits_its_own_stage_outcome_label() {
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(logs.clone())
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NONE)
+            .with_target(true)
+            .with_ansi(false)
+            .with_level(true)
+            .finish();
+        let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
+        let _guard = tracing::dispatcher::set_default(&dispatch);
+
+        let observed = run_lead_stage_case(
+            "lead-route-superseded-telemetry",
+            StageOutcome::LeadRouteSuperseded {
+                reason: "a newer passing observation landed".into(),
+            },
+        )
+        .await;
+        assert_eq!(observed.stage_runs, 1, "the fixture reached the Lead stage");
+
+        let captured = logs.take();
+        assert!(
+            captured.contains("supervisor.stage_outcome")
+                && captured.contains("outcome=\"lead_route_superseded\"")
+                && captured.contains("task_id=lead-route-superseded-telemetry"),
+            "the run must emit a stage-outcome event that names the supersession \
+             and the task it happened to, got:\n{captured}",
+        );
+        for sibling in [
+            "outcome=\"failed\"",
+            "outcome=\"lead_escalate\"",
+            "outcome=\"lead_parked\"",
+        ] {
+            assert!(
+                !captured.contains(sibling),
+                "a superseded route must not be reported as {sibling}, got:\n{captured}",
+            );
+        }
+    }
+
     #[test]
     fn cargo_target_run_dir_helper_matches_expected_cache_path() {
         let task_run_id = "019eb956-ac3a-7492-b51c-bcd904f65a21";
@@ -5309,6 +5740,7 @@ mod tests {
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             expected_role: RoleKind::Worker,
             transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -5389,6 +5821,7 @@ mod tests {
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             expected_role: RoleKind::Worker,
             transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let provider_supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), provider_services);
         let provider_spec = TaskRunSpec {
@@ -5495,6 +5928,7 @@ mod tests {
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             expected_role: RoleKind::Worker,
             transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -5566,6 +6000,7 @@ mod tests {
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             expected_role: RoleKind::Worker,
             transitions: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let summary_supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), summary_services);
         let summary_spec = TaskRunSpec {
@@ -6101,6 +6536,7 @@ mod tests {
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             expected_role: RoleKind::Planner,
             transitions: transitions.clone(),
+            service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {
@@ -6194,6 +6630,7 @@ mod tests {
             execute_stage_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             expected_role: RoleKind::Planner,
             transitions: transitions.clone(),
+            service_calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         });
         let supervisor = TaskRunSupervisor::new(Arc::clone(&mirror), services);
         let spec = TaskRunSpec {

--- a/server/tests/leadership_quiescence.rs
+++ b/server/tests/leadership_quiescence.rs
@@ -337,3 +337,140 @@ async fn the_no_lock_branch_still_closes_admission_and_joins_before_returning() 
     assert_eq!(counts.in_flight, 0, "{counts:?}");
     assert!(counts.drained, "{counts:?}");
 }
+
+// ---------------------------------------------------------------------------
+// The composition site: one scope, two waiters
+// ---------------------------------------------------------------------------
+
+/// One Rust source with its `//` line comments removed.
+///
+/// The guard below matches on *code*. Without this, a comment that merely names
+/// the token under guard would satisfy the assertion the guard exists to make.
+/// Quote- and escape-aware, so a `//` inside a string literal is left alone
+/// rather than truncating the line it sits on.
+fn strip_line_comments(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    for line in source.lines() {
+        let bytes = line.as_bytes();
+        let mut quoted = false;
+        let mut index = 0usize;
+        let mut end = line.len();
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\\' if quoted => index += 1,
+                b'"' => quoted = !quoted,
+                b'/' if !quoted && bytes.get(index + 1) == Some(&b'/') => {
+                    end = index;
+                    break;
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+        out.push_str(&line[..end]);
+        out.push('\n');
+    }
+    out
+}
+
+/// Leadership and the coordinator are handed the **same** scope object.
+///
+/// Both tests above pass a scope they constructed themselves, so they prove the
+/// ordering contract for *whatever* scope leadership is given. Neither can
+/// prove that the scope leadership waits on is the one the coordinator admits
+/// its provider actions into — and if it is not, every assertion in this file
+/// still passes while the property they exist to protect is gone.
+///
+/// The failure is silent by construction. `CoordinatorDeps::new` seeds a
+/// **private** `ProviderActionScope::new()` (see the field comment: "off-server
+/// and test contexts get a private scope from `Default`"), so deleting
+/// `.with_provider_action_scope(..)` from the builder chain does not fail to
+/// compile and does not log. It gives the coordinator a second, disjoint scope:
+/// `rerun_failed_jobs` futures are admitted into that one, leadership's
+/// `wait_until_drained` watches an empty one, reports a graceful drain
+/// immediately, and releases the advisory lock while a provider future from
+/// this incarnation is still alive. That is the exact ordering
+/// `recover_calling_owner` cannot defend against, because it trusts lock
+/// ownership.
+///
+/// SOURCE-LEVEL, and honestly labelled. A behavioural witness would have to
+/// spawn the whole agent stack (`AppState::initialize_agents`) and then read the
+/// coordinator's scope back — and `CoordinatorHandle` exposes no accessor for
+/// it. Adding one so this test could exist would be inventing the seam the test
+/// claims to witness, and the alternative — rebuilding the deps chain here — is
+/// a fixture performing the composition it is meant to observe. What is
+/// checkable without inventing anything is that both consumers name the same
+/// field, and that is what this asserts.
+///
+/// Comments are stripped before matching, so a comment naming the field
+/// satisfies nothing here.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Delete `.with_provider_action_scope(self.inner.provider_action_scope.clone())`
+///     from the `CoordinatorDeps` builder chain in `AppState::initialize_agents`:
+///     the first assertion fails.
+/// (b) Hand the coordinator a fresh scope
+///     (`.with_provider_action_scope(ProviderActionScope::new())`): the same
+///     assertion fails, because the argument is no longer the shared field.
+/// (c) Make `AppState::provider_action_scope()` return a fresh scope rather
+///     than `self.inner.provider_action_scope.clone()`: the accessor assertion
+///     fails — leadership would otherwise wait on a scope with no producer at
+///     all.
+/// (d) Pass `None` for the scope in `main.rs`, or bind `leader_action_scope`
+///     from anything other than `state.provider_action_scope()`: the two
+///     `main.rs` assertions fail, and `quiesce_provider_actions` would
+///     early-return on every shutdown — the pre-`nafu` behaviour, with the lock
+///     released unconditionally.
+#[test]
+fn the_leader_scope_and_the_coordinator_scope_are_one_object() {
+    const FIELD: &str = "self.inner.provider_action_scope.clone()";
+
+    let state = strip_line_comments(include_str!("../src/server/state/mod.rs"));
+
+    assert!(
+        state.contains(&format!(".with_provider_action_scope({FIELD})")),
+        "the coordinator must be built with the SAME scope leadership waits on; \
+         `CoordinatorDeps::new` otherwise seeds a private one and the two \
+         waiters watch disjoint sets of futures",
+    );
+    let accessor = state
+        .find("pub fn provider_action_scope(&self)")
+        .expect("`AppState` must expose the scope leadership is handed");
+    let body_end = accessor
+        + state[accessor..]
+            .find("\n    }")
+            .expect("the accessor must have a body");
+    assert!(
+        state[accessor..body_end].contains(FIELD),
+        "the accessor leadership is handed must return that same field, not a \
+         fresh scope",
+    );
+
+    assert_eq!(
+        state.matches("ProviderActionScope::new()").count(),
+        1,
+        "`AppState` must construct exactly one scope; a second `new()` anywhere \
+         in this file is a second, disjoint set of provider futures",
+    );
+    assert!(
+        state.contains(
+            "provider_action_scope: djinn_orchestration_types::ProviderActionScope::new(),"
+        ),
+        "and the one construction must be the field initialiser, so everything \
+         downstream clones it rather than minting its own",
+    );
+
+    // ── And `main.rs` hands it to leadership rather than `None` ─────────────
+    let main = strip_line_comments(include_str!("../src/main.rs"));
+
+    assert!(
+        main.contains("let leader_action_scope = state.provider_action_scope();"),
+        "the leader scope must come from `AppState`, which is what makes it the \
+         coordinator's",
+    );
+    assert!(
+        main.contains("Some(leader_action_scope),"),
+        "and it must be handed to `run_with_leadership`; `None` makes \
+         `quiesce_provider_actions` a no-op on every shutdown path",
+    );
+}


### PR DESCRIPTION
Closes the remaining AC12 and AC11 gaps for proposal [nafu](https://code.djinnai.io/proposals/019fccac-e07d-7493-a1bc-18996e7d439a), found by the confirmation adversarial audit after #3103.

The audit verified all eight of #3103's deletion probes now kill correctly — but ruled AC12 still not met, because AC12 requires the command list to *prove* the wiring, and two production lines remained deletable with the entire six-command list green.

## Gap A — `close_ci_routes_on_success`

Deleting **both** call sites in `pr_watcher.rs` left all six commands green (131/54/11/47/8/2) and the method fully dead. Consequence: a merged or passing PR never closes its head's Tier-2 lease, `current_failed_identities` never returns to zero, and `permits_rollback` is permanently false — one line silently disabling the mechanism the rollback safety argument rests on.

The behavioural route was investigated first and is genuinely out of reach: both call sites sit after `gh_client.get_pull_request(..)`, and `resolve_installation_client` builds `GitHubApiClient::for_installation`, which hard-codes `GITHUB_API_BASE`. The `for_installation_with_base_url` seam exists in `djinn-provider` but the coordinator has no path to it and no HTTP double. So this splits into two halves:

- **`close_ci_routes_on_success_terminalizes_the_route_and_unblocks_rollback`** (behavioural). The method previously had **no test in any crate**. Plants an open `reserved` route and walks `DisabledClean` (no-op) → `Quiescing` (report shows `current_failed_identities: 1`, `permits_rollback: false`) → close (row `Terminal`, report `0`/`true`, stored verdict cross-checked against `recomputed_verdict()`), over both `merged` values.
- **`the_pr_poller_closes_ci_routes_on_both_merge_and_pass`** (source-level, labelled as such). Strips comments first, so a comment naming the method satisfies nothing. Asserts exactly two call tokens, final arguments `["true", "false"]` in file order, no local `fn` shadowing, and that call 0 sits inside `if pr.merged == Some(true)` before `apply_pr_merge`, call 1 inside the `CiStatus::Passing` arm.

## Gap B — `emit_ci_route_report()`

Was deletable because its only observable is a `tracing::info!`. Now covered behaviourally on that real observable via `#[tracing_test::traced_test]` — the idiom this crate already uses in `failover_chain_logging_captures_candidate_events` — rather than by inventing a table. Drives the production tick with a stranded reservation whose head has moved, asserts `logs_contain("ci route report")` and `logs_contain("suppressed_before_provider_call=1")`, with a precondition that the log is absent beforehand.

## Gap C — AC11 provenance

AC11 constrains provenance, which no behavioural test can observe: a byte-identical inlined copy of `ci_triage::is_inconclusive` passes everything by construction. `the_routing_modules_consume_ci_triage_and_branch_on_no_forbidden_key` uses the `include_str!` + token precedent this repo already accepts (`from_env_delegates_to_the_covered_lookup`), over the eight nafu-owned production modules: the three `ci_triage::` call tokens present, no local `fn` shadowing them, and no comparison operator applied to `.name`, `target.repo`, `target.owner`, or `repository_id`.

**Deliberate nuance:** `transient_fingerprint` hashes `cr.name.trim().to_lowercase()`, so the fingerprint is *keyed* on job name while never *branching* on it. All four `.name` uses in nafu production code were enumerated and none is a branch, which is why the assertion targets comparison operators rather than token appearance — a ban on the token would trip on the codebase's own fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
