### PR TITLE
nafu: fix the red acceptance command and witness the two load-bearing wiring lines

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "uuid",
  "workspace-hack",
 ]

--- a/server/crates/djinn-agent/src/actors/coordinator/mod.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/mod.rs
@@ -183,3 +183,131 @@ mod tests {
         let _: fn(CoordinatorDeps) -> CoordinatorHandle = spawn_coordinator;
     }
 }
+
+// ─── The provider-action scope hop (proposal `nafu`, S28) ───────────────────
+
+/// The CI-route provider-action scope handoff across this facade.
+///
+/// # Why this module carries `ci_routing` in its name
+///
+/// `nafu`'s acceptance list reaches this crate through
+/// `cargo test -p djinn-agent --lib ci_routing`, which filters on the test
+/// path. A witness for the scope hop that no acceptance command executes is a
+/// witness that cannot fail, which is exactly the gap this test closes. The
+/// name is also what the thing is: `CoordinatorDeps::provider_action_scope` is
+/// documented in `djinn-coordinator` as "the leader-scoped registry every
+/// CI-route provider mutation is admitted into".
+#[cfg(test)]
+mod ci_routing_scope_handoff_tests {
+    use super::*;
+
+    /// The scope handed to this facade is the scope the coordinator holds.
+    ///
+    /// BEHAVIOURAL, and it can be: `ProviderActionScope` is an `Arc`-backed
+    /// handle, so "the same object" is directly observable without adding an
+    /// accessor to `CoordinatorHandle` — admit an action through the handle the
+    /// caller kept, then read `in_flight()` off the handle that landed inside
+    /// `djinn_coordinator::CoordinatorDeps`. A private copy reports 0; the same
+    /// object reports 1.
+    ///
+    /// # What the mutation costs in production
+    ///
+    /// Replace [`CoordinatorDeps::with_provider_action_scope`]'s body with
+    /// `let _ = scope; self` and nothing fails to compile and nothing logs:
+    /// `djinn_coordinator::CoordinatorDeps::new` seeds a **private**
+    /// `ProviderActionScope::new()`, so the coordinator silently keeps that
+    /// one. `rerun_failed_jobs` and `enable_auto_merge` futures are then
+    /// admitted into a scope leadership never sees;
+    /// `quiesce_provider_actions` finds an empty scope and returns
+    /// immediately; and the coordinator advisory lock is released while a
+    /// provider future from this incarnation is still live. That is the
+    /// exclusion AC3 states in terms, and the evidence acceptance command 6
+    /// exists to supply. Command 6's own fixture,
+    /// `the_leader_scope_and_the_coordinator_scope_are_one_object`, asserted
+    /// only over `server/src/…` and so stopped at `AppState`'s builder call —
+    /// the forwarder is one crate further in. It now carries a source-level
+    /// cross-check of this same hop; this test is the behavioural half.
+    ///
+    /// NAMED FAILING MUTATIONS.
+    /// (a) `let _ = scope; self`, or deleting the `self.inner = …` assignment:
+    ///     `deps` then holds the private scope `CoordinatorDeps::new` seeded,
+    ///     `in_flight()` is 0 while a guard is alive, and the first assertion
+    ///     fails.
+    /// (b) `self.inner.with_provider_action_scope(ProviderActionScope::new())`
+    ///     — forwarding *a* scope rather than *the* scope: identical failure.
+    /// (c) Making `ProviderActionScope::clone` deep-copy instead of sharing the
+    ///     `Arc`: the first assertion fails, and it must — every waiter in
+    ///     `nafu` would be watching its own private set of futures.
+    ///
+    /// The third assertion (the count falls back to 0 when the guard drops) is
+    /// what stops a mutation that hands the coordinator a *pre-loaded* scope
+    /// from passing: the observation has to track the guard's lifetime, not
+    /// merely be non-zero once.
+    #[tokio::test]
+    async fn the_scope_handed_to_the_facade_is_the_scope_the_coordinator_holds() {
+        let db = crate::test_helpers::create_test_db();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let agent = crate::test_helpers::agent_context_from_db(db.clone(), cancel.clone());
+        let pool = crate::actors::slot::SlotPoolHandle::spawn(
+            agent.clone(),
+            cancel.clone(),
+            crate::actors::slot::SlotPoolConfig {
+                models: Vec::new(),
+                role_priorities: std::collections::HashMap::new(),
+            },
+        );
+        let (events_tx, _events_rx) = tokio::sync::broadcast::channel(8);
+
+        // The scope `AppState` owns and `leadership.rs` waits on.
+        let leader = djinn_orchestration_types::ProviderActionScope::new();
+        let deps = CoordinatorDeps::new(
+            events_tx,
+            cancel,
+            db,
+            pool,
+            agent.catalog.clone(),
+            agent.health_tracker.clone(),
+            agent.role_registry.clone(),
+            agent.background_work_tasks.clone(),
+            agent.lsp.clone(),
+        )
+        .with_provider_action_scope(leader.clone());
+
+        // Vacuity guard first: `in_flight` is an observation, not a constant,
+        // and an untouched scope reports nothing. Without this the assertion
+        // below would also hold for an accessor that always answered 1.
+        assert_eq!(
+            deps.inner.provider_action_scope.in_flight(),
+            0,
+            "control: nothing has been admitted yet",
+        );
+
+        let admitted = leader
+            .admit()
+            .expect("an open scope admits; the fixture never closes it");
+
+        assert_eq!(
+            deps.inner.provider_action_scope.in_flight(),
+            1,
+            "the coordinator must hold the SAME scope object the caller kept: \
+             an action admitted through the leader's handle has to be visible \
+             through the coordinator's, or leadership waits on an empty scope \
+             and releases the advisory lock with a provider future still live",
+        );
+        assert_eq!(
+            leader.counts().admitted_total,
+            deps.inner.provider_action_scope.counts().admitted_total,
+            "and both handles must report one shared ledger, not two that \
+             happen to agree on the live count",
+        );
+
+        drop(admitted);
+        assert_eq!(
+            deps.inner.provider_action_scope.in_flight(),
+            0,
+            "the coordinator's view must follow the guard's lifetime — that is \
+             precisely what `quiesce_provider_actions` waits on before the lock \
+             is released",
+        );
+    }
+}

--- a/server/crates/djinn-agent/src/supervisor_impl/ci_routing/guard_tests.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/ci_routing/guard_tests.rs
@@ -182,6 +182,43 @@ impl Guarded {
     async fn task_status(&self) -> String {
         djinn_db::test_support::task_status_for_test(&self.db, &self.subject.id).await
     }
+
+    /// Make the board believe `head` is this task's PR head, the way the PR
+    /// poller does.
+    ///
+    /// `Task::ci_head_sha` is not a column: every task SELECT derives it from
+    /// the newest `task_pr_ci_snapshots` row. So a snapshot upsert — not a
+    /// task update — is what "the head moved" looks like to the re-read
+    /// inside `apply_lead_ci_result`, and going through the production writer
+    /// is what stops this fixture from staging a value the production path
+    /// could never see.
+    async fn observe_pr_head(&self, head: &str) {
+        djinn_db::TaskRepository::new(self.db.clone(), djinn_core::events::EventBus::noop())
+            .upsert_ci_snapshot(djinn_core::models::TaskPrCiSnapshotInput {
+                task_id: self.subject.id.clone(),
+                pr_number: PR,
+                head_sha: head.to_owned(),
+                ci_status: djinn_core::models::CiStatus::Failing,
+                blocking_required_check_names: vec!["Quality Gate / test".to_owned()],
+                primary_blocking_check: Some("Quality Gate / test".to_owned()),
+                failure_annotations: None,
+                failure_fingerprint: None,
+                same_signature_count: 0,
+                last_remediation_base_sha: None,
+            })
+            .await
+            .expect("seed the board's PR head observation");
+    }
+
+    /// The production dependency bundle `apply_lead_ci_result` takes, over
+    /// **this** fixture's database, so the re-read it performs hits the rows
+    /// seeded above.
+    fn agent_context(&self) -> crate::context::AgentContext {
+        crate::test_helpers::agent_context_from_db(
+            self.db.clone(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+    }
 }
 
 /// A valid repair, cited and with a repository-valid command.
@@ -312,6 +349,180 @@ async fn a_moved_head_applies_nothing() {
         stage_outcome_after_guard(&adjudication.plan, &effect, "stale"),
         StageOutcome::LeadRouteSuperseded { .. }
     ));
+}
+
+// ---------------------------------------------------------------------------
+// S20: where the guard's `observed` head actually comes from
+// ---------------------------------------------------------------------------
+
+/// The production derivation reads the **live** head, not the stored one.
+///
+/// # Why this fixture has to exist
+///
+/// Every other fixture in this file calls [`apply_under_guard`] with a
+/// `CiObservedNow` it built itself, which means the value under test is the
+/// test's own. That leaves the one line production actually depends on — the
+/// re-read of `Task::ci_head_sha` inside `stage::apply_lead_ci_result` —
+/// completely unwitnessed, and this mutation survives the entire `nafu`
+/// acceptance list green:
+///
+/// ```ignore
+/// &ci_routing::CiObservedNow { pr_head_sha: ci.guard.identity.pr_head_sha.clone() }
+/// ```
+///
+/// `observed_identity` then equals the stored identity by construction,
+/// `resolve_tier2_lease`'s head comparison can never fail, and **every** delayed
+/// or stale Lead result applies: a reopen plus a worker dispatch against
+/// evidence a newer head already superseded. That is the double-spent session
+/// the proposal exists to stop.
+///
+/// So this drives the production function, and the only difference between the
+/// two halves below is one row in the database.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) The mutation above (or any other way of deriving `observed_head` from
+///     `ci.guard.identity` rather than from the re-read): the moved half's
+///     `LeadRouteSuperseded` assertion fails AND its durable
+///     `SupersededBeforeApply` assertion fails — two independent witnesses, one
+///     the value the supervisor acts on and one the row the next poll reads.
+///     (The board-status and worker-attempt assertions are negative space, not
+///     the kill: nothing at this layer writes them on either branch. They are
+///     here to catch a future edit that makes the guarded path mutate the board
+///     directly, which is what "applies nothing" has to keep meaning.)
+/// (b) Drop the `.and_then(|task| task.ci_head_sha)` and re-read some other
+///     field: the moved half fails the same way, because the moved head is only
+///     ever visible through `ci_head_sha`.
+/// (c) Invert the guard (`CiGuardOutcome::Current` unconditionally, or a
+///     tautological repository comparison): the moved half fails.
+/// (d) Make the guard refuse unconditionally: the **current** half fails, which
+///     is the vacuity guard — without it every negative in the moved half would
+///     also hold for a function that never applies anything.
+/// (e) Point the re-read at a different task id: the current half's re-read
+///     misses, falls back to the stored head and still passes, but the moved
+///     half's re-read also misses and it fails on every assertion.
+#[tokio::test]
+async fn the_production_derivation_reads_the_live_head_not_the_stored_one() {
+    // ── The board still believes in the head the route reserved ────────────
+    let current = guarded().await;
+    current.observe_pr_head(HEAD).await;
+    let current_ctx = current.context();
+    let current_adjudication = repair(&current_ctx);
+
+    let applied = crate::supervisor_impl::stage::apply_lead_ci_result(
+        &current.agent_context(),
+        &current.subject.id,
+        &current_ctx,
+        &current_adjudication,
+    )
+    .await;
+
+    assert!(
+        matches!(applied, StageOutcome::LeadReopen { .. }),
+        "vacuity guard: a current head must still APPLY through the production \
+         derivation, or the refusal below proves nothing. Got {applied:?}"
+    );
+    let current_row = current.row().await;
+    assert_eq!(
+        current_row.adjudicated_outcome(),
+        Some(CiRouteOutcome::RepairReopened),
+        "and the guard's own transaction must have persisted the repair"
+    );
+    assert_eq!(
+        current_row.reopen_mode,
+        Some(djinn_db::CiReopenMode::Repair)
+    );
+
+    // ── The same call, the same payload, one different snapshot row ────────
+    let moved = guarded().await;
+    moved.observe_pr_head(MOVED_HEAD).await;
+    let moved_ctx = moved.context();
+    let moved_adjudication = repair(&moved_ctx);
+    let status_before = moved.task_status().await;
+    let attempts_before = moved.worker_attempts().await;
+
+    let refused = crate::supervisor_impl::stage::apply_lead_ci_result(
+        &moved.agent_context(),
+        &moved.subject.id,
+        &moved_ctx,
+        &moved_adjudication,
+    )
+    .await;
+
+    assert!(
+        matches!(refused, StageOutcome::LeadRouteSuperseded { .. }),
+        "the live head moved, so the supervisor must be handed the inert \
+         outcome rather than a reopen. Got {refused:?}"
+    );
+    let moved_row = moved.row().await;
+    assert_eq!(
+        moved_row.adjudicated_outcome(),
+        Some(CiRouteOutcome::SupersededBeforeApply),
+        "and the obsolete attempt must be closed as superseded in the same \
+         transaction, not left open for a second adjudication"
+    );
+    assert_eq!(
+        moved_row.reopen_mode, None,
+        "a superseded attempt records no reopen mode"
+    );
+    assert!(
+        moved_row.superseded_by_evidence.is_some(),
+        "the identity that defeated the compare-and-set must be recorded"
+    );
+    assert_eq!(
+        moved.task_status().await,
+        status_before,
+        "no board mutation: a `PrCiFailed` reopen against superseded evidence \
+         is the double-spend this guard exists to stop"
+    );
+    assert_eq!(
+        moved.worker_attempts().await,
+        attempts_before,
+        "and no worker session may be charged for it"
+    );
+}
+
+/// No snapshot to compare against is **not** evidence that the head moved.
+///
+/// The re-read is `Option`-typed all the way down and falls back to the stored
+/// head. That fallback is load-bearing in the opposite direction from the
+/// fixture above: a route whose task carries no `task_pr_ci_snapshots` row yet
+/// must still be able to apply, or the guard refuses every Lead result on a
+/// task the poller has not written a snapshot for.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) `unwrap_or_default()` in place of
+///     `unwrap_or_else(|| ci.guard.identity.pr_head_sha.clone())`: the observed
+///     head becomes `""`, which never equals the stored head, and this fails on
+///     both assertions.
+/// (b) Any fallback naming a constant other than the stored head: same failure.
+///
+/// This is also why the fixture above seeds a snapshot on BOTH halves — without
+/// it, its "current" half would be exercising this fallback rather than a
+/// successful re-read, and mutation (b) there would survive.
+#[tokio::test]
+async fn an_absent_snapshot_falls_back_to_the_stored_head_rather_than_refusing() {
+    let g = guarded().await;
+    let ctx = g.context();
+    let adjudication = repair(&ctx);
+
+    // Deliberately no `observe_pr_head`: `Task::ci_head_sha` is NULL here.
+    let applied = crate::supervisor_impl::stage::apply_lead_ci_result(
+        &g.agent_context(),
+        &g.subject.id,
+        &ctx,
+        &adjudication,
+    )
+    .await;
+
+    assert!(
+        matches!(applied, StageOutcome::LeadReopen { .. }),
+        "an absent snapshot is silence, not a moved head. Got {applied:?}"
+    );
+    assert_eq!(
+        g.row().await.adjudicated_outcome(),
+        Some(CiRouteOutcome::RepairReopened),
+        "and the resolution must be persisted, not merely projected"
+    );
 }
 
 /// A merge landed while Lead was thinking. Same answer, different mechanism:

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -818,7 +818,15 @@ pub(super) fn lead_ci_adjudication(
 /// The freshly observed head comes from a **re-read** of the task, not from the
 /// `task` this run started with: a value loaded at dispatch is as old as the
 /// Lead session, and noticing what moved during that session is the entire job.
-async fn apply_lead_ci_result(
+///
+/// `pub(super)` so `ci_routing::guard_tests` can drive **this** function rather
+/// than the layer below it. The re-read on the next few lines is the sole input
+/// to the guard's head comparison, and replacing it with
+/// `ci.guard.identity.pr_head_sha.clone()` makes that comparison a tautology —
+/// a mutation every fixture that calls `apply_under_guard` with a hand-built
+/// `CiObservedNow` survives by construction. See
+/// `the_production_derivation_reads_the_live_head_not_the_stored_one`.
+pub(super) async fn apply_lead_ci_result(
     agent_context: &AgentContext,
     task_id: &str,
     ci: &ci_routing::CiAdjudicationContext,

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -3970,12 +3970,18 @@ async fn record_ci_snapshot_refuses_an_unproven_enumeration() {
 /// the reachable guarantees are the predicate test (which proves the shared
 /// function is right) and this one (which proves both branches still call it).
 /// Reverting either branch to a bare `checks.check_runs.is_empty()` fails here.
+///
+/// Comments are stripped before matching — this was the one guard in the family
+/// that did not do so, which made it satisfiable by writing prose: a comment
+/// merely *naming* `empty_check_set_is_authoritatively_green` in a branch that
+/// had reverted to `checks.check_runs.is_empty()` kept it green.
 #[test]
 fn both_lane_fast_paths_consult_the_completeness_predicate() {
-    for (label, source) in [
+    for (label, raw) in [
         ("pr_draft", include_str!("../../pr_watcher.rs")),
         ("pr_review", include_str!("../../pr_review_watcher.rs")),
     ] {
+        let source = strip_line_comments(raw);
         assert!(
             source.contains("empty_check_set_is_authoritatively_green"),
             "the {label} no-CI fast path must consult the completeness predicate",
@@ -5965,6 +5971,55 @@ fn strip_line_comments(source: &str) -> String {
     out
 }
 
+/// Comment-stripped source re-joined into **statements** rather than lines.
+///
+/// The AC11 guard asks whether a comparison is applied to a forbidden key
+/// class. Asked per physical line, that question is evaded by a line break:
+///
+/// ```ignore
+/// if cr.name
+///     == "Quality Gate / test"
+/// ```
+///
+/// puts the key on one line and the operator on the next, and neither line
+/// alone trips a per-line rule. So a line is joined to the following one while
+/// it does not end a statement. The terminators are `;`, `{`, `}` and `,` —
+/// exactly what ends a Rust statement, a block, or one argument of a call or
+/// macro — which is what keeps unrelated neighbours apart:
+///
+/// ```ignore
+/// let n = cr.name.clone();   // ends with `;` — its own statement
+/// if a == b {                // never fused with the line above
+/// ```
+///
+/// Verified against all eight routing modules: the rule finds nothing there
+/// that the per-line rule did not, so the tightening adds no false positive.
+///
+/// The `usize` is the 1-based physical line the statement started on, so a
+/// failure can still name a line.
+fn logical_lines(code: &str) -> Vec<(usize, String)> {
+    let mut out: Vec<(usize, String)> = Vec::new();
+    let mut pending: Option<(usize, String)> = None;
+    for (index, line) in code.lines().enumerate() {
+        let number = index + 1;
+        let (start, mut text) = pending.take().unwrap_or_else(|| (number, String::new()));
+        if !text.is_empty() {
+            text.push(' ');
+        }
+        text.push_str(line);
+        let trimmed = text.trim_end();
+        if trimmed.is_empty() || trimmed.ends_with([';', '{', '}', ',']) {
+            out.push((start, text));
+        } else {
+            pending = Some((start, text));
+        }
+    }
+    if let Some(rest) = pending {
+        out.push(rest);
+    }
+    out
+}
+
 /// The PR poller hands both lane routers the LIVE gate.
 ///
 /// Source-level, and honestly labelled as such, for exactly the reason
@@ -6662,7 +6717,9 @@ async fn the_route_sweep_emits_the_routing_report() {
 /// (c) Add `if cr.name.contains("Quality Gate") { … }` — or any comparison on a
 ///     check name, `target.repo`, `target.owner`, or `repository_id` — anywhere
 ///     in a routing module: the forbidden-branch assertion fails, naming the
-///     file and line.
+///     file and line. Including when rustfmt splits it across a line break
+///     (`if cr.name\n    == "Quality Gate"`), which the earlier per-physical-line
+///     form of this check could not see: see [`logical_lines`].
 /// (d) Special-case a migration framework, a build tool, an artifact type, or a
 ///     provider incident label (`"sqlx"`, `"cargo"`, `"incident"`, …): the
 ///     forbidden-vocabulary assertion fails. A branch on one of those classes
@@ -6753,15 +6810,17 @@ fn the_routing_modules_consume_ci_triage_and_branch_on_no_forbidden_key() {
             );
         }
 
-        for (index, line) in code.lines().enumerate() {
-            if !FORBIDDEN_KEYS.iter().any(|key| line.contains(key)) {
+        // Statements, not physical lines: a comparison split across a line
+        // break is the one evasion a per-line rule cannot see, and rustfmt
+        // produces exactly that split as soon as the expression is long.
+        for (number, statement) in logical_lines(&code) {
+            if !FORBIDDEN_KEYS.iter().any(|key| statement.contains(key)) {
                 continue;
             }
-            let number = index + 1;
-            let text = line.trim();
+            let text = statement.trim();
             for comparison in COMPARISONS {
                 assert!(
-                    !line.contains(comparison),
+                    !statement.contains(comparison),
                     "{label}:{number}: `{text}` applies `{comparison}` to a \
                      forbidden key class. AC11 allows a job name, repository, or \
                      owner to be *carried* — hashed into a fingerprint, logged, \

--- a/server/crates/djinn-supervisor/Cargo.toml
+++ b/server/crates/djinn-supervisor/Cargo.toml
@@ -49,3 +49,15 @@ djinn-db = { path = "../djinn-db", features = ["test-support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }
 tracing-subscriber = "0.3"
+# `#[tracing_test::traced_test]` — a PROCESS-GLOBAL capture subscriber, which is
+# the only kind that is correct under `cargo test` at default parallelism.
+# `tracing::dispatcher::set_default` is thread-local, but `Interest` is cached
+# per callsite in a PROCESS-GLOBAL registry: whichever thread first hits a
+# callsite decides its interest for every thread, and a sibling test hitting it
+# with no dispatcher installed caches `Interest::never()` — permanently, because
+# nothing rebuilds the cache afterwards. The events then never reach the
+# thread-local capture and the assertion looks like a missing emission.
+# `tracing-test` installs its subscriber with `set_global_default` over a LEAKED
+# `Dispatch`, so no thread is ever without one. See `djinn-coordinator`, which
+# uses the same crate for the same reason.
+tracing-test = "0.2"

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -5563,20 +5563,37 @@ mod tests {
     ///     the deletion that has to be caught here.
     /// (c) Move the emit after the outcome `match` (so a `break`ing arm skips
     ///     it): same failure as (b), because every Lead outcome breaks.
+    ///
+    /// # Why `#[traced_test]` and not a thread-local subscriber
+    ///
+    /// This fixture used to install its own capture with
+    /// `tracing::dispatcher::set_default`, and it failed on unmutated `main`
+    /// under `cargo test` at default parallelism (11 of 14 runs; 3 of 3 alone;
+    /// 3 of 3 when paired with
+    /// [`lead_route_superseded_run_applies_nothing_and_stays_interrupted`]).
+    /// `set_default` is thread-local but `Interest` is **not**: `tracing_core`
+    /// caches one interest value per callsite in a process-global registry, and
+    /// the thread that first reaches a callsite decides that value for every
+    /// thread. A sibling test in this same filter drives the same production
+    /// run loop with no dispatcher installed on its thread, so it can reach the
+    /// `supervisor.stage_outcome` callsite first, register it against
+    /// `NoSubscriber` (`Interest::never()`), and disable it for the whole
+    /// process — permanently, because only registering another `Dispatch`
+    /// rebuilds the cache. The event then never reaches this thread's capture
+    /// while `stage_runs == 1` still passes, which reads as a missing emission
+    /// rather than a lost subscriber.
+    ///
+    /// `tracing-test` installs its capture once with `set_global_default` over
+    /// a leaked `Dispatch` (constructing it registers it, rebuilding every
+    /// cached interest and pinning the global max-level hint), so from then on
+    /// no thread is ever without a subscriber and no callsite can be poisoned.
+    /// `logs_contain`/`logs_assert` then filter that shared buffer by this
+    /// test's own span scope, so a sibling's events cannot satisfy — or
+    /// falsify — anything asserted below. `djinn-coordinator` uses the same
+    /// crate for the same assertion in `the_route_sweep_emits_the_routing_report`.
     #[tokio::test]
+    #[tracing_test::traced_test]
     async fn lead_route_superseded_emits_its_own_stage_outcome_label() {
-        let logs = CapturedLogs::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
-            .with_writer(logs.clone())
-            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NONE)
-            .with_target(true)
-            .with_ansi(false)
-            .with_level(true)
-            .finish();
-        let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
-        let _guard = tracing::dispatcher::set_default(&dispatch);
-
         let observed = run_lead_stage_case(
             "lead-route-superseded-telemetry",
             StageOutcome::LeadRouteSuperseded {
@@ -5586,13 +5603,33 @@ mod tests {
         .await;
         assert_eq!(observed.stage_runs, 1, "the fixture reached the Lead stage");
 
-        let captured = logs.take();
+        // Vacuity guard on the harness itself: if the capture were dead, every
+        // negative below would hold and the positives would be the only thing
+        // standing. So assert the positives first, and assert them together —
+        // `logs_assert` sees only the lines emitted inside this test's span,
+        // and requires ONE line to carry all three, so a `lead_route_superseded`
+        // label attached to some other task's event satisfies nothing.
+        logs_assert(|lines: &[&str]| {
+            let matched = lines
+                .iter()
+                .filter(|line| {
+                    line.contains("supervisor.stage_outcome")
+                        && line.contains("outcome=\"lead_route_superseded\"")
+                        && line.contains("task_id=lead-route-superseded-telemetry")
+                })
+                .count();
+            if matched == 1 {
+                return Ok(());
+            }
+            Err(format!(
+                "the run must emit exactly one stage-outcome event naming the \
+                 supersession and the task it happened to; found {matched} in:\n{}",
+                lines.join("\n"),
+            ))
+        });
         assert!(
-            captured.contains("supervisor.stage_outcome")
-                && captured.contains("outcome=\"lead_route_superseded\"")
-                && captured.contains("task_id=lead-route-superseded-telemetry"),
-            "the run must emit a stage-outcome event that names the supersession \
-             and the task it happened to, got:\n{captured}",
+            logs_contain("supervisor.stage_outcome"),
+            "and the event must be the stage-outcome one",
         );
         for sibling in [
             "outcome=\"failed\"",
@@ -5600,8 +5637,8 @@ mod tests {
             "outcome=\"lead_parked\"",
         ] {
             assert!(
-                !captured.contains(sibling),
-                "a superseded route must not be reported as {sibling}, got:\n{captured}",
+                !logs_contain(sibling),
+                "a superseded route must not be reported as {sibling}",
             );
         }
     }

--- a/server/tests/leadership_quiescence.rs
+++ b/server/tests/leadership_quiescence.rs
@@ -421,6 +421,13 @@ fn strip_line_comments(source: &str) -> String {
 ///     `main.rs` assertions fail, and `quiesce_provider_actions` would
 ///     early-return on every shutdown — the pre-`nafu` behaviour, with the lock
 ///     released unconditionally.
+/// (e) Replace the body of the djinn-agent facade's
+///     `CoordinatorDeps::with_provider_action_scope` with `let _ = scope; self`,
+///     or change `spawn_coordinator` to build a fresh inner deps: the last two
+///     assertions fail. Every assertion before them reads `server/src/…` only,
+///     so the scope reaching `AppState`'s builder call proves nothing about the
+///     scope reaching the actor — the adapter is one crate further in, and its
+///     private `inner` is why deleting the forward is silent.
 #[test]
 fn the_leader_scope_and_the_coordinator_scope_are_one_object() {
     const FIELD: &str = "self.inner.provider_action_scope.clone()";
@@ -472,5 +479,46 @@ fn the_leader_scope_and_the_coordinator_scope_are_one_object() {
         main.contains("Some(leader_action_scope),"),
         "and it must be handed to `run_with_leadership`; `None` makes \
          `quiesce_provider_actions` a no-op on every shutdown path",
+    );
+
+    // ── And the djinn-agent facade actually FORWARDS it ────────────────────
+    //
+    // `AppState` builds `djinn_agent::actors::coordinator::CoordinatorDeps`,
+    // not `djinn_coordinator`'s. Everything above proves the scope reaches that
+    // adapter; nothing above proves the adapter passes it on. The adapter's
+    // `with_provider_action_scope` is a one-line forwarder whose body can be
+    // replaced with `let _ = scope; self` with every assertion in this file —
+    // and every other `nafu` acceptance command — still green, because
+    // `djinn_coordinator::CoordinatorDeps::new` seeds a private
+    // `ProviderActionScope::new()` the coordinator then keeps.
+    //
+    // The behavioural witness for that hop lives where it can observe the
+    // object: `djinn_agent::actors::coordinator::ci_routing_scope_handoff_tests`
+    // admits an action through the caller's handle and reads `in_flight()` off
+    // the forwarded one. This is the cheap cross-check that the chain from
+    // `AppState` to the spawned actor has no other gap.
+    let agent = strip_line_comments(include_str!(
+        "../crates/djinn-agent/src/actors/coordinator/mod.rs"
+    ));
+
+    let forwarder = agent
+        .find("pub fn with_provider_action_scope(")
+        .expect("the djinn-agent coordinator facade must expose the forwarder");
+    let forwarder_end = forwarder
+        + agent[forwarder..]
+            .find("\n    }")
+            .expect("the forwarder must have a body");
+    assert!(
+        agent[forwarder..forwarder_end]
+            .contains("self.inner = self.inner.with_provider_action_scope(scope);"),
+        "the djinn-agent facade must FORWARD the scope to the inner deps; \
+         dropping the argument leaves the coordinator on the private scope \
+         `CoordinatorDeps::new` seeded, and leadership then waits on a scope no \
+         provider action ever enters",
+    );
+    assert!(
+        agent.contains("djinn_coordinator::CoordinatorHandle::spawn(deps.inner)"),
+        "and the spawn helper must hand over that same `inner`, or the forwarded \
+         scope never reaches the actor at all",
     );
 }


### PR DESCRIPTION
Clears the three blockers the final adversarial audit raised against proposal [nafu](https://code.djinnai.io/proposals/019fccac-e07d-7493-a1bc-18996e7d439a). The audit ruled AC12 NOT MET; ACs 1-11, 13 and 14 were confirmed met with applied-and-reverted mutations.

## 1. Acceptance command 7 was red on unmutated main

`cargo test -p djinn-supervisor --lib lead_route_superseded` exited 101 on clean main — **11 of 14 runs** at default parallelism, passing at `--test-threads=1` and in isolation.

The root cause is **not** the max-level hint but the process-global **callsite `Interest` cache**. `DefaultCallsite::register` computes interest once; with only one dispatcher ever registered, `Rebuilder::JustOne` consults `dispatcher::get_default()` *on the registering thread*. A sibling driving the same production run loop with no dispatcher on its thread reaches the `supervisor.stage_outcome` callsite first, registers it against `NoSubscriber` as `Interest::never()`, and disables it for every thread — permanently, since `set_global_default` alone never rebuilds the cache.

Fixed with `#[tracing_test::traced_test]`, as `djinn-coordinator` already does for the identical assertion. `tracing_test`'s subscriber goes through `Dispatch::new` → `callsite::register_dispatch`, which rebuilds interest for every registered callsite (repairing a poisoned one) and leaks the `Arc`, so no later rebuild can collapse it. After this change no test in the filter calls `set_default` at all.

**Assertions were strengthened, not weakened.** The old test did three `contains` over the whole buffer, which could land on different lines; the new one uses `logs_assert` to require exactly one line, inside this test's own span, carrying all three of `supervisor.stage_outcome`, `outcome="lead_route_superseded"` and the task id. Relabelling the arm and deleting `emit_stage_outcome_event(..)` both still fail.

Ten sibling tests share the `set_default` pattern but none is in the acceptance filter, and CI's nextest is process-per-test. Left alone — the leaked global dispatcher actually makes them strictly more reliable in a single-process run.

## 2. S20 — `apply_lead_ci_result`'s live-head re-read (load-bearing)

Production derives `observed_head` from a re-read of the live `task.ci_head_sha`; that value is the sole input to the supervisor's atomic current-identity guard. Substituting the route's own stored head made the guard incapable of failing, so **every delayed or stale Lead result would apply** — a reopen plus a worker dispatch against evidence a newer head had already superseded. All seven commands stayed green, because the existing tests call `apply_under_guard` directly with a hand-built `CiObservedNow`.

Two **behavioural** fixtures now drive the production function over the real-DB `guarded()` harness, differing only in one `task_pr_ci_snapshots` row. One kills the stored-head substitution; the other kills `unwrap_or_default()`. The doc comment is explicit that the board-status and worker-attempt assertions are negative space rather than the kill — the two killing witnesses are the `StageOutcome` variant and the durable `SupersededBeforeApply` row.

## 3. S28 — the `CoordinatorDeps` scope hop (load-bearing)

Neutralising `with_provider_action_scope` left the coordinator on a privately seeded scope, so leadership waited on a scope nothing registers into and **released the advisory lock while a `rerun_failed_jobs` future was live** — the exclusion AC3 names in terms. The existing guard inspects only `state/mod.rs` and `main.rs`, so it could not see the hop.

`ProviderActionScope` is `Arc`-backed with a public `in_flight()`, so this is covered **behaviourally** without inventing a seam: a test in the module that owns the private field builds the real deps, admits an action through the leader scope, and reads `in_flight()` back from the coordinator side. Kills both `let _ = scope; self` and passing a fresh scope. The module name contains `ci_routing` so acceptance command 4's substring filter actually executes it — a witness no command runs is precisely this round's failure mode. A source cross-check in command 6 extends the existing guard across the hop.

## Also

- `both_lane_fast_paths_consult_the_completeness_predicate` now strips comments like its siblings (it was satisfiable by prose).
- The AC11 forbidden-branch check iterates logical statements rather than physical lines, so a comparison split across two lines no longer evades it. Validated against all eight routing modules — zero hits, identical to the per-line rule, no false positives.

## Known residual

`djinn_coordinator`'s `actor.rs:800`, where the deps' scope is moved onto the spawned actor, remains unwitnessed: `CoordinatorHandle` exposes no accessor and adding one purely to make it testable would invent the seam. This PR covers `AppState` → agent facade → `inner` → `spawn_coordinator`; the final store into the actor struct is the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
