### PR TITLE
fix(5205): give knowledge injection back its scope and lexical signals

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/injection_wiring_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/injection_wiring_tests.rs
@@ -1,0 +1,298 @@
+//! Production-shaped guards for knowledge injection's *retrieval wiring*.
+//!
+//! Proposal `5205` replaced boolean scope-overlap eligibility with a six-signal
+//! RRF fusion, and every signal was proven in isolation. Injection still
+//! collapsed on deploy — average candidates per retrieval fell from 50.0 to 0.2
+//! and 27 of 35 traces recorded `outcome='empty'` — because the *call site* fed
+//! the base-tree loader a value that is not a filesystem path, so validated
+//! scope was empty for 100% of production dispatches and the fusion ran on its
+//! lexical list alone.
+//!
+//! Every test here therefore drives the same entry point dispatch drives
+//! (`assemble_prompt_context`) with the same `project_path` dispatch passes
+//! (`task.project_id`), and asserts the side effect that matters: the scoped
+//! note reaches the rendered prompt. A test that supplies its own
+//! `ListedBaseTree` cannot fail this way and so cannot guard against it.
+
+use super::*;
+
+use djinn_core::events::EventBus;
+use djinn_db::NoteRepository;
+use tokio_util::sync::CancellationToken;
+
+use super::test_support::create_project_epic_task;
+use crate::roles::WorkerRole;
+use crate::test_helpers::agent_context_from_db;
+
+/// A repository path the task text will name, and the note scope that covers it.
+const TASK_FILE_PATH: &str = "server/crates/djinn-agent/src/actors/slot/reply_loop.rs";
+const NOTE_SCOPE_DIR: &str = "server/crates/djinn-agent/src/actors/slot";
+
+/// Note prose sharing **no** term with [`task_text`], so nothing here can be
+/// retrieved lexically and the assertion can only be satisfied by scope.
+const DISJOINT_NOTE_BODY: &str = "Marmalade cartography enumerates purple velvet. Zebra hibernation quietly \
+     precedes frozen tundra migration across nine basalt plateaus.";
+
+/// Task title and description whose vocabulary is disjoint from
+/// [`DISJOINT_NOTE_BODY`] apart from the repository path itself — which is not
+/// part of `notes.search_vector` (that column covers title, tags, and content).
+fn task_text() -> (String, String) {
+    (
+        "Rework carousel throttling".to_owned(),
+        format!("Touches {TASK_FILE_PATH} for the carousel throttling rework."),
+    )
+}
+
+/// Stand up a real Git repository at `{root}/{project_id}.git` holding
+/// `tracked`, committed on `branch`.
+///
+/// This is deliberately a real repository driven through `git`, not a synthetic
+/// [`ListedBaseTree`]: the defect under test was that production never reached
+/// `git` at all, so a fake tree provider would paper straight over it.
+async fn seed_project_mirror(
+    root: &std::path::Path,
+    project_id: &str,
+    branch: &str,
+    tracked: &[&str],
+) {
+    let repo = root.join(format!("{project_id}.git"));
+    std::fs::create_dir_all(&repo).expect("create mirror dir");
+    let run = |args: Vec<String>| {
+        let repo = repo.clone();
+        async move {
+            djinn_git::run_git_command(repo, args)
+                .await
+                .unwrap_or_else(|error| panic!("git failed: {error}"));
+        }
+    };
+    let owned = |args: &[&str]| {
+        args.iter()
+            .map(|a| (*a).to_owned())
+            .collect::<Vec<String>>()
+    };
+
+    run(owned(&["init", "-q", "-b", branch])).await;
+    run(owned(&["config", "user.email", "guard@example.test"])).await;
+    run(owned(&["config", "user.name", "Injection Guard"])).await;
+    for path in tracked {
+        let file = repo.join(path);
+        if let Some(parent) = file.parent() {
+            std::fs::create_dir_all(parent).expect("create tracked parent dir");
+        }
+        std::fs::write(&file, b"// tracked\n").expect("write tracked file");
+    }
+    run(owned(&["add", "-A"])).await;
+    run(owned(&["commit", "-q", "-m", "seed base revision"])).await;
+}
+
+/// Create one knowledge note with the given scope and a body that cannot be
+/// found lexically from the task text.
+async fn seed_disjoint_note(
+    db: &djinn_db::Database,
+    project_id: &str,
+    title: &str,
+    scope_paths: &str,
+) -> djinn_memory::Note {
+    let note_repo = NoteRepository::new(db.clone(), EventBus::noop());
+    let note = note_repo
+        .create_with_scope(
+            project_id,
+            title,
+            DISJOINT_NOTE_BODY,
+            "pattern",
+            None,
+            "[]",
+            scope_paths,
+        )
+        .await
+        .expect("create scoped note");
+    note_repo
+        .set_confidence(&note.id, 0.9)
+        .await
+        .expect("set confidence");
+    note
+}
+
+/// Drive prompt assembly exactly the way `supervisor_impl::stage` does,
+/// including its `project_path` value.
+async fn assemble_like_dispatch(db: djinn_db::Database, task: &Task) -> PromptContext {
+    let app_state = agent_context_from_db(db, CancellationToken::new());
+    let worktree = crate::test_helpers::test_tempdir("injection-wiring-worktree-");
+    let role = WorkerRole;
+    assemble_prompt_context(PromptContextInputs {
+        task,
+        runtime_role: &role,
+        role_for_epic_check: &role,
+        // `stage.rs` sets this to `task.project_id`, because the prompt hands it
+        // to MCP tools as `project=…`. Anything that treats it as a path is a bug.
+        project_path: &task.project_id,
+        worktree_path: worktree.path(),
+        conflict_ctx: None,
+        merge_validation_ctx: None,
+        prompt_setup_commands: None,
+        system_prompt_extensions: "",
+        resolved_skills: &[],
+        app_state: &app_state,
+        read_sources: &[],
+        worker_resume_note: None,
+        arbiter_directive: None,
+        mcp_server_instructions: &std::collections::BTreeMap::new(),
+        extension_diagnostics: &[],
+        cancellation: None,
+        memory_intent_planner: None,
+    })
+    .await
+}
+
+/// The pin on the wiring defect itself, with no database in the way.
+///
+/// `project_path` is `task.project_id`, so treating it as a repository root
+/// resolves nothing. The mirror must be what base-tree resolution finds.
+#[test]
+fn base_tree_root_resolves_the_project_mirror_not_the_project_id() {
+    let mut env = knowledge_context_test_env_guard();
+    let root = crate::test_helpers::test_tempdir("injection-wiring-mirror-");
+    env.set_mirror_root(root.path());
+    let project_id = "019ea3bd-a305-73e3-806c-4edcc96ebfe2";
+
+    assert_eq!(
+        resolve_base_tree_root(project_id, project_id),
+        None,
+        "with no mirror on disk there is no base-tree root: the project id is \
+         not a path, and inventing one would validate prose against the wrong tree"
+    );
+
+    let mirror = root.path().join(format!("{project_id}.git"));
+    std::fs::create_dir_all(&mirror).expect("create mirror dir");
+    assert_eq!(
+        resolve_base_tree_root(project_id, project_id),
+        Some(mirror),
+        "the project's bare mirror is the base-tree root dispatch must read"
+    );
+}
+
+/// AC-shaped guard: a corpus where most notes carry scope paths and the task
+/// text shares **no** lexical term with any of them still yields injected
+/// knowledge, through the real dispatch wiring.
+///
+/// Against the pre-fix wiring this fails: `load_base_tree` is handed the project
+/// id, finds no repository, and `derive_task_scope_paths` returns an empty scope
+/// with `tree_provider_unavailable`, so the scope signal contributes nothing and
+/// the deliberately disjoint corpus is unreachable.
+#[tokio::test]
+async fn scoped_notes_reach_the_prompt_when_the_task_text_shares_no_lexical_term() {
+    let mut env = knowledge_context_test_env_guard();
+    env.clear();
+    let mirror_root = crate::test_helpers::test_tempdir("injection-wiring-mirror-");
+    env.set_mirror_root(mirror_root.path());
+
+    let db = djinn_db::Database::ephemeral().await.expect("ephemeral db");
+    let events = EventBus::noop();
+    let mut task = create_project_epic_task(&db, &events, "Wiring epic", "Wiring task").await;
+    let (title, description) = task_text();
+    task.title = title;
+    task.description = description;
+    task.design = String::new();
+
+    seed_project_mirror(
+        mirror_root.path(),
+        &task.project_id,
+        &project_target_branch(
+            &task,
+            &agent_context_from_db(db.clone(), CancellationToken::new()),
+        )
+        .await,
+        &[TASK_FILE_PATH, "README.md"],
+    )
+    .await;
+
+    // Production shape: 8 of 10 eligible notes carry scope paths (measured at
+    // 8,498 of 10,482 active eligible notes, 81%). None of them is lexically
+    // reachable from the task text.
+    let mut scoped = Vec::new();
+    for index in 0..8 {
+        scoped.push(
+            seed_disjoint_note(
+                &db,
+                &task.project_id,
+                &format!("Marmalade cartography note {index}"),
+                &format!("[\"{NOTE_SCOPE_DIR}\"]"),
+            )
+            .await,
+        );
+    }
+    for index in 0..2 {
+        seed_disjoint_note(
+            &db,
+            &task.project_id,
+            &format!("Unscoped marmalade note {index}"),
+            "[]",
+        )
+        .await;
+    }
+
+    let ctx = assemble_like_dispatch(db, &task).await;
+
+    let injected: Vec<&str> = scoped
+        .iter()
+        .map(|note| note.permalink.as_str())
+        .filter(|permalink| ctx.system_prompt.contains(permalink))
+        .collect();
+    assert!(
+        !injected.is_empty(),
+        "no scoped note reached the prompt: the validated-scope signal \
+         contributed nothing even though 8 of 10 eligible notes are scoped to \
+         {NOTE_SCOPE_DIR} and the task names {TASK_FILE_PATH}"
+    );
+}
+
+/// The lexical list is one contributing signal, not the eligibility gate.
+///
+/// A note sharing *some* of the task's vocabulary must still be retrievable.
+/// The pre-fix `Ranked` mode AND-joined the first twelve query terms, so a whole
+/// title plus description had to appear in one note — measured against the
+/// production corpus, 22 of 25 recent tasks matched zero notes that way, and
+/// with scope dead that empty list was the entire candidate universe.
+#[tokio::test]
+async fn partial_lexical_overlap_still_produces_candidates() {
+    let mut env = knowledge_context_test_env_guard();
+    env.clear();
+    // No mirror: this test isolates the lexical signal, so validated scope must
+    // stay empty and cannot be what satisfies the assertion.
+    let empty_root = crate::test_helpers::test_tempdir("injection-wiring-no-mirror-");
+    env.set_mirror_root(empty_root.path());
+
+    let db = djinn_db::Database::ephemeral().await.expect("ephemeral db");
+    let events = EventBus::noop();
+    let mut task = create_project_epic_task(&db, &events, "Lexical epic", "Lexical task").await;
+    task.title = "Rework carousel throttling".to_owned();
+    task.description = "The carousel stalls whenever a deferred repaint arrives \
+         before the sampler window closes and the queue drains."
+        .to_owned();
+    task.design = String::new();
+
+    // Shares "carousel" with the task and nothing else. Under an AND-joined
+    // twelve-term query this note is unreachable.
+    let note_repo = NoteRepository::new(db.clone(), EventBus::noop());
+    let overlapping = note_repo
+        .create(
+            &task.project_id,
+            "Carousel behaviour",
+            "Marmalade cartography of the carousel, unrelated to everything else.",
+            "pattern",
+            "[]",
+        )
+        .await
+        .expect("create overlapping note");
+    note_repo
+        .set_confidence(&overlapping.id, 0.9)
+        .await
+        .expect("set confidence");
+
+    let ctx = assemble_like_dispatch(db, &task).await;
+    assert!(
+        ctx.system_prompt.contains(&overlapping.permalink),
+        "a note overlapping one query term was not retrieved: the lexical signal \
+         is still gating on every term rather than ranking by overlap"
+    );
+}

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context.rs
@@ -2,7 +2,7 @@
 //! Role-specific prompt-context assembly: conflict, activity, epic, knowledge,
 //! code-graph, and CI directives → rendered system prompt with extensions + skills.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use djinn_core::extension_diagnostics::ExtensionLoadDiagnosticV1;
 use djinn_core::models::Task;
@@ -34,6 +34,7 @@ pub(crate) struct KnowledgeContextTestEnvGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
     rollout: Option<std::ffi::OsString>,
     legacy: Option<std::ffi::OsString>,
+    mirror_root: Option<std::ffi::OsString>,
 }
 
 // Only in-crate unit tests mutate the rollout variables. Test-support callers
@@ -57,6 +58,13 @@ impl KnowledgeContextTestEnvGuard {
         // SAFETY: this guard serializes all knowledge-context rollout tests.
         unsafe { std::env::set_var(KNOWLEDGE_CONTEXT_LEGACY_ENV, value) }
     }
+
+    /// Point bare-mirror resolution at `root` for the life of this guard, so a
+    /// test can stand up the repository that `resolve_base_tree_root` reads.
+    pub(super) fn set_mirror_root(&mut self, root: &std::path::Path) {
+        // SAFETY: this guard serializes all knowledge-context rollout tests.
+        unsafe { std::env::set_var(MIRROR_ROOT_ENV, root) }
+    }
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -73,6 +81,10 @@ impl Drop for KnowledgeContextTestEnvGuard {
                 Some(value) => std::env::set_var(KNOWLEDGE_CONTEXT_LEGACY_ENV, value),
                 None => std::env::remove_var(KNOWLEDGE_CONTEXT_LEGACY_ENV),
             }
+            match &self.mirror_root {
+                Some(value) => std::env::set_var(MIRROR_ROOT_ENV, value),
+                None => std::env::remove_var(MIRROR_ROOT_ENV),
+            }
         }
     }
 }
@@ -85,9 +97,16 @@ pub(crate) fn knowledge_context_test_env_guard() -> KnowledgeContextTestEnvGuard
     KnowledgeContextTestEnvGuard {
         rollout: std::env::var_os(KNOWLEDGE_CONTEXT_ROLLOUT_ENV),
         legacy: std::env::var_os(KNOWLEDGE_CONTEXT_LEGACY_ENV),
+        mirror_root: std::env::var_os(MIRROR_ROOT_ENV),
         _lock: lock,
     }
 }
+
+/// Mirror-root override honoured by [`crate::repo_access::mirror_root`], saved
+/// and restored by [`KnowledgeContextTestEnvGuard`] because base-tree
+/// resolution reads it.
+#[cfg(any(test, feature = "test-support"))]
+const MIRROR_ROOT_ENV: &str = "DJINN_MIRROR_ROOT";
 
 mod ci_directive;
 mod diagnostics;
@@ -483,18 +502,46 @@ pub(crate) async fn project_target_branch(task: &Task, app_state: &AgentContext)
     }
 }
 
+/// Resolve the filesystem root whose Git history holds the attempt's base
+/// revision.
+///
+/// **This is not `project_path`.** `PromptContextInputs::project_path` is the
+/// value the prompt hands to MCP tools as `project=…`, and dispatch sets it to
+/// `task.project_id` — a UUID, deliberately, because `ProjectRepository::resolve`
+/// accepts ids and `owner/repo` slugs but not filesystem paths
+/// (`supervisor_impl::stage`). Handing that UUID to `git` made
+/// [`load_base_tree`] return `None` for *every* production dispatch, so
+/// `derive_task_scope_paths` recorded `tree_provider_unavailable`, the validated
+/// scope was always empty, and knowledge injection degenerated to its lexical
+/// signal alone.
+///
+/// The server and every task-run pod carry the project's **bare mirror** at
+/// `{mirror_root}/{project_id}.git`, which holds exactly the revision an attempt
+/// branches from, so that is the primary source. A `project_path` that really is
+/// a directory (local runs, worker worktrees, tests) is the fallback. Returning
+/// `None` keeps the specified degradation: empty scope with a typed reason.
+pub(crate) fn resolve_base_tree_root(project_id: &str, project_path: &str) -> Option<PathBuf> {
+    let mirror = crate::repo_access::mirror_path(project_id);
+    if mirror.is_dir() {
+        return Some(mirror);
+    }
+    let direct = Path::new(project_path);
+    direct.is_dir().then(|| direct.to_path_buf())
+}
+
 /// Build the base-revision tree provider for `task`'s attempt.
 ///
-/// Resolution order is `origin/<target>`, then `<target>`, then `HEAD`. Every
-/// failure mode returns `None`, which [`derive_task_scope_paths`] turns into an
-/// explicit empty scope with a typed fallback reason: provider unavailability is
-/// a specified degradation, never a hard error and never a licence to trust
-/// unvalidated prose tokens.
+/// Resolution order is `origin/<target>`, then `<target>`, then `HEAD`. A bare
+/// mirror publishes the upstream branch as a local head (`refs/heads/main`, no
+/// `origin/` remote-tracking ref), which is why plain `<target>` must stay in
+/// the ladder. Every failure mode returns `None`, which
+/// [`derive_task_scope_paths`] turns into an explicit empty scope with a typed
+/// fallback reason: provider unavailability is a specified degradation, never a
+/// hard error and never a licence to trust unvalidated prose tokens.
 pub(crate) async fn load_base_tree(
-    project_path: &str,
+    repo_root: &Path,
     target_branch: &str,
 ) -> Option<ListedBaseTree> {
-    let repo_root = std::path::Path::new(project_path);
     if !repo_root.exists() {
         return None;
     }
@@ -1338,7 +1385,10 @@ pub(crate) async fn assemble_prompt_context(inputs: PromptContextInputs<'_>) -> 
                 task_id = %task.short_id,
             );
             async move {
-                load_base_tree(project_path, &project_target_branch(task, app_state).await).await
+                // The base tree comes from the project's own repository, which
+                // `project_path` does not name (see `resolve_base_tree_root`).
+                let root = resolve_base_tree_root(&task.project_id, project_path)?;
+                load_base_tree(&root, &project_target_branch(task, app_state).await).await
             }
             .instrument(span)
         }
@@ -1797,3 +1847,7 @@ mod ci_directive_tests;
 #[cfg(test)]
 #[path = "knowledge_trace_tests.rs"]
 mod knowledge_trace_tests;
+
+#[cfg(test)]
+#[path = "injection_wiring_tests.rs"]
+mod injection_wiring_tests;

--- a/server/crates/djinn-db/src/repositories/note/lexical_search.rs
+++ b/server/crates/djinn-db/src/repositories/note/lexical_search.rs
@@ -9,6 +9,21 @@ pub enum LexicalSearchBackend {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LexicalSearchMode {
     Ranked,
+    /// Same ranking and SQL as [`LexicalSearchMode::Ranked`], but the query
+    /// terms are **disjoined** instead of conjoined.
+    ///
+    /// `Ranked` AND-joins the first 12 terms, which turns the lexical signal
+    /// into a boolean gate: a whole task title plus description has to appear in
+    /// one note before that note is returned at all. Measured against the
+    /// production corpus, 22 of 25 recent tasks matched **zero** notes that way.
+    /// That is acceptable for a user-typed search box, where precision is the
+    /// point, and wrong for one contributing list of a reciprocal-rank fusion,
+    /// where the fusion — not the term parser — decides what wins.
+    ///
+    /// Disjunction makes it a *ranker*: `ts_rank` already scores documents by
+    /// how much of the query they cover, so the caller's `LIMIT` keeps the most
+    /// lexically related notes and drops the rest.
+    RankedAny,
     Dedup,
     Contradiction,
     Discovery,
@@ -98,27 +113,54 @@ pub fn sanitize_sqlite_fts5_query(raw: &str) -> Option<String> {
     )
 }
 
-pub fn sanitize_postgres_tsquery(raw: &str) -> Option<String> {
-    let tokens = raw
+/// Disjunctive counterpart to [`sanitize_sqlite_fts5_query`], for
+/// [`LexicalSearchMode::RankedAny`]. FTS5's implicit operator is `AND`, so the
+/// `OR` has to be written out.
+pub fn sanitize_sqlite_fts5_query_any(raw: &str) -> Option<String> {
+    let tokens: Vec<&str> = raw
         .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|t| {
+            let t = t.to_uppercase();
+            !t.is_empty() && t != "AND" && t != "OR" && t != "NOT" && t != "NEAR"
+        })
+        .collect();
+    if tokens.is_empty() {
+        return None;
+    }
+    Some(
+        tokens
+            .into_iter()
+            .map(|t| format!("\"{t}\""))
+            .collect::<Vec<_>>()
+            .join(" OR "),
+    )
+}
+
+/// The query terms both Postgres sanitizers share: `[A-Za-z0-9_]` runs with
+/// surrounding underscores trimmed, boolean keywords dropped so they cannot be
+/// reinterpreted as `tsquery` operators, capped at 12.
+fn postgres_tsquery_terms(raw: &str) -> Vec<&str> {
+    raw.split(|c: char| !c.is_alphanumeric() && c != '_')
         .map(|term| term.trim_matches('_'))
         .filter(|term| {
             let upper = term.to_uppercase();
             !term.is_empty() && upper != "AND" && upper != "OR" && upper != "NOT"
         })
         .take(12)
-        .collect::<Vec<_>>();
+        .collect()
+}
 
+/// Render the shared terms as a `to_tsquery` expression joined by `joiner`.
+///
+/// Longer terms get the `:*` prefix-match operator so partial tokens still hit.
+/// [`postgres_tsquery_terms`] strips everything except `[A-Za-z0-9_]`, so the
+/// lexemes are safe to interpolate into the tsquery string — but we still pass
+/// the whole expression as a *bound parameter* to `to_tsquery`, never as raw SQL.
+fn render_postgres_tsquery(raw: &str, joiner: &str) -> Option<String> {
+    let tokens = postgres_tsquery_terms(raw);
     if tokens.is_empty() {
         return None;
     }
-
-    // Build a valid Postgres `to_tsquery` expression. Terms are AND-joined
-    // (`&`) and longer terms get the `:*` prefix-match operator so partial
-    // tokens still hit. The sanitizer above strips everything except
-    // [A-Za-z0-9_], so the lexemes are safe to interpolate into the tsquery
-    // string — but we still pass the whole expression as a *bound parameter*
-    // to `to_tsquery`, never as raw SQL.
     Some(
         tokens
             .into_iter()
@@ -130,8 +172,20 @@ pub fn sanitize_postgres_tsquery(raw: &str) -> Option<String> {
                 }
             })
             .collect::<Vec<_>>()
-            .join(" & "),
+            .join(joiner),
     )
+}
+
+pub fn sanitize_postgres_tsquery(raw: &str) -> Option<String> {
+    render_postgres_tsquery(raw, " & ")
+}
+
+/// Disjunctive counterpart to [`sanitize_postgres_tsquery`], for
+/// [`LexicalSearchMode::RankedAny`]. Same terms, same prefix operators, `|`
+/// instead of `&`, so the expression scores partial overlap instead of
+/// requiring every term.
+pub fn sanitize_postgres_tsquery_any(raw: &str) -> Option<String> {
+    render_postgres_tsquery(raw, " | ")
 }
 
 pub fn build_lexical_search_plan(
@@ -139,9 +193,17 @@ pub fn build_lexical_search_plan(
     mode: LexicalSearchMode,
     raw_query: &str,
 ) -> Result<Option<LexicalSearchPlan>> {
-    let query = match backend {
-        LexicalSearchBackend::SqliteFts5 => sanitize_sqlite_fts5_query(raw_query),
-        LexicalSearchBackend::PostgresTsvector => sanitize_postgres_tsquery(raw_query),
+    // Term joining is a per-mode decision, not a per-backend one: `RankedAny`
+    // disjoins so the lexical list ranks rather than gates (see the variant).
+    let query = match (backend, mode) {
+        (LexicalSearchBackend::SqliteFts5, LexicalSearchMode::RankedAny) => {
+            sanitize_sqlite_fts5_query_any(raw_query)
+        }
+        (LexicalSearchBackend::SqliteFts5, _) => sanitize_sqlite_fts5_query(raw_query),
+        (LexicalSearchBackend::PostgresTsvector, LexicalSearchMode::RankedAny) => {
+            sanitize_postgres_tsquery_any(raw_query)
+        }
+        (LexicalSearchBackend::PostgresTsvector, _) => sanitize_postgres_tsquery(raw_query),
     };
 
     let Some(query) = query else {
@@ -158,6 +220,18 @@ pub fn build_lexical_search_plan(
             score_descending: false,
             replacement_notes: vec![
                 "Uses FTS5 virtual table and bm25() column weighting.",
+                "MySQL replacement should order by MATCH() score DESC instead of bm25 ASC.",
+            ],
+        },
+        (LexicalSearchBackend::SqliteFts5, LexicalSearchMode::RankedAny) => LexicalSearchPlan {
+            backend,
+            mode,
+            sql: "SELECT n.id, bm25(notes_fts, 3.0, 1.0, 2.0) as bm25_score\nFROM notes_fts\nJOIN notes n ON notes_fts.rowid = n.rowid\nWHERE notes_fts MATCH $11\n  AND n.project_id = $22\n  AND n.status = 'active'\n  AND ($33 = '' OR n.folder = $43)\n  AND ($54 = '' OR n.note_type = $64)\nORDER BY bm25(notes_fts, 3.0, 1.0, 2.0)\nLIMIT $75".to_owned(),
+            query,
+            score_alias: "bm25_score",
+            score_descending: false,
+            replacement_notes: vec![
+                "Same SQL as Ranked; only the sanitized MATCH expression differs (OR-joined terms).",
                 "MySQL replacement should order by MATCH() score DESC instead of bm25 ASC.",
             ],
         },
@@ -208,6 +282,20 @@ pub fn build_lexical_search_plan(
             score_descending: true,
             replacement_notes: vec![
                 "Uses the generated `notes.search_vector` tsvector + GIN index.",
+                "Ranks with ts_rank() (higher = better) instead of bm25.",
+            ],
+        },
+        (LexicalSearchBackend::PostgresTsvector, LexicalSearchMode::RankedAny) => LexicalSearchPlan {
+            backend,
+            mode,
+            // Bind order (see `ranked_lexical_scores`): $1 query, $2 project_id,
+            // $3/$4 folder (guard + equality), $5/$6 note_type, $7 limit.
+            sql: "SELECT n.id, ts_rank(n.search_vector, to_tsquery('english', $1))::float8 AS fulltext_score\nFROM notes n\nWHERE n.project_id = $2\n  AND n.status = 'active'\n  AND ($3 = '' OR n.folder = $4)\n  AND ($5 = '' OR n.note_type = $6)\n  AND n.search_vector @@ to_tsquery('english', $1)\nORDER BY fulltext_score DESC, n.id ASC\nLIMIT $7".to_owned(),
+            query,
+            score_alias: "fulltext_score",
+            score_descending: true,
+            replacement_notes: vec![
+                "Same SQL as Ranked; only the sanitized tsquery differs (`|` instead of `&`).",
                 "Ranks with ts_rank() (higher = better) instead of bm25.",
             ],
         },
@@ -325,6 +413,62 @@ mod tests {
     fn postgres_thresholds_must_be_non_negative() {
         assert!(validate_postgres_tsvector_threshold(0.0).is_ok());
         assert!(validate_postgres_tsvector_threshold(-0.1).is_err());
+    }
+
+    /// `RankedAny` must disjoin, keeping the terms, the prefix operators, and
+    /// the 12-term cap identical to `Ranked`. Only the operator differs, so the
+    /// two modes stay comparable ranked lists over the same query.
+    #[test]
+    fn postgres_any_sanitizer_disjoins_the_same_terms() {
+        assert_eq!(
+            sanitize_postgres_tsquery("rust sqlite _ bm25"),
+            Some("rust:* & sqlite:* & bm25:*".to_owned())
+        );
+        assert_eq!(
+            sanitize_postgres_tsquery_any("rust sqlite _ bm25"),
+            Some("rust:* | sqlite:* | bm25:*".to_owned())
+        );
+    }
+
+    #[test]
+    fn sqlite_any_sanitizer_writes_the_or_operator() {
+        // FTS5's implicit operator is AND, so disjunction has to be explicit.
+        assert_eq!(
+            sanitize_sqlite_fts5_query("rust sqlite"),
+            Some("\"rust\" \"sqlite\"".to_owned())
+        );
+        assert_eq!(
+            sanitize_sqlite_fts5_query_any("rust sqlite"),
+            Some("\"rust\" OR \"sqlite\"".to_owned())
+        );
+    }
+
+    /// The two ranked modes must stay SQL- and bind-identical: they share one
+    /// execution helper, so a divergent bind order would silently misbind.
+    #[test]
+    fn ranked_any_plan_is_sql_identical_to_ranked() {
+        for backend in [
+            LexicalSearchBackend::PostgresTsvector,
+            LexicalSearchBackend::SqliteFts5,
+        ] {
+            let ranked =
+                build_lexical_search_plan(backend, LexicalSearchMode::Ranked, "alpha beta")
+                    .unwrap()
+                    .unwrap();
+            let any =
+                build_lexical_search_plan(backend, LexicalSearchMode::RankedAny, "alpha beta")
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(ranked.sql, any.sql, "{backend:?}");
+            assert_eq!(ranked.score_alias, any.score_alias, "{backend:?}");
+            assert_eq!(ranked.score_descending, any.score_descending, "{backend:?}");
+            assert_eq!(
+                ranked.needs_query_bind(),
+                any.needs_query_bind(),
+                "{backend:?}"
+            );
+            assert_ne!(ranked.query, any.query, "{backend:?}");
+        }
     }
 
     #[test]

--- a/server/crates/djinn-db/src/repositories/note/search.rs
+++ b/server/crates/djinn-db/src/repositories/note/search.rs
@@ -1050,20 +1050,26 @@ impl NoteRepository {
         // a whole task title plus description returned zero notes for 22 of 25
         // sampled production tasks, and with scope/semantic/graph contributing
         // nothing that single empty list was the entire candidate universe.
-        let lexical_scores = self
-            .ranked_lexical_scores_in_mode(
+        //
+        // Lexical and scope read disjoint predicates over the same table and
+        // neither feeds the other, so they overlap rather than serialize. Both
+        // are hundreds of milliseconds against the production corpus and this
+        // runs on the dispatch prompt path, where the retired scope-overlap
+        // query already cost ~1.5s on average.
+        let (lexical_scores, scope_scores) = tokio::join!(
+            self.ranked_lexical_scores_in_mode(
                 LexicalSearchMode::RankedAny,
                 project_id,
                 "",
                 "",
                 query,
                 raw_limit as i64,
-            )
-            .await?;
+            ),
+            self.ranked_scope_signal(project_id, task_paths, note_types, window),
+        );
+        let lexical_scores = lexical_scores?;
+        let scope_scores = scope_scores?;
         let semantic_scores = semantic_scores.unwrap_or_default();
-        let scope_scores = self
-            .ranked_scope_signal(project_id, task_paths, note_types, window)
-            .await?;
 
         // `seed_ids` are only the *seeds* for spreading activation, not the
         // candidate universe. Graph proximity returns neighbours outside its

--- a/server/crates/djinn-db/src/repositories/note/search.rs
+++ b/server/crates/djinn-db/src/repositories/note/search.rs
@@ -150,7 +150,37 @@ impl NoteRepository {
         query: &str,
         limit: i64,
     ) -> Result<Vec<(String, f64)>> {
-        let Some(plan) = self.lexical_search_plan(LexicalSearchMode::Ranked, query)? else {
+        self.ranked_lexical_scores_in_mode(
+            LexicalSearchMode::Ranked,
+            project_id,
+            folder,
+            note_type,
+            query,
+            limit,
+        )
+        .await
+    }
+
+    /// [`Self::ranked_lexical_scores`] with the term-joining mode chosen by the
+    /// caller. Both modes share the same SQL, bind order, and scoring; only the
+    /// sanitized query expression differs.
+    async fn ranked_lexical_scores_in_mode(
+        &self,
+        mode: LexicalSearchMode,
+        project_id: &str,
+        folder: &str,
+        note_type: &str,
+        query: &str,
+        limit: i64,
+    ) -> Result<Vec<(String, f64)>> {
+        debug_assert!(
+            matches!(
+                mode,
+                LexicalSearchMode::Ranked | LexicalSearchMode::RankedAny
+            ),
+            "only the Ranked plans share this bind order"
+        );
+        let Some(plan) = self.lexical_search_plan(mode, query)? else {
             return Ok(vec![]);
         };
         // NOTE: dynamic SQL (backend-specific FTS query built from a runtime plan) — compile-time check not possible
@@ -1015,8 +1045,20 @@ impl NoteRepository {
         // *eligible* rows to retain per signal.
         let raw_limit = window.saturating_mul(INJECTION_RAW_SIGNAL_MULTIPLIER);
 
+        // The lexical list is one contributing signal of a fusion, not the
+        // eligibility gate, so it disjoins its terms (`RankedAny`). AND-joining
+        // a whole task title plus description returned zero notes for 22 of 25
+        // sampled production tasks, and with scope/semantic/graph contributing
+        // nothing that single empty list was the entire candidate universe.
         let lexical_scores = self
-            .ranked_lexical_scores(project_id, "", "", query, raw_limit as i64)
+            .ranked_lexical_scores_in_mode(
+                LexicalSearchMode::RankedAny,
+                project_id,
+                "",
+                "",
+                query,
+                raw_limit as i64,
+            )
             .await?;
         let semantic_scores = semantic_scores.unwrap_or_default();
         let scope_scores = self


### PR DESCRIPTION
## Incident

Proposal `5205` shipped in v0.7.44 and collapsed knowledge injection. Measured on production 3h after deploy:

| | before | after |
|---|---|---|
| avg `candidate_count` | 50.0 | **0.2** |
| avg `injected_count` | 10.0 | **0.2** |
| `outcome='empty'` | — | **27 / 35** |

Across all 8 candidates retrieved since the deploy: `lexical=8/8`, `temporal=8/8`, `scope=0`, `semantic=0`, `graph=0`, `task_affinity=0`.

## Root cause per dead signal

### 1. Scope — broken. `load_base_tree` was handed a UUID, not a path.

`supervisor_impl/stage.rs` sets `project_path` to `task.project_id` *on purpose*: the prompt hands that value to MCP tools as `project=…`, and `ProjectRepository::resolve` accepts ids and `owner/repo` slugs but not filesystem paths. `5205` then added

```rust
load_base_tree(project_path, &project_target_branch(task, app_state).await)
```

which does `Path::new("019ea3bd-…")` → `!exists()` → `None`. So `derive_task_scope_paths` took the `tree = None` branch on **every** production dispatch.

Confirmed read-only on the box — this is 100% of ranked traces, not a tail:

```sql
SELECT trigger->>'scope_fallback_reason', trigger->>'task_paths', count(*)
FROM retrieval_traces WHERE entry_point='load_knowledge_context'
  AND trigger->>'shape'='ranked_injection_v1' GROUP BY 1,2;
-- tree_provider_unavailable | [] | 36
```

(The reason *was* being logged, in `trigger.scope_fallback_reason` — AC10 is fine, it was just easy to miss.)

The scope **SQL** is innocent. Replaying the prefilter against the production corpus with one realistic task path matches 1,496 of 8,501 eligible scoped notes:

```
task_path = 'server/crates/djinn-agent'  →  scope_matches=1496  eligible_with_scope=8501
```

`NORMALIZED_SCOPE_VALUE_SQL` and `INJECTION_SCOPE_SCAN_CAP` were never the problem; the signal was starved of input.

**Fix:** new `resolve_base_tree_root(project_id, project_path)` resolves the project's bare mirror at `{mirror_root}/{project_id}.git` first, falling back to `project_path` when it really is a directory (local runs, worker worktrees, tests). Verified on the server pod: `DJINN_HOME=/var/lib/djinn` → the mirror exists, `djinn_git::git_command()` already injects `safe.directory` so the cross-UID mount is readable, and `git ls-tree -r --name-only main` returns 6,174 paths. A bare mirror has no `origin/` remote-tracking ref, which is why `load_base_tree`'s `origin/<target>` → `<target>` → `HEAD` ladder already resolves it on the second rung.

**Projected recovery.** Replaying the exact validated-scope derivation (regex → `normalize_scope_token` → `resolve_scope_token`) over the last 25 production tasks against the real tracked-path set: **18 of 25 (72%)** yield a non-empty validated scope, e.g. `eo8g → server/crates/djinn-slot/src/reply_loop/model_turn_admission.rs`, `ma8c → 3 paths`. Today it is 0 of 25.

### 2. Lexical — broken as a *fusion signal*. It was a boolean AND gate.

`sanitize_postgres_tsquery` AND-joins the first 12 terms. The injection query is title + description, so a whole sentence had to appear in one note. Replaying the real sanitizer against the last 25 production tasks and the live corpus:

```
22 of 25 tasks → 0 matching notes
 2 of 25 tasks → 1 note
 1 of 25 tasks → 2 notes
```

That is fine for a user-typed search box and wrong for one contributing list of an RRF fusion, where the fusion decides what wins. With scope dead this empty list *was* the entire candidate universe — which is exactly the 27/35 `empty` rate.

**Fix:** new `LexicalSearchMode::RankedAny` — identical SQL, bind order and scoring, terms joined with `|` instead of `&`. `ts_rank` already scores by query coverage, so the existing `LIMIT` keeps the most related notes. Used **only** by `search_knowledge_injection_candidates`; `memory_search`, dedup and contradiction keep `Ranked` precision unchanged.

### Latency

Both revived signals cost real time, measured read-only against the production database:

| query | warm |
|---|---|
| OR-joined lexical, 12 prefix terms, `LIMIT 200` | ~280 ms |
| scope prefilter for one resolved task path (769 rows) | ~560 ms |

They read disjoint predicates and neither feeds the other, so `search_knowledge_injection_candidates` now runs them under `tokio::join!` instead of back to back. Sized against what this path used to cost:

```sql
SELECT trigger->>'shape', count(*), avg(candidate_fetch_ms), max(candidate_fetch_ms) …
-- ranked_injection_v1 |  49 |  285.9 ms |  989 ms   (today, with 4 signals dead)
-- scope_paths         | 419 | 1516.6 ms | 6219 ms   (the retired pre-5205 path)
```

So a fully-populated fusion lands well under the query `5205` replaced.

### 3. Graph — legitimately empty, downstream of 1 and 2.

Seeds are `lexical ∪ semantic ∪ scope`. All three were empty, so spreading activation had nothing to spread from. No defect in the `453eb367` universe fix; it recovers once scope produces seeds.

### 4. Task affinity — legitimately empty.

`task_affinity_scores` derives from task/epic `memory_refs`. On production only **10 of 178** recently-updated tasks carry any (5.6%). Zero is the correct answer for the other 94%. No defect.

### 5. Semantic — dead by construction, **not fixed here**.

`load_knowledge_context_with_planner` passes `semantic_scores: None` as a literal. There is no embedding seam on `AgentContext` at all (the MCP path gets one via `server.state.embed_memory_query` + `repo.with_vector_store`). So semantic could never fire from this entry point regardless of configuration — and `OPENAI_API_KEY` is empty in the server env anyway, so wiring it would change nothing today. Left as a follow-up: it needs an embedding seam plus a working embedding credential, and adds per-dispatch latency.

## Failing-then-passing repro

`server/crates/djinn-agent/src/actors/slot/lifecycle/injection_wiring_tests.rs` drives the **real** entry point (`assemble_prompt_context`) with the **real** `project_path` dispatch passes (`task.project_id`), against a **real** git repository — a synthetic `ListedBaseTree` cannot reproduce a defect whose essence is that production never reached `git`.

`scoped_notes_reach_the_prompt_when_the_task_text_shares_no_lexical_term` seeds the production shape: 8 of 10 eligible notes carry `scope_paths` (measured: 8,498 of 10,482, 81%), all with prose sharing **no** term with the task text, and asserts the side effect — a scoped note's permalink appears in the rendered system prompt.

Isolation, run three ways:

| | scope test | lexical test |
|---|---|---|
| both fixes reverted | **FAIL** (`no scoped note reached the prompt…`) | **FAIL** (`…still gating on every term`) |
| scope fix only | PASS | FAIL |
| both fixes | PASS | PASS |

The scope guard passes with the lexical signal still AND-gated, so it is satisfied by scope and nothing else.

## Not added: the bounded fallback (AC2)

AC2 forbids `load_knowledge_context` from calling `query_by_scope_overlap`, and I have not violated it. Proposing it explicitly instead:

- **A zero-candidate fallback is no longer the pressing gap.** Once scope is wired, a zero-candidate outcome means the corpus genuinely holds nothing scoped to or lexically near the task. The collapse was a wiring bug wearing a "no results" costume, not a missing safety net.
- **If one is wanted anyway**, the right shape is *not* `query_by_scope_overlap` — that is the recency lottery `5205` deliberately retired. It would be: when the fused list is empty *and* validated scope is non-empty, emit the top-N of `ranked_scope_signal` directly (already ordered by component distance, already bounded by the window). That stays inside the ranking contract and needs only an AC2 amendment naming it.
- **The real missing net is observability.** `memory.retrieval_zero_result` and `injection_starvation` both exist as doctor checks and **neither fired** during this incident — `doctor_findings` shows `memory.retrieval_zero_result` last emitting on 2026-07-20 and `injection_starvation` never. Worth a separate task: find out why the retrieval-health snapshot stopped producing findings, and add an alarm on the rate of `trigger->>'scope_fallback_reason' = 'tree_provider_unavailable'`, which would have named this bug on the first tick.

## Gates

- `./scripts/check-migrations-immutable.sh` — OK (no migration needed)
- `cargo fmt --all --check` — clean
- workspace clippy `--all-targets --features qdrant -D warnings` — clean (exit 0)
- `cargo nextest run -p djinn-agent -E 'test(injection_wiring)'` — 3/3 green; 2/3 fail on the pre-fix code (see the isolation table above)
- `cargo nextest run -p djinn-db -E '…search_ranking or …search_stats or …graph_scoring or lexical_search'` — 64/64 green
- `cargo nextest run -p djinn-agent -E 'test(injection_wiring) or test(knowledge_trace_tests)'` — 27/27 green
- Full CI on commit `63591b3` (the fix commit): all 8 `Server Test` shards, `Server Clippy`, `Server Guards`, `Server sqlx Freshness` and `Quality Gate` green. `57fbe17` (the `tokio::join!`) re-runs the same gates.
- `make sqlx-verify` — not applicable: no `sqlx::query!`/`query_as!` macro was added or changed (the touched call sites use the runtime `sqlx::query_as::<_, _>(&sql)` API), and `server/.sqlx/` is unmodified. CI's `Server sqlx Freshness` check passed regardless.

One caveat on local runs: a first attempt at the whole `djinn-db`/`djinn-agent`/`djinn-slot` suite timed out *en masse* on tests unrelated to this change (`arbiter_park_transaction`, `ci_routing::guard_tests`, `crud_storage::create_and_get_note`) while two nextest suites and a workspace clippy shared one machine and one test Postgres. Every timeout fired at exactly the 90s terminate-after, i.e. machine contention rather than a regression — the narrower runs above were re-done on an idle box, and CI's sharded run is the authoritative signal.
