### PR TITLE
nafu: witness the seven deletable production-wiring gaps (AC12/AC13/AC9)

### DIFF
--- a/server/crates/djinn-agent/src/supervisor_impl/ci_routing/guard_tests.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/ci_routing/guard_tests.rs
@@ -1045,6 +1045,43 @@ fn strip_line_comments(source: &str) -> String {
     out
 }
 
+/// The single argument of the call whose opening parenthesis has just been
+/// consumed, with its trailing comma and surrounding whitespace removed.
+///
+/// Paren-aware, because the argument this file cares about is itself a call
+/// (`directive.as_ref()`) and a naive scan to the first `)` would stop inside
+/// it. Panics rather than guessing if the argument list is not exactly one
+/// item — a second argument means the call's contract changed and the assertion
+/// built on it needs a human, not a silent pass.
+fn sole_argument(after_open_paren: &str) -> &str {
+    let mut depth = 1usize;
+    let mut end = after_open_paren.len();
+    for (index, character) in after_open_paren.char_indices() {
+        match character {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = index;
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let argument = after_open_paren[..end].trim().trim_end_matches(',').trim();
+    assert!(
+        !argument.is_empty(),
+        "vacuity: the call was given no argument at all",
+    );
+    assert_eq!(
+        argument.matches(',').count(),
+        0,
+        "expected a single-argument call, got `{argument}`",
+    );
+    argument
+}
+
 /// The supervisor's Lead stage arm is what reaches the `nafu` contract at all.
 ///
 /// SOURCE-LEVEL, and honestly labelled: `execute_stage` is the enclosing
@@ -1083,15 +1120,57 @@ fn strip_line_comments(source: &str) -> String {
 ///     definition alone) and the call assertion fails.
 /// (d) Inline `apply_lead_ci_result`'s body at the call site: the same failure,
 ///     for the same reason.
+/// (e) `read_arbiter_directive(directive.as_ref())` →
+///     `read_arbiter_directive(None)`: the *token* is still there, so the
+///     presence assertion below is satisfied and so is every arm-ordering
+///     assertion — while every Lead session answers `NoRoute` and takes the
+///     legacy path, a `diagnose` payload is rejected as `Failed`, the arbiter
+///     decision-failure counter is charged, and the task parks at the cap.
+///     `apply_lead_ci_result` becomes dead code with the whole `nafu` command
+///     list green. The ARGUMENT assertion is what fails.
+/// (f) Rebind `directive` from anything other than the arbitration row — e.g.
+///     `let directive: Option<serde_json::Value> = None;`: the binding
+///     assertion fails, which is the same mutation wearing a different hat.
 #[test]
 fn the_supervisors_lead_stage_arm_reads_the_route_and_applies_it_under_the_guard() {
     let code = strip_line_comments(include_str!("../stage.rs"));
 
+    const READ: &str = "ci_routing::CiAdjudicationContext::read_arbiter_directive(";
+    assert_eq!(
+        code.matches(READ).count(),
+        1,
+        "exactly one read of the route block in the Lead stage arm; without it \
+         every Lead session takes the legacy arbiter path and the feature is \
+         unreachable from production. A second one would inherit no guard",
+    );
+
+    // The ARGUMENT, not merely the call. `read_arbiter_directive(None)` leaves
+    // the token in place and reverts the whole feature.
+    let read = code.find(READ).expect("the read call is present") + READ.len();
+    let argument = sole_argument(&code[read..]);
+    assert_eq!(
+        argument, "directive.as_ref()",
+        "the Lead stage arm must hand the arbitration row's OWN directive to \
+         the reader; a literal `None` (or any other stand-in) makes every Lead \
+         session answer `NoRoute`, which is the feature-disabled row of the \
+         mixed-version matrix — permanently, in production",
+    );
+
+    // …and `directive` must be the row's, read from the hold cycle the
+    // coordinator wrote the `ci_route` block onto.
+    let binding = code
+        .find("let directive = {")
+        .expect("the Lead stage arm binds the arbitration directive");
     assert!(
-        code.contains("ci_routing::CiAdjudicationContext::read_arbiter_directive("),
-        "the Lead stage arm must READ the route block; without this call every \
-         Lead session takes the legacy arbiter path and the feature is \
-         unreachable from production",
+        binding < read,
+        "the directive is resolved BEFORE it is read; a later binding is a \
+         different value",
+    );
+    assert!(
+        code[binding..read].contains(".resolve_current_hold_cycle(&task.id)"),
+        "and it must come from THIS task's current arbitration hold cycle — the \
+         row `tier2_dispatch` writes the `ci_route` block onto. Any other \
+         source is a directive no coordinator produced",
     );
 
     // The application half, and that it is the GUARDED one.

--- a/server/crates/djinn-agent/src/supervisor_impl/ci_routing/tests.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/ci_routing/tests.rs
@@ -1488,15 +1488,24 @@ mod lead_ci_routing {
     ///
     /// # Why the assertions are shaped this way
     ///
-    /// Asserting only "LeadRouteSuperseded encodes as 19" would still pass if
-    /// someone appended a twentieth variant after it — it would still be at
-    /// 19, and it would no longer be last. So the load-bearing assertion is
-    /// the *negative* one: index 19 decodes, and index 20 does not exist.
+    /// Asserting only "LeadRouteSuperseded encodes as 20" would still pass if
+    /// someone appended a twenty-first variant after it — it would still be at
+    /// 20, and it would no longer be last. So one load-bearing assertion is
+    /// the *negative* one: index 20 decodes, and index 21 does not exist.
     /// Together they say "this is the highest index the enum has", which is
     /// the only spelling of "appended last" the wire format can witness.
+    ///
+    /// That negative assertion is necessary and **not sufficient**, because it
+    /// answers a question about payload shapes rather than about position: a
+    /// re-tagged `{reason: String}` body fails to parse as most neighbouring
+    /// variants whatever their index. So the tail is additionally pinned
+    /// positionally — the three variants immediately below
+    /// `LeadRouteSuperseded` have their wire indices asserted too, which is
+    /// what makes an insertion *anywhere* in the enum move one of the numbers
+    /// this fixture reads.
     #[test]
     fn lead_route_superseded_is_the_last_wire_variant() {
-        use djinn_supervisor::StageOutcome;
+        use djinn_supervisor::{ModelTurnAdmissionStageOutcome, StageOutcome};
 
         let outcome = StageOutcome::LeadRouteSuperseded {
             reason: "head advanced".to_string(),
@@ -1527,10 +1536,31 @@ mod lead_ci_routing {
             index + 1
         );
 
-        // 3. Every variant an old worker already writes keeps its index, so
-        //    old-writer-to-new-reader still decodes. `WorkerDone` is index 0
-        //    and `Failed` is 14; if LeadRouteSuperseded had been inserted
-        //    rather than appended, one of these would have shifted.
+        // 3. It sits at the tail index, and the three variants immediately
+        //    before it sit at theirs.
+        //
+        //    Assertion 2 alone does NOT pin this, and the gap is not
+        //    theoretical. Move `LeadRouteSuperseded` up one slot, to just above
+        //    `ModelTurnAdmission`, and assertion 2 still passes — for
+        //    *payload-shape* reasons that have nothing to do with position: the
+        //    re-tagged body is `{reason: String}` and index+1 would then be
+        //    `ModelTurnAdmission(<nested enum>)`, which fails to parse, so
+        //    "index + 1 does not decode" reads as "nothing follows me". The two
+        //    anchors below it (`WorkerDone` = 0, `Failed` = 14) both sit BEFORE
+        //    the insertion point, so neither shifts either. Meanwhile
+        //    `ModelTurnAdmission`, `LeadParked` and `LeadSuperseded` have each
+        //    moved up by one, and an old worker's `LeadParked` frame decodes on
+        //    a new launcher as `LeadSuperseded` — a park read as a terminal
+        //    close.
+        //
+        //    So the tail is pinned POSITIONALLY: any insertion anywhere in the
+        //    enum shifts at least one of these five indices.
+        assert_eq!(
+            index, 20,
+            "LeadRouteSuperseded's wire index moved; every variant declared \
+             after the insertion point now decodes as a different outcome on a \
+             mixed-version fleet"
+        );
         for (expected, old) in [
             (0u32, StageOutcome::WorkerDone),
             (
@@ -1538,6 +1568,25 @@ mod lead_ci_routing {
                 StageOutcome::Failed {
                     reason: "boom".to_string(),
                     provider_failure: None,
+                },
+            ),
+            (
+                17u32,
+                StageOutcome::ModelTurnAdmission(ModelTurnAdmissionStageOutcome::Wait(
+                    djinn_db::ModelTurnAdmissionWait::Draining,
+                )),
+            ),
+            (
+                18u32,
+                StageOutcome::LeadParked {
+                    park_dossier_json: "{}".to_string(),
+                },
+            ),
+            (
+                19u32,
+                StageOutcome::LeadSuperseded {
+                    reason: "decomposed".to_string(),
+                    replacement_task_ids: vec!["t456".to_string()],
                 },
             ),
         ] {

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -2774,6 +2774,20 @@ impl CoordinatorActor {
 /// method.
 #[cfg(test)]
 pub(crate) fn actor_with_test_db(db: Database) -> CoordinatorActor {
+    actor_with_test_db_and_scope(db, ProviderActionScope::new())
+}
+
+/// As [`actor_with_test_db`], with the leader's provider-action scope injected
+/// through the same `CoordinatorDeps::with_provider_action_scope` builder
+/// `server/src/leadership.rs` uses in production.
+///
+/// Separate from [`actor_with_test_db`] only so the existing callers keep their
+/// one-argument call; the constructor path is identical.
+#[cfg(test)]
+pub(crate) fn actor_with_test_db_and_scope(
+    db: Database,
+    provider_action_scope: ProviderActionScope,
+) -> CoordinatorActor {
     use crate::test_helpers;
     use djinn_slot::{ModelSlotConfig, SlotPoolConfig};
     use std::collections::HashSet;
@@ -2811,7 +2825,8 @@ pub(crate) fn actor_with_test_db(db: Database) -> CoordinatorActor {
             std::sync::Arc::new(RoleRegistry::new()),
             BackgroundWorkTracker::default(),
             djinn_lsp::LspManager::new(),
-        ),
+        )
+        .with_provider_action_scope(provider_action_scope),
         receiver,
         sender,
         status_tx,

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -3144,7 +3144,8 @@ fn the_reserved_sweep_interval_is_bounded_in_absolute_time() {
          {FLOOR:?} floor, which makes it a hot loop over the route table",
     );
     assert_eq!(
-        crate::pr_poller::CI_ROUTE_SWEEP_INTERVAL, RESERVED_SWEEP_INTERVAL,
+        crate::pr_poller::CI_ROUTE_SWEEP_INTERVAL,
+        RESERVED_SWEEP_INTERVAL,
         "the tick's interval IS the executor's constant; a second, independent \
          constant lets the tick and the recovery contract drift apart",
     );
@@ -3207,7 +3208,8 @@ async fn the_actor_admits_into_the_leaders_provider_action_scope() {
         .admit()
         .expect("an open scope admits");
     assert_eq!(
-        leader.in_flight(), 1,
+        leader.in_flight(),
+        1,
         "a future the coordinator admitted must be visible to the half that \
          holds the advisory lock",
     );

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -3029,6 +3029,225 @@ fn from_env_delegates_to_the_covered_lookup() {
     );
 }
 
+/// …and the poller's accessor must actually CALL it.
+///
+/// SOURCE-LEVEL, and honestly labelled, for the reason the accessor's own doc
+/// comment gives: `CoordinatorActor::ci_routing_gate` carries a `#[cfg(test)]`
+/// seam (`test_ci_routing_gate`) precisely so no fixture has to mutate
+/// process-global environment, and **every** fixture in this file sets it. That
+/// same seam is what leaves the production fall-through unwitnessed. Replace
+/// `CiRoutingGate::from_env()` with `CiRoutingGate::DisabledClean` and
+/// `DJINN_CI_EVIDENCE_ROUTING` is read by nothing in the tree — the feature is
+/// permanently unreachable in production, on every deploy, with no operator
+/// action that can turn it on — while the whole `nafu` command list stays at
+/// its baseline counts, because the fixtures never reach this line.
+///
+/// This is the *same shape* the gate module confesses next door:
+/// `unwrap_or_default()` → `unwrap_or(Enabled)` inside `from_env` turned the
+/// feature on fleet-wide with 2148 tests green. That mutation was closed by
+/// moving the default into `from_lookup` and pinning `from_env` above. This is
+/// the other half — the *call to* `from_env` — and it fails in the opposite
+/// direction: silently off rather than silently on.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) `CiRoutingGate::from_env()` → any `CiRoutingGate::<posture>` literal:
+///     the `from_env()` assertion fails AND the posture ban fails.
+/// (b) `CiRoutingGate::from_env()` → `CiRoutingGate::default()`: the same two.
+/// (c) Dropping the `#[cfg(test)]` on the override so the seam ships: the seam
+///     assertion fails — a production binary whose gate can be overridden from
+///     memory is not a gate.
+/// (d) Deleting or renaming the accessor: the uniqueness `expect` fails, which
+///     is what forces a new accessor to be looked at rather than silently
+///     inheriting no guard.
+#[test]
+fn the_ci_routing_gate_accessor_reads_the_environment_in_production() {
+    const SIGNATURE: &str = "pub(crate) fn ci_routing_gate(&self) -> CiRoutingGate {";
+    let source = strip_line_comments(include_str!("../../ci_lane_routing.rs"));
+    assert_eq!(
+        source.matches(SIGNATURE).count(),
+        1,
+        "exactly one gate accessor; a changed count needs this test updated, \
+         not ignored",
+    );
+
+    let body = source
+        .split(SIGNATURE)
+        .nth(1)
+        .expect("ci_lane_routing.rs defines the gate accessor");
+    let body = &body[..body
+        .find("\n    }")
+        .expect("the accessor body terminates at its own indentation")];
+    assert!(
+        !body.trim().is_empty(),
+        "vacuity guard: the extracted accessor body is empty, so nothing below \
+         is being asserted about anything",
+    );
+
+    assert!(
+        body.contains("CiRoutingGate::from_env()"),
+        "the accessor's production fall-through must READ the environment \
+         through the covered constructor; without this call the gate variable \
+         is never read and the whole feature is unreachable in production. \
+         Found:\n{body}",
+    );
+    for posture in ["DisabledClean", "Quiescing", "Enabled", "default()"] {
+        assert!(
+            !body.contains(&format!("CiRoutingGate::{posture}")),
+            "the accessor RESOLVES a posture, it never names one; found \
+             `CiRoutingGate::{posture}` in:\n{body}",
+        );
+    }
+    assert!(
+        body.contains("#[cfg(test)]") && body.contains("self.test_ci_routing_gate"),
+        "the one permitted override is the `#[cfg(test)]` seam; an \
+         unconditional override would ship a gate production cannot trust. \
+         Found:\n{body}",
+    );
+}
+
+/// The recurring reservation sweep has to fire inside a process lifetime.
+///
+/// The sweep fixtures below drive the production tick by winding
+/// `last_ci_route_sweep` back with [`a_sweep_interval_ago`] — which is defined
+/// as `2 * CI_ROUTE_SWEEP_INTERVAL`, i.e. *relative to the constant under
+/// test*. That is a second opinion from the same witness: set
+/// `RESERVED_SWEEP_INTERVAL` to a year and every one of those fixtures still
+/// passes, because the fixture's idea of "long enough ago" moves with it, while
+/// in production the sweep never runs once. The rows it exists for are exactly
+/// the ones no poller revisits — a `reserved` row whose head has moved — so
+/// they would sit stranded, holding their charge, until the process restarts.
+///
+/// So the bound here is ABSOLUTE, in units the constant cannot redefine.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) `from_secs(60)` → any value above five minutes: the ceiling fails.
+/// (b) `from_secs(60)` → a sub-second value: the floor fails (that is a hot
+///     loop over the route table on every tick, not a sweep).
+/// (c) Pointing `CI_ROUTE_SWEEP_INTERVAL` at a second, independent constant:
+///     the equality fails, because the tick and the recovery contract would be
+///     free to drift apart.
+#[test]
+fn the_reserved_sweep_interval_is_bounded_in_absolute_time() {
+    const CEILING: Duration = Duration::from_secs(5 * 60);
+    const FLOOR: Duration = Duration::from_secs(1);
+
+    assert!(
+        RESERVED_SWEEP_INTERVAL <= CEILING,
+        "the reserved sweep must fire within a process lifetime: \
+         {RESERVED_SWEEP_INTERVAL:?} exceeds the {CEILING:?} ceiling, which \
+         strands every `reserved` row the polling path cannot revisit until \
+         the coordinator restarts",
+    );
+    assert!(
+        RESERVED_SWEEP_INTERVAL >= FLOOR,
+        "and it must remain a sweep: {RESERVED_SWEEP_INTERVAL:?} is below the \
+         {FLOOR:?} floor, which makes it a hot loop over the route table",
+    );
+    assert_eq!(
+        crate::pr_poller::CI_ROUTE_SWEEP_INTERVAL, RESERVED_SWEEP_INTERVAL,
+        "the tick's interval IS the executor's constant; a second, independent \
+         constant lets the tick and the recovery contract drift apart",
+    );
+}
+
+/// The coordinator admits into the LEADER's provider-action scope.
+///
+/// `CoordinatorActor::new` destructures `CoordinatorDeps` and moves the scope
+/// across. Replace that move with a fresh `ProviderActionScope::new()` and the
+/// actor admits every `rerun_failed_jobs` future into a private registry nobody
+/// waits on: `server/src/leadership.rs` polls the scope *it* built, reads zero
+/// in flight, and releases the coordinator advisory lock while a provider
+/// mutation is still running — which is the single thing AC "the lock is not
+/// released while a provider future is live" forbids. Every other fixture in
+/// this file reads the scope back off the actor it built, so the actor agrees
+/// with itself and all of them stay green.
+///
+/// Behavioural: no new seam is needed. `provider_action_scope` is already
+/// `pub(super)` and `CoordinatorDeps::with_provider_action_scope` is the same
+/// builder production uses.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) `provider_action_scope,` → `provider_action_scope: ProviderActionScope::new()`
+///     in `CoordinatorActor::new`: the leader-to-actor assertion fails on the
+///     first admit.
+/// (b) Dropping `.with_provider_action_scope(..)` from the deps builder: the
+///     same failure, for the same reason.
+/// (c) Making `ProviderActionScope::clone` deep rather than `Arc`-shared: both
+///     directions fail.
+#[tokio::test]
+async fn the_actor_admits_into_the_leaders_provider_action_scope() {
+    let db = Database::open_in_memory().expect("ephemeral test database");
+    let leader = ProviderActionScope::new();
+    let actor = crate::actor::actor_with_test_db_and_scope(db, leader.clone());
+
+    // Vacuity: both halves start empty, so a non-zero reading below is caused
+    // by the admit and not by the fixture's own setup.
+    assert_eq!(leader.in_flight(), 0, "vacuity: the leader starts empty");
+    assert_eq!(
+        actor.provider_action_scope.in_flight(),
+        0,
+        "vacuity: the actor starts empty",
+    );
+
+    // Leader → actor. This is the direction leadership reads.
+    let held = leader.admit().expect("an open scope admits");
+    assert_eq!(
+        actor.provider_action_scope.in_flight(),
+        1,
+        "the actor must share the LEADER's scope; a private one reports zero \
+         while a provider future is live, and the advisory lock is released \
+         out from under it",
+    );
+    drop(held);
+    assert_eq!(actor.provider_action_scope.in_flight(), 0);
+
+    // Actor → leader. This is the direction the routing executor writes.
+    let held = actor
+        .provider_action_scope
+        .admit()
+        .expect("an open scope admits");
+    assert_eq!(
+        leader.in_flight(), 1,
+        "a future the coordinator admitted must be visible to the half that \
+         holds the advisory lock",
+    );
+    drop(held);
+    assert_eq!(leader.in_flight(), 0);
+
+    // And the rollback posture is one fact, not two.
+    leader.close_admission();
+    assert!(
+        actor.provider_action_scope.is_admission_closed(),
+        "closing admission on the leader's half must close the coordinator's; \
+         two scopes would let the coordinator keep admitting after leadership \
+         declared the drain",
+    );
+
+    // ── The one hop above this that nothing can read back ──────────────────
+    //
+    // Production reaches `CoordinatorActor::new` through
+    // `CoordinatorHandle::spawn`, which rebuilds the deps with a struct-update
+    // to default the consolidation runner. `..deps` carries the scope; naming
+    // the field explicitly there would silently replace it, and `spawn` returns
+    // a handle with no scope accessor, so no fixture can observe the swap.
+    // Adding an accessor purely to observe it would be inventing the seam under
+    // test, so this hop is asserted textually: the spawn helper may not name a
+    // scope at all.
+    let handle = strip_line_comments(include_str!("../../../handle.rs"));
+    assert!(
+        handle.contains("..deps"),
+        "`CoordinatorHandle::spawn` must carry the caller's deps forward with a \
+         struct update; enumerating the fields makes a dropped one a silent \
+         behaviour change rather than a compile error",
+    );
+    assert!(
+        !handle.contains("ProviderActionScope"),
+        "and it must never name the scope: the only correct value is the one \
+         `AppState` built, and spawning with a fresh one hands leadership an \
+         empty registry to wait on",
+    );
+}
+
 // ===========================================================================
 // The complete-empty compatibility paths
 // ===========================================================================
@@ -6518,6 +6737,12 @@ fn a_routed_pr_draft_disposition_turns_the_legacy_remedy_off() {
 ///     legacy remedy anywhere in the file: the occurrence counts fail, which
 ///     forces a new caller to be looked at rather than silently inheriting no
 ///     guard.
+/// (f) Qualify the condition — `… .is_routed() && false`, or `&& gate ==
+///     CiRoutingGate::Enabled`, or any other conjunct: the head is still
+///     `if self`, `return;` is still inside a well-formed block, and the block
+///     still ends before both remedies, so (a)–(e) all hold. The
+///     nothing-between-the-disposition-and-the-brace assertion is what fails,
+///     and it is the only one that can.
 #[test]
 fn a_routed_merge_group_disposition_replaces_the_legacy_queue_remedy() {
     let code = strip_line_comments(include_str!("../../pr_commands.rs"));
@@ -6593,6 +6818,26 @@ fn a_routed_merge_group_disposition_replaces_the_legacy_queue_remedy() {
         "a routed merge-group failure must LEAVE `handle_queue_failure`; falling \
          out of this branch hands the same dequeue to the legacy remedies as well",
     );
+
+    // …and the disposition must be the WHOLE condition.
+    //
+    // Everything above pins the head (`if self`), the body (`return;`) and the
+    // ordering (before both remedies). That leaves exactly one place a conjunct
+    // can hide — between `.is_routed()` and the brace it opens — and a conjunct
+    // there is not cosmetic: `… .is_routed() && false` satisfies every one of
+    // those assertions while the branch becomes unreachable, so the route layer
+    // takes the evidence AND `handle_queue_failure` runs on to
+    // `PrCiFailed`. One dequeue then reopens the task for rework and re-enters
+    // the queue, which is the double-spend the whole proposal exists to stop.
+    let qualifier = code[after_routed..open].trim();
+    assert!(
+        qualifier.is_empty(),
+        "the routed disposition is the ENTIRE branch condition; found \
+         `{qualifier}` between `.is_routed()` and the branch it opens. A \
+         conjunct there turns the early return off while the head, the body and \
+         the ordering all still read correctly",
+    );
+
     assert!(
         block < park && park < reopen,
         "and it must leave BEFORE either legacy remedy is reachable: the park at \

--- a/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
+++ b/server/crates/djinn-db/src/repositories/ci_route_attempt_tests.rs
@@ -4152,6 +4152,146 @@ async fn hold_observation_is_idempotent_across_restart() {
     assert_eq!(other.poll_sequence, 2);
 }
 
+/// One hold streak per `(repository, PR, head, lane, dequeue)` identity — on
+/// the PR-head lane, where `dequeue_id IS NULL`.
+///
+/// # Why NULL is the whole story here
+///
+/// `lock_or_create_streak` creates with `INSERT … ON CONFLICT DO NOTHING` and
+/// **no conflict target**, so the only thing standing between two simultaneous
+/// creations and two rows is `NULLS NOT DISTINCT` on
+/// `ci_incomplete_hold_streaks_identity_uniq` (migration 195). Drop that one
+/// clause and, under the default `NULLS DISTINCT`, every PR-head streak is
+/// unique to itself no matter how many of them exist: two concurrent
+/// coordinator polls mint two streaks for one head, each counts alone, and
+/// `CI_INCOMPLETE_HOLD_MAX_POLLS` is reached at twice the wall-clock — or
+/// never, if the polls keep splitting. The bounded hold silently becomes an
+/// unbounded one, which is the stall the bound exists to prevent.
+///
+/// Every other hold fixture in this file polls **sequentially**, and a
+/// sequential second poll finds the first row under `SELECT … FOR UPDATE`
+/// before it ever attempts an insert. So none of them touches the clause, and
+/// dropping it leaves the whole `nafu` command list at its baseline counts.
+///
+/// # The two halves
+///
+/// 1. **The race**, driven through the production repository: two reservations
+///    for one identity, concurrently, from a state where no row exists.
+/// 2. **The collapse**, deterministic: the creation statement
+///    `lock_or_create_streak` issues, replayed verbatim against the identity
+///    columns of the row that already exists. Under the index it is absorbed
+///    (`rows_affected() == 0`); without it, it silently mints a second streak.
+///    This half does not depend on how the runtime happened to interleave, so
+///    it holds the contract even if (1) is scheduled sequentially.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn one_pr_head_identity_holds_one_streak_across_concurrent_polls() {
+    let f = fixture().await;
+    let identity = hold_identity(&f.subject, "headsha-concurrent-identity");
+    assert!(
+        identity.dequeue_id.is_none(),
+        "vacuity: this fixture is about the PR-head lane, whose dequeue id is \
+         NULL — that is the column the identity index has to collapse",
+    );
+    assert_eq!(
+        count_rows(&f.db, "SELECT COUNT(*) FROM ci_incomplete_hold_streaks").await,
+        0,
+        "vacuity: no streak exists yet, so both reservations below race to \
+         CREATE one rather than finding it",
+    );
+
+    // ── (1) Two concurrent polls of one PR head ────────────────────────────
+    //
+    // Two repositories, as two coordinator ticks would hold: nothing is shared
+    // between them but the database.
+    let left = CiIncompleteHoldRepository::new(f.db.clone());
+    let right = CiIncompleteHoldRepository::new(f.db.clone());
+    let left_poll = uuid::Uuid::now_v7().to_string();
+    let right_poll = uuid::Uuid::now_v7().to_string();
+    let (first, second) = tokio::join!(
+        left.reserve_poll(&identity, &left_poll),
+        right.reserve_poll(&identity, &right_poll),
+    );
+    let first = first.expect("the first concurrent reservation");
+    let second = second.expect("the second concurrent reservation");
+
+    assert_eq!(
+        first.streak_id, second.streak_id,
+        "two polls of ONE PR head are one identity and must share one streak; \
+         separate streaks each count alone and the bound is never reached",
+    );
+    assert_eq!(
+        count_rows(&f.db, "SELECT COUNT(*) FROM ci_incomplete_hold_streaks").await,
+        1,
+        "exactly one hold row per repository/PR/head/lane/dequeue identity",
+    );
+    let mut sequences = [first.poll_sequence, second.poll_sequence];
+    sequences.sort_unstable();
+    assert_eq!(
+        sequences,
+        [1, 2],
+        "and both polls draw from that ONE streak's sequence space, so neither \
+         is silently ordering itself against a private counter",
+    );
+
+    // ── (2) The collapse, without relying on the scheduler ─────────────────
+    //
+    // The identity columns are read back off the surviving row so this replays
+    // the production statement against the production values rather than a
+    // hand-built approximation of them.
+    let (subject_kind, subject_id, repository_id, pr_number, pr_head_sha, lane, dequeue_id): (
+        String,
+        String,
+        String,
+        i64,
+        String,
+        String,
+        Option<String>,
+    ) = sqlx::query_as(
+        "SELECT subject_kind, subject_id, repository_id, pr_number, pr_head_sha, lane, dequeue_id \
+         FROM ci_incomplete_hold_streaks",
+    )
+    .fetch_one(f.db.pool())
+    .await
+    .expect("the single surviving streak");
+    assert!(
+        dequeue_id.is_none(),
+        "vacuity: the surviving row really does carry a NULL dequeue id",
+    );
+
+    // Verbatim from `lock_or_create_streak`: no conflict target, so the index
+    // is the entire guard.
+    let absorbed = sqlx::query(
+        "INSERT INTO ci_incomplete_hold_streaks \
+           (id, subject_kind, subject_id, repository_id, pr_number, pr_head_sha, lane, dequeue_id) \
+         VALUES ($8, $1, $2, $3, $4, $5, $6, $7) ON CONFLICT DO NOTHING",
+    )
+    .bind(&subject_kind)
+    .bind(&subject_id)
+    .bind(&repository_id)
+    .bind(pr_number)
+    .bind(&pr_head_sha)
+    .bind(&lane)
+    .bind(dequeue_id)
+    .bind(uuid::Uuid::now_v7().to_string())
+    .execute(f.db.pool())
+    .await
+    .expect("a duplicate creation is absorbed, never an error");
+
+    assert_eq!(
+        absorbed.rows_affected(),
+        0,
+        "the creation statement is `ON CONFLICT DO NOTHING` with NO target, so \
+         `NULLS NOT DISTINCT` on the identity index is the only thing that can \
+         absorb a duplicate PR-head streak. Without it this insert succeeds and \
+         one PR head owns two streaks",
+    );
+    assert_eq!(
+        count_rows(&f.db, "SELECT COUNT(*) FROM ci_incomplete_hold_streaks").await,
+        1,
+        "and the row count is what that means operationally",
+    );
+}
+
 /// Sequence reservation, not arrival time, is the authority order.
 ///
 /// A poll that reserved earlier but lands later is **superseded**: it writes

--- a/server/crates/djinn-db/tests/migrations_immutable.rs
+++ b/server/crates/djinn-db/tests/migrations_immutable.rs
@@ -54,28 +54,17 @@ fn postgres_migration_names_are_canonical_and_increasing() {
 
 #[test]
 fn postgres_migration_150_is_immutable() {
-    let bytes = fs::read(
-        migrations_dir("migrations_postgres").join("150_service_preset_wrapper_identity.sql"),
-    )
-    .expect("migration 150 readable");
-    let digest = Sha256::digest(bytes);
-
-    assert_eq!(
-        format!("{digest:x}"),
-        "c341372f7b745f384175ef412d1d40a7c809b8194930cf16533eb638d49f3dc1"
+    assert_migration_unchanged(
+        "150_service_preset_wrapper_identity.sql",
+        "c341372f7b745f384175ef412d1d40a7c809b8194930cf16533eb638d49f3dc1",
     );
 }
 
 #[test]
 fn postgres_migration_167_is_immutable() {
-    let bytes =
-        fs::read(migrations_dir("migrations_postgres").join("167_launcher_authority_mode.sql"))
-            .expect("migration 167 readable");
-    let digest = Sha256::digest(bytes);
-
-    assert_eq!(
-        format!("{digest:x}"),
-        "137a03e948625947052b6aeed64dea53efa6a99184c30fd832815619e26edae7"
+    assert_migration_unchanged(
+        "167_launcher_authority_mode.sql",
+        "137a03e948625947052b6aeed64dea53efa6a99184c30fd832815619e26edae7",
     );
 }
 
@@ -96,18 +85,92 @@ fn postgres_migration_167_is_immutable() {
 /// delta actually lives.
 #[test]
 fn postgres_migration_193_is_immutable() {
-    let bytes = fs::read(migrations_dir("migrations_postgres").join("193_ci_route_attempts.sql"))
-        .expect("migration 193 readable");
-    let digest = Sha256::digest(bytes);
+    assert_migration_unchanged(
+        "193_ci_route_attempts.sql",
+        "f8d980da51aabd745bc89f163109ba23ee1198a76d5ae8d2271290f4321d906c",
+    );
+}
+
+/// Assert one migration file still hashes to the digest recorded when it
+/// merged.
+///
+/// Factored out because the pins below say the same thing about four files and
+/// the remediation instruction is the part worth stating once, carefully: sqlx
+/// stores a per-file checksum in `_sqlx_migrations`, so a mutated file is not a
+/// review nit — every database that already applied it refuses to boot.
+fn assert_migration_unchanged(file: &str, expected: &str) {
+    let bytes = fs::read(migrations_dir("migrations_postgres").join(file))
+        .unwrap_or_else(|error| panic!("migration `{file}` readable: {error}"));
+    assert!(
+        !bytes.is_empty(),
+        "vacuity: migration `{file}` is empty, so its digest asserts nothing"
+    );
+    let digest = format!("{:x}", Sha256::digest(&bytes));
 
     assert_eq!(
-        format!("{digest:x}"),
-        "f8d980da51aabd745bc89f163109ba23ee1198a76d5ae8d2271290f4321d906c",
-        "migration 193 was modified after it merged to main. sqlx stores its \
-         checksum in `_sqlx_migrations` and every database that already applied \
-         it will refuse to boot. Restore it byte-for-byte \
+        digest, expected,
+        "migration `{file}` was modified after it merged to main. sqlx stores \
+         its checksum in `_sqlx_migrations` and every database that already \
+         applied it will refuse to boot. Restore it byte-for-byte \
          (`git checkout origin/main -- \
-         server/crates/djinn-db/migrations_postgres/193_ci_route_attempts.sql`) \
-         and express the change as a new migration instead."
+         server/crates/djinn-db/migrations_postgres/{file}`) and express the \
+         change as a new migration instead."
+    );
+}
+
+/// 194 is pinned for the same reason 193 is, and it is not this proposal's.
+///
+/// `scripts/check-migrations-immutable.sh` diffs `origin/main...HEAD`, so a
+/// migration that a branch forked *before* is classified as `Added` by that
+/// branch and excluded by `--diff-filter=MRD`. Every migration added after a
+/// long-lived branch's fork point is therefore editable from that branch with
+/// the guard green. A content hash does not care about the merge base.
+#[test]
+fn postgres_migration_194_is_immutable() {
+    assert_migration_unchanged(
+        "194_liveness_evidence_trigger_identity.sql",
+        "25bbe45b0d677dfb4ab155def5b58dd5c649a536a3a658fa7d984b754d861ada",
+    );
+}
+
+/// 195 carries the `ci_route_attempts` wave-5 delta, and is the migration the
+/// `nafu` stack is most likely to reach for.
+///
+/// It is where 193's corrective DDL was moved to *because* 193 had already
+/// merged — which makes 195 the next file a wave is tempted to grow rather than
+/// supersede. It also holds two `NULLS NOT DISTINCT` clauses (the evidence
+/// identity index and the incomplete-hold identity index) whose deletion is
+/// invisible to every sequential fixture; the behavioural half of that contract
+/// is `ci_route_attempt_tests::one_pr_head_identity_holds_one_streak_across_concurrent_polls`,
+/// and this pin is the half that says the clause may not be removed by editing
+/// the applied migration.
+///
+/// Named `ci_route_attempts_…` deliberately: 195's DDL is `ALTER TABLE
+/// ci_route_attempts` plus the two relations that table's routing contract
+/// depends on, so the name is honest AND the pin is reachable from the
+/// proposal's `cargo test -p djinn-db ci_route_attempt` filter. A migration
+/// guard no acceptance command runs is a guard that fails after the fact.
+#[test]
+fn ci_route_attempts_migration_195_is_immutable() {
+    assert_migration_unchanged(
+        "195_ci_route_lead_rejection_and_rollback_reports.sql",
+        "8aa11a5b1277a4fc41b4b35b7869f4be914c083b087a3016b377e5f701ff2ddb",
+    );
+}
+
+/// 196 retires `process_terminated` from the `calling`-recovery quiescence
+/// vocabulary.
+///
+/// Pinned because reinstating a value in an applied `CHECK` constraint by
+/// editing this file is exactly the shape the branch-diff guard cannot see, and
+/// because the value it removes is the one an operator under pressure would
+/// most want back — it is the only spelling of "the process died" the schema
+/// ever had, and the migration's own comment explains at length why nothing can
+/// soundly produce it.
+#[test]
+fn postgres_migration_196_is_immutable() {
+    assert_migration_unchanged(
+        "196_ci_route_quiescence_proof_graceful_drain_only.sql",
+        "1a4ef8d00cc4723c6ddc1e6d7e3bf6bcb39269252d8880c20e4a5ac1c55cc72b",
     );
 }

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -319,6 +319,16 @@ pub enum StageOutcome {
     ///
     /// Also produced when the `ci_route` block is present but unparseable: a
     /// route that cannot be guarded must not be applied.
+    ///
+    /// # Declared LAST, and it has to stay that way
+    ///
+    /// The worker/launcher envelope is positional bincode: the variant index is
+    /// derived from declaration order and nothing else in the frame identifies
+    /// it. Inserting anything above this variant silently renumbers it and
+    /// every variant between — an old worker's `LeadParked` frame would decode
+    /// on a new launcher as `LeadSuperseded`, a human-review hold read as a
+    /// terminal close. `lead_ci_routing::lead_route_superseded_is_the_last_wire_variant`
+    /// pins the tail positionally for exactly that reason.
     LeadRouteSuperseded {
         /// Why the guard refused, for the log and the run outcome.
         reason: String,


### PR DESCRIPTION
Closes the seven wiring gaps the closing adversarial audit found against proposal [nafu](https://code.djinnai.io/proposals/019fccac-e07d-7493-a1bc-18996e7d439a), which ruled **AC12 and AC13 NOT MET** and AC9 partially met. (Command 7's flake was separately confirmed fixed: 50/50 at default parallelism, with a control that reproduced 9/14 failures by reverting only the `traced_test` hunk.)

## The proof, not the claim

Every hole was verified by applying the neutralization first and confirming the acceptance list stayed green:

**Before** — all seven neutralizations applied, no witnesses: `140 / 54 / 11 / 52 / 9 / 3 / 4`, **zero failures**. Every hole reproduced.

**After** — same neutralizations, witnesses added:

| Hole | Neutralization | Now fails |
|---|---|---|
| **H1** | `ci_routing_gate()` → `DisabledClean` — the env var is **never read**, feature permanently unreachable in production | `the_ci_routing_gate_accessor_reads_the_environment_in_production` |
| **H2** | merge-group `is_routed()` guard `&& false` — route **and** legacy `PrCiFailed` reopen both run | `a_routed_merge_group_disposition_replaces_the_legacy_queue_remedy` |
| **H3** | `read_arbiter_directive(None)` — supervisor never consumes a route; every Lead session takes the legacy path and parks at the cap | `the_supervisors_lead_stage_arm_reads_the_route_and_applies_it_under_the_guard` (left `"None"`, right `"directive.as_ref()"`) |
| **H4** | actor keeps a private `ProviderActionScope` — leadership releases the advisory lock with a live provider future | `the_actor_admits_into_the_leaders_provider_action_scope` (left `0`, right `1`) |
| **H5** | `RESERVED_SWEEP_INTERVAL` → 1 year — the tick sweep never fires in any process lifetime | `the_reserved_sweep_interval_is_bounded_in_absolute_time` |
| **H6** | drop `NULLS NOT DISTINCT` — concurrent PR-head polls mint multiple streaks for one head (AC9) | `one_pr_head_identity_holds_one_streak_across_concurrent_polls` — genuinely raced, two distinct streak ids |
| **H7** | move `LeadRouteSuperseded` off the enum tail — renumbers three variants an old worker writes (AC13) | `lead_route_superseded_is_the_last_wire_variant` (left `17`, right `20`) |
| **H8** | edit migration 195 | `ci_route_attempts_migration_195_is_immutable` |

## Why these existed

**H1** is the sharpest: every fixture injects the gate through the `#[cfg(test)] test_ci_routing_gate` seam, so nothing ever reached the line that calls `from_env()`. The module's own doc comment confesses the identical shape once before — `unwrap_or_default()` → `unwrap_or(Enabled)` turned the feature on fleet-wide with 2148 tests green. `from_lookup` was hardened; the *call to* `from_env` was not.

**H5** was a second opinion from the same witness: the fixture drove the tick via `a_sweep_interval_ago()`, a helper defined *in terms of the constant it was meant to bound*.

**H7** passed under its own mutation for payload-shape reasons — a `{reason: String}` body re-tagged as `ModelTurnAdmission(nested enum)` fails to parse — while both its anchors (`WorkerDone=0`, `Failed=14`) sit before the insertion point. It now pins the tail positionally.

## Scope discipline

H2, H3 and H7 **strengthen existing tests** rather than adding duplicates — H2's guard already pinned the head, body and ordering, just not the condition. H1 and H2 are source-level and labelled as such with the reason (`GitHubApiClient` hard-codes `api.github.com`; the gate seam is `#[cfg(test)]`). H4, H5 and H6 are behavioural.

One further hop was found and closed during the sweep: `CoordinatorHandle::spawn` rebuilds `CoordinatorDeps` with `..deps`, so naming `provider_action_scope` there would silently replace it, and `spawn` returns a handle with no accessor. Pinned textually rather than by inventing an accessor.

## Production behaviour is unchanged

The only non-test edits are a `#[cfg(test)]` `actor_with_test_db_and_scope` helper and a doc comment on the `StageOutcome` tail. Migration 195 is byte-identical (verified by sha256 and by the new pin passing). `cargo clippy --all-targets -- -D warnings` clean across all five crates.

Final: `143 / 55 / 11 / 52 / 9 / 3 / 4`, all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
