### PR TITLE
fix(9xih): make AC2 true on the real note-creation path, and close the ceiling breach

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/memory_tools/write_services.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/write_services.rs
@@ -1,3 +1,4 @@
+use djinn_db::repositories::note::CONFIDENCE_CEILING;
 use djinn_db::{
     NoteRepository, NoteRevisionCreateState, NoteRevisionDesiredState, NoteRevisionEventKind,
     NoteRevisionMutation, NoteRevisionReason, NoteRevisionUpdateState,
@@ -131,7 +132,23 @@ pub(super) async fn create_note(
                 tags: tags_json.to_owned(),
                 retrieval_anchor: params.retrieval_anchor.clone(),
                 scope_paths: scope_paths_json,
-                confidence: 0.5,
+                // An authored note is an assertion its author believes, so it
+                // starts at the top of the epistemic range. `CONFIDENCE_CEILING`
+                // rather than `1.0`: `bayesian_update` has no effect on a prior
+                // of exactly 1.0, so a note created there is unfalsifiable —
+                // `CONTRADICTION` cannot move it and `USER_CONFIRM` can only
+                // clamp it downward.
+                //
+                // This must stay equal to the `notes.confidence` column
+                // default. The column default is dead code on this path (the
+                // revision mutation binds `confidence` explicitly), so the two
+                // are pinned together by
+                // `memory_write_creates_notes_at_the_confidence_ceiling`.
+                //
+                // Session-extracted notes deliberately start lower (0.5, see
+                // `djinn-slot/src/llm_extraction.rs`): those are machine
+                // proposals, not authored assertions.
+                confidence: CONFIDENCE_CEILING,
             }),
             attribution,
             provenance,

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/writes_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/writes_tests.rs
@@ -15,6 +15,7 @@ mod tests {
 
     use djinn_core::auth_context::{REVISION_CALLER_CONTEXT, TrustedRevisionCallerContext};
     use djinn_core::events::EventBus;
+    use djinn_db::repositories::note::CONFIDENCE_CEILING;
     use djinn_db::{Database, NoteRepository, ProjectRepository};
     use rmcp::{Json, handler::server::wrapper::Parameters};
     use tokio::time::sleep;
@@ -23,7 +24,8 @@ mod tests {
         server::DjinnMcpServer,
         state::stubs::test_mcp_state,
         tools::memory_tools::{
-            BrokenLinksParams, EditParams, ListParams, ReadParams, WriteParams, ops,
+            BrokenLinksParams, EditParams, ListParams, MemoryConfirmParams, ReadParams,
+            WriteParams, ops,
             write_dedup_types::{MemoryWriteDedupDecider, MemoryWriteDedupDecision},
         },
     };
@@ -1134,6 +1136,152 @@ mod tests {
                 assert_eq!(
                     error.count, 1,
                     "missing candidate should record exactly one error"
+                );
+            })
+            .await;
+    }
+
+    // ── proposal 9xih AC2, asserted on the PRODUCTION creation path ─────────
+    //
+    // `notes.confidence` carries a column default of `CONFIDENCE_CEILING`, and
+    // a migration test proves that default is stored and that a bare INSERT
+    // lands on it. That proves the default EXISTS; it does not prove any note
+    // the system actually makes GETS it, because every production writer goes
+    // through `mutate_with_revision`, which binds `confidence` explicitly and
+    // therefore never exercises the column default.
+    //
+    // These two tests go through `memory_write` / `memory_confirm` — the real
+    // authored-note path — so the column default and the value new notes
+    // actually receive cannot drift apart again in silence.
+
+    /// AC2, first clause: a note created through `memory_write` starts at the
+    /// confidence ceiling, not at the session-extraction prior.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_write_creates_notes_at_the_confidence_ceiling() {
+        let caller = TrustedRevisionCallerContext::authenticated_human("writes-test-user")
+            .expect("valid test revision caller");
+        REVISION_CALLER_CONTEXT
+            .scope(Some(caller), async {
+                let tmp = workspace_tempdir();
+                let db = Database::open_in_memory().unwrap();
+                let state = test_mcp_state(db.clone());
+                let project = create_project(&db, tmp.path()).await;
+                let server = DjinnMcpServer::new(state);
+                let repo = NoteRepository::new(db.clone(), EventBus::noop());
+
+                let Json(created) = server
+                    .memory_write(Parameters(WriteParams {
+                        reason: "record an authored design decision".to_string(),
+                        project: project.slug(),
+                        title: "Authored Confidence Baseline".to_string(),
+                        content: "An authored note asserting a decision the author believes."
+                            .to_string(),
+                        note_type: "design".to_string(),
+                        status: None,
+                        tags: None,
+                        scope_paths: None,
+                        retrieval_anchor: None,
+                    }))
+                    .await;
+                assert!(created.error.is_none(), "write failed: {:?}", created.error);
+                let id = created.id.clone().expect("note created");
+
+                let persisted = repo.get(&id).await.unwrap().expect("note row");
+                assert_eq!(
+                    persisted.confidence, CONFIDENCE_CEILING,
+                    "memory_write must create notes at CONFIDENCE_CEILING; the column \
+                     default is dead code for this path because the revision mutation \
+                     binds confidence explicitly"
+                );
+
+                // Negative control: the assertion above is only meaningful if the
+                // stored column default agrees with it. If someone changes the
+                // default without changing the writer (or vice versa), the two
+                // halves of AC2 would silently disagree again.
+                let column_default: Option<String> = sqlx::query_scalar(
+                    "SELECT column_default FROM information_schema.columns \
+                     WHERE table_name = 'notes' AND column_name = 'confidence'",
+                )
+                .fetch_one(db.pool())
+                .await
+                .expect("read stored column default");
+                let column_default = column_default.expect("notes.confidence has a default");
+                assert!(
+                    column_default.starts_with(&CONFIDENCE_CEILING.to_string()),
+                    "stored notes.confidence default `{column_default}` disagrees with the \
+                     value the production creation path writes ({CONFIDENCE_CEILING})"
+                );
+            })
+            .await;
+    }
+
+    /// AC2, ordering clause: applying `USER_CONFIRM` must never move a note
+    /// BELOW an otherwise untouched peer.
+    ///
+    /// The hazard is real whenever any writer can park a note above the
+    /// ceiling: `update_confidence` clamps the posterior back to the ceiling,
+    /// so confirming an above-ceiling note demotes it under a peer nobody
+    /// touched. This exercises the property end to end through `memory_write`
+    /// + `memory_confirm`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_confirm_never_lowers_a_note_below_an_untouched_peer() {
+        let caller = TrustedRevisionCallerContext::authenticated_human("writes-test-user")
+            .expect("valid test revision caller");
+        REVISION_CALLER_CONTEXT
+            .scope(Some(caller), async {
+                let tmp = workspace_tempdir();
+                let db = Database::open_in_memory().unwrap();
+                let state = test_mcp_state(db.clone());
+                let project = create_project(&db, tmp.path()).await;
+                let server = DjinnMcpServer::new(state);
+                let repo = NoteRepository::new(db.clone(), EventBus::noop());
+
+                let mut ids = Vec::new();
+                for title in ["Confirmed Peer", "Untouched Peer"] {
+                    let Json(created) = server
+                        .memory_write(Parameters(WriteParams {
+                            reason: "record an authored design decision".to_string(),
+                            project: project.slug(),
+                            title: title.to_string(),
+                            content: format!("Distinct authored body for {title}."),
+                            note_type: "design".to_string(),
+                            status: None,
+                            tags: None,
+                            scope_paths: None,
+                            retrieval_anchor: None,
+                        }))
+                        .await;
+                    assert!(created.error.is_none(), "write failed: {:?}", created.error);
+                    ids.push(created.id.clone().expect("note created"));
+                }
+                let (confirmed_id, untouched_id) = (ids[0].clone(), ids[1].clone());
+
+                let untouched_before = repo.get(&untouched_id).await.unwrap().unwrap().confidence;
+
+                let Json(response) = server
+                    .memory_confirm(Parameters(MemoryConfirmParams {
+                        project: project.slug(),
+                        identifier: confirmed_id.clone(),
+                        comment: None,
+                    }))
+                    .await;
+                assert!(
+                    response.error.is_none(),
+                    "confirm failed: {:?}",
+                    response.error
+                );
+
+                let confirmed_after = repo.get(&confirmed_id).await.unwrap().unwrap().confidence;
+                let untouched_after = repo.get(&untouched_id).await.unwrap().unwrap().confidence;
+
+                assert_eq!(
+                    untouched_after, untouched_before,
+                    "confirming one note must not move its peer"
+                );
+                assert!(
+                    confirmed_after >= untouched_after,
+                    "USER_CONFIRM lowered the confirmed note ({confirmed_after}) below an \
+                     untouched peer ({untouched_after}); proposal 9xih AC2 forbids this"
                 );
             })
             .await;

--- a/server/crates/djinn-control-plane/src/tools/memory_tools/writes_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/memory_tools/writes_tests.rs
@@ -1186,6 +1186,10 @@ mod tests {
                 assert!(created.error.is_none(), "write failed: {:?}", created.error);
                 let id = created.id.clone().expect("note created");
 
+                // Read the PERSISTED row back through the repository, not the
+                // tool's return value: the defect this test exists for was a
+                // wrong value being written, and a response body echoing the
+                // same wrong value would have agreed with it.
                 let persisted = repo.get(&id).await.unwrap().expect("note row");
                 assert_eq!(
                     persisted.confidence, CONFIDENCE_CEILING,
@@ -1194,23 +1198,12 @@ mod tests {
                      binds confidence explicitly"
                 );
 
-                // Negative control: the assertion above is only meaningful if the
-                // stored column default agrees with it. If someone changes the
-                // default without changing the writer (or vice versa), the two
-                // halves of AC2 would silently disagree again.
-                let column_default: Option<String> = sqlx::query_scalar(
-                    "SELECT column_default FROM information_schema.columns \
-                     WHERE table_name = 'notes' AND column_name = 'confidence'",
-                )
-                .fetch_one(db.pool())
-                .await
-                .expect("read stored column default");
-                let column_default = column_default.expect("notes.confidence has a default");
-                assert!(
-                    column_default.starts_with(&CONFIDENCE_CEILING.to_string()),
-                    "stored notes.confidence default `{column_default}` disagrees with the \
-                     value the production creation path writes ({CONFIDENCE_CEILING})"
-                );
+                // The other half of AC2 — that the stored `notes.confidence`
+                // column default agrees with the value written here — is
+                // asserted in djinn-db, where reading `information_schema`
+                // does not cross the raw-SQL boundary:
+                // `stored_confidence_default_equals_the_constant_production_writes`
+                // in tests/migrations_note_confidence_range_repair.rs.
             })
             .await;
     }

--- a/server/crates/djinn-control-plane/tests/memory_revision_readers.rs
+++ b/server/crates/djinn-control-plane/tests/memory_revision_readers.rs
@@ -252,7 +252,12 @@ async fn history_returns_newest_first_events_for_live_note() {
     assert_eq!(oldest["content_after"], "alpha\nbeta\n");
     assert_eq!(oldest["reason"], "create reader fixture");
     assert!(oldest["confidence_before"].is_null());
-    assert_eq!(oldest["confidence_after"], 0.5);
+    // `memory_write` creates an authored note at CONFIDENCE_CEILING; the
+    // session-extraction prior (0.5) belongs to a different writer.
+    assert_eq!(
+        oldest["confidence_after"],
+        djinn_db::repositories::note::CONFIDENCE_CEILING
+    );
 }
 
 #[tokio::test]
@@ -640,7 +645,10 @@ async fn diff_includes_intervening_non_content_events() {
     assert_eq!(event["note_seq"], 3);
     assert!(event["content_before"].is_null());
     assert!(event["content_after"].is_null());
-    assert_eq!(event["confidence_before"], 0.5);
+    assert_eq!(
+        event["confidence_before"],
+        djinn_db::repositories::note::CONFIDENCE_CEILING
+    );
     assert_eq!(event["confidence_after"], 0.9);
     assert_eq!(event["reason"], "bump confidence");
 }

--- a/server/crates/djinn-db/migrations_postgres/201_note_confidence_range_repair.sql
+++ b/server/crates/djinn-db/migrations_postgres/201_note_confidence_range_repair.sql
@@ -1,0 +1,50 @@
+-- Migration 201: return every `notes.confidence` to the epistemic range
+-- [CONFIDENCE_FLOOR, CONFIDENCE_CEILING] = [0.025, 0.975] (proposal 9xih).
+--
+-- WHY THIS IS NEEDED AFTER 197.
+--
+-- Migration 197 normalized the column default and the exactly-1.0 rows to the
+-- ceiling, on the premise that `notes.confidence` is bounded above by
+-- `CONFIDENCE_CEILING`. That premise was only enforced by `set_confidence`
+-- (which clamps) and `update_confidence` (which goes through `bayesian_update`,
+-- which clamps). A third writer — `NoteRepository::mutate_with_revision` — bound
+-- the caller's value straight into the UPDATE with no range check, and the
+-- extraction duplicate-confirmation path re-derived the Bayesian posterior
+-- inline instead of calling `bayesian_update`, so it skipped the clamp. Repeated
+-- duplicate confirmations therefore walked notes ABOVE the ceiling, asymptotically
+-- toward 1.0.
+--
+-- That is not a cosmetic overshoot. It reintroduces exactly the hazard 197 was
+-- written to remove: `update_confidence` clamps to the ceiling, so applying the
+-- POSITIVE `USER_CONFIRM` signal to an above-ceiling note LOWERS it to 0.975 —
+-- below every untouched above-ceiling peer in confidence ordering. Confirming a
+-- note demotes it.
+--
+-- The code-side fixes land in the same change: the duplicate boost now calls
+-- `bayesian_update`, and `mutate_with_revision` rejects any desired state whose
+-- confidence falls outside the range. This file repairs the rows those writers
+-- already produced, so the invariant holds over stored data and not merely over
+-- future writes.
+--
+-- DEPLOYMENT-NEUTRAL BY CONSTRUCTION. The statements below are predicates over
+-- the whole table. No project id, note id, or "our data looks like X" assumption
+-- appears, so this is correct for any operator's database — including a
+-- brand-new one where every UPDATE matches zero rows.
+--
+-- IDEMPOTENT. After the first pass every row satisfies the range, so the WHERE
+-- clauses match nothing on a re-run and the file leaves the database in the
+-- identical state.
+
+-- Above-ceiling rows come back to the ceiling. This is the only defensible
+-- target: the pre-clamp posterior is not recoverable (the number of duplicate
+-- confirmations that produced it is not stored on the row), and every one of
+-- these values was, by the ceiling invariant, meant to be 0.975 all along.
+UPDATE notes SET confidence = 0.975 WHERE confidence > 0.975;
+
+-- Below-floor rows come up to the floor, for symmetry and for the same reason:
+-- the range is closed at both ends, `bayesian_update` clamps at both ends, and
+-- a stored value outside it cannot be the posterior of any signal. In practice
+-- this is the `0.0` written by the memory-enrichment entity/claim writer, which
+-- now writes `CONFIDENCE_FLOOR`. Both values sit far below `STALE_CITATION`
+-- (0.3), so injection eligibility and archival lifecycle are unchanged.
+UPDATE notes SET confidence = 0.025 WHERE confidence < 0.025;

--- a/server/crates/djinn-db/src/repositories/note/mutation.rs
+++ b/server/crates/djinn-db/src/repositories/note/mutation.rs
@@ -1093,12 +1093,38 @@ fn validate_command(command: &NoteRevisionMutation) -> Result<()> {
             "event kind does not match desired final state".to_owned(),
         ));
     }
-    if let NoteRevisionDesiredState::GuardedPatch { confidence, .. } = &command.desired
+    // Every desired state that carries a confidence must be inside the
+    // epistemic range, not just `GuardedPatch`.
+    //
+    // `set_confidence` clamps and `update_confidence` goes through
+    // `bayesian_update` (which clamps), so those two writers cannot leave the
+    // range. `mutate_with_revision` is the third confidence writer and it binds
+    // the caller's value straight into the UPDATE/INSERT. While only
+    // `GuardedPatch` was checked, an out-of-range caller value landed silently:
+    // proposal 9xih's ceiling was breached in production by the extraction
+    // duplicate boost re-deriving a Bayesian posterior without the clamp, and
+    // notes reached ~1.0 — the unfalsifiable state the ceiling exists to
+    // prevent. Rejecting rather than clamping keeps the mistake loud at the
+    // call site instead of silently rewriting what the caller asked for.
+    let bounded_confidence = match &command.desired {
+        NoteRevisionDesiredState::Create(state) => Some(("create", state.confidence)),
+        NoteRevisionDesiredState::Existing { confidence, .. } => Some(("existing", *confidence)),
+        NoteRevisionDesiredState::ExistingWithMetadata(state) => {
+            Some(("existing with metadata", state.confidence))
+        }
+        NoteRevisionDesiredState::GuardedPatch { confidence, .. } => {
+            Some(("guarded patch", *confidence))
+        }
+        NoteRevisionDesiredState::DeprecateWithSupersedes { .. }
+        | NoteRevisionDesiredState::Delete
+        | NoteRevisionDesiredState::ExtractionSkipped => None,
+    };
+    if let Some((label, confidence)) = bounded_confidence
         && (!confidence.is_finite()
-            || !(CONFIDENCE_FLOOR..=CONFIDENCE_CEILING).contains(confidence))
+            || !(CONFIDENCE_FLOOR..=CONFIDENCE_CEILING).contains(&confidence))
     {
         return Err(Error::InvalidData(format!(
-            "guarded patch confidence must be within [{CONFIDENCE_FLOOR}, {CONFIDENCE_CEILING}]"
+            "{label} confidence must be within [{CONFIDENCE_FLOOR}, {CONFIDENCE_CEILING}], got {confidence}"
         )));
     }
     if command.event_kind == NoteRevisionEventKind::ExtractionSkipped

--- a/server/crates/djinn-db/src/repositories/note/scoring.rs
+++ b/server/crates/djinn-db/src/repositories/note/scoring.rs
@@ -530,6 +530,39 @@ mod tests {
         );
     }
 
+    /// AC2's ordering clause, generalized: applying `USER_CONFIRM` to ANY note
+    /// inside the epistemic range never moves it below where it started, so it
+    /// can never fall below an untouched peer.
+    ///
+    /// The clause holds *because* the range invariant holds, and only then. The
+    /// second half of this test is the counterexample: any prior ABOVE the
+    /// ceiling is demoted by confirmation, because `bayesian_update` clamps the
+    /// posterior back down. That is not hypothetical — an unclamped extraction
+    /// duplicate boost put real notes there, which is why the range is now
+    /// enforced at every writer (`set_confidence`, `update_confidence`, and
+    /// `mutate_with_revision`) and repaired in stored data by migration 201.
+    #[test]
+    fn user_confirm_is_monotone_across_the_whole_epistemic_range() {
+        let mut prior = CONFIDENCE_FLOOR;
+        while prior <= CONFIDENCE_CEILING {
+            let confirmed = bayesian_update(prior, USER_CONFIRM);
+            assert!(
+                confirmed >= prior,
+                "USER_CONFIRM lowered a note from {prior} to {confirmed}; it would then \
+                 sort below any untouched peer (proposal 9xih AC2)"
+            );
+            prior += 0.005;
+        }
+
+        // The counterexample that makes the invariant load-bearing.
+        let above_ceiling = 0.9863813229571984_f64;
+        assert!(
+            bayesian_update(above_ceiling, USER_CONFIRM) < above_ceiling,
+            "an above-ceiling note MUST be demoted by confirmation; if this ever stops \
+             being true the range invariant has stopped being what protects AC2"
+        );
+    }
+
     #[test]
     fn repeated_low_signals_never_cross_floor() {
         let mut confidence = 0.5;

--- a/server/crates/djinn-db/src/repositories/note/tests/mutation.rs
+++ b/server/crates/djinn-db/src/repositories/note/tests/mutation.rs
@@ -1043,3 +1043,140 @@ async fn deprecate_with_supersedes_preserves_note_owned_data_and_recorded_associ
     assert_eq!(deprecate_event.task_id.as_deref(), Some("task"));
     assert_eq!(deprecate_event.task_run_id.as_deref(), Some("run"));
 }
+
+/// `mutate_with_revision` is the THIRD confidence writer, alongside
+/// `set_confidence` (which clamps) and `update_confidence` (which goes through
+/// `bayesian_update`, which clamps). It binds the caller's value straight into
+/// the INSERT/UPDATE, so without a range check it is the one writer that can
+/// leave `[CONFIDENCE_FLOOR, CONFIDENCE_CEILING]`.
+///
+/// It did. Production accumulated notes at ~1.0 — the unfalsifiable state
+/// proposal 9xih's ceiling exists to remove, and the state in which the
+/// POSITIVE `USER_CONFIRM` signal DEMOTES a note (its clamp pulls it back to
+/// the ceiling, below untouched above-ceiling peers).
+///
+/// Only `GuardedPatch` was validated before. Every desired state that names a
+/// confidence is validated now, asserted per variant so a future variant cannot
+/// quietly inherit the old hole.
+#[tokio::test]
+async fn revision_mutation_rejects_confidence_outside_the_epistemic_range() {
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let (tx, _rx) = broadcast::channel(8);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db.clone(), event_bus_for(&tx));
+
+    // The values production actually reached, plus both endpoints' neighbours.
+    let out_of_range = [
+        0.9863813229571984_f64, // one unclamped duplicate boost off the ceiling
+        0.999999999999202,      // many of them: effectively unfalsifiable
+        1.0,
+        0.0,
+        -0.5,
+        f64::NAN,
+    ];
+
+    for bad in out_of_range {
+        let note_id = uuid::Uuid::now_v7().to_string();
+        let mut command = create_command(&project.id, note_id.clone());
+        let NoteRevisionDesiredState::Create(state) = &mut command.desired else {
+            unreachable!("create_command builds a Create state")
+        };
+        state.permalink = format!("reference/ledger-note-{note_id}");
+        state.confidence = bad;
+        assert!(
+            repo.mutate_with_revision(command).await.is_err(),
+            "creating a note at confidence {bad} must be rejected"
+        );
+        assert!(
+            repo.get(&note_id).await.unwrap().is_none(),
+            "a rejected create at confidence {bad} must not have persisted a row"
+        );
+    }
+
+    // Now an existing in-range note, to prove the update variants are guarded
+    // too and that a rejection leaves the stored value untouched.
+    let note_id = uuid::Uuid::now_v7().to_string();
+    repo.mutate_with_revision(create_command(&project.id, note_id.clone()))
+        .await
+        .unwrap();
+    let before = repo.get(&note_id).await.unwrap().unwrap();
+
+    for bad in out_of_range {
+        for desired in [
+            NoteRevisionDesiredState::Existing {
+                content: "updated content".to_owned(),
+                confidence: bad,
+            },
+            NoteRevisionDesiredState::ExistingWithMetadata(NoteRevisionUpdateState {
+                title: before.title.clone(),
+                permalink: before.permalink.clone(),
+                content: "updated content".to_owned(),
+                note_type: before.note_type.clone(),
+                folder: before.folder.clone(),
+                tags: before.tags.clone(),
+                retrieval_anchor: None,
+                confidence: bad,
+            }),
+            NoteRevisionDesiredState::GuardedPatch {
+                expected_content: before.content.clone(),
+                content: "updated content".to_owned(),
+                confidence: bad,
+            },
+        ] {
+            assert!(
+                repo.mutate_with_revision(NoteRevisionMutation {
+                    project_id: project.id.clone(),
+                    note_id: Some(note_id.clone()),
+                    event_kind: NoteRevisionEventKind::Updated,
+                    desired,
+                    attribution: TrustedNoteRevisionAttribution::system(
+                        NoteRevisionSubsystem::Extraction
+                    ),
+                    provenance: TrustedNoteRevisionProvenance::new(
+                        Some("session".into()),
+                        Some("task".into()),
+                        Some("run".into())
+                    )
+                    .unwrap(),
+                    reason: NoteRevisionReason::new("out of range confidence").unwrap(),
+                })
+                .await
+                .is_err(),
+                "updating to confidence {bad} must be rejected"
+            );
+        }
+    }
+
+    let after = repo.get(&note_id).await.unwrap().unwrap();
+    assert_eq!(after.confidence, before.confidence);
+    assert_eq!(after.content, before.content);
+
+    // Negative control: an in-range value on the same command shape still
+    // commits, so the assertions above reject the confidence and not the shape.
+    let ok = repo
+        .mutate_with_revision(NoteRevisionMutation {
+            project_id: project.id.clone(),
+            note_id: Some(note_id.clone()),
+            event_kind: NoteRevisionEventKind::Updated,
+            desired: NoteRevisionDesiredState::Existing {
+                content: "updated content".to_owned(),
+                confidence: CONFIDENCE_CEILING,
+            },
+            attribution: TrustedNoteRevisionAttribution::system(NoteRevisionSubsystem::Extraction),
+            provenance: TrustedNoteRevisionProvenance::new(
+                Some("session".into()),
+                Some("task".into()),
+                Some("run".into()),
+            )
+            .unwrap(),
+            reason: NoteRevisionReason::new("in range confidence").unwrap(),
+        })
+        .await
+        .unwrap();
+    assert!(ok.changed);
+    assert_eq!(
+        repo.get(&note_id).await.unwrap().unwrap().confidence,
+        CONFIDENCE_CEILING
+    );
+}

--- a/server/crates/djinn-db/tests/confidence_write_boundary.rs
+++ b/server/crates/djinn-db/tests/confidence_write_boundary.rs
@@ -200,6 +200,179 @@ fn removed_outcome_writers_are_absent_from_their_former_call_sites() {
     }
 }
 
+// ── The THIRD confidence writer: `mutate_with_revision` ─────────────────────
+//
+// The allowlist above scans for `set_confidence(` / `update_confidence(`. Those
+// were the only two writers 9xih hardened, and for months the guard above was
+// read as "nothing else can write confidence". It was not true.
+//
+// `NoteRepository::mutate_with_revision` binds a caller-supplied `confidence`
+// straight into the notes UPDATE/INSERT. It is a confidence writer with a
+// completely different call shape, so the scan above never saw it — which is
+// how two defects lived in production with this file green:
+//
+//   * `memory_write` created every authored note at `0.5` (the session-
+//     extraction prior) instead of the ceiling, making the column default 9xih
+//     migrated dead code for the only path that actually creates authored notes.
+//   * the extraction duplicate boost re-derived the Bayesian posterior inline,
+//     skipping `bayesian_update`'s clamp, and walked notes above the ceiling
+//     toward the unfalsifiable 1.0 state 9xih exists to remove.
+//
+// Structurally, `mutate_with_revision` is now range-checked in
+// `validate_command`, so no caller can leave `[CONFIDENCE_FLOOR,
+// CONFIDENCE_CEILING]`. The tests below pin the remaining judgement calls: WHICH
+// files may name a confidence on a revision command at all, and that the two
+// values are the deliberate ones rather than whatever a refactor last copied.
+
+/// Every construction site of a revision desired-state that carries a
+/// confidence. Adding a file here asserts the same thing the allowlist above
+/// asserts: this call site concerns the note's TRUTH.
+const ALLOWED_REVISION_CONFIDENCE_FILES: [(&str, &str); 6] = [
+    (
+        "crates/djinn-db/src/repositories/note/mutation.rs",
+        "defines the revision desired states and range-checks them",
+    ),
+    (
+        "crates/djinn-db/src/repositories/note/consolidation.rs",
+        "carries the consolidated note's own clamped confidence forward",
+    ),
+    (
+        "crates/djinn-control-plane/src/tools/memory_tools/write_services.rs",
+        "memory_write: an authored assertion starts at CONFIDENCE_CEILING",
+    ),
+    (
+        "crates/djinn-control-plane/src/tools/memory_tools/edit_ops.rs",
+        "memory_edit carries the note's own confidence forward; editing prose is \
+         not evidence about the note's truth",
+    ),
+    (
+        "crates/djinn-slot/src/llm_extraction.rs",
+        "session-extraction prior (0.5) and the duplicate-confirmation posterior",
+    ),
+    (
+        "crates/djinn-slot/src/memory_enrichment.rs",
+        "entity/claim scaffolding notes sit at CONFIDENCE_FLOOR",
+    ),
+];
+
+/// `NoteRevisionCreateState`/`NoteRevisionUpdateState` construction and the
+/// `Existing`/`GuardedPatch` variants all carry a `confidence` field, written
+/// as `confidence:` in struct-literal position.
+#[test]
+fn only_epistemic_call_sites_may_name_a_confidence_on_a_revision_command() {
+    let root = server_root();
+    let mut files = Vec::new();
+    collect_rust_files(&root.join("crates"), &mut files);
+    collect_rust_files(&root.join("src"), &mut files);
+
+    let mut offenders: Vec<String> = Vec::new();
+    let mut seen_allowed: Vec<&str> = Vec::new();
+
+    for path in &files {
+        let relative = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if is_test_path(&relative) {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let production = text.split("#[cfg(test)]").next().unwrap_or("");
+        // Only files that actually build a revision command.
+        if !production.contains("NoteRevisionDesiredState::") {
+            continue;
+        }
+        if !production.contains("confidence:") {
+            continue;
+        }
+        match ALLOWED_REVISION_CONFIDENCE_FILES
+            .iter()
+            .find(|(allowed, _)| *allowed == relative)
+        {
+            Some((allowed, _)) => seen_allowed.push(allowed),
+            None => offenders.push(relative),
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "these production files set notes.confidence through a revision command but are \
+         not on the epistemic allowlist in this test:\n  {}\n\n\
+         `mutate_with_revision` is a confidence writer just like `set_confidence` and \
+         `update_confidence`; the same rule applies (proposal 9xih AC1).",
+        offenders.join("\n  ")
+    );
+
+    for (allowed, reason) in ALLOWED_REVISION_CONFIDENCE_FILES {
+        assert!(
+            seen_allowed.contains(&allowed),
+            "expected `{allowed}` to still set a confidence on a revision command ({reason}); \
+             it does not, so this guard is no longer detecting anything and must be updated"
+        );
+    }
+}
+
+/// The value `memory_write` gives a new authored note, pinned by source.
+///
+/// AC2 says new notes default to the ceiling. The `notes.confidence` column
+/// default says the same thing. But `memory_write` goes through
+/// `mutate_with_revision`, which binds `confidence` explicitly — so the column
+/// default is never exercised for an authored note and cannot be the thing that
+/// makes AC2 true. From 2026-07-16 (#2168, the attributed-writer cutover) until
+/// this fix, that literal was `0.5` and every authored note in production was
+/// created off the ceiling while the migration test stayed green.
+///
+/// The behavioural proof lives in
+/// `djinn-control-plane`'s `memory_write_creates_notes_at_the_confidence_ceiling`,
+/// which reads the persisted row back. This is the cheap structural companion:
+/// it fails on a bare numeric literal reappearing at the create site.
+#[test]
+fn memory_write_creates_notes_at_the_named_ceiling_constant() {
+    let source = std::fs::read_to_string(
+        server_root().join("crates/djinn-control-plane/src/tools/memory_tools/write_services.rs"),
+    )
+    .expect("read write_services.rs");
+    let production = source.split("#[cfg(test)]").next().unwrap_or("");
+    assert!(
+        production.contains("confidence: CONFIDENCE_CEILING,"),
+        "memory_write must create authored notes at the named CONFIDENCE_CEILING \
+         constant, not a copied literal that can drift from the column default"
+    );
+}
+
+/// The extraction duplicate boost must go through `bayesian_update`, which is
+/// the only place the `[CONFIDENCE_FLOOR, CONFIDENCE_CEILING]` clamp lives.
+///
+/// It previously re-derived `(p*s) / (p*s + (1-p)*(1-s))` inline. The formula
+/// was right and the clamp was missing, so the boost walked notes past the
+/// ceiling toward 1.0. An inline re-derivation is the specific failure mode
+/// here, so the guard is on the shape of the arithmetic.
+#[test]
+fn extraction_duplicate_boost_uses_the_clamping_helper() {
+    let source =
+        std::fs::read_to_string(server_root().join("crates/djinn-slot/src/llm_extraction.rs"))
+            .expect("read llm_extraction.rs");
+    let production = source.split("#[cfg(test)]").next().unwrap_or("");
+    let boost = production
+        .split("async fn boost_duplicate_confidence")
+        .nth(1)
+        .expect("boost_duplicate_confidence must still exist");
+    let body = &boost[..boost.len().min(2_000)];
+    assert!(
+        body.contains("bayesian_update("),
+        "boost_duplicate_confidence must call bayesian_update, which clamps to \
+         [CONFIDENCE_FLOOR, CONFIDENCE_CEILING); re-deriving the posterior inline \
+         skips the clamp (proposal 9xih)"
+    );
+    assert!(
+        !body.contains("DUPLICATE_CONFIDENCE_SIGNAL)\n        / ("),
+        "boost_duplicate_confidence must not re-derive the Bayesian posterior inline"
+    );
+}
+
 /// `CO_ACCESS_HIGH` and `TASK_SUCCESS` were deleted, not merely unused: an
 /// available constant is an invitation to wire it back up.
 #[test]

--- a/server/crates/djinn-db/tests/migrations_note_confidence_range_repair.rs
+++ b/server/crates/djinn-db/tests/migrations_note_confidence_range_repair.rs
@@ -1,0 +1,328 @@
+//! Migration coverage for 201 — return every stored `notes.confidence` to
+//! `[CONFIDENCE_FLOOR, CONFIDENCE_CEILING]` (proposal 9xih follow-up).
+//!
+//! Migration 197 normalized the column default and the exactly-1.0 rows on the
+//! premise that the ceiling bounds `notes.confidence`. It did not, because
+//! `mutate_with_revision` wrote caller-supplied values with no range check and
+//! the extraction duplicate boost re-derived the Bayesian posterior without
+//! `bayesian_update`'s clamp. This migration repairs the rows that produced.
+//!
+//! Every fixture row in this file is constructed by the test itself. No id,
+//! project, or timestamp is taken from any particular deployment: the migration
+//! is a structural predicate over a whole table and is asserted as such.
+
+use std::path::{Path, PathBuf};
+
+use sqlx::postgres::{PgConnection, PgPool, PgPoolOptions};
+use sqlx::{Connection, Executor};
+
+const MIGRATION_VERSION: u64 = 201;
+const MIGRATION_FILE: &str = "201_note_confidence_range_repair.sql";
+const MIGRATION_OPERATOR_ID: &str = "00000000-0000-7000-8000-000000000201";
+const CREATOR_CONTRACT_VERSION: u64 = 142;
+
+/// Must equal `djinn_db::repositories::note::CONFIDENCE_CEILING`.
+const CONFIDENCE_CEILING: f64 = 0.975;
+/// Must equal `djinn_db::repositories::note::CONFIDENCE_FLOOR`.
+const CONFIDENCE_FLOOR: f64 = 0.025;
+
+fn server_prefix(base: &str) -> String {
+    base.rsplit_once('/')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(base)
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+fn migrations_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations_postgres")
+}
+
+fn migration_entries(dir: &Path) -> Vec<(u64, PathBuf)> {
+    let mut entries: Vec<(u64, PathBuf)> = std::fs::read_dir(dir)
+        .expect("read migrations dir")
+        .map(|entry| {
+            let path = entry.expect("migration dir entry").path();
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            let version = name
+                .split_once('_')
+                .and_then(|(prefix, _)| prefix.parse::<u64>().ok())
+                .unwrap_or(0);
+            (version, path)
+        })
+        .filter(|(_, path)| {
+            path.extension().and_then(|extension| extension.to_str()) == Some("sql")
+        })
+        .collect();
+    entries.sort_by(|(left_version, left_path), (right_version, right_path)| {
+        left_version.cmp(right_version).then_with(|| {
+            left_path
+                .file_name()
+                .unwrap_or_default()
+                .cmp(right_path.file_name().unwrap_or_default())
+        })
+    });
+    entries
+}
+
+async fn with_temp_database<T, Fut>(suffix: &str, f: impl FnOnce(String) -> Fut) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    let base = djinn_db::test_database_base_url();
+    let prefix = server_prefix(&base);
+    let db_name = format!("djinn_migration_{suffix}_{}", uuid::Uuid::now_v7().simple());
+    let admin_url = format!("{prefix}/postgres");
+    let mut admin = PgConnection::connect(&admin_url)
+        .await
+        .expect("connect postgres admin database");
+    admin
+        .execute(format!(r#"CREATE DATABASE "{db_name}""#).as_str())
+        .await
+        .expect("create migration test database");
+    drop(admin);
+
+    let db_url = format!("{prefix}/{db_name}");
+    let result = f(db_url).await;
+
+    let mut admin = PgConnection::connect(&admin_url)
+        .await
+        .expect("reconnect postgres admin database");
+    let _ = admin
+        .execute(
+            format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+            )
+            .as_str(),
+        )
+        .await;
+    admin
+        .execute(format!(r#"DROP DATABASE IF EXISTS "{db_name}""#).as_str())
+        .await
+        .expect("drop migration test database");
+
+    result
+}
+
+async fn seed_migration_operator(conn: &mut PgConnection) {
+    conn.execute(
+        format!(
+            "INSERT INTO users (id, github_id, github_login) VALUES \
+             ('{MIGRATION_OPERATOR_ID}', 9000000201, 'confidence-range-migration-operator') \
+             ON CONFLICT DO NOTHING"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("seed designated migration operator");
+}
+
+async fn apply_prior_migrations(conn: &mut PgConnection) {
+    conn.execute(
+        format!(
+            "SELECT set_config('djinn.migration_designated_operator_user_id', '{MIGRATION_OPERATOR_ID}', false)"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("set designated operator GUC");
+
+    for (version, path) in migration_entries(&migrations_dir()) {
+        if version >= MIGRATION_VERSION {
+            break;
+        }
+        if version == CREATOR_CONTRACT_VERSION {
+            seed_migration_operator(conn).await;
+        }
+        let sql = std::fs::read_to_string(&path).expect("read prior migration sql");
+        conn.execute(sql.as_str())
+            .await
+            .unwrap_or_else(|error| panic!("apply migration {} failed: {error}", path.display()));
+    }
+}
+
+async fn apply_migration_201(conn: &mut PgConnection) {
+    let sql =
+        std::fs::read_to_string(migrations_dir().join(MIGRATION_FILE)).expect("read migration 201");
+    conn.execute(sql.as_str())
+        .await
+        .expect("apply migration 201");
+}
+
+async fn seed_project(conn: &mut PgConnection, project_id: &str) {
+    conn.execute(
+        format!(
+            "INSERT INTO projects (id, name, github_owner, github_repo) \
+             VALUES ('{project_id}', '{project_id}', 'owner-{project_id}', 'repo-{project_id}')"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("seed project");
+}
+
+/// Insert one note with an explicit confidence, bypassing the column default so
+/// the assertions cannot accidentally be reading it.
+async fn seed_note(
+    conn: &mut PgConnection,
+    project_id: &str,
+    slug: &str,
+    confidence: f64,
+) -> String {
+    let id = uuid::Uuid::now_v7().to_string();
+    conn.execute(
+        format!(
+            "INSERT INTO notes \
+                 (id, project_id, permalink, title, file_path, tags, content, scope_paths, \
+                  confidence, created_at, updated_at, last_accessed) \
+             VALUES ('{id}', '{project_id}', 'reference/{slug}', '{slug}', '', '[]', 'body', '[]', \
+                     {confidence}, '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z', \
+                     '2026-01-01T00:00:00.000Z')"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("seed note");
+    id
+}
+
+async fn confidence_of(pool: &PgPool, note_id: &str) -> f64 {
+    sqlx::query_scalar::<_, f64>("SELECT confidence FROM notes WHERE id = $1")
+        .bind(note_id)
+        .fetch_one(pool)
+        .await
+        .expect("read migrated note confidence")
+}
+
+/// Every stored confidence lands inside `[FLOOR, CEILING]`; nothing already
+/// inside the range is touched; and a second application changes nothing.
+#[tokio::test]
+async fn migration_201_clamps_out_of_range_confidence_and_is_idempotent() {
+    with_temp_database("conf_range", |db_url| async move {
+        let mut conn = PgConnection::connect(&db_url)
+            .await
+            .expect("connect migration database");
+        apply_prior_migrations(&mut conn).await;
+
+        let project_id = format!("p{}", uuid::Uuid::now_v7().simple());
+        seed_project(&mut conn, &project_id).await;
+
+        // The exact orbit the unclamped extraction duplicate boost produced:
+        // bayesian_update applied repeatedly to a ceiling-normalized note with
+        // the 0.65 duplicate signal, with the clamp missing.
+        let just_over = seed_note(&mut conn, &project_id, "just-over", 0.9863813229571984).await;
+        let far_over = seed_note(&mut conn, &project_id, "far-over", 0.999999999999202).await;
+        let at_one = seed_note(&mut conn, &project_id, "at-one", 1.0).await;
+        // The enrichment entity/claim writer's old below-floor value.
+        let at_zero = seed_note(&mut conn, &project_id, "at-zero", 0.0).await;
+
+        // In-range rows. These are real posteriors and must survive byte for
+        // byte — including the two endpoints, which the WHERE clauses use
+        // strict comparisons to exclude.
+        let at_ceiling = seed_note(&mut conn, &project_id, "at-ceiling", CONFIDENCE_CEILING).await;
+        let at_floor = seed_note(&mut conn, &project_id, "at-floor", CONFIDENCE_FLOOR).await;
+        let extraction_prior = seed_note(&mut conn, &project_id, "prior", 0.5).await;
+        let decayed = seed_note(&mut conn, &project_id, "decayed", 0.15).await;
+
+        apply_migration_201(&mut conn).await;
+        drop(conn);
+
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&db_url)
+            .await
+            .expect("connect migrated pool");
+
+        for (id, label) in [
+            (&just_over, "just over the ceiling"),
+            (&far_over, "far over the ceiling"),
+            (&at_one, "exactly 1.0"),
+        ] {
+            assert_eq!(
+                confidence_of(&pool, id).await,
+                CONFIDENCE_CEILING,
+                "{label} must be clamped to CONFIDENCE_CEILING"
+            );
+        }
+        assert_eq!(
+            confidence_of(&pool, &at_zero).await,
+            CONFIDENCE_FLOOR,
+            "a below-floor row must be clamped to CONFIDENCE_FLOOR"
+        );
+
+        for (id, expected, label) in [
+            (&at_ceiling, CONFIDENCE_CEILING, "a row at the ceiling"),
+            (&at_floor, CONFIDENCE_FLOOR, "a row at the floor"),
+            (&extraction_prior, 0.5, "the session-extraction prior"),
+            (&decayed, 0.15, "a decayed posterior"),
+        ] {
+            assert_eq!(
+                confidence_of(&pool, id).await,
+                expected,
+                "{label} is already in range and must not be rewritten"
+            );
+        }
+
+        // Whole-table predicate, not just the seeded ids.
+        let out_of_range: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM notes WHERE confidence < $1 OR confidence > $2",
+        )
+        .bind(CONFIDENCE_FLOOR)
+        .bind(CONFIDENCE_CEILING)
+        .fetch_one(&pool)
+        .await
+        .expect("count out-of-range rows");
+        assert_eq!(
+            out_of_range, 0,
+            "no note may sit outside the epistemic range"
+        );
+
+        // Idempotence: a second application is a no-op over every row.
+        let before: Vec<(String, f64)> =
+            sqlx::query_as("SELECT id, confidence FROM notes ORDER BY id")
+                .fetch_all(&pool)
+                .await
+                .expect("snapshot before re-run");
+        let mut conn = PgConnection::connect(&db_url)
+            .await
+            .expect("reconnect for idempotence run");
+        apply_migration_201(&mut conn).await;
+        drop(conn);
+        let after: Vec<(String, f64)> =
+            sqlx::query_as("SELECT id, confidence FROM notes ORDER BY id")
+                .fetch_all(&pool)
+                .await
+                .expect("snapshot after re-run");
+        assert_eq!(
+            before, after,
+            "re-applying migration 201 must change nothing"
+        );
+
+        pool.close().await;
+    })
+    .await;
+}
+
+/// Negative control for the whole file: on a database with no notes at all the
+/// migration still applies cleanly. A deployment-neutral migration must be
+/// correct for an operator whose `notes` table is empty.
+#[tokio::test]
+async fn migration_201_applies_to_an_empty_notes_table() {
+    with_temp_database("conf_range_empty", |db_url| async move {
+        let mut conn = PgConnection::connect(&db_url)
+            .await
+            .expect("connect migration database");
+        apply_prior_migrations(&mut conn).await;
+        apply_migration_201(&mut conn).await;
+
+        let count: i64 = sqlx::query_scalar("SELECT count(*) FROM notes")
+            .fetch_one(&mut conn)
+            .await
+            .expect("count notes");
+        assert_eq!(count, 0);
+    })
+    .await;
+}

--- a/server/crates/djinn-db/tests/migrations_note_confidence_range_repair.rs
+++ b/server/crates/djinn-db/tests/migrations_note_confidence_range_repair.rs
@@ -306,6 +306,74 @@ async fn migration_201_clamps_out_of_range_confidence_and_is_idempotent() {
     .await;
 }
 
+/// The other half of AC2: the stored `notes.confidence` column default must
+/// equal the constant the production creation path writes.
+///
+/// These two numbers are structurally independent. The column default lives in
+/// migration 197; the value new authored notes actually receive is a Rust
+/// constant bound explicitly by `mutate_with_revision`, so the default is never
+/// exercised on that path and cannot enforce anything. They silently disagreed
+/// from #2168 until this change — the default said `0.975`, every authored note
+/// was created at `0.5`, and the migration test stayed green because it only
+/// ever asked whether the default EXISTED.
+///
+/// The behavioural half — that `memory_write` persists `CONFIDENCE_CEILING` —
+/// is asserted through the repository layer in djinn-control-plane's
+/// `memory_write_creates_notes_at_the_confidence_ceiling`. This is the half
+/// that needs `information_schema`, so it lives here rather than crossing the
+/// raw-SQL boundary out of djinn-db.
+#[tokio::test]
+async fn stored_confidence_default_equals_the_constant_production_writes() {
+    // Pin the local copy to the real constant first, so a change to
+    // `CONFIDENCE_CEILING` cannot leave this file asserting a stale literal.
+    assert_eq!(
+        CONFIDENCE_CEILING,
+        djinn_db::repositories::note::CONFIDENCE_CEILING,
+        "this file's CONFIDENCE_CEILING copy has drifted from the production constant"
+    );
+    assert_eq!(
+        CONFIDENCE_FLOOR,
+        djinn_db::repositories::note::CONFIDENCE_FLOOR,
+        "this file's CONFIDENCE_FLOOR copy has drifted from the production constant"
+    );
+
+    with_temp_database("conf_default", |db_url| async move {
+        let mut conn = PgConnection::connect(&db_url)
+            .await
+            .expect("connect migration database");
+        apply_prior_migrations(&mut conn).await;
+        apply_migration_201(&mut conn).await;
+
+        let column_default: Option<String> = sqlx::query_scalar(
+            "SELECT column_default FROM information_schema.columns \
+             WHERE table_name = 'notes' AND column_name = 'confidence'",
+        )
+        .fetch_one(&mut conn)
+        .await
+        .expect("read stored column default");
+        let column_default = column_default.expect("notes.confidence has a stored default");
+
+        // Postgres renders the default with a type annotation, e.g. `0.975`.
+        // Compare on the leading numeric literal rather than the whole string.
+        let rendered = column_default
+            .split("::")
+            .next()
+            .unwrap_or(&column_default)
+            .trim()
+            .to_owned();
+        let parsed: f64 = rendered.parse().unwrap_or_else(|_| {
+            panic!("notes.confidence default `{column_default}` is not numeric")
+        });
+        assert_eq!(
+            parsed,
+            djinn_db::repositories::note::CONFIDENCE_CEILING,
+            "stored notes.confidence default `{column_default}` disagrees with the constant \
+             the production creation path writes"
+        );
+    })
+    .await;
+}
+
 /// Negative control for the whole file: on a database with no notes at all the
 /// migration still applies cleanly. A deployment-neutral migration must be
 /// correct for an operator whose `notes` table is empty.

--- a/server/crates/djinn-slot/src/llm_extraction.rs
+++ b/server/crates/djinn-slot/src/llm_extraction.rs
@@ -5206,8 +5206,16 @@ mod evidence_merge_regression_tests {
         let provider = ScriptedProvider::new(vec![
             r#"{"decision":"already_known","existing_note_id":"existing-note-1"}"#.to_owned(),
         ]);
+        // `CONFIDENCE_CEILING`, not `1.0`. This fixture needs a prior on which
+        // the duplicate boost is a no-op, and it used to get that from `1.0`
+        // being an absorbing state of the raw Bayesian update — which is the
+        // very defect proposal 9xih removed: a note at 1.0 cannot be moved by
+        // ANY signal, including `CONTRADICTION`. The boost now clamps, so the
+        // ceiling is the real fixed point, and `1.0` is no longer a state a
+        // note can be in (migration 201 repaired the stored rows and the
+        // revision boundary rejects it).
         let mut existing = test_existing_note();
-        existing.confidence = 1.0;
+        existing.confidence = djinn_db::repositories::note::CONFIDENCE_CEILING;
         let repo = RecordingExtractionRepository::with_existing(existing);
         let context = test_context(&repo, &provider);
         let mut quality = ExtractionQuality::default();

--- a/server/crates/djinn-slot/src/llm_extraction.rs
+++ b/server/crates/djinn-slot/src/llm_extraction.rs
@@ -2177,9 +2177,17 @@ async fn boost_duplicate_confidence(
         Ok(Some(note)) => note,
         Ok(None) | Err(_) => return false,
     };
-    let updated_confidence = (existing.confidence * DUPLICATE_CONFIDENCE_SIGNAL)
-        / (existing.confidence * DUPLICATE_CONFIDENCE_SIGNAL
-            + (1.0 - existing.confidence) * (1.0 - DUPLICATE_CONFIDENCE_SIGNAL));
+    // `bayesian_update`, not an inline re-derivation of the same formula: the
+    // canonical helper clamps the posterior to
+    // `[CONFIDENCE_FLOOR, CONFIDENCE_CEILING]`. Re-deriving it here skipped
+    // that clamp and let repeated duplicate confirmations walk a note past the
+    // ceiling toward 1.0 — the unfalsifiable state proposal 9xih exists to
+    // remove, and the state in which `USER_CONFIRM` DEMOTES a note (its own
+    // clamp pulls it back to the ceiling, below untouched above-ceiling peers).
+    let updated_confidence = djinn_db::repositories::note::bayesian_update(
+        existing.confidence,
+        DUPLICATE_CONFIDENCE_SIGNAL,
+    );
     if updated_confidence == existing.confidence {
         return false;
     }
@@ -5601,6 +5609,121 @@ mod evidence_merge_regression_tests {
                 .iter()
                 .any(|op| op.mutation.event_kind == NoteRevisionEventKind::Updated)
         );
+    }
+
+    /// Proposal 9xih: `CONFIDENCE_CEILING` is a hard invariant on
+    /// `notes.confidence`, not a property of one code path. A note already at
+    /// the ceiling that is confirmed as a duplicate must stay at the ceiling.
+    ///
+    /// The duplicate boost writes through `mutate_with_revision` rather than
+    /// `update_confidence`, so it does not inherit `bayesian_update`'s clamp
+    /// for free. Before the fix it re-derived the posterior inline and drove
+    /// notes to ~1.0 — the exact unfalsifiable state the ceiling exists to
+    /// prevent, and the state that makes `USER_CONFIRM` DEMOTE a note (the
+    /// clamp pulls it back to the ceiling, below untouched above-ceiling
+    /// peers).
+    #[tokio::test]
+    async fn duplicate_confidence_boost_never_exceeds_the_confidence_ceiling() {
+        let provider = ScriptedProvider::new(vec![
+            r#"{"decision":"already_known","existing_note_id":"existing-note-1"}"#.to_string(),
+        ]);
+        // A prior just under the ceiling: the unclamped posterior for this
+        // prior is 0.9836…, i.e. the boost overshoots. Starting exactly AT the
+        // ceiling would not exercise the write at all, because the clamped
+        // posterior equals the prior and the boost short-circuits.
+        let mut near_ceiling = test_existing_note();
+        near_ceiling.confidence = 0.97;
+        let repo = RecordingExtractionRepository::with_existing(near_ceiling);
+        let context = ExtractionContext {
+            note_repo: &repo,
+            provider: &provider,
+            project_id: "project-1",
+            project_path: "/projects/project-1",
+            knowledge_branch_target: &KnowledgeBranchTarget::Main,
+            session_id: "new",
+            task_id: "task-1",
+            task_run_id: None,
+            task_short_id: "t1",
+            task_title: "Test task",
+            task_description: "Test task description",
+            provenance: "footer",
+            caller_attributed: true,
+            session_scope_paths: &[],
+            created_note_ids: Mutex::new(HashSet::new()),
+            candidate_lookup: CandidateLookup::with_override(test_candidate_lookup),
+        };
+        let mut quality = ExtractionQuality::default();
+        process_extracted_note(&context, "case", &test_extracted_case(), &mut quality).await;
+
+        let ceiling = djinn_db::repositories::note::CONFIDENCE_CEILING;
+        let revisions = repo.revisions();
+        // Negative control: if the duplicate path stopped running at all, the
+        // loop below would be vacuously satisfied.
+        let boost = revisions
+            .iter()
+            .find(|op| op.mutation.event_kind == NoteRevisionEventKind::ConfidenceChanged)
+            .expect("the duplicate-confidence path must still run for this test to prove anything");
+        assert_eq!(
+            boost.after_confidence,
+            Some(ceiling),
+            "a boost that would overshoot must land exactly on CONFIDENCE_CEILING"
+        );
+        for revision in &revisions {
+            if let Some(after) = revision.after_confidence {
+                assert!(
+                    after <= ceiling,
+                    "duplicate boost wrote confidence {after}, above CONFIDENCE_CEILING \
+                     {ceiling}; the ceiling is an invariant of notes.confidence, and a note \
+                     above it is demoted by USER_CONFIRM (proposal 9xih AC2)"
+                );
+            }
+        }
+    }
+
+    /// The companion property: a note already AT the ceiling is not written at
+    /// all by a duplicate confirmation. The clamped posterior equals the prior,
+    /// so there is no evidence to record and no revision event to emit.
+    #[tokio::test]
+    async fn duplicate_confirmation_of_a_ceiling_note_writes_nothing() {
+        let provider = ScriptedProvider::new(vec![
+            r#"{"decision":"already_known","existing_note_id":"existing-note-1"}"#.to_string(),
+        ]);
+        let mut at_ceiling = test_existing_note();
+        at_ceiling.confidence = djinn_db::repositories::note::CONFIDENCE_CEILING;
+        let repo = RecordingExtractionRepository::with_existing(at_ceiling);
+        let context = ExtractionContext {
+            note_repo: &repo,
+            provider: &provider,
+            project_id: "project-1",
+            project_path: "/projects/project-1",
+            knowledge_branch_target: &KnowledgeBranchTarget::Main,
+            session_id: "new",
+            task_id: "task-1",
+            task_run_id: None,
+            task_short_id: "t1",
+            task_title: "Test task",
+            task_description: "Test task description",
+            provenance: "footer",
+            caller_attributed: true,
+            session_scope_paths: &[],
+            created_note_ids: Mutex::new(HashSet::new()),
+            candidate_lookup: CandidateLookup::with_override(test_candidate_lookup),
+        };
+        let mut quality = ExtractionQuality::default();
+        process_extracted_note(&context, "case", &test_extracted_case(), &mut quality).await;
+
+        assert!(
+            !repo
+                .revisions()
+                .iter()
+                .any(|op| op.mutation.event_kind == NoteRevisionEventKind::ConfidenceChanged),
+            "a note at CONFIDENCE_CEILING has nowhere to go; the duplicate boost must \
+             record no confidence change rather than an above-ceiling one"
+        );
+        // Negative control: the decision path really did classify this as a
+        // duplicate, so "no confidence event" is a real outcome and not an
+        // extraction that never got that far.
+        assert_eq!(quality.boost_fallback, 1);
     }
 
     #[tokio::test]

--- a/server/crates/djinn-slot/src/memory_enrichment.rs
+++ b/server/crates/djinn-slot/src/memory_enrichment.rs
@@ -30,7 +30,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use djinn_db::repositories::note::{
-    MemoryEntityKind, MemoryEntityRef, MemoryEntityType, NoteAssociationKind,
+    CONFIDENCE_FLOOR, MemoryEntityKind, MemoryEntityRef, MemoryEntityType, NoteAssociationKind,
     NoteRevisionCreateState, NoteRevisionDesiredState, NoteRevisionEventKind, NoteRevisionMutation,
     NoteRevisionReason, NoteRevisionSubsystem, TrustedNoteRevisionAttribution,
     TrustedNoteRevisionProvenance, folder_for_type,
@@ -486,7 +486,14 @@ async fn persist_entity(
                 tags: "[]".to_owned(),
                 retrieval_anchor: Some(canonical_name.to_owned()),
                 scope_paths: "[]".to_owned(),
-                confidence: 0.0,
+                // `CONFIDENCE_FLOOR`, not `0.0`: entity and claim notes are
+                // structural scaffolding for the memory graph, not asserted
+                // knowledge, so they sit at the bottom of the epistemic range
+                // — but `notes.confidence` is bounded by
+                // `[CONFIDENCE_FLOOR, CONFIDENCE_CEILING]`, and `0.0` was
+                // outside it. Both values are far below `STALE_CITATION`, so
+                // injection eligibility is unchanged.
+                confidence: CONFIDENCE_FLOOR,
             }),
             attribution: TrustedNoteRevisionAttribution::system(NoteRevisionSubsystem::Enrichment),
             provenance: TrustedNoteRevisionProvenance::default(),
@@ -531,7 +538,14 @@ async fn persist_claim(
                 tags: "[]".to_owned(),
                 retrieval_anchor: Some(statement.to_owned()),
                 scope_paths: "[]".to_owned(),
-                confidence: 0.0,
+                // `CONFIDENCE_FLOOR`, not `0.0`: entity and claim notes are
+                // structural scaffolding for the memory graph, not asserted
+                // knowledge, so they sit at the bottom of the epistemic range
+                // — but `notes.confidence` is bounded by
+                // `[CONFIDENCE_FLOOR, CONFIDENCE_CEILING]`, and `0.0` was
+                // outside it. Both values are far below `STALE_CITATION`, so
+                // injection eligibility is unchanged.
+                confidence: CONFIDENCE_FLOOR,
             }),
             attribution: TrustedNoteRevisionAttribution::system(NoteRevisionSubsystem::Enrichment),
             provenance: TrustedNoteRevisionProvenance::default(),

--- a/server/crates/djinn-slot/src/memory_enrichment.rs
+++ b/server/crates/djinn-slot/src/memory_enrichment.rs
@@ -1799,7 +1799,10 @@ mod tests {
             )
         );
         assert_eq!(revisions[0].confidence_before, None);
-        assert_eq!(revisions[0].confidence_after, Some(0.0));
+        // `CONFIDENCE_FLOOR`, not 0.0: `notes.confidence` is bounded by
+        // `[CONFIDENCE_FLOOR, CONFIDENCE_CEILING]` and the revision boundary
+        // now rejects anything outside it.
+        assert_eq!(revisions[0].confidence_after, Some(CONFIDENCE_FLOOR));
         assert_eq!(revisions[0].reason, "enrichment:create entity note");
         assert_eq!(revisions[1].actor_kind, "system");
         assert_eq!(revisions[1].subsystem.as_deref(), Some("enrichment"));
@@ -1812,7 +1815,7 @@ mod tests {
             )
         );
         assert_eq!(revisions[1].confidence_before, None);
-        assert_eq!(revisions[1].confidence_after, Some(0.0));
+        assert_eq!(revisions[1].confidence_after, Some(CONFIDENCE_FLOOR));
         assert_eq!(revisions[1].reason, "enrichment:create claim note");
 
         let (same_entity_id, entity_changed) =


### PR DESCRIPTION
Proposal `9xih` shipped in v0.7.44 with AC2 false in production. This fixes it, and fixes a second, more serious defect found in the same place.

AC2: *"New notes default to `0.975`; an idempotent migration changes only exact `1.0` confidence values to `0.975`; and applying `USER_CONFIRM` cannot lower a note below an otherwise untouched note in confidence ordering."*

## Root cause: `mutate_with_revision` is an unguarded third confidence writer

9xih hardened the two confidence writers it knew about. `set_confidence` clamps; `update_confidence` routes through `bayesian_update`, which clamps. `confidence_write_boundary.rs` scans the whole workspace for `set_confidence(` / `update_confidence(` and allowlists the epistemic call sites.

There is a third writer. `NoteRepository::mutate_with_revision` binds a caller-supplied `confidence` straight into the notes `INSERT`/`UPDATE`. It has a completely different call shape, so the boundary guard never saw it — and `validate_command` range-checked only the `GuardedPatch` variant, leaving `Create`, `Existing`, and `ExistingWithMetadata` unbounded. **Every production note-creation path goes through it**, so the `DEFAULT 0.975` migration 197 installed is dead code for every note the system actually makes.

Two live defects followed.

### 1. Authored notes were created at `0.5`, not the ceiling (AC2 clause 1)

`memory_tools/write_services.rs::create_note` hardcoded `confidence: 0.5`. That literal arrived in #2168 (2026-07-16, the attributed-writer cutover), which moved `memory_write` off `repo.create_with_scope*` / `create_with_status*` — which omit `confidence` from the INSERT and therefore took the column default — onto `mutate_with_revision`, and copied the extraction prior into the new call. From that commit onward the column default was never exercised for an authored note, so 9xih's migration of it changed nothing observable.

Production, 3h after deploy: 36 notes created, 0 at `0.975`.

**`0.5` is not wrong everywhere — only here.** It is the deliberate "unproven machine proposal" prior for session extraction, documented in `scoring.rs`, written into every extracted note's provenance footer, and allowlisted as epistemic in `confidence_write_boundary.rs`. It stays `0.5` in `llm_extraction.rs`. The bug was applying it to *authored* notes, which are assertions their author believes.

### 2. The ceiling was already breached, and AC2's ordering clause was false (AC2 clause 3)

`llm_extraction.rs::boost_duplicate_confidence` re-derived the Bayesian posterior inline:

```rust
let updated_confidence = (existing.confidence * DUPLICATE_CONFIDENCE_SIGNAL)
    / (existing.confidence * DUPLICATE_CONFIDENCE_SIGNAL
        + (1.0 - existing.confidence) * (1.0 - DUPLICATE_CONFIDENCE_SIGNAL));
```

The formula matches `bayesian_update`. The clamp does not exist. Repeated duplicate confirmations therefore walked notes **above** `CONFIDENCE_CEILING`, asymptotically toward `1.0`.

Production: **86 notes above the ceiling**, max `0.999999999999202`, every one of them on the exact `bayesian_update(x, 0.65)` orbit, exclusively `case`/`pattern`/`pitfall`. `note_revision_events` shows the ladder directly, `confidence_after` climbing `0.65 → 0.775 → 0.865 → … → 0.99999999996` under reason `confirmed duplicate extracted knowledge`.

This is exactly the state migration 197 was written to eliminate. A note at ~1.0 is unfalsifiable — `bayesian_update` has no effect on it — and worse, `update_confidence` clamps, so **applying `USER_CONFIRM` to any of those 86 notes drops it to `0.975`, below every untouched above-ceiling peer.** AC2's ordering clause is false in production right now. The hypothesis that the hazard was dormant because new notes sit at `0.5` (where a positive signal raises them) held only for the creation path; the duplicate boost re-armed it from the other end.

## Fix

| Change | File |
| --- | --- |
| `memory_write` creates authored notes at `CONFIDENCE_CEILING` | `memory_tools/write_services.rs` |
| duplicate boost calls `bayesian_update` instead of re-deriving it | `djinn-slot/src/llm_extraction.rs` |
| `validate_command` range-checks **every** desired state that names a confidence, not just `GuardedPatch` | `note/mutation.rs` |
| enrichment entity/claim notes use `CONFIDENCE_FLOOR` instead of the out-of-range `0.0` | `djinn-slot/src/memory_enrichment.rs` |
| migration 201 returns all stored rows to `[0.025, 0.975]` | `201_note_confidence_range_repair.sql` |

Migration numbering: main carries 197/198/199, so 200 is free and **201 is uncontested**. The gap is deliberate — renumbering to close it would only risk a fresh collision.

Rejecting rather than clamping in `validate_command` keeps the mistake loud at the call site instead of silently rewriting what the caller asked for.

## Repro: failing on `main`, passing here

The migration test proved the default *exists* — `information_schema` says `0.975`, and a bare `INSERT` relying on the default lands there. Both true, neither is the production path. Those assertions are kept; these join them by going through the real writers.

- `memory_write_creates_notes_at_the_confidence_ceiling` (`djinn-control-plane`) — calls `server.memory_write(...)`, then reads the **persisted row** back through `NoteRepository::get`, not the tool's return value: the defect was a wrong value being *written*, and a response body echoing the same wrong value would have agreed with it. On `main`: `left: 0.5, right: 0.975`.
- `stored_confidence_default_equals_the_constant_production_writes` (`djinn-db`) — the other half: the stored `information_schema` column default must equal the constant the writer uses. These two numbers are structurally independent — the default lives in migration 197, the written value is a Rust constant bound explicitly by `mutate_with_revision` — and they silently disagreed from #2168 until now. It lives in `djinn-db` because reading the catalog would otherwise cross the raw-SQL boundary. It also pins that file's local `CONFIDENCE_CEILING`/`CONFIDENCE_FLOOR` copies to the production constants, so the migration test cannot assert a stale literal.
- `duplicate_confidence_boost_never_exceeds_the_confidence_ceiling` (`djinn-slot`) — on `main`: `duplicate boost wrote confidence 0.9863813229571984, above CONFIDENCE_CEILING 0.975`. That is the value production actually holds.
- `duplicate_confirmation_of_a_ceiling_note_writes_nothing` — companion: a note at the ceiling has nowhere to go, so no confidence event is recorded at all.
- `user_confirm_never_lowers_a_note_below_an_untouched_peer` (`djinn-control-plane`) — AC2's ordering clause end to end through `memory_write` + `memory_confirm`.
- `user_confirm_is_monotone_across_the_whole_epistemic_range` (`scoring.rs`) — the clause generalized over the range, plus the counterexample proving it holds *because* the range invariant holds.
- `revision_mutation_rejects_confidence_outside_the_epistemic_range` (`note/tests/mutation.rs`) — every variant, every out-of-range value production reached, plus an in-range negative control.
- `only_epistemic_call_sites_may_name_a_confidence_on_a_revision_command` (`confidence_write_boundary.rs`) — extends the guard to the writer it structurally could not see.
- `migration_201_clamps_out_of_range_confidence_and_is_idempotent` + an empty-table control.

Two existing fixtures had to be retired because they encoded the defect:

- `terminal_duplicate_confidence_noop_records_one_trusted_skipped_revision` seeded a note at `1.0` and got its no-op from `1.0` being an absorbing state of the *raw* Bayesian update. That absorbing state is exactly what 9xih removed. With the boost clamped, `CONFIDENCE_CEILING` is the real fixed point, so the fixture uses it — and `1.0` is no longer a state a note can be in.
- the enrichment revision snapshot expected the out-of-range `0.0` the entity/claim writer used to emit; it now expects `CONFIDENCE_FLOOR`.
- `memory_revision_readers` asserted `confidence_after == 0.5` for a note created through `memory_write`; it now asserts `CONFIDENCE_CEILING` via the named constant.

## Confidence drift: legitimate

Notes at `0.975` went 1,433 → 1,386 in the 3h after deploy. That drift is stale-citation decay, an allowlisted epistemic writer, and not a leak:

- `note_revision_events` has exactly **10** rows ever with `confidence_before = 0.975`. All predate the deploy (July), all from `extraction`/authored updates. **Zero** post-deploy exits from the ceiling are recorded, and **zero** `deleted` events from the ceiling.
- `lifecycle.rs::decay_note_confidence` is the only confidence writer that leaves no trace at all — it writes through `set_confidence`, which neither emits a revision event nor bumps `updated_at`. Silent exits from the ceiling are its signature and nothing else's.
- It only touches `case`/`pattern`/`pitfall` (`note_type IN (...)` in the candidate SQL), and it runs `DECAY_ITERATION_CAP` steps per tick, so a decaying note jumps straight past `STALE_CITATION` rather than resting on an intermediate value. Consistent with production: **no** note sits on an intermediate `0.975`-decay orbit value, while 25 extracted-type notes crossed to ≤ 0.3 in the same window.

No non-epistemic writer has crept back into `set_confidence` / `update_confidence` — the existing guard is green and its negative controls still fire. The leak was in the opposite direction and through a writer the guard could not see, which is why the guard is extended here.

## Note for the proposal: the code was not bent to fit the AC's literal wording

AC2's first clause reads *"New notes default to `0.975`"*. Taken literally that is a claim about **all** new notes, and satisfying it literally would mean creating session-extracted notes at the ceiling too. **That would be wrong, and this PR deliberately does not do it.**

`0.5` is the considered prior for an unproven machine proposal. It is documented in `scoring.rs`, written into every extracted note's provenance footer (`Confidence: 0.5 (session-extracted)`), and already allowlisted as an epistemic call site in `confidence_write_boundary.rs`. Raising it would assert that an LLM's first-pass extraction is as credible as a human writing down a decision they believe. Enrichment entity/claim notes are the mirror case: graph scaffolding, not asserted knowledge, so they sit at `CONFIDENCE_FLOOR`.

So the split is:

| writer | confidence | why |
| --- | --- | --- |
| `memory_write` (authored) | `CONFIDENCE_CEILING` | an assertion its author believes — **this is what was broken** |
| session extraction | `0.5` | unproven machine proposal — unchanged, deliberately |
| enrichment entity/claim | `CONFIDENCE_FLOOR` | graph scaffolding, not a claim |

Proposed amendment: **"new *authored* notes default to `0.975`"**. The code change here makes that true; the AC's current wording is what needs to move, not the extraction prior.

## Gates

- `./scripts/check-migrations-immutable.sh` — OK, no existing migrations modified, no duplicate versions
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --no-fail-fast -p djinn-control-plane -p djinn-slot -p djinn-db -p djinn-coordinator -p djinn-agent` — 104 targets green (djinn-db lib alone: 1556 passed)
- `./scripts/check-raw-sql-boundary.sh` — clean (5 files outside djinn-db checked); `./scripts/test-check-raw-sql-boundary.sh` — 59 passed, 0 failed
- `make sqlx-verify` — up to date (405 generated == 405 committed, byte-identical); the diff adds and removes zero `sqlx::query!` macro invocations
- `make tool-goldens-check` — up to date; no `#[tool]` description or param struct touched

Rebased onto `9a85c1d5a` (latest main, includes #3112 and #3113).
