### PR TITLE
fix(codex): scope the post-401 OAuth refresh to the credential owner

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/helpers/provider_resolution.rs
+++ b/server/crates/djinn-agent/src/actors/slot/helpers/provider_resolution.rs
@@ -263,22 +263,54 @@ async fn try_load_or_refresh_copilot(
 }
 
 /// Attempt a host-side silent OAuth token refresh after a mid-run 401.
+///
+/// `owner` is the credential owner (the task creator) and MUST be passed
+/// explicitly. This runs from the slot's terminal-report handling, *outside*
+/// the `SESSION_USER_ID.scope(created_by_user_id, …)` that wraps credential
+/// resolution at dispatch, so the ambient task-local is `None` here. Without an
+/// explicit owner the underlying `get_decrypted` resolves only the org-shared
+/// (`owner_user_id IS NULL`) row: a user-owned OAuth token reads as missing,
+/// this returns `false`, and the caller marks a perfectly live credential
+/// revoked ("owner must reconnect") — while its own `mark_revoked` *does* take
+/// the owner and so revokes the very row this lookup could not see.
+/// `djinn_provider::oauth::keepalive` carries the same hazard and the same fix.
+///
 /// Returns `true` when the model is OAuth-backed and the token is now live.
 /// Returns `false` for non-OAuth providers and for a refresh that itself fails.
-pub async fn refresh_oauth_credential_after_401(model_id: &str, app_state: &AgentContext) -> bool {
+pub async fn refresh_oauth_credential_after_401(
+    model_id: &str,
+    app_state: &AgentContext,
+    owner: Option<&str>,
+) -> bool {
+    let credential_repo =
+        CredentialRepository::new(app_state.db.clone(), app_state.event_bus.clone());
+    refresh_oauth_credential_for_owner(model_id, &credential_repo, owner).await
+}
+
+/// Repository-level body of [`refresh_oauth_credential_after_401`], split out
+/// so the owner scoping is provable without constructing an [`AgentContext`].
+async fn refresh_oauth_credential_for_owner(
+    model_id: &str,
+    credential_repo: &CredentialRepository,
+    owner: Option<&str>,
+) -> bool {
     let Ok((provider_id, _model_name)) = parse_model_id(model_id) else {
         return false;
     };
     let effective_id = effective_oauth_provider_id(&provider_id);
-    let credential_repo =
-        CredentialRepository::new(app_state.db.clone(), app_state.event_bus.clone());
-    match effective_id {
-        "chatgpt_codex" => try_load_or_refresh_codex(&credential_repo).await.is_some(),
-        "githubcopilot" => try_load_or_refresh_copilot(&credential_repo)
-            .await
-            .is_some(),
-        _ => false,
-    }
+    let refresh = async {
+        match effective_id {
+            "chatgpt_codex" => try_load_or_refresh_codex(credential_repo).await.is_some(),
+            "githubcopilot" => try_load_or_refresh_copilot(credential_repo).await.is_some(),
+            _ => false,
+        }
+    };
+    // Scope the write-back as well as the load: a refresh saves through
+    // `CredentialRepository::set`, which reads the same ambient owner, so an
+    // unscoped save would rewrite a user-private token as the org-shared row.
+    djinn_core::auth_context::SESSION_USER_ID
+        .scope(owner.map(str::to_string), refresh)
+        .await
 }
 
 pub async fn load_provider_credential(
@@ -736,5 +768,65 @@ mod tests {
             provider.is_some(),
             "API-key provider must be created for Anthropic reasoning model"
         );
+    }
+
+    /// The post-401 silent refresh runs from the slot's terminal-report
+    /// handling, where no `SESSION_USER_ID` scope is in effect — the only scope
+    /// on the dispatch path wraps credential *resolution* and is long gone by
+    /// then. Before the owner was threaded through, the lookup therefore
+    /// resolved only the org-shared (`owner_user_id IS NULL`) row, a user-owned
+    /// Codex token read as missing, and the caller marked a live credential
+    /// revoked ("owner must reconnect") — using an owner it *did* have.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn post_401_refresh_sees_a_user_owned_codex_token_with_no_ambient_scope() {
+        use djinn_core::events::EventBus;
+        use djinn_db::{Database, UserRepository};
+
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        let uid = UserRepository::new(db.clone())
+            .upsert_from_github(9_401, "fern-401", None, None)
+            .await
+            .unwrap()
+            .id;
+        let repo = CredentialRepository::new(db.clone(), EventBus::noop());
+        // `expires_at` far in the future so `is_expired()` is false and the
+        // assertion never depends on a live token exchange.
+        let tokens = serde_json::json!({
+            "access_token": "at",
+            "refresh_token": "rt",
+            "id_token": Value::Null,
+            "expires_at": 4_102_444_800_i64,
+            "account_id": Value::Null,
+        })
+        .to_string();
+        repo.set_with_owner(
+            "chatgpt_codex",
+            crate::oauth::codex::CODEX_OAUTH_DB_KEY,
+            &tokens,
+            Some(&uid),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            djinn_core::auth_context::current_user_id().is_none(),
+            "the test must run unscoped to reproduce the terminal-report context"
+        );
+        assert!(
+            refresh_oauth_credential_for_owner("openai/gpt-5.6-sol", &repo, Some(&uid)).await,
+            "a live user-owned codex token must refresh silently — `false` here is what \
+             makes the supervisor mark the credential revoked"
+        );
+
+        // Same call without the owner sees only the org-shared row: the exact
+        // pre-fix behaviour. Skipped when a legacy filesystem token cache
+        // exists, since `load_from_db` falls back to (and migrates) it.
+        if !crate::oauth::codex::CodexTokens::cache_path().exists() {
+            assert!(
+                !refresh_oauth_credential_for_owner("openai/gpt-5.6-sol", &repo, None).await,
+                "an owner-less lookup must not resolve another scope's token"
+            );
+        }
     }
 }

--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -557,7 +557,10 @@ async fn apply_provider_breaker_feedback(
                 (false, true, retry_after_ms)
             }
             djinn_runtime::ProviderFailureClass::AuthInvalid => {
-                if refresh_oauth_credential_after_401(model_id, app_state).await {
+                // `creator_scope` is required: this runs outside the dispatch-time
+                // `SESSION_USER_ID` scope, so an owner-less lookup would miss a
+                // user-owned OAuth token and revoke a live credential.
+                if refresh_oauth_credential_after_401(model_id, app_state, creator_scope).await {
                     app_state
                         .health_tracker
                         .record_stall(creator_scope, model_id, false);

--- a/ui/src/components/settings/ConnectionsTab.test.tsx
+++ b/ui/src/components/settings/ConnectionsTab.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { ConnectedProvider } from "@/api/userConfig";
+import type { CatalogProvider, ConnectedProvider } from "@/api/userConfig";
+import { fetchUserCatalog, fetchUserConnectedProviders } from "@/api/userConfig";
 import { render, screen } from "@/test/test-utils";
 
 import { ConnectionsTab } from "./ConnectionsTab";
@@ -112,5 +113,34 @@ describe("ConnectionsTab", () => {
 
     // ChatGPT/Codex is its own compact row, not duplicated as a plain provider.
     expect(screen.getByText("ChatGPT / Codex")).toBeInTheDocument();
+  });
+
+  it("takes the codex revoked reason from the catalog, not the connected list", async () => {
+    // `provider_connected` drops every provider carrying a revoked reason and
+    // hardcodes `revoked_reason: null` on the ones it returns, so the reason is
+    // only ever present in the catalog. Reading it off the connected list could
+    // never yield anything, and the row silently degraded to the plain
+    // never-connected "Sign in with a device code" subtitle — leaving the user
+    // signed out with no stated cause.
+    const reason =
+      "chatgpt_codex rejected the credential (HTTP 401 — token revoked or invalid). " +
+      "Reconnect this provider to resume.";
+    vi.mocked(fetchUserConnectedProviders).mockResolvedValueOnce(
+      connected.filter((provider) => provider.id !== "openai"),
+    );
+    vi.mocked(fetchUserCatalog).mockResolvedValueOnce([
+      {
+        id: "openai",
+        name: "OpenAI",
+        connected: false,
+        connection_methods: [],
+        env_vars: ["OPENAI_API_KEY"],
+        revoked_reason: reason,
+      } as unknown as CatalogProvider,
+    ]);
+
+    render(<ConnectionsTab />);
+
+    expect(await screen.findByText(`Disconnected — ${reason}`)).toBeInTheDocument();
   });
 });

--- a/ui/src/components/settings/ConnectionsTab.tsx
+++ b/ui/src/components/settings/ConnectionsTab.tsx
@@ -65,9 +65,13 @@ export function ConnectionsTab() {
   // `openai` API key, by contrast, is an org-provided key.)
   const openaiProvider = (connected.data ?? []).find((p) => p.id === "openai");
   const codexConnected = openaiProvider?.connection_methods.includes("oauth") ?? false;
-  const codexRevokedReason = (
-    openaiProvider as { revoked_reason?: string } | undefined
-  )?.revoked_reason;
+  // The reason has to come from the CATALOG, not the connected list: the
+  // connected endpoint drops every provider carrying a revoked reason and
+  // hardcodes `revoked_reason: null` on the ones it returns, so sourcing it
+  // there can only ever yield `undefined` and the row silently degrades to the
+  // never-connected "Sign in with a device code" subtitle.
+  const codexRevokedReason = (catalog.data ?? []).find((p) => p.id === "openai")
+    ?.revoked_reason;
 
   // Split connected providers into the two buckets, then collapse subscriptions
   // by shared credential. The Codex sub is rendered by its dedicated OAuth row,


### PR DESCRIPTION
## The symptom

`chatgpt_codex rejected the credential (HTTP 401 — token revoked or invalid). Reconnect this provider to resume.` — repeatedly, on a credential that is fine. Dispatch stays healthy and Codex requests keep succeeding while the provider shows as disconnected.

Live evidence from the VPS server pod:

```
14:01:56  Codex: token refreshed successfully (lifecycle)
14:03:15  supervisor: marked credential revoked after 401 — owner must reconnect
14:03:15.78  openai_responses: building request  base_url=https://chatgpt.com/backend-api/codex
14:03:45  Codex: device-code flow completed, tokens persisted   ← user reconnects
14:12:53  supervisor: marked credential revoked after 401 — owner must reconnect
14:12:54 … 14:14:50  openai_responses: building request  (all succeeding)
```

## Root cause

A mid-run 401 is meant to trigger a silent host-side refresh, and only fall through to "revoked" when *that* fails. For any user-owned OAuth credential the refresh could never succeed, so the fallthrough was the only reachable branch.

- `refresh_oauth_credential_after_401` → `try_load_or_refresh_codex` → `CodexTokens::load_from_db` → `CredentialRepository::get_decrypted` → ambient `auth_context::current_user_id()`.
- It is called from `apply_provider_breaker_feedback` during terminal-report handling — outside the `SESSION_USER_ID.scope(created_by_user_id, …)` that wraps `resolve_credentials` at dispatch. The task-local is `None` there, and by contract that resolves **only** the org-shared (`owner_user_id IS NULL`) row.
- The token is user-private, so the lookup returned `None` → refresh reported failure → `surface_credential_revocation` fired. `mark_revoked` *does* take `creator_scope`, so it revoked the exact row the refresh could not see.

`djinn_provider::oauth::keepalive` already documents this hazard ("The leader has no `SESSION_USER_ID` task-local, so stamp the owning user explicitly") and handles it with `load_from_db_for_owner` + an explicit scope around the save. This path never got the same treatment.

The 401s themselves are real but benign — a long or resumed run outliving the access token stamped into its pod at dispatch. That is precisely what the silent refresh exists to absorb.

## Blast radius beyond the banner

- `provider_connected` drops the provider (`connected && revoked_reason.is_none()`), so it reads as disconnected everywhere.
- The keepalive sweep **skips revoked rows**, so background token refresh stops until the user re-authenticates.
- `record_stall(scope, model, escalate=true)` trips the breaker — `openai/gpt-5.6-sol` was observed `auto_disabled` off a single false failure, taking that model out of the lane.

## The fix

1. Thread the owner into `refresh_oauth_credential_after_401` and scope the lookup under `SESSION_USER_ID`. The scope also covers the write-back: a refresh saves via `CredentialRepository::set`, which reads the same ambient owner, so an unscoped save would rewrite a user-private token as the org-shared row.
2. UI: `ConnectionsTab` sourced the revoked reason from the connected-providers response, which by construction drops every revoked provider and hardcodes `revoked_reason: null` on the rest — so the reason was always `undefined` and `CodexSignInRow` rendered the plain never-connected "Sign in with a device code" subtitle instead of "Disconnected — <reason>". Source it from the catalog, which carries it.

## Tests

Both are genuine regression tests — verified to fail without their fix:

- `post_401_refresh_sees_a_user_owned_codex_token_with_no_ambient_scope` — seeds a user-owned Codex token, asserts the post-401 refresh finds it with no ambient scope in effect. Without the scope: `a live user-owned codex token must refresh silently`.
- `takes the codex revoked reason from the catalog, not the connected list` — asserts the reason reaches the row. Without the fix: `Unable to find an element with the text: Disconnected — …`.

Ran locally: `cargo test -p djinn-agent --lib provider_resolution` (10 passed) and `supervisor_runner` (22 passed) against an ephemeral Postgres, `cargo clippy -p djinn-agent --tests` clean, `vitest ConnectionsTab` (2 passed), `tsc --noEmit` and `eslint` clean.

## Note for after deploy

The revoked flag is only cleared by a credential write (`CredentialRepository::set`), so a flagged credential currently un-flags itself at the next expiry-driven dispatch refresh and then re-flags on the next 401 — which is the flapping connected/disconnected state. One sign-in after this deploys settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)