### PR TITLE
fix(breaker): give the model hard-disable a half-open probe instead of a permanent latch

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/provider_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/provider_tools.rs
@@ -184,12 +184,35 @@ pub struct ModelHealthOutput {
     pub disable_ttl_trips: u32,
     #[schemars(with = "Option<i64>")]
     pub cooldown_seconds_remaining: Option<u64>,
-    /// Hard-disabled by the trip-rate ceiling: held unavailable with no
-    /// auto-expiry until a human re-enables it via `model_health(action=enable)`.
-    /// When true, `cooldown_seconds_remaining` is null (there is no auto-expiry).
+    /// Hard-disabled (quarantined) by the trip-rate ceiling: held unavailable
+    /// except for a single half-open probe dispatch admitted once per
+    /// quarantine period. When true, `cooldown_seconds_remaining` is null (the
+    /// ordinary cooldown ladder does not own this bucket) and
+    /// `hard_disable_probe_seconds_remaining` says when the next probe is due.
+    /// A human can still release it immediately with
+    /// `model_health(action=enable)`.
     pub hard_disabled: bool,
+    /// Seconds until the next half-open probe dispatch is admitted; `0` means a
+    /// probe is admissible right now, and `null` means the bucket is not
+    /// quarantined. Read this before reaching for `enable`: a `hard_disabled`
+    /// bucket recovers on its own if its next probe succeeds. Its absence is
+    /// what made the 2026-08-12 → 08-16 outage unreadable — `hard_disabled:
+    /// true, trips_in_window: 0, cooldown: null` gave an operator no way to tell
+    /// a permanent state from a wait.
+    #[schemars(with = "Option<i64>")]
+    pub hard_disable_probe_seconds_remaining: Option<u64>,
+    /// The quarantine was released by a successful probe, but the bucket has not
+    /// yet produced enough clean sessions to have its history forgiven: it is
+    /// dispatchable at full throughput, and a single further breaker trip
+    /// re-quarantines it at the next (longer) tier.
+    pub hard_disable_on_probation: bool,
+    /// Escalation tier of the quarantine ladder: `0` = 6h, doubling per failed
+    /// probe to a 7-day ceiling. Survives restarts.
+    #[schemars(with = "i64")]
+    pub hard_disable_probe_tier: u32,
     /// Number of breaker trips inside the rolling trip-rate window (6h). When it
-    /// reaches the ceiling (8) the bucket hard-disables.
+    /// reaches the ceiling (8) the bucket hard-disables — or `1` while
+    /// `hard_disable_on_probation` is set.
     #[schemars(with = "i64")]
     pub trips_in_window: u32,
 }
@@ -206,6 +229,9 @@ impl From<ModelHealth> for ModelHealthOutput {
             disable_ttl_trips: value.disable_ttl_trips,
             cooldown_seconds_remaining: value.cooldown_seconds_remaining,
             hard_disabled: value.hard_disabled,
+            hard_disable_probe_seconds_remaining: value.hard_disable_probe_seconds_remaining,
+            hard_disable_on_probation: value.hard_disable_on_probation,
+            hard_disable_probe_tier: value.hard_disable_probe_tier,
             trips_in_window: value.trips_in_window,
         }
     }

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -1090,6 +1090,15 @@ impl CoordinatorActor {
 
             match dispatch_fn(&self.pool, model_id).await {
                 Ok(()) => {
+                    // A dispatch was actually accepted onto this model. If the
+                    // bucket is hard-disabled this is the ONE half-open probe
+                    // its quarantine admitted, and consuming it here — at the
+                    // single point where a real task is exposed, not at the
+                    // `is_available` predicate above, which is a pure read
+                    // consulted several times per decision — re-arms the
+                    // quarantine before the probe's verdict is known. No-op for
+                    // a healthy bucket.
+                    self.health.note_dispatch_accepted(scope, model_id);
                     tracing::Span::current().record("outcome", "ok");
                     tracing::info!(outcome = "ok", model_id = %model_id, label);
                     super::lane_resolution_log::emit_failover_candidate_accepted(

--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -169,6 +169,48 @@ const _: () = assert!(
     "HARD_DISABLE_MAX_PROBE_TIER must be large enough to actually reach the ceiling"
 );
 
+/// Trips required to re-quarantine a bucket that is on **probation** — i.e. one
+/// whose latch was released by a successful half-open probe but which has not
+/// yet re-proven itself (see [`HARD_DISABLE_PROBATION_SUCCESSES`]).
+///
+/// A probation bucket has already demonstrated it can reach
+/// [`TRIP_RATE_CEILING`], and it was handed the lane back on the strength of a
+/// SINGLE session. Making it earn eight fresh trips before it can be
+/// re-quarantined is what turns a lucky probe into a flap: the first version of
+/// this change cleared `trip_times`, `disable_ttl_trips` and the quarantine tier
+/// on a probe success, leaving the bucket byte-identical to a never-tripped
+/// model. Measured against the `xiaomi-token-plan-sgp/mimo-v2.5-pro` profile
+/// (78 failures / 16 successes — roughly one success in six), that produced one
+/// lucky probe followed by **4712 exposed sessions in 30 days and no re-latch**:
+/// strictly worse than the permanent latch it replaced. The escalation ladder
+/// was only ever reachable by a model whose backend was completely gone, which
+/// is not the class either incident belongs to.
+///
+/// `1` — a single trip re-quarantines. A trip still costs
+/// [`CIRCUIT_BREAKER_THRESHOLD`] consecutive breaker-eligible failures, so a
+/// genuinely recovered model (which produces none) sails through probation with
+/// full throughput, while an intermittently-broken one is back in quarantine
+/// within a handful of sessions — and at the NEXT tier, because the tier is
+/// preserved across the release.
+const HARD_DISABLE_PROBATION_TRIP_CEILING: usize = 1;
+
+/// Consecutive successful sessions a bucket on probation must produce before the
+/// hard-disable history is forgiven and it returns to the ordinary
+/// [`TRIP_RATE_CEILING`] with a reset quarantine tier.
+///
+/// Deliberately evidence-based rather than clock-based: "prove you work" is the
+/// question probation asks, and a wall-clock window would forgive a model that
+/// was merely idle. `5` separates the two incident profiles cleanly — the
+/// recovered model from the 4-day outage went 10-for-10 immediately and clears
+/// probation on its fifth session, while a one-success-in-six model has a
+/// ~1-in-7776 chance of ever clearing it and therefore stays permanently one
+/// trip away from re-quarantine.
+///
+/// Runtime-only counter (`consecutive_successes`): a restart restarts the streak,
+/// which only ever keeps a bucket on probation LONGER. That is the safe
+/// direction.
+const HARD_DISABLE_PROBATION_SUCCESSES: u32 = 5;
+
 /// Quarantine length for an escalation `tier`: [`HARD_DISABLE_QUARANTINE_BASE`]
 /// doubled once per prior failed probe, capped at [`HARD_DISABLE_QUARANTINE_MAX`].
 fn quarantine_for_tier(tier: u32) -> Duration {
@@ -328,6 +370,21 @@ pub struct ModelHealth {
     /// pre-half-open snapshots, which load at tier 0 (the base quarantine).
     #[serde(default)]
     pub hard_disable_probe_tier: u32,
+    /// Seconds until the next half-open probe dispatch is admissible. `None`
+    /// when the bucket is not hard-disabled; `Some(0)` when a probe is
+    /// admissible right now. This is the field that answers "will this recover
+    /// on its own, and when?" — the question an operator could not answer for
+    /// four days. Derived, like `cooldown_seconds_remaining`, so `restore_all`
+    /// ignores it and re-anchors from the persisted tier instead.
+    #[serde(default)]
+    pub hard_disable_probe_seconds_remaining: Option<u64>,
+    /// The bucket's quarantine was released by a successful probe but it has not
+    /// yet produced enough clean sessions to have its hard-disable history
+    /// forgiven: it is dispatchable at full throughput, but a single breaker
+    /// trip re-quarantines it one rung higher. `#[serde(default)]` for
+    /// back-compat with pre-half-open snapshots.
+    #[serde(default)]
+    pub hard_disable_on_probation: bool,
     /// Number of breaker trips currently inside the rolling [`TRIP_RATE_WINDOW`].
     /// Surfaced so operators can see how close a bucket is to the hard-disable
     /// ceiling. `#[serde(default)]` for back-compat with pre-ceiling snapshots.
@@ -388,12 +445,47 @@ struct ModelState {
     hard_disable_probe_tier: u32,
     /// Whether a half-open probe has been handed out and has not yet been
     /// resolved. Set by `note_dispatch_accepted`, cleared by the first
-    /// failure/success that follows. Its only job is to make the tier escalate
-    /// **once per probe** rather than once per failure record — a single bad
-    /// session can produce both a stall and a failure. Runtime-only: a restart
-    /// drops it, which at worst costs one un-escalated quarantine, and
-    /// `restore_all` re-anchors the deadline anyway.
+    /// failure/success that follows.
+    ///
+    /// This is the **authority gate on quarantine transitions**, and nothing
+    /// else may move them:
+    ///
+    /// * Only an admitted probe's success can release the latch. A success from
+    ///   a session that was already in flight when the latch was set proves
+    ///   nothing about the quarantine — for a *flapping* model such successes
+    ///   are routine, and letting one release the quarantine having admitted
+    ///   zero probes hands the lane back for free.
+    /// * Only an admitted probe's failure can push the deadline out. Not every
+    ///   dispatch path consults the breaker (e.g. evidence-dispatch recovery
+    ///   reaches the pool without a `HealthTracker` read at all), so a
+    ///   health-blind path failing every few hours would otherwise re-anchor the
+    ///   quarantine forever and produce a silent permanent outage — the exact
+    ///   bug this whole change exists to remove, reintroduced by a different
+    ///   route. Measured: one failure record every 5h admitted **zero** probes
+    ///   in 30 simulated days, with the tier pinned at 0 so nothing showed it.
+    /// * It also makes the tier escalate once per *probe* rather than once per
+    ///   failure record, since a single bad session can emit both a stall and a
+    ///   typed failure.
+    ///
+    /// Note this gate does NOT weaken the fail-closed bound: exposure is bounded
+    /// by `note_dispatch_accepted` pushing the deadline at accept time, before
+    /// any verdict exists.
+    ///
+    /// Runtime-only: a restart drops it, which at worst costs one un-escalated
+    /// quarantine, and `restore_all` re-anchors the deadline anyway.
     probe_outstanding: bool,
+    /// The latch was released by a successful half-open probe, but the bucket
+    /// has not yet re-proven itself with [`HARD_DISABLE_PROBATION_SUCCESSES`]
+    /// clean sessions. While set, a single trip re-quarantines the bucket at the
+    /// NEXT tier (see [`HARD_DISABLE_PROBATION_TRIP_CEILING`]).
+    ///
+    /// Persisted, because forgetting it across a restart is what would let an
+    /// intermittently-broken model reset its history by waiting for a deploy.
+    hard_disable_on_probation: bool,
+    /// Consecutive successful sessions with no intervening failure. Drives the
+    /// probation exit only. Runtime-only; a restart restarts the streak, which
+    /// keeps a bucket on probation longer (the safe direction).
+    consecutive_successes: u32,
     /// Monotonic timestamps of recent breaker trips, pruned to
     /// [`TRIP_RATE_WINDOW`]. When its length reaches [`TRIP_RATE_CEILING`] the
     /// bucket is hard-disabled. Only genuine (escalating) trips are recorded —
@@ -451,6 +543,17 @@ impl ModelState {
             .count() as u32
     }
 
+    /// Trips required to (re-)quarantine this bucket right now: the ordinary
+    /// [`TRIP_RATE_CEILING`], or [`HARD_DISABLE_PROBATION_TRIP_CEILING`] while
+    /// the bucket is on probation after a released quarantine.
+    fn effective_trip_ceiling(&self) -> usize {
+        if self.hard_disable_on_probation {
+            HARD_DISABLE_PROBATION_TRIP_CEILING
+        } else {
+            TRIP_RATE_CEILING
+        }
+    }
+
     /// Record a genuine breaker trip against the rolling trip-rate window and
     /// hard-disable the bucket if the ceiling is reached. Returns `true` when
     /// this trip crossed the ceiling (for one-shot logging).
@@ -459,32 +562,53 @@ impl ModelState {
         self.trip_times
             .retain(|t| now.duration_since(*t) < TRIP_RATE_WINDOW);
         self.trip_times.push(now);
-        if !self.hard_disabled && self.trip_times.len() >= TRIP_RATE_CEILING {
+        if !self.hard_disabled && self.trip_times.len() >= self.effective_trip_ceiling() {
+            // A bucket on probation is RE-quarantining, so it resumes the
+            // escalation ladder rather than restarting it: the tier it carried
+            // out of its last quarantine is the tier it goes back in above.
+            // Without this, an intermittently-broken model that wins one probe
+            // per cycle would be quarantined for a flat 6h forever.
+            let relatch = self.hard_disable_on_probation;
+            self.hard_disable_probe_tier = if relatch {
+                self.hard_disable_probe_tier
+                    .saturating_add(1)
+                    .min(HARD_DISABLE_MAX_PROBE_TIER)
+            } else {
+                0
+            };
+            self.hard_disable_on_probation = false;
             self.hard_disabled = true;
             // No ordinary cooldown: clear the deadline so `is_available` relies
             // solely on the quarantine gate below.
             self.cooldown_until = None;
-            self.hard_disable_probe_tier = 0;
-            self.probe_available_at = Some(now + quarantine_for_tier(0));
+            self.probe_available_at = Some(now + quarantine_for_tier(self.hard_disable_probe_tier));
             self.probe_outstanding = false;
             return true;
         }
         false
     }
 
-    /// Resolve a hard-disabled bucket's half-open probe as **failed**, or —
-    /// when no probe was outstanding — simply re-anchor the quarantine at this
-    /// fresh piece of bad evidence.
+    /// Resolve an **outstanding** half-open probe as failed: re-latch, push the
+    /// deadline a full quarantine out, and — unless the failure was a transient
+    /// upstream fault — advance the escalation tier.
     ///
-    /// Escalation is charged once per *probe*, not once per failure record: a
-    /// single doomed session can emit both a stall and a typed failure, and
-    /// double-charging would jump a model from the 6h base to the 7d ceiling on
-    /// one bad dispatch. Either way the deadline is pushed to
-    /// `now + quarantine_for_tier(tier)`, which is what "measured from the last
-    /// trip" means.
-    fn fail_probe(&mut self, now: Instant) {
-        if self.probe_outstanding {
-            self.probe_outstanding = false;
+    /// Does nothing when no probe is outstanding, and that guard is load-bearing
+    /// (see `probe_outstanding`): not every dispatch path consults the breaker,
+    /// so an unconditional re-anchor lets a health-blind path postpone the probe
+    /// forever and turn the quarantine into the silent permanent outage this
+    /// whole change exists to remove. Returns `true` when a probe was actually
+    /// resolved, so callers log a verdict rather than a phantom one.
+    ///
+    /// Escalation is also charged once per *probe* rather than once per failure
+    /// record, because a single doomed session can emit both a stall and a typed
+    /// failure and double-charging would jump a model several rungs on one
+    /// dispatch.
+    fn resolve_probe_failure(&mut self, now: Instant, escalate: bool) -> bool {
+        if !self.probe_outstanding {
+            return false;
+        }
+        self.probe_outstanding = false;
+        if escalate {
             self.hard_disable_probe_tier = self
                 .hard_disable_probe_tier
                 .saturating_add(1)
@@ -500,10 +624,34 @@ impl ModelState {
         // is done — the quarantine ladder owns the bucket instead. Pushing
         // probe failures into it would also miscount, because a single latching
         // `trip_breaker` burst delivers several failure records in a row.
+        true
     }
 
-    /// Release the hard-disable latch. Used by a successful half-open probe and
-    /// by the human `enable`/`reset` controls. Also clears the ordinary
+    /// Release the latch on a successful half-open probe, moving the bucket onto
+    /// **probation** rather than back to a clean slate.
+    ///
+    /// The distinction is the whole point. A probe success is real evidence the
+    /// model works right now, so the lane must reopen at full throughput — that
+    /// is what fixes the 4-day outage. But it is evidence from ONE session about
+    /// a bucket that reached eight trips in six hours, and treating it as a full
+    /// pardon (clearing the tier, the trip window and the escalating cooldown)
+    /// is what let a one-success-in-six model escape the ladder entirely. So the
+    /// tier survives, and until the bucket produces
+    /// [`HARD_DISABLE_PROBATION_SUCCESSES`] clean sessions a single trip puts it
+    /// straight back into quarantine one rung higher.
+    fn release_quarantine_to_probation(&mut self) {
+        self.hard_disabled = false;
+        self.probe_available_at = None;
+        self.probe_outstanding = false;
+        self.hard_disable_on_probation = true;
+        // `hard_disable_probe_tier` is deliberately PRESERVED.
+        self.auto_disabled = false;
+        self.cooldown_until = None;
+    }
+
+    /// Fully clear the hard-disable, its probation and its escalation ladder.
+    /// This is the human `enable`/`reset` authority path, and the probation exit
+    /// once a bucket has re-proven itself. Also clears the ordinary
     /// auto-disable, because a quarantined bucket carries `auto_disabled: true`
     /// with `cooldown_until: None` — a state `is_available` would otherwise read
     /// as a never-expiring cooldown.
@@ -512,8 +660,19 @@ impl ModelState {
         self.probe_available_at = None;
         self.hard_disable_probe_tier = 0;
         self.probe_outstanding = false;
+        self.hard_disable_on_probation = false;
         self.auto_disabled = false;
         self.cooldown_until = None;
+    }
+
+    /// Seconds until this bucket's next half-open probe is admissible; `None`
+    /// when it is not quarantined, and `Some(0)` when one is admissible now.
+    fn probe_seconds_remaining(&self, now: Instant) -> Option<u64> {
+        if !self.hard_disabled {
+            return None;
+        }
+        let at = self.probe_available_at?;
+        Some(at.saturating_duration_since(now).as_secs())
     }
 
     fn cooldown_seconds_remaining(&self, now: Instant) -> Option<u64> {
@@ -540,6 +699,8 @@ impl ModelState {
             cooldown_seconds_remaining: self.cooldown_seconds_remaining(now),
             hard_disabled: self.hard_disabled,
             hard_disable_probe_tier: self.hard_disable_probe_tier,
+            hard_disable_probe_seconds_remaining: self.probe_seconds_remaining(now),
+            hard_disable_on_probation: self.hard_disable_on_probation,
             trips_in_window: self.trips_in_window(now),
         }
     }
@@ -747,21 +908,23 @@ impl HealthTracker {
             .breaker_eligible_consecutive_failures
             .saturating_add(1);
 
-        // Half-open probe verdict. While a bucket is hard-disabled the ONLY
-        // dispatch that can reach it is the single probe the quarantine
-        // admitted, so any failure here is that probe failing: re-latch, double
-        // the quarantine and return. Falling through to the ordinary ladder
-        // would be wrong twice over — it would need three strikes to react at
-        // all, and it would log a second, phantom "breaker tripped".
+        // Half-open probe verdict — see `resolve_probe_failure`. It re-latches
+        // and escalates only when a probe is actually outstanding; a failure
+        // arriving from a health-blind dispatch path leaves the quarantine
+        // deadline alone rather than postponing the probe forever. Either way
+        // we return: falling through to the ordinary ladder while latched would
+        // need three strikes to react and would log a phantom second trip.
         if state.hard_disabled {
-            state.fail_probe(now);
-            tracing::warn!(
-                model_id = %key.model_id,
-                scope = ?key.scope,
-                probe_tier = state.hard_disable_probe_tier,
-                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
-                "half-open probe of a hard-disabled model failed — re-quarantined"
-            );
+            if state.resolve_probe_failure(now, true) {
+                tracing::warn!(
+                    model_id = %key.model_id,
+                    scope = ?key.scope,
+                    probe_tier = state.hard_disable_probe_tier,
+                    next_probe_in_secs =
+                        quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                    "half-open probe of a hard-disabled model failed — re-quarantined"
+                );
+            }
             return;
         }
 
@@ -814,6 +977,36 @@ impl HealthTracker {
         state.breaker_eligible_consecutive_failures = 0;
         state.transient_consecutive_failures = 0;
         state.total_successes += 1;
+        state.consecutive_successes = state.consecutive_successes.saturating_add(1);
+
+        if state.hard_disabled {
+            // Only an ADMITTED PROBE's success may release a quarantine. A
+            // success from a session that was already in flight when the latch
+            // was set (realistic whenever `max_sessions > 1` for the same
+            // `(scope, model)`) says nothing about whether the quarantine was
+            // right: for a *flapping* model such successes are routine, and
+            // releasing on one hands the lane back having admitted zero probes.
+            // Everything the quarantine owns — the latch, the deadline, the
+            // tier — is therefore left untouched here, as are the ladder
+            // counters below, which would otherwise let a stray success wipe
+            // the history that justified the latch.
+            if !state.probe_outstanding {
+                return;
+            }
+            // The probe came back clean. Reopen the lane at full throughput,
+            // but onto PROBATION rather than a clean slate — see
+            // `release_quarantine_to_probation`.
+            state.release_quarantine_to_probation();
+            tracing::info!(
+                model_id = %model_id,
+                scope = ?scope,
+                probe_tier = state.hard_disable_probe_tier,
+                probation_successes_required = HARD_DISABLE_PROBATION_SUCCESSES,
+                "half-open probe succeeded — quarantine released onto probation \
+                 (one further trip re-quarantines at the next tier)"
+            );
+        }
+
         // A productive session is proof the model recovered — reset the
         // escalating-cooldown tier and clear the rolling trip window so the next
         // failure starts fresh at the base cooldown and the hard-disable ceiling
@@ -827,23 +1020,24 @@ impl HealthTracker {
         state.consecutive_throttle_trips = 0;
         state.throttle_streak_started_at = None;
         state.last_trip_throttle = false;
-        // A success on a quarantined bucket means the half-open probe came back
-        // clean: release the latch. This is the only automatic exit from a
-        // hard-disable, and it is deliberately not gated on `probe_outstanding`
-        // — a productive session is direct positive evidence about the model
-        // whichever path produced it, and a genuinely-dead model cannot
-        // manufacture one. `clear_hard_disable` also drops `auto_disabled` /
-        // `cooldown_until`, which the guard below could not: a quarantined
-        // bucket has `auto_disabled: true` with no cooldown deadline, so
-        // `is_available` reads `false` and the guard would never fire.
-        if state.hard_disabled {
+
+        // Probation exit: enough consecutive clean sessions to forgive the
+        // hard-disable history and hand back the ordinary `TRIP_RATE_CEILING`
+        // with a reset quarantine tier. A model that is actually healthy again
+        // reaches this in five sessions; a one-success-in-six model effectively
+        // never does, and so stays one trip away from re-quarantine.
+        if state.hard_disable_on_probation
+            && state.consecutive_successes >= HARD_DISABLE_PROBATION_SUCCESSES
+        {
             state.clear_hard_disable();
             tracing::info!(
                 model_id = %model_id,
                 scope = ?scope,
-                "half-open probe succeeded — hard-disable quarantine released"
+                consecutive_successes = state.consecutive_successes,
+                "model re-proved itself after a released quarantine — probation cleared"
             );
         }
+
         if state.auto_disabled && state.is_available(now) {
             state.auto_disabled = false;
             state.cooldown_until = None;
@@ -905,17 +1099,20 @@ impl HealthTracker {
         state.consecutive_failures += 1;
         state.breaker_eligible_consecutive_failures += 1;
         state.total_failures += 1;
+        state.consecutive_successes = 0;
 
         // Half-open probe verdict — see `apply_breaker_check_for`.
         if state.hard_disabled {
-            state.fail_probe(now);
-            tracing::warn!(
-                model_id = %key.model_id,
-                scope = ?key.scope,
-                probe_tier = state.hard_disable_probe_tier,
-                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
-                "half-open probe of a hard-disabled model failed — re-quarantined"
-            );
+            if state.resolve_probe_failure(now, true) {
+                tracing::warn!(
+                    model_id = %key.model_id,
+                    scope = ?key.scope,
+                    probe_tier = state.hard_disable_probe_tier,
+                    next_probe_in_secs =
+                        quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                    "half-open probe of a hard-disabled model failed — re-quarantined"
+                );
+            }
             return;
         }
 
@@ -997,20 +1194,30 @@ impl HealthTracker {
         state.consecutive_failures += 1;
         state.transient_consecutive_failures += 1;
         state.total_failures += 1;
+        state.consecutive_successes = 0;
 
-        // Half-open probe verdict — see `apply_breaker_check_for`. A transient
-        // upstream fault is a weak signal in general, but a bucket that has
-        // already earned a hard-disable does not get the benefit of the doubt:
-        // its one probe produced nothing usable, so it waits again.
+        // Half-open probe verdict — see `apply_breaker_check_for`, but WITHOUT
+        // escalation (`escalate = false`). The probe produced nothing usable, so
+        // the bucket serves another quarantine period; it does not serve a
+        // longer one. This crate's own position is that a transient upstream
+        // fault is a load signal and says nothing about model health — it trips
+        // at `TRANSIENT_BREAKER_THRESHOLD` (20) rather than
+        // `CIRCUIT_BREAKER_THRESHOLD` (3) for exactly that reason — and the
+        // 4-day outage's latch was itself minted during a transient provider
+        // incident. Letting one 5xx double a quarantine would compound that
+        // mistake at the one moment the model is being re-examined.
         if state.hard_disabled {
-            state.fail_probe(now);
-            tracing::warn!(
-                model_id = %key.model_id,
-                scope = ?key.scope,
-                probe_tier = state.hard_disable_probe_tier,
-                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
-                "half-open probe of a hard-disabled model failed (transient) — re-quarantined"
-            );
+            if state.resolve_probe_failure(now, false) {
+                tracing::warn!(
+                    model_id = %key.model_id,
+                    scope = ?key.scope,
+                    probe_tier = state.hard_disable_probe_tier,
+                    next_probe_in_secs =
+                        quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                    "half-open probe of a hard-disabled model hit a TRANSIENT upstream fault \
+                     — re-quarantined at the same tier, not escalated"
+                );
+            }
             return;
         }
 
@@ -1095,6 +1302,7 @@ impl HealthTracker {
         let state = map.entry(key.clone()).or_default();
         state.consecutive_failures += 1;
         state.total_failures += 1;
+        state.consecutive_successes = 0;
 
         // Half-open probe verdict — see `apply_breaker_check_for`. Note this
         // runs BEFORE the throttle-streak bookkeeping below: while quarantined
@@ -1102,14 +1310,16 @@ impl HealthTracker {
         // hard-disable quarantine ladder, and only one of the two may own the
         // bucket's next deadline.
         if state.hard_disabled {
-            state.fail_probe(now);
-            tracing::warn!(
-                model_id = %key.model_id,
-                scope = ?key.scope,
-                probe_tier = state.hard_disable_probe_tier,
-                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
-                "half-open probe of a hard-disabled model stalled — re-quarantined"
-            );
+            if state.resolve_probe_failure(now, true) {
+                tracing::warn!(
+                    model_id = %key.model_id,
+                    scope = ?key.scope,
+                    probe_tier = state.hard_disable_probe_tier,
+                    next_probe_in_secs =
+                        quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                    "half-open probe of a hard-disabled model stalled — re-quarantined"
+                );
+            }
             return;
         }
 
@@ -1397,6 +1607,28 @@ impl HealthTracker {
                     .min(HARD_DISABLE_MAX_PROBE_TIER);
                 state.probe_available_at =
                     Some(now + quarantine_for_tier(state.hard_disable_probe_tier));
+            } else if health.hard_disable_on_probation {
+                // Released by a probe but not yet re-proven. Probation is
+                // persisted for the same reason the tier is: without it, a
+                // model whose quarantine keeps getting released by lucky probes
+                // could launder its history through a deploy and go back to
+                // needing eight fresh trips. The consecutive-success streak that
+                // ENDS probation is runtime-only, so a restart restarts it —
+                // keeping the bucket on probation longer, the safe direction.
+                state.hard_disable_on_probation = true;
+                // The tier the bucket carried out of its last quarantine, so
+                // the re-latch a single trip triggers resumes the ladder one
+                // rung higher rather than restarting at the 6h base.
+                state.hard_disable_probe_tier = health
+                    .hard_disable_probe_tier
+                    .min(HARD_DISABLE_MAX_PROBE_TIER);
+                if health.auto_disabled {
+                    if let Some(seconds) = health.cooldown_seconds_remaining.filter(|s| *s > 0) {
+                        state.cooldown_until = Some(now + Duration::from_secs(seconds));
+                    } else {
+                        state.auto_disabled = false;
+                    }
+                }
             } else if health.auto_disabled {
                 if let Some(seconds) = health.cooldown_seconds_remaining {
                     if seconds > 0 {
@@ -1436,6 +1668,8 @@ impl HealthTracker {
                 cooldown_seconds_remaining: None,
                 hard_disabled: false,
                 hard_disable_probe_tier: 0,
+                hard_disable_probe_seconds_remaining: None,
+                hard_disable_on_probation: false,
                 trips_in_window: 0,
             })
     }

--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -84,6 +84,101 @@ const TRIP_RATE_CEILING: usize = 8;
 /// Rolling window over which [`TRIP_RATE_CEILING`] trips force a hard-disable.
 const TRIP_RATE_WINDOW: Duration = Duration::from_secs(6 * 60 * 60);
 
+/// Base **quarantine** for a hard-disabled bucket: how long after its most
+/// recent trip the breaker waits before admitting a single *half-open probe*.
+///
+/// ## Why this exists (incident, 2026-08-12 → 2026-08-16)
+///
+/// [`TRIP_RATE_CEILING`] is a rate-based trigger that used to have a permanent,
+/// never-re-evaluated consequence: `hard_disabled` was latched and
+/// `is_available` returned `false` forever, with no code path other than a human
+/// `model_health(enable)` able to clear it. `openai/gpt-5.6-terra` — the only
+/// candidate in a user's `implement` lane — latched during a transient provider
+/// incident on 08-12 and stayed latched for four days, so every dispatch went
+/// `breaker_open` → `failover_chain_exhausted` → cooldown, forever. The
+/// autonomous build loop was dead the entire time. When inspected the bucket
+/// read `hard_disabled: true` with **`trips_in_window: 0`**: every trip that
+/// justified the latch had already aged out of [`TRIP_RATE_WINDOW`], and nothing
+/// ever reconsidered. A manual reset showed 10/10 successes immediately.
+///
+/// A circuit breaker that can never probe is not a breaker, it is a fuse only a
+/// human can replace. This constant is the quarantine before the *one* probe.
+///
+/// ## Why exactly six hours
+///
+/// Three independent bounds pin this number, and the compile-time assertions
+/// below enforce two of them:
+///
+/// 1. **It must exceed [`MAX_COOLDOWN`] (4h).** The hard-disable exists because
+///    "even a 4h ceiling still lets a hopeless model flap a couple of times a
+///    day". A quarantine at or below the escalating ladder's own ceiling would
+///    make the hard-disable indistinguishable from an ordinary cooldown and
+///    reintroduce exactly the pathology it was added to stop.
+/// 2. **It equals [`TRIP_RATE_WINDOW`], and that equality is load-bearing.**
+///    The deadline is anchored at the bucket's *most recent trip*, so when the
+///    probe is finally admitted every trip that justified the latch is at least
+///    `TRIP_RATE_WINDOW` old and has therefore been pruned: `trips_in_window`
+///    is provably `0` at probe time. The probe asks "is this model healthy
+///    *now*" against a window that no longer contains a single piece of the
+///    evidence for the latch — which is precisely the state the incident bucket
+///    was sitting in, ignored, for four days. Shorter, and the probe fires while
+///    the latch is still justified by live evidence; longer, and the breaker
+///    keeps punishing a model for evidence it has already discarded.
+/// 3. **The exposure it buys is negligible.** At most ONE task is exposed per
+///    quarantine period (see [`HealthTracker::note_dispatch_accepted`]), so
+///    tier 0 costs at most 4 probe dispatches a day — against the ~50
+///    trips/night the original flap incident sustained, and against the 8
+///    consecutive 429 crashes that cost one production task 5.75h. Each failed
+///    probe then doubles the wait, so a genuinely-dead model converges on one
+///    probe a week.
+///
+/// This is deliberately *not* written as `TRIP_RATE_WINDOW` (an alias would let
+/// a future edit to the trip window silently move the quarantine); the
+/// relationship is asserted instead.
+const HARD_DISABLE_QUARANTINE_BASE: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// Ceiling of the escalating quarantine ladder: **7 days**.
+///
+/// Each failed probe doubles the quarantine (6h → 12h → 24h → 48h → 96h → 7d),
+/// so a model whose backend is genuinely gone converges on one exposed task per
+/// week — cheap enough to be irrelevant to the fleet, while still guaranteeing
+/// that a model whose provider eventually comes back recovers *without* a human.
+/// A week is also comfortably past the point where an operator has noticed, so
+/// the ceiling is about not permanently giving up rather than about throughput.
+const HARD_DISABLE_QUARANTINE_MAX: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+/// Highest quarantine tier, i.e. the number of doublings needed to reach
+/// [`HARD_DISABLE_QUARANTINE_MAX`]. Clamping the *tier* (rather than only the
+/// resulting `Duration`) keeps [`quarantine_for_tier`]'s loop bounded no matter
+/// how many probe failures accumulate.
+const HARD_DISABLE_MAX_PROBE_TIER: u32 = 5;
+
+const _: () = assert!(
+    HARD_DISABLE_QUARANTINE_BASE.as_secs() > MAX_COOLDOWN.as_secs(),
+    "the hard-disable quarantine must outlast the escalating cooldown ceiling, \
+     or the hard-disable adds nothing over an ordinary cooldown and the flap returns"
+);
+const _: () = assert!(
+    HARD_DISABLE_QUARANTINE_BASE.as_secs() == TRIP_RATE_WINDOW.as_secs(),
+    "the quarantine is anchored at the last trip so that `trips_in_window` is \
+     provably 0 when the half-open probe fires; that invariant requires equality"
+);
+const _: () = assert!(
+    HARD_DISABLE_QUARANTINE_BASE.as_secs() << HARD_DISABLE_MAX_PROBE_TIER
+        >= HARD_DISABLE_QUARANTINE_MAX.as_secs(),
+    "HARD_DISABLE_MAX_PROBE_TIER must be large enough to actually reach the ceiling"
+);
+
+/// Quarantine length for an escalation `tier`: [`HARD_DISABLE_QUARANTINE_BASE`]
+/// doubled once per prior failed probe, capped at [`HARD_DISABLE_QUARANTINE_MAX`].
+fn quarantine_for_tier(tier: u32) -> Duration {
+    let mut quarantine = HARD_DISABLE_QUARANTINE_BASE;
+    for _ in 0..tier.min(HARD_DISABLE_MAX_PROBE_TIER) {
+        quarantine = (quarantine * 2).min(HARD_DISABLE_QUARANTINE_MAX);
+    }
+    quarantine
+}
+
 /// Number of *consecutive* throttle trips (`record_stall(escalate=false)`) with
 /// no intervening success after which a throttle stops being treated as a
 /// clock-resetting quota blip and starts escalating like a genuine failure.
@@ -218,11 +313,21 @@ pub struct ModelHealth {
     /// **or when hard-disabled** (a hard-disable has no auto-expiry).
     pub cooldown_seconds_remaining: Option<u64>,
     /// Hard-disabled: the trip-rate ceiling ([`TRIP_RATE_CEILING`] trips within
-    /// [`TRIP_RATE_WINDOW`]) was hit, so the bucket is held unavailable with NO
-    /// auto-expiry until a human re-enables it. `#[serde(default)]` keeps older
-    /// persisted snapshots (which had no such field) loading as not-hard-disabled.
+    /// [`TRIP_RATE_WINDOW`]) was hit, so the bucket is **quarantined** — held
+    /// unavailable except for a single half-open probe dispatch admitted once
+    /// per (escalating) quarantine period, until either that probe succeeds or a
+    /// human re-enables it. `#[serde(default)]` keeps older persisted snapshots
+    /// (which had no such field) loading as not-hard-disabled.
     #[serde(default)]
     pub hard_disabled: bool,
+    /// Escalation tier of the hard-disable quarantine ladder: `0` at the moment
+    /// of the latch, incremented by every failed half-open probe, clamped at
+    /// [`HARD_DISABLE_MAX_PROBE_TIER`]. Persisted so a server restart cannot
+    /// demote a long-quarantined dead model back to the 6h base and start
+    /// probing it four times a day. `#[serde(default)]` for back-compat with
+    /// pre-half-open snapshots, which load at tier 0 (the base quarantine).
+    #[serde(default)]
+    pub hard_disable_probe_tier: u32,
     /// Number of breaker trips currently inside the rolling [`TRIP_RATE_WINDOW`].
     /// Surfaced so operators can see how close a bucket is to the hard-disable
     /// ceiling. `#[serde(default)]` for back-compat with pre-ceiling snapshots.
@@ -257,9 +362,38 @@ struct ModelState {
     total_failures: u32,
     total_successes: u32,
     disable_ttl_trips: u32,
-    /// Hard-disabled by the trip-rate ceiling — no auto-expiry, human re-enable
-    /// only. Distinct from `auto_disabled` (which self-heals on cooldown).
+    /// Hard-disabled (quarantined) by the trip-rate ceiling. Distinct from
+    /// `auto_disabled` (which self-heals on a cooldown deadline): while this is
+    /// set, availability is governed **solely** by `probe_available_at`, and the
+    /// only way back to `false` is a successful half-open probe or a human
+    /// re-enable.
     hard_disabled: bool,
+    /// Deadline after which a hard-disabled bucket admits exactly ONE half-open
+    /// probe dispatch. Anchored at the bucket's most recent trip (not at the
+    /// moment the latch was set), so a bucket that keeps failing its probes
+    /// keeps pushing its own deadline out. `None` whenever `hard_disabled` is
+    /// `false`; always `Some` while it is `true`.
+    ///
+    /// Consuming the probe (`note_dispatch_accepted`) pushes this forward by a
+    /// full quarantine *immediately*, before the probe's verdict is known. That
+    /// is what bounds exposure to at most one task per quarantine period even
+    /// when the verdict never arrives (task killed, leader failover, pod OOM):
+    /// the breaker fails closed rather than re-opening the lane.
+    probe_available_at: Option<Instant>,
+    /// Escalation tier for `probe_available_at`; see [`quarantine_for_tier`].
+    /// Incremented once per *failed* probe and clamped at
+    /// [`HARD_DISABLE_MAX_PROBE_TIER`]. Persisted (unlike the throttle streak)
+    /// because losing it across a restart would reset a week-long quarantine on
+    /// a dead model back to the 6h base.
+    hard_disable_probe_tier: u32,
+    /// Whether a half-open probe has been handed out and has not yet been
+    /// resolved. Set by `note_dispatch_accepted`, cleared by the first
+    /// failure/success that follows. Its only job is to make the tier escalate
+    /// **once per probe** rather than once per failure record — a single bad
+    /// session can produce both a stall and a failure. Runtime-only: a restart
+    /// drops it, which at worst costs one un-escalated quarantine, and
+    /// `restore_all` re-anchors the deadline anyway.
+    probe_outstanding: bool,
     /// Monotonic timestamps of recent breaker trips, pruned to
     /// [`TRIP_RATE_WINDOW`]. When its length reaches [`TRIP_RATE_CEILING`] the
     /// bucket is hard-disabled. Only genuine (escalating) trips are recorded —
@@ -289,9 +423,18 @@ struct ModelState {
 
 impl ModelState {
     fn is_available(&self, now: Instant) -> bool {
-        // Hard-disabled buckets never auto-recover — a human must re-enable.
+        // Hard-disabled (quarantined) buckets are unavailable EXCEPT inside the
+        // half-open probe window: once `HARD_DISABLE_QUARANTINE_BASE` (doubling
+        // per failed probe) has elapsed since the most recent trip, exactly one
+        // dispatch is admitted so the breaker can find out whether the model
+        // recovered. `note_dispatch_accepted` pushes the deadline forward the
+        // moment that dispatch is accepted, so this window closes again after a
+        // single task rather than re-opening the lane. This is the whole
+        // difference between a breaker and a fuse: the pre-2026-08-16 code
+        // returned a flat `false` here and a transient provider incident became
+        // permanent configuration state that outlived its cause by four days.
         if self.hard_disabled {
-            return false;
+            return matches!(self.probe_available_at, Some(at) if now >= at);
         }
         if !self.auto_disabled {
             return true;
@@ -318,12 +461,59 @@ impl ModelState {
         self.trip_times.push(now);
         if !self.hard_disabled && self.trip_times.len() >= TRIP_RATE_CEILING {
             self.hard_disabled = true;
-            // No auto-expiry: clear the cooldown deadline so `is_available`
-            // relies solely on the `hard_disabled` gate until a human re-enables.
+            // No ordinary cooldown: clear the deadline so `is_available` relies
+            // solely on the quarantine gate below.
             self.cooldown_until = None;
+            self.hard_disable_probe_tier = 0;
+            self.probe_available_at = Some(now + quarantine_for_tier(0));
+            self.probe_outstanding = false;
             return true;
         }
         false
+    }
+
+    /// Resolve a hard-disabled bucket's half-open probe as **failed**, or —
+    /// when no probe was outstanding — simply re-anchor the quarantine at this
+    /// fresh piece of bad evidence.
+    ///
+    /// Escalation is charged once per *probe*, not once per failure record: a
+    /// single doomed session can emit both a stall and a typed failure, and
+    /// double-charging would jump a model from the 6h base to the 7d ceiling on
+    /// one bad dispatch. Either way the deadline is pushed to
+    /// `now + quarantine_for_tier(tier)`, which is what "measured from the last
+    /// trip" means.
+    fn fail_probe(&mut self, now: Instant) {
+        if self.probe_outstanding {
+            self.probe_outstanding = false;
+            self.hard_disable_probe_tier = self
+                .hard_disable_probe_tier
+                .saturating_add(1)
+                .min(HARD_DISABLE_MAX_PROBE_TIER);
+        }
+        self.probe_available_at = Some(now + quarantine_for_tier(self.hard_disable_probe_tier));
+        // Stay latched, with no ordinary cooldown deadline: while hard-disabled,
+        // `is_available` reads `probe_available_at` and nothing else.
+        self.auto_disabled = true;
+        self.cooldown_until = None;
+        // `trip_times` is deliberately NOT touched here. It exists solely to
+        // detect the ceiling crossing, and once the bucket is latched that job
+        // is done — the quarantine ladder owns the bucket instead. Pushing
+        // probe failures into it would also miscount, because a single latching
+        // `trip_breaker` burst delivers several failure records in a row.
+    }
+
+    /// Release the hard-disable latch. Used by a successful half-open probe and
+    /// by the human `enable`/`reset` controls. Also clears the ordinary
+    /// auto-disable, because a quarantined bucket carries `auto_disabled: true`
+    /// with `cooldown_until: None` — a state `is_available` would otherwise read
+    /// as a never-expiring cooldown.
+    fn clear_hard_disable(&mut self) {
+        self.hard_disabled = false;
+        self.probe_available_at = None;
+        self.hard_disable_probe_tier = 0;
+        self.probe_outstanding = false;
+        self.auto_disabled = false;
+        self.cooldown_until = None;
     }
 
     fn cooldown_seconds_remaining(&self, now: Instant) -> Option<u64> {
@@ -349,6 +539,7 @@ impl ModelState {
             disable_ttl_trips: self.disable_ttl_trips,
             cooldown_seconds_remaining: self.cooldown_seconds_remaining(now),
             hard_disabled: self.hard_disabled,
+            hard_disable_probe_tier: self.hard_disable_probe_tier,
             trips_in_window: self.trips_in_window(now),
         }
     }
@@ -552,15 +743,33 @@ impl HealthTracker {
             return;
         };
 
+        state.breaker_eligible_consecutive_failures = state
+            .breaker_eligible_consecutive_failures
+            .saturating_add(1);
+
+        // Half-open probe verdict. While a bucket is hard-disabled the ONLY
+        // dispatch that can reach it is the single probe the quarantine
+        // admitted, so any failure here is that probe failing: re-latch, double
+        // the quarantine and return. Falling through to the ordinary ladder
+        // would be wrong twice over — it would need three strikes to react at
+        // all, and it would log a second, phantom "breaker tripped".
+        if state.hard_disabled {
+            state.fail_probe(now);
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                probe_tier = state.hard_disable_probe_tier,
+                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                "half-open probe of a hard-disabled model failed — re-quarantined"
+            );
+            return;
+        }
+
         // If the previous cooldown expired, clear the flag so we can re-trip.
         if state.auto_disabled && state.is_available(now) {
             state.auto_disabled = false;
             state.cooldown_until = None;
         }
-
-        state.breaker_eligible_consecutive_failures = state
-            .breaker_eligible_consecutive_failures
-            .saturating_add(1);
 
         if !state.auto_disabled
             && state.breaker_eligible_consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD
@@ -618,10 +827,72 @@ impl HealthTracker {
         state.consecutive_throttle_trips = 0;
         state.throttle_streak_started_at = None;
         state.last_trip_throttle = false;
+        // A success on a quarantined bucket means the half-open probe came back
+        // clean: release the latch. This is the only automatic exit from a
+        // hard-disable, and it is deliberately not gated on `probe_outstanding`
+        // — a productive session is direct positive evidence about the model
+        // whichever path produced it, and a genuinely-dead model cannot
+        // manufacture one. `clear_hard_disable` also drops `auto_disabled` /
+        // `cooldown_until`, which the guard below could not: a quarantined
+        // bucket has `auto_disabled: true` with no cooldown deadline, so
+        // `is_available` reads `false` and the guard would never fire.
+        if state.hard_disabled {
+            state.clear_hard_disable();
+            tracing::info!(
+                model_id = %model_id,
+                scope = ?scope,
+                "half-open probe succeeded — hard-disable quarantine released"
+            );
+        }
         if state.auto_disabled && state.is_available(now) {
             state.auto_disabled = false;
             state.cooldown_until = None;
         }
+    }
+
+    /// Tell the breaker that a dispatch to this `(scope, model)` bucket was
+    /// **accepted** — a session is about to run on it.
+    ///
+    /// For a healthy bucket this is a no-op. For a *quarantined* one it consumes
+    /// the single half-open probe that [`ModelState::is_available`] just
+    /// admitted, pushing the next probe deadline a full quarantine into the
+    /// future before the probe's verdict is known.
+    ///
+    /// Consuming here rather than at the availability check is deliberate:
+    /// `is_available` is a pure predicate consulted several times per dispatch
+    /// decision (and by diagnostics), whereas this fires exactly once, at the
+    /// point a real task is actually exposed to the model. And pushing the
+    /// deadline *before* the verdict is what makes the bound unconditional — if
+    /// the probe's outcome never arrives (task killed, leader failover, pod
+    /// OOM) the bucket stays quarantined for another full period instead of
+    /// re-opening the lane. At most one task is exposed per quarantine period,
+    /// which is the property that keeps the 2026-07 flap (disable 5 min →
+    /// re-enable → grab a slot → crash in <10s → repeat, one production task
+    /// losing 5.75h to 8 consecutive 429 crashes) impossible.
+    pub fn note_dispatch_accepted(&self, scope: Option<&str>, model_id: &str) {
+        let now = self.now();
+        let mut map = self.inner.lock().unwrap();
+        let Some(state) = map.get_mut(&HealthKey::new(scope, model_id)) else {
+            return;
+        };
+        if !state.hard_disabled {
+            return;
+        }
+        if !state.probe_available_at.is_some_and(|at| now >= at) {
+            // Not the probe window — nothing to consume. Reachable only if a
+            // caller dispatched to a bucket the breaker said was unavailable.
+            return;
+        }
+        state.probe_outstanding = true;
+        state.probe_available_at = Some(now + quarantine_for_tier(state.hard_disable_probe_tier));
+        tracing::warn!(
+            model_id = %model_id,
+            scope = ?scope,
+            probe_tier = state.hard_disable_probe_tier,
+            trips_in_window = state.trips_in_window(now),
+            next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+            "admitting a single half-open probe dispatch to a hard-disabled model"
+        );
     }
 
     /// Record a failed invocation.  Trips the circuit breaker when the
@@ -634,6 +905,19 @@ impl HealthTracker {
         state.consecutive_failures += 1;
         state.breaker_eligible_consecutive_failures += 1;
         state.total_failures += 1;
+
+        // Half-open probe verdict — see `apply_breaker_check_for`.
+        if state.hard_disabled {
+            state.fail_probe(now);
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                probe_tier = state.hard_disable_probe_tier,
+                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                "half-open probe of a hard-disabled model failed — re-quarantined"
+            );
+            return;
+        }
 
         // If the previous cooldown expired, clear the flag so we can re-trip.
         if state.auto_disabled && state.is_available(now) {
@@ -713,6 +997,22 @@ impl HealthTracker {
         state.consecutive_failures += 1;
         state.transient_consecutive_failures += 1;
         state.total_failures += 1;
+
+        // Half-open probe verdict — see `apply_breaker_check_for`. A transient
+        // upstream fault is a weak signal in general, but a bucket that has
+        // already earned a hard-disable does not get the benefit of the doubt:
+        // its one probe produced nothing usable, so it waits again.
+        if state.hard_disabled {
+            state.fail_probe(now);
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                probe_tier = state.hard_disable_probe_tier,
+                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                "half-open probe of a hard-disabled model failed (transient) — re-quarantined"
+            );
+            return;
+        }
 
         // If the previous cooldown expired, clear the flag so we can re-trip.
         if state.auto_disabled && state.is_available(now) {
@@ -795,6 +1095,23 @@ impl HealthTracker {
         let state = map.entry(key.clone()).or_default();
         state.consecutive_failures += 1;
         state.total_failures += 1;
+
+        // Half-open probe verdict — see `apply_breaker_check_for`. Note this
+        // runs BEFORE the throttle-streak bookkeeping below: while quarantined
+        // the model is not on the throttle ladder at all, it is on the
+        // hard-disable quarantine ladder, and only one of the two may own the
+        // bucket's next deadline.
+        if state.hard_disabled {
+            state.fail_probe(now);
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                probe_tier = state.hard_disable_probe_tier,
+                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                "half-open probe of a hard-disabled model stalled — re-quarantined"
+            );
+            return;
+        }
 
         // If the previous cooldown expired, clear the flag so we can re-trip
         // (and so `disable_ttl_trips` keeps escalating across stalls).
@@ -921,7 +1238,17 @@ impl HealthTracker {
                         key.clone(),
                         state.auto_disabled,
                         state.hard_disabled,
-                        state.cooldown_until,
+                        // A quarantined bucket has no ordinary cooldown; its
+                        // deadline is the next half-open probe. Rendering that
+                        // as `until` is the point: a `hard_disabled` entry used
+                        // to show `until: null`, which is exactly why the
+                        // 4-day outage looked like a permanent, uninterpretable
+                        // state rather than a wait with an end.
+                        if state.hard_disabled {
+                            state.probe_available_at
+                        } else {
+                            state.cooldown_until
+                        },
                         state.consecutive_failures,
                     )
                 })
@@ -936,17 +1263,23 @@ impl HealthTracker {
         let mut snapshot: Vec<_> = entries
             .into_iter()
             .filter_map(
-                |(key, auto_disabled, hard_disabled, cooldown_until, consecutive_failures)| {
+                |(key, auto_disabled, hard_disabled, deadline_until, consecutive_failures)| {
                     let state = if hard_disabled {
-                        "hard_disabled"
+                        // Distinguish "quarantined, waiting" from "quarantined,
+                        // one probe dispatch is admissible right now".
+                        if deadline_until.is_some_and(|until| now >= until) {
+                            "hard_disabled_probe"
+                        } else {
+                            "hard_disabled"
+                        }
                     } else if !auto_disabled {
                         return None;
-                    } else if cooldown_until.is_some_and(|until| now >= until) {
+                    } else if deadline_until.is_some_and(|until| now >= until) {
                         "half_open"
                     } else {
                         "open"
                     };
-                    let until = cooldown_until.map(|deadline| {
+                    let until = deadline_until.map(|deadline| {
                         let wall = if deadline >= now {
                             wall_now + (deadline - now)
                         } else {
@@ -1035,10 +1368,35 @@ impl HealthTracker {
             };
 
             if health.hard_disabled {
-                // A hard-disable has no auto-expiry — keep it disabled with no
-                // cooldown deadline regardless of the persisted remaining seconds.
+                // A hard-disable has no ordinary cooldown — keep it disabled
+                // with no cooldown deadline regardless of the persisted
+                // remaining seconds; availability is the quarantine gate only.
                 state.auto_disabled = true;
                 state.cooldown_until = None;
+                // `Instant`s cannot cross the persist boundary, so the
+                // quarantine deadline is re-anchored at `now` using the
+                // PERSISTED escalation tier. Two properties fall out, and both
+                // matter:
+                //
+                // * A restart can only ever DELAY the next probe — it charges a
+                //   full fresh quarantine — never shorten one and never fire a
+                //   probe at boot. A crash-loop or a rapid deploy train
+                //   therefore cannot be turned into a probe loop, and a
+                //   genuinely-dead model cannot be resurrected into a flap by
+                //   restarting the server.
+                // * Because the tier survives, a model that has failed its way
+                //   out to the 7-day rung stays on the 7-day rung. Dropping the
+                //   tier would silently demote it to the 6h base and quadruple
+                //   its daily exposure across every deploy.
+                //
+                // The cost is that a long-quarantined model's remaining wait
+                // restarts. That is the safe direction, and at the ceiling it is
+                // bounded by one extra week.
+                state.hard_disable_probe_tier = health
+                    .hard_disable_probe_tier
+                    .min(HARD_DISABLE_MAX_PROBE_TIER);
+                state.probe_available_at =
+                    Some(now + quarantine_for_tier(state.hard_disable_probe_tier));
             } else if health.auto_disabled {
                 if let Some(seconds) = health.cooldown_seconds_remaining {
                     if seconds > 0 {
@@ -1077,6 +1435,7 @@ impl HealthTracker {
                 disable_ttl_trips: 0,
                 cooldown_seconds_remaining: None,
                 hard_disabled: false,
+                hard_disable_probe_tier: 0,
                 trips_in_window: 0,
             })
     }
@@ -1122,33 +1481,59 @@ impl HealthTracker {
         keys.len()
     }
 
-    /// Re-enable an auto-disabled (or **hard-disabled**) bucket without clearing
-    /// failure/success counters. This is the human re-enable path a hard-disable
-    /// requires, so it also clears the trip-rate window: otherwise the ceiling
-    /// would still be tripped and the very next failure would immediately
-    /// re-hard-disable the bucket.
+    /// Re-enable an auto-disabled (or **hard-disabled**/quarantined) bucket
+    /// without clearing its lifetime `total_failures` / `total_successes`.
+    ///
+    /// This is the human authority path and it takes effect **immediately** and
+    /// unconditionally: the quarantine deadline and escalation tier are dropped
+    /// along with both disable flags, so an operator never has to wait out a
+    /// half-open quarantine they have already overruled.
+    ///
+    /// It also clears the trip-rate window and every *streak* counter —
+    /// `consecutive_failures`, `breaker_eligible_consecutive_failures`,
+    /// `transient_consecutive_failures` and the throttle streak. Clearing the
+    /// streaks is a deliberate 2026-08-16 change, not the original behaviour:
+    /// `enable` used to clear only the disable flags, leaving
+    /// `breaker_eligible_consecutive_failures` at or above
+    /// [`CIRCUIT_BREAKER_THRESHOLD`], so the very next failure re-tripped the
+    /// breaker on the spot and operators had to follow every `enable` with a
+    /// `reset` to make it stick. A re-enable that cannot survive one failure is
+    /// not a re-enable. The streaks are transient evidence *about the state the
+    /// human just overruled*; the lifetime totals are the audit trail and are
+    /// preserved, which is what still distinguishes `enable` from `reset`.
+    ///
+    /// `disable_ttl_trips` is deliberately **kept**: the operator vouched that
+    /// the model is usable now, not that its history never happened, so if it
+    /// does trip again the escalating cooldown resumes where it left off. The
+    /// first successful session clears it (see [`Self::record_success`]).
     pub fn enable(&self, scope: Option<&str>, model_id: &str) {
         let mut map = self.inner.lock().unwrap();
         let state = map.entry(HealthKey::new(scope, model_id)).or_default();
-        state.auto_disabled = false;
-        state.hard_disabled = false;
-        state.cooldown_until = None;
-        state.trip_times.clear();
+        Self::apply_enable(state);
     }
 
-    /// Re-enable every scope's bucket for `model_id` without clearing failure
-    /// counters (ops convenience: "let everyone use this model again now"). Also
-    /// clears any hard-disable + the trip-rate window (see [`Self::enable`]).
-    /// Returns the number of buckets re-enabled.
+    /// Shared body of [`Self::enable`] / [`Self::enable_model_all_scopes`].
+    fn apply_enable(state: &mut ModelState) {
+        state.clear_hard_disable();
+        state.trip_times.clear();
+        state.consecutive_failures = 0;
+        state.breaker_eligible_consecutive_failures = 0;
+        state.transient_consecutive_failures = 0;
+        state.consecutive_throttle_trips = 0;
+        state.throttle_streak_started_at = None;
+        state.last_trip_throttle = false;
+    }
+
+    /// Re-enable every scope's bucket for `model_id` without clearing lifetime
+    /// totals (ops convenience: "let everyone use this model again now"). Also
+    /// clears any hard-disable quarantine, the trip-rate window and the failure
+    /// streaks (see [`Self::enable`]). Returns the number of buckets re-enabled.
     pub fn enable_model_all_scopes(&self, model_id: &str) -> usize {
         let mut map = self.inner.lock().unwrap();
         let mut n = 0;
         for (key, state) in map.iter_mut() {
             if key.model_id == model_id {
-                state.auto_disabled = false;
-                state.hard_disabled = false;
-                state.cooldown_until = None;
-                state.trip_times.clear();
+                Self::apply_enable(state);
                 n += 1;
             }
         }

--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -1,7 +1,7 @@
 // djinn:allow-oversize — per-(scope, model) breaker state: typed-failure, throttle, stall and transient ladders share one mutex-guarded catalog.
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use djinn_core::clock::{Clock, SystemClock};
 use serde::{Deserialize, Serialize};
@@ -169,47 +169,99 @@ const _: () = assert!(
     "HARD_DISABLE_MAX_PROBE_TIER must be large enough to actually reach the ceiling"
 );
 
-/// Trips required to re-quarantine a bucket that is on **probation** — i.e. one
-/// whose latch was released by a successful half-open probe but which has not
-/// yet re-proven itself (see [`HARD_DISABLE_PROBATION_SUCCESSES`]).
+/// Successful sessions a bucket on probation must win to have its hard-disable
+/// history forgiven, out of a trial of [`HARD_DISABLE_PROBATION_TRIAL_SESSIONS`].
 ///
-/// A probation bucket has already demonstrated it can reach
-/// [`TRIP_RATE_CEILING`], and it was handed the lane back on the strength of a
-/// SINGLE session. Making it earn eight fresh trips before it can be
-/// re-quarantined is what turns a lucky probe into a flap: the first version of
-/// this change cleared `trip_times`, `disable_ttl_trips` and the quarantine tier
-/// on a probe success, leaving the bucket byte-identical to a never-tripped
-/// model. Measured against the `xiaomi-token-plan-sgp/mimo-v2.5-pro` profile
-/// (78 failures / 16 successes — roughly one success in six), that produced one
-/// lucky probe followed by **4712 exposed sessions in 30 days and no re-latch**:
-/// strictly worse than the permanent latch it replaced. The escalation ladder
-/// was only ever reachable by a model whose backend was completely gone, which
-/// is not the class either incident belongs to.
-///
-/// `1` — a single trip re-quarantines. A trip still costs
-/// [`CIRCUIT_BREAKER_THRESHOLD`] consecutive breaker-eligible failures, so a
-/// genuinely recovered model (which produces none) sails through probation with
-/// full throughput, while an intermittently-broken one is back in quarantine
-/// within a handful of sessions — and at the NEXT tier, because the tier is
-/// preserved across the release.
-const HARD_DISABLE_PROBATION_TRIP_CEILING: usize = 1;
-
-/// Consecutive successful sessions a bucket on probation must produce before the
-/// hard-disable history is forgiven and it returns to the ordinary
-/// [`TRIP_RATE_CEILING`] with a reset quarantine tier.
+/// Probation is the state a bucket enters when a half-open probe SUCCEEDS. The
+/// lane reopens at full throughput — that is what fixes the 4-day outage — but
+/// the quarantine tier is preserved and the bucket must win a short,
+/// hard-bounded trial before its history is written off.
 ///
 /// Deliberately evidence-based rather than clock-based: "prove you work" is the
 /// question probation asks, and a wall-clock window would forgive a model that
-/// was merely idle. `5` separates the two incident profiles cleanly — the
-/// recovered model from the 4-day outage went 10-for-10 immediately and clears
-/// probation on its fifth session, while a one-success-in-six model has a
-/// ~1-in-7776 chance of ever clearing it and therefore stays permanently one
-/// trip away from re-quarantine.
-///
-/// Runtime-only counter (`consecutive_successes`): a restart restarts the streak,
-/// which only ever keeps a bucket on probation LONGER. That is the safe
-/// direction.
+/// was merely idle.
 const HARD_DISABLE_PROBATION_SUCCESSES: u32 = 5;
+
+/// Hard ceiling on how many dispatches a bucket on probation may be handed
+/// before it is either forgiven or re-quarantined.
+///
+/// ## Why probation is counted, not streaked
+///
+/// The first version of probation re-quarantined on a *trip*, and a trip needs
+/// [`CIRCUIT_BREAKER_THRESHOLD`] **consecutive** breaker-eligible failures, with
+/// any interleaved success resetting that counter. That made probation defeated
+/// by failure CLUSTERING rather than by failure rate: a model that never happens
+/// to fail three times in a row was never re-quarantined at all, however bad it
+/// was. Measured over 30 simulated days with probation nominally in force:
+///
+/// ```text
+///   one success in 2 → 42840 exposed, never re-quarantined
+///   one success in 3 → 42840 exposed, never re-quarantined
+///   F,F,S repeating  → 40682 exposed, never re-quarantined
+///   one success in 6 →    17 exposed  (the single input the old test asserted)
+/// ```
+///
+/// 42840 is bit-for-bit the number the pre-probation version was rejected for.
+/// `origin/main` exposes 0. So the bound has to be a property of the mechanism
+/// rather than of the input distribution.
+///
+/// ## The bound
+///
+/// Probation is now a fixed trial: **win [`HARD_DISABLE_PROBATION_SUCCESSES`] of
+/// at most this many sessions**. Successes and failures are counted
+/// independently and neither resets the other, so clustering is irrelevant. The
+/// trial resolves in one of three ways, all of them inside this many dispatches:
+///
+/// * [`HARD_DISABLE_PROBATION_SUCCESSES`] wins → history forgiven;
+/// * [`probation_failure_ceiling`] losses → re-quarantined one tier higher (the
+///   point at which winning has become arithmetically impossible);
+/// * this many dispatches consumed without either → re-quarantined.
+///
+/// The third clause is what makes the bound unconditional. It is counted in
+/// [`HealthTracker::note_dispatch_accepted`], at the moment a task is actually
+/// exposed, so it holds even when sessions produce no outcome record at all
+/// (killed task, leader failover, pod OOM) — the same fail-closed reasoning as
+/// the probe itself. Exposure per released quarantine is therefore at most
+/// `1 + HARD_DISABLE_PROBATION_TRIAL_SESSIONS` sessions, by construction,
+/// against any input whatsoever.
+///
+/// `6` leaves a genuinely recovered model room for one bad session out of six
+/// (the 4-day outage's model went 10-for-10 and clears on its fifth), while a
+/// one-success-in-six model needs at least 5 wins in 6 — probability
+/// `C(6,5)·(1/6)^5·(5/6) + (1/6)^6 ≈ 0.00066`, about 1 in 1500 — so it is
+/// re-quarantined essentially every cycle, one rung higher each time.
+const HARD_DISABLE_PROBATION_TRIAL_SESSIONS: u32 = 6;
+
+const _: () = assert!(
+    HARD_DISABLE_PROBATION_TRIAL_SESSIONS >= HARD_DISABLE_PROBATION_SUCCESSES,
+    "the probation trial must be long enough that the bucket can actually win it"
+);
+
+/// Failures that make the probation trial unwinnable and therefore re-quarantine
+/// the bucket at once. Derived, not tuned: once this many sessions are lost,
+/// [`HARD_DISABLE_PROBATION_SUCCESSES`] wins can no longer fit inside
+/// [`HARD_DISABLE_PROBATION_TRIAL_SESSIONS`].
+///
+/// This counts EVERY kind of failure record, including a throttle-classified
+/// stall (`record_stall(escalate = false)`). That is deliberate, and it is what
+/// makes probation bite on the class the 5.75h flap incident actually belonged
+/// to: the throttle ladder normally waits for
+/// [`PERSISTENT_THROTTLE_TRIP_THRESHOLD`] (6) consecutive trips before it
+/// escalates at all, so a bucket on probation would otherwise burn six 429
+/// crashes before being re-quarantined. On probation it burns two.
+const fn probation_failure_ceiling() -> u32 {
+    HARD_DISABLE_PROBATION_TRIAL_SESSIONS - HARD_DISABLE_PROBATION_SUCCESSES + 1
+}
+
+/// Wall-clock instant as whole Unix seconds. Pre-epoch times (only reachable
+/// from a badly-skewed host clock) render as a negative offset rather than
+/// panicking.
+fn unix_seconds(wall: SystemTime) -> i64 {
+    match wall.duration_since(UNIX_EPOCH) {
+        Ok(d) => d.as_secs() as i64,
+        Err(e) => -(e.duration().as_secs() as i64),
+    }
+}
 
 /// Quarantine length for an escalation `tier`: [`HARD_DISABLE_QUARANTINE_BASE`]
 /// doubled once per prior failed probe, capped at [`HARD_DISABLE_QUARANTINE_MAX`].
@@ -374,10 +426,27 @@ pub struct ModelHealth {
     /// when the bucket is not hard-disabled; `Some(0)` when a probe is
     /// admissible right now. This is the field that answers "will this recover
     /// on its own, and when?" — the question an operator could not answer for
-    /// four days. Derived, like `cooldown_seconds_remaining`, so `restore_all`
-    /// ignores it and re-anchors from the persisted tier instead.
+    /// four days. Purely derived for display; `restore_all` reads the absolute
+    /// deadline below instead, so that a snapshot taken long before a boot is
+    /// not treated as if it were taken at boot.
     #[serde(default)]
     pub hard_disable_probe_seconds_remaining: Option<u64>,
+    /// Absolute **wall-clock** deadline for the next half-open probe, as a Unix
+    /// timestamp in seconds. `None` when the bucket is not hard-disabled.
+    ///
+    /// This is what makes a quarantine survive a restart without being either
+    /// wiped or extended. `Instant`s are monotonic and meaningless across a
+    /// process boundary, so the first version of this change re-anchored the
+    /// deadline at `now + quarantine_for_tier(tier)` on boot — charging a FULL
+    /// fresh quarantine every restart. Measured against this repo's real deploy
+    /// cadence (median gap 6.08h across the last 25 release tags, 12 of 24 gaps
+    /// under 6h, some as low as 0.6h) that starved the probe outright: a deploy
+    /// every 4h admitted **zero** probes in 30 days, and the escalation ladder
+    /// made it worse, not better — at the 7-day rung essentially every deploy
+    /// lands inside the quarantine. That is the 4-day outage reproduced through
+    /// a different door.
+    #[serde(default)]
+    pub hard_disable_probe_at_unix: Option<i64>,
     /// The bucket's quarantine was released by a successful probe but it has not
     /// yet produced enough clean sessions to have its hard-disable history
     /// forgiven: it is dispatchable at full throughput, but a single breaker
@@ -474,18 +543,29 @@ struct ModelState {
     /// Runtime-only: a restart drops it, which at worst costs one un-escalated
     /// quarantine, and `restore_all` re-anchors the deadline anyway.
     probe_outstanding: bool,
-    /// The latch was released by a successful half-open probe, but the bucket
-    /// has not yet re-proven itself with [`HARD_DISABLE_PROBATION_SUCCESSES`]
-    /// clean sessions. While set, a single trip re-quarantines the bucket at the
-    /// NEXT tier (see [`HARD_DISABLE_PROBATION_TRIP_CEILING`]).
+    /// The latch was released by a successful half-open probe, but the bucket has
+    /// not yet won its trial (see [`HARD_DISABLE_PROBATION_TRIAL_SESSIONS`]).
+    /// While set, the bucket is dispatchable at full throughput but every
+    /// dispatch and every outcome is counted against the probation ledger below.
     ///
     /// Persisted, because forgetting it across a restart is what would let an
-    /// intermittently-broken model reset its history by waiting for a deploy.
+    /// intermittently-broken model launder its history by waiting for a deploy.
     hard_disable_on_probation: bool,
-    /// Consecutive successful sessions with no intervening failure. Drives the
-    /// probation exit only. Runtime-only; a restart restarts the streak, which
-    /// keeps a bucket on probation longer (the safe direction).
-    consecutive_successes: u32,
+    /// Probation ledger: sessions won so far in the current trial. Reset by
+    /// `release_quarantine_to_probation`, so a success recorded while the bucket
+    /// was still QUARANTINED cannot pre-charge the trial — the flaw that let
+    /// four stray successes plus one probe success deliver an immediate full
+    /// pardon in the same call.
+    probation_successes: u32,
+    /// Probation ledger: sessions lost so far in the current trial. Counted
+    /// independently of `probation_successes` — neither resets the other — which
+    /// is what makes the trial immune to failure clustering.
+    probation_failures: u32,
+    /// Probation ledger: dispatches actually handed out during the current
+    /// trial, counted at acceptance. This is the outcome-independent bound: a
+    /// session that never reports anything still consumes trial budget, so
+    /// exposure is capped whatever the sessions do.
+    probation_dispatches: u32,
     /// Monotonic timestamps of recent breaker trips, pruned to
     /// [`TRIP_RATE_WINDOW`]. When its length reaches [`TRIP_RATE_CEILING`] the
     /// bucket is hard-disabled. Only genuine (escalating) trips are recorded —
@@ -543,46 +623,106 @@ impl ModelState {
             .count() as u32
     }
 
-    /// Trips required to (re-)quarantine this bucket right now: the ordinary
-    /// [`TRIP_RATE_CEILING`], or [`HARD_DISABLE_PROBATION_TRIP_CEILING`] while
-    /// the bucket is on probation after a released quarantine.
-    fn effective_trip_ceiling(&self) -> usize {
-        if self.hard_disable_on_probation {
-            HARD_DISABLE_PROBATION_TRIP_CEILING
+    /// Put a bucket back into quarantine, one rung further up the ladder when it
+    /// was already carrying a tier (a probation re-quarantine, or a failed
+    /// probe). Shared by every route into the hard-disabled state so they cannot
+    /// drift apart.
+    fn enter_quarantine(&mut self, now: Instant, escalate_tier: bool) {
+        self.hard_disable_probe_tier = if escalate_tier {
+            self.hard_disable_probe_tier
+                .saturating_add(1)
+                .min(HARD_DISABLE_MAX_PROBE_TIER)
         } else {
-            TRIP_RATE_CEILING
-        }
+            0
+        };
+        self.hard_disable_on_probation = false;
+        self.clear_probation_ledger();
+        self.hard_disabled = true;
+        // No ordinary cooldown: clear the deadline so `is_available` relies
+        // solely on the quarantine gate.
+        self.cooldown_until = None;
+        self.probe_available_at = Some(now + quarantine_for_tier(self.hard_disable_probe_tier));
+        self.probe_outstanding = false;
+    }
+
+    fn clear_probation_ledger(&mut self) {
+        self.probation_successes = 0;
+        self.probation_failures = 0;
+        self.probation_dispatches = 0;
     }
 
     /// Record a genuine breaker trip against the rolling trip-rate window and
     /// hard-disable the bucket if the ceiling is reached. Returns `true` when
     /// this trip crossed the ceiling (for one-shot logging).
+    ///
+    /// Note this is the ORDINARY path only. A bucket on probation is
+    /// re-quarantined by its trial ledger (`charge_probation_failure` /
+    /// `charge_probation_dispatch`), not by this rolling window: a trip needs
+    /// [`CIRCUIT_BREAKER_THRESHOLD`] *consecutive* failures, so keying probation
+    /// off it made probation defeated by failure clustering rather than by
+    /// failure rate. See [`HARD_DISABLE_PROBATION_TRIAL_SESSIONS`].
     fn register_trip(&mut self, now: Instant) -> bool {
         // Prune trips that have aged out of the window, then record this one.
         self.trip_times
             .retain(|t| now.duration_since(*t) < TRIP_RATE_WINDOW);
         self.trip_times.push(now);
-        if !self.hard_disabled && self.trip_times.len() >= self.effective_trip_ceiling() {
-            // A bucket on probation is RE-quarantining, so it resumes the
-            // escalation ladder rather than restarting it: the tier it carried
-            // out of its last quarantine is the tier it goes back in above.
-            // Without this, an intermittently-broken model that wins one probe
-            // per cycle would be quarantined for a flat 6h forever.
-            let relatch = self.hard_disable_on_probation;
-            self.hard_disable_probe_tier = if relatch {
-                self.hard_disable_probe_tier
-                    .saturating_add(1)
-                    .min(HARD_DISABLE_MAX_PROBE_TIER)
-            } else {
-                0
-            };
-            self.hard_disable_on_probation = false;
-            self.hard_disabled = true;
-            // No ordinary cooldown: clear the deadline so `is_available` relies
-            // solely on the quarantine gate below.
-            self.cooldown_until = None;
-            self.probe_available_at = Some(now + quarantine_for_tier(self.hard_disable_probe_tier));
-            self.probe_outstanding = false;
+        if !self.hard_disabled && self.trip_times.len() >= TRIP_RATE_CEILING {
+            self.enter_quarantine(now, false);
+            return true;
+        }
+        false
+    }
+
+    /// Charge one lost session against the probation trial, re-quarantining the
+    /// bucket when the trial has become unwinnable. Returns `true` if it did.
+    ///
+    /// Counted, never streaked, and counted for EVERY class of failure record —
+    /// including throttle-classified stalls, which the ordinary ladder would
+    /// otherwise let run to `PERSISTENT_THROTTLE_TRIP_THRESHOLD` (6) before
+    /// escalating at all.
+    fn charge_probation_failure(&mut self, now: Instant) -> bool {
+        if !self.hard_disable_on_probation {
+            return false;
+        }
+        self.probation_failures = self.probation_failures.saturating_add(1);
+        if self.probation_failures >= probation_failure_ceiling() {
+            self.enter_quarantine(now, true);
+            return true;
+        }
+        false
+    }
+
+    /// Charge one won session against the probation trial, forgiving the
+    /// hard-disable history once the bucket has won enough of them. Returns
+    /// `true` if probation ended.
+    fn charge_probation_success(&mut self) -> bool {
+        if !self.hard_disable_on_probation {
+            return false;
+        }
+        self.probation_successes = self.probation_successes.saturating_add(1);
+        if self.probation_successes >= HARD_DISABLE_PROBATION_SUCCESSES {
+            self.clear_hard_disable();
+            return true;
+        }
+        false
+    }
+
+    /// Charge one dispatch against the probation trial and re-quarantine the
+    /// bucket if the trial budget is now spent.
+    ///
+    /// This is the clause that makes the probation bound unconditional: it fires
+    /// on exposure rather than on outcome, so a run of sessions that never
+    /// report anything (killed task, leader failover, pod OOM) still ends the
+    /// trial instead of leaving the lane open indefinitely.
+    fn charge_probation_dispatch(&mut self, now: Instant) -> bool {
+        if !self.hard_disable_on_probation {
+            return false;
+        }
+        self.probation_dispatches = self.probation_dispatches.saturating_add(1);
+        if self.probation_dispatches >= HARD_DISABLE_PROBATION_TRIAL_SESSIONS
+            && self.probation_successes < HARD_DISABLE_PROBATION_SUCCESSES
+        {
+            self.enter_quarantine(now, true);
             return true;
         }
         false
@@ -636,14 +776,25 @@ impl ModelState {
     /// a bucket that reached eight trips in six hours, and treating it as a full
     /// pardon (clearing the tier, the trip window and the escalating cooldown)
     /// is what let a one-success-in-six model escape the ladder entirely. So the
-    /// tier survives, and until the bucket produces
-    /// [`HARD_DISABLE_PROBATION_SUCCESSES`] clean sessions a single trip puts it
-    /// straight back into quarantine one rung higher.
+    /// tier survives, and the bucket must win
+    /// [`HARD_DISABLE_PROBATION_SUCCESSES`] of at most
+    /// [`HARD_DISABLE_PROBATION_TRIAL_SESSIONS`] sessions before the history is
+    /// written off.
+    ///
+    /// The ledger is reset here, and that reset is load-bearing: successes
+    /// recorded while the bucket was still QUARANTINED must not pre-charge the
+    /// trial. Without it, four stray successes on a quarantined bucket (a
+    /// health-blind path, or sessions in flight at latch time — the class the
+    /// `record_success` gate itself calls routine) left the counter at four, so
+    /// the very next probe success released the latch and fell straight through
+    /// to the exit check in the same call: a full pardon, byte-identical to a
+    /// never-tripped model, from one probe.
     fn release_quarantine_to_probation(&mut self) {
         self.hard_disabled = false;
         self.probe_available_at = None;
         self.probe_outstanding = false;
         self.hard_disable_on_probation = true;
+        self.clear_probation_ledger();
         // `hard_disable_probe_tier` is deliberately PRESERVED.
         self.auto_disabled = false;
         self.cooldown_until = None;
@@ -661,6 +812,7 @@ impl ModelState {
         self.hard_disable_probe_tier = 0;
         self.probe_outstanding = false;
         self.hard_disable_on_probation = false;
+        self.clear_probation_ledger();
         self.auto_disabled = false;
         self.cooldown_until = None;
     }
@@ -684,7 +836,7 @@ impl ModelState {
         }
     }
 
-    fn to_health(&self, key: &HealthKey, now: Instant) -> ModelHealth {
+    fn to_health(&self, key: &HealthKey, now: Instant, wall_now: SystemTime) -> ModelHealth {
         ModelHealth {
             model_id: key.model_id.clone(),
             scope: key.scope.clone(),
@@ -700,6 +852,9 @@ impl ModelState {
             hard_disabled: self.hard_disabled,
             hard_disable_probe_tier: self.hard_disable_probe_tier,
             hard_disable_probe_seconds_remaining: self.probe_seconds_remaining(now),
+            hard_disable_probe_at_unix: self
+                .probe_seconds_remaining(now)
+                .map(|remaining| unix_seconds(wall_now).saturating_add(remaining as i64)),
             hard_disable_on_probation: self.hard_disable_on_probation,
             trips_in_window: self.trips_in_window(now),
         }
@@ -928,6 +1083,21 @@ impl HealthTracker {
             return;
         }
 
+        // Probation trial: one session lost. Charged for every failure class —
+        // including throttle-classified stalls, which the ordinary ladder would
+        // let run to PERSISTENT_THROTTLE_TRIP_THRESHOLD before escalating at all.
+        if state.charge_probation_failure(now) {
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                probation_failures = probation_failure_ceiling(),
+                probe_tier = state.hard_disable_probe_tier,
+                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                "model lost its probation trial — re-quarantined one tier higher"
+            );
+            return;
+        }
+
         // If the previous cooldown expired, clear the flag so we can re-trip.
         if state.auto_disabled && state.is_available(now) {
             state.auto_disabled = false;
@@ -977,7 +1147,11 @@ impl HealthTracker {
         state.breaker_eligible_consecutive_failures = 0;
         state.transient_consecutive_failures = 0;
         state.total_successes += 1;
-        state.consecutive_successes = state.consecutive_successes.saturating_add(1);
+        // NOTE: nothing probation-related is charged before the quarantine gate
+        // below. The probation ledger is advanced only by
+        // `charge_probation_success`, which no-ops unless the bucket is actually
+        // on probation, so a success on a QUARANTINED bucket cannot pre-charge
+        // the trial it will later be handed.
 
         if state.hard_disabled {
             // Only an ADMITTED PROBE's success may release a quarantine. A
@@ -1002,9 +1176,15 @@ impl HealthTracker {
                 scope = ?scope,
                 probe_tier = state.hard_disable_probe_tier,
                 probation_successes_required = HARD_DISABLE_PROBATION_SUCCESSES,
+                probation_trial_sessions = HARD_DISABLE_PROBATION_TRIAL_SESSIONS,
                 "half-open probe succeeded — quarantine released onto probation \
-                 (one further trip re-quarantines at the next tier)"
+                 (must win {HARD_DISABLE_PROBATION_SUCCESSES} of the next \
+                 {HARD_DISABLE_PROBATION_TRIAL_SESSIONS} sessions)"
             );
+            // The probe's own success is NOT charged to the trial: the ledger was
+            // just reset, and the trial is about what the model does with the
+            // lane it has been handed back.
+            return;
         }
 
         // A productive session is proof the model recovered — reset the
@@ -1021,20 +1201,17 @@ impl HealthTracker {
         state.throttle_streak_started_at = None;
         state.last_trip_throttle = false;
 
-        // Probation exit: enough consecutive clean sessions to forgive the
-        // hard-disable history and hand back the ordinary `TRIP_RATE_CEILING`
-        // with a reset quarantine tier. A model that is actually healthy again
-        // reaches this in five sessions; a one-success-in-six model effectively
-        // never does, and so stays one trip away from re-quarantine.
-        if state.hard_disable_on_probation
-            && state.consecutive_successes >= HARD_DISABLE_PROBATION_SUCCESSES
-        {
-            state.clear_hard_disable();
+        // Probation trial: one session won. Counted, not streaked — an
+        // interleaved failure does not reset it, and does not need to, because
+        // the failure is counted independently against
+        // `probation_failure_ceiling()`.
+        if state.charge_probation_success() {
             tracing::info!(
                 model_id = %model_id,
                 scope = ?scope,
-                consecutive_successes = state.consecutive_successes,
-                "model re-proved itself after a released quarantine — probation cleared"
+                required = HARD_DISABLE_PROBATION_SUCCESSES,
+                "model won its probation trial after a released quarantine — \
+                 hard-disable history forgiven"
             );
         }
 
@@ -1050,7 +1227,9 @@ impl HealthTracker {
     /// For a healthy bucket this is a no-op. For a *quarantined* one it consumes
     /// the single half-open probe that [`ModelState::is_available`] just
     /// admitted, pushing the next probe deadline a full quarantine into the
-    /// future before the probe's verdict is known.
+    /// future before the probe's verdict is known. For one on **probation** it
+    /// spends a session of the trial budget, ending the trial when the budget
+    /// runs out.
     ///
     /// Consuming here rather than at the availability check is deliberate:
     /// `is_available` is a pure predicate consulted several times per dispatch
@@ -1070,6 +1249,21 @@ impl HealthTracker {
             return;
         };
         if !state.hard_disabled {
+            // Probation trial budget. Charged on EXPOSURE rather than on
+            // outcome, so a run of sessions that never report anything cannot
+            // hold the lane open: the trial ends either way.
+            if state.charge_probation_dispatch(now) {
+                tracing::warn!(
+                    model_id = %model_id,
+                    scope = ?scope,
+                    trial_sessions = HARD_DISABLE_PROBATION_TRIAL_SESSIONS,
+                    probe_tier = state.hard_disable_probe_tier,
+                    next_probe_in_secs =
+                        quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                    "model spent its probation trial budget without winning it — \
+                     re-quarantined one tier higher"
+                );
+            }
             return;
         }
         if !state.probe_available_at.is_some_and(|at| now >= at) {
@@ -1099,7 +1293,6 @@ impl HealthTracker {
         state.consecutive_failures += 1;
         state.breaker_eligible_consecutive_failures += 1;
         state.total_failures += 1;
-        state.consecutive_successes = 0;
 
         // Half-open probe verdict — see `apply_breaker_check_for`.
         if state.hard_disabled {
@@ -1113,6 +1306,21 @@ impl HealthTracker {
                     "half-open probe of a hard-disabled model failed — re-quarantined"
                 );
             }
+            return;
+        }
+
+        // Probation trial: one session lost. Charged for every failure class —
+        // including throttle-classified stalls, which the ordinary ladder would
+        // let run to PERSISTENT_THROTTLE_TRIP_THRESHOLD before escalating at all.
+        if state.charge_probation_failure(now) {
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                probation_failures = probation_failure_ceiling(),
+                probe_tier = state.hard_disable_probe_tier,
+                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                "model lost its probation trial — re-quarantined one tier higher"
+            );
             return;
         }
 
@@ -1194,7 +1402,6 @@ impl HealthTracker {
         state.consecutive_failures += 1;
         state.transient_consecutive_failures += 1;
         state.total_failures += 1;
-        state.consecutive_successes = 0;
 
         // Half-open probe verdict — see `apply_breaker_check_for`, but WITHOUT
         // escalation (`escalate = false`). The probe produced nothing usable, so
@@ -1218,6 +1425,21 @@ impl HealthTracker {
                      — re-quarantined at the same tier, not escalated"
                 );
             }
+            return;
+        }
+
+        // Probation trial: one session lost. Charged for every failure class —
+        // including throttle-classified stalls, which the ordinary ladder would
+        // let run to PERSISTENT_THROTTLE_TRIP_THRESHOLD before escalating at all.
+        if state.charge_probation_failure(now) {
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                probation_failures = probation_failure_ceiling(),
+                probe_tier = state.hard_disable_probe_tier,
+                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                "model lost its probation trial — re-quarantined one tier higher"
+            );
             return;
         }
 
@@ -1302,7 +1524,6 @@ impl HealthTracker {
         let state = map.entry(key.clone()).or_default();
         state.consecutive_failures += 1;
         state.total_failures += 1;
-        state.consecutive_successes = 0;
 
         // Half-open probe verdict — see `apply_breaker_check_for`. Note this
         // runs BEFORE the throttle-streak bookkeeping below: while quarantined
@@ -1320,6 +1541,21 @@ impl HealthTracker {
                     "half-open probe of a hard-disabled model stalled — re-quarantined"
                 );
             }
+            return;
+        }
+
+        // Probation trial: one session lost. Charged for every failure class —
+        // including throttle-classified stalls, which the ordinary ladder would
+        // let run to PERSISTENT_THROTTLE_TRIP_THRESHOLD before escalating at all.
+        if state.charge_probation_failure(now) {
+            tracing::warn!(
+                model_id = %key.model_id,
+                scope = ?key.scope,
+                probation_failures = probation_failure_ceiling(),
+                probe_tier = state.hard_disable_probe_tier,
+                next_probe_in_secs = quarantine_for_tier(state.hard_disable_probe_tier).as_secs(),
+                "model lost its probation trial — re-quarantined one tier higher"
+            );
             return;
         }
 
@@ -1430,7 +1666,11 @@ impl HealthTracker {
     pub fn all_health(&self) -> Vec<ModelHealth> {
         let now = self.now();
         let map = self.inner.lock().unwrap();
-        let mut health: Vec<_> = map.iter().map(|(key, s)| s.to_health(key, now)).collect();
+        let wall_now = self.clock.now();
+        let mut health: Vec<_> = map
+            .iter()
+            .map(|(key, s)| s.to_health(key, now, wall_now))
+            .collect();
         health.sort_by(|a, b| {
             a.scope
                 .cmp(&b.scope)
@@ -1554,6 +1794,7 @@ impl HealthTracker {
     /// Replace all tracked health state with a persisted snapshot.
     pub fn restore_all(&self, snapshot: Vec<ModelHealth>) {
         let now = self.now();
+        let wall_now = self.clock.now();
         let mut map = self.inner.lock().unwrap();
         map.clear();
         for health in snapshot {
@@ -1583,38 +1824,54 @@ impl HealthTracker {
                 // remaining seconds; availability is the quarantine gate only.
                 state.auto_disabled = true;
                 state.cooldown_until = None;
-                // `Instant`s cannot cross the persist boundary, so the
-                // quarantine deadline is re-anchored at `now` using the
-                // PERSISTED escalation tier. Two properties fall out, and both
-                // matter:
-                //
-                // * A restart can only ever DELAY the next probe — it charges a
-                //   full fresh quarantine — never shorten one and never fire a
-                //   probe at boot. A crash-loop or a rapid deploy train
-                //   therefore cannot be turned into a probe loop, and a
-                //   genuinely-dead model cannot be resurrected into a flap by
-                //   restarting the server.
-                // * Because the tier survives, a model that has failed its way
-                //   out to the 7-day rung stays on the 7-day rung. Dropping the
-                //   tier would silently demote it to the 6h base and quadruple
-                //   its daily exposure across every deploy.
-                //
-                // The cost is that a long-quarantined model's remaining wait
-                // restarts. That is the safe direction, and at the ceiling it is
-                // bounded by one extra week.
                 state.hard_disable_probe_tier = health
                     .hard_disable_probe_tier
                     .min(HARD_DISABLE_MAX_PROBE_TIER);
-                state.probe_available_at =
-                    Some(now + quarantine_for_tier(state.hard_disable_probe_tier));
+                // `Instant`s are monotonic and meaningless across a process
+                // boundary, so the quarantine's remaining time is carried as an
+                // absolute WALL-CLOCK deadline and converted back to a local
+                // deadline here. A restart therefore neither wipes the
+                // quarantine nor extends it: elapsed downtime counts against it
+                // exactly as uptime would.
+                //
+                // The alternative — re-anchoring at `now + quarantine_for_tier`
+                // — looked conservative and was not. It charged a FULL fresh
+                // quarantine on every boot, so against this repo's real deploy
+                // cadence (median gap 6.08h over the last 25 release tags, 12 of
+                // 24 gaps under 6h) the probe simply never fired: a deploy every
+                // 4h admitted ZERO probes in 30 days. The escalation ladder made
+                // it strictly worse, because at the 7-day rung essentially every
+                // deploy lands inside the quarantine. That is the 4-day outage
+                // reproduced through a different door, which is why the deadline
+                // is now persisted rather than recomputed.
+                //
+                // The remaining time is still clamped to this tier's quarantine:
+                // a corrupt or clock-skewed snapshot may shorten a quarantine
+                // (bounded by the ordinary ladder) but can never manufacture one
+                // longer than the tier allows.
+                let remaining = match health.hard_disable_probe_at_unix {
+                    Some(deadline) => Duration::from_secs(
+                        deadline.saturating_sub(unix_seconds(wall_now)).max(0) as u64,
+                    )
+                    .min(quarantine_for_tier(state.hard_disable_probe_tier)),
+                    // Pre-deadline snapshot (or a bucket persisted by an older
+                    // build): fall back to a full quarantine from now. Strictly
+                    // the conservative direction, and it self-corrects on the
+                    // next persist.
+                    None => quarantine_for_tier(state.hard_disable_probe_tier),
+                };
+                state.probe_available_at = Some(now + remaining);
             } else if health.hard_disable_on_probation {
                 // Released by a probe but not yet re-proven. Probation is
                 // persisted for the same reason the tier is: without it, a
                 // model whose quarantine keeps getting released by lucky probes
                 // could launder its history through a deploy and go back to
-                // needing eight fresh trips. The consecutive-success streak that
-                // ENDS probation is runtime-only, so a restart restarts it —
-                // keeping the bucket on probation longer, the safe direction.
+                // needing eight fresh trips. The trial LEDGER is runtime-only,
+                // so a restart restarts the trial from zero: the bucket must
+                // win its sessions again. That direction is safe — it can only
+                // keep a bucket on probation longer — and the trial is bounded
+                // by `HARD_DISABLE_PROBATION_TRIAL_SESSIONS` dispatches either
+                // way, so restarting it cannot become an exposure leak.
                 state.hard_disable_on_probation = true;
                 // The tier the bucket carried out of its last quarantine, so
                 // the re-latch a single trip triggers resumes the ladder one
@@ -1652,10 +1909,11 @@ impl HealthTracker {
     /// state if untracked).
     pub fn model_health(&self, scope: Option<&str>, model_id: &str) -> ModelHealth {
         let now = self.now();
+        let wall_now = self.clock.now();
         let key = HealthKey::new(scope, model_id);
         let map = self.inner.lock().unwrap();
         map.get(&key)
-            .map(|s| s.to_health(&key, now))
+            .map(|s| s.to_health(&key, now, wall_now))
             .unwrap_or(ModelHealth {
                 model_id: model_id.to_owned(),
                 scope: scope.map(str::to_owned),
@@ -1669,6 +1927,7 @@ impl HealthTracker {
                 hard_disabled: false,
                 hard_disable_probe_tier: 0,
                 hard_disable_probe_seconds_remaining: None,
+                hard_disable_probe_at_unix: None,
                 hard_disable_on_probation: false,
                 trips_in_window: 0,
             })

--- a/server/crates/djinn-provider/src/catalog/health_tests.rs
+++ b/server/crates/djinn-provider/src/catalog/health_tests.rs
@@ -709,6 +709,8 @@ fn restore_all_rehydrates_disabled_state_without_new_trip() {
         cooldown_seconds_remaining: Some(4),
         hard_disabled: false,
         hard_disable_probe_tier: 0,
+        hard_disable_probe_seconds_remaining: None,
+        hard_disable_on_probation: false,
         trips_in_window: 1,
     }]);
 
@@ -777,6 +779,8 @@ fn restore_all_rehydrates_disabled_state_without_new_trip() {
         cooldown_seconds_remaining: Some(2),
         hard_disabled: false,
         hard_disable_probe_tier: 0,
+        hard_disable_probe_seconds_remaining: None,
+        hard_disable_on_probation: false,
         trips_in_window: 1,
     }]);
     assert!(!ht.is_available(scope, "a/model"));
@@ -1357,7 +1361,8 @@ fn quarantine_admits_exactly_one_probe_and_a_clean_probe_recovers_the_model() {
         "the probe is consumed at dispatch acceptance; the lane does not re-open"
     );
 
-    // The probe succeeds → latch released, window reset, model fully healthy.
+    // The probe succeeds → the lane reopens at full throughput, but onto
+    // PROBATION, not a clean slate.
     ht.record_success(S, TEST_MODEL);
     let health = ht.model_health(S, TEST_MODEL);
     assert!(
@@ -1365,9 +1370,33 @@ fn quarantine_admits_exactly_one_probe_and_a_clean_probe_recovers_the_model() {
         "a clean probe releases the quarantine"
     );
     assert!(!health.auto_disabled);
-    assert_eq!(health.hard_disable_probe_tier, 0);
+    assert!(
+        health.hard_disable_on_probation,
+        "one session is enough to reopen the lane, not enough to forgive eight trips"
+    );
     assert_eq!(health.trips_in_window, 0);
     assert_eq!(health.disable_ttl_trips, 0);
+    assert!(ht.is_available(S, TEST_MODEL));
+    assert_eq!(
+        health.hard_disable_probe_seconds_remaining, None,
+        "not quarantined → no next-probe deadline is reported"
+    );
+
+    // Four more clean sessions (five in total) forgive the history.
+    for _ in 1..HARD_DISABLE_PROBATION_SUCCESSES {
+        assert!(
+            ht.model_health(S, TEST_MODEL).hard_disable_on_probation,
+            "probation is not cleared early"
+        );
+        ht.record_success(S, TEST_MODEL);
+    }
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        !health.hard_disable_on_probation,
+        "a model that goes {HARD_DISABLE_PROBATION_SUCCESSES}-for-\
+         {HARD_DISABLE_PROBATION_SUCCESSES} has re-proven itself"
+    );
+    assert_eq!(health.hard_disable_probe_tier, 0);
     assert!(ht.is_available(S, TEST_MODEL));
 }
 
@@ -1441,6 +1470,341 @@ fn a_failing_probe_relatches_and_dispatch_exposure_stays_bounded_for_thirty_days
         "a model that fails every probe stays latched"
     );
     assert!(!ht.is_available(S, TEST_MODEL));
+}
+
+/// Simulate a dispatch loop polling the breaker every minute for `days` against
+/// a model that succeeds one session in `success_every` and fails the rest.
+/// Returns the elapsed-minute stamp of each admitted dispatch.
+///
+/// This is the input class both production incidents actually belong to. A model
+/// that fails 100% of the time reaches the quarantine ladder trivially; the
+/// dangerous one is the model that wins occasionally, because every win is an
+/// opportunity to launder its history.
+fn simulate_intermittent_model_dispatch_loop(
+    ht: &HealthTracker,
+    clock: &TestClock,
+    days: u64,
+    success_every: u64,
+) -> Vec<u64> {
+    let mut admitted = Vec::new();
+    let mut session: u64 = 0;
+    for minute in 0..(days * 24 * 60) {
+        if ht.is_available(S, TEST_MODEL) {
+            admitted.push(minute);
+            ht.note_dispatch_accepted(S, TEST_MODEL);
+            if session.is_multiple_of(success_every) {
+                ht.record_success(S, TEST_MODEL);
+            } else {
+                ht.record_failure(S, TEST_MODEL);
+            }
+            session += 1;
+        }
+        clock.advance_mono(Duration::from_secs(60));
+    }
+    admitted
+}
+
+#[test]
+fn an_intermittently_succeeding_model_cannot_launder_its_quarantine_history() {
+    // D1 — THE REGRESSION THAT MATTERS MOST. A probe success releases the
+    // quarantine, and the first version of this change also cleared the trip
+    // window, the escalating-cooldown tier and the quarantine tier along with
+    // it, leaving the bucket byte-identical to a never-tripped model. Measured
+    // against the `xiaomi-token-plan-sgp/mimo-v2.5-pro` profile (78 failures /
+    // 16 successes ≈ one success in six) that produced ONE lucky probe followed
+    // by 4712 exposed sessions in 30 days and no re-latch — strictly worse than
+    // the permanent latch it replaced.
+    //
+    // The fix is probation: the release preserves the tier, and a single trip
+    // re-quarantines one rung higher until the model produces
+    // `HARD_DISABLE_PROBATION_SUCCESSES` clean sessions in a row.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+
+    let admitted = simulate_intermittent_model_dispatch_loop(&ht, &clock, 30, 6);
+
+    // Measured: 17 sessions, at minutes
+    // [360,361,362,363, 1083, 2523, 5403,5404,5405,5406, 11166, 21246,
+    //  31326,31327,31328,31329, 41409].
+    // The shape is the design working: a probe that wins reopens the lane onto
+    // probation, three more failures re-trip it, and it goes straight back in
+    // one rung higher (6h → 12h → 24h → 48h → 96h → 7d). Before the probation
+    // gate the same input produced 4712 sessions and never re-latched; on
+    // `origin/main` it produces 0 and never recovers.
+    assert!(
+        admitted.len() <= 24,
+        "30 days against a one-success-in-six model exposed {} sessions (17 when \
+         this was written). Each released quarantine costs one probe plus the \
+         CIRCUIT_BREAKER_THRESHOLD failures it takes to re-trip, across at most \
+         8 quarantine cycles — far above that means a lucky probe is laundering \
+         the bucket's history: {admitted:?}",
+        admitted.len()
+    );
+    assert!(
+        !admitted.is_empty(),
+        "…and it still probes: this must not become a fuse again"
+    );
+
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        health.hard_disabled,
+        "after 30 days a one-success-in-six model must end up quarantined, not \
+         running free ({health:?})"
+    );
+    assert!(
+        health.hard_disable_probe_tier >= 1,
+        "each re-quarantine resumes the ladder one rung higher rather than \
+         restarting at the 6h base; tier is {}",
+        health.hard_disable_probe_tier
+    );
+
+    // The probation gate is what does this. Prove it directly: a released
+    // bucket that never manages a clean streak stays one trip from quarantine.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_success(S, TEST_MODEL);
+    assert!(ht.model_health(S, TEST_MODEL).hard_disable_on_probation);
+    // One trip — CIRCUIT_BREAKER_THRESHOLD failures — and it is back in.
+    for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+        ht.record_failure(S, TEST_MODEL);
+    }
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        health.hard_disabled,
+        "ONE trip re-quarantines a bucket on probation; it does not get eight"
+    );
+    assert_eq!(
+        health.hard_disable_probe_tier, 1,
+        "and it resumes the ladder one rung higher than the quarantine it left"
+    );
+    assert!(!health.hard_disable_on_probation);
+    // …at the longer quarantine, measured.
+    clock.advance_mono(quarantine_for_tier(1) - Duration::from_secs(1));
+    assert!(!ht.is_available(S, TEST_MODEL));
+    clock.advance_mono(Duration::from_secs(1));
+    assert!(ht.is_available(S, TEST_MODEL));
+}
+
+#[test]
+fn a_success_without_an_admitted_probe_cannot_release_a_quarantine() {
+    // D2. A session already in flight when the latch was set completes
+    // successfully afterwards. That says nothing about whether the quarantine
+    // was right — for a flapping model such successes are routine — so it must
+    // not release the latch, and must not wipe the history that justified it.
+    // Precondition in production is simply `max_sessions > 1` on the same
+    // `(scope, model)`.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    let latched = ht.model_health(S, TEST_MODEL);
+
+    clock.advance_mono(Duration::from_secs(60));
+    ht.record_success(S, TEST_MODEL);
+
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        health.hard_disabled,
+        "only an ADMITTED PROBE's success may release a quarantine"
+    );
+    assert!(!health.hard_disable_on_probation);
+    assert!(!ht.is_available(S, TEST_MODEL));
+    assert_eq!(
+        health.trips_in_window, latched.trips_in_window,
+        "a stray success must not wipe the rolling trip window"
+    );
+    assert_eq!(
+        health.disable_ttl_trips, latched.disable_ttl_trips,
+        "…nor the escalating-cooldown ladder"
+    );
+    assert_eq!(health.hard_disable_probe_tier, 0);
+    assert_eq!(
+        health.total_successes, 1,
+        "the success is still counted for diagnostics"
+    );
+
+    // The quarantine is neither shortened nor extended by it: the probe still
+    // arrives exactly one base quarantine after the latching trip.
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE - Duration::from_secs(61));
+    assert!(!ht.is_available(S, TEST_MODEL));
+    clock.advance_mono(Duration::from_secs(1));
+    assert!(ht.is_available(S, TEST_MODEL));
+}
+
+#[test]
+fn health_blind_failures_cannot_postpone_the_probe_forever() {
+    // D3. Not every dispatch path consults the breaker — evidence-dispatch
+    // recovery reaches the pool through `resolve_dispatch_models_for_role`,
+    // which never reads the HealthTracker. If any failure record re-anchored the
+    // quarantine, such a path failing every few hours would postpone the probe
+    // indefinitely: a silent permanent outage, with the tier pinned at 0 so
+    // nothing in the health output would show it. Measured before the fix: one
+    // failure record every 5h ⇒ ZERO probes in 30 simulated days.
+    //
+    // The assertion is a comparison, not a threshold: the noisy run must admit
+    // exactly the same probes as a quiet one.
+    let quiet_clock = test_clock();
+    let quiet = tracker_on(&quiet_clock);
+    hard_disable_via_trip_rate(&quiet, &quiet_clock);
+    let baseline = simulate_dead_model_dispatch_loop(&quiet, &quiet_clock, 30);
+
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    let mut admitted = Vec::new();
+    let noise_period_minutes = 5 * 60;
+    for minute in 0..(30 * 24 * 60u64) {
+        if ht.is_available(S, TEST_MODEL) {
+            admitted.push(minute);
+            ht.note_dispatch_accepted(S, TEST_MODEL);
+            ht.record_stall(S, TEST_MODEL, true);
+        }
+        if minute.is_multiple_of(noise_period_minutes) {
+            // A health-blind dispatch path failing against the quarantined
+            // bucket, with no probe outstanding.
+            ht.record_failure(S, TEST_MODEL);
+        }
+        clock.advance_mono(Duration::from_secs(60));
+    }
+
+    assert!(
+        !baseline.is_empty(),
+        "fixture precondition: the quiet run must admit probes at all"
+    );
+    assert_eq!(
+        admitted,
+        baseline,
+        "a failure with no probe outstanding must not move the quarantine \
+         deadline; noisy run admitted {} probes vs {} for the quiet run",
+        admitted.len(),
+        baseline.len()
+    );
+}
+
+#[test]
+fn a_transient_upstream_fault_re_quarantines_without_escalating() {
+    // D4. This crate's position is that a transient 5xx is a LOAD signal, not a
+    // model-health signal — it trips at TRANSIENT_BREAKER_THRESHOLD (20) rather
+    // than CIRCUIT_BREAKER_THRESHOLD (3) for exactly that reason, and the
+    // 4-day outage's latch was itself minted during a transient provider
+    // incident. So a probe that dies on a 5xx serves another quarantine period,
+    // not a longer one.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    assert!(ht.is_available(S, TEST_MODEL));
+
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_transient_failure(S, TEST_MODEL);
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        health.hard_disabled,
+        "the probe still failed: stay quarantined"
+    );
+    assert_eq!(
+        health.hard_disable_probe_tier, 0,
+        "a transient upstream fault must not double the quarantine"
+    );
+
+    // Same tier ⇒ the next probe is one BASE away, not two.
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE - Duration::from_secs(1));
+    assert!(
+        !ht.is_available(S, TEST_MODEL),
+        "boundary: one second early"
+    );
+    clock.advance_mono(Duration::from_secs(1));
+    assert!(ht.is_available(S, TEST_MODEL));
+
+    // A genuine failure on the next probe DOES escalate, so the ladder is not
+    // simply disabled.
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_failure(S, TEST_MODEL);
+    assert_eq!(ht.model_health(S, TEST_MODEL).hard_disable_probe_tier, 1);
+}
+
+#[test]
+fn model_health_reports_the_next_probe_deadline_to_operators() {
+    // D5. `model_health` is the surface that was actually used to diagnose the
+    // outage, and `hard_disabled: true, trips_in_window: 0, cooldown: null` gave
+    // an operator no way to distinguish a permanent state from a wait.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+
+    let health = ht.model_health(S, TEST_MODEL);
+    assert_eq!(
+        health.hard_disable_probe_seconds_remaining,
+        Some(HARD_DISABLE_QUARANTINE_BASE.as_secs()),
+        "a quarantined bucket must say when it will next re-examine itself"
+    );
+    assert!(health.cooldown_seconds_remaining.is_none());
+
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE - Duration::from_secs(90));
+    assert_eq!(
+        ht.model_health(S, TEST_MODEL)
+            .hard_disable_probe_seconds_remaining,
+        Some(90)
+    );
+
+    clock.advance_mono(Duration::from_secs(90));
+    assert_eq!(
+        ht.model_health(S, TEST_MODEL)
+            .hard_disable_probe_seconds_remaining,
+        Some(0),
+        "0 means a probe is admissible right now"
+    );
+    assert!(ht.is_available(S, TEST_MODEL));
+
+    // A healthy bucket reports no deadline at all.
+    ht.reset(S, TEST_MODEL);
+    assert_eq!(
+        ht.model_health(S, TEST_MODEL)
+            .hard_disable_probe_seconds_remaining,
+        None
+    );
+}
+
+#[test]
+fn probation_survives_a_restart_so_it_cannot_be_laundered_through_a_deploy() {
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    clock.advance_mono(quarantine_for_tier(0));
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_failure(S, TEST_MODEL);
+    clock.advance_mono(quarantine_for_tier(1));
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_success(S, TEST_MODEL);
+
+    let snapshot = ht.all_health();
+    assert!(snapshot[0].hard_disable_on_probation);
+    assert_eq!(snapshot[0].hard_disable_probe_tier, 1);
+
+    let boot_clock = test_clock();
+    let booted = tracker_on(&boot_clock);
+    booted.restore_all(snapshot);
+    let health = booted.model_health(S, TEST_MODEL);
+    assert!(
+        health.hard_disable_on_probation,
+        "a restart must not forgive an unproven bucket"
+    );
+    assert_eq!(health.hard_disable_probe_tier, 1);
+    assert!(
+        booted.is_available(S, TEST_MODEL),
+        "probation is still fully dispatchable"
+    );
+
+    // …and one trip still re-quarantines it, at tier 2.
+    for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+        booted.record_failure(S, TEST_MODEL);
+    }
+    let health = booted.model_health(S, TEST_MODEL);
+    assert!(health.hard_disabled);
+    assert_eq!(health.hard_disable_probe_tier, 2);
 }
 
 #[test]

--- a/server/crates/djinn-provider/src/catalog/health_tests.rs
+++ b/server/crates/djinn-provider/src/catalog/health_tests.rs
@@ -708,6 +708,7 @@ fn restore_all_rehydrates_disabled_state_without_new_trip() {
         disable_ttl_trips: 1,
         cooldown_seconds_remaining: Some(4),
         hard_disabled: false,
+        hard_disable_probe_tier: 0,
         trips_in_window: 1,
     }]);
 
@@ -729,8 +730,20 @@ fn restore_all_rehydrates_disabled_state_without_new_trip() {
     let enabled = ht.model_health(scope, "a/model");
     assert!(ht.is_available(scope, "a/model"));
     assert!(!enabled.auto_disabled);
+    // `enable` keeps the escalation tier (the operator vouched the model is
+    // usable now, not that its history never happened)…
     assert_eq!(enabled.disable_ttl_trips, 1);
-    assert_eq!(enabled.consecutive_failures, CIRCUIT_BREAKER_THRESHOLD);
+    // …but as of 2026-08-16 it DOES clear the failure streak. Leaving
+    // `consecutive_failures` at the threshold meant the very next failure
+    // re-tripped the breaker, so every `enable` had to be chased with a `reset`
+    // to make it stick. See `HealthTracker::enable`.
+    assert_eq!(enabled.consecutive_failures, 0);
+    assert_eq!(enabled.breaker_eligible_consecutive_failures, 0);
+    assert_eq!(
+        enabled.total_failures, 10,
+        "the lifetime audit trail still survives `enable` — that is what \
+         distinguishes it from `reset`"
+    );
 
     ht.record_success(scope, "a/model");
     let restored = ht.model_health(scope, "a/model");
@@ -763,6 +776,7 @@ fn restore_all_rehydrates_disabled_state_without_new_trip() {
         disable_ttl_trips: 1,
         cooldown_seconds_remaining: Some(2),
         hard_disabled: false,
+        hard_disable_probe_tier: 0,
         trips_in_window: 1,
     }]);
     assert!(!ht.is_available(scope, "a/model"));
@@ -1233,4 +1247,556 @@ fn clear_task_provider_failure_drops_the_signal() {
     );
     ht.clear_task_provider_failure("task-2");
     assert_eq!(ht.peek_task_provider_failure("task-2"), None);
+}
+
+// ---------------------------------------------------------------------------
+// Half-open recovery from a hard-disable (quarantine + single probe).
+//
+// Incident being fixed: 2026-08-12 → 2026-08-16. `openai/gpt-5.6-terra` — the
+// only candidate in a user's `implement` lane — hit the 8-trips/6h ceiling
+// during a transient provider incident and latched `hard_disabled: true`. Four
+// days later it still read `hard_disabled: true` with `trips_in_window: 0`:
+// every trip that justified the latch had aged out of the rolling window and
+// nothing ever reconsidered, so every dispatch went `breaker_open` →
+// `failover_chain_exhausted` → cooldown. The autonomous build loop was dead the
+// whole time; a manual reset produced 10/10 successes immediately.
+//
+// The counter-pressure these tests must also hold: the permanence was NOT
+// gratuitous. It exists to stop the flap where a hopeless model is re-enabled
+// on a clock, grabs a priority slot, crashes in <10s and repeats — one
+// production task lost 5.75h to 8 consecutive 429 crashes. So every test below
+// that proves recovery is paired with one that bounds exposure.
+// ---------------------------------------------------------------------------
+
+use djinn_core::clock::TestClock;
+use std::time::SystemTime;
+
+fn test_clock() -> Arc<TestClock> {
+    Arc::new(TestClock::new(SystemTime::UNIX_EPOCH, Instant::now()))
+}
+
+fn tracker_on(clock: &Arc<TestClock>) -> HealthTracker {
+    HealthTracker::with_clock(clock.clone() as Arc<dyn Clock>)
+}
+
+/// Drive a bucket to the trip-rate ceiling on the *test* clock, leaving `now`
+/// exactly at the instant of the latching trip (so quarantine deadlines can be
+/// reasoned about relative to it).
+///
+/// Each trip needs three breaker-eligible failures, and the escalating cooldown
+/// between trips must expire before the next trip can register. The cooldowns
+/// sum to ~1.5h, comfortably inside `TRIP_RATE_WINDOW`, so all eight trips land
+/// in one window — which is what the ceiling requires.
+fn hard_disable_via_trip_rate(ht: &HealthTracker, clock: &TestClock) {
+    for trip in 0..TRIP_RATE_CEILING {
+        if trip > 0 {
+            let remaining = ht
+                .model_health(S, TEST_MODEL)
+                .cooldown_seconds_remaining
+                .unwrap_or(0);
+            clock.advance_mono(Duration::from_secs(remaining + 1));
+        }
+        for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+            ht.record_failure(S, TEST_MODEL);
+        }
+    }
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        health.hard_disabled,
+        "fixture precondition: {TRIP_RATE_CEILING} trips inside the window must hard-disable"
+    );
+    assert_eq!(health.trips_in_window, TRIP_RATE_CEILING as u32);
+}
+
+#[test]
+fn quarantine_admits_exactly_one_probe_and_a_clean_probe_recovers_the_model() {
+    // THE INCIDENT, REPRODUCED. This is the test that fails against the
+    // pre-fix `is_available` (`if self.hard_disabled { return false; }`).
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+
+    // `now` is the latching trip. One second before the quarantine deadline the
+    // bucket is unavailable AND the latching trip is still inside the rolling
+    // window — the latch is still justified by live evidence.
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE - Duration::from_secs(1));
+    let health = ht.model_health(S, TEST_MODEL);
+    assert_eq!(
+        health.trips_in_window, 1,
+        "one second before the deadline the latching trip has not yet aged out"
+    );
+    assert!(
+        !ht.is_available(S, TEST_MODEL),
+        "no probe is admitted before the quarantine deadline"
+    );
+
+    // Exactly at the deadline the rolling window is provably empty — this is
+    // the `trips_in_window: 0, hard_disabled: true` state the incident bucket
+    // sat in for four days — and exactly one probe is admitted.
+    clock.advance_mono(Duration::from_secs(1));
+    let health = ht.model_health(S, TEST_MODEL);
+    assert_eq!(
+        health.trips_in_window, 0,
+        "the base quarantine equals TRIP_RATE_WINDOW precisely so that every trip \
+         justifying the latch has aged out by the time the probe fires"
+    );
+    assert!(
+        health.hard_disabled,
+        "the probe is not a re-enable: the bucket is still latched"
+    );
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "REGRESSION GUARD (4-day outage): a decayed hard-disable must admit a probe"
+    );
+
+    // Consuming the probe closes the window again immediately — the lane does
+    // not re-open, one task is exposed.
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    assert!(
+        !ht.is_available(S, TEST_MODEL),
+        "the probe is consumed at dispatch acceptance; the lane does not re-open"
+    );
+
+    // The probe succeeds → latch released, window reset, model fully healthy.
+    ht.record_success(S, TEST_MODEL);
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        !health.hard_disabled,
+        "a clean probe releases the quarantine"
+    );
+    assert!(!health.auto_disabled);
+    assert_eq!(health.hard_disable_probe_tier, 0);
+    assert_eq!(health.trips_in_window, 0);
+    assert_eq!(health.disable_ttl_trips, 0);
+    assert!(ht.is_available(S, TEST_MODEL));
+}
+
+/// Simulate a dispatch loop polling the breaker every minute for `days`,
+/// treating every admitted dispatch as a probe that crashes. Returns the
+/// elapsed-minute stamp of each admitted dispatch.
+fn simulate_dead_model_dispatch_loop(ht: &HealthTracker, clock: &TestClock, days: u64) -> Vec<u64> {
+    let mut admitted = Vec::new();
+    for minute in 0..(days * 24 * 60) {
+        if ht.is_available(S, TEST_MODEL) {
+            admitted.push(minute);
+            // Exactly the 2026-07 flap shape: the dispatch is accepted, the
+            // session grabs a slot and dies almost immediately.
+            ht.note_dispatch_accepted(S, TEST_MODEL);
+            ht.record_stall(S, TEST_MODEL, true);
+        }
+        clock.advance_mono(Duration::from_secs(60));
+    }
+    admitted
+}
+
+#[test]
+fn a_failing_probe_relatches_and_dispatch_exposure_stays_bounded_for_thirty_days() {
+    // THE FLAP MUST STAY IMPOSSIBLE. This is the assertion that protects the
+    // 5.75h/8-crash incident from recurring: over a month of continuous polling
+    // against a model that fails every single probe, the *count* of tasks
+    // actually exposed is single digits, and no two exposures are close
+    // together.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+
+    let admitted = simulate_dead_model_dispatch_loop(&ht, &clock, 30);
+
+    assert!(
+        admitted.len() <= 8,
+        "30 days of polling a permanently-broken model exposed {} tasks; the \
+         quarantine ladder must keep this in single digits (the flap incident \
+         burned 8 tasks in 5.75 HOURS)",
+        admitted.len()
+    );
+    assert!(
+        !admitted.is_empty(),
+        "…but it must not be a fuse either: a breaker that can never probe is \
+         what caused the 4-day outage"
+    );
+
+    // No exposure inside the first 5.75h — the exact wall-clock the flap
+    // incident burned through 8 crashes.
+    let flap_incident_minutes = 345;
+    assert!(
+        admitted.iter().all(|m| *m >= flap_incident_minutes),
+        "a task was exposed inside the 5.75h window the original flap consumed: {admitted:?}"
+    );
+
+    // Every gap between consecutive exposures is at least the base quarantine.
+    for pair in admitted.windows(2) {
+        let gap_minutes = pair[1] - pair[0];
+        assert!(
+            gap_minutes >= HARD_DISABLE_QUARANTINE_BASE.as_secs() / 60,
+            "consecutive probes {} and {} are only {gap_minutes} minutes apart",
+            pair[0],
+            pair[1]
+        );
+    }
+
+    // And the model is still effectively disabled at the end of the month.
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        health.hard_disabled,
+        "a model that fails every probe stays latched"
+    );
+    assert!(!ht.is_available(S, TEST_MODEL));
+}
+
+#[test]
+fn repeated_probe_failures_escalate_the_quarantine_to_the_ceiling() {
+    // GENUINELY-DEAD MODEL. The gap between successive probes must grow —
+    // 6h, 12h, 24h, 48h, 96h — and then pin at the 7-day ceiling rather than
+    // growing without bound (which would be a fuse again).
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+
+    let admitted = simulate_dead_model_dispatch_loop(&ht, &clock, 30);
+    let hour = 60u64;
+    let gaps: Vec<u64> = std::iter::once(admitted[0])
+        .chain(admitted.windows(2).map(|p| p[1] - p[0]))
+        .collect();
+
+    assert_eq!(
+        gaps,
+        vec![
+            6 * hour,
+            12 * hour,
+            24 * hour,
+            48 * hour,
+            96 * hour,
+            168 * hour,
+            168 * hour,
+            168 * hour,
+        ],
+        "quarantine must double per failed probe and then pin at the 7-day ceiling"
+    );
+
+    let health = ht.model_health(S, TEST_MODEL);
+    assert_eq!(
+        health.hard_disable_probe_tier, HARD_DISABLE_MAX_PROBE_TIER,
+        "the escalation tier saturates instead of overflowing"
+    );
+    assert_eq!(
+        quarantine_for_tier(health.hard_disable_probe_tier),
+        HARD_DISABLE_QUARANTINE_MAX
+    );
+    // The tier is clamped, so an absurd number of further failures cannot push
+    // the quarantine past the documented ceiling.
+    assert_eq!(
+        quarantine_for_tier(u32::MAX),
+        HARD_DISABLE_QUARANTINE_MAX,
+        "the ceiling is a real ceiling"
+    );
+}
+
+#[test]
+fn one_bad_probe_session_escalates_the_quarantine_exactly_one_tier() {
+    // A single doomed session can emit more than one failure record (a stall
+    // AND a typed failure). Escalation is charged per PROBE, not per record,
+    // so one bad probe must not jump the model from the 6h base to the ceiling.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    assert!(ht.is_available(S, TEST_MODEL));
+
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_stall(S, TEST_MODEL, true);
+    ht.record_failure(S, TEST_MODEL);
+    ht.record_transient_failure(S, TEST_MODEL);
+    ht.apply_breaker_check_for(S, TEST_MODEL);
+    assert_eq!(
+        ht.model_health(S, TEST_MODEL).hard_disable_probe_tier,
+        1,
+        "four failure records from one probe must charge exactly one tier"
+    );
+
+    // The un-escalated records still re-anchor the deadline at the latest bad
+    // evidence, so the next probe is a full tier-1 quarantine away.
+    clock.advance_mono(quarantine_for_tier(1) - Duration::from_secs(1));
+    assert!(
+        !ht.is_available(S, TEST_MODEL),
+        "boundary: one second early"
+    );
+    clock.advance_mono(Duration::from_secs(1));
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "boundary: exactly at the deadline"
+    );
+}
+
+#[test]
+fn an_unobserved_probe_still_closes_the_window_for_a_full_quarantine() {
+    // The probe's verdict may never arrive: the task is killed, the leader
+    // fails over, the pod OOMs. The bound must not depend on the verdict —
+    // consuming the probe re-arms the quarantine immediately, so the breaker
+    // fails CLOSED rather than leaving the lane open.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    assert!(ht.is_available(S, TEST_MODEL));
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+
+    // No success, no failure — nothing at all is recorded afterwards.
+    for _ in 0..(HARD_DISABLE_QUARANTINE_BASE.as_secs() / 60) {
+        assert!(
+            !ht.is_available(S, TEST_MODEL),
+            "an unresolved probe must not leave the lane open"
+        );
+        clock.advance_mono(Duration::from_secs(60));
+    }
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "…and the bucket is not wedged either: the next quarantine still elapses"
+    );
+}
+
+#[test]
+fn note_dispatch_accepted_is_inert_for_a_healthy_or_cooling_bucket() {
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    // Untracked bucket: no entry is created.
+    ht.note_dispatch_accepted(S, "never/seen");
+    assert!(ht.all_health().is_empty());
+
+    // Healthy bucket: counters untouched.
+    ht.record_success(S, TEST_MODEL);
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(!health.hard_disabled);
+    assert_eq!(health.hard_disable_probe_tier, 0);
+    assert!(ht.is_available(S, TEST_MODEL));
+
+    // Ordinary (non-hard) cooldown: consuming a probe is a no-op, the ordinary
+    // cooldown ladder still owns the bucket.
+    trip_breaker(&ht, TEST_MODEL);
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    assert!(!ht.is_available(S, TEST_MODEL));
+    clock.advance_mono(INITIAL_COOLDOWN + Duration::from_secs(1));
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "the ordinary escalating cooldown is unchanged by the quarantine work"
+    );
+}
+
+#[test]
+fn human_enable_overrides_the_quarantine_immediately_and_survives_one_failure() {
+    // HUMAN CONTROLS STAY AUTHORITATIVE. `enable` must take effect at once,
+    // mid-quarantine, without waiting for any probe window.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    // Fail a probe first so there is a non-zero tier to clear.
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_failure(S, TEST_MODEL);
+    assert_eq!(ht.model_health(S, TEST_MODEL).hard_disable_probe_tier, 1);
+    clock.advance_mono(Duration::from_secs(60 * 60));
+    assert!(!ht.is_available(S, TEST_MODEL), "mid-quarantine");
+
+    let total_failures_before = ht.model_health(S, TEST_MODEL).total_failures;
+    ht.enable(S, TEST_MODEL);
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "a human re-enable takes effect immediately regardless of quarantine state"
+    );
+    assert!(!health.hard_disabled);
+    assert!(!health.auto_disabled);
+    assert_eq!(health.hard_disable_probe_tier, 0);
+    assert_eq!(health.trips_in_window, 0);
+    // Deliberate 2026-08-16 change: `enable` now clears the failure STREAKS, so
+    // the operator does not have to chase it with `reset` to stop the very next
+    // failure re-tripping the breaker.
+    assert_eq!(health.consecutive_failures, 0);
+    assert_eq!(health.breaker_eligible_consecutive_failures, 0);
+    ht.record_failure(S, TEST_MODEL);
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "one failure after a human re-enable must not instantly re-trip the breaker"
+    );
+    // …but the lifetime audit trail is preserved — that is what still
+    // distinguishes `enable` from `reset`.
+    assert!(ht.model_health(S, TEST_MODEL).total_failures > total_failures_before);
+}
+
+#[test]
+fn human_reset_clears_the_quarantine_and_the_counters() {
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    assert!(!ht.is_available(S, TEST_MODEL));
+
+    ht.reset(S, TEST_MODEL);
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(ht.is_available(S, TEST_MODEL));
+    assert!(!health.hard_disabled);
+    assert_eq!(health.hard_disable_probe_tier, 0);
+    assert_eq!(health.total_failures, 0, "reset also wipes the audit trail");
+
+    // `enable_model_all_scopes` (the `model_health(enable)` MCP path) behaves
+    // the same across every scope.
+    let ht = tracker_on(&clock);
+    for scope in [Some("user-a"), Some("user-b")] {
+        for _ in 0..(TRIP_RATE_CEILING * CIRCUIT_BREAKER_THRESHOLD as usize) {
+            ht.record_failure(scope, TEST_MODEL);
+            let remaining = ht
+                .model_health(scope, TEST_MODEL)
+                .cooldown_seconds_remaining
+                .unwrap_or(0);
+            clock.advance_mono(Duration::from_secs(remaining + 1));
+        }
+        assert!(ht.model_health(scope, TEST_MODEL).hard_disabled);
+    }
+    assert_eq!(ht.enable_model_all_scopes(TEST_MODEL), 2);
+    for scope in [Some("user-a"), Some("user-b")] {
+        assert!(ht.is_available(scope, TEST_MODEL));
+        assert!(!ht.model_health(scope, TEST_MODEL).hard_disabled);
+    }
+}
+
+#[test]
+fn a_restart_re_anchors_the_quarantine_and_can_never_probe_at_boot() {
+    // RESTART SEMANTICS. `Instant`s do not cross the persist boundary, so the
+    // deadline is re-anchored at `now` from the PERSISTED tier. A restart must
+    // therefore only ever delay the next probe — never fire one at boot, and
+    // never demote a long-quarantined dead model back to the 6h base.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    // Fail two probes to reach tier 2 (a 24h quarantine).
+    for _ in 0..2 {
+        clock.advance_mono(quarantine_for_tier(
+            ht.model_health(S, TEST_MODEL).hard_disable_probe_tier,
+        ));
+        assert!(ht.is_available(S, TEST_MODEL));
+        ht.note_dispatch_accepted(S, TEST_MODEL);
+        ht.record_failure(S, TEST_MODEL);
+    }
+    let snapshot = ht.all_health();
+    assert_eq!(snapshot.len(), 1);
+    assert_eq!(snapshot[0].hard_disable_probe_tier, 2);
+
+    // A restart loop: 100 boots, each with an hour of uptime, admits nothing.
+    let restart_clock = test_clock();
+    let restarted = tracker_on(&restart_clock);
+    for _ in 0..100 {
+        restarted.restore_all(snapshot.clone());
+        for _ in 0..60 {
+            assert!(
+                !restarted.is_available(S, TEST_MODEL),
+                "a restart must never resurrect a quarantined model into a probe"
+            );
+            restart_clock.advance_mono(Duration::from_secs(60));
+        }
+    }
+
+    // After a single boot the wait is the persisted tier's quarantine (24h),
+    // not the 6h base — the escalation survived.
+    let boot_clock = test_clock();
+    let booted = tracker_on(&boot_clock);
+    booted.restore_all(snapshot);
+    assert_eq!(
+        booted.model_health(S, TEST_MODEL).hard_disable_probe_tier,
+        2
+    );
+    boot_clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    assert!(
+        !booted.is_available(S, TEST_MODEL),
+        "the persisted tier survived the restart: 6h is not enough at tier 2"
+    );
+    boot_clock.advance_mono(quarantine_for_tier(2) - HARD_DISABLE_QUARANTINE_BASE);
+    assert!(
+        booted.is_available(S, TEST_MODEL),
+        "…and the quarantine still ends, so a restart cannot make a latch permanent"
+    );
+}
+
+#[test]
+fn pre_half_open_snapshots_load_as_quarantined_at_the_base_tier() {
+    // Back-compat: a snapshot persisted before this change has no
+    // `hard_disable_probe_tier`. It must deserialize, stay hard-disabled, and
+    // recover on the base quarantine — i.e. the very buckets stranded by the
+    // 4-day outage heal themselves after one deploy plus 6h.
+    let raw = r#"[{
+        "model_id": "openai/gpt-5.6-terra",
+        "scope": "user-a",
+        "auto_disabled": true,
+        "consecutive_failures": 3,
+        "total_failures": 24,
+        "total_successes": 1753,
+        "disable_ttl_trips": 8,
+        "cooldown_seconds_remaining": null,
+        "hard_disabled": true,
+        "trips_in_window": 0
+    }]"#;
+    let snapshot: Vec<ModelHealth> = serde_json::from_str(raw).expect("legacy snapshot parses");
+    assert_eq!(snapshot[0].hard_disable_probe_tier, 0);
+
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    ht.restore_all(snapshot);
+    let scope = Some("user-a");
+    let model = "openai/gpt-5.6-terra";
+    assert!(!ht.is_available(scope, model));
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE - Duration::from_secs(1));
+    assert!(!ht.is_available(scope, model));
+    clock.advance_mono(Duration::from_secs(1));
+    assert!(
+        ht.is_available(scope, model),
+        "a bucket stranded by the outage recovers on the base quarantine"
+    );
+    ht.note_dispatch_accepted(scope, model);
+    ht.record_success(scope, model);
+    assert!(!ht.model_health(scope, model).hard_disabled);
+}
+
+#[test]
+fn debug_snapshot_distinguishes_a_waiting_quarantine_from_an_admissible_probe() {
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+
+    let entry = ht.debug_snapshot().into_iter().next().unwrap();
+    assert_eq!(entry.state, "hard_disabled");
+    assert!(
+        entry.until.is_some(),
+        "a quarantined bucket now renders its next-probe deadline; it used to \
+         render `null`, which is why the outage read as an uninterpretable \
+         permanent state"
+    );
+
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    let entry = ht.debug_snapshot().into_iter().next().unwrap();
+    assert_eq!(entry.state, "hard_disabled_probe");
+    // The metrics gauge agrees: a bucket in its probe window is half-open.
+    let metric = ht.breaker_metric_snapshot().into_iter().next().unwrap();
+    assert_eq!(metric.state, BreakerState::HalfOpen);
+}
+
+#[test]
+fn throttle_cooling_deprioritization_is_unchanged_by_the_quarantine() {
+    // The throttle path (`PERSISTENT_THROTTLE_TRIP_THRESHOLD`,
+    // `last_trip_throttle`, `is_throttle_cooling`) must behave exactly as before
+    // for a bucket that is not hard-disabled.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    ht.record_stall(S, TEST_MODEL, false);
+    assert!(ht.is_throttle_cooling(S, TEST_MODEL));
+    assert!(!ht.model_health(S, TEST_MODEL).hard_disabled);
+    assert_eq!(
+        ht.model_health(S, TEST_MODEL).disable_ttl_trips,
+        0,
+        "a non-persistent throttle still does not ratchet the cap"
+    );
+    clock.advance_mono(STALL_MIN_COOLDOWN + Duration::from_secs(1));
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "a one-off throttle still self-heals"
+    );
+    ht.record_success(S, TEST_MODEL);
+    assert!(!ht.is_throttle_cooling(S, TEST_MODEL));
 }

--- a/server/crates/djinn-provider/src/catalog/health_tests.rs
+++ b/server/crates/djinn-provider/src/catalog/health_tests.rs
@@ -710,6 +710,7 @@ fn restore_all_rehydrates_disabled_state_without_new_trip() {
         hard_disabled: false,
         hard_disable_probe_tier: 0,
         hard_disable_probe_seconds_remaining: None,
+        hard_disable_probe_at_unix: None,
         hard_disable_on_probation: false,
         trips_in_window: 1,
     }]);
@@ -780,6 +781,7 @@ fn restore_all_rehydrates_disabled_state_without_new_trip() {
         hard_disabled: false,
         hard_disable_probe_tier: 0,
         hard_disable_probe_seconds_remaining: None,
+        hard_disable_probe_at_unix: None,
         hard_disable_on_probation: false,
         trips_in_window: 1,
     }]);
@@ -1375,26 +1377,31 @@ fn quarantine_admits_exactly_one_probe_and_a_clean_probe_recovers_the_model() {
         "one session is enough to reopen the lane, not enough to forgive eight trips"
     );
     assert_eq!(health.trips_in_window, 0);
-    assert_eq!(health.disable_ttl_trips, 0);
+    assert_eq!(
+        health.disable_ttl_trips, TRIP_RATE_CEILING as u32,
+        "the probe reopens the lane but forgives nothing yet: the escalating \
+         cooldown ladder is intact until a PROBATION session succeeds"
+    );
     assert!(ht.is_available(S, TEST_MODEL));
     assert_eq!(
         health.hard_disable_probe_seconds_remaining, None,
         "not quarantined → no next-probe deadline is reported"
     );
 
-    // Four more clean sessions (five in total) forgive the history.
-    for _ in 1..HARD_DISABLE_PROBATION_SUCCESSES {
+    // The probe's own success does NOT pre-charge the trial; the bucket must
+    // now win HARD_DISABLE_PROBATION_SUCCESSES sessions of its own.
+    for won in 0..HARD_DISABLE_PROBATION_SUCCESSES {
         assert!(
             ht.model_health(S, TEST_MODEL).hard_disable_on_probation,
-            "probation is not cleared early"
+            "probation is not cleared early (after {won} wins)"
         );
+        ht.note_dispatch_accepted(S, TEST_MODEL);
         ht.record_success(S, TEST_MODEL);
     }
     let health = ht.model_health(S, TEST_MODEL);
     assert!(
         !health.hard_disable_on_probation,
-        "a model that goes {HARD_DISABLE_PROBATION_SUCCESSES}-for-\
-         {HARD_DISABLE_PROBATION_SUCCESSES} has re-proven itself"
+        "a model that wins its whole trial has re-proven itself"
     );
     assert_eq!(health.hard_disable_probe_tier, 0);
     assert!(ht.is_available(S, TEST_MODEL));
@@ -1472,30 +1479,36 @@ fn a_failing_probe_relatches_and_dispatch_exposure_stays_bounded_for_thirty_days
     assert!(!ht.is_available(S, TEST_MODEL));
 }
 
-/// Simulate a dispatch loop polling the breaker every minute for `days` against
-/// a model that succeeds one session in `success_every` and fails the rest.
-/// Returns the elapsed-minute stamp of each admitted dispatch.
+/// Outcome a simulated session produces.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SimOutcome {
+    Success,
+    Failure,
+}
+
+/// Simulate a dispatch loop polling the breaker every minute for `days`,
+/// dispatching whenever the breaker says the model is available and feeding each
+/// dispatch the next outcome from `pattern` (cycled). Returns the elapsed-minute
+/// stamp of every admitted dispatch.
 ///
-/// This is the input class both production incidents actually belong to. A model
-/// that fails 100% of the time reaches the quarantine ladder trivially; the
-/// dangerous one is the model that wins occasionally, because every win is an
-/// opportunity to launder its history.
-fn simulate_intermittent_model_dispatch_loop(
+/// This is the harness the whole flap bound rests on. It drives the real public
+/// API in the real order — `is_available` → `note_dispatch_accepted` → outcome —
+/// so nothing here can pass by bypassing a gate production would hit.
+fn simulate_dispatch_loop(
     ht: &HealthTracker,
     clock: &TestClock,
     days: u64,
-    success_every: u64,
+    pattern: &[SimOutcome],
 ) -> Vec<u64> {
     let mut admitted = Vec::new();
-    let mut session: u64 = 0;
+    let mut session: usize = 0;
     for minute in 0..(days * 24 * 60) {
         if ht.is_available(S, TEST_MODEL) {
             admitted.push(minute);
             ht.note_dispatch_accepted(S, TEST_MODEL);
-            if session.is_multiple_of(success_every) {
-                ht.record_success(S, TEST_MODEL);
-            } else {
-                ht.record_failure(S, TEST_MODEL);
+            match pattern[session % pattern.len()] {
+                SimOutcome::Success => ht.record_success(S, TEST_MODEL),
+                SimOutcome::Failure => ht.record_failure(S, TEST_MODEL),
             }
             session += 1;
         }
@@ -1504,63 +1517,144 @@ fn simulate_intermittent_model_dispatch_loop(
     admitted
 }
 
+/// `S,F,F,…` — one success in `success_every` sessions.
+fn one_success_in(success_every: usize) -> Vec<SimOutcome> {
+    let mut p = vec![SimOutcome::Failure; success_every];
+    p[0] = SimOutcome::Success;
+    p
+}
+
 #[test]
-fn an_intermittently_succeeding_model_cannot_launder_its_quarantine_history() {
-    // D1 — THE REGRESSION THAT MATTERS MOST. A probe success releases the
-    // quarantine, and the first version of this change also cleared the trip
-    // window, the escalating-cooldown tier and the quarantine tier along with
-    // it, leaving the bucket byte-identical to a never-tripped model. Measured
-    // against the `xiaomi-token-plan-sgp/mimo-v2.5-pro` profile (78 failures /
-    // 16 successes ≈ one success in six) that produced ONE lucky probe followed
-    // by 4712 exposed sessions in 30 days and no re-latch — strictly worse than
-    // the permanent latch it replaced.
+fn probation_bounds_exposure_across_every_failure_pattern_not_just_one() {
+    // THE BOUND, ACROSS INPUT CLASSES.
     //
-    // The fix is probation: the release preserves the tier, and a single trip
-    // re-quarantines one rung higher until the model produces
-    // `HARD_DISABLE_PROBATION_SUCCESSES` clean sessions in a row.
-    let clock = test_clock();
-    let ht = tracker_on(&clock);
-    hard_disable_via_trip_rate(&ht, &clock);
+    // The previous version of this test asserted a single hardcoded input
+    // (`success_every = 6`) and passed at 17 — while `success_every = 3` went
+    // through the identical assertion shape at 42840, because probation
+    // re-quarantined on a *trip* and a trip needs CIRCUIT_BREAKER_THRESHOLD
+    // CONSECUTIVE failures. A model that never happens to fail three times in a
+    // row was never re-quarantined at all. Probation was defeated by failure
+    // CLUSTERING, not by failure rate, so a bound measured at one point on the
+    // distribution proved nothing about any other point.
+    //
+    // The trial is now counted rather than streaked, and bounded by dispatches
+    // rather than by outcomes, so the bound is a property of the mechanism. This
+    // asserts it across the whole adversarial family at once.
+    let mut table: Vec<(String, usize, bool, u32)> = Vec::new();
 
-    let admitted = simulate_intermittent_model_dispatch_loop(&ht, &clock, 30, 6);
+    let mut patterns: Vec<(String, Vec<SimOutcome>)> = Vec::new();
+    for every in [2usize, 3, 4, 6] {
+        patterns.push((format!("one success in {every}"), one_success_in(every)));
+    }
+    patterns.push((
+        "F,F,S repeating".to_string(),
+        vec![
+            SimOutcome::Failure,
+            SimOutcome::Failure,
+            SimOutcome::Success,
+        ],
+    ));
+    patterns.push((
+        "S,S,F repeating".to_string(),
+        vec![
+            SimOutcome::Success,
+            SimOutcome::Success,
+            SimOutcome::Failure,
+        ],
+    ));
+    patterns.push((
+        "alternating S,F".to_string(),
+        vec![SimOutcome::Success, SimOutcome::Failure],
+    ));
+    patterns.push(("all failures".to_string(), vec![SimOutcome::Failure]));
 
-    // Measured: 17 sessions, at minutes
-    // [360,361,362,363, 1083, 2523, 5403,5404,5405,5406, 11166, 21246,
-    //  31326,31327,31328,31329, 41409].
-    // The shape is the design working: a probe that wins reopens the lane onto
-    // probation, three more failures re-trip it, and it goes straight back in
-    // one rung higher (6h → 12h → 24h → 48h → 96h → 7d). Before the probation
-    // gate the same input produced 4712 sessions and never re-latched; on
-    // `origin/main` it produces 0 and never recovers.
-    assert!(
-        admitted.len() <= 24,
-        "30 days against a one-success-in-six model exposed {} sessions (17 when \
-         this was written). Each released quarantine costs one probe plus the \
-         CIRCUIT_BREAKER_THRESHOLD failures it takes to re-trip, across at most \
-         8 quarantine cycles — far above that means a lucky probe is laundering \
-         the bucket's history: {admitted:?}",
-        admitted.len()
-    );
-    assert!(
-        !admitted.is_empty(),
-        "…and it still probes: this must not become a fuse again"
-    );
+    for (label, pattern) in &patterns {
+        let clock = test_clock();
+        let ht = tracker_on(&clock);
+        hard_disable_via_trip_rate(&ht, &clock);
+        let admitted = simulate_dispatch_loop(&ht, &clock, 30, pattern);
+        let health = ht.model_health(S, TEST_MODEL);
+        table.push((
+            label.clone(),
+            admitted.len(),
+            health.hard_disabled,
+            health.hard_disable_probe_tier,
+        ));
+    }
 
-    let health = ht.model_health(S, TEST_MODEL);
-    assert!(
-        health.hard_disabled,
-        "after 30 days a one-success-in-six model must end up quarantined, not \
-         running free ({health:?})"
-    );
-    assert!(
-        health.hard_disable_probe_tier >= 1,
-        "each re-quarantine resumes the ladder one rung higher rather than \
-         restarting at the 6h base; tier is {}",
-        health.hard_disable_probe_tier
-    );
+    let rendered: String = table
+        .iter()
+        .map(|(label, n, hard, tier)| {
+            format!("  {label:<20} exposed={n:<6} quarantined={hard:<5} tier={tier}\n")
+        })
+        .collect();
 
-    // The probation gate is what does this. Prove it directly: a released
-    // bucket that never manages a clean streak stays one trip from quarantine.
+    // Per released quarantine the mechanism admits at most 1 probe plus
+    // HARD_DISABLE_PROBATION_TRIAL_SESSIONS trial sessions, and there are at
+    // most 8 quarantine cycles inside 30 days once the ladder escalates, so the
+    // structural worst case is 8 * 7 = 56. Measured on this mechanism:
+    //
+    //   one success in 2   exposed=32   quarantined=true  tier=5
+    //   one success in 3   exposed=24   quarantined=true  tier=5
+    //   one success in 4   exposed=16   quarantined=true  tier=5
+    //   one success in 6   exposed=12   quarantined=true  tier=5
+    //   F,F,S repeating    exposed=20   quarantined=true  tier=5
+    //   S,S,F repeating    exposed=48   quarantined=true  tier=5
+    //   alternating S,F    exposed=32   quarantined=true  tier=5
+    //   all failures       exposed= 8   quarantined=true  tier=5
+    //
+    // Before the trial was counted rather than streaked, the same table read
+    // 42840 / 42840 / 32 / 17 / 40682 for the first five rows, with
+    // `quarantined=false` — and `origin/main` reads 0 everywhere with a
+    // permanent latch. The ceiling below sits above the structural worst case
+    // and three orders of magnitude under the clustering hole.
+    let ceiling = 80;
+    for (label, n, _, _) in &table {
+        assert!(
+            *n <= ceiling,
+            "pattern '{label}' exposed {n} sessions in 30 days (ceiling {ceiling}). \
+             The bound must hold for EVERY failure pattern, not the one the test \
+             happens to sample — that is exactly how the clustering hole survived \
+             review.\n{rendered}"
+        );
+    }
+
+    // …and none of them may end up running free: a model that keeps failing must
+    // end the month quarantined, whatever its clustering.
+    for (label, _, hard_disabled, _) in &table {
+        assert!(
+            hard_disabled,
+            "pattern '{label}' left the model NOT quarantined after 30 days of \
+             failures — this is the end-state the flap was rejected for.\n{rendered}"
+        );
+    }
+
+    // …and the ladder must have escalated, i.e. re-quarantines resumed one rung
+    // higher rather than restarting at the 6h base every time.
+    for (label, _, _, tier) in &table {
+        assert!(
+            *tier >= 1,
+            "pattern '{label}' never escalated its quarantine tier.\n{rendered}"
+        );
+    }
+
+    // Finally: the mechanism must not have become a fuse. Every pattern still
+    // gets probed.
+    for (label, n, _, _) in &table {
+        assert!(
+            *n > 0,
+            "pattern '{label}' was never probed at all — that is the 4-day \
+             outage, not a fix.\n{rendered}"
+        );
+    }
+}
+
+#[test]
+fn a_probation_trial_is_bounded_by_dispatches_even_with_no_outcomes_at_all() {
+    // The trial's hard bound is charged on EXPOSURE, not on outcome. A run of
+    // sessions that report nothing (killed task, leader failover, pod OOM) must
+    // still end the trial, or a released quarantine would hold the lane open
+    // indefinitely on a model that has told us nothing.
     let clock = test_clock();
     let ht = tracker_on(&clock);
     hard_disable_via_trip_rate(&ht, &clock);
@@ -1568,25 +1662,157 @@ fn an_intermittently_succeeding_model_cannot_launder_its_quarantine_history() {
     ht.note_dispatch_accepted(S, TEST_MODEL);
     ht.record_success(S, TEST_MODEL);
     assert!(ht.model_health(S, TEST_MODEL).hard_disable_on_probation);
-    // One trip — CIRCUIT_BREAKER_THRESHOLD failures — and it is back in.
-    for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+
+    let mut exposed = 0;
+    for _ in 0..1000 {
+        if !ht.is_available(S, TEST_MODEL) {
+            break;
+        }
+        exposed += 1;
+        ht.note_dispatch_accepted(S, TEST_MODEL);
+        // No outcome recorded at all.
+        clock.advance_mono(Duration::from_secs(60));
+    }
+    assert_eq!(
+        exposed, HARD_DISABLE_PROBATION_TRIAL_SESSIONS as usize,
+        "a probation trial must be spent by dispatches even when nothing reports back"
+    );
+    let health = ht.model_health(S, TEST_MODEL);
+    assert!(health.hard_disabled, "spent trial → re-quarantined");
+    assert_eq!(health.hard_disable_probe_tier, 1, "…one rung higher");
+}
+
+#[test]
+fn probation_re_quarantines_on_counted_failures_regardless_of_clustering() {
+    // The specific mechanism behind the table above: failures are counted, not
+    // streaked, so interleaved successes cannot hold the trial open. Under the
+    // old trip-based rule this exact interleaving (S,F,S,F,…) never produced
+    // CIRCUIT_BREAKER_THRESHOLD consecutive failures and so never re-quarantined.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_success(S, TEST_MODEL);
+    assert!(ht.model_health(S, TEST_MODEL).hard_disable_on_probation);
+
+    // Alternate success/failure so no failure streak ever reaches the ordinary
+    // three-strike trip threshold.
+    let mut sessions = 0;
+    while !ht.model_health(S, TEST_MODEL).hard_disabled {
+        sessions += 1;
+        assert!(
+            sessions <= HARD_DISABLE_PROBATION_TRIAL_SESSIONS,
+            "interleaved successes must not hold the trial open indefinitely"
+        );
+        ht.note_dispatch_accepted(S, TEST_MODEL);
+        ht.record_success(S, TEST_MODEL);
+        ht.note_dispatch_accepted(S, TEST_MODEL);
         ht.record_failure(S, TEST_MODEL);
+        assert!(
+            ht.model_health(S, TEST_MODEL)
+                .breaker_eligible_consecutive_failures
+                <= 1,
+            "fixture precondition: the success keeps the consecutive-failure \
+             streak at or below 1, so the ordinary trip ladder never fires and \
+             only the counted trial can re-quarantine this bucket"
+        );
     }
     let health = ht.model_health(S, TEST_MODEL);
+    assert!(health.hard_disabled);
+    assert_eq!(health.hard_disable_probe_tier, 1);
+}
+
+#[test]
+fn probation_tightens_the_throttle_ladder_too() {
+    // The 5.75h flap incident was a THROTTLE flap: `record_stall(escalate=false)`
+    // skips the trip ladder entirely until PERSISTENT_THROTTLE_TRIP_THRESHOLD (6)
+    // consecutive trips, so a bucket on probation would burn six 429 crashes
+    // before being re-quarantined — reducing the documented 8-crash incident to
+    // 6 rather than to something that matters. The probation trial counts every
+    // failure class, throttles included.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_success(S, TEST_MODEL);
+    assert!(ht.model_health(S, TEST_MODEL).hard_disable_on_probation);
+
+    let mut throttle_crashes = 0;
+    while !ht.model_health(S, TEST_MODEL).hard_disabled {
+        throttle_crashes += 1;
+        assert!(
+            throttle_crashes <= PERSISTENT_THROTTLE_TRIP_THRESHOLD,
+            "a probation bucket must be re-quarantined well before the \
+             persistent-throttle ladder would even start escalating"
+        );
+        ht.note_dispatch_accepted(S, TEST_MODEL);
+        ht.record_stall(S, TEST_MODEL, false);
+        clock.advance_mono(STALL_MIN_COOLDOWN + Duration::from_secs(1));
+    }
+    assert_eq!(
+        throttle_crashes,
+        probation_failure_ceiling(),
+        "probation must cut the throttle flap to the trial's failure ceiling, \
+         not to PERSISTENT_THROTTLE_TRIP_THRESHOLD"
+    );
+    assert_eq!(ht.model_health(S, TEST_MODEL).hard_disable_probe_tier, 1);
+}
+
+#[test]
+fn stray_successes_on_a_quarantined_bucket_cannot_pre_charge_the_probation_trial() {
+    // The probation exit counter used to be incremented BEFORE the
+    // `!probe_outstanding` guard, so successes on a still-quarantined bucket
+    // (health-blind path, or sessions in flight at latch time — the class the
+    // guard's own comment calls routine) pre-charged it. Four of them left the
+    // counter at 4, and the next probe success then released the latch and fell
+    // straight through to the exit check in the same call: a full pardon,
+    // byte-identical to a never-tripped model, from a single probe.
+    let clock = test_clock();
+    let ht = tracker_on(&clock);
+    hard_disable_via_trip_rate(&ht, &clock);
+
+    for _ in 0..(HARD_DISABLE_PROBATION_SUCCESSES - 1) {
+        ht.record_success(S, TEST_MODEL);
+        let health = ht.model_health(S, TEST_MODEL);
+        assert!(
+            health.hard_disabled,
+            "stray successes do not release the latch"
+        );
+        assert!(!health.hard_disable_on_probation);
+    }
+
+    clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    assert!(ht.is_available(S, TEST_MODEL));
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_success(S, TEST_MODEL);
+
+    let health = ht.model_health(S, TEST_MODEL);
     assert!(
-        health.hard_disabled,
-        "ONE trip re-quarantines a bucket on probation; it does not get eight"
+        !health.hard_disabled,
+        "the probe still releases the quarantine"
+    );
+    assert!(
+        health.hard_disable_on_probation,
+        "…onto PROBATION. Four stray successes plus one probe success must not \
+         add up to a full pardon"
     );
     assert_eq!(
-        health.hard_disable_probe_tier, 1,
-        "and it resumes the ladder one rung higher than the quarantine it left"
+        health.hard_disable_probe_tier, 0,
+        "the tier is preserved across the release, not zeroed by a pardon"
     );
-    assert!(!health.hard_disable_on_probation);
-    // …at the longer quarantine, measured.
-    clock.advance_mono(quarantine_for_tier(1) - Duration::from_secs(1));
-    assert!(!ht.is_available(S, TEST_MODEL));
-    clock.advance_mono(Duration::from_secs(1));
-    assert!(ht.is_available(S, TEST_MODEL));
+
+    // And the trial genuinely starts from zero: one failure short of the
+    // ceiling still leaves it on probation, and the ceiling-th re-quarantines.
+    for _ in 0..(probation_failure_ceiling() - 1) {
+        ht.note_dispatch_accepted(S, TEST_MODEL);
+        ht.record_failure(S, TEST_MODEL);
+        assert!(!ht.model_health(S, TEST_MODEL).hard_disabled);
+    }
+    ht.note_dispatch_accepted(S, TEST_MODEL);
+    ht.record_failure(S, TEST_MODEL);
+    assert!(ht.model_health(S, TEST_MODEL).hard_disabled);
 }
 
 #[test]
@@ -1769,7 +1995,14 @@ fn model_health_reports_the_next_probe_deadline_to_operators() {
 }
 
 #[test]
-fn probation_survives_a_restart_so_it_cannot_be_laundered_through_a_deploy() {
+fn probation_survives_the_persist_restore_round_trip() {
+    // Deliberately named for what it proves: the `all_health()` → `restore_all()`
+    // serde round-trip preserves probation and the tier. That round-trip only
+    // becomes a *deploy* because `AppState::run_model_health_persist_loop`
+    // writes the snapshot on a cadence and once more on graceful shutdown —
+    // before that loop existed, `persist_model_health_state` had three callers,
+    // all of them human `model_health` admin actions, so none of this state was
+    // durable in practice regardless of what the round-trip preserved.
     let clock = test_clock();
     let ht = tracker_on(&clock);
     hard_disable_via_trip_rate(&ht, &clock);
@@ -2023,11 +2256,11 @@ fn human_reset_clears_the_quarantine_and_the_counters() {
 }
 
 #[test]
-fn a_restart_re_anchors_the_quarantine_and_can_never_probe_at_boot() {
-    // RESTART SEMANTICS. `Instant`s do not cross the persist boundary, so the
-    // deadline is re-anchored at `now` from the PERSISTED tier. A restart must
-    // therefore only ever delay the next probe — never fire one at boot, and
-    // never demote a long-quarantined dead model back to the 6h base.
+fn a_restart_preserves_the_quarantine_deadline_in_both_directions() {
+    // RESTART SEMANTICS. `Instant`s are monotonic and meaningless across a
+    // process boundary, so the remaining quarantine is carried as an absolute
+    // WALL-CLOCK deadline. A restart must neither wipe the quarantine nor extend
+    // it, and this asserts both directions — the safe one AND the starvation one.
     let clock = test_clock();
     let ht = tracker_on(&clock);
     hard_disable_via_trip_rate(&ht, &clock);
@@ -2043,40 +2276,125 @@ fn a_restart_re_anchors_the_quarantine_and_can_never_probe_at_boot() {
     let snapshot = ht.all_health();
     assert_eq!(snapshot.len(), 1);
     assert_eq!(snapshot[0].hard_disable_probe_tier, 2);
+    assert!(
+        snapshot[0].hard_disable_probe_at_unix.is_some(),
+        "the snapshot must carry an absolute wall-clock deadline, not just a tier"
+    );
 
-    // A restart loop: 100 boots, each with an hour of uptime, admits nothing.
-    let restart_clock = test_clock();
-    let restarted = tracker_on(&restart_clock);
-    for _ in 0..100 {
-        restarted.restore_all(snapshot.clone());
-        for _ in 0..60 {
-            assert!(
-                !restarted.is_available(S, TEST_MODEL),
-                "a restart must never resurrect a quarantined model into a probe"
-            );
-            restart_clock.advance_mono(Duration::from_secs(60));
-        }
-    }
-
-    // After a single boot the wait is the persisted tier's quarantine (24h),
-    // not the 6h base — the escalation survived.
+    // SAFE DIRECTION: a boot immediately after the snapshot does not fire a
+    // probe, and still waits out the persisted tier's quarantine.
     let boot_clock = test_clock();
     let booted = tracker_on(&boot_clock);
-    booted.restore_all(snapshot);
+    booted.restore_all(snapshot.clone());
     assert_eq!(
         booted.model_health(S, TEST_MODEL).hard_disable_probe_tier,
-        2
+        2,
+        "the escalation tier survives the restart"
     );
-    boot_clock.advance_mono(HARD_DISABLE_QUARANTINE_BASE);
+    assert!(!booted.is_available(S, TEST_MODEL), "no probe at boot");
+    boot_clock.advance_mono(quarantine_for_tier(2) - Duration::from_secs(1));
     assert!(
         !booted.is_available(S, TEST_MODEL),
-        "the persisted tier survived the restart: 6h is not enough at tier 2"
+        "boundary: one second early"
     );
-    boot_clock.advance_mono(quarantine_for_tier(2) - HARD_DISABLE_QUARANTINE_BASE);
+    boot_clock.advance_mono(Duration::from_secs(1));
     assert!(
         booted.is_available(S, TEST_MODEL),
         "…and the quarantine still ends, so a restart cannot make a latch permanent"
     );
+
+    // NOT-EXTENDED DIRECTION: time that passed while the process was down counts
+    // against the quarantine. Boot with the wall clock advanced most of the way
+    // to the deadline and only the remainder should be left — under the old
+    // `now + quarantine_for_tier(tier)` re-anchoring this charged a full fresh
+    // 24h instead.
+    let late_clock = Arc::new(TestClock::new(
+        SystemTime::UNIX_EPOCH + quarantine_for_tier(2) - Duration::from_secs(120),
+        Instant::now(),
+    ));
+    let late = tracker_on(&late_clock);
+    late.restore_all(snapshot.clone());
+    let remaining = late
+        .model_health(S, TEST_MODEL)
+        .hard_disable_probe_seconds_remaining
+        .expect("quarantined");
+    assert!(
+        (110..=130).contains(&remaining),
+        "downtime must count against the quarantine; {remaining}s remained where \
+         ~120s was expected"
+    );
+
+    // CLAMP: a corrupt or clock-skewed snapshot cannot manufacture a quarantine
+    // longer than the tier allows.
+    let mut skewed = snapshot.clone();
+    skewed[0].hard_disable_probe_at_unix = Some(i64::MAX / 2);
+    let skew_clock = test_clock();
+    let skewed_tracker = tracker_on(&skew_clock);
+    skewed_tracker.restore_all(skewed);
+    skew_clock.advance_mono(quarantine_for_tier(2));
+    assert!(
+        skewed_tracker.is_available(S, TEST_MODEL),
+        "a far-future deadline is clamped to this tier's quarantine"
+    );
+}
+
+#[test]
+fn repeated_restarts_inside_the_quarantine_cannot_starve_the_probe() {
+    // THE STARVATION DIRECTION — the failure mode the "never probes at boot"
+    // assertion above is blind to.
+    //
+    // Re-anchoring the deadline at `now + quarantine_for_tier(tier)` on every
+    // boot charges a FULL fresh quarantine per restart, so any deploy cadence
+    // shorter than the quarantine starves the probe completely. Measured against
+    // this repo's real cadence (median gap 6.08h across the last 25 release
+    // tags, 12 of 24 gaps under 6h, some as low as 0.6h), probes admitted in 30
+    // days by deploy interval were: 1h→0, 4h→0, 5h→0, 6h→1, 8h→1. The escalation
+    // ladder made it worse rather than better, because at the 7-day rung
+    // essentially every deploy lands inside the quarantine. That is the 4-day
+    // outage reproduced through a different door.
+    //
+    // With an absolute deadline, restarts are irrelevant: the noisy run must
+    // admit exactly the probes the quiet one does.
+    for restart_every_minutes in [60u64, 4 * 60, 5 * 60] {
+        let quiet_clock = test_clock();
+        let quiet = tracker_on(&quiet_clock);
+        hard_disable_via_trip_rate(&quiet, &quiet_clock);
+        let baseline = simulate_dead_model_dispatch_loop(&quiet, &quiet_clock, 30);
+        assert!(
+            !baseline.is_empty(),
+            "fixture precondition: the quiet run must admit probes at all"
+        );
+
+        let clock = test_clock();
+        let ht = tracker_on(&clock);
+        hard_disable_via_trip_rate(&ht, &clock);
+        let mut admitted = Vec::new();
+        for minute in 0..(30 * 24 * 60u64) {
+            if ht.is_available(S, TEST_MODEL) {
+                admitted.push(minute);
+                ht.note_dispatch_accepted(S, TEST_MODEL);
+                ht.record_stall(S, TEST_MODEL, true);
+            }
+            if minute > 0 && minute.is_multiple_of(restart_every_minutes) {
+                // A deploy: persist, then restore into the same tracker exactly
+                // as `persist_model_health_state` / `restore_model_health_state`
+                // do across a process restart.
+                let snapshot = ht.all_health();
+                ht.restore_all(snapshot);
+            }
+            clock.advance_mono(Duration::from_secs(60));
+        }
+
+        assert_eq!(
+            admitted,
+            baseline,
+            "restarting every {restart_every_minutes} minutes changed the probe \
+             schedule: {} probes vs {} for an uninterrupted run. A deploy train \
+             must not be able to starve the quarantine's probe.",
+            admitted.len(),
+            baseline.len()
+        );
+    }
 }
 
 #[test]

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -12118,11 +12118,28 @@
               "format": "int64"
             },
             "hard_disabled": {
-              "description": "Hard-disabled by the trip-rate ceiling: held unavailable with no\nauto-expiry until a human re-enables it via `model_health(action=enable)`.\nWhen true, `cooldown_seconds_remaining` is null (there is no auto-expiry).",
+              "description": "Hard-disabled (quarantined) by the trip-rate ceiling: held unavailable\nexcept for a single half-open probe dispatch admitted once per\nquarantine period. When true, `cooldown_seconds_remaining` is null (the\nordinary cooldown ladder does not own this bucket) and\n`hard_disable_probe_seconds_remaining` says when the next probe is due.\nA human can still release it immediately with\n`model_health(action=enable)`.",
               "type": "boolean"
             },
+            "hard_disable_probe_seconds_remaining": {
+              "description": "Seconds until the next half-open probe dispatch is admitted; `0` means a\nprobe is admissible right now, and `null` means the bucket is not\nquarantined. Read this before reaching for `enable`: a `hard_disabled`\nbucket recovers on its own if its next probe succeeds. Its absence is\nwhat made the 2026-08-12 → 08-16 outage unreadable — `hard_disabled:\ntrue, trips_in_window: 0, cooldown: null` gave an operator no way to tell\na permanent state from a wait.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "hard_disable_on_probation": {
+              "description": "The quarantine was released by a successful probe, but the bucket has not\nyet produced enough clean sessions to have its history forgiven: it is\ndispatchable at full throughput, and a single further breaker trip\nre-quarantines it at the next (longer) tier.",
+              "type": "boolean"
+            },
+            "hard_disable_probe_tier": {
+              "description": "Escalation tier of the quarantine ladder: `0` = 6h, doubling per failed\nprobe to a 7-day ceiling. Survives restarts.",
+              "type": "integer",
+              "format": "int64"
+            },
             "trips_in_window": {
-              "description": "Number of breaker trips inside the rolling trip-rate window (6h). When it\nreaches the ceiling (8) the bucket hard-disables.",
+              "description": "Number of breaker trips inside the rolling trip-rate window (6h). When it\nreaches the ceiling (8) the bucket hard-disables — or `1` while\n`hard_disable_on_probation` is set.",
               "type": "integer",
               "format": "int64"
             }
@@ -12135,6 +12152,8 @@
             "total_successes",
             "disable_ttl_trips",
             "hard_disabled",
+            "hard_disable_on_probation",
+            "hard_disable_probe_tier",
             "trips_in_window"
           ]
         },

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -2079,6 +2079,14 @@ impl AppState {
 
         self.restore_model_health_state().await;
 
+        // Keep that snapshot durable. Without this loop the breaker's
+        // "persisted" quarantine state only ever reached the database when an
+        // operator ran an admin command (see `run_model_health_persist_loop`).
+        let persist_self = self.clone();
+        tokio::spawn(async move {
+            persist_self.run_model_health_persist_loop().await;
+        });
+
         // NOTE: stale-session finalization is a mutating sweep and now runs in
         // `become_leader()` — only the active (lock-holding) pod may touch
         // `running` sessions, otherwise a standby pod would interrupt the
@@ -2894,6 +2902,47 @@ impl AppState {
                 }
             }
             Err(e) => tracing::warn!(error = %e, "failed to serialize model health state"),
+        }
+    }
+
+    /// Persist the model-health snapshot on a fixed cadence, and once more on
+    /// shutdown.
+    ///
+    /// Until this existed, `persist_model_health_state` had exactly three
+    /// callers, all of them the human `model_health` reset/reset_all/enable
+    /// actions. Nothing wrote the snapshot periodically and nothing wrote it at
+    /// shutdown, so every property the breaker documents as "persisted" — the
+    /// hard-disable latch, its escalation tier, its probation state and its
+    /// wall-clock probe deadline — was in practice only as durable as the last
+    /// time an operator happened to run an admin command. A quarantined model
+    /// could be silently forgiven by a deploy, which is precisely the laundering
+    /// the probation mechanism exists to prevent.
+    ///
+    /// The cadence is deliberately short relative to the 6h base quarantine: the
+    /// worst case is losing one interval of quarantine progress on an ungraceful
+    /// kill, and at five minutes that is negligible against every deadline the
+    /// breaker tracks. The write is a single settings-row upsert.
+    async fn run_model_health_persist_loop(self) {
+        const PERSIST_INTERVAL: Duration = Duration::from_secs(5 * 60);
+        let cancel = self.cancel().clone();
+        let mut ticker = tokio::time::interval(PERSIST_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // The first tick completes immediately; skip it so startup does not
+        // immediately re-persist what `restore_model_health_state` just loaded.
+        ticker.tick().await;
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    self.persist_model_health_state().await;
+                }
+                _ = cancel.cancelled() => {
+                    // Graceful shutdown: take one final snapshot so an orderly
+                    // restart resumes the exact quarantine state it left.
+                    self.persist_model_health_state().await;
+                    tracing::debug!("model-health persist loop stopped; final snapshot written");
+                    return;
+                }
+            }
         }
     }
 

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -12099,8 +12099,25 @@ expression: signatures
               "format": "int64",
               "type": "integer"
             },
+            "hard_disable_on_probation": {
+              "description": "The quarantine was released by a successful probe, but the bucket has not\nyet produced enough clean sessions to have its history forgiven: it is\ndispatchable at full throughput, and a single further breaker trip\nre-quarantines it at the next (longer) tier.",
+              "type": "boolean"
+            },
+            "hard_disable_probe_seconds_remaining": {
+              "description": "Seconds until the next half-open probe dispatch is admitted; `0` means a\nprobe is admissible right now, and `null` means the bucket is not\nquarantined. Read this before reaching for `enable`: a `hard_disabled`\nbucket recovers on its own if its next probe succeeds. Its absence is\nwhat made the 2026-08-12 → 08-16 outage unreadable — `hard_disabled:\ntrue, trips_in_window: 0, cooldown: null` gave an operator no way to tell\na permanent state from a wait.",
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "hard_disable_probe_tier": {
+              "description": "Escalation tier of the quarantine ladder: `0` = 6h, doubling per failed\nprobe to a 7-day ceiling. Survives restarts.",
+              "format": "int64",
+              "type": "integer"
+            },
             "hard_disabled": {
-              "description": "Hard-disabled by the trip-rate ceiling: held unavailable with no\nauto-expiry until a human re-enables it via `model_health(action=enable)`.\nWhen true, `cooldown_seconds_remaining` is null (there is no auto-expiry).",
+              "description": "Hard-disabled (quarantined) by the trip-rate ceiling: held unavailable\nexcept for a single half-open probe dispatch admitted once per\nquarantine period. When true, `cooldown_seconds_remaining` is null (the\nordinary cooldown ladder does not own this bucket) and\n`hard_disable_probe_seconds_remaining` says when the next probe is due.\nA human can still release it immediately with\n`model_health(action=enable)`.",
               "type": "boolean"
             },
             "model_id": {
@@ -12122,7 +12139,7 @@ expression: signatures
               "type": "integer"
             },
             "trips_in_window": {
-              "description": "Number of breaker trips inside the rolling trip-rate window (6h). When it\nreaches the ceiling (8) the bucket hard-disables.",
+              "description": "Number of breaker trips inside the rolling trip-rate window (6h). When it\nreaches the ceiling (8) the bucket hard-disables — or `1` while\n`hard_disable_on_probation` is set.",
               "format": "int64",
               "type": "integer"
             }
@@ -12135,6 +12152,8 @@ expression: signatures
             "total_successes",
             "disable_ttl_trips",
             "hard_disabled",
+            "hard_disable_on_probation",
+            "hard_disable_probe_tier",
             "trips_in_window"
           ],
           "type": "object"

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -5520,9 +5520,35 @@ export namespace ModelHealthOutputSchema {
    */
   disable_ttl_trips: number
   /**
-   * Hard-disabled by the trip-rate ceiling: held unavailable with no
-   * auto-expiry until a human re-enables it via `model_health(action=enable)`.
-   * When true, `cooldown_seconds_remaining` is null (there is no auto-expiry).
+   * The quarantine was released by a successful probe, but the bucket has not
+   * yet produced enough clean sessions to have its history forgiven: it is
+   * dispatchable at full throughput, and a single further breaker trip
+   * re-quarantines it at the next (longer) tier.
+   */
+  hard_disable_on_probation: boolean
+  /**
+   * Seconds until the next half-open probe dispatch is admitted; `0` means a
+   * probe is admissible right now, and `null` means the bucket is not
+   * quarantined. Read this before reaching for `enable`: a `hard_disabled`
+   * bucket recovers on its own if its next probe succeeds. Its absence is
+   * what made the 2026-08-12 → 08-16 outage unreadable — `hard_disabled:
+   * true, trips_in_window: 0, cooldown: null` gave an operator no way to tell
+   * a permanent state from a wait.
+   */
+  hard_disable_probe_seconds_remaining?: number
+  /**
+   * Escalation tier of the quarantine ladder: `0` = 6h, doubling per failed
+   * probe to a 7-day ceiling. Survives restarts.
+   */
+  hard_disable_probe_tier: number
+  /**
+   * Hard-disabled (quarantined) by the trip-rate ceiling: held unavailable
+   * except for a single half-open probe dispatch admitted once per
+   * quarantine period. When true, `cooldown_seconds_remaining` is null (the
+   * ordinary cooldown ladder does not own this bucket) and
+   * `hard_disable_probe_seconds_remaining` says when the next probe is due.
+   * A human can still release it immediately with
+   * `model_health(action=enable)`.
    */
   hard_disabled: boolean
   model_id: string
@@ -5536,7 +5562,8 @@ export namespace ModelHealthOutputSchema {
   total_successes: number
   /**
    * Number of breaker trips inside the rolling trip-rate window (6h). When it
-   * reaches the ceiling (8) the bucket hard-disables.
+   * reaches the ceiling (8) the bucket hard-disables — or `1` while
+   * `hard_disable_on_probation` is set.
    */
   trips_in_window: number
   [k: string]: any


### PR DESCRIPTION
## The outage

The autonomous build loop was dead for four days, 2026-08-12 → 2026-08-16.

`openai/gpt-5.6-terra` was the **only** candidate in the user's `implement` lane. A transient provider incident on 08-12 pushed it past the trip-rate ceiling (`TRIP_RATE_CEILING` = 8 trips within `TRIP_RATE_WINDOW` = 6h) and it latched `hard_disabled: true`. Every worker dispatch after that went `breaker_open` → `failover_chain_exhausted` → cooldown, forever.

On 08-16 the bucket read:

```
hard_disabled: true, auto_disabled: true, disable_ttl_trips: 8,
cooldown_seconds_remaining: null, trips_in_window: 0
```

**`trips_in_window: 0`.** Every trip that justified the latch had already aged out of the rolling 6-hour window, yet the latch was still set. A manual reset produced 10/10 successes immediately, on top of 1753 completions in the trailing 30-day window.

The defect: **a rate-based trigger with a permanent, never-re-evaluated consequence.** `ModelState::is_available` began with an unconditional `if self.hard_disabled { return false; }`, and `register_trip` explicitly cleared `cooldown_until` so nothing else could ever clear it.

## The tension

The permanence was **not** gratuitous, and this PR does not delete it. A model that trips 8×/6h "is broken, and continuing to auto-re-enable it just keeps feeding it priority tasks it cannot complete." There is a documented prior incident of exactly that flapping — disable 5 min → re-enable → grab a slot → crash in <10s → repeat, with **one production task losing 5.75h to 8 consecutive 429 crashes**.

So the requirement is narrow: **recover from a decayed transient without reintroducing the flap.** Two rounds of adversarial review were spent finding places where the second half of that sentence quietly failed.

## The design

| | |
|---|---|
| **Quarantine base** | 6h, anchored at the bucket's most recent trip |
| **Admission** | exactly **one** probe dispatch per quarantine period |
| **Failed probe** | re-latch + double the quarantine (6h → 12h → 24h → 48h → 96h → 7d ceiling) |
| **Successful probe** | release to **probation**, not to a clean slate |
| **Probation** | win 5 of at most 6 sessions, else re-quarantine one rung higher |
| **Restart** | absolute wall-clock deadline — neither wiped nor extended |
| **Human `enable`/`reset`** | immediate and authoritative at any point |

### Why 6 hours

Three bounds, two enforced at compile time by `const _: () = assert!(...)`:

1. **It must exceed `MAX_COOLDOWN` (4h)**, or the hard-disable is indistinguishable from the escalating ladder it backstops.
2. **It equals `TRIP_RATE_WINDOW`, and that equality is load-bearing.** Because the deadline is anchored at the most recent trip, by the time the probe fires every trip that justified the latch has been pruned — `trips_in_window` is provably `0` at probe time. The probe asks "is this model healthy **now**" against a window that no longer contains any of the evidence for the latch. That is exactly the state the incident bucket sat in, ignored, for four days.
3. **Exposure is negligible**: one task per quarantine period, escalating to one per week.

### Probation: why a probe success is not a pardon

A probe success is real evidence, so the lane reopens at **full throughput** — that is what fixes the outage. But it is evidence from one session about a bucket that reached eight trips in six hours. The first version treated it as a full pardon (clearing the tier, trip window and cooldown ladder), which let an intermittently-broken model escape the escalation ladder entirely.

Probation preserves the tier and runs a **counted, bounded trial**: win `HARD_DISABLE_PROBATION_SUCCESSES` (5) of at most `HARD_DISABLE_PROBATION_TRIAL_SESSIONS` (6). Successes and failures are counted independently and neither resets the other, so **failure clustering is irrelevant** — the flaw that survived the first review. The trial resolves three ways, all inside the budget:

* 5 wins → history forgiven;
* `probation_failure_ceiling()` (derived: 2) losses → re-quarantined one rung higher;
* budget spent without either → re-quarantined.

The third clause is charged in `note_dispatch_accepted` — on **exposure**, not outcome — so the bound holds even when sessions never report anything. Exposure per released quarantine is at most `1 + 6` sessions **by construction, against any input**.

A genuinely recovered model (the outage's went 10-for-10) wins its trial with full throughput throughout. A one-success-in-six model must win ≥5 of 6: `C(6,5)·(1/6)^5·(5/6) + (1/6)^6 ≈ 0.00066`, about 1 in 1500.

### Restart: an absolute wall-clock deadline

`Instant`s are meaningless across a process boundary. Re-anchoring at `now + quarantine_for_tier(tier)` looked conservative and was not — it charged a full fresh quarantine every boot. Measured probes admitted in 30 days by deploy cadence: **1h→0, 4h→0, 5h→0, 6h→1, 8h→1**, against a real cadence of median 6.08h with 12 of 24 gaps under 6h. The escalation ladder made starvation *more* certain, not less. That is the original outage through a different door.

The quarantine now carries `hard_disable_probe_at_unix` and `restore_all` restores the remainder from it: downtime counts exactly as uptime would. The remainder is clamped to the tier's quarantine, so a corrupt or skewed snapshot can shorten a quarantine but never manufacture a longer one.

### Durability

`persist_model_health_state` previously had three callers, all human admin actions — no periodic persist, none on shutdown. Every "persisted" property was only as durable as the last time an operator ran a command. `AppState::run_model_health_persist_loop` now writes on a 5-minute cadence and once more on cancellation.

### `enable` vs `reset`

Both remain authoritative and immediate. `enable` additionally clears the failure **streaks** while preserving lifetime totals: it used to leave `breaker_eligible_consecutive_failures` at or above `CIRCUIT_BREAKER_THRESHOLD`, so the next failure re-tripped on the spot and every `enable` had to be chased with a `reset`. `disable_ttl_trips` is deliberately kept — the operator vouched the model is usable now, not that its history never happened.

### Operator surface

`model_health` now reports `hard_disable_probe_seconds_remaining` (`Some(0)` = probe admissible now, `None` = not quarantined), `hard_disable_on_probation` and `hard_disable_probe_tier`, and the `hard_disabled` doc no longer claims "no auto-expiry until a human re-enables". This is the surface that was actually used to diagnose the outage, where `hard_disabled: true, trips_in_window: 0, cooldown: null` gave no way to tell a permanent state from a wait.

## The exposure table

30 simulated days, one-minute polling, driving the real API in the real order (`is_available` → `note_dispatch_accepted` → outcome). Asserted in `probation_bounds_exposure_across_every_failure_pattern_not_just_one`:

| pattern | this PR | after round-2 fixes (clustering hole) | `origin/main` |
|---|---|---|---|
| one success in 2 | **32** · quarantined · tier 5 | 42840 · never re-quarantined | 0 · permanent latch |
| one success in 3 | **24** · quarantined · tier 5 | 42840 · never re-quarantined | 0 |
| one success in 4 | **16** · quarantined · tier 5 | 32 | 0 |
| one success in 6 | **12** · quarantined · tier 5 | 17 | 0 |
| F,F,S repeating | **20** · quarantined · tier 5 | 40682 · never re-quarantined | 0 |
| S,S,F repeating | **48** · quarantined · tier 5 | 42840 · never re-quarantined | 0 |
| alternating S,F | **32** · quarantined · tier 5 | 42840 · never re-quarantined | 0 |
| all failures | **8** · quarantined · tier 5 | 8 | 0 |

Every row asserts four properties, not one: bounded exposure, ends quarantined, escalated past tier 0, and **still probed at all** (a zero would be the 4-day outage, not a fix). The structural worst case is `8 cycles × (1 probe + 6 trial sessions) = 56`; the ceiling is 80.

The previous round asserted a single hardcoded `success_every = 6`, passed at 17, and `success_every = 3` went through the identical assertion shape at 42840. That is why this is a table.

## Which tests prove what

| test | defect |
|---|---|
| `quarantine_admits_exactly_one_probe_and_a_clean_probe_recovers_the_model` | the incident; fails on `main` |
| `probation_bounds_exposure_across_every_failure_pattern_not_just_one` | N1 clustering |
| `probation_re_quarantines_on_counted_failures_regardless_of_clustering` | N1 mechanism |
| `a_probation_trial_is_bounded_by_dispatches_even_with_no_outcomes_at_all` | N1 unbounded window |
| `probation_tightens_the_throttle_ladder_too` | N4 |
| `stray_successes_on_a_quarantined_bucket_cannot_pre_charge_the_probation_trial` | N2 |
| `repeated_restarts_inside_the_quarantine_cannot_starve_the_probe` | N3 starvation |
| `a_restart_preserves_the_quarantine_deadline_in_both_directions` | N3 both directions + skew clamp |
| `a_success_without_an_admitted_probe_cannot_release_a_quarantine` | D2 |
| `health_blind_failures_cannot_postpone_the_probe_forever` | D3 |
| `a_transient_upstream_fault_re_quarantines_without_escalating` | D4 |
| `model_health_reports_the_next_probe_deadline_to_operators` | D5 |

### Surgical reverts

| reverted | tests that fail | measured |
|---|---|---|
| N1 counted trial → trip-based | 5 | table reads 42840 / 42840 / 32 / 17 / 40682 — matching the review exactly |
| N2 ledger reset | 4 | full pardon from four stray successes + one probe |
| N3 wall-clock deadline | 2 | 0 probes vs 8 under an hourly deploy |
| D1 probation release | 3 | 42840, never re-latches |
| D2 `probe_outstanding` on success | 1 | latch released with 0 probes admitted |
| D3 `probe_outstanding` on failure | 13 | 0 probes vs 6 for the quiet baseline |
| `is_available` half-open branch | 8 | permanent latch restored |

Restored: **68/68 pass**.

## Test results

| Command | Result |
|---|---|
| `-p djinn-provider --lib catalog::health` | **68 passed / 0 failed** |
| `-p djinn-provider --lib` | **630 / 0** |
| `-p djinn-control-plane` | **1022 / 0** across 12 targets |
| `-p djinn-server --lib` | **665 / 0** (2 ignored) |
| `-p djinn-coordinator --features test-support --lib` | 2308 / 1 — load-sensitive, passes in isolation, identical on `origin/main` under the same invocation |
| `cargo clippy --workspace --all-targets --features qdrant --keep-going` | clean |
| `cargo fmt --all`, `git diff --check` | clean |
| `make tool-goldens-check` | up to date |
| raw-SQL boundary + self-test | OK / 59 passed 0 failed |

Private PostgreSQL on port 55219, torn down. All work inside the agent worktree.

## Not verified

* No staging/production run.
* The persist loop is wired and compiles, but its 5-minute cadence and shutdown write are not covered by an integration test — `djinn-server` has no harness that boots `AppState` and advances time.
* `HARD_DISABLE_PROBATION_SUCCESSES = 5` and `HARD_DISABLE_PROBATION_TRIAL_SESSIONS = 6` are reasoned, not tuned against production data. The binding constraint is the trial length, not either constant alone.
* `evidence_dispatch_recovery` still dispatches without consulting the breaker at all. It can no longer corrupt the quarantine (D3), but that gap is pre-existing, in another module, and deserves its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
