### PR TITLE
fix(pr-poller): observe a merged PR before every advance gate (4vnt/#3153, 3kza/#3155)

### DIFF
--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -6766,8 +6766,12 @@ fn the_pr_poller_closes_ci_routes_on_both_merge_and_pass() {
     );
 
     // ── Each call site sits in the branch that needs it ─────────────────────
+    //
+    // The merged branch is the `Merged` arm of the terminal-state match that
+    // now runs BEFORE the tripwire active-hold gate (the `4vnt`/`3kza` fix); a
+    // merged PR is ground truth and no Djinn-side gate may precede it.
     let merged_branch = code
-        .find("if pr.merged == Some(true) {")
+        .find("merged_reconcile::PrTerminalState::Merged => {")
         .expect("the merged branch is in pr_watcher.rs");
     let apply_merge = code
         .find("self.apply_pr_merge(")

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_routing/executor/tests.rs
@@ -6725,8 +6725,7 @@ async fn the_quiescence_report_counts_the_leaders_live_provider_futures() {
 ///     `["true", "false"]` assertion fails — and a merged PR would record
 ///     `passed`, or a passing one `merged`.
 /// (e) Move the merged-branch call after `apply_pr_merge`, or out of the
-///     `pr.merged == Some(true)` branch entirely: the first range assertion
-///     fails.
+///     `PrTerminalState::Merged` arm entirely: the first range assertion fails.
 /// (f) Move the passing-branch call out of the `CiStatus::Passing` arm: the
 ///     second range assertion fails.
 /// (g) Shadow the lane-routing method with a local `fn` of the same name in

--- a/server/crates/djinn-coordinator/src/pr_poller/merged_reconcile.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/merged_reconcile.rs
@@ -1,38 +1,102 @@
-//! Blind-spot merged-PR reconciliation.
+//! Merged-PR reconciliation (the poller's safety net).
 //!
-//! The PR poller's status-scoped loops only poll `pr_draft` and `pr_review`
-//! tasks. A PR can merge — or its head CI can change — while its task sits in a
-//! status the poller never observes (`open`, `in_progress`, `needs_task_review`,
-//! `needs_lead_intervention`, ...). When that happens the merge is never noticed
-//! and, worse, the task's promoted CI snapshot can stay frozen at `failing`,
-//! which makes the respawn guard bypass open-PR adoption and dispatch rework
-//! workers against an already-merged PR.
+//! A PR can merge — or its head CI can change — without the status-scoped
+//! poller loops terminalizing the task. Two shapes cause that:
 //!
-//! This pass closes that blind spot. It runs on the slow stale-sweep cadence
-//! (never per tick) over the bounded set of non-terminal tasks that carry a
-//! `pr_url` and are NOT in a poller-owned status. For each it fetches PR state
-//! via the same installation-token GitHub plumbing the poller already uses:
+//! 1. The task sits in a status the poller never observes (`open`,
+//!    `in_progress`, `needs_task_review`, `needs_lead_intervention`, ...). The
+//!    merge is never noticed and, worse, the task's promoted CI snapshot can
+//!    stay frozen at `failing`, which makes the respawn guard bypass open-PR
+//!    adoption and dispatch rework workers against an already-merged PR.
+//! 2. The task IS in a poller-owned status (`pr_draft` / `pr_review`) but the
+//!    owning loop `continue`d past its merge check. This is not hypothetical:
+//!    incidents `4vnt`/#3153 and `3kza`/#3155 both stranded in `pr_draft`
+//!    because an active tripwire hold short-circuited the `pr_draft` loop
+//!    *before* its merged branch (see `pr_watcher::poll_pr_draft_tasks`). The
+//!    primary defect is fixed there, but this pass must cover those statuses
+//!    too: a net with a hole exactly where the primary mechanism operates is
+//!    not a net. A task that never terminalizes never releases its dependents,
+//!    so the blast radius is a silently-stalled dependency chain, not a wrong
+//!    status column.
+//!
+//! The pass runs on the slow stale-sweep cadence (never per tick) over the
+//! bounded set of non-terminal tasks that carry a `pr_url`. For each it fetches
+//! PR state via the same installation-token GitHub plumbing the poller uses:
 //!
 //! - MERGED → terminalize with the same merge bookkeeping the poller applies for
-//!   a `pr_review` merge (the `pr_merge` path), routed through
-//!   `user_override → pr_review` first because `PrMerge` is only a valid
-//!   transition from `pr_draft`/`pr_review`. This mirrors the manual
-//!   `user_override → pr_merge` an operator runs today.
+//!   a `pr_review` merge (the `pr_merge` path). From `pr_draft`/`pr_review` the
+//!   `PrMerge` transition applies directly; from any other status the task is
+//!   first routed through `user_override → pr_review` because `PrMerge` is only
+//!   valid from those two. This mirrors the manual `user_override → pr_merge`
+//!   an operator runs today.
 //! - CLOSED-unmerged → left untouched (log only); abandoned-PR closing policy is
-//!   out of scope.
-//! - OPEN → left untouched; the CI snapshot is refreshed in the same pass so a
-//!   poisoned `failing` snapshot cannot bypass adoption forever.
+//!   out of scope. The poller-owned loops already force-close this case
+//!   themselves.
+//! - OPEN → left untouched. For blind-spot statuses the CI snapshot is refreshed
+//!   in the same pass so a poisoned `failing` snapshot cannot bypass adoption
+//!   forever; for poller-owned statuses the owning loop refreshes it every tick,
+//!   so this pass does not duplicate the provider fan-out.
+//!
+//! Terminalization is idempotent by construction: the query excludes `closed`,
+//! and the task row is re-read immediately before the transition, so a task the
+//! poller closed in the same tick is skipped rather than double-transitioned.
 
 use super::*;
 use djinn_core::models::TaskStatus;
 use djinn_provider::github_api::PrState;
 
-/// Audit reason recorded on the `user_override → pr_review` step that routes a
-/// blind-spot task into a state from which `PrMerge` can terminalize it. Names
-/// the reconciliation so the audit trail shows WHY the task closed outside the
-/// normal poller merge path.
+/// Audit reason recorded on the transition that terminalizes a task outside the
+/// normal poller merge path — on the `user_override → pr_review` routing step
+/// for a blind-spot status, or directly on the `pr_merge` step when the task is
+/// already in `pr_draft`/`pr_review`. Names the reconciliation so the audit
+/// trail shows WHY the task closed outside the normal poller merge path.
 const RECONCILE_MERGE_REASON: &str = "reconciled: PR merged while task was outside PR-poller-owned statuses \
      (blind-spot merged-PR reconciliation)";
+
+/// Task statuses the PR poller's status-scoped loops own and poll every tick.
+///
+/// The reconciliation pass still *covers* these (a miss in the owning loop is
+/// exactly what stranded `4vnt` and `3kza`), but it declines the non-terminal
+/// side effects — CI-snapshot refresh — for them, because the owning loop
+/// already performs those on its own cadence.
+pub(crate) fn status_is_poller_owned(status: &str) -> bool {
+    matches!(status, "pr_draft" | "pr_review")
+}
+
+/// GitHub's terminal verdict on a PR, independent of any Djinn-side gate.
+///
+/// This is the single classifier both the `pr_draft` poll loop
+/// (`pr_watcher::poll_pr_draft_tasks`) and this reconciliation pass consult, so
+/// the primary path and the safety net cannot drift into disagreeing about what
+/// "merged" means. A merged PR is ground truth: the work is on the base branch
+/// and no Djinn-side gate can un-land it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrTerminalState {
+    /// The PR merged. Ground truth — outranks every Djinn-side gate.
+    Merged,
+    /// The PR was closed without merging.
+    ClosedUnmerged,
+    /// The PR is still open.
+    Live,
+}
+
+/// Classify a fetched PR's terminal state.
+///
+/// `merged` wins over `state` unconditionally: GitHub reports merged PRs as
+/// closed, so a `Closed` state says nothing on its own. Deliberately takes no
+/// SHA argument — merge detection must never depend on a stored head SHA, which
+/// a force-push invalidates (both incident branches were force-pushed during a
+/// rebase, leaving `task_attempts.github_head_sha` stale against the merged
+/// head).
+pub(crate) fn classify_pr_terminal_state(merged: bool, state: PrState) -> PrTerminalState {
+    if merged {
+        PrTerminalState::Merged
+    } else if state == PrState::Closed {
+        PrTerminalState::ClosedUnmerged
+    } else {
+        PrTerminalState::Live
+    }
+}
 
 /// The action the reconciliation pass takes for a blind-spot task, decided
 /// purely from the fetched PR state. Extracted so the branch logic is testable
@@ -51,24 +115,24 @@ pub(crate) enum BlindSpotReconcileAction {
 ///
 /// A merged PR is ground truth and wins even if GitHub also reports the PR as
 /// closed (merged PRs are closed). Only an unmerged closed PR maps to
-/// `LogClosedUnmerged`.
+/// `LogClosedUnmerged`. Delegates to [`classify_pr_terminal_state`], the same
+/// classifier the `pr_draft` poll loop uses.
 pub(crate) fn decide_blindspot_reconcile_action(
     merged: bool,
     state: PrState,
 ) -> BlindSpotReconcileAction {
-    if merged {
-        BlindSpotReconcileAction::Terminalize
-    } else if state == PrState::Closed {
-        BlindSpotReconcileAction::LogClosedUnmerged
-    } else {
-        BlindSpotReconcileAction::RefreshCiOnly
+    match classify_pr_terminal_state(merged, state) {
+        PrTerminalState::Merged => BlindSpotReconcileAction::Terminalize,
+        PrTerminalState::ClosedUnmerged => BlindSpotReconcileAction::LogClosedUnmerged,
+        PrTerminalState::Live => BlindSpotReconcileAction::RefreshCiOnly,
     }
 }
 
 impl CoordinatorActor {
-    /// Reconcile merged-but-unnoticed PRs for tasks the poller's status-scoped
-    /// loops never observe. Runs on the slow stale-sweep cadence; the query is
-    /// bounded to non-terminal tasks with a `pr_url` that are not poller-owned.
+    /// Reconcile merged-but-unnoticed PRs. Runs on the slow stale-sweep
+    /// cadence; the query is bounded to non-terminal tasks with a `pr_url`,
+    /// poller-owned statuses included (see the module doc — excluding them is
+    /// what let `4vnt` and `3kza` strand).
     pub(crate) async fn reconcile_blindspot_merged_prs(&self) {
         let task_repo = self.task_repo();
         let project_repo = djinn_db::ProjectRepository::new(
@@ -166,6 +230,16 @@ impl CoordinatorActor {
                     // open-PR adoption forever. `record_ci_snapshot` is the sole
                     // writer of the GitHub-derived CI fields and handles head-SHA
                     // change resets internally.
+                    //
+                    // Except for poller-owned statuses: their loop records the
+                    // same snapshot from its own fetch every tick, so repeating
+                    // it here would only duplicate the provider fan-out
+                    // (required contexts, merge-group correlation) on the slow
+                    // sweep. Coverage of those statuses exists for the MERGED
+                    // ground-truth case, not to take over live CI observation.
+                    if status_is_poller_owned(&task.status) {
+                        continue;
+                    }
                     let pr_number = pull_number as i64;
                     self.record_ci_snapshot(
                         &task.id,
@@ -185,29 +259,72 @@ impl CoordinatorActor {
         }
     }
 
-    /// Terminalize a blind-spot task whose PR has merged, using the poller's
-    /// standard merge bookkeeping (`apply_pr_merge`). `PrMerge` is only valid
-    /// from `pr_draft`/`pr_review`, so the task is first routed into `pr_review`
-    /// via `user_override` (the reconciliation-named audit step) — the same
-    /// two-step an operator performs manually. On override failure the merge is
-    /// skipped (retried next slow tick) rather than leaving a half-applied state.
+    /// Terminalize a task whose PR has merged, using the poller's standard
+    /// merge bookkeeping (`apply_pr_merge`).
+    ///
+    /// `PrMerge` is only valid from `pr_draft`/`pr_review`:
+    ///
+    /// - Already in one of those (the `4vnt`/`3kza` shape — the owning loop
+    ///   missed the merge): apply `PrMerge` directly, carrying
+    ///   [`RECONCILE_MERGE_REASON`] as the transition reason so the audit trail
+    ///   still names the reconciliation. Routing through `user_override` first
+    ///   would emit a pointless extra status change and an extra audit row.
+    /// - Any other (blind-spot) status: route into `pr_review` via
+    ///   `user_override` carrying the same reason — the same two-step an
+    ///   operator performs manually. On override failure the merge is skipped
+    ///   (retried next slow tick) rather than leaving a half-applied state.
+    ///
+    /// Idempotent: the task row is re-read first, and a task that already
+    /// reached `closed` (the poller terminalized it between the query and here)
+    /// is left alone. Without that re-read the two paths race on the same merge
+    /// and the loser logs a failed illegal transition every slow tick.
     async fn terminalize_reconciled_merge(
         &self,
         task: &Task,
         pr_url: &str,
         merge_commit_sha: Option<&str>,
     ) {
-        if let Err(e) = self
-            .task_repo()
-            .transition(
-                &task.id,
-                TransitionAction::UserOverride,
-                "system",
-                "pr_poller",
-                Some(RECONCILE_MERGE_REASON),
-                Some(TaskStatus::PrReview),
-            )
-            .await
+        let task_repo = self.task_repo();
+        let current = match task_repo.get(&task.id).await {
+            Ok(Some(current)) => current,
+            Ok(None) => {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    "PR reconcile: task disappeared before merge terminalization"
+                );
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    error = %e,
+                    "PR reconcile: failed to re-read task before merge terminalization; \
+                     skipping this tick"
+                );
+                return;
+            }
+        };
+        if current.status == TaskStatus::Closed.as_str() {
+            tracing::debug!(
+                task_id = %task.short_id,
+                "PR reconcile: task already terminal (poller won the race) — nothing to do"
+            );
+            return;
+        }
+
+        // `PrMerge` needs `pr_draft`/`pr_review`. Route anything else there
+        // first; a task already in one of them merges directly.
+        if !status_is_poller_owned(&current.status)
+            && let Err(e) = task_repo
+                .transition(
+                    &task.id,
+                    TransitionAction::UserOverride,
+                    "system",
+                    "pr_poller",
+                    Some(RECONCILE_MERGE_REASON),
+                    Some(TaskStatus::PrReview),
+                )
+                .await
         {
             tracing::warn!(
                 task_id = %task.short_id,
@@ -222,12 +339,13 @@ impl CoordinatorActor {
         // (the merge landed unobserved). Record `not_applicable` — the same
         // value the pr_draft merged path uses — so the merge facts are recorded
         // without asserting a review outcome we did not witness.
-        self.apply_pr_merge(
+        self.apply_pr_merge_with_reason(
             &task.id,
             pr_url,
             merge_commit_sha,
             Some("not_applicable"),
             "not_applicable",
+            Some(RECONCILE_MERGE_REASON),
         )
         .await;
     }
@@ -289,10 +407,58 @@ mod tests {
         );
     }
 
-    // ── Blind-spot query bounds ─────────────────────────────────────────────
+    #[test]
+    fn a_merged_pr_outranks_every_djinn_side_gate() {
+        // The 4vnt/3kza root cause, stated as a classifier contract: nothing
+        // about a merged PR is conditional. `classify_pr_terminal_state` takes
+        // no gate state and no SHA, so neither an active tripwire hold nor a
+        // force-pushed (stale) stored head can produce anything but `Merged`.
+        assert_eq!(
+            classify_pr_terminal_state(true, PrState::Closed),
+            PrTerminalState::Merged
+        );
+        assert_eq!(
+            classify_pr_terminal_state(true, PrState::Open),
+            PrTerminalState::Merged
+        );
+        assert_eq!(
+            classify_pr_terminal_state(false, PrState::Closed),
+            PrTerminalState::ClosedUnmerged
+        );
+        assert_eq!(
+            classify_pr_terminal_state(false, PrState::Open),
+            PrTerminalState::Live
+        );
+    }
 
+    #[test]
+    fn poller_owned_statuses_are_exactly_pr_draft_and_pr_review() {
+        assert!(status_is_poller_owned("pr_draft"));
+        assert!(status_is_poller_owned("pr_review"));
+        for other in [
+            "open",
+            "in_progress",
+            "needs_task_review",
+            "needs_lead_intervention",
+            "approved",
+            "closed",
+        ] {
+            assert!(
+                !status_is_poller_owned(other),
+                "{other} is not a poller-owned status"
+            );
+        }
+    }
+
+    // ── Reconciliation query bounds ─────────────────────────────────────────
+
+    /// REGRESSION (`4vnt`/#3153, `3kza`/#3155): the reconciliation query used
+    /// to exclude `pr_draft`/`pr_review` — the exact statuses both stranded
+    /// tasks were in — leaving the safety net with a hole precisely where the
+    /// primary mechanism operates. Every non-terminal task with a `pr_url` must
+    /// now be reconcilable, whichever status it sits in.
     #[tokio::test]
-    async fn list_reconcilable_excludes_poller_owned_terminal_and_prless() {
+    async fn list_reconcilable_covers_poller_owned_statuses() {
         let db = Database::open_in_memory().unwrap();
         let bus = EventBus::noop();
         let epic_repo = EpicRepository::new(db.clone(), bus.clone());
@@ -327,8 +493,9 @@ mod tests {
             Some("https://github.com/acme/repo/pull/3"),
         )
         .await;
-        // Poller-owned statuses — the pr_draft/pr_review loops own these.
-        let _draft = seed_task(
+        // Poller-owned statuses — the incident shape. The owning loop can miss
+        // a merge (it did, twice), so these MUST be covered too.
+        let draft = seed_task(
             &repo,
             &epic.id,
             "draft+pr",
@@ -336,7 +503,7 @@ mod tests {
             Some("https://github.com/acme/repo/pull/4"),
         )
         .await;
-        let _review = seed_task(
+        let review = seed_task(
             &repo,
             &epic.id,
             "review+pr",
@@ -358,20 +525,382 @@ mod tests {
         assert!(got.contains(&open.id));
         assert!(got.contains(&in_progress.id));
         assert!(got.contains(&ntr.id));
+        assert!(
+            got.contains(&draft.id),
+            "a pr_draft task with a merged-but-unnoticed PR is the 4vnt/3kza shape; \
+             excluding it is the safety-net hole this fix closes"
+        );
+        assert!(
+            got.contains(&review.id),
+            "pr_review has the same exposure as pr_draft"
+        );
         assert_eq!(
             got.len(),
-            3,
-            "only non-terminal, non-poller-owned tasks with a pr_url must be returned"
+            5,
+            "every non-terminal task with a pr_url must be reconcilable"
         );
+    }
+
+    /// A task the poller already terminalized must never be re-selected: the
+    /// query is the first (and cheapest) idempotency barrier.
+    #[tokio::test]
+    async fn list_reconcilable_excludes_terminalized_tasks() {
+        let db = Database::open_in_memory().unwrap();
+        let bus = EventBus::noop();
+        let epic_repo = EpicRepository::new(db.clone(), bus.clone());
+        let epic = epic_repo
+            .create("recon epic", "", "", "", "", None)
+            .await
+            .unwrap();
+        let repo = TaskRepository::new(db.clone(), bus);
+
+        let task = seed_task(
+            &repo,
+            &epic.id,
+            "already-merged",
+            "pr_draft",
+            Some("https://github.com/acme/repo/pull/9"),
+        )
+        .await;
+        assert_eq!(repo.list_reconcilable_pr_tasks().await.unwrap().len(), 1);
+
+        // The poller wins the race and closes it with merge semantics.
+        repo.transition(
+            &task.id,
+            TransitionAction::PrMerge,
+            "system",
+            "pr_poller",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            repo.list_reconcilable_pr_tasks().await.unwrap().is_empty(),
+            "a closed task must never be reconciled again"
+        );
+    }
+
+    // ── Merge terminalization driven through the production path ───────────
+    //
+    // These build a real `CoordinatorActor` and call the production
+    // `terminalize_reconciled_merge` — the same method
+    // `reconcile_blindspot_merged_prs` calls once GitHub reports the PR merged.
+    // Only the GitHub fetch is elided (there is no HTTP fake in this crate), so
+    // the merge facts are passed in exactly as the fetch would supply them.
+
+    /// Build a coordinator actor plus an epic, returning everything a
+    /// terminalization test needs. Caller must `cancel.cancel()` at the end.
+    async fn reconcile_fixture(
+        db: &Database,
+    ) -> (
+        crate::actor::CoordinatorActor,
+        tokio_util::sync::CancellationToken,
+        TaskRepository,
+        String,
+    ) {
+        let (tx, _rx) = tokio::sync::broadcast::channel(64);
+        let (actor, cancel) = crate::test_helpers::make_coordinator_actor_cancellable(db, &tx);
+        let bus = EventBus::noop();
+        let epic_repo = EpicRepository::new(db.clone(), bus.clone());
+        let epic = epic_repo
+            .create("recon epic", "", "", "", "", None)
+            .await
+            .unwrap();
+        let repo = TaskRepository::new(db.clone(), bus);
+        (actor, cancel, repo, epic.id)
+    }
+
+    /// REGRESSION (`4vnt`/#3153, `3kza`/#3155), the incident shape end to end.
+    ///
+    /// A task sits in `pr_draft` — the status the poller owns — while its PR is
+    /// merged. Before this fix the reconciliation query refused to look at
+    /// `pr_draft` at all, so nothing terminalized it and the task stayed open
+    /// with `closed_at: null` (5 days for `4vnt`). Now it closes with merge
+    /// semantics: `close_reason = completed`, a populated `merge_commit_sha`
+    /// (both incidents left it `null`), and an audit trail that names the
+    /// reconciliation. And the dependent — the thing that actually cost the
+    /// build loop — is released.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn merged_pr_in_pr_draft_terminalizes_and_releases_its_dependent() {
+        let db = Database::open_in_memory().unwrap();
+        let (actor, cancel, repo, epic_id) = reconcile_fixture(&db).await;
+
+        let pr_url = "https://github.com/djinnos/djinn/pull/3153";
+        let task = seed_task(
+            &repo,
+            &epic_id,
+            "stranded-in-pr-draft",
+            "pr_draft",
+            Some(pr_url),
+        )
+        .await;
+        // The dependency chain that silently dropped out of the build loop.
+        let dependent = seed_task(&repo, &epic_id, "blocked-dependent", "open", None).await;
+        repo.add_blocker(&dependent.id, &task.id).await.unwrap();
+
+        let ready_before: Vec<String> = repo
+            .list_ready(djinn_db::ReadyQuery::default())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert!(
+            !ready_before.contains(&dependent.id),
+            "precondition: the dependent must be blocked while the merged task stays open"
+        );
+
+        // The reconciler must select it in the first place.
+        let selected = repo.list_reconcilable_pr_tasks().await.unwrap();
+        let selected_task = selected
+            .iter()
+            .find(|t| t.id == task.id)
+            .expect("a pr_draft task with a merged PR must be reconcilable");
+        assert_eq!(
+            decide_blindspot_reconcile_action(true, PrState::Closed),
+            BlindSpotReconcileAction::Terminalize
+        );
+
+        actor
+            .terminalize_reconciled_merge(selected_task, pr_url, Some("0c4e0a5224be4133"))
+            .await;
+
+        let closed = repo.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(closed.status, "closed");
+        assert_eq!(closed.close_reason.as_deref(), Some("completed"));
+        assert!(closed.closed_at.is_some(), "closed_at must be populated");
+        assert_eq!(
+            closed.merge_commit_sha.as_deref(),
+            Some("0c4e0a5224be4133"),
+            "a task closed as merged must record which commit merged it"
+        );
+
+        let activity = repo.list_activity(&task.id).await.unwrap();
+        assert!(
+            activity
+                .iter()
+                .any(|a| a.payload.contains("blind-spot merged-PR reconciliation")),
+            "the audit trail must name why the task closed outside the normal poller path"
+        );
+
+        let ready_after: Vec<String> = repo
+            .list_ready(djinn_db::ReadyQuery::default())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert!(
+            ready_after.contains(&dependent.id),
+            "closing the merged task must release its blocked dependent — \
+             the un-released dependency chain IS the damage this bug caused"
+        );
+
+        cancel.cancel();
+        db.pool().close().await;
+    }
+
+    /// REGRESSION: the force-pushed-branch shape observed on BOTH incidents.
+    ///
+    /// `4vnt` held `ci.head_sha = d41958f6…` (the merged head) but
+    /// `task_attempts.github_head_sha = b3aaede1…` (the pre-force-push head);
+    /// `3kza` showed `fef4a526…` vs `0d67ee6e…`. Merge terminalization must not
+    /// consult either stored SHA — a force-push invalidates them, and a merge
+    /// check keyed off one would strand the task for a second, independent
+    /// reason. Here every stored SHA disagrees with the merge commit and the
+    /// task must still terminalize.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn force_pushed_stale_head_shas_do_not_block_terminalization() {
+        use djinn_db::{CreateTaskAttemptParams, FillTaskAttemptParams, TaskAttemptRepository};
+
+        let db = Database::open_in_memory().unwrap();
+        let (actor, cancel, repo, epic_id) = reconcile_fixture(&db).await;
+
+        let pr_url = "https://github.com/djinnos/djinn/pull/3155";
+        let task = seed_task(&repo, &epic_id, "force-pushed", "pr_draft", Some(pr_url)).await;
+
+        // Snapshot head: the merged head. Attempt head: the stale pre-rebase
+        // head. Exactly the divergence both production tasks carried.
+        const MERGED_HEAD: &str = "fef4a526f115c7e5ca6b86cf76856676389f176f";
+        const STALE_ATTEMPT_HEAD: &str = "0d67ee6e892124e38221a515b466b3b7a582f4d1";
+        const MERGE_COMMIT: &str = "06253f5ab0b48f14769598a8cded90a013d90206";
+
+        repo.upsert_ci_snapshot(TaskPrCiSnapshotInput {
+            task_id: task.id.clone(),
+            pr_number: 3155,
+            head_sha: MERGED_HEAD.into(),
+            ci_status: CiStatus::Passing,
+            blocking_required_check_names: vec![],
+            primary_blocking_check: None,
+            failure_annotations: None,
+            failure_fingerprint: None,
+            same_signature_count: 0,
+            last_remediation_base_sha: None,
+        })
+        .await
+        .unwrap();
+
+        let attempts = TaskAttemptRepository::new(db.clone());
+        let attempt = attempts
+            .create_or_get_pending(CreateTaskAttemptParams {
+                id: &uuid::Uuid::now_v7().to_string(),
+                task_id: &task.id,
+                role: "worker",
+                dispatch_key: &format!("dk-{}", uuid::Uuid::now_v7()),
+                session_id: None,
+                attempt_seq: None,
+                dispatch_owner_incarnation_id: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .unwrap();
+        attempts
+            .fill_nullable_fields(FillTaskAttemptParams {
+                id: &attempt.id,
+                checkpoint_ref: None,
+                submit_ref: None,
+                pr_url: None,
+                mirror_head_sha: Some(STALE_ATTEMPT_HEAD),
+                github_head_sha: Some(STALE_ATTEMPT_HEAD),
+                github_publication_error: None,
+                summary: None,
+                summary_json: None,
+                log_tail: None,
+            })
+            .await
+            .unwrap();
+
+        // Select through the real reconciliation query, not a hand-built row:
+        // the force-pushed task must be *reachable* by the pass as well as
+        // terminalizable by it.
+        let selected = repo.list_reconcilable_pr_tasks().await.unwrap();
+        let stale = selected
+            .iter()
+            .find(|t| t.id == task.id)
+            .expect("a force-pushed pr_draft task with a merged PR must be reconcilable");
+        assert_eq!(stale.ci_head_sha.as_deref(), Some(MERGED_HEAD));
+        assert_eq!(
+            stale.ci_github_head_sha.as_deref(),
+            Some(STALE_ATTEMPT_HEAD)
+        );
+        assert_ne!(
+            stale.ci_github_head_sha.as_deref(),
+            Some(MERGE_COMMIT),
+            "precondition: every stored head must disagree with the merge commit"
+        );
+
+        actor
+            .terminalize_reconciled_merge(stale, pr_url, Some(MERGE_COMMIT))
+            .await;
+
+        let closed = repo.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(
+            closed.status, "closed",
+            "a stale stored head SHA must not prevent a merged PR from terminalizing its task"
+        );
+        assert_eq!(closed.merge_commit_sha.as_deref(), Some(MERGE_COMMIT));
+
+        cancel.cancel();
+        db.pool().close().await;
+    }
+
+    /// Terminalizing twice must be a no-op the second time: the reconciler and
+    /// the (now-fixed) poller loop can both observe the same merged PR, and the
+    /// loser must not emit a second transition or a second audit row.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconciled_merge_is_idempotent() {
+        let db = Database::open_in_memory().unwrap();
+        let (actor, cancel, repo, epic_id) = reconcile_fixture(&db).await;
+
+        let pr_url = "https://github.com/djinnos/djinn/pull/4242";
+        let task = seed_task(&repo, &epic_id, "double-observed", "pr_draft", Some(pr_url)).await;
+
+        actor
+            .terminalize_reconciled_merge(&task, pr_url, Some("cafef00dcafef00d"))
+            .await;
+        let after_first = repo.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(after_first.status, "closed");
+        let activity_after_first = repo.list_activity(&task.id).await.unwrap().len();
+
+        // Second pass, still holding the PRE-merge task row — exactly what the
+        // reconciler holds when the poller closes the task between the query
+        // and the terminalization.
+        actor
+            .terminalize_reconciled_merge(&task, pr_url, Some("cafef00dcafef00d"))
+            .await;
+
+        let after_second = repo.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(after_second.status, "closed");
+        assert_eq!(
+            after_second.closed_at, after_first.closed_at,
+            "a second reconciliation pass must not re-close an already-closed task"
+        );
+        assert_eq!(
+            repo.list_activity(&task.id).await.unwrap().len(),
+            activity_after_first,
+            "a second reconciliation pass must not emit any audit row"
+        );
+
+        cancel.cancel();
+        db.pool().close().await;
+    }
+
+    /// Negative control: a task the POLLER already terminalized (via the normal
+    /// `pr_merge` path, no reconciliation reason) must be left completely alone
+    /// — no second transition, no reconciliation audit row grafted onto it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn poller_terminalized_task_is_left_alone() {
+        let db = Database::open_in_memory().unwrap();
+        let (actor, cancel, repo, epic_id) = reconcile_fixture(&db).await;
+
+        let pr_url = "https://github.com/djinnos/djinn/pull/4243";
+        let task = seed_task(&repo, &epic_id, "poller-closed", "pr_draft", Some(pr_url)).await;
+        repo.set_merge_commit_sha(&task.id, "beefbeefbeefbeef")
+            .await
+            .unwrap();
+        repo.transition(
+            &task.id,
+            TransitionAction::PrMerge,
+            "system",
+            "pr_poller",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let baseline_activity = repo.list_activity(&task.id).await.unwrap().len();
+
+        actor
+            .terminalize_reconciled_merge(&task, pr_url, Some("beefbeefbeefbeef"))
+            .await;
+
+        let after = repo.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(after.status, "closed");
+        assert_eq!(
+            repo.list_activity(&task.id).await.unwrap().len(),
+            baseline_activity,
+            "reconciling a task the poller already closed must be a pure no-op"
+        );
+        assert!(
+            !repo
+                .list_activity(&task.id)
+                .await
+                .unwrap()
+                .iter()
+                .any(|a| a.payload.contains("blind-spot merged-PR reconciliation")),
+            "no reconciliation audit row may be grafted onto a normally-closed task"
+        );
+
+        cancel.cancel();
+        db.pool().close().await;
     }
 
     // ── Merge terminalization via the state machine ─────────────────────────
     //
-    // Building a full `CoordinatorActor` to drive `terminalize_reconciled_merge`
-    // is too heavyweight for a unit test (see `pr_poller/tests.rs`). The
-    // load-bearing claim — that a blind-spot status can be closed with merge
-    // semantics via the exact `user_override → pr_review` then `pr_merge`
-    // sequence the reconciler uses — is validated directly against the state
+    // The blind-spot (non-poller-owned) route additionally needs the
+    // `user_override → pr_review` hop, validated directly against the state
     // machine and merge bookkeeping below.
     #[tokio::test]
     async fn open_task_with_merged_pr_closes_with_merge_semantics_and_audit() {

--- a/server/crates/djinn-coordinator/src/pr_poller/merged_reconcile.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/merged_reconcile.rs
@@ -34,8 +34,9 @@
 //!   themselves.
 //! - OPEN → left untouched. For blind-spot statuses the CI snapshot is refreshed
 //!   in the same pass so a poisoned `failing` snapshot cannot bypass adoption
-//!   forever; for poller-owned statuses the owning loop refreshes it every tick,
-//!   so this pass does not duplicate the provider fan-out.
+//!   forever; for poller-owned statuses the owning loop already refreshes it
+//!   every tick, so this pass skips the redundant `record_ci_snapshot` write
+//!   (the PR fetch above it has happened either way).
 //!
 //! Terminalization is idempotent by construction: the query excludes `closed`,
 //! and the task row is re-read immediately before the transition, so a task the
@@ -232,10 +233,12 @@ impl CoordinatorActor {
                     // change resets internally.
                     //
                     // Except for poller-owned statuses: their loop records the
-                    // same snapshot from its own fetch every tick, so repeating
-                    // it here would only duplicate the provider fan-out
-                    // (required contexts, merge-group correlation) on the slow
-                    // sweep. Coverage of those statuses exists for the MERGED
+                    // same snapshot from its own fetch every tick, so writing it
+                    // again here buys nothing. The PR + check-runs fetch above
+                    // has already happened by this point — only the
+                    // `record_ci_snapshot` write and its own follow-up provider
+                    // calls (required contexts, merge-group correlation) are
+                    // skipped. Coverage of those statuses exists for the MERGED
                     // ground-truth case, not to take over live CI observation.
                     if status_is_poller_owned(&task.status) {
                         continue;
@@ -587,8 +590,13 @@ mod tests {
     // These build a real `CoordinatorActor` and call the production
     // `terminalize_reconciled_merge` — the same method
     // `reconcile_blindspot_merged_prs` calls once GitHub reports the PR merged.
-    // Only the GitHub fetch is elided (there is no HTTP fake in this crate), so
-    // the merge facts are passed in exactly as the fetch would supply them.
+    // The GitHub fetch is elided and the merge facts passed in exactly as the
+    // fetch would supply them, which keeps these focused on the terminalization
+    // itself. The crate DOES have an HTTP double available
+    // (`pr_poller::installation::set_installation_client_base_url_for_test` plus
+    // wiremock — see `supervisor_impl::pr::tests::
+    // merged_pr_under_active_tripwire_hold_still_closes_its_pr_draft_task`), so
+    // reach for that when the behaviour under test involves the fetch itself.
 
     /// Build a coordinator actor plus an epic, returning everything a
     /// terminalization test needs. Caller must `cancel.cancel()` at the end.
@@ -841,6 +849,92 @@ mod tests {
             repo.list_activity(&task.id).await.unwrap().len(),
             activity_after_first,
             "a second reconciliation pass must not emit any audit row"
+        );
+
+        cancel.cancel();
+        db.pool().close().await;
+    }
+
+    /// The blind-spot route: a merged PR whose task sits in a status `PrMerge`
+    /// cannot be applied from. `terminalize_reconciled_merge` must take the
+    /// `user_override → pr_review` hop before merging, and the whole sequence
+    /// must land the same merge semantics the poller-owned route produces.
+    ///
+    /// This is the ONLY test that pins that hop. Deleting the `user_override`
+    /// block leaves every other test in this module green: they all seed
+    /// `pr_draft`, which needs no hop. The blind-spot statuses (`open`,
+    /// `in_progress`, `needs_task_review`, `needs_lead_intervention`, …) are the
+    /// original reason this pass exists, and `needs_task_review` in particular
+    /// is the status `poll_pr_review_stuck_tasks` leaves a merged PR sitting in
+    /// — that loop observes the merge and just `continue`s, so this pass is the
+    /// only thing that terminalizes it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn merged_pr_in_a_blind_spot_status_routes_through_pr_review_and_closes() {
+        let db = Database::open_in_memory().unwrap();
+        let (actor, cancel, repo, epic_id) = reconcile_fixture(&db).await;
+
+        let pr_url = "https://github.com/djinnos/djinn/pull/4244";
+        // `needs_task_review`: not poller-owned, so `PrMerge` is illegal from
+        // here and the reconciler must route through `pr_review` first.
+        let task = seed_task(
+            &repo,
+            &epic_id,
+            "merged-while-in-review",
+            "needs_task_review",
+            Some(pr_url),
+        )
+        .await;
+        assert!(
+            !status_is_poller_owned(&task.status),
+            "precondition: this test must exercise the hop, not the direct path"
+        );
+        let dependent = seed_task(&repo, &epic_id, "blind-spot-dependent", "open", None).await;
+        repo.add_blocker(&dependent.id, &task.id).await.unwrap();
+
+        let selected = repo.list_reconcilable_pr_tasks().await.unwrap();
+        let selected_task = selected
+            .iter()
+            .find(|t| t.id == task.id)
+            .expect("a blind-spot task with a merged PR must be reconcilable");
+
+        actor
+            .terminalize_reconciled_merge(selected_task, pr_url, Some("0badc0de0badc0de"))
+            .await;
+
+        let closed = repo.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(
+            closed.status, "closed",
+            "a blind-spot status must reach `closed`; without the \
+             `user_override → pr_review` hop the `pr_merge` transition is \
+             rejected and the task stays open forever"
+        );
+        assert_eq!(closed.close_reason.as_deref(), Some("completed"));
+        assert!(closed.closed_at.is_some(), "closed_at must be populated");
+        assert_eq!(
+            closed.merge_commit_sha.as_deref(),
+            Some("0badc0de0badc0de"),
+            "the blind-spot route must record the merge commit too"
+        );
+
+        let activity = repo.list_activity(&task.id).await.unwrap();
+        assert!(
+            activity
+                .iter()
+                .any(|a| a.payload.contains("blind-spot merged-PR reconciliation")),
+            "the `user_override` hop must carry RECONCILE_MERGE_REASON so the \
+             audit trail explains the out-of-band close"
+        );
+
+        let ready: Vec<String> = repo
+            .list_ready(djinn_db::ReadyQuery::default())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert!(
+            ready.contains(&dependent.id),
+            "the blind-spot route must release blocked dependents as well"
         );
 
         cancel.cancel();

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_review_handlers.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_review_handlers.rs
@@ -424,6 +424,35 @@ impl CoordinatorActor {
         review: Option<&str>,
         merge_queue: &str,
     ) {
+        self.apply_pr_merge_with_reason(
+            task_id,
+            pr_url,
+            merge_commit_sha,
+            review,
+            merge_queue,
+            None,
+        )
+        .await;
+    }
+
+    /// [`Self::apply_pr_merge`] with an explicit audit reason on the `pr_merge`
+    /// transition.
+    ///
+    /// The normal poller paths pass `None` — a merge observed by the loop that
+    /// owns the task needs no explanation. The reconciliation pass passes its
+    /// `RECONCILE_MERGE_REASON` so a task closed outside the normal path still
+    /// says why in its audit trail, even when it was already in
+    /// `pr_draft`/`pr_review` and therefore needed no `user_override` routing
+    /// step to carry that reason.
+    pub(crate) async fn apply_pr_merge_with_reason(
+        &self,
+        task_id: &str,
+        pr_url: &str,
+        merge_commit_sha: Option<&str>,
+        review: Option<&str>,
+        merge_queue: &str,
+        reason: Option<&str>,
+    ) {
         self.record_pr_outcome_facts(pr_url, review, Some(merge_queue), None)
             .await;
         if let Some(sha) = merge_commit_sha.filter(|s| !s.is_empty()) {
@@ -452,7 +481,7 @@ impl CoordinatorActor {
             Some("PR merged and task completed"),
         )
         .await;
-        self.apply_pr_transition(task_id, TransitionAction::PrMerge, None)
+        self.apply_pr_transition(task_id, TransitionAction::PrMerge, reason)
             .await;
     }
 

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs
@@ -127,16 +127,17 @@ impl CoordinatorActor {
                 )
                 .await;
 
-            // ── GitHub terminal ground truth (BEFORE any advance gate) ───
+            // ── Merged? GitHub ground truth, BEFORE any advance gate ─────
             //
             // A merged PR is ground truth: the work is on the base branch and
             // no Djinn-side gate can un-land it. Every gate below this point
             // (tripwire active-hold, CI gate, merge-conflict check, undraft)
-            // exists to stop Djinn *advancing* a PR toward merge. Evaluating
-            // any of them first turns it into a permanent mask over merge
-            // detection — and a task that never terminalizes never releases its
-            // dependents, so the damage is a silently-stalled dependency chain,
-            // not a stale status column.
+            // exists to stop Djinn *advancing* a PR toward merge, and once
+            // GitHub says merged every one of those advance actions is already
+            // moot. Evaluating any of them first turns it into a permanent mask
+            // over merge detection — and a task that never terminalizes never
+            // releases its dependents, so the damage is a silently-stalled
+            // dependency chain, not a stale status column.
             //
             // This ordering IS the incident. `4vnt`/#3153 and `3kza`/#3155 each
             // had a `tripwire.gate.held` activity event on the PR's *live* head
@@ -148,6 +149,10 @@ impl CoordinatorActor {
             // respectively — blocking dependents `296y` and `i58q` — until an
             // operator closed them by hand. `poll_pr_review_tasks` has always
             // had the correct order; only this loop was inverted.
+            //
+            // ONLY the merged case moves. `ClosedUnmerged` deliberately stays
+            // BELOW the hold, unchanged from before this fix — see the block
+            // after the gate for why hoisting it would be a wrong-close.
             //
             // Classification is deliberately SHA-free: both branches had been
             // force-pushed during a rebase, leaving `task_attempts
@@ -186,37 +191,53 @@ impl CoordinatorActor {
                     self.review_stuck_sha_first_seen.remove(&task.id);
                     continue;
                 }
-                merged_reconcile::PrTerminalState::ClosedUnmerged => {
-                    tracing::info!(
-                        task_id = %task.short_id,
-                        pr = pull_number,
-                        "PR poller: PR closed without merge → force-closing task"
-                    );
-                    poll_stack::boxed(|| {
-                        self.apply_pr_transition(
-                            &task.id,
-                            TransitionAction::ForceClose,
-                            Some("PR was closed without merging"),
-                        )
-                    })
-                    .await;
-                    self.pr_status_cache.remove(&task.id);
-                    self.pr_draft_first_seen.remove(&task.id);
-                    self.review_stuck_sha_first_seen.remove(&task.id);
-                    continue;
-                }
-                merged_reconcile::PrTerminalState::Live => {}
+                // Handled below the tripwire gate, on purpose.
+                merged_reconcile::PrTerminalState::ClosedUnmerged
+                | merged_reconcile::PrTerminalState::Live => {}
             }
 
             // ── Tripwire active-hold reconciliation ──────────────────────
             // Re-check hold state before any PR advance; reapply tampered labels.
-            // Only reachable for a PR that is still open, so a hold can no
+            // Only reachable for a PR that did NOT merge, so a hold can no
             // longer mask a merge that already happened.
             if self
                 .reconcile_tripwire_hold(&task, pull_number, &pr.head.sha)
                 .await
             {
                 // Active hold — do not advance; ensure label stays on.
+                self.pr_status_cache.remove(&task.id);
+                self.pr_draft_first_seen.remove(&task.id);
+                self.review_stuck_sha_first_seen.remove(&task.id);
+                continue;
+            }
+
+            // ── PR closed without merge ──────────────────────────────────
+            //
+            // Stays BELOW the tripwire gate, exactly where it has always been.
+            // Unlike a merge, this is not a fact Djinn merely records: it
+            // force-closes the task, and `ForceClose` is exempt from the
+            // blocks-others guard (`task/status.rs`), so it RELEASES every
+            // dependent. Hoisting it above the hold would mean a reviewer who
+            // closes a human-review-held PR unmerged — intending a redo —
+            // instead releases dependents to build on work that never landed.
+            // That wrong-close direction is worse than the stranding this fix
+            // addresses, and no part of the `4vnt`/`3kza` incident required it:
+            // both PRs merged. A held, closed-unmerged PR keeps the pre-fix
+            // behaviour of holding in `pr_draft`.
+            if pr.state == PrState::Closed {
+                tracing::info!(
+                    task_id = %task.short_id,
+                    pr = pull_number,
+                    "PR poller: PR closed without merge → force-closing task"
+                );
+                poll_stack::boxed(|| {
+                    self.apply_pr_transition(
+                        &task.id,
+                        TransitionAction::ForceClose,
+                        Some("PR was closed without merging"),
+                    )
+                })
+                .await;
                 self.pr_status_cache.remove(&task.id);
                 self.pr_draft_first_seen.remove(&task.id);
                 self.review_stuck_sha_first_seen.remove(&task.id);

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs
@@ -127,62 +127,96 @@ impl CoordinatorActor {
                 )
                 .await;
 
+            // ── GitHub terminal ground truth (BEFORE any advance gate) ───
+            //
+            // A merged PR is ground truth: the work is on the base branch and
+            // no Djinn-side gate can un-land it. Every gate below this point
+            // (tripwire active-hold, CI gate, merge-conflict check, undraft)
+            // exists to stop Djinn *advancing* a PR toward merge. Evaluating
+            // any of them first turns it into a permanent mask over merge
+            // detection — and a task that never terminalizes never releases its
+            // dependents, so the damage is a silently-stalled dependency chain,
+            // not a stale status column.
+            //
+            // This ordering IS the incident. `4vnt`/#3153 and `3kza`/#3155 each
+            // had a `tripwire.gate.held` activity event on the PR's *live* head
+            // (`d41958f6…` and `fef4a526…`), so `reconcile_tripwire_hold`
+            // returned `true` on every tick from the block that used to sit
+            // here. Both PRs were then merged outside Djinn while held; the
+            // loop `continue`d before ever reading `pr.merged`, and the tasks
+            // sat in `pr_draft` with `closed_at: null` for 5 days and 1 minute
+            // respectively — blocking dependents `296y` and `i58q` — until an
+            // operator closed them by hand. `poll_pr_review_tasks` has always
+            // had the correct order; only this loop was inverted.
+            //
+            // Classification is deliberately SHA-free: both branches had been
+            // force-pushed during a rebase, leaving `task_attempts
+            // .github_head_sha` (`b3aaede1…` / `0d67ee6e…`) stale against the
+            // merged head. Merge detection that consults a stored SHA would
+            // have stranded these tasks for a second, independent reason.
+            match merged_reconcile::classify_pr_terminal_state(
+                pr.merged == Some(true),
+                pr.state.clone(),
+            ) {
+                merged_reconcile::PrTerminalState::Merged => {
+                    tracing::info!(
+                        task_id = %task.short_id,
+                        pr = pull_number,
+                        "PR poller: PR merged → closing task"
+                    );
+                    // `nafu`: a merge is authoritative over every pending route
+                    // for this subject. Closing here is what stops a merged PR
+                    // leaving its head's Tier-2 lease held against the next head.
+                    poll_stack::boxed(|| {
+                        self.close_ci_routes_on_success(&task.id, pull_number, true)
+                    })
+                    .await;
+                    poll_stack::boxed(|| {
+                        self.apply_pr_merge(
+                            &task.id,
+                            task.pr_url.as_deref().unwrap_or_default(),
+                            pr.merge_commit_sha.as_deref(),
+                            Some("not_applicable"),
+                            "not_applicable",
+                        )
+                    })
+                    .await;
+                    self.pr_status_cache.remove(&task.id);
+                    self.pr_draft_first_seen.remove(&task.id);
+                    self.review_stuck_sha_first_seen.remove(&task.id);
+                    continue;
+                }
+                merged_reconcile::PrTerminalState::ClosedUnmerged => {
+                    tracing::info!(
+                        task_id = %task.short_id,
+                        pr = pull_number,
+                        "PR poller: PR closed without merge → force-closing task"
+                    );
+                    poll_stack::boxed(|| {
+                        self.apply_pr_transition(
+                            &task.id,
+                            TransitionAction::ForceClose,
+                            Some("PR was closed without merging"),
+                        )
+                    })
+                    .await;
+                    self.pr_status_cache.remove(&task.id);
+                    self.pr_draft_first_seen.remove(&task.id);
+                    self.review_stuck_sha_first_seen.remove(&task.id);
+                    continue;
+                }
+                merged_reconcile::PrTerminalState::Live => {}
+            }
+
             // ── Tripwire active-hold reconciliation ──────────────────────
             // Re-check hold state before any PR advance; reapply tampered labels.
+            // Only reachable for a PR that is still open, so a hold can no
+            // longer mask a merge that already happened.
             if self
                 .reconcile_tripwire_hold(&task, pull_number, &pr.head.sha)
                 .await
             {
                 // Active hold — do not advance; ensure label stays on.
-                self.pr_status_cache.remove(&task.id);
-                self.pr_draft_first_seen.remove(&task.id);
-                self.review_stuck_sha_first_seen.remove(&task.id);
-                continue;
-            }
-
-            // ── Merged? ───────────────────────────────────────────────────────
-            if pr.merged == Some(true) {
-                tracing::info!(
-                    task_id = %task.short_id,
-                    pr = pull_number,
-                    "PR poller: PR merged → closing task"
-                );
-                // `nafu`: a merge is authoritative over every pending route for
-                // this subject. Closing here is what stops a merged PR leaving
-                // its head's Tier-2 lease held against the next head.
-                poll_stack::boxed(|| self.close_ci_routes_on_success(&task.id, pull_number, true))
-                    .await;
-                poll_stack::boxed(|| {
-                    self.apply_pr_merge(
-                        &task.id,
-                        task.pr_url.as_deref().unwrap_or_default(),
-                        pr.merge_commit_sha.as_deref(),
-                        Some("not_applicable"),
-                        "not_applicable",
-                    )
-                })
-                .await;
-                self.pr_status_cache.remove(&task.id);
-                self.pr_draft_first_seen.remove(&task.id);
-                self.review_stuck_sha_first_seen.remove(&task.id);
-                continue;
-            }
-
-            // ── PR closed without merge ───────────────────────────────────────
-            if pr.state == PrState::Closed {
-                tracing::info!(
-                    task_id = %task.short_id,
-                    pr = pull_number,
-                    "PR poller: PR closed without merge → force-closing task"
-                );
-                poll_stack::boxed(|| {
-                    self.apply_pr_transition(
-                        &task.id,
-                        TransitionAction::ForceClose,
-                        Some("PR was closed without merging"),
-                    )
-                })
-                .await;
                 self.pr_status_cache.remove(&task.id);
                 self.pr_draft_first_seen.remove(&task.id);
                 self.review_stuck_sha_first_seen.remove(&task.id);

--- a/server/crates/djinn-coordinator/src/pr_poller/tripwire_merge_gate_tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tripwire_merge_gate_tests.rs
@@ -545,24 +545,24 @@ fn strip_line_comments(source: &str) -> String {
 /// `poll_pr_review_tasks` always had the correct order; only this loop was
 /// inverted.
 ///
-/// SOURCE-LEVEL, and honestly labelled. Both branches sit after
-/// `gh_client.get_pull_request(..)`, and `resolve_installation_client` builds
-/// `GitHubApiClient::for_installation`, which hard-codes `api.github.com`; this
-/// crate carries no HTTP double and no base-URL seam on that path, so no test
-/// in this crate can drive `poll_pr_draft_tasks` to either branch. The
-/// behavioural half of the proof is the reconciliation coverage in
-/// `merged_reconcile::tests` (which does run the real terminalization against a
-/// real database); this half proves the primary loop cannot regress back into
-/// gating merge detection.
+/// SOURCE-LEVEL, and honestly labelled: this pins the *ordering* of two blocks,
+/// which no behavioural assertion states directly. It is a supplement, not a
+/// substitute — the behavioural proof of the same fix is
+/// `supervisor_impl::pr::tests::
+/// merged_pr_under_active_tripwire_hold_still_closes_its_pr_draft_task`, which
+/// drives the real `poll_pr_draft_tasks` against a wiremock GitHub through the
+/// `set_installation_client_base_url_for_test` seam and observes `pr_draft` vs
+/// `closed`. Prefer extending that test over adding assertions here.
 ///
 /// NAMED FAILING MUTATIONS.
-/// (a) Move `reconcile_tripwire_hold` back above the terminal-state match —
-///     the exact production state before this fix: the ordering assertion
-///     fails.
+/// (a) Move `reconcile_tripwire_hold` back above the merged arm — the exact
+///     production state before this fix: the ordering assertion fails.
 /// (b) Delete the terminal-state match (never terminalize from `pr_draft`):
 ///     the `Merged` arm is not found.
 /// (c) Delete the tripwire hold call: the hold anchor is not found.
 /// (d) Gate the merged arm on a stored head SHA: the SHA-free assertion fails.
+/// (e) Hoist the closed-without-merge block above the hold: the
+///     force-close-stays-below assertion fails.
 #[test]
 fn a_merged_pr_is_observed_before_the_tripwire_hold_gate() {
     let code = strip_line_comments(include_str!("pr_watcher.rs"));
@@ -575,9 +575,9 @@ fn a_merged_pr_is_observed_before_the_tripwire_hold_gate() {
     let merged_arm = body
         .find("merged_reconcile::PrTerminalState::Merged => {")
         .expect("the pr_draft loop must have a merged-PR terminalization arm");
-    let closed_arm = body
-        .find("merged_reconcile::PrTerminalState::ClosedUnmerged => {")
-        .expect("the pr_draft loop must have a closed-without-merge arm");
+    let force_close = body
+        .find("TransitionAction::ForceClose,")
+        .expect("the pr_draft loop must still force-close a closed-unmerged PR");
     let hold_gate = body
         .find(".reconcile_tripwire_hold(")
         .expect("the pr_draft loop must still evaluate the tripwire active hold");
@@ -589,10 +589,16 @@ fn a_merged_pr_is_observed_before_the_tripwire_hold_gate() {
          its task in pr_draft forever and never releases its dependents \
          (incidents 4vnt/#3153 and 3kza/#3155)",
     );
+    // The deliberate asymmetry. `ForceClose` is exempt from the blocks-others
+    // guard, so hoisting the closed-unmerged branch above the hold would let a
+    // reviewer who closes a held PR unmerged (intending a redo) release every
+    // dependent onto work that never landed. Merging is a fact Djinn records;
+    // force-closing is an action Djinn takes.
     assert!(
-        closed_arm < hold_gate,
-        "a PR closed without merging is equally terminal and must not be masked \
-         by an advance gate either",
+        hold_gate < force_close,
+        "the closed-without-merge force-close must stay BELOW the tripwire hold \
+         — unlike a merge it releases dependents, and releasing them onto work \
+         that never landed is a worse failure than the stranding this fixes",
     );
 
     let classify = body

--- a/server/crates/djinn-coordinator/src/pr_poller/tripwire_merge_gate_tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tripwire_merge_gate_tests.rs
@@ -502,3 +502,115 @@ fn tamper_idempotency_key_is_deterministic() {
         "different gate key must produce different tamper key"
     );
 }
+
+// ── Gate ordering in `poll_pr_draft_tasks` (4vnt / 3kza regression) ────────
+
+/// Strip `//` line comments so a comment naming a symbol satisfies nothing
+/// below. Mirrors the helper the sibling `ci_routing` source guards use.
+fn strip_line_comments(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    for line in source.lines() {
+        let bytes = line.as_bytes();
+        let mut quoted = false;
+        let mut index = 0usize;
+        let mut end = line.len();
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\\' if quoted => index += 1,
+                b'"' => quoted = !quoted,
+                b'/' if !quoted && bytes.get(index + 1) == Some(&b'/') => {
+                    end = index;
+                    break;
+                }
+                _ => {}
+            }
+            index += 1;
+        }
+        out.push_str(&line[..end]);
+        out.push('\n');
+    }
+    out
+}
+
+/// REGRESSION (`4vnt`/PR #3153, `3kza`/PR #3155): in `poll_pr_draft_tasks` the
+/// merged-PR branch MUST precede the tripwire active-hold gate.
+///
+/// This is the primary root cause. Both tasks carried a `tripwire.gate.held`
+/// activity event on their PR's *live* head (`d41958f6…`, `fef4a526…`), so
+/// `reconcile_tripwire_hold` returned `true` on every poll. The hold check used
+/// to sit ABOVE the merged check, so the loop `continue`d before ever reading
+/// `pr.merged`. Both PRs merged anyway, and the tasks sat in `pr_draft` with
+/// `closed_at: null` — 5 days for `4vnt` — holding dependents `296y` and `i58q`
+/// out of the build loop until an operator closed them by hand.
+/// `poll_pr_review_tasks` always had the correct order; only this loop was
+/// inverted.
+///
+/// SOURCE-LEVEL, and honestly labelled. Both branches sit after
+/// `gh_client.get_pull_request(..)`, and `resolve_installation_client` builds
+/// `GitHubApiClient::for_installation`, which hard-codes `api.github.com`; this
+/// crate carries no HTTP double and no base-URL seam on that path, so no test
+/// in this crate can drive `poll_pr_draft_tasks` to either branch. The
+/// behavioural half of the proof is the reconciliation coverage in
+/// `merged_reconcile::tests` (which does run the real terminalization against a
+/// real database); this half proves the primary loop cannot regress back into
+/// gating merge detection.
+///
+/// NAMED FAILING MUTATIONS.
+/// (a) Move `reconcile_tripwire_hold` back above the terminal-state match —
+///     the exact production state before this fix: the ordering assertion
+///     fails.
+/// (b) Delete the terminal-state match (never terminalize from `pr_draft`):
+///     the `Merged` arm is not found.
+/// (c) Delete the tripwire hold call: the hold anchor is not found.
+/// (d) Gate the merged arm on a stored head SHA: the SHA-free assertion fails.
+#[test]
+fn a_merged_pr_is_observed_before_the_tripwire_hold_gate() {
+    let code = strip_line_comments(include_str!("pr_watcher.rs"));
+
+    let poll_start = code
+        .find("pub(crate) async fn poll_pr_draft_tasks(")
+        .expect("poll_pr_draft_tasks is in pr_watcher.rs");
+    let body = &code[poll_start..];
+
+    let merged_arm = body
+        .find("merged_reconcile::PrTerminalState::Merged => {")
+        .expect("the pr_draft loop must have a merged-PR terminalization arm");
+    let closed_arm = body
+        .find("merged_reconcile::PrTerminalState::ClosedUnmerged => {")
+        .expect("the pr_draft loop must have a closed-without-merge arm");
+    let hold_gate = body
+        .find(".reconcile_tripwire_hold(")
+        .expect("the pr_draft loop must still evaluate the tripwire active hold");
+
+    assert!(
+        merged_arm < hold_gate,
+        "a merged PR is ground truth and must be observed BEFORE the tripwire \
+         active-hold gate; with the gate first, a held head that merges strands \
+         its task in pr_draft forever and never releases its dependents \
+         (incidents 4vnt/#3153 and 3kza/#3155)",
+    );
+    assert!(
+        closed_arm < hold_gate,
+        "a PR closed without merging is equally terminal and must not be masked \
+         by an advance gate either",
+    );
+
+    let classify = body
+        .find("merged_reconcile::classify_pr_terminal_state(")
+        .expect("terminal state must come from the shared classifier");
+    assert!(
+        classify < merged_arm,
+        "the merged arm must be driven by the shared classifier, so the primary \
+         loop and the reconciliation safety net cannot disagree about `merged`",
+    );
+
+    let classify_args = &body[classify..merged_arm];
+    for sha_token in ["head_sha", "head.sha", "merge_commit_sha"] {
+        assert!(
+            !classify_args.contains(sha_token),
+            "merge detection must not consult `{sha_token}`: both incident \
+             branches were force-pushed during a rebase, leaving every stored \
+             head SHA stale against the merged head",
+        );
+    }
+}

--- a/server/crates/djinn-coordinator/src/supervisor_impl/pr_tests.rs
+++ b/server/crates/djinn-coordinator/src/supervisor_impl/pr_tests.rs
@@ -1535,3 +1535,236 @@ async fn retained_legacy_cleanup_reaches_inline_and_stale_provider_boundaries() 
         set_installation_client_base_url_for_test(None);
     }
 }
+
+/// END-TO-END REGRESSION for tasks `4vnt` (PR #3153) and `3kza` (PR #3155).
+///
+/// Drives the **real** `poll_pr_draft_tasks` — production entry point, real
+/// installation-token client, real CI snapshot recording, real tripwire
+/// active-hold reconciliation — against a PR that GitHub reports as merged
+/// while an active `tripwire.gate.held` finding sits on that PR's live head.
+/// Only the HTTP endpoint is redirected, via the existing
+/// `set_installation_client_base_url_for_test` seam.
+///
+/// Before the fix the loop evaluated `reconcile_tripwire_hold` first, saw an
+/// active hold, and `continue`d before ever reading `pr.merged`. Both
+/// production tasks therefore sat in `pr_draft` with `closed_at: null` — 5 days
+/// for `4vnt` — and their dependents (`296y`, `i58q`) stayed blocked until an
+/// operator closed them by hand. A merged PR is ground truth: no Djinn-side
+/// advance gate may precede observing it.
+///
+/// The fixture reproduces the force-push shape too: the stored CI-snapshot head
+/// is the pre-force-push SHA, so a merge check keyed off any stored SHA would
+/// still strand the task.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn merged_pr_under_active_tripwire_hold_still_closes_its_pr_draft_task() {
+    let _lifecycle_guard = RETAINED_LEGACY_LIFECYCLE_GUARD.lock().await;
+    use crate::pr_poller::installation::set_installation_client_base_url_for_test;
+    use crate::tripwires::{
+        TRIPWIRE_EVENT_GATE_HELD,
+        activity_payloads::{
+            TripwireEvidenceSpan, TripwireFindingSummary, TripwireGateDecisionPayload,
+            TripwireSeverity,
+        },
+    };
+    use djinn_core::events::EventBus;
+    use djinn_core::models::{CiStatus, TaskPrCiSnapshotInput};
+    use djinn_db::{Database, EpicRepository, TaskRepository};
+    use djinn_provider::github_app::installations::prime_cache_for_tests;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    const INSTALLATION: u64 = 42_425;
+    const URL: &str = "https://github.com/acme/widget/pull/3155";
+    /// The head GitHub reports and merged.
+    const MERGED_HEAD: &str = "fef4a526f115c7e5ca6b86cf76856676389f176f";
+    /// The pre-force-push head Djinn still had stored (the `3kza` divergence).
+    const STALE_STORED_HEAD: &str = "0d67ee6e892124e38221a515b466b3b7a582f4d1";
+    const MERGE_COMMIT: &str = "06253f5ab0b48f14769598a8cded90a013d90206";
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/widget/pulls/3155"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "number": 3155,
+            "title": "merged while held",
+            // GitHub reports merged PRs as closed; `merged` is the ground truth.
+            "state": "closed",
+            "merged": true,
+            "merge_commit_sha": MERGE_COMMIT,
+            "html_url": URL,
+            "head": {"ref": "task/3kza", "sha": MERGED_HEAD},
+            "base": {"ref": "main", "sha": "base"},
+            "node_id": "PR_3kza"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/acme/widget/commits/{MERGED_HEAD}/check-runs"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 1,
+            "check_runs": [{
+                "id": 1, "name": "ci", "status": "completed", "conclusion": "success",
+                "html_url": "https://example.test/check/1"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let db = Database::open_in_memory().unwrap();
+    let events = EventBus::noop();
+    let epic = EpicRepository::new(db.clone(), events.clone())
+        .create("merged-under-hold", "", "", "", "", None)
+        .await
+        .unwrap();
+    let tasks = TaskRepository::new(db.clone(), events);
+    let task = tasks
+        .create(
+            &epic.id,
+            "merged while tripwire-held",
+            "",
+            "",
+            "task",
+            0,
+            "worker",
+            Some("pr_draft"),
+        )
+        .await
+        .unwrap();
+    tasks.set_pr_url(&task.id, URL).await.unwrap();
+    djinn_db::test_support::persist_project_github_installation_for_test(
+        &db,
+        &task.project_id,
+        "acme",
+        "widget",
+        INSTALLATION,
+    )
+    .await;
+    prime_cache_for_tests(INSTALLATION, "ghs_installation_fixture");
+
+    // The dependency chain that silently dropped out of the build loop.
+    let dependent = tasks
+        .create(&epic.id, "dependent", "", "", "task", 0, "worker", None)
+        .await
+        .unwrap();
+    tasks.add_blocker(&dependent.id, &task.id).await.unwrap();
+
+    // Stale stored head — the force-push shape both incidents carried.
+    tasks
+        .upsert_ci_snapshot(TaskPrCiSnapshotInput {
+            task_id: task.id.clone(),
+            pr_number: 3155,
+            head_sha: STALE_STORED_HEAD.into(),
+            ci_status: CiStatus::Passing,
+            blocking_required_check_names: vec![],
+            primary_blocking_check: None,
+            failure_annotations: None,
+            failure_fingerprint: None,
+            same_signature_count: 0,
+            last_remediation_base_sha: None,
+        })
+        .await
+        .unwrap();
+
+    // The active tripwire hold on the PR's LIVE head — the gate that used to
+    // mask merge detection for five days.
+    let finding = TripwireFindingSummary {
+        rule_id: "large_delete_or_rewrite".into(),
+        reason_code: "tripwire.large_delete_or_rewrite".into(),
+        severity: TripwireSeverity::HumanReviewRequired,
+        evidence: TripwireEvidenceSpan {
+            path: "server/crates/djinn-coordinator/src/rules.rs".into(),
+            start_line: None,
+            end_line: None,
+            evidence_redacted: false,
+        },
+        idempotency_key: "sha256:held-finding-1".into(),
+        content_fingerprint: "fp:sha256:held-finding-1".into(),
+        downgrade_reason: None,
+    };
+    let held = TripwireGateDecisionPayload {
+        event_type: TRIPWIRE_EVENT_GATE_HELD.to_owned(),
+        task_id: task.id.clone(),
+        project_id: task.project_id.clone(),
+        pr_number: Some(3155),
+        head_sha: MERGED_HEAD.into(),
+        base_sha: None,
+        policy_revision: "org-policy:default".into(),
+        allowlist_revision: None,
+        findings: vec![finding],
+        enforcement_finding_count: 1,
+        report_only_finding_count: 0,
+        idempotency_key: "sha256:held-gate-1".into(),
+        decided_at: None,
+    };
+    tasks
+        .log_activity(
+            Some(&task.id),
+            "coordinator",
+            "system",
+            TRIPWIRE_EVENT_GATE_HELD,
+            &serde_json::to_string(&held).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    unsafe { std::env::set_var("GITHUB_APP_ID", "1") };
+    set_installation_client_base_url_for_test(Some(server.uri()));
+
+    let (tx, _rx) = tokio::sync::broadcast::channel(8);
+    let (mut actor, cancel) = crate::test_helpers::make_coordinator_actor_cancellable(&db, &tx);
+    // Satisfy the production minimum-age guard without a 10s sleep: pretend the
+    // task has been in `pr_draft` for a minute. Every other gate is real.
+    actor.pr_draft_first_seen.insert(
+        task.id.clone(),
+        std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_secs(60))
+            .expect("monotonic clock is at least 60s past boot"),
+    );
+
+    // Sanity: the hold really is active on the live head, so this test is
+    // exercising the masked path and not a trivially-unheld one.
+    let reloaded = tasks.get(&task.id).await.unwrap().unwrap();
+    assert!(
+        actor
+            .reconcile_tripwire_hold(&reloaded, 3155, MERGED_HEAD)
+            .await,
+        "precondition: an active tripwire hold must be present on the merged head"
+    );
+
+    actor.poll_pr_draft_tasks().await;
+
+    let closed = tasks.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        closed.status, "closed",
+        "a merged PR must close its task even while a tripwire hold is active on \
+         its head — the hold gates ADVANCING a PR, not observing one that already \
+         merged (incidents 4vnt/#3153 and 3kza/#3155)"
+    );
+    assert_eq!(closed.close_reason.as_deref(), Some("completed"));
+    assert!(closed.closed_at.is_some(), "closed_at must be populated");
+    assert_eq!(
+        closed.merge_commit_sha.as_deref(),
+        Some(MERGE_COMMIT),
+        "a task closed as merged must record which commit merged it"
+    );
+
+    let ready: Vec<String> = tasks
+        .list_ready(djinn_db::ReadyQuery::default())
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|t| t.id)
+        .collect();
+    assert!(
+        ready.contains(&dependent.id),
+        "closing the merged task must release its blocked dependent"
+    );
+
+    set_installation_client_base_url_for_test(None);
+    cancel.cancel();
+    db.pool().close().await;
+}

--- a/server/crates/djinn-db/src/repositories/task/reads.rs
+++ b/server/crates/djinn-db/src/repositories/task/reads.rs
@@ -164,16 +164,25 @@ impl TaskRepository {
             .await?)
     }
 
-    /// List tasks the PR poller's status-scoped loops never observe but which
-    /// still carry a live PR reference: a non-empty `pr_url`, a non-terminal
-    /// status, and a status the poller does NOT own (`pr_draft` / `pr_review`
-    /// are polled directly and must be excluded so their loops keep sole
-    /// ownership). This is the poller's blind spot (`open`, `in_progress`,
-    /// `needs_task_review`, `needs_lead_intervention`, ...): a PR can merge —
-    /// or its head CI can change — while the task sits in one of these states
-    /// with nothing reconciling it. The reconciliation pass iterates this set.
-    /// The result is intentionally small (only non-terminal tasks that ever
-    /// opened a PR), so a single unfiltered scan per slow tick is cheap.
+    /// List every non-terminal task that still carries a live PR reference: a
+    /// non-empty `pr_url` and a status other than `closed`. The merged-PR
+    /// reconciliation pass iterates this set. The result is intentionally small
+    /// (only non-terminal tasks that ever opened a PR), so a single unfiltered
+    /// scan per slow tick is cheap.
+    ///
+    /// This deliberately does **not** exclude the poller-owned statuses
+    /// `pr_draft` / `pr_review`. It used to, on the theory that their own poll
+    /// loops kept sole ownership — which put the hole in the safety net exactly
+    /// where the primary mechanism operates. Tasks `4vnt` (PR #3153, 5 days)
+    /// and `3kza` (PR #3155) both stranded in `pr_draft` with a merged PR
+    /// because the `pr_draft` loop `continue`d past its own merge check on an
+    /// active tripwire hold, and nothing else was allowed to look. A task that
+    /// never terminalizes never releases its dependents, so the cost of the
+    /// exclusion was a silently-stalled dependency chain.
+    ///
+    /// Covering these statuses is safe because terminalization is idempotent:
+    /// `closed` is excluded here and the reconciler re-reads the task row
+    /// immediately before transitioning it.
     pub async fn list_reconcilable_pr_tasks(&self) -> Result<Vec<Task>> {
         self.db.ensure_initialized().await?;
         Ok(sqlx::query_as::<_, Task>(
@@ -211,7 +220,7 @@ impl TaskRepository {
                     CAST(0 AS BIGINT) AS unresolved_blocker_count
              FROM tasks
              WHERE pr_url IS NOT NULL AND pr_url <> ''
-               AND status NOT IN ('closed', 'pr_draft', 'pr_review')
+               AND status <> 'closed'
              ORDER BY priority, created_at"#,
         )
         .fetch_all(self.db.pool())


### PR DESCRIPTION
A PR merges, the commit is on `main`, and the djinn task stays at `pr_draft` forever with `closed_at: null` and `merge_commit_sha: null`. It never self-heals. The damage is not the status column — **a task that never closes never releases its blockers**, so a whole dependency chain silently drops out of the build loop.

Observed twice in production on 2026-08-16.

| task | PR | merged | stranded | dependent |
|---|---|---|---|---|
| `4vnt` | #3153 | 2026-08-11T13:22:12Z | **5 days** in `pr_draft`, all 5 ACs met, `ci_status: passing` | `296y`, blocked the whole time; dispatched within seconds of a manual close |
| `3kza` | #3155 | 2026-08-16T23:14:10Z | `pr_draft` with `ci.last_seen_at: 23:14:54` — the poller ran **44 s after** the merge | `i58q`, released the instant the task was closed by hand |

## Primary root cause

`poll_pr_draft_tasks` evaluated the **tripwire active-hold gate before reading `pr.merged`**.

`server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs` (pre-fix line numbers):

```
116  let ci_status = self.record_ci_snapshot(...).await;   // advances ci.last_seen_at
132  if self.reconcile_tripwire_hold(&task, pull_number, &pr.head.sha).await {
141      continue;                                          // ← masks everything below
     }
144  if pr.merged == Some(true) { ... }                     // never reached
172  if pr.state == PrState::Closed { ... }                 // never reached
```

Both tasks carry a `tripwire.gate.held` activity row on the PR's **live** head, with `severity: human_review_required` and no matching release — so `reconcile_tripwire_hold` returned `true` on every tick, forever:

* `4vnt` — held on `d41958f6…` at 2026-08-09T16:56:24Z (3 × `dependency_identity_change`); PR merged 2026-08-11.
* `3kza` — held on `fef4a526…` at 2026-08-16T22:55:55Z (3 × `large_delete_or_rewrite`); PR merged 19 min later.

`ci.last_seen_at` advancing *past* the merge is what pins the location: the loop reached `record_ci_snapshot` (line 116) and then `continue`d, and the only statement between that call and the merged branch is the tripwire hold. `poll_pr_review_tasks` has always had the correct order (merged → closed → CI gate → tripwire gate); only the `pr_draft` loop was inverted.

### Hypotheses ruled out

| hypothesis | verdict | evidence |
|---|---|---|
| merge detection keyed off a stale stored SHA | **no** | the branch is `pr.merged == Some(true)` from the live fetch; no SHA is compared. `ci_head_sha` matched the merged head exactly on both tasks (`d41958f6`, `fef4a526`). |
| the merge queue merges a different commit than the PR head | **no** | same — no SHA comparison exists on this path. |
| `task_pr_handling_is_eligible` / direct-delivery gating short-circuits | **no** | that check (line 41) precedes `record_ci_snapshot` (line 116), and `ci.last_seen_at` kept advancing — so eligibility passed on every tick. |
| the `pr_draft` loop has no merge-terminalization branch at all | **no** | it exists at line 144; it was simply unreachable under a hold. |

The `github_head_sha` divergence noted during triage (`b3aaede1…` vs `d41958f6…`; `0d67ee6e…` vs `fef4a526…`) is real — both branches were force-pushed during a rebase — but it is **not** this bug's cause. It is preserved as a regression anyway, because a future SHA-keyed merge check would strand these same tasks for a second, independent reason.

`merge_commit_sha: null` on both tasks is a consequence of the operator's manual close (a plain `pr_draft → closed` status change), not a separate defect: `apply_pr_merge` already persists it. The reconciliation path now asserts it.

## The safety-net hole

`merged_reconcile.rs` exists precisely for "a PR merged and nobody noticed". Its query, `TaskRepository::list_reconcilable_pr_tasks` (`djinn-db/src/repositories/task/reads.rs`), read:

```sql
WHERE pr_url IS NOT NULL AND pr_url <> ''
  AND status NOT IN ('closed', 'pr_draft', 'pr_review')
```

It excluded `pr_draft` and `pr_review` — the exact statuses both incidents were stuck in — on the theory that the poller loops kept sole ownership there. That put the hole in the net precisely where the primary mechanism operates, so a miss in the poller loop was covered by nothing and never self-healed.

## What changed

**Primary** (`pr_watcher.rs`) — **only** the merged branch moves above the tripwire hold, driven by a new shared classifier `merged_reconcile::classify_pr_terminal_state(merged, state)`. It takes no SHA and no gate state, so neither a hold nor a stored head can gate merge detection. The reconciler's `decide_blindspot_reconcile_action` delegates to the same classifier, so the primary path and the safety net cannot drift apart on what "merged" means.

The closed-unmerged branch deliberately **stays below** the hold, byte-identical to `main`. Merging is a fact Djinn records — once GitHub says merged, every advance action below the gate is moot. Force-closing is an action Djinn *takes*, and `ForceClose` is exempt from the blocks-others guard (`task/status.rs:634`), so it releases every dependent. Hoisting it would mean a reviewer who closes a human-review-held PR unmerged, intending a redo, instead releases dependents onto work that never landed — a wrong-close, worse than the stranding this fixes, and not required by either incident. The ordering guard now pins the asymmetry in both directions.

**Safety net** (`reads.rs`, `merged_reconcile.rs`) — the query becomes `status <> 'closed'`. Terminalization routing splits: a task already in `pr_draft`/`pr_review` takes `PrMerge` directly (carrying `RECONCILE_MERGE_REASON` on the `pr_merge` transition via the new `apply_pr_merge_with_reason`), skipping the pointless `user_override → pr_review` hop; blind-spot statuses keep that hop, since `PrMerge` is only valid from those two. Idempotency: the task row is re-read immediately before the transition and a `closed` task is skipped, so the poller and the reconciler observing the same merge cannot double-transition. Open PRs in poller-owned statuses are left completely alone — their own loop refreshes CI every tick.

## Tests

Each of the first six was verified to **fail against the pre-fix code** and pass after (stash-and-verify runs in the task report).

| test | proves |
|---|---|
| `merged_pr_under_active_tripwire_hold_still_closes_its_pr_draft_task` (`supervisor_impl/pr_tests.rs`) | **End-to-end.** Drives the real `poll_pr_draft_tasks` — real installation-token client, real CI snapshot recording, real tripwire hold reconciliation, only the HTTP endpoint redirected via the existing wiremock seam — against a PR GitHub reports as `merged: true` with an active hold on the live head *and* a stale stored head SHA. **Pre-fix it observes `pr_draft`**; post-fix `closed` / `completed` / populated `merge_commit_sha`, and the blocked dependent becomes ready. |
| `a_merged_pr_is_observed_before_the_tripwire_hold_gate` | Source-level ordering guard, honestly labelled, with named failing mutations — the loop cannot regress into gating merge detection again. Verified to fail when the tripwire block is moved back above the terminal match. |
| `list_reconcilable_covers_poller_owned_statuses` | The safety-net hole: `pr_draft`/`pr_review` tasks with a PR are reconcilable. |
| `merged_pr_in_pr_draft_terminalizes_and_releases_its_dependent` | The 4vnt/3kza shape through the reconciler: select → decide → terminalize; `close_reason: completed`, populated `merge_commit_sha`, reconciliation named in the audit trail, **and the blocked dependent becomes ready**. |
| `force_pushed_stale_head_shas_do_not_block_terminalization` | Stored snapshot head and `task_attempts.github_head_sha` both stale against the merged head (the production divergence, verbatim SHAs) — the task still terminalizes. |
| `merged_pr_in_a_blind_spot_status_routes_through_pr_review_and_closes` | The `user_override → pr_review` hop for a non-poller-owned status (`needs_task_review`) — the status `poll_pr_review_stuck_tasks` leaves a merged PR sitting in, since that loop observes the merge and merely `continue`s. Verified by deleting the hop: 12 passed, 1 failed, only this test. |
| `reconciled_merge_is_idempotent` / `poller_terminalized_task_is_left_alone` / `list_reconcilable_excludes_terminalized_tasks` | Running twice, and running against a task the poller already terminalized, causes no second transition and no extra audit row. |
| `closed_unmerged_logs_only`, `open_pr_refreshes_ci_only` (preserved) | Negative controls: a CLOSED-unmerged PR still does not close its task; an OPEN PR is still left alone with only a CI refresh. |

**Results:** `cargo nextest run -p djinn-coordinator --lib --features test-support` → **2319 passed, 0 failed**. `cargo fmt --all`, `git diff --check`, `cargo clippy` (djinn-db + djinn-coordinator, lib + tests) all clean. `BASE_SHA=origin/main ./scripts/check-raw-sql-boundary.sh` → OK (6 files checked); `./scripts/test-check-raw-sql-boundary.sh` → 59 passed, 0 failed. All DB-backed tests ran against a dedicated throwaway Postgres, never the shared test database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
