### PR TITLE
chore(hb3s): Prove persisted Phase-C rejection closure through migrated Postgres

### DIFF
--- a/server/crates/djinn-coordinator/src/model_turn_admission.rs
+++ b/server/crates/djinn-coordinator/src/model_turn_admission.rs
@@ -1488,85 +1488,85 @@ mod tests {
                 .expect("restore pool labels");
         };
 
-        // Malformed durable summary.
-        for malformed in [
-            "{",
-            "null",
-            r#"{"provider_id":"canonical-provider","model_id":"namespace/foo","trainable":true,"diagnostics":[],"reporter_text":"leak"}"#,
-            r#"{"provider_id":"canonical-provider","model_id":"namespace/foo","trainable":true,"diagnostics":[{"pool_id":9,"code":"free_text"}]}"#,
-        ] {
-            restore().await;
-            repository
-                .upsert_raw_controller_window_for_test(
-                    pool_id,
-                    2,
-                    WINDOW_START,
-                    WINDOW_END,
-                    5,
-                    4,
-                    malformed,
-                )
-                .await
-                .expect("raw malformed write");
-            assert!(
-                read(2, WINDOW_START, WINDOW_END).await.is_none(),
-                "malformed durable summary {malformed} must yield no learner window"
-            );
-        }
-
-        // Durable second-precision bounds that disagree with the sequence, and
-        // an aligned pair that is not the exact 60-second half-open window.
-        for (label, started_at, ended_at) in [
+        // Malformed summaries, sequence/boundary-mismatched bounds, and invalid
+        // counts cannot reach the learner because migration 210's hardened
+        // ledger will not store them at all — proved here against the real
+        // schema, with `project_learner_window`'s pure regression in `djinn-db`
+        // covering the same shapes should a corrupted store ever produce one.
+        let json = serde_json::to_string(&summary).expect("summary json");
+        let unstorable: Vec<(&str, i64, &str, &str, i64, i64, &str)> = vec![
+            ("truncated summary", 2, WINDOW_START, WINDOW_END, 5, 4, "{"),
+            ("null summary", 2, WINDOW_START, WINDOW_END, 5, 4, "null"),
+            (
+                "summary with an extra key",
+                2,
+                WINDOW_START,
+                WINDOW_END,
+                5,
+                4,
+                r#"{"provider_id":"canonical-provider","model_id":"namespace/foo","trainable":true,"diagnostics":[],"reporter_text":"leak"}"#,
+            ),
+            (
+                "summary with an unknown reason code",
+                2,
+                WINDOW_START,
+                WINDOW_END,
+                5,
+                4,
+                r#"{"provider_id":"canonical-provider","model_id":"namespace/foo","trainable":false,"diagnostics":[{"pool_id":0,"code":"free_text"}]}"#,
+            ),
             (
                 "sequence disagrees with durable start",
+                2,
                 "1970-01-01T00:03:00Z",
                 "1970-01-01T00:04:00Z",
+                5,
+                4,
+                &json,
             ),
             (
                 "sub-minute durable span",
+                2,
                 "1970-01-01T00:02:00Z",
                 "1970-01-01T00:02:30Z",
+                5,
+                4,
+                &json,
             ),
-        ] {
+            (
+                "negative admitted count",
+                2,
+                WINDOW_START,
+                WINDOW_END,
+                -1,
+                4,
+                &json,
+            ),
+        ];
+        for (label, sequence, started_at, ended_at, admitted, completed, body) in unstorable {
             restore().await;
-            repository
-                .upsert_raw_controller_window_for_test(
-                    pool_id,
-                    2,
-                    started_at,
-                    ended_at,
-                    5,
-                    4,
-                    &serde_json::to_string(&summary).expect("summary json"),
-                )
-                .await
-                .expect("raw boundary write");
             assert!(
-                read(2, started_at, ended_at).await.is_none(),
-                "{label} must yield no learner window"
+                repository
+                    .upsert_raw_controller_window_for_test(
+                        pool_id, sequence, started_at, ended_at, admitted, completed, body,
+                    )
+                    .await
+                    .is_err(),
+                "the durable ledger must refuse {label} outright"
+            );
+            assert_eq!(
+                read(2, WINDOW_START, WINDOW_END).await,
+                Some(PhaseCLearnerWindowV1 {
+                    pool_id,
+                    window_sequence: 2,
+                    started_at: WINDOW_START.into(),
+                    ended_at: WINDOW_END.into(),
+                    admitted_turns: 5,
+                    completed_turns: 4,
+                }),
+                "a refused write must not disturb the window already stored"
             );
         }
-
-        // Count-invalid: the durable ledger physically refuses negative counts,
-        // so a negative count can only ever reach the projection through a
-        // corrupted store — where `project_learner_window` rejects it (proved by
-        // the djinn-db projection regression).
-        restore().await;
-        assert!(
-            repository
-                .upsert_raw_controller_window_for_test(
-                    pool_id,
-                    2,
-                    WINDOW_START,
-                    WINDOW_END,
-                    -1,
-                    4,
-                    &serde_json::to_string(&summary).expect("summary json"),
-                )
-                .await
-                .is_err(),
-            "the durable ledger must reject a negative turn count outright"
-        );
 
         // Pool-label mismatch: the summary copy still resolves, but the pool's
         // own durable labels no longer agree with it.
@@ -1836,3 +1836,10 @@ mod tests {
         );
     }
 }
+
+/// Migration-backed Phase-C conformance (task hb3s). Kept as a child module
+/// so it can build `ExpectedAttemptPathV1` values the way production does,
+/// through this module's deliberately private route fields.
+#[cfg(test)]
+#[path = "model_turn_admission_phase_c_postgres_tests.rs"]
+mod phase_c_postgres_tests;

--- a/server/crates/djinn-coordinator/src/model_turn_admission_phase_c_postgres_tests.rs
+++ b/server/crates/djinn-coordinator/src/model_turn_admission_phase_c_postgres_tests.rs
@@ -1,0 +1,610 @@
+//! Phase-C controller-window conformance over migrated Postgres (epic ai6g, hb3s).
+//!
+//! Every window here comes out of the real qualifier and goes through gscv's
+//! catalog-qualified persistence seam, then comes back — or does not — through
+//! the exact-bound learner seam. Nothing hand-builds a summary and calls it
+//! evidence, and nothing asks the database to decide catalog membership.
+
+use super::*;
+use djinn_core::models::{Model, Pricing, Provider};
+use djinn_db::{Database, repositories::test_support::seed_scoped_model_turn_admission_fixture};
+use djinn_provider::{ProviderAttemptAbortResultV1, ProviderAttemptTerminalV1, ProviderOutcomeV1};
+
+const PROVIDER: &str = "hb3s-provider";
+const MODEL: &str = "namespace/hb3s-model";
+const WINDOW_START: &str = "1970-01-01T00:02:00Z";
+const WINDOW_END: &str = "1970-01-01T00:03:00Z";
+const SEQUENCE: i64 = 2;
+
+fn catalog() -> CatalogService {
+    let catalog = CatalogService::new();
+    catalog.add_custom_provider(
+        Provider {
+            id: PROVIDER.into(),
+            name: "hb3s Provider".into(),
+            npm: String::new(),
+            env_vars: vec!["HB3S_API_KEY".into()],
+            base_url: "https://example.invalid/v1".into(),
+            docs_url: String::new(),
+            is_openai_compatible: true,
+        },
+        vec![Model {
+            id: MODEL.into(),
+            provider_id: PROVIDER.into(),
+            name: "hb3s Model".into(),
+            tool_call: false,
+            reasoning: false,
+            attachment: false,
+            context_window: 1,
+            output_limit: 1,
+            pricing: Pricing::default(),
+        }],
+    );
+    catalog
+}
+
+fn path(pool_id: i64, revision: &str) -> ExpectedAttemptPathV1 {
+    ExpectedAttemptPathV1 {
+        slot_pod_uid: "slot-uid".into(),
+        deployment_revision: revision.into(),
+        provider: PROVIDER.into(),
+        model_scope: MODEL.into(),
+        pool_id,
+    }
+}
+
+fn window() -> AlignedPhaseCWindowV1 {
+    AlignedPhaseCWindowV1::new(120).expect("aligned window")
+}
+
+fn accounting() -> PhaseCWindowAccountingV1 {
+    PhaseCWindowAccountingV1 {
+        window_sequence: SEQUENCE,
+        started_at: WINDOW_START.into(),
+        ended_at: WINDOW_END.into(),
+        admitted_turns: 8,
+        completed_turns: 8,
+    }
+}
+
+fn covered(path: ExpectedAttemptPathV1) -> PhaseCCapabilityEvidenceV1 {
+    PhaseCCapabilityEvidenceV1 {
+        path,
+        coverage_start_second: 120,
+        coverage_end_second: 180,
+        observed_at_second: 150,
+        covered: true,
+    }
+}
+
+fn complete_attempt(path: ExpectedAttemptPathV1) -> PhaseCAdmittedAttemptV1 {
+    let provider = ProviderOutcomeV1 {
+        terminal: ProviderAttemptTerminalV1::Completed,
+        authoritative_usage: None,
+        observation: None,
+        abort: ProviderAttemptAbortResultV1::NotRequested,
+        token_emission: Default::default(),
+    };
+    let stages = [
+        (PhaseCAttemptStageV1::Decision, 121),
+        (PhaseCAttemptStageV1::Dispatch, 122),
+        (PhaseCAttemptStageV1::Heartbeat, 123),
+        (PhaseCAttemptStageV1::ProviderOutcome, 124),
+        (PhaseCAttemptStageV1::Reconcile, 125),
+    ]
+    .into_iter()
+    .map(|(stage, timestamp_second)| PhaseCAttemptStageEvidenceV1 {
+        stage,
+        timestamp_second,
+        outcome: if stage == PhaseCAttemptStageV1::ProviderOutcome {
+            PhaseCAttemptEvidenceOutcomeV1::Provider(Box::new(provider.clone()))
+        } else {
+            PhaseCAttemptEvidenceOutcomeV1::Recorded
+        },
+    })
+    .collect();
+    PhaseCAdmittedAttemptV1 {
+        path,
+        admitted_at_second: 120,
+        has_authoritative_usage: true,
+        lease_expired: false,
+        breaker_open: false,
+        stages,
+    }
+}
+
+async fn seed(db: &Database, credential: &str) -> i64 {
+    seed_scoped_model_turn_admission_fixture(
+        db,
+        credential,
+        PROVIDER,
+        MODEL,
+        "shadow",
+        "supported",
+        1,
+    )
+    .await
+}
+
+async fn learner(
+    repository: &ModelTurnAdmissionRepository,
+    catalog: &CatalogService,
+    pool_id: i64,
+) -> Option<PhaseCLearnerWindowV1> {
+    learner_catalog_qualified_phase_c_window_v1(
+        repository,
+        catalog,
+        pool_id,
+        SEQUENCE,
+        WINDOW_START,
+        WINDOW_END,
+    )
+    .await
+    .expect("learner read")
+}
+
+/// A complete window is the only thing the qualifier admits, and the only thing
+/// that survives the round trip through migrated Postgres.
+#[tokio::test]
+async fn a_complete_window_round_trips_through_the_migrated_ledger() {
+    let db = Database::ephemeral().await.expect("db");
+    let pool_id = seed(&db, "hb3s-complete").await;
+    let repository = ModelTurnAdmissionRepository::new(db);
+    let catalog = catalog();
+    let path = path(pool_id, "revision-1");
+
+    let qualification = qualify_aligned_phase_c_window_v1(
+        window(),
+        std::slice::from_ref(&path),
+        &[covered(path.clone())],
+        &[complete_attempt(path.clone())],
+    );
+    assert!(
+        qualification.admitted && qualification.diagnostics.is_empty(),
+        "a complete chain under complete coverage must qualify: {qualification:?}"
+    );
+
+    persist_catalog_qualified_phase_c_window_v1(
+        &repository,
+        &catalog,
+        &path,
+        accounting(),
+        &qualification,
+    )
+    .await
+    .expect("persist the qualified window");
+
+    assert_eq!(
+        learner(&repository, &catalog, pool_id).await,
+        Some(PhaseCLearnerWindowV1 {
+            pool_id,
+            window_sequence: SEQUENCE,
+            started_at: WINDOW_START.into(),
+            ended_at: WINDOW_END.into(),
+            admitted_turns: 8,
+            completed_turns: 8,
+        })
+    );
+
+    // Nothing but the exact bounds is visible, and the label pair still has to
+    // resolve in the *current* catalog.
+    assert!(
+        learner_catalog_qualified_phase_c_window_v1(
+            &repository,
+            &catalog,
+            pool_id,
+            SEQUENCE,
+            WINDOW_START,
+            "1970-01-01T00:04:00Z",
+        )
+        .await
+        .expect("boundary-mismatched learner read")
+        .is_none()
+    );
+    catalog.remove_custom_provider(PROVIDER);
+    assert!(
+        learner(&repository, &catalog, pool_id).await.is_none(),
+        "a catalog-removed route must stop training an already-durable window"
+    );
+}
+
+/// Every incomplete-coverage and incomplete-chain shape the qualifier can
+/// report persists as a real diagnostic window, and none of them can train.
+#[tokio::test]
+async fn every_diagnostic_window_persists_and_stays_learner_invisible() {
+    let db = Database::ephemeral().await.expect("db");
+    let repository = ModelTurnAdmissionRepository::new(db.clone());
+    let catalog = catalog();
+    let base = path(0, "revision-1");
+
+    // (label, expected diagnostic, capability evidence, attempt mutation)
+    type Case = (
+        &'static str,
+        PhaseCWindowDiagnosticCodeV1,
+        fn(&ExpectedAttemptPathV1) -> Vec<PhaseCCapabilityEvidenceV1>,
+        fn(&mut PhaseCAdmittedAttemptV1),
+    );
+    let noop: fn(&mut PhaseCAdmittedAttemptV1) = |_| {};
+    let one_covered: fn(&ExpectedAttemptPathV1) -> Vec<PhaseCCapabilityEvidenceV1> =
+        |path| vec![covered(path.clone())];
+
+    let cases: Vec<Case> = vec![
+        (
+            "missing capability report",
+            PhaseCWindowDiagnosticCodeV1::MissingCapability,
+            |_| Vec::new(),
+            noop,
+        ),
+        (
+            "silent (uncovered) capability report",
+            PhaseCWindowDiagnosticCodeV1::UncoveredCapability,
+            |path| {
+                vec![PhaseCCapabilityEvidenceV1 {
+                    covered: false,
+                    ..covered(path.clone())
+                }]
+            },
+            noop,
+        ),
+        (
+            "duplicate capability report",
+            PhaseCWindowDiagnosticCodeV1::DuplicateCapability,
+            |path| vec![covered(path.clone()), covered(path.clone())],
+            noop,
+        ),
+        (
+            "partial capability coverage",
+            PhaseCWindowDiagnosticCodeV1::PartialCapabilityCoverage,
+            |path| {
+                vec![PhaseCCapabilityEvidenceV1 {
+                    coverage_start_second: 130,
+                    ..covered(path.clone())
+                }]
+            },
+            noop,
+        ),
+        (
+            "heartbeat observed outside the window",
+            PhaseCWindowDiagnosticCodeV1::StaleHeartbeat,
+            |path| {
+                vec![PhaseCCapabilityEvidenceV1 {
+                    observed_at_second: 60,
+                    ..covered(path.clone())
+                }]
+            },
+            noop,
+        ),
+        (
+            "revision-skewed capability report",
+            PhaseCWindowDiagnosticCodeV1::UnexpectedCapability,
+            |path| {
+                vec![
+                    covered(path.clone()),
+                    covered(ExpectedAttemptPathV1 {
+                        deployment_revision: "revision-2".into(),
+                        ..path.clone()
+                    }),
+                ]
+            },
+            noop,
+        ),
+        (
+            "missing authoritative usage",
+            PhaseCWindowDiagnosticCodeV1::MissingUsage,
+            one_covered,
+            |attempt| attempt.has_authoritative_usage = false,
+        ),
+        (
+            "expired lease",
+            PhaseCWindowDiagnosticCodeV1::ExpiredLease,
+            one_covered,
+            |attempt| attempt.lease_expired = true,
+        ),
+        (
+            "open breaker",
+            PhaseCWindowDiagnosticCodeV1::OpenBreaker,
+            one_covered,
+            |attempt| attempt.breaker_open = true,
+        ),
+        (
+            "incomplete chain",
+            PhaseCWindowDiagnosticCodeV1::MissingStage,
+            one_covered,
+            |attempt| {
+                attempt
+                    .stages
+                    .retain(|item| item.stage != PhaseCAttemptStageV1::Reconcile)
+            },
+        ),
+        (
+            "duplicate chain stage",
+            PhaseCWindowDiagnosticCodeV1::DuplicateStage,
+            one_covered,
+            |attempt| {
+                let first = attempt.stages[0].clone();
+                attempt.stages.push(first);
+            },
+        ),
+        (
+            "missing stage outcome",
+            PhaseCWindowDiagnosticCodeV1::MissingStageOutcome,
+            one_covered,
+            |attempt| {
+                for item in attempt.stages.iter_mut() {
+                    if item.stage == PhaseCAttemptStageV1::Heartbeat {
+                        item.outcome = PhaseCAttemptEvidenceOutcomeV1::Missing;
+                    }
+                }
+            },
+        ),
+        (
+            "provider stage without a provider outcome",
+            PhaseCWindowDiagnosticCodeV1::InvalidStageOutcome,
+            one_covered,
+            |attempt| {
+                for item in attempt.stages.iter_mut() {
+                    if item.stage == PhaseCAttemptStageV1::ProviderOutcome {
+                        item.outcome = PhaseCAttemptEvidenceOutcomeV1::Recorded;
+                    }
+                }
+            },
+        ),
+        (
+            "stage recorded outside the window",
+            PhaseCWindowDiagnosticCodeV1::StageOutsideWindow,
+            one_covered,
+            |attempt| attempt.stages[0].timestamp_second = 60,
+        ),
+        (
+            "reordered chain",
+            PhaseCWindowDiagnosticCodeV1::ReversedStages,
+            one_covered,
+            |attempt| {
+                attempt.stages[0].timestamp_second = 179;
+            },
+        ),
+    ];
+
+    for (index, (label, expected, evidence, mutate)) in cases.into_iter().enumerate() {
+        let pool_id = seed(&db, &format!("hb3s-diag-{index}")).await;
+        let path = ExpectedAttemptPathV1 {
+            pool_id,
+            ..base.clone()
+        };
+        let mut attempt = complete_attempt(path.clone());
+        mutate(&mut attempt);
+        let qualification = qualify_aligned_phase_c_window_v1(
+            window(),
+            std::slice::from_ref(&path),
+            &evidence(&path),
+            &[attempt],
+        );
+        assert!(
+            !qualification.admitted,
+            "{label} must not qualify: {qualification:?}"
+        );
+        assert!(
+            qualification
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == expected),
+            "{label} must report {expected:?}, got {:?}",
+            qualification.diagnostics
+        );
+
+        persist_catalog_qualified_phase_c_window_v1(
+            &repository,
+            &catalog,
+            &path,
+            accounting(),
+            &qualification,
+        )
+        .await
+        .unwrap_or_else(|error| panic!("{label} must persist as a diagnostic window: {error}"));
+
+        // The row is really there — this is not a silently skipped write.
+        let stored = repository
+            .controller_window_summary_for_test(pool_id, SEQUENCE)
+            .await
+            .expect("read persisted summary")
+            .unwrap_or_else(|| panic!("{label} left no durable row"));
+        assert!(!stored.trainable, "{label} must be stored as untrainable");
+        assert!(
+            !stored.diagnostics.is_empty(),
+            "{label} must store its reason codes"
+        );
+        assert!(
+            stored
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.pool_id == 0 || diagnostic.pool_id == pool_id),
+            "{label} stored a foreign pool identity: {:?}",
+            stored.diagnostics
+        );
+
+        assert!(
+            learner(&repository, &catalog, pool_id).await.is_none(),
+            "{label} must remain learner-invisible"
+        );
+    }
+
+    // An attempt on a path outside the coordinator-owned denominator is an
+    // unknown path, and is reported against the zero sentinel.
+    let pool_id = seed(&db, "hb3s-unknown-path").await;
+    let expected = ExpectedAttemptPathV1 {
+        pool_id,
+        ..base.clone()
+    };
+    let foreign = ExpectedAttemptPathV1 {
+        slot_pod_uid: "other-slot".into(),
+        ..expected.clone()
+    };
+    let qualification = qualify_aligned_phase_c_window_v1(
+        window(),
+        std::slice::from_ref(&expected),
+        &[covered(expected.clone())],
+        &[complete_attempt(foreign)],
+    );
+    assert!(
+        qualification
+            .diagnostics
+            .iter()
+            .any(
+                |diagnostic| diagnostic.code == PhaseCWindowDiagnosticCodeV1::UnknownAttemptPath
+                    && diagnostic.pool_id == 0
+            ),
+        "an unknown attempt path must be reported against the zero sentinel: {qualification:?}"
+    );
+    persist_catalog_qualified_phase_c_window_v1(
+        &repository,
+        &catalog,
+        &expected,
+        accounting(),
+        &qualification,
+    )
+    .await
+    .expect("persist the unknown-path diagnostic window");
+    assert!(learner(&repository, &catalog, pool_id).await.is_none());
+
+    // An empty denominator is itself a diagnostic, reported against the sentinel.
+    let empty = qualify_aligned_phase_c_window_v1(window(), &[], &[], &[]);
+    assert!(
+        empty.diagnostics.iter().any(|diagnostic| diagnostic.code
+            == PhaseCWindowDiagnosticCodeV1::EmptyExpectedDenominator
+            && diagnostic.pool_id == 0),
+        "{empty:?}"
+    );
+}
+
+/// Each pool owns its own diagnostics. A sibling's positive identity is neither
+/// serialised into another pool's summary nor accepted by the typed boundary.
+#[tokio::test]
+async fn multi_pool_qualification_keeps_every_diagnostic_pool_local() {
+    let db = Database::ephemeral().await.expect("db");
+    let first = seed(&db, "hb3s-pool-a").await;
+    let second = seed(&db, "hb3s-pool-b").await;
+    let repository = ModelTurnAdmissionRepository::new(db);
+    let catalog = catalog();
+
+    let first_path = path(first, "revision-1");
+    let second_path = ExpectedAttemptPathV1 {
+        slot_pod_uid: "slot-uid-b".into(),
+        ..path(second, "revision-1")
+    };
+    let mut first_attempt = complete_attempt(first_path.clone());
+    first_attempt.has_authoritative_usage = false;
+    let mut second_attempt = complete_attempt(second_path.clone());
+    second_attempt.breaker_open = true;
+
+    let qualification = qualify_aligned_phase_c_window_v1(
+        window(),
+        &[first_path.clone(), second_path.clone()],
+        &[covered(first_path.clone()), covered(second_path.clone())],
+        &[first_attempt, second_attempt],
+    );
+    assert!(!qualification.admitted);
+    // The shared qualification really does mention both pools; the per-pool
+    // filtering below is therefore doing work.
+    assert!(
+        qualification
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.pool_id == first)
+            && qualification
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.pool_id == second)
+    );
+
+    for path in [&first_path, &second_path] {
+        persist_catalog_qualified_phase_c_window_v1(
+            &repository,
+            &catalog,
+            path,
+            accounting(),
+            &qualification,
+        )
+        .await
+        .expect("persist per-pool diagnostics");
+    }
+
+    for (pool_id, sibling, own_code, sibling_code) in [
+        (
+            first,
+            second,
+            PhaseCWindowDiagnosticCodeV1::MissingUsage,
+            PhaseCWindowDiagnosticCodeV1::OpenBreaker,
+        ),
+        (
+            second,
+            first,
+            PhaseCWindowDiagnosticCodeV1::OpenBreaker,
+            PhaseCWindowDiagnosticCodeV1::MissingUsage,
+        ),
+    ] {
+        let stored = repository
+            .controller_window_summary_for_test(pool_id, SEQUENCE)
+            .await
+            .expect("read persisted summary")
+            .expect("persisted summary");
+        let json = serde_json::to_value(&stored.diagnostics).expect("diagnostics json");
+        let json = json.as_array().expect("diagnostics array");
+        assert!(
+            json.iter()
+                .all(|diagnostic| diagnostic["pool_id"] == 0 || diagnostic["pool_id"] == pool_id),
+            "pool {pool_id} stored a foreign identity: {json:?}"
+        );
+        assert!(
+            !json
+                .iter()
+                .any(|diagnostic| diagnostic["pool_id"] == sibling),
+            "pool {pool_id} must not carry pool {sibling}'s identity"
+        );
+        let own = serde_json::to_value(own_code).expect("own code");
+        let other = serde_json::to_value(sibling_code).expect("sibling code");
+        assert!(json.iter().any(|diagnostic| diagnostic["code"] == own));
+        assert!(!json.iter().any(|diagnostic| diagnostic["code"] == other));
+        assert!(learner(&repository, &catalog, pool_id).await.is_none());
+    }
+
+    // The typed storage boundary refuses a sibling's positive identity outright,
+    // so the filtering above is a contract and not merely a convention.
+    let forged = PhaseCWindowQualificationV1 {
+        admitted: false,
+        diagnostics: qualification.diagnostics.clone(),
+    };
+    let smuggled = ExpectedAttemptPathV1 {
+        pool_id: first,
+        ..second_path.clone()
+    };
+    assert!(
+        persist_catalog_qualified_phase_c_window_v1(
+            &repository,
+            &catalog,
+            &smuggled,
+            PhaseCWindowAccountingV1 {
+                window_sequence: 3,
+                started_at: "1970-01-01T00:03:00Z".into(),
+                ended_at: "1970-01-01T00:04:00Z".into(),
+                ..accounting()
+            },
+            &forged,
+        )
+        .await
+        .is_ok(),
+        "the wrapper filters foreign identities rather than failing the write"
+    );
+    let stored = repository
+        .controller_window_summary_for_test(first, 3)
+        .await
+        .expect("read persisted summary")
+        .expect("persisted summary");
+    assert!(
+        stored
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.pool_id == 0 || diagnostic.pool_id == first),
+        "{:?}",
+        stored.diagnostics
+    );
+}

--- a/server/crates/djinn-db/migrations_postgres/210_phase_c_controller_window_hardening.sql
+++ b/server/crates/djinn-db/migrations_postgres/210_phase_c_controller_window_hardening.sql
@@ -1,0 +1,86 @@
+-- Additive hardening for the existing Phase-C controller-window ledger created
+-- by 173_model_turn_admission.sql. No second ledger is introduced: every
+-- constraint below attaches to `model_turn_controller_windows` itself.
+--
+-- The coordinator remains the sole catalog authority. Nothing here validates a
+-- provider/model route against a models.dev snapshot or treats the pool label
+-- pair as proof of catalog membership; the schema only enforces the structural,
+-- closed shape that the typed Rust boundary already asserts, so a row that
+-- bypasses that boundary still cannot become a trainable learner window.
+
+-- Exact aligned 60-second half-open bounds at second precision.
+ALTER TABLE model_turn_controller_windows
+    ADD CONSTRAINT model_turn_controller_windows_aligned_minute CHECK (
+        (started_at AT TIME ZONE 'UTC') = date_trunc('minute', started_at AT TIME ZONE 'UTC')
+        AND ended_at = started_at + interval '60 seconds'
+    );
+
+-- `window_sequence` is the aligned minute index of `started_at`.
+ALTER TABLE model_turn_controller_windows
+    ADD CONSTRAINT model_turn_controller_windows_sequence_matches_start CHECK (
+        window_sequence = floor(extract(epoch FROM (started_at AT TIME ZONE 'UTC')) / 60)::bigint
+    );
+
+-- Closed typed summary: exactly four top-level keys, typed values, bounded
+-- closed diagnostic reason codes, pool-local-or-zero diagnostic identity, and
+-- trainable implying no diagnostics.
+CREATE OR REPLACE FUNCTION model_turn_controller_window_summary_is_closed(
+    owning_pool_id BIGINT,
+    summary TEXT
+) RETURNS BOOLEAN
+LANGUAGE sql
+IMMUTABLE
+AS $fn$
+    -- CASE, not a chain of ANDs: `AND` gives no evaluation-order guarantee, so
+    -- an unparsable summary would raise 22P02 out of the cast instead of simply
+    -- failing the constraint. The guard has to run first, and only CASE
+    -- promises that.
+    SELECT CASE
+        WHEN summary IS NULL THEN false
+        WHEN NOT (summary IS JSON OBJECT) THEN false
+        ELSE (
+            SELECT (parsed.s - 'provider_id' - 'model_id' - 'trainable' - 'diagnostics' = '{}'::jsonb)
+               AND (parsed.s ?& array['provider_id', 'model_id', 'trainable', 'diagnostics'])
+               AND jsonb_typeof(parsed.s -> 'provider_id') = 'string'
+               AND btrim(parsed.s ->> 'provider_id') <> ''
+               AND length(parsed.s ->> 'provider_id') <= 191
+               AND jsonb_typeof(parsed.s -> 'model_id') = 'string'
+               AND btrim(parsed.s ->> 'model_id') <> ''
+               AND length(parsed.s ->> 'model_id') <= 191
+               AND jsonb_typeof(parsed.s -> 'trainable') = 'boolean'
+               AND jsonb_typeof(parsed.s -> 'diagnostics') = 'array'
+               AND jsonb_array_length(parsed.s -> 'diagnostics') <= 64
+               AND NOT (
+                   (parsed.s ->> 'trainable')::boolean
+                   AND jsonb_array_length(parsed.s -> 'diagnostics') > 0
+               )
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM jsonb_array_elements(parsed.s -> 'diagnostics') AS element
+                   WHERE jsonb_typeof(element) <> 'object'
+                      OR element - 'pool_id' - 'code' <> '{}'::jsonb
+                      OR NOT (element ?& array['pool_id', 'code'])
+                      OR jsonb_typeof(element -> 'pool_id') <> 'number'
+                      OR (element ->> 'pool_id') !~ '^(0|[1-9][0-9]*)$'
+                      OR (element ->> 'pool_id')::bigint NOT IN (0, owning_pool_id)
+                      OR jsonb_typeof(element -> 'code') <> 'string'
+                      OR (element ->> 'code') NOT IN (
+                             'empty_expected_denominator', 'missing_capability',
+                             'unexpected_capability', 'duplicate_capability',
+                             'uncovered_capability', 'partial_capability_coverage',
+                             'stale_heartbeat', 'unknown_attempt_path', 'missing_usage',
+                             'expired_lease', 'open_breaker', 'missing_stage',
+                             'duplicate_stage', 'missing_stage_outcome',
+                             'stage_outside_window', 'reversed_stages',
+                             'invalid_stage_outcome'
+                         )
+               )
+            FROM (SELECT summary::jsonb AS s) AS parsed
+        )
+    END;
+$fn$;
+
+ALTER TABLE model_turn_controller_windows
+    ADD CONSTRAINT model_turn_controller_windows_summary_closed CHECK (
+        model_turn_controller_window_summary_is_closed(pool_id, summary)
+    );

--- a/server/crates/djinn-db/tests/controller_window_repository.rs
+++ b/server/crates/djinn-db/tests/controller_window_repository.rs
@@ -1,0 +1,676 @@
+//! Migration 210 — Phase-C controller-window hardening (epic ai6g, task hb3s).
+//!
+//! The typed Rust boundary in `djinn-db` already refuses an out-of-contract
+//! controller window, but a boundary is only a boundary while every writer goes
+//! through it. These regressions prove the *durable ledger itself* refuses the
+//! same shapes, so a row that reached Postgres by any other route still cannot
+//! become a trainable learner window.
+//!
+//! Catalog authority is deliberately absent here. The schema knows nothing about
+//! models.dev, and the pool label pair is never treated as proof of catalog
+//! membership; that revalidation stays at the coordinator seam.
+
+use std::path::{Path, PathBuf};
+
+use djinn_db::{Database, repositories::test_support::seed_scoped_model_turn_admission_fixture};
+use sqlx::postgres::{PgConnection, PgPoolOptions};
+use sqlx::{Connection, Executor};
+
+const MIGRATION_VERSION: u64 = 210;
+const MIGRATION_FILE: &str = "210_phase_c_controller_window_hardening.sql";
+
+fn base_database_url() -> String {
+    djinn_db::test_database_base_url()
+}
+
+fn server_prefix(base: &str) -> String {
+    base.rsplit_once('/')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(base)
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+fn migrations_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations_postgres")
+}
+
+fn migration_entries(dir: &Path) -> Vec<(u64, PathBuf)> {
+    let mut entries: Vec<(u64, PathBuf)> = std::fs::read_dir(dir)
+        .expect("read migrations dir")
+        .map(|entry| {
+            let path = entry.expect("migration dir entry").path();
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            let version = name
+                .split_once('_')
+                .and_then(|(prefix, _)| prefix.parse::<u64>().ok())
+                .unwrap_or(0);
+            (version, path)
+        })
+        .filter(|(_, path)| path.extension().and_then(|e| e.to_str()) == Some("sql"))
+        .collect();
+    entries.sort_by(|(av, ap), (bv, bp)| {
+        av.cmp(bv).then_with(|| {
+            ap.file_name()
+                .unwrap_or_default()
+                .cmp(bp.file_name().unwrap_or_default())
+        })
+    });
+    entries
+}
+
+async fn with_temp_database<T, Fut>(suffix: &str, f: impl FnOnce(String) -> Fut) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    let base = base_database_url();
+    let prefix = server_prefix(&base);
+    let db_name = format!(
+        "djinn_migration_{}_{}",
+        suffix,
+        uuid::Uuid::now_v7().simple()
+    );
+    let admin_url = format!("{prefix}/postgres");
+    let mut admin = PgConnection::connect(&admin_url)
+        .await
+        .expect("connect postgres admin database");
+    admin
+        .execute(format!(r#"CREATE DATABASE "{db_name}""#).as_str())
+        .await
+        .expect("create migration test database");
+    drop(admin);
+
+    let db_url = format!("{prefix}/{db_name}");
+    let result = f(db_url).await;
+
+    let mut admin = PgConnection::connect(&admin_url)
+        .await
+        .expect("reconnect postgres admin database");
+    let _ = admin
+        .execute(
+            format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+            )
+            .as_str(),
+        )
+        .await;
+    admin
+        .execute(format!(r#"DROP DATABASE IF EXISTS "{db_name}""#).as_str())
+        .await
+        .expect("drop migration test database");
+
+    result
+}
+
+async fn assert_hardened_schema(db_url: &str) {
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(db_url)
+        .await
+        .expect("connect migration test database");
+
+    for constraint in [
+        "model_turn_controller_windows_aligned_minute",
+        "model_turn_controller_windows_sequence_matches_start",
+        "model_turn_controller_windows_summary_closed",
+    ] {
+        let present: Option<String> = sqlx::query_scalar(
+            "SELECT conname FROM pg_constraint \
+             WHERE conrelid = 'model_turn_controller_windows'::regclass \
+               AND contype = 'c' AND conname = $1",
+        )
+        .bind(constraint)
+        .fetch_optional(&pool)
+        .await
+        .unwrap_or_else(|e| panic!("inspect constraint {constraint}: {e}"));
+        assert_eq!(
+            present.as_deref(),
+            Some(constraint),
+            "expected CHECK constraint {constraint}"
+        );
+    }
+
+    // Exactly one controller-window ledger: the hardening is additive.
+    let tables: Vec<String> = sqlx::query_scalar(
+        "SELECT table_name FROM information_schema.tables \
+         WHERE table_schema = 'public' AND table_name LIKE '%controller_window%' \
+         ORDER BY table_name",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("inspect controller-window tables");
+    assert_eq!(tables, vec!["model_turn_controller_windows".to_owned()]);
+
+    pool.close().await;
+}
+
+#[tokio::test]
+async fn migration_210_applies_on_a_fresh_database() {
+    with_temp_database("fresh_phase_c_windows", |db_url| async move {
+        djinn_db::test_support::apply_all_migrations_to_fresh_database(&db_url).await;
+        assert_hardened_schema(&db_url).await;
+    })
+    .await;
+}
+
+/// The hardening is additive: it applies on top of the *prior* schema, over a
+/// ledger that already holds a controller-window row, and leaves that row alone.
+#[tokio::test]
+async fn migration_210_applies_additively_over_the_prior_schema() {
+    with_temp_database("prior_phase_c_windows", |db_url| async move {
+        const OPERATOR: &str = "00000000-0000-7000-8000-000000000210";
+        djinn_db::migrations::bootstrap_designated_operator(
+            &db_url,
+            &djinn_db::migrations::DesignatedOperatorBootstrap {
+                user_id: OPERATOR.to_owned(),
+                github_id: 9_000_000_210,
+                github_login: "hb3s-migration-operator".to_owned(),
+                github_name: None,
+                github_avatar_url: None,
+            },
+        )
+        .await
+        .expect("bootstrap designated operator");
+
+        let mut conn = PgConnection::connect(&db_url)
+            .await
+            .expect("connect prior migration database");
+        sqlx::query("SELECT set_config('djinn.migration_designated_operator_user_id', $1, false)")
+            .bind(OPERATOR)
+            .execute(&mut conn)
+            .await
+            .expect("publish designated operator to the migration session");
+        for (version, path) in migration_entries(&migrations_dir()) {
+            if version >= MIGRATION_VERSION {
+                break;
+            }
+            // Versions below the creator contract are already applied by the
+            // bootstrap above.
+            if version == 0 || version < 142 {
+                continue;
+            }
+            let sql = std::fs::read_to_string(&path).expect("read migration sql");
+            conn.execute(sql.as_str())
+                .await
+                .unwrap_or_else(|err| panic!("apply migration {} failed: {err}", path.display()));
+        }
+
+        // A pre-existing, in-contract controller-window row must survive the
+        // hardening: the new constraints are validated against it, not around it.
+        conn.execute(
+            "INSERT INTO credentials (id, provider_id, key_name, encrypted_value) \
+             VALUES ('hb3s-prior', 'zai', 'hb3s-prior-key', decode('00', 'hex'))",
+        )
+        .await
+        .expect("seed prior credential");
+        let pool_id: i64 = sqlx::query_scalar(
+            "INSERT INTO model_turn_pools (credential_id, provider_id, model_id) \
+             VALUES ('hb3s-prior', 'zai', 'glm-5') RETURNING id",
+        )
+        .fetch_one(&mut conn)
+        .await
+        .expect("seed prior pool");
+        sqlx::query(
+            "INSERT INTO model_turn_controller_windows \
+             (pool_id, window_sequence, started_at, ended_at, admitted_turns, completed_turns, summary) \
+             VALUES ($1, 2, '1970-01-01T00:02:00Z'::timestamptz, '1970-01-01T00:03:00Z'::timestamptz, 5, 4, $2)",
+        )
+        .bind(pool_id)
+        .bind(TRAINABLE)
+        .execute(&mut conn)
+        .await
+        .expect("seed prior controller window");
+
+        let sql = std::fs::read_to_string(migrations_dir().join(MIGRATION_FILE))
+            .expect("read hardening migration sql");
+        conn.execute(sql.as_str())
+            .await
+            .expect("apply hardening migration after prior migrations");
+
+        let surviving: Vec<(i64, String)> = sqlx::query_as(
+            "SELECT window_sequence, summary FROM model_turn_controller_windows WHERE pool_id = $1",
+        )
+        .bind(pool_id)
+        .fetch_all(&mut conn)
+        .await
+        .expect("read back the pre-existing window");
+        assert_eq!(surviving, vec![(2, TRAINABLE.to_owned())]);
+        drop(conn);
+
+        assert_hardened_schema(&db_url).await;
+    })
+    .await;
+}
+
+#[test]
+fn hardening_migration_version_is_unique() {
+    let versions: Vec<u64> = migration_entries(&migrations_dir())
+        .into_iter()
+        .map(|(version, _)| version)
+        .filter(|version| *version == MIGRATION_VERSION)
+        .collect();
+    assert_eq!(
+        versions.len(),
+        1,
+        "migration version {MIGRATION_VERSION} must be owned by exactly one file"
+    );
+}
+
+/// Write a controller-window row with no Rust-side validation at all, so each
+/// assertion below is about what the durable ledger accepts, not about what the
+/// typed boundary happens to forward to it.
+#[allow(clippy::too_many_arguments)]
+async fn raw_insert(
+    db: &Database,
+    pool_id: i64,
+    window_sequence: i64,
+    started_at: &str,
+    ended_at: &str,
+    admitted_turns: i64,
+    completed_turns: i64,
+    summary: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO model_turn_controller_windows \
+         (pool_id, window_sequence, started_at, ended_at, admitted_turns, completed_turns, summary) \
+         VALUES ($1, $2, $3::timestamptz, $4::timestamptz, $5, $6, $7) \
+         ON CONFLICT (pool_id, window_sequence) DO UPDATE SET \
+           started_at = EXCLUDED.started_at, ended_at = EXCLUDED.ended_at, \
+           admitted_turns = EXCLUDED.admitted_turns, \
+           completed_turns = EXCLUDED.completed_turns, summary = EXCLUDED.summary",
+    )
+    .bind(pool_id)
+    .bind(window_sequence)
+    .bind(started_at)
+    .bind(ended_at)
+    .bind(admitted_turns)
+    .bind(completed_turns)
+    .bind(summary)
+    .execute(db.pool())
+    .await
+    .map(|_| ())
+}
+
+const TRAINABLE: &str =
+    r#"{"provider_id":"zai","model_id":"glm-5","trainable":true,"diagnostics":[]}"#;
+
+/// `(label, window_sequence, started_at, ended_at, admitted, completed, summary)`.
+type RejectedWindow = (&'static str, i64, String, String, i64, i64, Option<String>);
+
+#[tokio::test]
+async fn hardened_ledger_accepts_only_exact_aligned_closed_windows() {
+    let db = Database::ephemeral().await.expect("db");
+    let pool_id = seed_scoped_model_turn_admission_fixture(
+        &db,
+        "hb3s-owning",
+        "zai",
+        "glm-5",
+        "shadow",
+        "supported",
+        1,
+    )
+    .await;
+    let unrelated = seed_scoped_model_turn_admission_fixture(
+        &db,
+        "hb3s-unrelated",
+        "zai",
+        "glm-5",
+        "shadow",
+        "supported",
+        1,
+    )
+    .await;
+
+    // Exactly two shapes are durable: the aligned trainable window, and an
+    // aligned diagnostic window carrying only its own pool plus the fixed zero
+    // sentinel.
+    raw_insert(
+        &db,
+        pool_id,
+        2,
+        "1970-01-01T00:02:00Z",
+        "1970-01-01T00:03:00Z",
+        5,
+        4,
+        Some(TRAINABLE),
+    )
+    .await
+    .expect("exact aligned trainable window is durable");
+    raw_insert(
+        &db,
+        pool_id,
+        3,
+        "1970-01-01T00:03:00Z",
+        "1970-01-01T00:04:00Z",
+        5,
+        4,
+        Some(&format!(
+            r#"{{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":[{{"pool_id":0,"code":"missing_capability"}},{{"pool_id":{pool_id},"code":"missing_usage"}}]}}"#
+        )),
+    )
+    .await
+    .expect("pool-local diagnostic window is durable");
+
+    let overlong = "x".repeat(192);
+    let many = (0..65)
+        .map(|_| format!(r#"{{"pool_id":{pool_id},"code":"missing_usage"}}"#))
+        .collect::<Vec<_>>()
+        .join(",");
+    let rejected: Vec<RejectedWindow> = vec![
+        (
+            "subsecond start",
+            2,
+            "1970-01-01T00:02:00.5Z".into(),
+            "1970-01-01T00:03:00.5Z".into(),
+            0,
+            0,
+            Some(TRAINABLE.into()),
+        ),
+        (
+            "unaligned start",
+            2,
+            "1970-01-01T00:02:30Z".into(),
+            "1970-01-01T00:03:30Z".into(),
+            0,
+            0,
+            Some(TRAINABLE.into()),
+        ),
+        (
+            "ninety second span",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:30Z".into(),
+            0,
+            0,
+            Some(TRAINABLE.into()),
+        ),
+        (
+            "thirty second span",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:02:30Z".into(),
+            0,
+            0,
+            Some(TRAINABLE.into()),
+        ),
+        (
+            "sequence disagrees with start",
+            9,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(TRAINABLE.into()),
+        ),
+        (
+            "negative admitted count",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            -1,
+            0,
+            Some(TRAINABLE.into()),
+        ),
+        (
+            "negative completed count",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            -1,
+            Some(TRAINABLE.into()),
+        ),
+        (
+            "absent summary",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            None,
+        ),
+        (
+            "summary that is not json",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some("not json".into()),
+        ),
+        (
+            "summary that is not an object",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some("[1,2]".into()),
+        ),
+        (
+            "extra top-level key",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(
+                r#"{"provider_id":"zai","model_id":"glm-5","trainable":true,"diagnostics":[],"reporter_text":"leak"}"#
+                    .into(),
+            ),
+        ),
+        (
+            "missing top-level key",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(r#"{"provider_id":"zai","model_id":"glm-5","trainable":true}"#.into()),
+        ),
+        (
+            "blank provider label",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(
+                r#"{"provider_id":"   ","model_id":"glm-5","trainable":true,"diagnostics":[]}"#
+                    .into(),
+            ),
+        ),
+        (
+            "overlong model label",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(format!(
+                r#"{{"provider_id":"zai","model_id":"{overlong}","trainable":true,"diagnostics":[]}}"#
+            )),
+        ),
+        (
+            "non-boolean trainable",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(
+                r#"{"provider_id":"zai","model_id":"glm-5","trainable":"yes","diagnostics":[]}"#
+                    .into(),
+            ),
+        ),
+        (
+            "diagnostics that are not an array",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(
+                r#"{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":{}}"#
+                    .into(),
+            ),
+        ),
+        (
+            "trainable with diagnostics",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(format!(
+                r#"{{"provider_id":"zai","model_id":"glm-5","trainable":true,"diagnostics":[{{"pool_id":{pool_id},"code":"missing_usage"}}]}}"#
+            )),
+        ),
+        (
+            "unbounded diagnostics",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(format!(
+                r#"{{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":[{many}]}}"#
+            )),
+        ),
+        (
+            "unknown reason code",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(format!(
+                r#"{{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":[{{"pool_id":{pool_id},"code":"free_text"}}]}}"#
+            )),
+        ),
+        (
+            "diagnostic carrying a slot identifier",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(format!(
+                r#"{{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":[{{"pool_id":{pool_id},"code":"missing_usage","slot_pod_uid":"leak"}}]}}"#
+            )),
+        ),
+        (
+            "diagnostic missing its pool identity",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(r#"{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":[{"code":"missing_usage"}]}"#.into()),
+        ),
+        (
+            "another pool's positive identity",
+            2,
+            "1970-01-01T00:02:00Z".into(),
+            "1970-01-01T00:03:00Z".into(),
+            0,
+            0,
+            Some(format!(
+                r#"{{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":[{{"pool_id":{unrelated},"code":"missing_usage"}}]}}"#
+            )),
+        ),
+    ];
+    for (label, sequence, started_at, ended_at, admitted, completed, summary) in rejected {
+        let outcome = raw_insert(
+            &db,
+            pool_id,
+            sequence,
+            &started_at,
+            &ended_at,
+            admitted,
+            completed,
+            summary.as_deref(),
+        )
+        .await;
+        assert!(
+            outcome.is_err(),
+            "{label} must be refused by the durable controller-window ledger"
+        );
+    }
+
+    // The two accepted rows are still exactly what was written; a refused write
+    // never partially replaced them.
+    let rows: Vec<(i64, String)> = sqlx::query_as(
+        "SELECT window_sequence, summary FROM model_turn_controller_windows \
+         WHERE pool_id = $1 ORDER BY window_sequence",
+    )
+    .bind(pool_id)
+    .fetch_all(db.pool())
+    .await
+    .expect("read back durable windows");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].0, 2);
+    assert_eq!(rows[0].1, TRAINABLE);
+}
+
+/// The persisted summary is privacy-bounded by construction: only opaque pool
+/// identities, closed reason codes, and the coordinator's catalog-qualified
+/// labels can survive a write.
+#[tokio::test]
+async fn durable_summaries_carry_no_sensitive_identifier() {
+    let db = Database::ephemeral().await.expect("db");
+    let pool_id = seed_scoped_model_turn_admission_fixture(
+        &db,
+        "hb3s-privacy",
+        "zai",
+        "glm-5",
+        "shadow",
+        "supported",
+        1,
+    )
+    .await;
+    for forbidden in [
+        "reporter_text",
+        "slot_pod_uid",
+        "deployment_revision",
+        "attempt_fingerprint",
+        "credential_id",
+        "user_id",
+        "account_id",
+        "project_id",
+        "request_id",
+        "lease_id",
+        "request_body",
+    ] {
+        let top_level = format!(
+            r#"{{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":[],"{forbidden}":"leak"}}"#
+        );
+        let per_diagnostic = format!(
+            r#"{{"provider_id":"zai","model_id":"glm-5","trainable":false,"diagnostics":[{{"pool_id":{pool_id},"code":"missing_usage","{forbidden}":"leak"}}]}}"#
+        );
+        for summary in [top_level, per_diagnostic] {
+            assert!(
+                raw_insert(
+                    &db,
+                    pool_id,
+                    2,
+                    "1970-01-01T00:02:00Z",
+                    "1970-01-01T00:03:00Z",
+                    0,
+                    0,
+                    Some(&summary),
+                )
+                .await
+                .is_err(),
+                "a summary carrying {forbidden} must be refused"
+            );
+        }
+    }
+    let stored: Option<String> =
+        sqlx::query_scalar("SELECT summary FROM model_turn_controller_windows WHERE pool_id = $1")
+            .bind(pool_id)
+            .fetch_optional(db.pool())
+            .await
+            .expect("read back durable windows");
+    assert!(stored.is_none(), "no forbidden summary reached the ledger");
+}


### PR DESCRIPTION
Epic `ai6g`, task `hb3s`, from proposal `96fy`.

Migration **210** hardens the existing `model_turn_controller_windows` ledger in
place — no second table, no catalog knowledge in the schema:

- exact aligned 60-second half-open bounds at second precision, and a
  `window_sequence` that must equal the aligned minute index of `started_at`;
- a closed typed summary: exactly four top-level keys, typed values, at most 64
  diagnostics, closed reason codes, per-diagnostic keys limited to
  `{pool_id, code}`, pool-local-or-zero diagnostic identity, and trainable
  implying no diagnostics.

The predicate is a `CASE`, not a chain of `AND`s: `AND` gives no
evaluation-order guarantee, so an unparsable summary would surface as a `22P02`
out of the `::jsonb` cast rather than as a constraint failure.

## Coverage

`server/crates/djinn-db/tests/controller_window_repository.rs` proves the
migration applies on a fresh database and additively over the prior schema with
an existing in-contract row still intact, then drives 21 out-of-contract shapes
and 22 privacy-leak shapes through a raw insert that bypasses the Rust boundary
entirely. Every one is refused by the ledger, and the two in-contract rows
survive unchanged.

`server/crates/djinn-coordinator/src/model_turn_admission_phase_c_postgres_tests.rs`
runs the real qualifier and gscv's coordinator seams end to end: a complete
window round-trips and then stops training the moment its provider leaves the
active catalog; fifteen distinct diagnostic shapes each persist as a real
durable row and stay learner-invisible; and a two-pool qualification stores each
pool only its own reason codes. It is a child module of `model_turn_admission`
because `ExpectedAttemptPathV1` keeps its route fields private on purpose.

gscv's learner regression is updated accordingly: the malformed-summary,
boundary-mismatched and count-invalid rows it used to store are now unstorable,
so it asserts the ledger refuses them and that a refused write leaves the
already-durable window untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)