### PR TITLE
chore(4x2v): Verify coordinator full-suite stabilization on the repository-owned PostgreSQL template

### DIFF
--- a/server/crates/djinn-db/tests/setup_test_template.rs
+++ b/server/crates/djinn-db/tests/setup_test_template.rs
@@ -22,11 +22,25 @@ async fn setup_test_template() {
     let mut conn = PgConnection::connect(&admin_url)
         .await
         .expect("connect admin");
+    // Clear `datistemplate` BEFORE dropping. A database still marked as a
+    // template refuses `DROP DATABASE` with 55006, and because the drop below
+    // used to be `let _ =`, that refusal was swallowed and only resurfaced as a
+    // baffling 42P04 "already exists" on the CREATE. That made this helper —
+    // the one AC that licenses `DJINN_TEST_TEMPLATE_PREBUILT` — fail on every
+    // machine that had already built a template once, i.e. every rerun.
+    let _ = sqlx::query(
+        "UPDATE pg_database SET datistemplate = FALSE WHERE datname = 'djinn_test_template'",
+    )
+    .execute(&mut conn)
+    .await;
     let _ = sqlx::query("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'djinn_test_template' AND pid <> pg_backend_pid()")
         .execute(&mut conn).await;
-    let _ = sqlx::query("DROP DATABASE IF EXISTS djinn_test_template")
+    // Not `let _ =`: a drop that cannot happen must fail here, where the error
+    // names the real cause, rather than being re-reported as a create conflict.
+    sqlx::query("DROP DATABASE IF EXISTS djinn_test_template")
         .execute(&mut conn)
-        .await;
+        .await
+        .expect("drop any pre-existing djinn_test_template before rebuilding it");
     sqlx::query("CREATE DATABASE djinn_test_template")
         .execute(&mut conn)
         .await


### PR DESCRIPTION
Integration verification slice for epic `lnfd`, replacing `2mgc` now that `un5x`, `2dt3`, and `hubl` have all landed.

## What was run

The exact acceptance procedure, against a local PostgreSQL 16:

1. Rebuilt the repository-owned template with `cargo test -p djinn-db --test setup_test_template -- --ignored --nocapture`.
   It printed the required sentinel:

   ```
   djinn_test_template ready at postgres://.../djinn_test_template
   DJINN_TEST_TEMPLATE_VERIFIED migrations=207
   ```

2. With `SQLX_OFFLINE` **unset**, `DATABASE_URL` pointing at the verified
   `djinn_test_template`, and `DJINN_TEST_DATABASE_URL` retained for clones, ran
   exactly:

   ```
   cargo test --manifest-path server/Cargo.toml -p djinn-coordinator
   ```

   Result:

   ```
   test result: ok. 2338 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 309.52s
   EXIT_CODE=0
   ```

   The run terminated on its own; nothing hung and no background work outlived it.

3. All three formerly failing tests named on the task passed inside that same run:

   ```
   test dispatch::task_dispatch::inflight_ledger_tests::wnd1_dispatch_race_harness_never_exceeds_caps_1_through_5 ... ok
   test direct_delivery::tests::production_ready_and_completion_admission_matrix_is_fail_closed ... ok
   test proposal_attempt_lifecycle::tests::attempt_pr_request_observation_survives_provider_failure ... ok
   ```

## The one defect this actually fixes

Step 1 does not survive its own second run, and that is the step which gates
everything else — it is the sole producer of the `DJINN_TEST_TEMPLATE_VERIFIED`
sentinel that licenses `DJINN_TEST_TEMPLATE_PREBUILT=1`.

`setup_test_template` marks the finished template `datistemplate = TRUE`. On the
next invocation, PostgreSQL refuses to drop a database still carrying that flag
(`42809 cannot drop a template database`). Because the drop was written
`let _ = sqlx::query("DROP DATABASE IF EXISTS ...")`, that refusal was discarded,
and the failure only resurfaced one statement later as a misleading
`42P04 database "djinn_test_template" already exists` from the `CREATE`.

So on any machine that had ever built the template once — which is every rerun,
and every developer box — the helper failed, and the error pointed at the wrong
statement.

The fix is two lines of cause, not consequence:

- clear `datistemplate` *before* attempting the drop, and
- stop swallowing the drop's error, so a drop that genuinely cannot happen fails
  where the message names the real reason.

### Evidence the fix is load-bearing

Not just "it passes now" — the guard was removed and the failure came back:

- With the fix, against a template already marked `datistemplate=true`, the
  helper succeeds twice in a row, printing `DJINN_TEST_TEMPLATE_VERIFIED
  migrations=207` each time.
- Deleting only the new `UPDATE pg_database SET datistemplate = FALSE` line and
  rerunning against the same marked template reproduces the failure, now
  correctly attributed:

  ```
  panicked at crates/djinn-db/tests/setup_test_template.rs:38:10:
  drop any pre-existing djinn_test_template before rebuilding it:
  PgDatabaseError { code: "42809", message: "cannot drop a template database" }
  ```

- Restoring the line returns the helper to green.

## Scope

Test-support only: one file, `server/crates/djinn-db/tests/setup_test_template.rs`.

No production code is touched. Default-disabled direct-delivery activation, the
accepted ready-dispatch continuation, production SQLx queries, liveness routing,
pollers/classifiers, and direct-vs-legacy task-PR boundaries are all unchanged —
this commit contains no edits outside that one `#[ignore]`d setup test.

## Note on nextest

Running the same suite under `cargo nextest run -p djinn-coordinator` on the same
box reports timeouts on ~12 DB-heavy tests. That is nextest's per-test 90s wall
clock meeting 16-way process-level parallelism against a single local PostgreSQL,
not a defect in the tests: each of those tests passes when run alone, all eight
CI `Server Test` shards are green, and the shared-process `cargo test` command
this task specifies completes all 2338 tests in 309s. No synchronization was
added or widened to accommodate it.
