### PR TITLE
chore(85cl): Add an exact-Applied closed replay fixture and immutable ready-dispatch snapshots

### DIFF
--- a/server/crates/djinn-coordinator/src/direct_delivery.rs
+++ b/server/crates/djinn-coordinator/src/direct_delivery.rs
@@ -3302,4 +3302,265 @@ mod ready_dispatch_repository_liveness_tests {
             "Conflict must not mutate immutable delivery state"
         );
     }
+
+    /// Independent, purpose-specific effect counters for one ready-dispatch
+    /// call. Nothing here is an aggregate: each field is observed at its own
+    /// production boundary, so a replay that skipped one effect but repeated
+    /// another cannot hide inside a single total.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct ReadyDispatchEffectCounts {
+        spawn_continuations: usize,
+        reconciliations: usize,
+        task_pr_operations: usize,
+        direct_appends: usize,
+        remote_ref_pushes: usize,
+        integrations: usize,
+        dependent_releases: usize,
+    }
+
+    fn task_pr_operation(operation: &BoundaryOperation) -> bool {
+        matches!(
+            operation,
+            BoundaryOperation::SupervisorPrOpen
+                | BoundaryOperation::TaskPrLookup
+                | BoundaryOperation::TaskPrAdopt
+                | BoundaryOperation::TaskPrStatusPoll
+                | BoundaryOperation::TaskPrReviewPoll
+                | BoundaryOperation::TaskPrMergedPoll
+                | BoundaryOperation::TaskPrInlineCleanup
+                | BoundaryOperation::TaskPrStaleCleanup
+                | BoundaryOperation::TaskPrCreate
+                | BoundaryOperation::TaskPrMerge
+                | BoundaryOperation::TaskPrAutoMerge
+                | BoundaryOperation::TaskPrApproval
+                | BoundaryOperation::TaskPrSignoff
+                | BoundaryOperation::TaskPrCustomEnqueue
+                | BoundaryOperation::AttemptPrCreateOrAdoptRequest
+        )
+    }
+
+    /// A repository fixture that is already settled when ready dispatch first
+    /// sees it.
+    ///
+    /// This is deliberately not the Applying scenario: there, the very first
+    /// `continue_ready_dispatch` call performs the reconciliation that produces
+    /// Applied, so "no second effect" is only ever observed on call two. Here
+    /// the engine runs to `TaskIntegrated` *before* the frame is entered, so
+    /// both invocations start from exact Applied plus closed and every effect
+    /// count below must stay at zero from the first call onward.
+    #[tokio::test]
+    async fn exact_applied_closed_ready_dispatch_replays_without_any_production_effect() {
+        use djinn_core::events::EventBus;
+        use djinn_db::test_support::{
+            direct_delivery_candidate_cardinality_for_test, direct_delivery_generations_for_test,
+            direct_delivery_matrix_counts_for_test, seed_direct_delivery_liveness_fixture_for_test,
+        };
+        use djinn_db::{Database, EpicRepository, ProposalBuildAttemptRepository, TaskRepository};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let boundary_operations = boundary_operations_scope().await;
+        let db = Database::open_in_memory().unwrap();
+        let epic = EpicRepository::new(db.clone(), EventBus::noop())
+            .create("applied-replay", "", "", "", "", None)
+            .await
+            .unwrap();
+
+        let source_updates = Arc::new(Mutex::new(0usize));
+        let dependent_updates = Arc::new(Mutex::new(0usize));
+        let observed_source = source_updates.clone();
+        let observed_dependent = dependent_updates.clone();
+        // Keep the two counters independent: an integration that released
+        // nothing and a release that integrated nothing are different failures,
+        // and one combined "task updated" total cannot tell them apart.
+        let source_task_id = Arc::new(Mutex::new(String::new()));
+        let dependent_task_id = Arc::new(Mutex::new(String::new()));
+        let source_id_for_events = source_task_id.clone();
+        let dependent_id_for_events = dependent_task_id.clone();
+        let observing_events = EventBus::new(move |event| {
+            if event.entity_type != "task" || event.action != "updated" {
+                return;
+            }
+            let id = event.payload["task"]["id"].as_str().unwrap_or_default();
+            if id == source_id_for_events.lock().unwrap().as_str() {
+                *observed_source.lock().unwrap() += 1;
+            } else if id == dependent_id_for_events.lock().unwrap().as_str() {
+                *observed_dependent.lock().unwrap() += 1;
+            }
+        });
+
+        let tasks = TaskRepository::new(db.clone(), observing_events.clone());
+        let task = tasks
+            .create(&epic.id, "applied", "", "", "task", 0, "", Some("approved"))
+            .await
+            .unwrap();
+        let dependent = tasks
+            .create(&epic.id, "dependent", "", "", "task", 0, "", Some("open"))
+            .await
+            .unwrap();
+        tasks.add_blocker(&dependent.id, &task.id).await.unwrap();
+        *source_task_id.lock().unwrap() = task.id.clone();
+        *dependent_task_id.lock().unwrap() = dependent.id.clone();
+
+        let fixture = seed_direct_delivery_liveness_fixture_for_test(
+            &db,
+            &epic.id,
+            &task.id,
+            Some("applying"),
+        )
+        .await;
+        assert_eq!(fixture.delivery_generation, Some(1));
+        assert!(task.pr_url.is_none());
+
+        let remote = Arc::new(Mutex::new(("fixture-base".to_owned(), 0usize)));
+        let engine = DirectDeliveryEngine::new(
+            RepositoryDeliveryLedger::new(
+                db.clone(),
+                ProposalBuildAttemptRepository::new(db.clone()),
+                TaskRepository::new(db.clone(), observing_events),
+            ),
+            FixtureRemote(remote.clone()),
+            FixtureBuilder,
+        );
+
+        // Reach exact Applied + closed through the real engine and the real
+        // `TaskIntegrated` repository transition, OUTSIDE the ready-dispatch
+        // frame. Everything after this point is replay.
+        let settle = crate::dispatch::wave_dispatch::run_direct_completion(|| {
+            engine.deliver(DeliverySource {
+                task_id: task.id.clone(),
+                delivery_generation: 1,
+                transition_id: "fixture-prepare".into(),
+                source_sha: "fixture-source".into(),
+                normalized_patch: "fixture-patch".into(),
+            })
+        })
+        .await
+        .expect("engine must settle the fixture generation");
+        assert!(
+            matches!(settle, DeliveryOutcome::Integrated { .. }),
+            "fixture must reach integration before the first ready-dispatch call, got {settle:?}"
+        );
+
+        let settled_task = tasks.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(
+            (
+                settled_task.status.as_str(),
+                settled_task.merge_commit_sha.as_deref()
+            ),
+            ("closed", Some("fixture-candidate")),
+            "initial state must be exact Applied plus closed, reached via TaskIntegrated"
+        );
+        let generations_before = direct_delivery_generations_for_test(&db, &task.id).await;
+        assert_eq!(generations_before.len(), 1);
+        assert_eq!(generations_before[0].state, "applied");
+        assert_eq!(generations_before[0].delivery_generation, 1);
+        assert_eq!(generations_before[0].candidate_sha, "fixture-candidate");
+        assert!(generations_before[0].applied);
+        let cardinality_before =
+            direct_delivery_candidate_cardinality_for_test(&db, &task.id).await;
+        assert_eq!(
+            (
+                cardinality_before.generations,
+                cardinality_before.distinct_candidates,
+                cardinality_before.distinct_build_attempts
+            ),
+            (1, 1, 1)
+        );
+        let matrix_before = direct_delivery_matrix_counts_for_test(&db).await;
+        assert_eq!(
+            *dependent_updates.lock().unwrap(),
+            1,
+            "the pre-frame integration must have released the dependent exactly once"
+        );
+
+        // Baseline every independent counter at zero for the replay window.
+        let spawn_continuations = Arc::new(AtomicUsize::new(0));
+        let reconciliations = Arc::new(AtomicUsize::new(0));
+        *source_updates.lock().unwrap() = 0;
+        *dependent_updates.lock().unwrap() = 0;
+        let pushes_before = remote.lock().unwrap().1;
+
+        for call in 1..=2 {
+            let checkpoint = boundary_operations.checkpoint();
+            let spawn_continuations_for_call = spawn_continuations.clone();
+            let reconciliations_for_call = reconciliations.clone();
+            let decision = crate::dispatch::task_dispatch::continue_ready_dispatch(
+                db.clone(),
+                &tasks,
+                &task.id,
+                || async move {
+                    reconciliations_for_call.fetch_add(1, Ordering::SeqCst);
+                    panic!("exact Applied must never re-enter the delivery engine")
+                },
+                || async move {
+                    spawn_continuations_for_call.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                decision,
+                crate::dispatch::task_dispatch::ReadyDispatchContinuation::Settled,
+                "call {call}: exact Applied plus closed must settle"
+            );
+
+            let operations = boundary_operations.operations_since(checkpoint);
+            let counts = ReadyDispatchEffectCounts {
+                spawn_continuations: spawn_continuations.load(Ordering::SeqCst),
+                reconciliations: reconciliations.load(Ordering::SeqCst),
+                task_pr_operations: operations.iter().filter(|op| task_pr_operation(op)).count(),
+                direct_appends: operations
+                    .iter()
+                    .filter(|op| matches!(op, BoundaryOperation::DirectAppend))
+                    .count(),
+                remote_ref_pushes: remote.lock().unwrap().1 - pushes_before,
+                integrations: *source_updates.lock().unwrap(),
+                dependent_releases: *dependent_updates.lock().unwrap(),
+            };
+            assert_eq!(
+                counts,
+                ReadyDispatchEffectCounts {
+                    spawn_continuations: 0,
+                    reconciliations: 0,
+                    task_pr_operations: 0,
+                    direct_appends: 0,
+                    remote_ref_pushes: 0,
+                    integrations: 0,
+                    dependent_releases: 0,
+                },
+                "call {call}: an already-settled generation must produce no production effect"
+            );
+            assert_eq!(
+                operations,
+                vec![
+                    BoundaryOperation::CapabilityProbe,
+                    BoundaryOperation::ResolveTaskActiveAttempt,
+                ],
+                "call {call}: settlement must be decided by the canonical probe and \
+                 attempt resolution alone"
+            );
+
+            assert_eq!(
+                tasks.get(&task.id).await.unwrap().unwrap().status,
+                "closed",
+                "call {call}: closed status must survive replay"
+            );
+            assert_eq!(
+                direct_delivery_generations_for_test(&db, &task.id).await,
+                generations_before,
+                "call {call}: the immutable delivery generation must be unchanged"
+            );
+            assert_eq!(
+                direct_delivery_candidate_cardinality_for_test(&db, &task.id).await,
+                cardinality_before,
+                "call {call}: candidate cardinality must not grow"
+            );
+            assert_eq!(
+                direct_delivery_matrix_counts_for_test(&db).await,
+                matrix_before,
+                "call {call}: attempt/ledger cardinality must not grow"
+            );
+        }
+    }
 }

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -28,6 +28,7 @@ pub mod test_support {
     pub use crate::query_observer::{QueryTrace, capture_queries};
     pub use crate::repositories::test_support::{
         AtomicEvidenceDemandCountsForTest, CanonicalTypedEvidenceReturnOutcomeForTest,
+        DirectDeliveryCandidateCardinalityForTest, DirectDeliveryGenerationSnapshotForTest,
         DirectDeliveryLivenessFixtureForTest, DirectDeliveryMatrixCountsForTest,
         EvidenceDispatchRecoveryFixtureForTest, EvidenceDispatchRecoverySnapshotForTest,
         HousekeepingFixture, HousekeepingFixtureExpectedCounts, HousekeepingFixtureProject,
@@ -51,7 +52,8 @@ pub mod test_support {
         correlate_task_to_refinement_run_for_test, corrupt_credential_encrypted_value,
         corrupt_refinement_task_role_for_test, count_rows_for_test,
         delete_proposal_lint_result_for_revision_for_test, delete_proposal_lint_results_for_test,
-        delete_session_row, direct_delivery_matrix_counts_for_test,
+        delete_session_row, direct_delivery_candidate_cardinality_for_test,
+        direct_delivery_generations_for_test, direct_delivery_matrix_counts_for_test,
         disable_direct_delivery_epoch_for_test, dispose_typed_evidence_validation_for_test,
         drop_table_cascade_for_test, drop_table_for_test,
         elapse_refinement_run_wall_clock_for_test, ensure_doctor_findings_schema,

--- a/server/crates/djinn-db/src/repositories/test_support.rs
+++ b/server/crates/djinn-db/src/repositories/test_support.rs
@@ -89,6 +89,102 @@ pub async fn direct_delivery_matrix_counts_for_test(
     }
 }
 
+/// One immutable delivery generation, read back exactly as persisted.
+///
+/// This is deliberately *not* an aggregate count. A whole-database
+/// `deliveries: Some(1)` stays identical when a replay rewrites the single
+/// row's state or candidate, so a cardinality snapshot cannot witness
+/// generation immutability. Comparing this struct can.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectDeliveryGenerationSnapshotForTest {
+    pub build_attempt_id: String,
+    pub delivery_generation: i64,
+    pub state: String,
+    pub candidate_sha: String,
+    pub base_sha: String,
+    pub conflict_reason: Option<String>,
+    pub applied: bool,
+}
+
+/// Snapshot every persisted delivery generation for one task, ordered by
+/// generation, so a caller can assert both which generations exist and that
+/// each one's identity is unchanged.
+///
+/// **Not for production use.** Panics on SQL errors.
+pub async fn direct_delivery_generations_for_test(
+    db: &Database,
+    task_id: &str,
+) -> Vec<DirectDeliveryGenerationSnapshotForTest> {
+    db.ensure_initialized().await.unwrap();
+    let rows = sqlx::query_as::<_, (String, i64, String, String, String, Option<String>, bool)>(
+        "SELECT build_attempt_id, delivery_generation, state, candidate_sha, base_sha, \
+         conflict_reason, applied_at IS NOT NULL \
+         FROM task_deliveries WHERE task_id = $1 \
+         ORDER BY delivery_generation, build_attempt_id",
+    )
+    .bind(task_id)
+    .fetch_all(db.pool())
+    .await
+    .expect("read direct-delivery generations for test");
+    rows.into_iter()
+        .map(
+            |(
+                build_attempt_id,
+                delivery_generation,
+                state,
+                candidate_sha,
+                base_sha,
+                conflict_reason,
+                applied,
+            )| DirectDeliveryGenerationSnapshotForTest {
+                build_attempt_id,
+                delivery_generation,
+                state,
+                candidate_sha,
+                base_sha,
+                conflict_reason,
+                applied,
+            },
+        )
+        .collect()
+}
+
+/// How many candidates one task's ledger has ever named, and how many of them
+/// are distinct.
+///
+/// `generations` counting up while `distinct_candidates` stays put is a rebuild
+/// retry; `distinct_candidates` counting up is a *new* candidate. Aggregate
+/// delivery counts conflate the two, so replay tests assert on this instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DirectDeliveryCandidateCardinalityForTest {
+    pub generations: i64,
+    pub distinct_candidates: i64,
+    pub distinct_build_attempts: i64,
+}
+
+/// Snapshot candidate cardinality for one task's delivery ledger.
+/// **Not for production use.** Panics on SQL errors.
+pub async fn direct_delivery_candidate_cardinality_for_test(
+    db: &Database,
+    task_id: &str,
+) -> DirectDeliveryCandidateCardinalityForTest {
+    db.ensure_initialized().await.unwrap();
+    let (generations, distinct_candidates, distinct_build_attempts) =
+        sqlx::query_as::<_, (i64, i64, i64)>(
+            "SELECT COUNT(*), COUNT(DISTINCT candidate_sha), COUNT(DISTINCT build_attempt_id) \
+             FROM task_deliveries WHERE task_id = $1",
+        )
+        .bind(task_id)
+        .fetch_one(db.pool())
+        .await
+        .expect("read direct-delivery candidate cardinality for test");
+    DirectDeliveryCandidateCardinalityForTest {
+        generations,
+        distinct_candidates,
+        distinct_build_attempts,
+    }
+}
+
 /// Canonical ownership and immutable-generation identity for liveness tests.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectDeliveryLivenessFixtureForTest {


### PR DESCRIPTION
Replacement slice 2 for `v8gs`, extending the repository-backed support that `zq6e` landed rather than rebuilding it.

## The gap this closes

`ready_dispatch_collaborator_reconciles_and_replays_repository_delivery` starts
from `Applying`. Its **first** `continue_ready_dispatch` call is the one that
performs the reconciliation producing `Applied`, so "a settled generation
produces no effect" is only ever observed on call two — the first call is
allowed to do everything.

This adds a distinct fixture that is already settled before the frame is ever
entered, so the zero-effect requirement binds from call one onward.

## The new fixture

`exact_applied_closed_ready_dispatch_replays_without_any_production_effect`
seeds `Applying` through the shared djinn-db liveness fixture, then drives the
**real** `DirectDeliveryEngine` — `RepositoryDeliveryLedger` over
`ProposalBuildAttemptRepository` and `TaskRepository` — to completion *outside*
the ready-dispatch frame. That path runs the genuine `TaskIntegrated` repository
transition, so the starting state is reached the way production reaches it, and
is asserted before the frame is touched:

- task `status = "closed"`, `merge_commit_sha = "fixture-candidate"`,
- exactly one delivery generation, `state = "applied"`, `applied_at` set,
- the dependent task released exactly once by that integration.

Only then is `continue_ready_dispatch` — the same top-level frame
`dispatch_ready_tasks` calls — invoked twice.

## Independent snapshots, not aggregate counts

The task asks for purpose-specific snapshots because the existing
`direct_delivery_matrix_counts_for_test` is whole-database cardinality: it still
reads `deliveries: Some(1)` if a replay *rewrote* the single row's state or
candidate. A cardinality snapshot structurally cannot witness generation
immutability.

Two new djinn-db helpers fix that:

- `direct_delivery_generations_for_test(db, task_id)` → `Vec<DirectDeliveryGenerationSnapshotForTest>`,
  reading back each generation's `build_attempt_id`, generation, state,
  `candidate_sha`, `base_sha`, conflict reason, and applied-ness exactly as
  persisted. Comparing the whole vector catches an in-place rewrite.
- `direct_delivery_candidate_cardinality_for_test(db, task_id)` →
  `{ generations, distinct_candidates, distinct_build_attempts }`. Generations
  climbing while distinct candidates hold still is a rebuild retry; distinct
  candidates climbing is a genuinely new candidate. One delivery total conflates
  the two.

On the coordinator side the five effect families are counted **separately**, at
their own production boundaries, never summed:

| effect | observed at |
|---|---|
| spawn | invocations of the legacy `continue_legacy_dispatch` continuation |
| task-PR | `BoundaryOperation::{SupervisorPrOpen, TaskPr*, AttemptPrCreateOrAdoptRequest}` |
| append | `BoundaryOperation::DirectAppend` |
| push | `AttemptRef::update_expected_old` ref-update count on the fixture remote |
| integration | `task updated` events whose payload id is the **source** task |
| dependent release | `task updated` events whose payload id is the **dependent** task |

Integration and dependent-release are deliberately two counters bound to two
different task ids: an integration that released nothing and a release that
integrated nothing are different failures, and a single "task updated" total
cannot tell them apart.

## What both calls assert

Each of the two invocations returns `Settled`, and after each one:

- all seven effect counters are exactly zero,
- the boundary trace is exactly `[CapabilityProbe, ResolveTaskActiveAttempt]` —
  settlement is decided by the canonical probe and attempt resolution alone,
- `status` is still `closed`,
- the generation snapshot vector is identical to the pre-frame snapshot,
- candidate cardinality is unchanged,
- attempt/ledger cardinality is unchanged.

The reconcile closure is `panic!("exact Applied must never re-enter the delivery
engine")`, so re-entry fails loudly rather than being counted after the fact.

## Evidence the assertions bite

A passing test proves nothing on its own, so the routing it depends on was
broken on purpose. Changing the production liveness mapping in
`admit_direct_delivery_liveness` so `Applied` yields `Dispatch` instead of
`Settled` makes it fail immediately, on call one:

```
assertion `left == right` failed: call 1: exact Applied plus closed must settle
  left: LegacyDispatch(())
 right: Settled
```

Restoring the mapping returns it to green. The test is reading real production
routing, not a fixture echo.

## Verification

- New test passes: `cargo nextest run -p djinn-coordinator exact_applied_closed_ready_dispatch_replays_without_any_production_effect` → 1 passed.
- Whole family green: `cargo nextest run -p djinn-coordinator direct_delivery` → **24 passed**, including the pre-existing Applying and Conflict cases and the fail-closed admission matrix.
- `cargo clippy -p djinn-coordinator -p djinn-db --all-targets --features djinn-db/test-support -- -D warnings` clean; `cargo fmt --all --check` clean.
- Raw-SQL boundary guard clean (the new queries live inside `djinn-db`, where raw sqlx is permitted); newly-added-test global-metrics guard clean.

## Scope

Test-support and test coverage only. The canonical no-ledger-row rule, epoch
defaults, pollers/classifiers, and direct task-PR restrictions are untouched —
the only non-test edit is two added re-export names in `djinn-db/src/lib.rs`.
