### PR TITLE
chore(yh4d): Implement aggregate-throughput learning and controller golden traces

### DIFF
--- a/server/crates/djinn-coordinator/src/model_turn_admission.rs
+++ b/server/crates/djinn-coordinator/src/model_turn_admission.rs
@@ -1837,6 +1837,12 @@ mod tests {
     }
 }
 
+/// Aggregate-throughput learning and the concurrency controller (task yh4d).
+/// A public child module so it can consume this module's catalog-qualified
+/// learner seam without widening the Phase-C boundary to a new crate.
+#[path = "model_turn_admission_subscription_learner.rs"]
+pub mod subscription_learner;
+
 /// Migration-backed Phase-C conformance (task hb3s). Kept as a child module
 /// so it can build `ExpectedAttemptPathV1` values the way production does,
 /// through this module's deliberately private route fields.

--- a/server/crates/djinn-coordinator/src/model_turn_admission_subscription_learner.rs
+++ b/server/crates/djinn-coordinator/src/model_turn_admission_subscription_learner.rs
@@ -1,0 +1,479 @@
+//! Subscription concurrency learning over qualified Phase-C windows (task yh4d).
+//!
+//! Everything here is pure except [`ingest_qualified_window_v1`], which is the
+//! only way a window reaches the learner at all: it goes through gscv's
+//! exact-bound, active-catalog-qualified coordinator seam. There is no raw
+//! controller-window query and no in-memory caller verdict — a caller cannot
+//! hand the learner a window it says is trainable.
+//!
+//! The rate is an **aggregate**: output tokens are assigned by emission
+//! timestamp and divided by the wall-clock length of the *union* of active
+//! stream intervals, clipped to the aligned window. Summed stream-seconds are
+//! never used; two fully overlapping streams occupy 60 seconds of wall clock,
+//! not 120.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use djinn_db::ModelTurnAdmissionRepository;
+use djinn_provider::{ProviderAttemptLossV1, ProviderAttemptTerminalV1, catalog::CatalogService};
+
+use super::{
+    AlignedPhaseCWindowV1, PhaseCLearnerWindowV1, learner_catalog_qualified_phase_c_window_v1,
+};
+
+// ── Contract constants ──────────────────────────────────────────────────────
+
+/// Lowest and highest concurrency target the controller may ever hold.
+pub const MIN_TARGET: i64 = 1;
+pub const MAX_TARGET: i64 = 32;
+/// A window teaches nothing below these thresholds.
+pub const MIN_COMPLETED_TURNS: i64 = 8;
+pub const MIN_ACTIVE_UNION_SECONDS: i64 = 30;
+/// Baseline smoothing.
+pub const BASELINE_EWMA_ALPHA: f64 = 0.2;
+/// A probe must beat the baseline by this fraction to count as growth.
+pub const GROWTH_THRESHOLD: f64 = 0.05;
+/// Resamples in the deterministic bootstrap, and the confidence it produces.
+pub const BOOTSTRAP_RESAMPLES: usize = 1_000;
+pub const BOOTSTRAP_CONFIDENCE: f64 = 0.95;
+/// Consecutive non-growing probes before the controller stops probing.
+pub const NON_GROWING_PROBE_LIMIT: i64 = 3;
+/// Windows held after the probe limit is reached.
+pub const PLATEAU_HOLD_WINDOWS: i64 = 5;
+
+// ── Aggregate throughput ────────────────────────────────────────────────────
+
+/// Output tokens emitted at one wall-clock second.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct OutputTokenEmissionV1 {
+    pub emitted_at_second: i64,
+    pub output_tokens: i64,
+}
+
+/// One stream that was actively producing over a half-open second interval.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActiveStreamV1 {
+    pub started_at_second: i64,
+    pub ended_at_second: i64,
+    pub emissions: Vec<OutputTokenEmissionV1>,
+}
+
+impl ActiveStreamV1 {
+    /// The part of this stream that lies inside the aligned half-open window,
+    /// or `None` when the clipped interval is empty.
+    fn clipped(&self, window: AlignedPhaseCWindowV1) -> Option<(i64, i64)> {
+        let start = self.started_at_second.max(window.start_second());
+        let end = self.ended_at_second.min(window.end_second());
+        (start < end).then_some((start, end))
+    }
+}
+
+/// Aggregate output rate over one aligned window.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AggregateThroughputV1 {
+    /// Output tokens whose emission timestamp fell inside the window and inside
+    /// the emitting stream's own clipped active interval.
+    pub output_tokens: i64,
+    /// Wall-clock seconds covered by the union of clipped active intervals.
+    pub active_union_seconds: i64,
+    /// `output_tokens / active_union_seconds`, or `0.0` when nothing was active.
+    pub tokens_per_second: f64,
+}
+
+/// Merge half-open intervals and return their total wall-clock length.
+fn union_seconds(mut intervals: Vec<(i64, i64)>) -> i64 {
+    intervals.sort_unstable();
+    let mut total = 0;
+    let mut current: Option<(i64, i64)> = None;
+    for (start, end) in intervals {
+        match current {
+            Some((open, close)) if start <= close => current = Some((open, close.max(end))),
+            Some((open, close)) => {
+                total += close - open;
+                current = Some((start, end));
+            }
+            None => current = Some((start, end)),
+        }
+    }
+    if let Some((open, close)) = current {
+        total += close - open;
+    }
+    total
+}
+
+/// Aggregate output rate for one aligned window.
+///
+/// Tokens are attributed by emission timestamp, and the denominator is the union
+/// of clipped active intervals — never the sum of per-stream durations.
+#[must_use]
+pub fn aggregate_output_throughput_v1(
+    window: AlignedPhaseCWindowV1,
+    streams: &[ActiveStreamV1],
+) -> AggregateThroughputV1 {
+    let mut intervals = Vec::with_capacity(streams.len());
+    let mut output_tokens = 0i64;
+    for stream in streams {
+        let Some((start, end)) = stream.clipped(window) else {
+            continue;
+        };
+        intervals.push((start, end));
+        for emission in &stream.emissions {
+            if start <= emission.emitted_at_second
+                && emission.emitted_at_second < end
+                && emission.output_tokens > 0
+            {
+                output_tokens = output_tokens.saturating_add(emission.output_tokens);
+            }
+        }
+    }
+    let active_union_seconds = union_seconds(intervals);
+    let tokens_per_second = if active_union_seconds > 0 {
+        output_tokens as f64 / active_union_seconds as f64
+    } else {
+        0.0
+    };
+    AggregateThroughputV1 {
+        output_tokens,
+        active_union_seconds,
+        tokens_per_second,
+    }
+}
+
+/// Per-stream rate samples for the bootstrap, one per stream that was active in
+/// the window. Each sample is that stream's own tokens over its own clipped
+/// wall-clock seconds, so the bootstrap measures spread across streams rather
+/// than resampling a single aggregate.
+#[must_use]
+pub fn per_stream_rate_samples_v1(
+    window: AlignedPhaseCWindowV1,
+    streams: &[ActiveStreamV1],
+) -> Vec<f64> {
+    let mut samples = Vec::with_capacity(streams.len());
+    for stream in streams {
+        let Some((start, end)) = stream.clipped(window) else {
+            continue;
+        };
+        let tokens: i64 = stream
+            .emissions
+            .iter()
+            .filter(|emission| {
+                start <= emission.emitted_at_second
+                    && emission.emitted_at_second < end
+                    && emission.output_tokens > 0
+            })
+            .map(|emission| emission.output_tokens)
+            .sum();
+        samples.push(tokens as f64 / (end - start) as f64);
+    }
+    samples
+}
+
+// ── Eligibility and baseline ────────────────────────────────────────────────
+
+/// A window teaches only with enough completed turns *and* enough wall clock in
+/// the union of active intervals.
+#[must_use]
+pub fn window_is_eligible_v1(completed_turns: i64, throughput: &AggregateThroughputV1) -> bool {
+    completed_turns >= MIN_COMPLETED_TURNS
+        && throughput.active_union_seconds >= MIN_ACTIVE_UNION_SECONDS
+}
+
+/// Exponentially weighted baseline, alpha 0.2.
+#[must_use]
+pub fn update_baseline_v1(baseline: Option<f64>, observed: f64) -> f64 {
+    match baseline {
+        None => observed,
+        Some(previous) => BASELINE_EWMA_ALPHA * observed + (1.0 - BASELINE_EWMA_ALPHA) * previous,
+    }
+}
+
+// ── Deterministic bootstrap ─────────────────────────────────────────────────
+
+/// xorshift64*, so a trace replays bit-identically from its seed. No process
+/// entropy and no wall clock enter the growth decision.
+struct DeterministicRngV1(u64);
+
+impl DeterministicRngV1 {
+    fn new(seed: u64) -> Self {
+        // A zero state is absorbing for xorshift; move it off zero.
+        Self(seed ^ 0x9E37_79B9_7F4A_7C15)
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    fn index(&mut self, len: usize) -> usize {
+        (self.next_u64() % len as u64) as usize
+    }
+}
+
+/// Lower bound of the deterministic 95% bootstrap interval for the mean of
+/// `samples`, or `None` when there is nothing to resample.
+#[must_use]
+pub fn bootstrap_lower_bound_v1(samples: &[f64], seed: u64) -> Option<f64> {
+    if samples.is_empty() {
+        return None;
+    }
+    let mut rng = DeterministicRngV1::new(seed);
+    let mut means = Vec::with_capacity(BOOTSTRAP_RESAMPLES);
+    for _ in 0..BOOTSTRAP_RESAMPLES {
+        let mut total = 0.0;
+        for _ in 0..samples.len() {
+            total += samples[rng.index(samples.len())];
+        }
+        means.push(total / samples.len() as f64);
+    }
+    // `total_cmp` rather than `partial_cmp(..).expect(..)`: a NaN sample would
+    // otherwise panic the controller instead of simply sorting last.
+    means.sort_by(f64::total_cmp);
+    let tail = (1.0 - BOOTSTRAP_CONFIDENCE) / 2.0;
+    let index = ((BOOTSTRAP_RESAMPLES as f64) * tail).floor() as usize;
+    Some(means[index.min(BOOTSTRAP_RESAMPLES - 1)])
+}
+
+/// Growth requires the bootstrap lower bound to clear the baseline by the 5%
+/// threshold. A point estimate that happens to be higher is not enough.
+#[must_use]
+pub fn growth_qualifies_v1(samples: &[f64], baseline: f64, seed: u64) -> bool {
+    bootstrap_lower_bound_v1(samples, seed)
+        .is_some_and(|lower| lower > baseline * (1.0 + GROWTH_THRESHOLD))
+}
+
+// ── Controller state ────────────────────────────────────────────────────────
+
+/// One attempt's terminal outcome, keyed by an opaque attempt identity. The
+/// identity is what deduplicates a loss; the typed B1 terminal is what makes it
+/// a loss at all.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttemptTerminalObservationV1 {
+    /// Opaque attempt identity. Never a raw request, lease, or credential id.
+    pub attempt: String,
+    pub terminal: ProviderAttemptTerminalV1,
+}
+
+impl AttemptTerminalObservationV1 {
+    /// Only a typed B1 failure is a loss. Completed and aborted are not.
+    #[must_use]
+    pub fn loss(&self) -> Option<ProviderAttemptLossV1> {
+        match self.terminal {
+            ProviderAttemptTerminalV1::Failed(loss) => Some(loss),
+            ProviderAttemptTerminalV1::Completed | ProviderAttemptTerminalV1::Aborted => None,
+        }
+    }
+}
+
+/// Everything one aligned window contributes to the controller.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SubscriptionWindowObservationV1 {
+    /// The qualified window, or `None` when the window was diagnostic, absent,
+    /// malformed, catalog-invalid, or boundary-mismatched.
+    pub qualified: Option<PhaseCLearnerWindowV1>,
+    pub throughput: AggregateThroughputV1,
+    pub rate_samples: Vec<f64>,
+    pub terminals: Vec<AttemptTerminalObservationV1>,
+    pub bootstrap_seed: u64,
+}
+
+/// Why the controller did what it did. Closed and non-identifying.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ControllerTransitionV1 {
+    /// No qualified window: nothing, including the baseline, moved.
+    HeldUnqualified,
+    /// Qualified but under the turn/wall-clock thresholds.
+    HeldIneligible,
+    /// A loss already counted against this controller.
+    HeldDuplicateLoss,
+    /// Probing is suspended after the non-growing probe limit.
+    HeldPlateau,
+    /// Eligible, probed, did not clear the confidence-bounded threshold.
+    ProbeDidNotGrow,
+    /// The third consecutive non-growing probe; probing suspends.
+    ProbeRejected,
+    Grew,
+    /// A new deduplicated loss reduced the target.
+    BackedOff,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SubscriptionControllerStateV1 {
+    target: Option<i64>,
+    baseline: Option<f64>,
+    non_growing_probes: i64,
+    remaining_hold_windows: i64,
+    counted_losses: BTreeSet<String>,
+}
+
+impl SubscriptionControllerStateV1 {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Targets start at 1 and never leave `[1, 32]`.
+    #[must_use]
+    pub fn target(&self) -> i64 {
+        self.target
+            .unwrap_or(MIN_TARGET)
+            .clamp(MIN_TARGET, MAX_TARGET)
+    }
+    #[must_use]
+    pub fn baseline(&self) -> Option<f64> {
+        self.baseline
+    }
+    #[must_use]
+    pub fn non_growing_probes(&self) -> i64 {
+        self.non_growing_probes
+    }
+    #[must_use]
+    pub fn remaining_hold_windows(&self) -> i64 {
+        self.remaining_hold_windows
+    }
+    fn set_target(&mut self, target: i64) {
+        self.target = Some(target.clamp(MIN_TARGET, MAX_TARGET));
+    }
+}
+
+/// Fold one window into the controller.
+///
+/// Order is the contract: an unqualified window changes nothing at all, a new
+/// loss takes precedence over any growth the same window could have shown, a
+/// repeated loss holds, and only then can an eligible window probe.
+pub fn observe_window_v1(
+    state: &mut SubscriptionControllerStateV1,
+    observation: &SubscriptionWindowObservationV1,
+) -> ControllerTransitionV1 {
+    let Some(qualified) = observation.qualified.as_ref() else {
+        return ControllerTransitionV1::HeldUnqualified;
+    };
+
+    // Loss precedence, applied before anything can read as growth.
+    let mut fresh = BTreeMap::new();
+    let mut repeated = false;
+    for terminal in &observation.terminals {
+        if terminal.loss().is_none() {
+            continue;
+        }
+        if state.counted_losses.contains(&terminal.attempt) {
+            repeated = true;
+        } else {
+            fresh.insert(terminal.attempt.clone(), ());
+        }
+    }
+    if !fresh.is_empty() {
+        for attempt in fresh.into_keys() {
+            state.counted_losses.insert(attempt);
+        }
+        // A single window's losses are one back-off, not one per attempt.
+        let reduced = ((state.target() as f64) * 0.9).floor() as i64;
+        state.set_target(reduced.max(MIN_TARGET));
+        state.non_growing_probes = 0;
+        state.remaining_hold_windows = 0;
+        return ControllerTransitionV1::BackedOff;
+    }
+    if repeated {
+        return ControllerTransitionV1::HeldDuplicateLoss;
+    }
+
+    if !window_is_eligible_v1(qualified.completed_turns, &observation.throughput) {
+        return ControllerTransitionV1::HeldIneligible;
+    }
+    if state.remaining_hold_windows > 0 {
+        state.remaining_hold_windows -= 1;
+        return ControllerTransitionV1::HeldPlateau;
+    }
+
+    // The decision reads the baseline as it stood *before* this window, so a
+    // window can never clear a threshold it just moved.
+    let baseline_before = state.baseline;
+    state.baseline = Some(update_baseline_v1(
+        baseline_before,
+        observation.throughput.tokens_per_second,
+    ));
+    let Some(baseline_before) = baseline_before else {
+        // The first eligible window establishes the baseline; there is nothing
+        // to have grown against yet.
+        return ControllerTransitionV1::ProbeDidNotGrow;
+    };
+    if growth_qualifies_v1(
+        &observation.rate_samples,
+        baseline_before,
+        observation.bootstrap_seed,
+    ) {
+        state.set_target(state.target() + 1);
+        state.non_growing_probes = 0;
+        return ControllerTransitionV1::Grew;
+    }
+    state.non_growing_probes += 1;
+    if state.non_growing_probes >= NON_GROWING_PROBE_LIMIT {
+        state.non_growing_probes = 0;
+        state.remaining_hold_windows = PLATEAU_HOLD_WINDOWS;
+        return ControllerTransitionV1::ProbeRejected;
+    }
+    ControllerTransitionV1::ProbeDidNotGrow
+}
+
+// ── Production ingestion ────────────────────────────────────────────────────
+
+/// Streams and terminals a completed window observed. Neither says whether the
+/// window is trainable — that verdict comes only from the durable ledger, read
+/// back through gscv's catalog-qualified seam below.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowActivityV1 {
+    pub streams: Vec<ActiveStreamV1>,
+    pub terminals: Vec<AttemptTerminalObservationV1>,
+}
+
+/// The exact durable window a learner is asking about. The bounds are carried
+/// verbatim because the storage read is exact-bound: an approximation of them is
+/// simply a window that does not exist.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QualifiedWindowRequestV1 {
+    pub pool_id: i64,
+    pub window: AlignedPhaseCWindowV1,
+    pub started_at: String,
+    pub ended_at: String,
+}
+
+/// The sole production ingestion path.
+///
+/// It re-reads the window through
+/// [`learner_catalog_qualified_phase_c_window_v1`], so a diagnostic, absent,
+/// malformed-summary, catalog-invalid, or boundary-mismatched window simply
+/// yields no qualified window and cannot reach any rate or state transition.
+pub async fn ingest_qualified_window_v1(
+    repository: &ModelTurnAdmissionRepository,
+    catalog: &CatalogService,
+    state: &mut SubscriptionControllerStateV1,
+    request: &QualifiedWindowRequestV1,
+    activity: &WindowActivityV1,
+) -> djinn_db::Result<ControllerTransitionV1> {
+    let window = request.window;
+    let qualified = learner_catalog_qualified_phase_c_window_v1(
+        repository,
+        catalog,
+        request.pool_id,
+        window
+            .start_second()
+            .div_euclid(AlignedPhaseCWindowV1::SECONDS),
+        &request.started_at,
+        &request.ended_at,
+    )
+    .await?;
+    let observation = SubscriptionWindowObservationV1 {
+        qualified,
+        throughput: aggregate_output_throughput_v1(window, &activity.streams),
+        rate_samples: per_stream_rate_samples_v1(window, &activity.streams),
+        terminals: activity.terminals.clone(),
+        // Deterministic in the window itself: the same window always replays to
+        // the same bootstrap.
+        bootstrap_seed: (request.pool_id as u64) ^ (window.start_second() as u64),
+    };
+    Ok(observe_window_v1(state, &observation))
+}
+
+#[cfg(test)]
+#[path = "model_turn_admission_subscription_learner_tests.rs"]
+mod tests;

--- a/server/crates/djinn-coordinator/src/model_turn_admission_subscription_learner_tests.rs
+++ b/server/crates/djinn-coordinator/src/model_turn_admission_subscription_learner_tests.rs
@@ -1,0 +1,658 @@
+//! Golden traces for aggregate-throughput learning and the concurrency
+//! controller (task yh4d).
+//!
+//! Every number here is the epic's contract, not a snapshot of whatever the
+//! implementation happened to produce: 100 aggregate tokens/s for one
+//! 6,000-token stream and for two overlapping 3,000-token streams, 140 for two
+//! overlapping 4,200-token streams, and a controller that walks 1 → 9 on eight
+//! qualifying probes and back to 8 on one deduplicated loss.
+
+use super::*;
+use djinn_core::models::{Model, Pricing, Provider};
+use djinn_db::{Database, repositories::test_support::seed_scoped_model_turn_admission_fixture};
+
+use crate::model_turn_admission::{
+    ExpectedAttemptPathV1, PhaseCWindowAccountingV1, PhaseCWindowDiagnosticCodeV1,
+    PhaseCWindowDiagnosticV1, PhaseCWindowQualificationV1,
+    persist_catalog_qualified_phase_c_window_v1,
+};
+
+const WINDOW_START_SECOND: i64 = 120;
+const WINDOW_START: &str = "1970-01-01T00:02:00Z";
+const WINDOW_END: &str = "1970-01-01T00:03:00Z";
+const PROVIDER: &str = "yh4d-provider";
+const MODEL: &str = "namespace/yh4d-model";
+
+fn window() -> AlignedPhaseCWindowV1 {
+    AlignedPhaseCWindowV1::new(WINDOW_START_SECOND).expect("aligned window")
+}
+
+/// A stream active over `[start, end)` emitting `tokens` in equal parts, one
+/// emission per second, so tokens really are assigned by emission timestamp.
+fn stream(start: i64, end: i64, tokens: i64) -> ActiveStreamV1 {
+    let seconds = end - start;
+    assert!(
+        seconds > 0 && tokens % seconds == 0,
+        "fixture must divide evenly"
+    );
+    ActiveStreamV1 {
+        started_at_second: start,
+        ended_at_second: end,
+        emissions: (start..end)
+            .map(|emitted_at_second| OutputTokenEmissionV1 {
+                emitted_at_second,
+                output_tokens: tokens / seconds,
+            })
+            .collect(),
+    }
+}
+
+// ── Aggregate rate goldens ──────────────────────────────────────────────────
+
+#[test]
+fn one_six_thousand_token_stream_is_one_hundred_aggregate_tokens_per_second() {
+    let throughput = aggregate_output_throughput_v1(window(), &[stream(120, 180, 6_000)]);
+    assert_eq!(throughput.output_tokens, 6_000);
+    assert_eq!(throughput.active_union_seconds, 60);
+    assert_eq!(throughput.tokens_per_second, 100.0);
+}
+
+#[test]
+fn two_overlapping_three_thousand_token_streams_are_also_one_hundred() {
+    let streams = [stream(120, 180, 3_000), stream(120, 180, 3_000)];
+    let throughput = aggregate_output_throughput_v1(window(), &streams);
+    assert_eq!(throughput.output_tokens, 6_000);
+    assert_eq!(
+        throughput.active_union_seconds, 60,
+        "two fully overlapping streams occupy 60 seconds of wall clock, not 120"
+    );
+    assert_eq!(throughput.tokens_per_second, 100.0);
+
+    // Summed stream-seconds would have produced 50 tokens/s. The union is
+    // therefore load-bearing and not an accidental agreement.
+    let summed_stream_seconds: i64 = streams
+        .iter()
+        .map(|stream| stream.ended_at_second - stream.started_at_second)
+        .sum();
+    assert_eq!(summed_stream_seconds, 120);
+    assert_ne!(
+        throughput.tokens_per_second,
+        throughput.output_tokens as f64 / summed_stream_seconds as f64
+    );
+}
+
+#[test]
+fn two_overlapping_forty_two_hundred_token_streams_are_one_hundred_forty() {
+    let throughput = aggregate_output_throughput_v1(
+        window(),
+        &[stream(120, 180, 4_200), stream(120, 180, 4_200)],
+    );
+    assert_eq!(throughput.output_tokens, 8_400);
+    assert_eq!(throughput.active_union_seconds, 60);
+    assert_eq!(throughput.tokens_per_second, 140.0);
+}
+
+#[test]
+fn crossing_streams_clip_to_the_half_open_window() {
+    // Each stream straddles a boundary; only the in-window halves count, and
+    // together they tile the window exactly once.
+    let leading = stream(90, 150, 6_000); // 100/s, half inside
+    let trailing = stream(150, 210, 6_000); // 100/s, half inside
+    let throughput = aggregate_output_throughput_v1(window(), &[leading, trailing]);
+    assert_eq!(throughput.active_union_seconds, 60);
+    assert_eq!(throughput.output_tokens, 6_000);
+    assert_eq!(throughput.tokens_per_second, 100.0);
+
+    // The window is half-open: a stream that ends exactly at the start, or
+    // begins exactly at the end, contributes nothing.
+    for outside in [stream(60, 120, 6_000), stream(180, 240, 6_000)] {
+        let throughput = aggregate_output_throughput_v1(window(), &[outside]);
+        assert_eq!(throughput.active_union_seconds, 0);
+        assert_eq!(throughput.output_tokens, 0);
+        assert_eq!(throughput.tokens_per_second, 0.0);
+    }
+
+    // An emission timestamped at the exact end second belongs to the next
+    // window, even when its stream is still active.
+    let boundary = ActiveStreamV1 {
+        started_at_second: 120,
+        ended_at_second: 240,
+        emissions: vec![
+            OutputTokenEmissionV1 {
+                emitted_at_second: 179,
+                output_tokens: 6_000,
+            },
+            OutputTokenEmissionV1 {
+                emitted_at_second: 180,
+                output_tokens: 999_999,
+            },
+        ],
+    };
+    let throughput = aggregate_output_throughput_v1(window(), &[boundary]);
+    assert_eq!(throughput.output_tokens, 6_000);
+    assert_eq!(throughput.active_union_seconds, 60);
+    assert_eq!(throughput.tokens_per_second, 100.0);
+}
+
+#[test]
+fn partial_overlap_unions_rather_than_sums() {
+    // [120,180) and [150,180): the union is the whole window, while summed
+    // stream-seconds would be 90 and would report 66.67 tokens/s.
+    let streams = [stream(120, 180, 3_000), stream(150, 180, 3_000)];
+    let throughput = aggregate_output_throughput_v1(window(), &streams);
+    assert_eq!(throughput.active_union_seconds, 60);
+    assert_eq!(throughput.output_tokens, 6_000);
+    assert_eq!(throughput.tokens_per_second, 100.0);
+    let summed_stream_seconds: i64 = streams
+        .iter()
+        .map(|stream| stream.ended_at_second - stream.started_at_second)
+        .sum();
+    assert_eq!(summed_stream_seconds, 90);
+    assert_ne!(
+        throughput.tokens_per_second,
+        throughput.output_tokens as f64 / summed_stream_seconds as f64
+    );
+}
+
+// ── Eligibility, baseline, bootstrap ────────────────────────────────────────
+
+#[test]
+fn eligibility_needs_eight_turns_and_thirty_union_seconds() {
+    let long = aggregate_output_throughput_v1(window(), &[stream(120, 180, 6_000)]);
+    let exactly_thirty = aggregate_output_throughput_v1(window(), &[stream(120, 150, 3_000)]);
+    let just_short = aggregate_output_throughput_v1(window(), &[stream(120, 149, 2_900)]);
+
+    assert_eq!(exactly_thirty.active_union_seconds, 30);
+    assert_eq!(just_short.active_union_seconds, 29);
+
+    assert!(window_is_eligible_v1(8, &long));
+    assert!(window_is_eligible_v1(8, &exactly_thirty));
+    assert!(!window_is_eligible_v1(7, &long));
+    assert!(!window_is_eligible_v1(8, &just_short));
+    // Two overlapping half-windows still only buy 30 union seconds.
+    let overlapping = aggregate_output_throughput_v1(
+        window(),
+        &[stream(120, 150, 1_500), stream(120, 150, 1_500)],
+    );
+    assert_eq!(overlapping.active_union_seconds, 30);
+}
+
+#[test]
+fn baseline_is_an_ewma_with_alpha_zero_point_two() {
+    assert_eq!(update_baseline_v1(None, 100.0), 100.0);
+    // 0.2 * 200 + 0.8 * 100
+    assert_eq!(update_baseline_v1(Some(100.0), 200.0), 120.0);
+    assert_eq!(update_baseline_v1(Some(120.0), 120.0), 120.0);
+}
+
+#[test]
+fn the_bootstrap_is_deterministic_and_confidence_bounded() {
+    let samples = vec![100.0, 104.0, 96.0, 102.0, 98.0];
+    let first = bootstrap_lower_bound_v1(&samples, 7).expect("bound");
+    let again = bootstrap_lower_bound_v1(&samples, 7).expect("bound");
+    assert_eq!(first, again, "the same seed must replay the same bound");
+    assert!(
+        first < 100.0,
+        "a 95% lower bound must sit below the sample mean, got {first}"
+    );
+    assert!(bootstrap_lower_bound_v1(&[], 7).is_none());
+
+    // A noisy sample set whose mean beats the baseline still fails when the
+    // lower bound does not clear the 5% threshold.
+    assert!(!growth_qualifies_v1(&[40.0, 170.0], 100.0, 7));
+    // A tight sample set well above the threshold passes.
+    assert!(growth_qualifies_v1(&[150.0, 152.0, 149.0], 100.0, 7));
+    // Exactly at the threshold is not growth.
+    assert!(!growth_qualifies_v1(&[105.0, 105.0, 105.0], 100.0, 7));
+}
+
+// ── Controller golden trace ─────────────────────────────────────────────────
+
+fn qualified(completed_turns: i64) -> PhaseCLearnerWindowV1 {
+    PhaseCLearnerWindowV1 {
+        pool_id: 1,
+        window_sequence: 2,
+        started_at: WINDOW_START.into(),
+        ended_at: WINDOW_END.into(),
+        admitted_turns: completed_turns,
+        completed_turns,
+    }
+}
+
+/// An eligible window whose per-stream samples all sit at `rate`.
+fn eligible_at(rate: f64) -> SubscriptionWindowObservationV1 {
+    SubscriptionWindowObservationV1 {
+        qualified: Some(qualified(8)),
+        throughput: AggregateThroughputV1 {
+            output_tokens: (rate * 60.0) as i64,
+            active_union_seconds: 60,
+            tokens_per_second: rate,
+        },
+        rate_samples: vec![rate, rate, rate],
+        terminals: Vec::new(),
+        bootstrap_seed: 42,
+    }
+}
+
+fn loss(attempt: &str) -> AttemptTerminalObservationV1 {
+    AttemptTerminalObservationV1 {
+        attempt: attempt.to_owned(),
+        terminal: ProviderAttemptTerminalV1::Failed(ProviderAttemptLossV1::RateLimited),
+    }
+}
+
+#[test]
+fn the_controller_walks_one_to_nine_then_backs_off_to_eight() {
+    let mut state = SubscriptionControllerStateV1::new();
+    assert_eq!(state.target(), 1, "targets start at 1");
+
+    // The first eligible window only establishes the baseline.
+    let mut rate = 100.0;
+    assert_eq!(
+        observe_window_v1(&mut state, &eligible_at(rate)),
+        ControllerTransitionV1::ProbeDidNotGrow
+    );
+    assert_eq!(state.target(), 1);
+    assert_eq!(state.baseline(), Some(100.0));
+
+    // Eight qualifying growth probes, each comfortably clearing the EWMA
+    // baseline by more than 5%, take the target from 1 to 9.
+    for probe in 1..=8 {
+        rate *= 1.5;
+        assert_eq!(
+            observe_window_v1(&mut state, &eligible_at(rate)),
+            ControllerTransitionV1::Grew,
+            "probe {probe} must qualify"
+        );
+        assert_eq!(state.target(), 1 + probe);
+    }
+    assert_eq!(state.target(), 9);
+
+    // One deduplicated loss: floor(0.9 * 9) = 8.
+    let mut window = eligible_at(rate * 1.5);
+    window.terminals = vec![loss("attempt-a")];
+    assert_eq!(
+        observe_window_v1(&mut state, &window),
+        ControllerTransitionV1::BackedOff,
+        "a loss takes precedence over the growth this same window would show"
+    );
+    assert_eq!(state.target(), 8);
+
+    // The same loss again is a duplicate and holds.
+    let mut duplicate = eligible_at(rate * 4.0);
+    duplicate.terminals = vec![loss("attempt-a")];
+    assert_eq!(
+        observe_window_v1(&mut state, &duplicate),
+        ControllerTransitionV1::HeldDuplicateLoss
+    );
+    assert_eq!(state.target(), 8);
+
+    // An unqualified window holds and moves nothing, including the baseline.
+    let baseline = state.baseline();
+    let mut unqualified = eligible_at(rate * 4.0);
+    unqualified.qualified = None;
+    assert_eq!(
+        observe_window_v1(&mut state, &unqualified),
+        ControllerTransitionV1::HeldUnqualified
+    );
+    assert_eq!(state.target(), 8);
+    assert_eq!(state.baseline(), baseline);
+
+    // So does an eligible-looking window that is under the thresholds.
+    let mut ineligible = eligible_at(rate * 4.0);
+    ineligible.qualified = Some(qualified(7));
+    assert_eq!(
+        observe_window_v1(&mut state, &ineligible),
+        ControllerTransitionV1::HeldIneligible
+    );
+    assert_eq!(state.target(), 8);
+    assert_eq!(state.baseline(), baseline);
+}
+
+#[test]
+fn three_non_growing_probes_are_rejected_and_five_plateau_windows_hold() {
+    let mut state = SubscriptionControllerStateV1::new();
+    // Establish a baseline, then feed a flat plateau.
+    assert_eq!(
+        observe_window_v1(&mut state, &eligible_at(100.0)),
+        ControllerTransitionV1::ProbeDidNotGrow
+    );
+    for probe in 1..=2 {
+        assert_eq!(
+            observe_window_v1(&mut state, &eligible_at(100.0)),
+            ControllerTransitionV1::ProbeDidNotGrow,
+            "plateau probe {probe}"
+        );
+        assert_eq!(state.non_growing_probes(), probe);
+    }
+    assert_eq!(
+        observe_window_v1(&mut state, &eligible_at(100.0)),
+        ControllerTransitionV1::ProbeRejected,
+        "the third consecutive non-growing probe suspends probing"
+    );
+    assert_eq!(state.remaining_hold_windows(), 5);
+    assert_eq!(state.target(), 1);
+
+    // Five held windows follow, and growth cannot slip through any of them.
+    for held in 1..=5 {
+        assert_eq!(
+            observe_window_v1(&mut state, &eligible_at(1_000.0)),
+            ControllerTransitionV1::HeldPlateau,
+            "held window {held}"
+        );
+        assert_eq!(state.target(), 1);
+        assert_eq!(state.remaining_hold_windows(), 5 - held);
+    }
+    // Probing resumes on the sixth.
+    assert_eq!(
+        observe_window_v1(&mut state, &eligible_at(10_000.0)),
+        ControllerTransitionV1::Grew
+    );
+    assert_eq!(state.target(), 2);
+}
+
+#[test]
+fn a_loss_can_never_also_count_as_growth() {
+    let mut state = SubscriptionControllerStateV1::new();
+    observe_window_v1(&mut state, &eligible_at(100.0));
+    for _ in 0..4 {
+        let mut growing = eligible_at(state.baseline().expect("baseline") * 4.0);
+        growing.terminals = Vec::new();
+        assert_eq!(
+            observe_window_v1(&mut state, &growing),
+            ControllerTransitionV1::Grew
+        );
+    }
+    assert_eq!(state.target(), 5);
+
+    // The very same window shape, plus one typed B1 failure, backs off instead.
+    let mut with_loss = eligible_at(state.baseline().expect("baseline") * 4.0);
+    with_loss.terminals = vec![loss("attempt-b")];
+    assert_eq!(
+        observe_window_v1(&mut state, &with_loss),
+        ControllerTransitionV1::BackedOff
+    );
+    assert_eq!(state.target(), 4);
+
+    // Completed and aborted terminals are not losses.
+    for terminal in [
+        ProviderAttemptTerminalV1::Completed,
+        ProviderAttemptTerminalV1::Aborted,
+    ] {
+        let mut window = eligible_at(state.baseline().expect("baseline") * 4.0);
+        window.terminals = vec![AttemptTerminalObservationV1 {
+            attempt: "attempt-c".to_owned(),
+            terminal,
+        }];
+        assert_eq!(
+            observe_window_v1(&mut state, &window),
+            ControllerTransitionV1::Grew,
+            "{terminal:?} must not read as a loss"
+        );
+    }
+}
+
+#[test]
+fn the_target_never_leaves_one_through_thirty_two() {
+    let mut state = SubscriptionControllerStateV1::new();
+    let mut rate = 100.0;
+    observe_window_v1(&mut state, &eligible_at(rate));
+    // Far more qualifying probes than the ceiling allows.
+    for _ in 0..64 {
+        rate *= 1.5;
+        observe_window_v1(&mut state, &eligible_at(rate));
+        assert!((MIN_TARGET..=MAX_TARGET).contains(&state.target()));
+    }
+    assert_eq!(state.target(), MAX_TARGET);
+
+    // And far more distinct losses than the floor allows.
+    for index in 0..64 {
+        let mut window = eligible_at(rate);
+        window.terminals = vec![loss(&format!("attempt-{index}"))];
+        observe_window_v1(&mut state, &window);
+        assert!((MIN_TARGET..=MAX_TARGET).contains(&state.target()));
+    }
+    assert_eq!(state.target(), MIN_TARGET);
+}
+
+// ── Production ingestion ────────────────────────────────────────────────────
+
+fn yh4d_catalog() -> CatalogService {
+    let catalog = CatalogService::new();
+    catalog.add_custom_provider(
+        Provider {
+            id: PROVIDER.into(),
+            name: "yh4d Provider".into(),
+            npm: String::new(),
+            env_vars: vec!["YH4D_API_KEY".into()],
+            base_url: "https://example.invalid/v1".into(),
+            docs_url: String::new(),
+            is_openai_compatible: true,
+        },
+        vec![Model {
+            id: MODEL.into(),
+            provider_id: PROVIDER.into(),
+            name: "yh4d Model".into(),
+            tool_call: false,
+            reasoning: false,
+            attachment: false,
+            context_window: 1,
+            output_limit: 1,
+            pricing: Pricing::default(),
+        }],
+    );
+    catalog
+}
+
+fn activity() -> WindowActivityV1 {
+    WindowActivityV1 {
+        streams: vec![stream(120, 180, 3_000), stream(120, 180, 3_000)],
+        terminals: Vec::new(),
+    }
+}
+
+/// Ingestion reads the verdict off the durable ledger through gscv's seam. A
+/// caller cannot assert that a diagnostic window is trainable, and a window that
+/// stops resolving in the active catalog stops feeding the learner.
+#[tokio::test]
+async fn production_ingestion_only_learns_from_a_catalog_qualified_durable_window() {
+    let db = Database::ephemeral().await.expect("db");
+    let pool_id = seed_scoped_model_turn_admission_fixture(
+        &db,
+        "yh4d-ingest",
+        PROVIDER,
+        MODEL,
+        "shadow",
+        "supported",
+        1,
+    )
+    .await;
+    let repository = ModelTurnAdmissionRepository::new(db);
+    let catalog = yh4d_catalog();
+    // A descendant module of `model_turn_admission`, so the deliberately
+    // private route fields are constructible here exactly as production does.
+    let path = ExpectedAttemptPathV1 {
+        slot_pod_uid: "slot-uid".into(),
+        deployment_revision: "revision-1".into(),
+        provider: PROVIDER.into(),
+        model_scope: MODEL.into(),
+        pool_id,
+    };
+    let accounting = |completed: i64| PhaseCWindowAccountingV1 {
+        window_sequence: 2,
+        started_at: WINDOW_START.into(),
+        ended_at: WINDOW_END.into(),
+        admitted_turns: completed,
+        completed_turns: completed,
+    };
+    let mut state = SubscriptionControllerStateV1::new();
+    let request = QualifiedWindowRequestV1 {
+        pool_id,
+        window: window(),
+        started_at: WINDOW_START.into(),
+        ended_at: WINDOW_END.into(),
+    };
+    let ingest = async |state: &mut SubscriptionControllerStateV1| {
+        ingest_qualified_window_v1(&repository, &catalog, state, &request, &activity())
+            .await
+            .expect("ingest")
+    };
+
+    // Absent: nothing persisted yet.
+    assert_eq!(
+        ingest(&mut state).await,
+        ControllerTransitionV1::HeldUnqualified
+    );
+    assert_eq!(state.baseline(), None);
+
+    // A diagnostic window is durable but never trainable, so it cannot reach a
+    // rate or state transition either.
+    persist_catalog_qualified_phase_c_window_v1(
+        &repository,
+        &catalog,
+        &path,
+        accounting(8),
+        &PhaseCWindowQualificationV1 {
+            admitted: false,
+            diagnostics: vec![PhaseCWindowDiagnosticV1 {
+                pool_id,
+                code: PhaseCWindowDiagnosticCodeV1::MissingUsage,
+            }],
+        },
+    )
+    .await
+    .expect("persist diagnostic window");
+    assert_eq!(
+        ingest(&mut state).await,
+        ControllerTransitionV1::HeldUnqualified
+    );
+    assert_eq!(state.baseline(), None);
+
+    // A trainable window over the same bounds does reach the learner, and it
+    // arrives with the aggregate rate — 100, not 50.
+    persist_catalog_qualified_phase_c_window_v1(
+        &repository,
+        &catalog,
+        &path,
+        accounting(8),
+        &PhaseCWindowQualificationV1 {
+            admitted: true,
+            diagnostics: Vec::new(),
+        },
+    )
+    .await
+    .expect("persist trainable window");
+    assert_eq!(
+        ingest(&mut state).await,
+        ControllerTransitionV1::ProbeDidNotGrow
+    );
+    assert_eq!(state.baseline(), Some(100.0));
+
+    // A window under the completed-turn threshold is eligible for nothing.
+    persist_catalog_qualified_phase_c_window_v1(
+        &repository,
+        &catalog,
+        &path,
+        accounting(7),
+        &PhaseCWindowQualificationV1 {
+            admitted: true,
+            diagnostics: Vec::new(),
+        },
+    )
+    .await
+    .expect("persist short window");
+    assert_eq!(
+        ingest(&mut state).await,
+        ControllerTransitionV1::HeldIneligible
+    );
+
+    // Losing the route from the active catalog stops the learner cold.
+    persist_catalog_qualified_phase_c_window_v1(
+        &repository,
+        &catalog,
+        &path,
+        accounting(8),
+        &PhaseCWindowQualificationV1 {
+            admitted: true,
+            diagnostics: Vec::new(),
+        },
+    )
+    .await
+    .expect("persist trainable window");
+    catalog.remove_custom_provider(PROVIDER);
+    assert_eq!(
+        ingest(&mut state).await,
+        ControllerTransitionV1::HeldUnqualified
+    );
+
+    // Boundary-mismatched bounds are invisible even while the row is present.
+    let restored = yh4d_catalog();
+    let mut other = SubscriptionControllerStateV1::new();
+    assert_eq!(
+        ingest_qualified_window_v1(
+            &repository,
+            &restored,
+            &mut other,
+            &QualifiedWindowRequestV1 {
+                pool_id,
+                window: AlignedPhaseCWindowV1::new(180).expect("aligned window"),
+                started_at: "1970-01-01T00:03:00Z".into(),
+                ended_at: "1970-01-01T00:04:00Z".into(),
+            },
+            &activity(),
+        )
+        .await
+        .expect("ingest"),
+        ControllerTransitionV1::HeldUnqualified
+    );
+    assert_eq!(other.baseline(), None);
+}
+
+/// The learner has exactly one ingestion seam, and it is gscv's catalog-
+/// qualified one. No raw controller-window query and no caller-supplied verdict
+/// may appear in this module's production source.
+#[test]
+fn learner_ingestion_has_no_raw_or_in_memory_bypass() {
+    let source = include_str!("model_turn_admission_subscription_learner.rs");
+    let production = source
+        .split("\n#[cfg(test)]")
+        .next()
+        .expect("production part");
+    // Split so this assertion is not itself a match.
+    let seam = concat!("learner_catalog_qualified_", "phase_c_window_v1(");
+    assert_eq!(
+        production.matches(seam).count(),
+        1,
+        "exactly one call to the catalog-qualified learner seam"
+    );
+    for forbidden in [
+        concat!("model_turn_", "controller_windows"),
+        concat!("sqlx", "::query"),
+        concat!(".learner_", "window("),
+        // No emergency cap, no breaker reset, no process-local admission
+        // semaphore, no resident scheduler, and no raw sensitive identifier.
+        "emergency_cap",
+        "emergency cap",
+        "reset_breaker",
+        "breaker_reset",
+        "Semaphore",
+        "resident",
+        "credential_id",
+        "user_id",
+        "account_id",
+        "project_id",
+        "request_id",
+        "lease_id",
+        "slot_pod_uid",
+        "snapshot.json",
+    ] {
+        assert!(
+            !production.contains(forbidden),
+            "the learner must not contain {forbidden}"
+        );
+    }
+    // The qualified verdict is read off the durable ledger, never taken from
+    // the activity the caller supplies.
+    assert!(!production.contains("activity.qualified"));
+    assert!(production.contains("qualified: Option<PhaseCLearnerWindowV1>"));
+}


### PR DESCRIPTION
Epic `ai6g`, task `yh4d`, from proposal `96fy`.

`model_turn_admission::subscription_learner` computes an aggregate output rate
and folds it into a bounded concurrency controller. Everything is pure except
one ingestion function, and that function re-reads the window through gscv's
exact-bound active-catalog-qualified seam — there is no raw controller-window
query and no caller-supplied trainability verdict, so a diagnostic, absent,
malformed, catalog-invalid, or boundary-mismatched window produces no qualified
window and cannot reach a rate or a state transition.

## Rate

Each stream is clipped to the aligned half-open window, output tokens are
attributed by emission timestamp, and the denominator is the **union** of
clipped active intervals. Golden traces pin the epic's contract:

| fixture | aggregate |
| --- | --- |
| one 6,000-token stream over 60 s | 100 tokens/s |
| two fully overlapping 3,000-token streams | 100 tokens/s |
| two fully overlapping 4,200-token streams | 140 tokens/s |
| two crossing streams, each half in-window | 100 tokens/s |

Each overlap case also asserts directly that summed stream-seconds would have
produced a *different* number, so the union is proved load-bearing rather than
coincidentally equal.

## Controller

Targets start at 1 and stay in `[1,32]`; eligibility needs 8 completed turns and
30 union seconds; the baseline is an EWMA at alpha 0.2; growth needs a
deterministic (xorshift64*, seeded) 95% bootstrap lower bound clearing the
baseline by 5%; a new deduplicated loss takes precedence over any growth the
same window would have shown and applies `floor(0.9 * target)`; a repeated loss
holds; three consecutive non-growing probes suspend probing for five windows.

The golden trace walks 1 → 9 on eight qualifying probes, 9 → 8 on one
deduplicated loss, holds on the duplicate, and holds on unqualified and
ineligible windows without moving even the baseline.

A source regression proves the module has exactly one call to the qualified
learner seam and contains no raw SQL, no emergency cap, no breaker reset, no
admission semaphore, no resident scheduler, and no raw sensitive identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)