### PR TITLE
chore(5fe1): Typed unresolved-finding projection and parity probe in `djinn-db`

### DIFF
--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -452,8 +452,9 @@ pub use repositories::{
         TribunalEvidenceReturnResultV1, TribunalEvidenceReturnV1, TypedEvidenceAttemptAllocation,
         TypedEvidenceBackfillReport, TypedEvidenceDemandDispatchErrorInput,
         TypedEvidenceDispositionProjection, TypedEvidenceFindingProjection,
-        TypedEvidenceLifecycleProjection, TypedEvidenceRepository,
-        TypedEvidenceRetryDispatchErrorInput, legacy_demand_hash, normalized_demand_hash,
+        TypedEvidenceLifecycleProjection, TypedEvidenceParityMismatchReason,
+        TypedEvidenceParityProbe, TypedEvidenceRepository, TypedEvidenceRetryDispatchErrorInput,
+        UnresolvedTypedEvidenceProjection, legacy_demand_hash, normalized_demand_hash,
     },
     usage_analytics::{
         EntityBreakdownRow, GroupDimension, ModelEffectivenessRow, ProjectModelMatrixRow,

--- a/server/crates/djinn-db/src/repositories/typed_evidence.rs
+++ b/server/crates/djinn-db/src/repositories/typed_evidence.rs
@@ -229,6 +229,83 @@ pub struct LegacyEvidenceParityProjection {
     pub spike_task_id: Option<String>,
 }
 
+/// The single unresolved typed finding for a proposal, carrying the
+/// diagnostics a structural gate needs to explain a refusal.
+///
+/// Selection is proposal-wide and lifecycle-scoped: `demanded_revision_seq` is
+/// provenance about where the demand originated, never a filter, so later
+/// proposal revisions cannot age a finding out of the projection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnresolvedTypedEvidenceProjection {
+    pub finding_id: String,
+    pub claim: serde_json::Value,
+    pub lifecycle: TribunalEvidenceLifecycle,
+    /// The revision the demand was raised against. Provenance only.
+    pub demanded_revision_seq: i32,
+    /// Sequence of the latest allocated attempt, absent before allocation.
+    pub attempt_seq: Option<i32>,
+    /// Validated outcome of the latest attempt's durable return, if any.
+    pub evidence_outcome: Option<TribunalEvidenceOutcome>,
+    /// Folding revision of a recorded disposition. Present only for a stale
+    /// disposition that did not carry the finding to a terminal lifecycle.
+    pub folding_revision: Option<i32>,
+    /// The most specific persisted failure text: an ingress validation error
+    /// for a `failed` finding, otherwise the first normalized failure or gap.
+    pub failure_detail: Option<String>,
+}
+
+/// Why the typed and legacy evidence authorities disagree for a proposal.
+///
+/// Consumers fail closed on any variant; the code exists so a refusal names
+/// which authority was ahead rather than reporting an opaque mismatch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TypedEvidenceParityMismatchReason {
+    /// Legacy compatibility authority (`linked_spike_task_id` or
+    /// `needs_evidence_claim`) is set while no typed unresolved finding exists.
+    LegacyAuthorityWithoutTypedFinding,
+    /// A typed finding that has not yet received a durable return exists while
+    /// the legacy compatibility columns are already cleared.
+    TypedFindingWithoutLegacyAuthority,
+    /// Both authorities claim a demand but the dual read rejects the binding —
+    /// claim, demand hash, attempt, or linked spike task disagree.
+    LegacyBindingDisagrees,
+    /// The proposal row does not exist, so neither authority is readable.
+    ProposalMissing,
+}
+
+impl TypedEvidenceParityMismatchReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyAuthorityWithoutTypedFinding => "legacy_authority_without_typed_finding",
+            Self::TypedFindingWithoutLegacyAuthority => "typed_finding_without_legacy_authority",
+            Self::LegacyBindingDisagrees => "legacy_binding_disagrees",
+            Self::ProposalMissing => "proposal_missing",
+        }
+    }
+}
+
+/// Result of comparing typed and legacy evidence authority for a proposal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TypedEvidenceParityProbe {
+    /// Both authorities describe the same evidence state.
+    Agreed,
+    /// The authorities disagree. Typed-mode consumers must fail closed.
+    Mismatch(TypedEvidenceParityMismatchReason),
+}
+
+impl TypedEvidenceParityProbe {
+    pub const fn mismatch_reason(self) -> Option<TypedEvidenceParityMismatchReason> {
+        match self {
+            Self::Agreed => None,
+            Self::Mismatch(reason) => Some(reason),
+        }
+    }
+
+    pub const fn is_mismatch(self) -> bool {
+        matches!(self, Self::Mismatch(_))
+    }
+}
+
 /// Coordinator-facing lifecycle authority. The repository owns the typed read
 /// and the mixed-version fence so consumers cannot recreate parity rules.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1266,6 +1343,146 @@ impl TypedEvidenceRepository {
         .bind(proposal_id)
         .fetch_one(&mut **tx)
         .await?)
+    }
+
+    /// Typed diagnostics for the proposal's single unresolved finding.
+    ///
+    /// This is the structural gate's only new input. It is deliberately the
+    /// projecting twin of [`Self::has_unresolved_in_transaction`]: same
+    /// proposal-wide, lifecycle-scoped selection, but carrying the identity a
+    /// refusal has to name.
+    pub async fn unresolved_projection(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<UnresolvedTypedEvidenceProjection>> {
+        let mut tx = self.db.pool().begin().await?;
+        let result = Self::unresolved_projection_in_transaction(&mut tx, proposal_id).await?;
+        tx.commit().await?;
+        Ok(result)
+    }
+
+    /// Transaction-scoped twin of [`Self::unresolved_projection`].
+    pub async fn unresolved_projection_in_transaction(
+        tx: &mut Transaction<'_, Postgres>,
+        proposal_id: &str,
+    ) -> Result<Option<UnresolvedTypedEvidenceProjection>> {
+        nonempty(&[proposal_id])?;
+        // The lifecycle predicate lives only here. Re-filtering the row in Rust
+        // would make the terminal-exclusion rule survive its own deletion.
+        let Some(row) = sqlx::query(
+            "SELECT f.id,f.claim,f.lifecycle,f.demanded_revision_seq, \
+                    (SELECT MAX(a.sequence) FROM typed_evidence_attempts a WHERE a.finding_id=f.id) AS attempt_seq, \
+                    (SELECT v.outcome FROM typed_evidence_validation_results v \
+                       JOIN typed_evidence_attempts a ON a.id=v.attempt_id \
+                      WHERE a.finding_id=f.id ORDER BY a.sequence DESC LIMIT 1) AS evidence_outcome, \
+                    (SELECT d.folding_revision FROM typed_evidence_dispositions d \
+                      WHERE d.finding_id=f.id ORDER BY d.folding_revision DESC LIMIT 1) AS folding_revision, \
+                    COALESCE( \
+                      (SELECT t.metadata->>'validation_error' FROM typed_evidence_transitions t \
+                        WHERE t.finding_id=f.id AND t.to_lifecycle='failed' \
+                          AND t.metadata->>'validation_error' IS NOT NULL \
+                        ORDER BY t.ordinal DESC LIMIT 1), \
+                      (SELECT i.detail FROM typed_evidence_issues i \
+                         JOIN typed_evidence_validation_results v ON v.id=i.validation_result_id \
+                         JOIN typed_evidence_attempts a ON a.id=v.attempt_id \
+                        WHERE a.finding_id=f.id ORDER BY a.sequence DESC, i.kind, i.id LIMIT 1) \
+                    ) AS failure_detail \
+               FROM typed_evidence_findings f \
+              WHERE f.proposal_id=$1 \
+                AND f.lifecycle IN ('demanded','spike_active','evidence_received','failed') \
+              ORDER BY f.id LIMIT 1",
+        )
+        .bind(proposal_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        else {
+            return Ok(None);
+        };
+        let evidence_outcome = row
+            .get::<Option<String>, _>("evidence_outcome")
+            .map(|value| parse_outcome(&value))
+            .transpose()?;
+        Ok(Some(UnresolvedTypedEvidenceProjection {
+            finding_id: row.get("id"),
+            claim: row.get("claim"),
+            lifecycle: parse(&row.get::<String, _>("lifecycle"))?,
+            demanded_revision_seq: row.get("demanded_revision_seq"),
+            attempt_seq: row.get("attempt_seq"),
+            evidence_outcome,
+            folding_revision: row.get("folding_revision"),
+            failure_detail: row.get("failure_detail"),
+        }))
+    }
+
+    /// Compare typed and legacy evidence authority for a proposal.
+    ///
+    /// Typed-mode consumers call this before trusting
+    /// [`Self::unresolved_projection`]: a mismatch means one authority is
+    /// ahead of the other and neither may be used to admit a transition.
+    pub async fn legacy_parity_probe(&self, proposal_id: &str) -> Result<TypedEvidenceParityProbe> {
+        let mut tx = self.db.pool().begin().await?;
+        let result = Self::legacy_parity_probe_in_transaction(&mut tx, proposal_id).await?;
+        tx.commit().await?;
+        Ok(result)
+    }
+
+    /// Transaction-scoped twin of [`Self::legacy_parity_probe`].
+    pub async fn legacy_parity_probe_in_transaction(
+        tx: &mut Transaction<'_, Postgres>,
+        proposal_id: &str,
+    ) -> Result<TypedEvidenceParityProbe> {
+        nonempty(&[proposal_id])?;
+        let Some(legacy) = sqlx::query(
+            "SELECT linked_spike_task_id,needs_evidence_claim FROM proposals WHERE id=$1 FOR SHARE",
+        )
+        .bind(proposal_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        else {
+            return Ok(TypedEvidenceParityProbe::Mismatch(
+                TypedEvidenceParityMismatchReason::ProposalMissing,
+            ));
+        };
+        // Either compatibility column standing alone still asserts a legacy
+        // demand: `demand_and_set_legacy_in_transaction` writes the claim
+        // before a spike task is allocated.
+        let legacy_asserts_demand = legacy
+            .get::<Option<String>, _>("linked_spike_task_id")
+            .is_some()
+            || legacy
+                .get::<Option<String>, _>("needs_evidence_claim")
+                .is_some();
+        let typed = Self::unresolved_projection_in_transaction(tx, proposal_id).await?;
+        match (legacy_asserts_demand, typed) {
+            (false, None) => Ok(TypedEvidenceParityProbe::Agreed),
+            (true, None) => Ok(TypedEvidenceParityProbe::Mismatch(
+                TypedEvidenceParityMismatchReason::LegacyAuthorityWithoutTypedFinding,
+            )),
+            (false, Some(projection)) => match projection.lifecycle {
+                // Receipt and ingress-failure both clear legacy authority in
+                // the same transaction as the transition, so a cleared legacy
+                // side agrees with a post-return finding.
+                TribunalEvidenceLifecycle::EvidenceReceived | TribunalEvidenceLifecycle::Failed => {
+                    Ok(TypedEvidenceParityProbe::Agreed)
+                }
+                _ => Ok(TypedEvidenceParityProbe::Mismatch(
+                    TypedEvidenceParityMismatchReason::TypedFindingWithoutLegacyAuthority,
+                )),
+            },
+            (true, Some(projection)) => match projection.lifecycle {
+                // A malformed ingress failure deliberately retains its
+                // compatibility link so the retry can re-dispatch against it.
+                TribunalEvidenceLifecycle::Failed => Ok(TypedEvidenceParityProbe::Agreed),
+                _ => match Self::dual_read_legacy_parity_in_transaction(tx, proposal_id).await? {
+                    Some(parity) if parity.finding.id == projection.finding_id => {
+                        Ok(TypedEvidenceParityProbe::Agreed)
+                    }
+                    _ => Ok(TypedEvidenceParityProbe::Mismatch(
+                        TypedEvidenceParityMismatchReason::LegacyBindingDisagrees,
+                    )),
+                },
+            },
+        }
     }
 
     pub async fn allocate_attempt_in_transaction(

--- a/server/crates/djinn-db/tests/typed_evidence_unresolved_projection.rs
+++ b/server/crates/djinn-db/tests/typed_evidence_unresolved_projection.rs
@@ -1,0 +1,537 @@
+//! Contract for the typed unresolved-finding projection and its legacy parity
+//! probe.
+//!
+//! The projection is the structural gate's only new input, so every assertion
+//! here is on persisted repository state reached through production writers.
+//! Lifecycle states are produced by `set_structured_needs_evidence_spike`,
+//! `submit_return_v1_for_task`, and `dispose_in_transaction` rather than by
+//! writing a lifecycle string, so a row cannot be labelled into a state the
+//! repository would refuse to reach.
+
+use djinn_core::{
+    events::EventBus,
+    models::{NeedsEvidenceClaim, TribunalEvidenceLifecycle, TribunalEvidenceOutcome},
+};
+use djinn_db::{
+    AdmitRefinementRunRequest, Database, DemandTypedEvidenceInput, ProposalCreateInput,
+    ProposalRepository, ProposalUpdateInput, RefinementAdmissionOutcome, RefinementAdmissionSource,
+    TypedEvidenceParityMismatchReason, TypedEvidenceParityProbe, TypedEvidenceRepository,
+    UnresolvedTypedEvidenceProjection, legacy_demand_hash,
+    test_support::{
+        CanonicalTypedEvidenceReturnOutcomeForTest, UsageTestTaskSeed,
+        dispose_typed_evidence_validation_for_test, materialize_judge_authority_for_test,
+        overwrite_legacy_evidence_authority_for_test,
+        seed_canonical_typed_evidence_ingress_fixture_for_test, seed_project, seed_task_row,
+    },
+};
+
+struct Fixture {
+    db: Database,
+    proposals: ProposalRepository,
+    project_id: String,
+    proposal_id: String,
+    spike_task_id: String,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let db = Database::ephemeral().await.unwrap();
+        db.ensure_initialized().await.unwrap();
+        let project_id = uuid::Uuid::now_v7().to_string();
+        seed_project(&db, &project_id, &format!("fixture-{project_id}")).await;
+        let spike_task_id = seed_task_row(
+            &db,
+            UsageTestTaskSeed {
+                project_id: &project_id,
+                status: "open",
+                close_reason: None,
+                total_reopen_count: 0,
+            },
+        )
+        .await;
+        let proposals = ProposalRepository::new(db.clone(), EventBus::noop());
+        let proposal = proposals
+            .create(ProposalCreateInput {
+                title: "typed evidence projection fixture",
+                body: "Fixture body for the unresolved typed evidence projection.",
+                acceptance_criteria: None,
+                status: None,
+                body_format: None,
+            })
+            .await
+            .unwrap();
+        Self {
+            db,
+            proposals,
+            project_id,
+            proposal_id: proposal.id,
+            spike_task_id,
+        }
+    }
+
+    fn typed(&self) -> TypedEvidenceRepository {
+        TypedEvidenceRepository::new(self.db.clone())
+    }
+
+    fn claim(&self) -> NeedsEvidenceClaim {
+        NeedsEvidenceClaim {
+            question: "Does the unresolved projection survive later revisions?".into(),
+            target_subsystem: "typed evidence projection".into(),
+            spec_unknown_anchor: "gate diagnostics".into(),
+            insufficient_in_session_research: "requires persisted lifecycle".into(),
+            expected_findings: "finding id, claim, lifecycle, originating revision".into(),
+            created_by_task_id: self.spike_task_id.clone(),
+            round: 1,
+            against_revision_seq: 1,
+        }
+    }
+
+    async fn projection(&self) -> Option<UnresolvedTypedEvidenceProjection> {
+        self.typed()
+            .unresolved_projection(&self.proposal_id)
+            .await
+            .unwrap()
+    }
+
+    async fn probe(&self) -> TypedEvidenceParityProbe {
+        self.typed()
+            .legacy_parity_probe(&self.proposal_id)
+            .await
+            .unwrap()
+    }
+
+    /// Reach `demanded`: a typed demand with no spike allocated yet.
+    async fn demand(&self) -> String {
+        let claim = serde_json::to_value(self.claim()).unwrap();
+        let finding_id = uuid::Uuid::now_v7().to_string();
+        let mut tx = self.db.pool().begin().await.unwrap();
+        TypedEvidenceRepository::demand_and_set_legacy_in_transaction(
+            &mut tx,
+            DemandTypedEvidenceInput {
+                finding_id: finding_id.clone(),
+                proposal_id: self.proposal_id.clone(),
+                demand_hash: legacy_demand_hash(&claim, None),
+                claim,
+                demanded_revision_seq: 1,
+                judge_task_id: self.spike_task_id.clone(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+        finding_id
+    }
+
+    /// Reach `spike_active` through the production structured demand writer.
+    async fn spike_active(&self) -> String {
+        self.proposals
+            .set_structured_needs_evidence_spike(
+                &self.proposal_id,
+                &self.spike_task_id,
+                &self.claim(),
+            )
+            .await
+            .unwrap();
+        self.projection().await.unwrap().finding_id
+    }
+
+    /// Reach `evidence_received` by submitting a canonical durable return.
+    async fn evidence_received(
+        &self,
+        expected: CanonicalTypedEvidenceReturnOutcomeForTest,
+    ) -> (String, String) {
+        let finding_id = self.spike_active().await;
+        let fixture = seed_canonical_typed_evidence_ingress_fixture_for_test(
+            &self.db,
+            &self.proposal_id,
+            &self.spike_task_id,
+            "projection",
+            expected,
+        )
+        .await;
+        assert_eq!(fixture.finding_id, finding_id);
+        close_spike_task(&self.db, &self.spike_task_id).await;
+        let result = self
+            .typed()
+            .submit_return_v1_for_task(&self.spike_task_id, fixture.return_payload.as_bytes())
+            .await
+            .unwrap();
+        (finding_id, result.validation_id)
+    }
+
+    /// Reach `failed` through the ingress rejection path: a payload the
+    /// validator refuses records an append-only failure fact for the attempt.
+    async fn failed(&self) -> String {
+        let finding_id = self.spike_active().await;
+        let fixture = seed_canonical_typed_evidence_ingress_fixture_for_test(
+            &self.db,
+            &self.proposal_id,
+            &self.spike_task_id,
+            "projection",
+            CanonicalTypedEvidenceReturnOutcomeForTest::Resolved,
+        )
+        .await;
+        close_spike_task(&self.db, &self.spike_task_id).await;
+        let mut payload: serde_json::Value = serde_json::from_str(&fixture.return_payload).unwrap();
+        // A rejected conclusion is validated before any normalized row is
+        // written, so this exercises the real rejection branch.
+        payload["conclusion"] = serde_json::json!("");
+        let error = self
+            .typed()
+            .submit_return_v1_for_task(
+                &self.spike_task_id,
+                serde_json::to_string(&payload).unwrap().as_bytes(),
+            )
+            .await
+            .expect_err("a malformed return must be rejected");
+        assert!(
+            format!("{error}").contains("missing_identity"),
+            "unexpected rejection: {error}"
+        );
+        finding_id
+    }
+
+    /// Materialize an active Judge and fold the received evidence terminally.
+    async fn dispose(&self, validation_id: &str, disposition: TribunalEvidenceLifecycle) {
+        self.proposals
+            .record_refinement_lifecycle(&self.proposal_id, "refinement_start", None)
+            .await
+            .unwrap();
+        let (run_id, generation) = match self
+            .proposals
+            .reap_and_admit(AdmitRefinementRunRequest {
+                proposal_id: self.proposal_id.clone(),
+                idempotency_key: format!("projection/{}/{disposition:?}", self.proposal_id),
+                source: RefinementAdmissionSource::Demand {
+                    demand_id: format!("projection/{}/{disposition:?}", self.proposal_id),
+                },
+                heartbeat_grace_millis: 60_000,
+            })
+            .await
+            .unwrap()
+        {
+            RefinementAdmissionOutcome::Admitted {
+                run_id, generation, ..
+            }
+            | RefinementAdmissionOutcome::Existing {
+                run_id, generation, ..
+            } => (run_id, generation),
+        };
+        let judge_task_id = seed_task_row(
+            &self.db,
+            UsageTestTaskSeed {
+                project_id: &self.project_id,
+                status: "open",
+                close_reason: None,
+                total_reopen_count: 0,
+            },
+        )
+        .await;
+        materialize_judge_authority_for_test(
+            &self.db,
+            &judge_task_id,
+            &run_id,
+            i64::from(generation),
+        )
+        .await;
+        let result = dispose_typed_evidence_validation_for_test(
+            &self.db,
+            validation_id,
+            &judge_task_id,
+            disposition,
+        )
+        .await;
+        assert_eq!(result.finding_lifecycle, disposition);
+    }
+
+    /// Append two further spec revisions after the demand was raised.
+    async fn advance_two_revisions(&self) {
+        for seq in 2..=3 {
+            let proposal = self
+                .proposals
+                .get(&self.proposal_id)
+                .await
+                .unwrap()
+                .unwrap();
+            let updated = self
+                .proposals
+                .update(
+                    &self.proposal_id,
+                    ProposalUpdateInput {
+                        title: &proposal.title,
+                        body: &format!("Fixture body revised for revision {seq}."),
+                        acceptance_criteria: &proposal.acceptance_criteria,
+                        status: &proposal.status,
+                        superseded_by: None,
+                        body_format: None,
+                        event_metadata: None,
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(updated.latest_revision_seq, seq);
+        }
+    }
+}
+
+/// The durable return path authenticates a closed spike task.
+async fn close_spike_task(db: &Database, spike_task_id: &str) {
+    sqlx::query("UPDATE tasks SET status='closed', close_reason='completed' WHERE id=$1")
+        .bind(spike_task_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+}
+
+/// Named so `cargo test -p djinn-db typed_evidence_unresolved_projection`
+/// selects every case in this file.
+mod typed_evidence_unresolved_projection {
+    use super::*;
+
+    #[tokio::test]
+    async fn projection_returns_the_finding_for_every_blocking_lifecycle() {
+        // demanded
+        let fixture = Fixture::new().await;
+        let finding_id = fixture.demand().await;
+        let projection = fixture.projection().await.expect("demanded must project");
+        assert_eq!(projection.finding_id, finding_id);
+        assert_eq!(projection.lifecycle, TribunalEvidenceLifecycle::Demanded);
+        assert_eq!(projection.demanded_revision_seq, 1);
+        assert_eq!(projection.attempt_seq, None);
+        assert_eq!(projection.evidence_outcome, None);
+        assert_eq!(projection.folding_revision, None);
+        assert_eq!(
+            projection.claim["question"],
+            serde_json::json!("Does the unresolved projection survive later revisions?")
+        );
+
+        // spike_active
+        let fixture = Fixture::new().await;
+        let finding_id = fixture.spike_active().await;
+        let projection = fixture
+            .projection()
+            .await
+            .expect("spike_active must project");
+        assert_eq!(projection.finding_id, finding_id);
+        assert_eq!(projection.lifecycle, TribunalEvidenceLifecycle::SpikeActive);
+        assert_eq!(projection.attempt_seq, Some(1));
+
+        // evidence_received, for each of the three validated outcomes
+        for (expected, outcome) in [
+            (
+                CanonicalTypedEvidenceReturnOutcomeForTest::Resolved,
+                TribunalEvidenceOutcome::Resolved,
+            ),
+            (
+                CanonicalTypedEvidenceReturnOutcomeForTest::Partial,
+                TribunalEvidenceOutcome::Partial,
+            ),
+            (
+                CanonicalTypedEvidenceReturnOutcomeForTest::Unresolved,
+                TribunalEvidenceOutcome::Unresolved,
+            ),
+        ] {
+            let fixture = Fixture::new().await;
+            let (finding_id, _) = fixture.evidence_received(expected).await;
+            let projection = fixture
+                .projection()
+                .await
+                .unwrap_or_else(|| panic!("evidence_received/{outcome:?} must project"));
+            assert_eq!(projection.finding_id, finding_id);
+            assert_eq!(
+                projection.lifecycle,
+                TribunalEvidenceLifecycle::EvidenceReceived
+            );
+            assert_eq!(projection.evidence_outcome, Some(outcome));
+            assert_eq!(projection.attempt_seq, Some(1));
+            // A resolved return has neither a failure nor a gap; the other two do.
+            assert_eq!(
+                projection.failure_detail.is_some(),
+                outcome != TribunalEvidenceOutcome::Resolved,
+                "failure detail presence must follow the validated outcome"
+            );
+        }
+
+        // failed
+        let fixture = Fixture::new().await;
+        let finding_id = fixture.failed().await;
+        let projection = fixture.projection().await.expect("failed must project");
+        assert_eq!(projection.finding_id, finding_id);
+        assert_eq!(projection.lifecycle, TribunalEvidenceLifecycle::Failed);
+        assert_eq!(
+            projection.failure_detail.as_deref(),
+            Some("missing_identity"),
+            "a failed finding carries its persisted ingress validation error"
+        );
+    }
+
+    #[tokio::test]
+    async fn projection_is_absent_for_both_terminal_lifecycles() {
+        for disposition in [
+            TribunalEvidenceLifecycle::Resolved,
+            TribunalEvidenceLifecycle::Withdrawn,
+        ] {
+            let fixture = Fixture::new().await;
+            let (finding_id, validation_id) = fixture
+                .evidence_received(CanonicalTypedEvidenceReturnOutcomeForTest::Resolved)
+                .await;
+            // Before the disposition the same finding is projected. This is the
+            // mutation fence for the lifecycle predicate: if the predicate is
+            // deleted the assertion below returns this exact id instead of `None`.
+            assert_eq!(
+                fixture.projection().await.map(|p| p.finding_id).as_deref(),
+                Some(finding_id.as_str())
+            );
+            fixture.dispose(&validation_id, disposition).await;
+            assert_eq!(
+                fixture.projection().await.map(|p| p.finding_id),
+                None,
+                "{disposition:?} must not project, and must not project as {finding_id}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn later_revisions_do_not_change_the_projection() {
+        let fixture = Fixture::new().await;
+        let finding_id = fixture.spike_active().await;
+        let before = fixture.projection().await.expect("demand must project");
+        assert_eq!(before.finding_id, finding_id);
+        assert_eq!(before.demanded_revision_seq, 1);
+
+        fixture.advance_two_revisions().await;
+        assert_eq!(
+            fixture
+                .proposals
+                .get(&fixture.proposal_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .latest_revision_seq,
+            3,
+            "the fixture must actually advance the proposal head to N+2"
+        );
+
+        let after = fixture
+            .projection()
+            .await
+            .expect("the demand still blocks at revision N+2");
+        assert_eq!(
+            after, before,
+            "demanded_revision_seq is provenance; the projection is selected proposal-wide"
+        );
+        assert_eq!(after.demanded_revision_seq, 1);
+    }
+
+    #[tokio::test]
+    async fn parity_probe_agrees_with_matching_authority() {
+        let fixture = Fixture::new().await;
+        assert_eq!(fixture.probe().await, TypedEvidenceParityProbe::Agreed);
+        fixture.spike_active().await;
+        assert_eq!(
+            fixture.probe().await,
+            TypedEvidenceParityProbe::Agreed,
+            "a dual-written demand must not read as a mismatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn parity_probe_distinguishes_the_two_drift_directions() {
+        // Legacy ahead: a compatibility link with no typed finding behind it.
+        let fixture = Fixture::new().await;
+        overwrite_legacy_evidence_authority_for_test(
+            &fixture.db,
+            &fixture.proposal_id,
+            Some(&fixture.spike_task_id),
+            Some(&serde_json::to_value(fixture.claim()).unwrap()),
+        )
+        .await;
+        assert_eq!(fixture.projection().await, None);
+        assert_eq!(
+            fixture.probe().await,
+            TypedEvidenceParityProbe::Mismatch(
+                TypedEvidenceParityMismatchReason::LegacyAuthorityWithoutTypedFinding
+            )
+        );
+
+        // Typed ahead: an unresolved pre-return finding whose legacy link is gone.
+        let fixture = Fixture::new().await;
+        let finding_id = fixture.spike_active().await;
+        overwrite_legacy_evidence_authority_for_test(&fixture.db, &fixture.proposal_id, None, None)
+            .await;
+        assert_eq!(
+            fixture.projection().await.map(|p| p.finding_id).as_deref(),
+            Some(finding_id.as_str()),
+            "the typed finding must still be unresolved for this to be drift"
+        );
+        assert_eq!(
+            fixture.probe().await,
+            TypedEvidenceParityProbe::Mismatch(
+                TypedEvidenceParityMismatchReason::TypedFindingWithoutLegacyAuthority
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn parity_mismatch_reason_codes_are_distinct_and_typed() {
+        let codes = [
+            TypedEvidenceParityMismatchReason::LegacyAuthorityWithoutTypedFinding,
+            TypedEvidenceParityMismatchReason::TypedFindingWithoutLegacyAuthority,
+            TypedEvidenceParityMismatchReason::LegacyBindingDisagrees,
+            TypedEvidenceParityMismatchReason::ProposalMissing,
+        ]
+        .map(TypedEvidenceParityMismatchReason::as_str);
+        let mut unique = codes.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), codes.len(), "reason codes must be distinct");
+        assert_eq!(
+            TypedEvidenceParityProbe::Agreed.mismatch_reason(),
+            None,
+            "agreement carries no reason code"
+        );
+    }
+
+    #[tokio::test]
+    async fn parity_probe_rejects_a_repointed_legacy_link() {
+        let fixture = Fixture::new().await;
+        fixture.spike_active().await;
+        let other_task_id = seed_task_row(
+            &fixture.db,
+            UsageTestTaskSeed {
+                project_id: &fixture.project_id,
+                status: "open",
+                close_reason: None,
+                total_reopen_count: 0,
+            },
+        )
+        .await;
+        overwrite_legacy_evidence_authority_for_test(
+            &fixture.db,
+            &fixture.proposal_id,
+            Some(&other_task_id),
+            Some(&serde_json::to_value(fixture.claim()).unwrap()),
+        )
+        .await;
+        assert_eq!(
+            fixture.probe().await,
+            TypedEvidenceParityProbe::Mismatch(
+                TypedEvidenceParityMismatchReason::LegacyBindingDisagrees
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn parity_probe_reports_a_missing_proposal() {
+        let db = Database::ephemeral().await.unwrap();
+        db.ensure_initialized().await.unwrap();
+        assert_eq!(
+            TypedEvidenceRepository::new(db)
+                .legacy_parity_probe(&uuid::Uuid::now_v7().to_string())
+                .await
+                .unwrap(),
+            TypedEvidenceParityProbe::Mismatch(TypedEvidenceParityMismatchReason::ProposalMissing)
+        );
+    }
+}


### PR DESCRIPTION
Task `5fe1` — first of the six-task `8tgo` chain (structural evidence gates and tribunal role context).

## What changed

`TypedEvidenceRepository::has_unresolved_in_transaction` returns a bare `bool`. That is enough to refuse a transition but not enough to explain one, and the structural gates landing in `0072` have to name the finding they are blocking on.

- **`UnresolvedTypedEvidenceProjection`** — the projecting twin of the boolean, carrying `finding_id`, `claim`, `lifecycle`, `demanded_revision_seq`, plus `attempt_seq`, `evidence_outcome`, `folding_revision`, and `failure_detail`.
- **`unresolved_projection` / `unresolved_projection_in_transaction`** — same proposal-wide, lifecycle-scoped selection as the boolean. The lifecycle predicate lives only in SQL; the row is not re-filtered in Rust, so the terminal-exclusion rule cannot survive its own deletion.
- **`legacy_parity_probe` / `_in_transaction`** — compares typed and legacy evidence authority and names which side is ahead with a typed reason code, so a mixed-version consumer fails closed with a diagnosis rather than an opaque `None`. Reuses `dual_read_legacy_parity` for the binding check.

The probe stays quiet on the two shapes that are legitimate rather than drift: legacy authority cleared after a durable receipt, and a malformed-ingress `failed` finding that deliberately retains its compatibility link for the retry.

## Acceptance criteria

| AC | How it is verified |
| --- | --- |
| Projects `Some` for `demanded`, `spike_active`, `evidence_received`×3 outcomes, `failed`; `None` for `resolved`/`withdrawn` | `projection_returns_the_finding_for_every_blocking_lifecycle` and `projection_is_absent_for_both_terminal_lifecycles`. Every state is reached through a production writer — `set_structured_needs_evidence_spike`, `submit_return_v1_for_task`, `dispose_in_transaction` — never by writing a lifecycle string. |
| Revisions N+1 / N+2 do not change the projection | `later_revisions_do_not_change_the_projection` advances the head through `ProposalRepository::update`, asserts `latest_revision_seq == 3`, then asserts the whole projection is **equal** to the pre-advance value. |
| Probe distinguishes both drift directions by reason code | `parity_probe_distinguishes_the_two_drift_directions` asserts two different `TypedEvidenceParityMismatchReason` variants; `parity_mismatch_reason_codes_are_distinct_and_typed` pins the codes as distinct. |
| Deleting the lifecycle filter makes `resolved`/`withdrawn` fail | Verified by mutation: removing `AND f.lifecycle IN (...)` from the query turns `projection_is_absent_for_both_terminal_lifecycles` red with `left: Some("01a011d2-…") right: None`. The test asserts the returned finding id, not a count. |

## Verification

```
cargo nextest run -p djinn-db typed_evidence_unresolved_projection
  8 tests run: 8 passed
cargo clippy -p djinn-db --all-targets   # clean
BASE_SHA=origin/main ./scripts/check-raw-sql-boundary.sh   # clean
```

No `sqlx::query!` macros were added, so the offline cache is unaffected. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
