### PR TITLE
chore(ci29): Fence startup census against the durable starting-to-CREATE transit

### DIFF
--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -3117,16 +3117,7 @@ pub(super) async fn reap_stale_task_runs_for_startup_with_census(
 /// CREATE, so authoritative absence cannot reap it. This never consults the
 /// startup age threshold or mutable repository state.
 fn startup_task_run_mutation_authorized(run: &crate::startup_census::CensusTaskRun) -> bool {
-    use crate::startup_census::{DurableRunState, GoneProvenance, TaskRunWitness};
-
-    matches!(
-        (run.durable_state, run.witness),
-        (_, TaskRunWitness::Gone(GoneProvenance::TerminalPresent))
-            | (
-                DurableRunState::Running,
-                TaskRunWitness::Gone(GoneProvenance::AuthoritativelyAbsent)
-            )
-    )
+    run.destructive_mutation_authorized()
 }
 
 /// Stage C may classify an attempt only when the immutable reduction proves

--- a/server/crates/djinn-coordinator/src/startup_census.rs
+++ b/server/crates/djinn-coordinator/src/startup_census.rs
@@ -58,6 +58,28 @@ pub struct CensusTaskRun {
     pub witness: TaskRunWitness,
 }
 
+impl CensusTaskRun {
+    /// Whether this run's immutable evidence authorizes a destructive startup
+    /// mutation of the run itself or of anything linked to it.
+    ///
+    /// A durable `starting` row whose Job is authoritatively absent can still
+    /// be inside the commit-then-CREATE window, so authoritative absence alone
+    /// never authorizes destruction for it. Every startup stage shares this
+    /// single rule: Stage A's session interruption, Stage B's task-run reaping,
+    /// and (through [`TaskCensusProjection`]) Stage C's attempt classification
+    /// must not disagree about whether one identity is destructively gone.
+    pub fn destructive_mutation_authorized(&self) -> bool {
+        matches!(
+            (self.durable_state, self.witness),
+            (_, TaskRunWitness::Gone(GoneProvenance::TerminalPresent))
+                | (
+                    DurableRunState::Running,
+                    TaskRunWitness::Gone(GoneProvenance::AuthoritativelyAbsent)
+                )
+        )
+    }
+}
+
 /// Per-task reduction used by stages which classify attempts rather than a
 /// single run.  A starting row with authoritative absence can still be between
 /// committing its ledger row and CREATE, so it is fenced as `CreationTransit`.

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -23,9 +23,7 @@ use djinn_coordinator::build_lease::BuildLeaseService;
 use djinn_coordinator::build_lease_reclaim::{BuildLeaseReclaimReport, BuildLeaseReclaimer};
 use djinn_coordinator::graph_warm_lease::BuildLeaseGraphWarmAdapter;
 use djinn_coordinator::run_dir_observe::{RunDirObserveSeams, arm_disk_observation};
-use djinn_coordinator::startup_census::{
-    GoneProvenance, InventoryAvailability, StartupCensus, TaskRunWitness,
-};
+use djinn_coordinator::startup_census::{InventoryAvailability, StartupCensus, TaskRunWitness};
 use djinn_core::clock::{Clock, SystemClock as SystemClockTrait};
 use djinn_core::models::KnowledgeInjectionConfig;
 use djinn_db::{
@@ -2508,15 +2506,12 @@ impl AppState {
     }
 
     /// Stage A: only positive destructive census evidence authorizes mutation.
-    #[cfg(not(test))]
-    async fn interrupt_stale_sessions_on_startup_with_census(&self, census: &StartupCensus) {
-        self.interrupt_stale_sessions_on_startup_with_census_impl(census)
-            .await;
-    }
-
-    /// Crate-visible only so the startup identity matrix drives the configured
-    /// Stage A path rather than the `NotConfigured` compatibility path.
-    #[cfg(test)]
+    ///
+    /// Crate-visible so the startup identity matrix — and, through
+    /// [`crate::test_helpers::run_startup_stage_a`], the integration test that
+    /// drives Stage A from inside the production dispatch seam — enter the
+    /// configured Stage A path rather than the `NotConfigured` compatibility
+    /// path. Production reaches it from `run_startup_recovery`.
     pub(crate) async fn interrupt_stale_sessions_on_startup_with_census(
         &self,
         census: &StartupCensus,
@@ -2538,17 +2533,18 @@ impl AppState {
                 repo.interrupt_running_except_task_run_ids(ids).await
             }
         } else {
+            // Stage A carries the census's durable run state, not only its
+            // `Gone` provenance. A durable `starting` row whose Job is
+            // authoritatively absent may simply not have been CREATEd yet, so
+            // it is fenced here exactly as it is in Stage B and Stage C —
+            // otherwise the three stages disagree about one identity and the
+            // session of a run that is mid-dispatch is destroyed.
             let gone: HashSet<&str> = census
                 .runs()
                 .iter()
                 .filter_map(|run| {
-                    matches!(
-                        run.witness,
-                        TaskRunWitness::Gone(
-                            GoneProvenance::AuthoritativelyAbsent | GoneProvenance::TerminalPresent
-                        )
-                    )
-                    .then_some(run.task_run_id.as_str())
+                    run.destructive_mutation_authorized()
+                        .then_some(run.task_run_id.as_str())
                 })
                 .collect();
             let mut session_ids = HashSet::new();

--- a/server/src/server/tests/startup_reconnectability.rs
+++ b/server/src/server/tests/startup_reconnectability.rs
@@ -330,7 +330,6 @@ async fn startup_stage_a_identity_matrix() {
         "the Live census witness preserves its durable linked session"
     );
     for id in [
-        absent_starting_session,
         absent_running_session,
         terminal_starting_session,
         terminal_running_session,
@@ -346,6 +345,10 @@ async fn startup_stage_a_identity_matrix() {
     }
     for id in [
         connected_session,
+        // A durable `starting` row whose Job is authoritatively absent may
+        // simply not have been CREATEd yet, so Stage A carries the census's
+        // durable run state and fences it exactly as Stage B and Stage C do.
+        absent_starting_session,
         // The registry intentionally has no connection for this identity; the
         // Live census witness—not connection absence—preserves it.
         disconnected_live_session,
@@ -371,8 +374,8 @@ async fn startup_stage_a_identity_matrix() {
             .await
             .expect("list remaining sessions")
             .len(),
-        10,
-        "exactly four of fourteen matrix sessions transition; ten fail closed"
+        11,
+        "exactly three of fourteen matrix sessions transition; eleven fail closed"
     );
     for (run_id, expected_status) in [
         (live, "running"),
@@ -751,8 +754,12 @@ async fn startup_stage_c_task_projection() {
         .interrupt_stale_sessions_on_startup_with_census(&census)
         .await;
         let secondary_stage_a_session = match name {
-            "gone-live" | "gone-unknown" => "running",
-            "gone-creation-transit" | "all-gone" => "interrupted",
+            // `gone-creation-transit` is a durable `starting` row with
+            // authoritative absence: Stage A carries that durable run state and
+            // preserves the linked session, matching Stage B's fence and the
+            // task-level `CreationTransit` projection Stage C consumes.
+            "gone-live" | "gone-unknown" | "gone-creation-transit" => "running",
+            "all-gone" => "interrupted",
             _ => unreachable!("projection matrix row is exhaustive"),
         };
         assert_eq!(
@@ -833,7 +840,9 @@ async fn startup_stage_c_task_projection() {
         assert_eq!(fixture.task_run_status(&primary).await, "interrupted");
         let (secondary_session_status, secondary_run_status) = match name {
             "gone-live" | "gone-unknown" => ("running", "running"),
-            "gone-creation-transit" => ("interrupted", "starting"),
+            // The starting row's commit-then-CREATE window is fenced in all
+            // three stages, so neither its session nor its ledger row moves.
+            "gone-creation-transit" => ("running", "starting"),
             "all-gone" => ("interrupted", "interrupted"),
             _ => unreachable!("projection matrix row is exhaustive"),
         };

--- a/server/src/test_helpers.rs
+++ b/server/src/test_helpers.rs
@@ -560,3 +560,20 @@ pub async fn initialize_mcp_session_with_headers(
 
     session_id
 }
+
+/// Drive production startup Stage A against an already-captured immutable
+/// census.
+///
+/// [`AppState::interrupt_stale_sessions_on_startup_with_census`] is
+/// crate-visible, so an integration test that must observe Stage A from inside
+/// the production dispatch seam cannot reach it directly. This forwards to that
+/// exact method with no logic of its own — production still enters Stage A
+/// through `run_startup_recovery`, which is what the ordering regressions pin.
+pub async fn run_startup_stage_a(
+    state: &AppState,
+    census: &djinn_coordinator::startup_census::StartupCensus,
+) {
+    state
+        .interrupt_stale_sessions_on_startup_with_census(census)
+        .await;
+}

--- a/server/tests/startup_create_transit_fence.rs
+++ b/server/tests/startup_create_transit_fence.rs
@@ -1,0 +1,622 @@
+//! The startup census must not mistake a dispatch that is mid-CREATE for a
+//! dispatch that died (task `ci29`, epic `43ww`, proposal `ih1w`).
+//!
+//! # Why this test enters where it does
+//!
+//! There is a real window in production between the moment
+//! `execute_runtime_report_phase` commits a `task_runs` row with
+//! `status = 'starting'` and the moment the Kubernetes Job for that run exists.
+//! A server that boots inside that window LISTs the namespace, does not find
+//! the Job, confirms its absence with an independent GET — and has, by every
+//! rule the census knows, *positive* evidence that the run is gone. It is not.
+//!
+//! Pre-seeding a `starting` row and then running the census proves nothing
+//! about that window, because a pre-seeded row is not inside it. So this test
+//! blocks *in* the window: the `SessionRuntime` it injects is the production
+//! seam's own launch verb, and the entire startup sequence — census
+//! acquisition, Stage A, Stage B, Stage C — runs inside `prepare`, after the
+//! durable `starting` commit and before the Job is created. When `prepare`
+//! returns, CREATE commits and the rest of the dispatch proceeds, which is what
+//! makes the preserved rows meaningful rather than merely untouched.
+//!
+//! # What is real here and what is not
+//!
+//! * **Postgres is real** — `Database::ephemeral()`, real repositories, real
+//!   constraints.
+//! * **The dispatch path is real** —
+//!   `djinn_agent::actors::slot::supervisor_runner::execute_runtime_report_phase`,
+//!   the function the slot actor calls in production, with no shim in front.
+//!   It is what writes the `starting` row this test fences.
+//! * **The startup sequence is real** — `StartupCensus::acquire`,
+//!   `AppState::interrupt_stale_sessions_on_startup_with_census` (through the
+//!   crate's own forwarding helper) and
+//!   `djinn_coordinator::complete_startup_reaper_phase`.
+//! * **Only the apiserver transport is substituted** — the namespace inventory
+//!   and the launcher Pod surface. The Job CREATE itself is the injected
+//!   runtime's `prepare`; what proves it committed is the durable
+//!   `build_pod_permits` row the seam binds to the returned Job UID *after*
+//!   `prepare` returns, which cannot exist unless the launch succeeded.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_coordinator::startup_census::{
+    GoneProvenance, StartupCensus, TaskCensusProjection, TaskRunWitness,
+};
+use djinn_core::clock::{Clock, SystemClock};
+use djinn_db::repositories::session::CreateSessionParams;
+use djinn_db::test_support::backdate_task_attempt_created_at;
+use djinn_db::{
+    BuildPodPermitRepository, BuildPodPermitState, CreateTaskAttemptParams, CreateTaskRunParams,
+    Database, EffectiveCreatorProvenance, ProjectRepository, SessionRepository,
+    TaskAttemptRepository, TaskRepository, TaskRunRepository, UserRepository,
+};
+use djinn_k8s::pod_resize::PodResizeError;
+use djinn_k8s::pod_resize_fixture::StoredTaskRunPod;
+use djinn_k8s::runtime::{JobAdmission, LauncherObservationError, ObservedLauncherSidecar};
+use djinn_k8s::{
+    ObjectPresence, UidGetResult, WorkloadInventory, WorkloadObjectKind, WorkloadRecord,
+};
+use djinn_launcher_protocol::LauncherAuthorityProtocol;
+use djinn_runtime::{
+    BiStream, ResolvedCredentials, RunHandle, RuntimeError, SessionRuntime, SupervisorFlow,
+    TaskRunOutcome, TaskRunReport, TaskRunSpec,
+};
+use djinn_server::server::AppState;
+use djinn_server::task_run_resize_bootstrap::{TaskRunPodSurface, TaskRunResizeAdmissionBridge};
+use tokio_util::sync::CancellationToken;
+
+const RENDERED_CEILING: &str = "4";
+const POD_UID: &str = "pod-uid-create-transit";
+const JOB_UID: &str = "job-uid-create-transit";
+const CONFIRMING_BUDGET: Duration = Duration::from_secs(5);
+
+// ── The apiserver surfaces ────────────────────────────────────────────────
+
+/// Adapts [`StoredTaskRunPod`] to the resize bootstrap's surface trait.
+#[derive(Clone)]
+struct FixtureSurface(StoredTaskRunPod);
+
+#[async_trait]
+impl TaskRunPodSurface for FixtureSurface {
+    async fn observe_launcher(
+        &self,
+        _task_run_id: &str,
+    ) -> Result<Option<ObservedLauncherSidecar>, LauncherObservationError> {
+        self.0.observe_launcher()
+    }
+
+    async fn resize_launcher_cpu(
+        &self,
+        pod_name: &str,
+        target_millicores: u64,
+    ) -> Result<(), PodResizeError> {
+        self.0
+            .resize_launcher_cpu(pod_name, target_millicores)
+            .await
+    }
+
+    async fn observe_job_admission(&self, _task_run_id: &str) -> JobAdmission {
+        self.0.job_admission()
+    }
+
+    async fn uid_fenced_delete(&self, task_run_id: &str, pod_uid: &str) -> Result<(), String> {
+        self.0.uid_fenced_delete(task_run_id, pod_uid)
+    }
+}
+
+/// A namespace inventory whose LIST is empty and whose per-object GET answers
+/// from a fixed table. This is the shape a real apiserver presents while a Job
+/// POST is still in flight: the object is not in the listing, and asking for it
+/// by name says it is not there either.
+struct AbsentInventory {
+    presence: HashMap<String, ObjectPresence>,
+}
+
+#[async_trait]
+impl WorkloadInventory for AbsentInventory {
+    async fn list(&self) -> Result<Vec<WorkloadRecord>, String> {
+        Ok(Vec::new())
+    }
+
+    async fn get_uid(&self, _: WorkloadObjectKind, _: &str, _: &str) -> UidGetResult {
+        UidGetResult::Uncertain
+    }
+
+    async fn presence(&self, _: WorkloadObjectKind, name: &str) -> ObjectPresence {
+        self.presence
+            .get(name)
+            .cloned()
+            .unwrap_or(ObjectPresence::Uncertain)
+    }
+}
+
+// ── What the startup sequence saw and did, from inside the window ─────────
+
+/// Everything the fenced startup sequence observed at the CREATE boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FenceObservation {
+    /// The durable status of the dispatching run when the barrier was reached.
+    status_at_barrier: Option<String>,
+    fenced_witness: Option<TaskRunWitness>,
+    fenced_projection: Option<TaskCensusProjection>,
+    control_witness: Option<TaskRunWitness>,
+    control_projection: Option<TaskCensusProjection>,
+    /// `(session, task run, attempt)` for the fenced dispatch after Stage A/B/C.
+    fenced_after: (String, String, String),
+    /// `(session, task run, attempt)` for the paired absent `running` control.
+    control_after: (String, String, String),
+}
+
+/// The paired control: an ordinary `running` dispatch whose Job is absent for
+/// exactly the same reason the fenced one's is — it is not there — but whose
+/// durable state carries no commit-then-CREATE excuse.
+#[derive(Clone)]
+struct AbsentRunningControl {
+    run_id: String,
+    session_id: String,
+    attempt_id: String,
+}
+
+/// A `SessionRuntime` that runs the whole production startup sequence at the
+/// instant of the Job POST, then lets the POST proceed.
+///
+/// `prepare` is the launch verb `execute_runtime_report_phase` calls; entering
+/// it means the durable `starting` commit has already happened and the Job does
+/// not exist yet. Doing the census work here — rather than signalling a barrier
+/// and racing another task — makes the window deterministic without a clock.
+struct CreateTransitFence {
+    db: Database,
+    inventory: Arc<AbsentInventory>,
+    control: AbsentRunningControl,
+    observed: Mutex<Option<FenceObservation>>,
+}
+
+impl CreateTransitFence {
+    fn observation(&self) -> FenceObservation {
+        self.observed
+            .lock()
+            .expect("fence observation mutex")
+            .clone()
+            .expect("prepare must have run the fenced startup sequence")
+    }
+}
+
+#[async_trait]
+impl SessionRuntime for CreateTransitFence {
+    async fn prepare(
+        &self,
+        spec: &TaskRunSpec,
+        _credentials: &ResolvedCredentials,
+    ) -> Result<RunHandle, RuntimeError> {
+        let runs = TaskRunRepository::new(self.db.clone());
+        let status_at_barrier = runs
+            .get(&spec.task_run_id)
+            .await
+            .expect("read the dispatching run at the CREATE boundary")
+            .map(|run| run.status);
+
+        // The window's own linked session. A `starting` run is promoted to
+        // `running` the moment a session is attached to it, so restore the
+        // committed pre-CREATE state the barrier is standing in.
+        let events = djinn_core::events::EventBus::noop();
+        let sessions = SessionRepository::new(self.db.clone(), events.clone());
+        let fenced_session = sessions
+            .create(CreateSessionParams {
+                project_id: &spec.project_id,
+                task_id: Some(&spec.task_id),
+                model: "openai/gpt-5.5",
+                agent_type: "worker",
+                metadata_json: None,
+                task_run_id: Some(&spec.task_run_id),
+                pricing: None,
+                cost_basis: None,
+            })
+            .await
+            .expect("link a session to the run that is mid-CREATE")
+            .id;
+        runs.update_status(
+            &spec.task_run_id,
+            djinn_core::models::TaskRunStatus::Starting,
+        )
+        .await
+        .expect("restore the committed pre-CREATE starting state");
+
+        // ── The production startup sequence, entirely inside the window ──
+        let census = StartupCensus::acquire(self.db.clone(), Some(self.inventory.clone()))
+            .await
+            .expect("acquire the immutable census while CREATE is blocked");
+        let witness_of = |run_id: &str| {
+            census
+                .runs()
+                .iter()
+                .find(|run| run.task_run_id == run_id)
+                .map(|run| run.witness)
+        };
+        let fenced_witness = witness_of(&spec.task_run_id);
+        let control_witness = witness_of(&self.control.run_id);
+        let fenced_projection = census.task_projection(&spec.task_id);
+        let control_task_id = runs
+            .get(&self.control.run_id)
+            .await
+            .expect("read control run")
+            .expect("control run exists")
+            .task_id;
+        let control_projection = census.task_projection(&control_task_id);
+
+        let state = AppState::new(self.db.clone(), CancellationToken::new());
+        djinn_server::test_helpers::run_startup_stage_a(&state, &census).await;
+        djinn_coordinator::complete_startup_reaper_phase(
+            &self.db,
+            "create-transit-fence-incarnation",
+            Some(&census),
+        )
+        .await;
+
+        let fenced_after = durable_triple(
+            &self.db,
+            &events,
+            &fenced_session,
+            &spec.task_run_id,
+            spec.task_attempt_id
+                .as_deref()
+                .expect("dispatch allocates a task attempt"),
+        )
+        .await;
+        let control_after = durable_triple(
+            &self.db,
+            &events,
+            &self.control.session_id,
+            &self.control.run_id,
+            &self.control.attempt_id,
+        )
+        .await;
+
+        *self.observed.lock().expect("fence observation mutex") = Some(FenceObservation {
+            status_at_barrier,
+            fenced_witness,
+            fenced_projection,
+            control_witness,
+            control_projection,
+            fenced_after,
+            control_after,
+        });
+
+        // ── Barrier released: the Job POST proceeds ──
+        Ok(RunHandle {
+            task_run_id: spec.task_run_id.clone(),
+            container_id: None,
+            pod_ref: Some("taskrun-create-transit".to_owned()),
+            started_at: SystemClock::new().now(),
+            job_uid: Some(JOB_UID.to_owned()),
+            launcher_authority_protocol: Some(LauncherAuthorityProtocol::ResizeV2),
+        })
+    }
+
+    async fn attach_stdio(&self, _handle: &RunHandle) -> Result<BiStream, RuntimeError> {
+        Err(RuntimeError::Attach(
+            "fixture runtime has no worker session".to_owned(),
+        ))
+    }
+
+    async fn cancel(&self, _handle: &RunHandle) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+
+    async fn teardown(&self, handle: RunHandle) -> Result<TaskRunReport, RuntimeError> {
+        Ok(TaskRunReport {
+            task_run_id: handle.task_run_id,
+            outcome: TaskRunOutcome::Closed {
+                reason: "fixture teardown".to_owned(),
+            },
+            stages_completed: Vec::new(),
+        })
+    }
+}
+
+async fn durable_triple(
+    db: &Database,
+    events: &djinn_core::events::EventBus,
+    session_id: &str,
+    run_id: &str,
+    attempt_id: &str,
+) -> (String, String, String) {
+    let session = SessionRepository::new(db.clone(), events.clone())
+        .get(session_id)
+        .await
+        .expect("read linked session")
+        .expect("linked session exists")
+        .status;
+    let run = TaskRunRepository::new(db.clone())
+        .get(run_id)
+        .await
+        .expect("read linked task run")
+        .expect("linked task run exists")
+        .status;
+    let attempt = TaskAttemptRepository::new(db.clone())
+        .get(attempt_id)
+        .await
+        .expect("read linked attempt")
+        .expect("linked attempt exists")
+        .outcome;
+    (session, run, attempt)
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+async fn seed_task(db: &Database, suffix: &str) -> djinn_core::models::Task {
+    let user = UserRepository::new(db.clone())
+        .upsert_from_github(
+            i64::try_from(uuid::Uuid::now_v7().as_u128() % 8_000_000_000_000_000_000)
+                .expect("github id"),
+            &format!("create-transit-{suffix}-{}", uuid::Uuid::now_v7()),
+            None,
+            None,
+        )
+        .await
+        .expect("seed user");
+    let project = ProjectRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create(
+            &format!("create-transit-{suffix}"),
+            "djinnos",
+            &format!("create-transit-{suffix}"),
+        )
+        .await
+        .expect("seed project");
+    TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create_in_project_with_provenance(
+            &project.id,
+            None,
+            EffectiveCreatorProvenance::explicit_user_id(&user.id),
+            "create transit",
+            "description",
+            "design",
+            "task",
+            2,
+            "owner",
+            None,
+            None,
+        )
+        .await
+        .expect("seed task")
+}
+
+/// The shape production dispatch presents to the seam: a fresh `task_run_id`
+/// and its `task_attempts` row, and **no** `task_runs` row — the seam commits
+/// that itself, which is the commit this test fences.
+async fn seed_as_dispatch_does(db: &Database) -> (djinn_core::models::Task, TaskRunSpec) {
+    let task = seed_task(db, "fenced").await;
+    let task_run_id = uuid::Uuid::now_v7().to_string();
+    let attempt_id = uuid::Uuid::now_v7().to_string();
+    TaskAttemptRepository::new(db.clone())
+        .create_or_get_pending(CreateTaskAttemptParams {
+            id: &attempt_id,
+            task_id: &task.id,
+            role: "worker",
+            dispatch_key: &format!("task-run:{task_run_id}"),
+            session_id: None,
+            attempt_seq: None,
+            dispatch_owner_incarnation_id: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed the exact attempt dispatch allocates");
+    // Stage C only considers attempts past its age gate. Without this the
+    // fenced attempt would survive because it is young, not because it is
+    // fenced — which would make the assertion vacuous.
+    backdate_task_attempt_created_at(db, &attempt_id, "1 hour").await;
+    let spec = TaskRunSpec {
+        task_run_id,
+        task_attempt_id: Some(attempt_id),
+        task_id: task.id.clone(),
+        execution_generation: 0,
+        project_id: task.project_id.clone(),
+        trigger: djinn_core::models::TaskRunTrigger::NewTask,
+        base_branch: "main".to_owned(),
+        task_branch: "djinn/create-transit".to_owned(),
+        flow: SupervisorFlow::NewTask,
+        model_id_per_role: Default::default(),
+        read_source_project_ids: Vec::new(),
+        knowledge_injection: djinn_core::models::KnowledgeInjectionConfig::default(),
+        github_owner: None,
+        github_install_token: None,
+        commit_author_name: None,
+        commit_author_email: None,
+        resume_lifecycle_metadata: None,
+        is_evidence_spike: false,
+    };
+    (task, spec)
+}
+
+/// A fully linked `running` dispatch whose Job is absent. Same census, same
+/// evidence class, different durable state.
+async fn seed_absent_running_control(db: &Database) -> AbsentRunningControl {
+    let task = seed_task(db, "control").await;
+    let run_id = uuid::Uuid::now_v7().to_string();
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: &run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed control task run");
+    let session_id = SessionRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(&run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .expect("seed control session")
+        .id;
+    let attempt_id = uuid::Uuid::now_v7().to_string();
+    TaskAttemptRepository::new(db.clone())
+        .create_or_get_pending(CreateTaskAttemptParams {
+            id: &attempt_id,
+            task_id: &task.id,
+            role: "worker",
+            dispatch_key: &format!("task-run:{run_id}"),
+            session_id: None,
+            attempt_seq: None,
+            dispatch_owner_incarnation_id: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .expect("seed control attempt");
+    backdate_task_attempt_created_at(db, &attempt_id, "1 hour").await;
+    AbsentRunningControl {
+        run_id,
+        session_id,
+        attempt_id,
+    }
+}
+
+// ── The regression ────────────────────────────────────────────────────────
+
+/// Drive the production dispatch seam, run the whole startup sequence at the
+/// Job-POST boundary, and prove the fence is state-specific.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_starting_create_transit_is_fenced() {
+    let db = Database::ephemeral().await.expect("ephemeral db");
+    let (_task, spec) = seed_as_dispatch_does(&db).await;
+    let control = seed_absent_running_control(&db).await;
+
+    let mut presence = HashMap::new();
+    presence.insert(
+        djinn_k8s::taskrun_job_name(&spec.task_run_id),
+        ObjectPresence::Absent,
+    );
+    presence.insert(
+        djinn_k8s::taskrun_job_name(&control.run_id),
+        ObjectPresence::Absent,
+    );
+    let inventory = Arc::new(AbsentInventory { presence });
+
+    let fence = Arc::new(CreateTransitFence {
+        db: db.clone(),
+        inventory,
+        control: control.clone(),
+        observed: Mutex::new(None),
+    });
+
+    let cluster = StoredTaskRunPod::resize_v2(POD_UID, RENDERED_CEILING);
+    let bridge = Arc::new(
+        TaskRunResizeAdmissionBridge::with_surface(
+            db.clone(),
+            Arc::new(FixtureSurface(cluster)) as Arc<dyn TaskRunPodSurface>,
+        )
+        .with_wait(CONFIRMING_BUDGET, Duration::from_millis(5)),
+    );
+    let mut context =
+        djinn_server::test_helpers::agent_context_from_db(db.clone(), CancellationToken::new());
+    assert!(
+        context.resize_admission.is_some(),
+        "AppState::agent_context() must already compose a resize admission bridge"
+    );
+    context.resize_admission = Some(bridge.clone());
+
+    let task = TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop())
+        .get(&spec.task_id)
+        .await
+        .expect("read dispatching task")
+        .expect("dispatching task exists");
+
+    djinn_agent::actors::slot::supervisor_runner::execute_runtime_report_phase(
+        fence.clone(),
+        &spec,
+        &ResolvedCredentials::default(),
+        &task,
+        "anthropic/claude-fixture",
+        &context,
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("the fenced dispatch is admitted");
+
+    let observed = fence.observation();
+
+    // AC1: the barrier is after the durable `starting` commit and before CREATE.
+    assert_eq!(
+        observed.status_at_barrier.as_deref(),
+        Some("starting"),
+        "the barrier must sit after the durable starting commit"
+    );
+
+    // AC2: the census independently confirms absence and still fences the run.
+    assert_eq!(
+        observed.fenced_witness,
+        Some(TaskRunWitness::Gone(GoneProvenance::AuthoritativelyAbsent)),
+        "an omitted Job confirmed absent by GET is authoritative absence"
+    );
+    assert_eq!(
+        observed.fenced_projection,
+        Some(TaskCensusProjection::CreationTransit),
+        "authoritative pre-CREATE absence of a durable starting row is CreationTransit"
+    );
+    assert_eq!(
+        observed.fenced_after,
+        (
+            "running".to_owned(),
+            "starting".to_owned(),
+            "pending".to_owned()
+        ),
+        "Stage A/B/C must leave the linked session, starting run and pending attempt alone"
+    );
+
+    // AC4: identical evidence, different durable state, opposite outcome.
+    assert_eq!(
+        observed.control_witness,
+        Some(TaskRunWitness::Gone(GoneProvenance::AuthoritativelyAbsent)),
+        "the control carries exactly the same Gone provenance"
+    );
+    assert_eq!(
+        observed.control_projection,
+        Some(TaskCensusProjection::DestructivelyGone)
+    );
+    assert_eq!(
+        observed.control_after,
+        (
+            "interrupted".to_owned(),
+            "interrupted".to_owned(),
+            "interrupted".to_owned()
+        ),
+        "the paired absent running dispatch is destructively reconciled, \
+         so the fence is state-specific rather than preserve-all"
+    );
+
+    // AC3: the barrier released and the launch committed. This row is written
+    // by the seam *after* `prepare` returned the Job UID, so it cannot exist
+    // unless CREATE succeeded and the dispatch continued past it.
+    let permit = BuildPodPermitRepository::new(db.clone())
+        .active(&spec.task_run_id)
+        .await
+        .expect("read permit")
+        .expect("the resumed dispatch must hold a permit");
+    assert_eq!(permit.job_uid.as_deref(), Some(JOB_UID));
+    assert_eq!(permit.state, BuildPodPermitState::BirthConfirmed);
+
+    // And the durable rows survive the resumed dispatch, not just the census.
+    assert_eq!(
+        TaskRunRepository::new(db.clone())
+            .get(&control.run_id)
+            .await
+            .expect("read control run after resume")
+            .expect("control run exists")
+            .status,
+        "interrupted"
+    );
+}


### PR DESCRIPTION
Implements board task `ci29` (epic `43ww`, proposal `ih1w`).

**Stacked on #3196 (`m91z`)** — the first commit on this branch is m91z's; the
diff reduces to the ci29 commit once #3196 merges.

## The window

Production dispatch commits a `task_runs` row with `status = 'starting'`
(`execute_runtime_report_phase` → `ensure_durable_task_run_row`) and only then
POSTs the Kubernetes Job. A server that boots inside that window LISTs the
namespace, does not find the Job, confirms the absence with an independent GET,
and holds *positive* `Gone(AuthoritativelyAbsent)` evidence for a run that is
very much alive.

Stage B already fenced this (`startup_task_run_mutation_authorized`), and Stage C
inherits the fence through `TaskCensusProjection::CreationTransit`. **Stage A did
not**: it collected every `Gone(_)` identity regardless of durable run state, so
the session of a run that was mid-CREATE was interrupted. The three stages
disagreed about one identity.

## Production change

`CensusTaskRun::destructive_mutation_authorized()` becomes the single shared rule
— terminal-present authorizes always; authoritative absence authorizes only for a
durable `running` row. Stage B's private predicate now delegates to it, and Stage
A uses it instead of matching on `witness` alone. No threshold, schema,
retention or periodic-policy change.

Two landed expectations move with the behaviour, both in the same direction:
`startup_stage_a_identity_matrix`'s `absent_starting` session and
`startup_stage_c_task_projection`'s `gone-creation-transit` secondary session are
now preserved (3 of 14 matrix sessions transition, not 4).

## The regression

`server/tests/startup_create_transit_fence.rs::startup_starting_create_transit_is_fenced`
drives the real dispatch path — `execute_runtime_report_phase`, no shim — and
blocks *inside* the window by running the entire production startup sequence
(`StartupCensus::acquire` → Stage A → `complete_startup_reaper_phase`) from within
the injected `SessionRuntime::prepare`, i.e. after the durable `starting` commit
and before the Job exists. Pre-seeding a `starting` row would not be in the window
at all.

It proves, from inside the barrier: the run is durably `starting`; the census
independently confirms absence and records `Gone(AuthoritativelyAbsent)` with a
task-level `CreationTransit` projection; and Stage A/B/C leave the linked running
session, the starting run and the aged pending attempt alone. A paired
otherwise-identical **absent `running`** dispatch in the *same* census is
`DestructivelyGone` and is reaped 1/1/1, so the fence is state-specific rather
than preserve-all. Both attempts are backdated past Stage C's age gate, so the
fenced one survives because it is fenced, not because it is young.

After `prepare` returns, CREATE commits: the durable `build_pod_permits` row the
seam binds to the returned Job UID reaches `BirthConfirmed`, which cannot happen
unless the launch succeeded and the dispatch continued past it.

`AppState::interrupt_stale_sessions_on_startup_with_census` loses its
`cfg(test)`/`cfg(not(test))` split and becomes plain `pub(crate)`;
`djinn_server::test_helpers::run_startup_stage_a` forwards to it with no logic of
its own.

## Verification

Each claim was checked against a deliberate production mutation:

| mutation | assertion that went red |
|---|---|
| Stage A collects every `Gone(_)` again | `Stage A/B/C must leave the linked session, starting run and pending attempt alone` |
| drop the `CreationTransit` arm from `project_tasks` | `authoritative pre-CREATE absence of a durable starting row is CreationTransit` |
| delete `ensure_durable_task_run_row` from the seam | the barrier can no longer link a session to the run — the test cannot reach its assertions |
| `destructive_mutation_authorized` returns `false` always | `the paired absent running dispatch is destructively reconciled, so the fence is state-specific rather than preserve-all` |

`cargo nextest run -p djinn-server` — 792/792 pass.
`cargo nextest run -p djinn-coordinator startup session_reaping incarnation_lease_liveness health:: startup_census` — 178/178 pass.
`cargo nextest run -p djinn-coordinator refinement` — 178/178 pass.
The new test was run 5× consecutively with no flake.
`cargo clippy` (db/coordinator/server, all targets, test-support) — clean.
`cargo fmt --all`, `git diff --check`, `check-raw-sql-boundary.sh` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)