### PR TITLE
chore(0072): Compose the projection into every structural gate and into `proposal_show`

### DIFF
--- a/server/crates/djinn-control-plane/src/state.rs
+++ b/server/crates/djinn-control-plane/src/state.rs
@@ -16,6 +16,7 @@ use crate::bridge::{
     CoordinatorOps, ExtensionDiagnosticsProbeOps, GitOps, LspOps, MemoryEnrichmentOps,
     RepoGraphOps, RuntimeOps, SemanticQueryEmbedding, SlotPoolOps, TaskrunJobRef,
 };
+use crate::tools::proposal_tools::TypedEvidenceGateMode;
 
 /// Independent controls for feedback-derived tribunal work.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -78,6 +79,14 @@ pub struct McpState {
     /// every caller, including the ones bound to a different database.
     doctor_registry: Option<Arc<DoctorRegistry>>,
     feedback_refinement_controls: FeedbackRefinementControls,
+    /// Rollout stage for the typed-evidence structural gate, resolved **once**
+    /// here and passed down as a parameter by every tool that gates on it.
+    ///
+    /// It lives on the state rather than being read from the environment at
+    /// each call site because `cargo test` runs a target's tests in one
+    /// process: a process-global toggle would leak one test's rollout stage
+    /// into another's and flake under parallel execution.
+    typed_evidence_gate_mode: TypedEvidenceGateMode,
 }
 
 impl McpState {
@@ -156,6 +165,7 @@ impl McpState {
             extension_diagnostics_probe: None,
             doctor_registry: None,
             feedback_refinement_controls: FeedbackRefinementControls::default(),
+            typed_evidence_gate_mode: TypedEvidenceGateMode::from_env(),
         }
     }
 
@@ -191,6 +201,19 @@ impl McpState {
 
     pub fn feedback_refinement_controls(&self) -> FeedbackRefinementControls {
         self.feedback_refinement_controls
+    }
+
+    /// Pin the typed-evidence rollout stage instead of taking it from the
+    /// environment. Production composition never calls this; tests do, so a
+    /// stage is chosen per-`McpState` rather than per-process.
+    pub fn with_typed_evidence_gate_mode(mut self, mode: TypedEvidenceGateMode) -> Self {
+        self.typed_evidence_gate_mode = mode;
+        self
+    }
+
+    /// The rollout stage every gating tool must pass into the gate.
+    pub fn typed_evidence_gate_mode(&self) -> TypedEvidenceGateMode {
+        self.typed_evidence_gate_mode
     }
 
     /// The doctor check registry `doctor_run` / `doctor_fix` must consult.

--- a/server/crates/djinn-control-plane/src/tools/debate_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/debate_tools.rs
@@ -297,6 +297,23 @@ impl DjinnMcpServer {
             return Json(err_debate(format!("round must be >= 1 (got {})", p.round)));
         }
 
+        // Structural gate: a Judge verdict is the tribunal's settlement of the
+        // spec, so it may not be issued while typed evidence the Judge itself
+        // demanded is still unresolved. Objections and rebuttals are argument,
+        // not settlement, and are deliberately ungated — as is a non-Judge
+        // verdict row, which does not drive the latest-verdict channel.
+        if kind == "verdict"
+            && p.agent_role.trim().eq_ignore_ascii_case("judge")
+            && let Some(refusal) = crate::tools::proposal_tools::typed_evidence_gate::typed_evidence_transition_refusal(
+                &repo,
+                &proposal.id,
+                self.state.typed_evidence_gate_mode(),
+            )
+            .await
+        {
+            return Json(err_debate(format!("cannot record judge verdict: {refusal}")));
+        }
+
         match repo
             .add_debate_trail_entry(ProposalDebateTrailCreateInput {
                 proposal_id: &proposal.id,

--- a/server/crates/djinn-control-plane/src/tools/proposal_ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_ops.rs
@@ -974,11 +974,63 @@ pub struct ProposalGateStatusModel {
     /// Needs-evidence spike parking state. `None` when not parked.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub needs_evidence: Option<NeedsEvidenceStatus>,
+    /// Typed evidence authority for this proposal.
+    ///
+    /// This is the normalized `typed_evidence_findings` lifecycle, distinct
+    /// from the legacy `needs_evidence` compatibility columns above — both are
+    /// reported so a mixed-version reader can tell which authority is speaking.
+    /// `None` when the rollout mode is `off`, when the proposal has no
+    /// unresolved typed finding, and when typed/legacy authority agree.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub typed_evidence: Option<TypedEvidenceGateStatus>,
     /// Whether a current human override exists for this revision.
     pub human_override_active: bool,
     /// Human-readable explanations of all gate failures, each naming the
     /// exact blocking condition. Empty when `ready` is true.
     pub blocked_explanations: Vec<String>,
+}
+
+/// Typed evidence authority section of the composed gate status.
+///
+/// Every field is projected from `TypedEvidenceRepository`; nothing here is
+/// re-derived from tasks or debate rows.
+#[derive(Serialize, Deserialize, Clone, schemars::JsonSchema)]
+pub struct TypedEvidenceGateStatus {
+    /// Rollout stage this evaluation ran under: `off`, `shadow`, or `enforce`.
+    pub mode: String,
+    /// Whether this section is currently refusing transitions.
+    pub blocking: bool,
+    /// Set when typed and legacy evidence authority disagree. The gate fails
+    /// closed on this in every mode, including `off`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parity_mismatch_reason: Option<String>,
+    /// Id of the unresolved typed finding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finding_id: Option<String>,
+    /// The finding's claim, serialized as JSON text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claim: Option<String>,
+    /// `demanded`, `spike_active`, `evidence_received`, or `failed`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<String>,
+    /// Revision the demand was raised against. Provenance, not a filter — the
+    /// finding keeps blocking as the proposal head advances past it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub demanded_revision_seq: Option<i32>,
+    /// Sequence of the latest allocated spike attempt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempt_seq: Option<i32>,
+    /// Validated outcome of the latest durable return: `resolved`, `partial`,
+    /// or `unresolved`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_outcome: Option<String>,
+    /// Folding revision of a recorded disposition that did not carry the
+    /// finding to a terminal lifecycle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub folding_revision: Option<i32>,
+    /// Most specific persisted failure text for the finding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_detail: Option<String>,
 }
 
 /// One DoR failure in the gate status.

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/create.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/create.rs
@@ -405,9 +405,15 @@ impl DjinnMcpServer {
         // tribunal conditions block the transition, downgrade to `draft`
         // instead of blocking creation.
         let proposal = if effective_status == "in_review" {
-            let gate =
-                evaluate_composed_gate(&repo, &proposal, body, &ac_json, resolved_target_ids.len())
-                    .await;
+            let gate = evaluate_composed_gate(
+                &repo,
+                &proposal,
+                body,
+                &ac_json,
+                resolved_target_ids.len(),
+                self.state.typed_evidence_gate_mode(),
+            )
+            .await;
             if let Some(_err) = gate.to_error_string() {
                 // Tribunal blocked — downgrade to draft.
                 match repo
@@ -862,7 +868,17 @@ impl DjinnMcpServer {
                     .map(|t| t.len())
                     .unwrap_or(0),
             };
-            Some(build_gate_status(&repo, &proposal, &proposal.body, ac_json, target_count).await)
+            Some(
+                build_gate_status(
+                    &repo,
+                    &proposal,
+                    &proposal.body,
+                    ac_json,
+                    target_count,
+                    self.state.typed_evidence_gate_mode(),
+                )
+                .await,
+            )
         } else {
             None
         };
@@ -1151,7 +1167,15 @@ impl DjinnMcpServer {
                 .await
                 .map(|t| t.len())
                 .unwrap_or(0);
-            let gate = evaluate_composed_gate(&repo, &existing, body, &ac_json, target_count).await;
+            let gate = evaluate_composed_gate(
+                &repo,
+                &existing,
+                body,
+                &ac_json,
+                target_count,
+                self.state.typed_evidence_gate_mode(),
+            )
+            .await;
             if let Some(err) = gate.to_error_string() {
                 return Json(err_single(err));
             }

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/lifecycle.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/lifecycle.rs
@@ -183,6 +183,7 @@ impl DjinnMcpServer {
                 &proposal.body,
                 &proposal.acceptance_criteria,
                 targets.len(),
+                self.state.typed_evidence_gate_mode(),
             )
             .await;
             if let Some(err) = gate.to_error_string() {

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/mod.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/mod.rs
@@ -56,6 +56,7 @@ mod mdx;
 mod params;
 mod revision_admission;
 pub mod signoff;
+pub mod typed_evidence_gate;
 
 // Re-export CRUD tool parameter types from `params.rs` so the public module path
 // `crate::tools::proposal_tools::{...}` stays stable for existing dispatch and
@@ -88,6 +89,11 @@ pub use signoff::ProposalSignoffParams;
 // Re-export shared readiness/gate helpers from `signoff.rs` so `create.rs`
 // and `lifecycle.rs` can continue importing from `super::*`.
 pub(super) use signoff::{build_gate_status, evaluate_composed_gate, parse_ac_items};
+
+// The typed-evidence structural gate. Its rollout stage is resolved once at
+// each MCP tool boundary and passed down as a parameter — never read from the
+// environment inside the gate.
+pub use typed_evidence_gate::TypedEvidenceGateMode;
 
 // Re-export MDX/block-patch types so the public module path
 // `crate::tools::proposal_tools::{...}` stays stable for existing dispatch

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff.rs
@@ -35,7 +35,18 @@ use crate::tools::proposal_readiness::{
 };
 use djinn_db::ProposalRepository;
 
+use super::typed_evidence_gate::{TypedEvidenceGateMode, typed_evidence_transition_refusal};
 use super::{err_single, proposal_not_found_error};
+
+/// `blocked_explanations` are sentence-cased for the UI, while gate failure
+/// strings are lower-cased for the error channel. Both render the same refusal.
+fn capitalize_first(value: &str) -> String {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
 
 // ── Param structs ───────────────────────────────────────────────────────────
 
@@ -59,12 +70,21 @@ pub(crate) fn parse_ac_items(ac_json: &str) -> Vec<AcceptanceCriterionItem> {
 // ── Composed gate: DoR + tribunal (task cuzf) ─────────────────────────────
 
 /// Result of the composed tribunal gate check.
-pub(crate) struct ComposedGateResult {
+///
+/// Public so contract tests can drive the gate itself rather than only the
+/// tools that wrap it — the matrix in `typed_evidence_gate_matrix` asserts on
+/// the exact failure strings this produces.
+pub struct ComposedGateResult {
     failures: Vec<String>,
 }
 
 impl ComposedGateResult {
-    pub(crate) fn to_error_string(&self) -> Option<String> {
+    /// Every collected failure, in evaluation order.
+    pub fn failures(&self) -> &[String] {
+        &self.failures
+    }
+
+    pub fn to_error_string(&self) -> Option<String> {
         if self.failures.is_empty() {
             return None;
         }
@@ -139,14 +159,26 @@ pub async fn current_human_gate_authority(
 /// Returns `ComposedGateResult` with all failures collected. Callers
 /// (proposal_create, proposal_update, proposal_signoff, proposal_graduate)
 /// convert failures into tool error responses.
-pub(crate) async fn evaluate_composed_gate(
+/// `typed_evidence_mode` is resolved once at the MCP tool boundary and passed
+/// in. It is never read from the environment here: `cargo test` runs a target's
+/// tests in one process, so a process-global toggle would leak one test's
+/// rollout stage into another's.
+pub async fn evaluate_composed_gate(
     repo: &ProposalRepository,
     proposal: &djinn_core::models::proposal::Proposal,
     body: &str,
     ac_json: &str,
     target_count: usize,
+    typed_evidence_mode: TypedEvidenceGateMode,
 ) -> ComposedGateResult {
     let mut failures: Vec<String> = Vec::new();
+
+    // 2e is evaluated up front but reported in place. Deferring the read until
+    // after the DoR early return would let a DoR-failing proposal skip the
+    // fail-closed parity check entirely, which is the one condition that must
+    // hold in every rollout mode.
+    let typed_evidence_failure =
+        typed_evidence_transition_refusal(repo, &proposal.id, typed_evidence_mode).await;
 
     // Update/import paths evaluate an unpersisted candidate. Keep their
     // candidate body/AC structural checks while obtaining current-head lint
@@ -169,7 +201,10 @@ pub(crate) async fn evaluate_composed_gate(
             failures.push(format!("proposal not ready for review: {details}"));
         }
         // Preserve the historical no-authority DoR blocking behavior: DoR-only
-        // failures stop the gate before tribunal diagnostics are appended.
+        // failures stop the gate before tribunal diagnostics are appended. The
+        // typed-evidence refusal is the one exception — it is a fail-closed
+        // condition, not a diagnostic.
+        failures.extend(typed_evidence_failure);
         return ComposedGateResult { failures };
     }
 
@@ -246,6 +281,10 @@ pub(crate) async fn evaluate_composed_gate(
         _ => {}
     }
 
+    // 2e. Typed evidence authority. The repository projection is the sole new
+    // input: this gate never re-derives lifecycle from tasks or debate rows.
+    failures.extend(typed_evidence_failure);
+
     ComposedGateResult { failures }
 }
 
@@ -253,12 +292,13 @@ pub(crate) async fn evaluate_composed_gate(
 ///
 /// Collects DoR failures, tribunal conditions, and human-readable explanations
 /// so the UI can render readiness without recomputing it client-side.
-pub(crate) async fn build_gate_status(
+pub async fn build_gate_status(
     repo: &ProposalRepository,
     proposal: &djinn_core::models::proposal::Proposal,
     _body: &str,
     _ac_json: &str,
     target_count: usize,
+    typed_evidence_mode: TypedEvidenceGateMode,
 ) -> crate::tools::proposal_ops::ProposalGateStatusModel {
     use crate::tools::proposal_ops::{GateFailureModel, ProposalGateStatusModel};
 
@@ -400,6 +440,37 @@ pub(crate) async fn build_gate_status(
         _ => None,
     };
 
+    // 2e. Typed evidence authority. `Off` reads nothing beyond the fail-closed
+    // parity probe, so a pre-rollout deployment renders exactly as before.
+    let typed_outcome =
+        crate::tools::proposal_tools::typed_evidence_gate::evaluate_typed_evidence_gate(
+            repo,
+            proposal_id,
+            typed_evidence_mode,
+        )
+        .await;
+    if let Some(failure) = typed_outcome.failure.as_deref() {
+        blocked_explanations.push(capitalize_first(failure));
+    }
+    let typed_evidence = typed_outcome.is_reportable().then(|| {
+        let projection = typed_outcome.projection.as_ref();
+        crate::tools::proposal_ops::TypedEvidenceGateStatus {
+            mode: typed_outcome.mode.as_str().to_string(),
+            blocking: typed_outcome.blocks(),
+            parity_mismatch_reason: typed_outcome.fail_closed_reason.clone(),
+            finding_id: projection.map(|p| p.finding_id.clone()),
+            claim: projection.map(|p| p.claim.to_string()),
+            lifecycle: projection.map(|p| p.lifecycle.as_str().to_string()),
+            demanded_revision_seq: projection.map(|p| p.demanded_revision_seq),
+            attempt_seq: projection.and_then(|p| p.attempt_seq),
+            evidence_outcome: projection
+                .and_then(|p| p.evidence_outcome)
+                .map(|outcome| format!("{outcome:?}").to_lowercase()),
+            folding_revision: projection.and_then(|p| p.folding_revision),
+            failure_detail: projection.and_then(|p| p.failure_detail.clone()),
+        }
+    });
+
     // Adversary dry count from refinement status (non-critical)
     let adversary_dry_count =
         match crate::tools::refinement_tools::build_refinement_status(repo, proposal_id).await {
@@ -410,6 +481,7 @@ pub(crate) async fn build_gate_status(
     let ready = blocked_explanations.is_empty();
 
     ProposalGateStatusModel {
+        typed_evidence,
         ready,
         dor_ready,
         dor_failures,
@@ -509,6 +581,7 @@ impl DjinnMcpServer {
                 &proposal.body,
                 &proposal.acceptance_criteria,
                 target_count,
+                self.state.typed_evidence_gate_mode(),
             )
             .await;
             if let Some(err) = gate.to_error_string() {

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff/signoff_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/signoff/signoff_tests.rs
@@ -872,6 +872,7 @@ What happens if D fails?
             &proposal.body,
             &proposal.acceptance_criteria,
             1,
+            crate::tools::proposal_tools::TypedEvidenceGateMode::Off,
         )
         .await;
         assert!(

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/typed_evidence_gate.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/typed_evidence_gate.rs
@@ -1,0 +1,244 @@
+//! Typed-evidence structural gate: the one place the repository's unresolved
+//! typed finding is turned into a transition refusal.
+//!
+//! Five transitions consume this — Judge verdict, human refinement acceptance,
+//! sign-off, verdict override, and graduation. Three of them
+//! (`proposal_signoff`, `proposal_graduate`, and re-entry into `in_review`)
+//! reach it through [`super::signoff::evaluate_composed_gate`]; the other two
+//! (`proposal_debate_append` for a Judge verdict, `proposal_refinement_resolve`,
+//! and `proposal_verdict_override`) call [`evaluate_typed_evidence_gate`]
+//! directly because they must not inherit the composed gate's DoR checks.
+//!
+//! ## Why the mode is a parameter
+//!
+//! [`TypedEvidenceGateMode`] is resolved **once, at the MCP tool boundary**,
+//! and passed down. It is deliberately not read from the environment inside the
+//! gate: `cargo test` runs a target's tests in one process, so a process-global
+//! toggle would make one test's rollout stage leak into another's and flake
+//! under parallel execution.
+
+use djinn_db::{
+    ProposalRepository, TypedEvidenceParityProbe, TypedEvidenceRepository,
+    UnresolvedTypedEvidenceProjection,
+};
+
+/// Environment variable consulted once per MCP tool call to pick the stage.
+pub const TYPED_EVIDENCE_GATE_ENV: &str = "DJINN_TYPED_EVIDENCE_GATE";
+
+/// Reason code emitted whenever the typed and legacy evidence authorities
+/// disagree. The gate fails closed on this in every mode, including `Off`:
+/// a disagreement means neither authority can be trusted to admit a
+/// transition, which is a different claim from "typed evidence is not live
+/// yet".
+pub const PARITY_MISMATCH_REASON: &str = "typed_evidence_parity_mismatch";
+
+/// Rollout stage for the typed-evidence structural gate.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TypedEvidenceGateMode {
+    /// The projection is not consulted and never surfaces. Only the parity
+    /// probe runs, so mixed-version drift still fails closed.
+    #[default]
+    Off,
+    /// The projection is read and surfaced on `proposal_show`, but an
+    /// unresolved finding does not block a transition.
+    Shadow,
+    /// An unresolved typed finding blocks the transition.
+    Enforce,
+}
+
+impl TypedEvidenceGateMode {
+    /// Resolve the stage from [`TYPED_EVIDENCE_GATE_ENV`].
+    ///
+    /// Call this at the MCP tool boundary and pass the result down. Unset or
+    /// unrecognized values stay [`TypedEvidenceGateMode::Off`], so a typo in a
+    /// deployment cannot silently arm the gate.
+    pub fn from_env() -> Self {
+        std::env::var(TYPED_EVIDENCE_GATE_ENV)
+            .as_deref()
+            .map_or(Self::Off, Self::parse)
+    }
+
+    /// The whole of the stage vocabulary. Anything unrecognized is `Off`, so a
+    /// typo in a deployment cannot silently arm the gate.
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "shadow" => Self::Shadow,
+            "enforce" => Self::Enforce,
+            _ => Self::Off,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Shadow => "shadow",
+            Self::Enforce => "enforce",
+        }
+    }
+}
+
+/// What the typed-evidence gate concluded for one proposal.
+#[derive(Clone, Debug)]
+pub(crate) struct TypedEvidenceGateOutcome {
+    pub mode: TypedEvidenceGateMode,
+    /// The unresolved finding, when one exists and the mode surfaces it.
+    pub projection: Option<UnresolvedTypedEvidenceProjection>,
+    /// Set when typed and legacy authority disagree, or when the repository
+    /// read itself failed. Both are fail-closed conditions in every mode.
+    pub fail_closed_reason: Option<String>,
+    /// The refusal string a blocked transition returns.
+    pub failure: Option<String>,
+}
+
+impl TypedEvidenceGateOutcome {
+    /// Nothing was read and nothing blocks.
+    fn clear(mode: TypedEvidenceGateMode) -> Self {
+        Self {
+            mode,
+            projection: None,
+            fail_closed_reason: None,
+            failure: None,
+        }
+    }
+
+    /// Whether this outcome refuses the transition.
+    pub fn blocks(&self) -> bool {
+        self.failure.is_some()
+    }
+
+    /// Whether the gate has anything at all to report to `proposal_show`.
+    pub fn is_reportable(&self) -> bool {
+        self.projection.is_some() || self.fail_closed_reason.is_some()
+    }
+}
+
+/// Render the refusal for an unresolved typed finding.
+///
+/// The four diagnostics are load-bearing: a Judge reading the refusal has to be
+/// able to find the finding, see the claim it is holding open, know which
+/// lifecycle state it is stuck in, and know which revision raised it.
+fn unresolved_failure(projection: &UnresolvedTypedEvidenceProjection) -> String {
+    let mut failure = format!(
+        "unresolved typed evidence finding {} (lifecycle: {}; demanded against revision {}; claim: {})",
+        projection.finding_id,
+        projection.lifecycle.as_str(),
+        projection.demanded_revision_seq,
+        projection.claim,
+    );
+    if let Some(outcome) = projection.evidence_outcome {
+        failure.push_str(&format!("; evidence outcome: {outcome:?}").to_lowercase());
+    }
+    if let Some(detail) = projection.failure_detail.as_deref() {
+        failure.push_str(&format!("; detail: {detail}"));
+    }
+    failure
+}
+
+/// Evaluate the typed-evidence gate for one proposal.
+///
+/// Fail-closed order matters. The parity probe runs first and in every mode: a
+/// disagreement between typed and legacy authority means the projection cannot
+/// be trusted either way, so no mode may admit the transition. Only once parity
+/// holds does the mode decide whether an unresolved finding blocks.
+pub(crate) async fn evaluate_typed_evidence_gate(
+    repo: &ProposalRepository,
+    proposal_id: &str,
+    mode: TypedEvidenceGateMode,
+) -> TypedEvidenceGateOutcome {
+    let typed = TypedEvidenceRepository::new(repo.db().clone());
+    let probe = match typed.legacy_parity_probe(proposal_id).await {
+        Ok(probe) => probe,
+        Err(error) => {
+            // An unreadable authority is indistinguishable from a mismatched
+            // one for the purposes of admitting a transition.
+            let reason = format!("{PARITY_MISMATCH_REASON}: probe unavailable ({error})");
+            return TypedEvidenceGateOutcome {
+                mode,
+                projection: None,
+                fail_closed_reason: Some(reason.clone()),
+                failure: Some(reason),
+            };
+        }
+    };
+    if let TypedEvidenceParityProbe::Mismatch(reason) = probe {
+        let reason = format!("{PARITY_MISMATCH_REASON}: {}", reason.as_str());
+        return TypedEvidenceGateOutcome {
+            mode,
+            projection: None,
+            fail_closed_reason: Some(reason.clone()),
+            failure: Some(reason),
+        };
+    }
+
+    // `Off` reads nothing further. This is what keeps a pre-rollout deployment
+    // byte-identical to the gate as it stood before typed evidence existed.
+    if mode == TypedEvidenceGateMode::Off {
+        return TypedEvidenceGateOutcome::clear(mode);
+    }
+
+    let projection = match typed.unresolved_projection(proposal_id).await {
+        Ok(projection) => projection,
+        Err(error) => {
+            let reason = format!("{PARITY_MISMATCH_REASON}: projection unavailable ({error})");
+            return TypedEvidenceGateOutcome {
+                mode,
+                projection: None,
+                fail_closed_reason: Some(reason.clone()),
+                failure: Some(reason),
+            };
+        }
+    };
+    let Some(projection) = projection else {
+        return TypedEvidenceGateOutcome::clear(mode);
+    };
+    let failure = (mode == TypedEvidenceGateMode::Enforce).then(|| unresolved_failure(&projection));
+    TypedEvidenceGateOutcome {
+        mode,
+        projection: Some(projection),
+        fail_closed_reason: None,
+        failure,
+    }
+}
+
+/// Refuse a transition that does not run the full composed gate.
+///
+/// Judge verdicts, human refinement acceptance, and verdict override each have
+/// their own preconditions and must not inherit DoR blocking, but they are
+/// still structural transitions over the same evidence authority.
+pub(crate) async fn typed_evidence_transition_refusal(
+    repo: &ProposalRepository,
+    proposal_id: &str,
+    mode: TypedEvidenceGateMode,
+) -> Option<String> {
+    evaluate_typed_evidence_gate(repo, proposal_id, mode)
+        .await
+        .failure
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unrecognized_modes_stay_off() {
+        // `parse` is the whole of `from_env`'s decision, so this covers the
+        // real mapping without touching the process environment — a shared env
+        // var is exactly the flake this parameterized design exists to avoid.
+        for (raw, expected) in [
+            ("off", TypedEvidenceGateMode::Off),
+            ("shadow", TypedEvidenceGateMode::Shadow),
+            ("SHADOW", TypedEvidenceGateMode::Shadow),
+            ("  Enforce ", TypedEvidenceGateMode::Enforce),
+            ("enforce!", TypedEvidenceGateMode::Off),
+            ("1", TypedEvidenceGateMode::Off),
+            ("", TypedEvidenceGateMode::Off),
+        ] {
+            assert_eq!(TypedEvidenceGateMode::parse(raw), expected, "for {raw:?}");
+        }
+    }
+
+    #[test]
+    fn default_mode_is_off() {
+        assert_eq!(TypedEvidenceGateMode::default(), TypedEvidenceGateMode::Off);
+    }
+}

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
@@ -21,6 +21,7 @@ use crate::tools::proposal_ops::{
     ProposalRefinementStopResponse, VerdictOverrideResponse,
 };
 use crate::tools::proposal_tools::feedback::human_feedback_disposition_contract_available;
+use crate::tools::proposal_tools::typed_evidence_gate::typed_evidence_transition_refusal;
 use crate::tools::refinement_helpers::validate_demand_evidence;
 pub use crate::tools::refinement_helpers::{
     ProposalRefinementDemandEvidenceParams, build_refinement_status,
@@ -827,6 +828,24 @@ impl DjinnMcpServer {
             }
         };
 
+        // Structural gate: accepting a refined spec is a transition over the
+        // same evidence authority as sign-off. Rejecting reverts to the
+        // pre-refinement snapshot and settles nothing, so it is not gated.
+        if accept
+            && let Some(refusal) = typed_evidence_transition_refusal(
+                &repo,
+                &proposal.id,
+                self.state.typed_evidence_gate_mode(),
+            )
+            .await
+        {
+            return Json(ResolveReviewResponse {
+                proposal_id: Some(proposal.id),
+                resolved: false,
+                error: Some(format!("cannot accept refinement: {refusal}")),
+            });
+        }
+
         match self.state.coordinator().await {
             Some(handle) => {
                 if let Err(e) = handle
@@ -947,6 +966,26 @@ impl DjinnMcpServer {
                 overridden: false,
                 override_on_revision_seq: None,
                 error: Some("override reason must not be empty".to_string()),
+            });
+        }
+
+        // Structural gate: a verdict override suppresses the needs-work
+        // channel, so it must not be usable to walk past unresolved typed
+        // evidence. This is a direct call rather than the composed gate — an
+        // override is precisely the tool for a DoR-imperfect proposal, so it
+        // must not inherit DoR blocking.
+        if let Some(refusal) = typed_evidence_transition_refusal(
+            &repo,
+            &proposal.id,
+            self.state.typed_evidence_gate_mode(),
+        )
+        .await
+        {
+            return Json(VerdictOverrideResponse {
+                proposal_id: Some(proposal.id),
+                overridden: false,
+                override_on_revision_seq: None,
+                error: Some(format!("cannot override verdict: {refusal}")),
             });
         }
 

--- a/server/crates/djinn-control-plane/tests/fixtures/typed_evidence_gate_off_baseline.json
+++ b/server/crates/djinn-control-plane/tests/fixtures/typed_evidence_gate_off_baseline.json
@@ -1,0 +1,15 @@
+{
+  "composed_failures": [],
+  "composed_error": null,
+  "gate_status": {
+    "ready": true,
+    "dor_ready": true,
+    "dor_failures": [],
+    "judge_needs_work": false,
+    "adversary_dry_count": 0,
+    "unresolved_blocking_count": 0,
+    "unresolved_blocking_ids": [],
+    "human_override_active": false,
+    "blocked_explanations": []
+  }
+}

--- a/server/crates/djinn-control-plane/tests/typed_evidence_gate_composition.rs
+++ b/server/crates/djinn-control-plane/tests/typed_evidence_gate_composition.rs
@@ -1,0 +1,672 @@
+//! Composition contract for the typed-evidence structural gate.
+//!
+//! Five transitions consume the repository projection: Judge verdict, human
+//! refinement acceptance, sign-off, verdict override, and graduation. Each is
+//! driven here through its real MCP tool against a migrated database, so a row
+//! cannot pass by asserting a status string.
+//!
+//! The rollout stage is pinned per-`McpState` rather than read from the
+//! process environment, so three modes can be exercised in one test binary
+//! without one test's stage leaking into another's.
+
+use djinn_control_plane::server::DjinnMcpServer;
+use djinn_control_plane::state::stubs::test_mcp_state;
+use djinn_control_plane::tools::proposal_tools::TypedEvidenceGateMode;
+use djinn_core::events::EventBus;
+use djinn_core::models::NeedsEvidenceClaim;
+use djinn_db::{
+    Database, ProjectRepository, ProposalCreateInput, ProposalRepository, TaskRepository,
+    TypedEvidenceRepository, UserRepository,
+    test_support::{
+        CanonicalTypedEvidenceReturnOutcomeForTest, UsageTestTaskSeed,
+        overwrite_legacy_evidence_authority_for_test,
+        seed_canonical_typed_evidence_ingress_fixture_for_test, seed_task_row,
+    },
+};
+use serde_json::{Value, json};
+
+/// A body that passes every deterministic DoR check, so the composed gate
+/// reaches its tribunal section instead of short-circuiting on readiness.
+const READY_BODY: &str = r#"
+# Problem
+Reviewers cannot tell whether a typed evidence demand is still open.
+
+# Scope
+In scope: the structural gate. Out of scope: the UI rendering.
+
+# Objectives
+- Block transitions on an unresolved typed finding
+- Report the finding on `proposal_show`
+
+## File map
+```file-map
+    server/crates/djinn-control-plane/src/tools/proposal_tools/signoff.rs
+    server/crates/djinn-db/src/repositories/typed_evidence.rs
+```
+
+# Dependencies
+Blocked by the typed evidence projection in `djinn-db`.
+
+# Open Questions
+What happens when typed and legacy authority disagree?
+"#;
+
+/// The five gated transitions, each named by the MCP tool that performs it.
+const TRANSITIONS: [&str; 5] = [
+    "proposal_debate_append",
+    "proposal_refinement_resolve",
+    "proposal_signoff",
+    "proposal_verdict_override",
+    "proposal_graduate",
+];
+
+struct Fixture {
+    db: Database,
+    proposals: ProposalRepository,
+    user_id: String,
+    proposal_id: String,
+    spike_task_id: String,
+    finding_id: String,
+}
+
+impl Fixture {
+    /// A DoR-ready, approved proposal carrying one unresolved typed finding in
+    /// `evidence_received`.
+    ///
+    /// That lifecycle is the point: the durable receipt already cleared the
+    /// legacy `linked_spike_task_id` / `needs_evidence_claim` columns, so the
+    /// pre-existing needs-evidence check (2d) sees nothing. Only the typed
+    /// projection knows the claim is still open — which is exactly the hole
+    /// this gate closes.
+    async fn blocked() -> Self {
+        let fixture = Self::unblocked().await;
+        fixture.raise_typed_demand().await;
+        fixture.deliver_typed_evidence().await;
+        fixture
+    }
+
+    /// The same proposal with no typed finding at all.
+    async fn unblocked() -> Self {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        let users = UserRepository::new(db.clone());
+        let user = users
+            .upsert_from_github(
+                i64::from(u32::from(std::process::id() as u16)) + 900_000,
+                &format!("typed-gate-{}", uuid::Uuid::now_v7()),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        users.set_role(&user.id, "engineer").await.unwrap();
+        let proposals = ProposalRepository::new(db.clone(), EventBus::noop());
+        let project = ProjectRepository::new(db.clone(), EventBus::noop())
+            .create(
+                &format!("svc-{}", uuid::Uuid::now_v7()),
+                "test",
+                &format!("svc-{}", uuid::Uuid::now_v7()),
+            )
+            .await
+            .unwrap();
+        let proposal = djinn_core::auth_context::SESSION_USER_ID
+            .scope(Some(user.id.clone()), async {
+                proposals
+                    .create(ProposalCreateInput {
+                        title: "Typed evidence gate composition",
+                        body: READY_BODY,
+                        acceptance_criteria: Some(
+                            r#"[{"criterion":"The gate refuses with the finding id","met":false}]"#,
+                        ),
+                        status: None,
+                        body_format: None,
+                    })
+                    .await
+            })
+            .await
+            .unwrap();
+        proposals
+            .add_target(&proposal.id, &project.id, "primary")
+            .await
+            .unwrap();
+        let spike_task_id = seed_task_row(
+            &db,
+            UsageTestTaskSeed {
+                project_id: &project.id,
+                status: "open",
+                close_reason: None,
+                total_reopen_count: 0,
+            },
+        )
+        .await;
+        Self {
+            db,
+            proposals,
+            user_id: user.id,
+            proposal_id: proposal.id,
+            spike_task_id,
+            finding_id: String::new(),
+        }
+    }
+
+    fn claim(&self) -> NeedsEvidenceClaim {
+        NeedsEvidenceClaim {
+            question: "Can the launcher share a cgroup across pods?".into(),
+            target_subsystem: "launcher".into(),
+            spec_unknown_anchor: "cgroup delegation".into(),
+            insufficient_in_session_research: "needs a live kernel probe".into(),
+            expected_findings: "a delegated cgroup or a kernel refusal".into(),
+            created_by_task_id: self.spike_task_id.clone(),
+            round: 1,
+            against_revision_seq: 1,
+        }
+    }
+
+    async fn raise_typed_demand(&self) {
+        self.proposals
+            .set_structured_needs_evidence_spike(
+                &self.proposal_id,
+                &self.spike_task_id,
+                &self.claim(),
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Submit a durable return, which moves the finding to `evidence_received`
+    /// and clears legacy authority in the same transaction.
+    async fn deliver_typed_evidence(&self) {
+        let fixture = seed_canonical_typed_evidence_ingress_fixture_for_test(
+            &self.db,
+            &self.proposal_id,
+            &self.spike_task_id,
+            "gate-composition",
+            CanonicalTypedEvidenceReturnOutcomeForTest::Partial,
+        )
+        .await;
+        // The durable return path authenticates a closed spike task. Close it
+        // through the task repository rather than raw SQL — the raw-SQL
+        // boundary applies to test files too.
+        TaskRepository::new(self.db.clone(), EventBus::noop())
+            .set_status_with_reason(&self.spike_task_id, "closed", Some("completed"))
+            .await
+            .unwrap();
+        TypedEvidenceRepository::new(self.db.clone())
+            .submit_return_v1_for_task(&self.spike_task_id, fixture.return_payload.as_bytes())
+            .await
+            .unwrap();
+        let proposal = self
+            .proposals
+            .get(&self.proposal_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            proposal.linked_spike_task_id.is_none() && proposal.needs_evidence_claim.is_none(),
+            "the receipt must clear legacy authority, or the legacy 2d check \
+             would be doing this gate's work"
+        );
+    }
+
+    fn typed_finding_id(&self) -> String {
+        if !self.finding_id.is_empty() {
+            return self.finding_id.clone();
+        }
+        unreachable!("call resolve_finding_id first")
+    }
+
+    async fn resolve_finding_id(&mut self) {
+        self.finding_id = TypedEvidenceRepository::new(self.db.clone())
+            .unresolved_projection(&self.proposal_id)
+            .await
+            .unwrap()
+            .expect("fixture must carry an unresolved typed finding")
+            .finding_id;
+    }
+
+    /// Put the proposal into the exact status each transition requires.
+    async fn set_status(&self, status: &str) {
+        let proposal = self
+            .proposals
+            .get(&self.proposal_id)
+            .await
+            .unwrap()
+            .unwrap();
+        self.proposals
+            .update(
+                &self.proposal_id,
+                djinn_db::ProposalUpdateInput {
+                    title: &proposal.title,
+                    body: &proposal.body,
+                    acceptance_criteria: &proposal.acceptance_criteria,
+                    status,
+                    superseded_by: None,
+                    body_format: Some(&proposal.body_format),
+                    event_metadata: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Reach `approved` the way the repository defines it: two fresh sign-offs
+    /// of distinct kinds on the head revision. Setting the column alone does
+    /// not work — `update` re-reconciles the approval gate and demotes back.
+    async fn approve(&self) {
+        self.set_status("in_review").await;
+        for kind in ["scoped", "technical"] {
+            self.proposals
+                .add_signoff(&self.proposal_id, kind, &self.user_id)
+                .await
+                .unwrap();
+        }
+        let proposal = self
+            .proposals
+            .get(&self.proposal_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            proposal.status, "approved",
+            "the graduation precondition must actually hold before the gate runs"
+        );
+    }
+
+    fn server(&self, mode: TypedEvidenceGateMode) -> DjinnMcpServer {
+        DjinnMcpServer::new(test_mcp_state(self.db.clone()).with_typed_evidence_gate_mode(mode))
+    }
+
+    /// Invoke one gated transition and return its error string, if any.
+    async fn attempt(&self, server: &DjinnMcpServer, transition: &str) -> Option<String> {
+        // `proposal_graduate` only reaches its gate from `approved`; sign-off
+        // only from `draft`/`in_review`. Satisfy the status precondition first
+        // so a refusal is the gate's, never a precondition's.
+        if transition == "proposal_graduate" {
+            self.approve().await;
+        } else {
+            self.set_status("in_review").await;
+        }
+        let args = match transition {
+            "proposal_debate_append" => json!({
+                "proposal_id": self.proposal_id,
+                "kind": "verdict",
+                "body": "approve: the spec is settled",
+                "blocking": false,
+                "agent_role": "judge",
+                "against_revision_seq": 1,
+                "round": 1,
+            }),
+            "proposal_refinement_resolve" => json!({
+                "proposal_id": self.proposal_id,
+                "decision": "accept",
+            }),
+            "proposal_signoff" => json!({ "id": self.proposal_id, "kind": "technical" }),
+            "proposal_verdict_override" => json!({
+                "proposal_id": self.proposal_id,
+                "reason": "human accepted the residual risk",
+            }),
+            "proposal_graduate" => json!({ "id": self.proposal_id }),
+            other => unreachable!("unknown transition {other}"),
+        };
+        let response = djinn_core::auth_context::SESSION_USER_ID
+            .scope(Some(self.user_id.clone()), async {
+                server.dispatch_tool(transition, args).await
+            })
+            .await
+            .unwrap_or_else(|error| json!({ "error": error }));
+        response
+            .get("error")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    }
+
+    /// Assert the durable row each refused transition would have written is
+    /// absent. Sign-off is exempt from the row check because reaching the
+    /// graduation precondition seeds two sign-offs by design; its refusal is
+    /// instead proven by the proposal never advancing.
+    async fn assert_transition_left_no_trace(&self, transition: &str) {
+        let proposal = self
+            .proposals
+            .get(&self.proposal_id)
+            .await
+            .unwrap()
+            .unwrap();
+        match transition {
+            "proposal_debate_append" => assert!(
+                self.proposals
+                    .latest_judge_verdict(&self.proposal_id)
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "a refused judge verdict must not persist a debate row"
+            ),
+            "proposal_signoff" => assert!(
+                self.proposals
+                    .signoffs(&self.proposal_id)
+                    .await
+                    .unwrap()
+                    .is_empty(),
+                "a refused sign-off must not persist a row"
+            ),
+            "proposal_verdict_override" => assert!(
+                self.proposals
+                    .latest_verdict_override(&self.proposal_id)
+                    .await
+                    .unwrap()
+                    .is_none(),
+                "a refused override must not persist a lifecycle row"
+            ),
+            "proposal_graduate" => assert_ne!(
+                proposal.status, "building",
+                "a refused graduation must not move the proposal to building"
+            ),
+            // `proposal_refinement_resolve` delegates to the coordinator, so
+            // its only durable trace is the one the coordinator would write.
+            // The refusal is asserted by the gate returning before that call.
+            _ => {}
+        }
+    }
+
+    async fn gate_status(&self, server: &DjinnMcpServer) -> Value {
+        let response = djinn_core::auth_context::SESSION_USER_ID
+            .scope(Some(self.user_id.clone()), async {
+                server
+                    .dispatch_tool("proposal_show", json!({ "id": self.proposal_id }))
+                    .await
+            })
+            .await
+            .unwrap();
+        response
+            .get("gate_status")
+            .cloned()
+            .expect("proposal_show must include gate_status")
+    }
+}
+
+/// AC1 — every one of the five transitions refuses under `Enforce`, and each
+/// refusal names all four typed diagnostics.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn enforce_blocks_all_five_transitions_with_the_four_typed_diagnostics() {
+    let mut fixture = Fixture::blocked().await;
+    fixture.resolve_finding_id().await;
+    let finding_id = fixture.typed_finding_id();
+    let server = fixture.server(TypedEvidenceGateMode::Enforce);
+
+    for transition in TRANSITIONS {
+        let error = fixture
+            .attempt(&server, transition)
+            .await
+            .unwrap_or_else(|| panic!("{transition} must be refused under Enforce"));
+        assert!(
+            error.contains(&finding_id),
+            "{transition} refusal must name the finding id: {error}"
+        );
+        assert!(
+            error.contains("Can the launcher share a cgroup across pods?"),
+            "{transition} refusal must quote the claim: {error}"
+        );
+        assert!(
+            error.contains("evidence_received"),
+            "{transition} refusal must name the lifecycle state: {error}"
+        );
+        assert!(
+            error.contains("demanded against revision 1"),
+            "{transition} refusal must name the originating revision seq: {error}"
+        );
+        // The refusal is not cosmetic: assert the persisted side effect the
+        // transition would have produced, not the returned message.
+        fixture.assert_transition_left_no_trace(transition).await;
+    }
+}
+
+/// AC1 control — the same five transitions are admitted once the typed finding
+/// is gone, so the refusals above are the gate's and not a precondition's.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn enforce_admits_every_transition_when_no_typed_finding_exists() {
+    let fixture = Fixture::unblocked().await;
+    let server = fixture.server(TypedEvidenceGateMode::Enforce);
+    for transition in TRANSITIONS {
+        let error = fixture.attempt(&server, transition).await;
+        assert!(
+            !error
+                .as_deref()
+                .is_some_and(|e| e.contains("typed evidence")),
+            "{transition} must not be refused by the typed gate: {error:?}"
+        );
+    }
+}
+
+/// AC2 — under `Off` the composed gate produces exactly the pre-change result.
+///
+/// The expected value is committed in
+/// `tests/fixtures/typed_evidence_gate_off_baseline.json` and was captured by
+/// running this test's fixture against the gate *before* check 2e existed. It
+/// is never regenerated: if `Off` ever starts adding, dropping, or reordering a
+/// failure, this goes red.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn off_mode_is_byte_identical_to_the_pre_change_gate() {
+    let baseline: Value = serde_json::from_str(include_str!(
+        "fixtures/typed_evidence_gate_off_baseline.json"
+    ))
+    .expect("baseline fixture is valid JSON");
+    let mut fixture = Fixture::blocked().await;
+    fixture.resolve_finding_id().await;
+    fixture.set_status("in_review").await;
+    let proposal = fixture
+        .proposals
+        .get(&fixture.proposal_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let composed = djinn_control_plane::tools::proposal_tools::signoff::evaluate_composed_gate(
+        &fixture.proposals,
+        &proposal,
+        &proposal.body,
+        &proposal.acceptance_criteria,
+        1,
+        TypedEvidenceGateMode::Off,
+    )
+    .await;
+    let status = djinn_control_plane::tools::proposal_tools::signoff::build_gate_status(
+        &fixture.proposals,
+        &proposal,
+        &proposal.body,
+        &proposal.acceptance_criteria,
+        1,
+        TypedEvidenceGateMode::Off,
+    )
+    .await;
+    let observed = json!({
+        "composed_failures": composed.failures(),
+        "composed_error": composed.to_error_string(),
+        "gate_status": serde_json::to_value(&status).unwrap(),
+    });
+    assert_eq!(
+        observed, baseline,
+        "Off mode must reproduce the pre-change gate byte for byte"
+    );
+
+    // Guard against a vacuous baseline: the same fixture under Enforce must
+    // differ, or this test would pass with the gate deleted entirely.
+    let enforced = djinn_control_plane::tools::proposal_tools::signoff::evaluate_composed_gate(
+        &fixture.proposals,
+        &proposal,
+        &proposal.body,
+        &proposal.acceptance_criteria,
+        1,
+        TypedEvidenceGateMode::Enforce,
+    )
+    .await;
+    assert_ne!(
+        enforced.failures(),
+        composed.failures(),
+        "the baseline is only meaningful if Enforce changes the result"
+    );
+}
+
+/// AC3 — a typed/legacy parity mismatch fails every transition closed, in all
+/// three modes, with the same reason code.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parity_mismatch_fails_closed_in_every_mode() {
+    for mode in [
+        TypedEvidenceGateMode::Off,
+        TypedEvidenceGateMode::Shadow,
+        TypedEvidenceGateMode::Enforce,
+    ] {
+        let fixture = Fixture::unblocked().await;
+        // Legacy authority ahead of typed: a compatibility link with no typed
+        // finding behind it. This is the mixed-version drift a rollback leaves.
+        overwrite_legacy_evidence_authority_for_test(
+            &fixture.db,
+            &fixture.proposal_id,
+            Some(&fixture.spike_task_id),
+            Some(&serde_json::to_value(fixture.claim()).unwrap()),
+        )
+        .await;
+        let server = fixture.server(mode);
+        for transition in TRANSITIONS {
+            let error = fixture
+                .attempt(&server, transition)
+                .await
+                .unwrap_or_else(|| {
+                    panic!("{transition} must fail closed on a parity mismatch in {mode:?}")
+                });
+            assert!(
+                error.contains("typed_evidence_parity_mismatch"),
+                "{transition} in {mode:?} must name the parity reason: {error}"
+            );
+        }
+    }
+}
+
+/// AC4 — `proposal_show` carries the typed section for a blocked proposal,
+/// omits it when there is no finding, and leaves the legacy fields alone.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proposal_show_reports_the_typed_section_without_disturbing_legacy_fields() {
+    let mut fixture = Fixture::blocked().await;
+    fixture.resolve_finding_id().await;
+    let finding_id = fixture.typed_finding_id();
+
+    let status = fixture
+        .gate_status(&fixture.server(TypedEvidenceGateMode::Enforce))
+        .await;
+    let typed = status
+        .get("typed_evidence")
+        .expect("a blocked proposal must carry the typed section");
+    assert_eq!(typed["finding_id"], json!(finding_id));
+    assert_eq!(typed["lifecycle"], json!("evidence_received"));
+    assert_eq!(typed["demanded_revision_seq"], json!(1));
+    assert_eq!(typed["mode"], json!("enforce"));
+    assert_eq!(typed["blocking"], json!(true));
+    assert_eq!(typed["evidence_outcome"], json!("partial"));
+    assert!(
+        typed["claim"]
+            .as_str()
+            .is_some_and(|claim| claim.contains("Can the launcher share a cgroup across pods?")),
+        "the typed section must carry the claim: {typed}"
+    );
+    assert_eq!(
+        status.get("ready"),
+        Some(&json!(false)),
+        "the typed section must make the gate not ready"
+    );
+    // The legacy channel is untouched: this fixture's receipt cleared it, so
+    // `needs_evidence` is absent exactly as it was before the typed section
+    // existed. The two authorities are reported independently.
+    assert!(
+        status.get("needs_evidence").is_none(),
+        "legacy needs-evidence must be reported from the legacy columns alone: {status}"
+    );
+
+    // Shadow surfaces the same finding without blocking.
+    let shadow = fixture
+        .gate_status(&fixture.server(TypedEvidenceGateMode::Shadow))
+        .await;
+    assert_eq!(shadow["typed_evidence"]["finding_id"], json!(finding_id));
+    assert_eq!(shadow["typed_evidence"]["blocking"], json!(false));
+    assert_eq!(shadow["typed_evidence"]["mode"], json!("shadow"));
+
+    // Off reports nothing typed at all.
+    let off = fixture
+        .gate_status(&fixture.server(TypedEvidenceGateMode::Off))
+        .await;
+    assert!(
+        off.get("typed_evidence").is_none(),
+        "Off must not surface a typed section: {off}"
+    );
+
+    // A proposal with no typed finding omits the section under every mode.
+    let clean = Fixture::unblocked().await;
+    for mode in [
+        TypedEvidenceGateMode::Off,
+        TypedEvidenceGateMode::Shadow,
+        TypedEvidenceGateMode::Enforce,
+    ] {
+        let status = clean.gate_status(&clean.server(mode)).await;
+        assert!(
+            status.get("typed_evidence").is_none(),
+            "no finding must mean no typed section in {mode:?}: {status}"
+        );
+    }
+}
+
+/// AC4 companion — the legacy `needs_evidence` fields still populate from the
+/// legacy columns, unchanged by the typed section.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn legacy_needs_evidence_fields_are_unchanged() {
+    let fixture = Fixture::unblocked().await;
+    fixture.raise_typed_demand().await;
+    let status = fixture
+        .gate_status(&fixture.server(TypedEvidenceGateMode::Enforce))
+        .await;
+    let legacy = status
+        .get("needs_evidence")
+        .expect("a legacy-parked proposal must still report needs_evidence");
+    assert_eq!(
+        legacy["spike_task_id"],
+        json!(fixture.spike_task_id),
+        "legacy spike id must come from the legacy column: {legacy}"
+    );
+    assert_eq!(legacy["spike_status"], json!("open"));
+    assert!(
+        legacy["claim"]
+            .as_str()
+            .is_some_and(|claim| claim.contains("Can the launcher share a cgroup across pods?")),
+        "legacy claim must be the legacy column text: {legacy}"
+    );
+    // Both authorities agree here, so the typed section reports the same
+    // finding alongside — never instead of — the legacy one.
+    assert_eq!(
+        status["typed_evidence"]["lifecycle"],
+        json!("spike_active"),
+        "typed and legacy sections must coexist: {status}"
+    );
+}
+
+/// The rollout stage is carried by the state, so two servers over the same
+/// database disagree about blocking without touching the process environment.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_rollout_stage_is_per_state_not_per_process() {
+    let fixture = Fixture::blocked().await;
+    assert!(
+        fixture
+            .attempt(
+                &fixture.server(TypedEvidenceGateMode::Enforce),
+                "proposal_signoff"
+            )
+            .await
+            .is_some_and(|error| error.contains("unresolved typed evidence finding")),
+        "Enforce must block"
+    );
+    assert!(
+        !fixture
+            .attempt(
+                &fixture.server(TypedEvidenceGateMode::Shadow),
+                "proposal_signoff"
+            )
+            .await
+            .is_some_and(|error| error.contains("unresolved typed evidence finding")),
+        "Shadow must not block, in the same process and against the same database"
+    );
+}

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -23116,6 +23116,17 @@
                 }
               ]
             },
+            "typed_evidence": {
+              "description": "Typed evidence authority for this proposal.\n\nThis is the normalized `typed_evidence_findings` lifecycle, distinct\nfrom the legacy `needs_evidence` compatibility columns above — both are\nreported so a mixed-version reader can tell which authority is speaking.\n`None` when the rollout mode is `off`, when the proposal has no\nunresolved typed finding, and when typed/legacy authority agree.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TypedEvidenceGateStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "human_override_active": {
               "description": "Whether a current human override exists for this revision.",
               "type": "boolean"
@@ -23156,6 +23167,90 @@
           "required": [
             "check",
             "message"
+          ]
+        },
+        "TypedEvidenceGateStatus": {
+          "description": "Typed evidence authority section of the composed gate status.\n\nEvery field is projected from `TypedEvidenceRepository`; nothing here is\nre-derived from tasks or debate rows.",
+          "type": "object",
+          "properties": {
+            "mode": {
+              "description": "Rollout stage this evaluation ran under: `off`, `shadow`, or `enforce`.",
+              "type": "string"
+            },
+            "blocking": {
+              "description": "Whether this section is currently refusing transitions.",
+              "type": "boolean"
+            },
+            "parity_mismatch_reason": {
+              "description": "Set when typed and legacy evidence authority disagree. The gate fails\nclosed on this in every mode, including `off`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "finding_id": {
+              "description": "Id of the unresolved typed finding.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "claim": {
+              "description": "The finding's claim, serialized as JSON text.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "lifecycle": {
+              "description": "`demanded`, `spike_active`, `evidence_received`, or `failed`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "demanded_revision_seq": {
+              "description": "Revision the demand was raised against. Provenance, not a filter — the\nfinding keeps blocking as the proposal head advances past it.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "attempt_seq": {
+              "description": "Sequence of the latest allocated spike attempt.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "evidence_outcome": {
+              "description": "Validated outcome of the latest durable return: `resolved`, `partial`,\nor `unresolved`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "folding_revision": {
+              "description": "Folding revision of a recorded disposition that did not carry the\nfinding to a terminal lifecycle.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "failure_detail": {
+              "description": "Most specific persisted failure text for the finding.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "mode",
+            "blocking"
           ]
         }
       },

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -22409,6 +22409,17 @@ expression: signatures
               "description": "Whether the composed gate passes (DoR ready + tribunal conditions met).",
               "type": "boolean"
             },
+            "typed_evidence": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TypedEvidenceGateStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Typed evidence authority for this proposal.\n\nThis is the normalized `typed_evidence_findings` lifecycle, distinct\nfrom the legacy `needs_evidence` compatibility columns above — both are\nreported so a mixed-version reader can tell which authority is speaking.\n`None` when the rollout mode is `off`, when the proposal has no\nunresolved typed finding, and when typed/legacy authority agree."
+            },
             "unresolved_blocking_count": {
               "description": "Count of unresolved blocking debate-trail entries.",
               "format": "int32",
@@ -22982,6 +22993,90 @@ expression: signatures
             "errors",
             "warnings",
             "skipped_tiers"
+          ],
+          "type": "object"
+        },
+        "TypedEvidenceGateStatus": {
+          "description": "Typed evidence authority section of the composed gate status.\n\nEvery field is projected from `TypedEvidenceRepository`; nothing here is\nre-derived from tasks or debate rows.",
+          "properties": {
+            "attempt_seq": {
+              "description": "Sequence of the latest allocated spike attempt.",
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "blocking": {
+              "description": "Whether this section is currently refusing transitions.",
+              "type": "boolean"
+            },
+            "claim": {
+              "description": "The finding's claim, serialized as JSON text.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "demanded_revision_seq": {
+              "description": "Revision the demand was raised against. Provenance, not a filter — the\nfinding keeps blocking as the proposal head advances past it.",
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "evidence_outcome": {
+              "description": "Validated outcome of the latest durable return: `resolved`, `partial`,\nor `unresolved`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "failure_detail": {
+              "description": "Most specific persisted failure text for the finding.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "finding_id": {
+              "description": "Id of the unresolved typed finding.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "folding_revision": {
+              "description": "Folding revision of a recorded disposition that did not carry the\nfinding to a terminal lifecycle.",
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "lifecycle": {
+              "description": "`demanded`, `spike_active`, `evidence_received`, or `failed`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mode": {
+              "description": "Rollout stage this evaluation ran under: `off`, `shadow`, or `enforce`.",
+              "type": "string"
+            },
+            "parity_mismatch_reason": {
+              "description": "Set when typed and legacy evidence authority disagree. The gate fails\nclosed on this in every mode, including `off`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "mode",
+            "blocking"
           ],
           "type": "object"
         },

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -10462,6 +10462,16 @@ export namespace ProposalShowOutputSchema {
    */
   ready: boolean
   /**
+   * Typed evidence authority for this proposal.
+   * 
+   * This is the normalized `typed_evidence_findings` lifecycle, distinct
+   * from the legacy `needs_evidence` compatibility columns above — both are
+   * reported so a mixed-version reader can tell which authority is speaking.
+   * `None` when the rollout mode is `off`, when the proposal has no
+   * unresolved typed finding, and when typed/legacy authority agree.
+   */
+  typed_evidence?: (TypedEvidenceGateStatus | null)
+  /**
    * Count of unresolved blocking debate-trail entries.
    */
   unresolved_blocking_count: number
@@ -10556,6 +10566,63 @@ export namespace ProposalShowOutputSchema {
    * The subsystem or module under investigation.
    */
   target_subsystem?: string
+  [k: string]: any
+  }
+  /**
+   * Typed evidence authority section of the composed gate status.
+   * 
+   * Every field is projected from `TypedEvidenceRepository`; nothing here is
+   * re-derived from tasks or debate rows.
+   */
+  export interface TypedEvidenceGateStatus {
+  /**
+   * Sequence of the latest allocated spike attempt.
+   */
+  attempt_seq?: number
+  /**
+   * Whether this section is currently refusing transitions.
+   */
+  blocking: boolean
+  /**
+   * The finding's claim, serialized as JSON text.
+   */
+  claim?: string
+  /**
+   * Revision the demand was raised against. Provenance, not a filter — the
+   * finding keeps blocking as the proposal head advances past it.
+   */
+  demanded_revision_seq?: number
+  /**
+   * Validated outcome of the latest durable return: `resolved`, `partial`,
+   * or `unresolved`.
+   */
+  evidence_outcome?: string
+  /**
+   * Most specific persisted failure text for the finding.
+   */
+  failure_detail?: string
+  /**
+   * Id of the unresolved typed finding.
+   */
+  finding_id?: string
+  /**
+   * Folding revision of a recorded disposition that did not carry the
+   * finding to a terminal lifecycle.
+   */
+  folding_revision?: number
+  /**
+   * `demanded`, `spike_active`, `evidence_received`, or `failed`.
+   */
+  lifecycle?: string
+  /**
+   * Rollout stage this evaluation ran under: `off`, `shadow`, or `enforce`.
+   */
+  mode: string
+  /**
+   * Set when typed and legacy evidence authority disagree. The gate fails
+   * closed on this in every mode, including `off`.
+   */
+  parity_mismatch_reason?: string
   [k: string]: any
   }
   /**


### PR DESCRIPTION
Task `0072` — second of the six-task `8tgo` chain. Stacked on `5fe1` (#3201, merged).

## What changed

Five transitions settle a proposal's spec: a Judge verdict, human refinement acceptance, sign-off, verdict override, and graduation. None of them could see an unresolved typed evidence finding, so a demand the Judge itself raised could be walked past by any of the five.

Check **2e** makes the `5fe1` repository projection the sole new input to all five.

**Where the gate is called from.** Three transitions already funnelled through `evaluate_composed_gate`. `proposal_debate_append` (Judge verdicts only), `proposal_refinement_resolve` (accept only), and `proposal_verdict_override` did **not** — the task design said they did, and that turned out to be wrong. They now call the typed gate directly rather than joining the composed gate, deliberately: an override is precisely the tool for a DoR-imperfect proposal, so it must not inherit DoR blocking. Objections and rebuttals are argument rather than settlement and stay ungated.

**Rollout switch.** `TypedEvidenceGateMode { Off, Shadow, Enforce }` is a *parameter* threaded into `evaluate_composed_gate` / `build_gate_status`, resolved once in `McpState::new`. It is never read from the environment inside the gate: a target's tests share one process, so a process-global toggle would leak one test's stage into another's and flake under nextest. Carrying it on the state also lets the tests drive the real MCP tools end to end under a chosen stage instead of asserting on a helper.

**Fail-closed.** A parity mismatch between typed and legacy authority refuses in *every* mode including `Off` — a disagreement means neither authority can be trusted, which is a different claim from "typed evidence is not live yet".

## Acceptance criteria

| AC | How it is verified |
| --- | --- |
| 1. Enforce blocks all five transitions, naming finding id / claim / lifecycle / revision seq | `enforce_blocks_all_five_transitions_with_the_four_typed_diagnostics` drives each of the five through `dispatch_tool` against a migrated Postgres, asserts all four diagnostics in the refusal, **and** asserts the durable row each transition would have written is absent (no debate row, no sign-off row, no override lifecycle row, status never reaches `building`). `enforce_admits_every_transition_when_no_typed_finding_exists` is the control, so the refusals are the gate's and not a precondition's. |
| 2. Off is byte-identical to the pre-change result | `off_mode_is_byte_identical_to_the_pre_change_gate` compares against `tests/fixtures/typed_evidence_gate_off_baseline.json`, captured by running this exact fixture against the gate **with check 2e removed**, then restored. The test also asserts `Enforce != Off` on the same fixture, so the baseline cannot pass vacuously with the gate deleted. |
| 3. Parity mismatch fails closed in all three modes | `parity_mismatch_fails_closed_in_every_mode` — 3 modes × 5 transitions = 15 refusals, each asserted to name `typed_evidence_parity_mismatch`. |
| 4. `proposal_show` typed section present when blocked, absent when no finding; legacy fields unchanged | `proposal_show_reports_the_typed_section_without_disturbing_legacy_fields` (Enforce populated + blocking, Shadow populated + non-blocking, Off absent, clean proposal absent under all three) and `legacy_needs_evidence_fields_are_unchanged` (legacy `needs_evidence` still sourced from the legacy columns, coexisting with the typed section). |
| 5. `make tool-goldens-check` exits zero; `typed_evidence_legacy_contract` still passes | Both run below. |

**Fixture note.** The blocked fixture sits in `evidence_received` with legacy authority already cleared by the durable receipt. That is the point: the pre-existing needs-evidence check (2d) sees nothing there, so only the typed projection knows the claim is still open — which is exactly the hole this gate closes. The fixture asserts the legacy columns are clear, so 2d cannot be doing 2e's work.

## Verification

```
cargo nextest run -p djinn-control-plane --test typed_evidence_gate_composition
  7 tests run: 7 passed
cargo nextest run -p djinn-control-plane
  1200 tests run: 1200 passed
cargo nextest run -p djinn-mcp-extension typed_evidence_legacy_contract
  1 test run: 1 passed
make tool-goldens-check        # "MCP tool-schema goldens are up to date." exit 0
cargo clippy -p djinn-control-plane --all-targets   # clean
BASE_SHA=origin/main ./scripts/check-raw-sql-boundary.sh   # 11 files, clean
```

All 8 tool-schema golden producers were regenerated **in this commit** alongside the schema change (`ui/src/api/generated/mcp-tools.gen.ts`, the server tool-schema snapshot, and the provider tool-schema projection fixture each carry the new `typed_evidence` section). No migrations; no `sqlx::query!` macros added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
